### PR TITLE
Fix analysis unit tests - linux

### DIFF
--- a/src/UnitTests/Analysis/IntraBlockDeadRegistersTests.cs
+++ b/src/UnitTests/Analysis/IntraBlockDeadRegistersTests.cs
@@ -36,9 +36,9 @@ namespace Reko.UnitTests.Analysis
     public class IntraBlockDeadRegistersTests
     {
         private string testResult;
-        private string toExpectedString(string [] lines)
+        private static string ToExpectedString(params string [] lines)
         {
-            List<string> stringlist = new List<string>();
+            var stringlist = new List<string>();
             foreach (var i in lines)
                 stringlist.Add("\t" + i);
             stringlist.Add ("");
@@ -66,9 +66,9 @@ namespace Reko.UnitTests.Analysis
                 m.Assign(a, 2);
                 m.Assign(a, 3);
             });
-            string expected = toExpectedString(new []{
+            string expected = ToExpectedString(
                 "a = 0x00000003"
-            });
+            );
             Assert.AreEqual(expected, testResult);
         }
 
@@ -82,11 +82,11 @@ namespace Reko.UnitTests.Analysis
                 m.Call("foo", 4);
                 m.Assign(a, 3);
             });
-            string expected = toExpectedString(new []{
+            string expected = ToExpectedString(
                 "a = 0x00000002",
                 "call <invalid> (retsize: 4;)",
                 "a = 0x00000003"
-            });
+            );
 
             Assert.AreEqual(expected, testResult);
         }
@@ -106,11 +106,11 @@ namespace Reko.UnitTests.Analysis
                 m.Assign(C, m.Cond(a));
                 m.BranchIf(m.Test(ConditionCode.LE, CN), "foo");
             });
-            string expected = toExpectedString(new []{
+            string expected = ToExpectedString(
                 "N = cond(a)",
                 "C = cond(a)",
                 "branch Test(LE,CN) foo"
-            });
+            );
             Assert.AreEqual(expected, testResult);
         }
 
@@ -130,12 +130,12 @@ namespace Reko.UnitTests.Analysis
                 m.Assign(N, m.Cond(a));
                 m.BranchIf(m.Test(ConditionCode.LE, CN), "foo");
             });
-            string expected = toExpectedString(new []{
+            string expected = ToExpectedString(
                 "a = a + 0x00000003",
                 "a = a + a",
                 "N = cond(a)",
                 "branch Test(LE,CN) foo"
-            });
+            );
 
             Assert.AreEqual(expected, testResult);
         }

--- a/src/UnitTests/Analysis/IntraBlockDeadRegistersTests.cs
+++ b/src/UnitTests/Analysis/IntraBlockDeadRegistersTests.cs
@@ -82,11 +82,10 @@ namespace Reko.UnitTests.Analysis
                 m.Call("foo", 4);
                 m.Assign(a, 3);
             });
-            string expected = String.Join(Environment.NewLine,new []{
-                "\ta = 0x00000002",
-                "\tcall <invalid> (retsize: 4;)",
-                "\ta = 0x00000003",
-                ""
+            string expected = toExpectedString(new []{
+                "a = 0x00000002",
+                "call <invalid> (retsize: 4;)",
+                "a = 0x00000003"
             });
 
             Assert.AreEqual(expected, testResult);

--- a/src/UnitTests/Analysis/IntraBlockDeadRegistersTests.cs
+++ b/src/UnitTests/Analysis/IntraBlockDeadRegistersTests.cs
@@ -36,7 +36,14 @@ namespace Reko.UnitTests.Analysis
     public class IntraBlockDeadRegistersTests
     {
         private string testResult;
-
+        private string toExpectedString(string [] lines)
+        {
+            List<string> stringlist = new List<string>();
+            foreach (var i in lines)
+                stringlist.Add("\t" + i);
+            stringlist.Add ("");
+            return String.Join (Environment.NewLine, stringlist.ToArray ());
+        }
         private void RunTest(Action<ProcedureBuilder> m)
         {
             var builder = new ProcedureBuilder();
@@ -59,7 +66,10 @@ namespace Reko.UnitTests.Analysis
                 m.Assign(a, 2);
                 m.Assign(a, 3);
             });
-            Assert.AreEqual("\ta = 0x00000003\r\n", testResult);
+            string expected = toExpectedString(new []{
+                "a = 0x00000003"
+            });
+            Assert.AreEqual(expected, testResult);
         }
 
         [Test(Description = "Calls clear killed stuff.")]
@@ -72,7 +82,14 @@ namespace Reko.UnitTests.Analysis
                 m.Call("foo", 4);
                 m.Assign(a, 3);
             });
-            Assert.AreEqual("\ta = 0x00000002\r\n\tcall <invalid> (retsize: 4;)\r\n\ta = 0x00000003\r\n", testResult);
+            string expected = String.Join(Environment.NewLine,new []{
+                "\ta = 0x00000002",
+                "\tcall <invalid> (retsize: 4;)",
+                "\ta = 0x00000003",
+                ""
+            });
+
+            Assert.AreEqual(expected, testResult);
         }
 
         [Test(Description = "Flags used clear killed bits.")]
@@ -90,7 +107,12 @@ namespace Reko.UnitTests.Analysis
                 m.Assign(C, m.Cond(a));
                 m.BranchIf(m.Test(ConditionCode.LE, CN), "foo");
             });
-            Assert.AreEqual("\tN = cond(a)\r\n\tC = cond(a)\r\n\tbranch Test(LE,CN) foo\r\n", testResult);
+            string expected = toExpectedString(new []{
+                "N = cond(a)",
+                "C = cond(a)",
+                "branch Test(LE,CN) foo"
+            });
+            Assert.AreEqual(expected, testResult);
         }
 
         [Test]
@@ -109,7 +131,14 @@ namespace Reko.UnitTests.Analysis
                 m.Assign(N, m.Cond(a));
                 m.BranchIf(m.Test(ConditionCode.LE, CN), "foo");
             });
-            Assert.AreEqual("\ta = a + 0x00000003\r\n\ta = a + a\r\n\tN = cond(a)\r\n\tbranch Test(LE,CN) foo\r\n", testResult);
+            string expected = toExpectedString(new []{
+                "a = a + 0x00000003",
+                "a = a + a",
+                "N = cond(a)",
+                "branch Test(LE,CN) foo"
+            });
+
+            Assert.AreEqual(expected, testResult);
         }
     }
 }

--- a/src/UnitTests/Analysis/SsaTests.cs
+++ b/src/UnitTests/Analysis/SsaTests.cs
@@ -76,7 +76,7 @@ namespace Reko.UnitTests.Analysis
 		[Test]
 		public void SsaSwitch()
 		{
-			RunFileTest("Fragments/Switch.asm", "Analysis/SsaSwitch.txt");
+			RunFileTest("Fragments/switch.asm", "Analysis/SsaSwitch.txt");
 		}
 		
 		[Test]

--- a/src/UnitTests/Analysis/TrashedRegisterFinder2Tests.cs
+++ b/src/UnitTests/Analysis/TrashedRegisterFinder2Tests.cs
@@ -234,7 +234,7 @@ Constants: cl:0x00
         [Test(Description="Tests propagation between caller and callee.")]
         public void TrfSubroutine_WithRegisterParameters()
         {
-            var sExp1 = "Preserved: r2\r\nTrashed: r1\r\n";
+            var sExp1 = String.Join(Environment.NewLine,new []{"Preserved: r2","Trashed: r1",""});
 
             // Subroutine does a small calculation in registers
             RunTest(sExp1, "Addition", m =>
@@ -245,7 +245,7 @@ Constants: cl:0x00
                 m.Return();
             });
 
-            var sExp2 = "Preserved: \r\nTrashed: Global memory,r1,r2\r\n";
+            var sExp2 = String.Join(Environment.NewLine,new []{"Preserved: ","Trashed: Global memory,r1,r2",""});
 
             RunTest(sExp2, m =>
             {


### PR DESCRIPTION
Mostly /r/n issues + one filename case difference.

Seems one of the committed files had different line endings though :cry: 

