### PR TITLE
Small fix to CParserTests

### DIFF
--- a/src/Gui/IUiPreferencesService.cs
+++ b/src/Gui/IUiPreferencesService.cs
@@ -206,7 +206,7 @@ namespace Reko.Gui
             {
                 Name = UiStyles.CodeKeyword,
                 Foreground = GetBrush((string)settingsSvc.Get(UiStyles.CodeKeywordColor, defCodeKwStyle.ForeColor)),
-                Font = GetFont((string)settingsSvc.Get(UiStyles.CodeKeywordFont, defCodeStyle))
+                Font = GetFont((string)settingsSvc.Get(UiStyles.CodeKeywordFont, defCodeStyle.FontName))
             };
             AddStyle(codeKwStyle);
 

--- a/src/tools/c2xml/UnitTests/CParserTests.cs
+++ b/src/tools/c2xml/UnitTests/CParserTests.cs
@@ -213,7 +213,7 @@ namespace Reko.Tools.C2Xml.UnitTests
             Lex("do {__noop(TagBase);} while((0,0));");
             var stat = parser.Parse_Stat();
             var sExp =
-                "(do \r\n" +
+				"(do " + Environment.NewLine +
                 "(((__noop TagBase)))) " +
                 "(Comma 0 0))";
             Assert.AreEqual(sExp, stat.ToString());

--- a/src/tools/c2xml/UnitTests/CParserTests.cs
+++ b/src/tools/c2xml/UnitTests/CParserTests.cs
@@ -213,7 +213,7 @@ namespace Reko.Tools.C2Xml.UnitTests
             Lex("do {__noop(TagBase);} while((0,0));");
             var stat = parser.Parse_Stat();
             var sExp =
-				"(do " + Environment.NewLine +
+                "(do " + Environment.NewLine +
                 "(((__noop TagBase)))) " +
                 "(Comma 0 0))";
             Assert.AreEqual(sExp, stat.ToString());


### PR DESCRIPTION
convert \r\n usage to platform independent Environment.NewLine
Fix keyword font access in UiPreferencesService
