### PR TITLE
M68k and AmigaOs fixes

### DIFF
--- a/src/Arch/M68k/M68kDisassembler.cs
+++ b/src/Arch/M68k/M68kDisassembler.cs
@@ -1419,12 +1419,13 @@ namespace Reko.Arch.M68k
         private static M68kInstruction d68020_cpscc(M68kDisassembler dasm)
         {
             uint extension1;
-            uint extension2;
             dasm.LIMIT_CPU_TYPES(M68020_PLUS);
+            // 0 - MMU
+            // 1 - MC68881/2 FPU
+            int cooprocessor_id = (dasm.instruction >> 9) & 7;
             extension1 = dasm.read_imm_16();
-            extension2 = dasm.read_imm_16();
-            dasm.g_dasm_str = string.Format("%ds%-4s  %s; (extension = %x) (2-3)", (dasm.instruction >> 9) & 7, g_cpcc[extension1 & 0x3f], dasm.get_ea_mode_str_8(dasm.instruction), extension2);
-            throw new NotImplementedException();
+            dasm.g_dasm_str = string.Format("{0}cpS{1}  %s; (extension = %x) (2-3)", cooprocessor_id, g_cpcc[extension1 & 0x3f], dasm.get_ea_mode_str_8(dasm.instruction));
+            return new M68kInstruction { code = Opcode.illegal };
         }
 
         private static M68kInstruction d68020_cptrapcc_0(M68kDisassembler dasm)
@@ -1434,7 +1435,7 @@ namespace Reko.Arch.M68k
             dasm.LIMIT_CPU_TYPES(M68020_PLUS);
             extension1 = dasm.read_imm_16();
             extension2 = dasm.read_imm_16();
-            dasm.g_dasm_str = string.Format("%dtrap%-4s; (extension = %x) (2-3)", (dasm.instruction >> 9) & 7, g_cpcc[extension1 & 0x3f], extension2);
+            dasm.g_dasm_str = string.Format("%dcptrap%-4s; (extension = %x) (2-3)", (dasm.instruction >> 9) & 7, g_cpcc[extension1 & 0x3f], extension2);
             throw new NotImplementedException();
         }
 

--- a/src/Environments/AmigaOS/AmigaOSPlatform.cs
+++ b/src/Environments/AmigaOS/AmigaOSPlatform.cs
@@ -80,7 +80,7 @@ namespace Reko.Environments.AmigaOS
             if (reg != Registers.a6)
                 return null;
             if (funcs == null)
-                funcs = LoadFuncs();
+                funcs = LoadLibraryDef("exec",33);
             SystemService svc;
             return funcs.TryGetValue(offset, out svc) ? svc : null;
         }
@@ -106,18 +106,18 @@ namespace Reko.Environments.AmigaOS
             return Address.Ptr32(c.ToUInt32());
         }
 
-        private Dictionary<int, SystemService> LoadFuncs()
+        private Dictionary<int, SystemService> LoadLibraryDef( string lib_name, int version ) 
         {
             var fsSvc = Services.RequireService<IFileSystemService>();
             var sser = Architecture.CreateProcedureSerializer(
                 new TypeLibraryLoader(Architecture,true),
                 DefaultCallingConvention);
 
-            using (var rdr = new StreamReader(fsSvc.CreateFileStream("exec.funcs", FileMode.Open, FileAccess.Read)))
+            using (var rdr = new StreamReader(fsSvc.CreateFileStream(lib_name+".funcs", FileMode.Open, FileAccess.Read)))
             {
                 var fpp = new FuncsFileParser((M68kArchitecture) this.Architecture, rdr);
                 fpp.Parse();
-                return fpp.FunctionsByA6Offset.Values
+                return fpp.FunctionsByLibBaseOffset.Values
                     .Select(amiSvc => new SystemService
                     {
                         Name = amiSvc.Name,

--- a/src/Environments/AmigaOS/FuncsFileParser.cs
+++ b/src/Environments/AmigaOS/FuncsFileParser.cs
@@ -43,7 +43,7 @@ namespace Reko.Environments.AmigaOS
         { 
             this.arch = arch;
             this.streamReader = streamReader;
-            this.FunctionsByA6Offset = new Dictionary<int, AmigaSystemFunction>();
+            this.FunctionsByLibBaseOffset = new Dictionary<int, AmigaSystemFunction>();
         }
 
         public void Parse()
@@ -55,7 +55,7 @@ namespace Reko.Environments.AmigaOS
                     break;
                 AmigaSystemFunction func = ParseLine(line);
                 if (func != null)
-                    FunctionsByA6Offset.Add(func.Offset, func);
+                    FunctionsByLibBaseOffset.Add(func.Offset, func);
             }
         }
 
@@ -132,7 +132,7 @@ namespace Reko.Environments.AmigaOS
             return tok.Value;
         }
         
-        public Dictionary<int, AmigaSystemFunction> FunctionsByA6Offset { get; private set; }
+        public Dictionary<int, AmigaSystemFunction> FunctionsByLibBaseOffset { get; private set; }
 
         private class Lexer
         {

--- a/src/UnitTests/Environments/AmigaOS/FuncsFileParserTests.cs
+++ b/src/UnitTests/Environments/AmigaOS/FuncsFileParserTests.cs
@@ -50,7 +50,7 @@ namespace Reko.UnitTests.Environments.AmigaOS
             var file = "";
             var ffp = CreateParser(file);
             ffp.Parse();
-            Assert.AreEqual(0, ffp.FunctionsByA6Offset.Count);
+            Assert.AreEqual(0, ffp.FunctionsByLibBaseOffset.Count);
         }
 
         [Test]
@@ -59,8 +59,8 @@ namespace Reko.UnitTests.Environments.AmigaOS
             var file = "#0107    666  0x029a                   CreateMsgPort ()\n";
             var ffp = CreateParser(file);
             ffp.Parse();
-            Assert.AreEqual(1, ffp.FunctionsByA6Offset.Count);
-            var func = ffp.FunctionsByA6Offset[-666];
+            Assert.AreEqual(1, ffp.FunctionsByLibBaseOffset.Count);
+            var func = ffp.FunctionsByLibBaseOffset[-666];
             Assert.AreEqual(-666, func.Offset);
             Assert.AreEqual("CreateMsgPort", func.Name);
             Assert.AreEqual(0, func.Signature.Arguments.Length);
@@ -72,8 +72,8 @@ namespace Reko.UnitTests.Environments.AmigaOS
             var file = "#0088    552  0x0228                     OpenLibrary ( libName/a1, version/d0 )";
             var ffp = CreateParser(file);
             ffp.Parse();
-            Assert.AreEqual(1, ffp.FunctionsByA6Offset.Count);
-            var func = ffp.FunctionsByA6Offset[-552];
+            Assert.AreEqual(1, ffp.FunctionsByLibBaseOffset.Count);
+            var func = ffp.FunctionsByLibBaseOffset[-552];
             Assert.AreEqual(-552, func.Offset);
             Assert.AreEqual("OpenLibrary", func.Name);
             Assert.AreEqual(2, func.Signature.Arguments.Length);
@@ -91,8 +91,8 @@ namespace Reko.UnitTests.Environments.AmigaOS
             var file = "#0004 4   4  Frobnitz ( argIn / a1; ret/d0 )";
             var ffp = CreateParser(file);
             ffp.Parse();
-            Assert.AreEqual(1, ffp.FunctionsByA6Offset.Count);
-            var func = ffp.FunctionsByA6Offset[-4];
+            Assert.AreEqual(1, ffp.FunctionsByLibBaseOffset.Count);
+            var func = ffp.FunctionsByLibBaseOffset[-4];
             Assert.IsNotNull(func.Signature.ReturnValue);
             Assert.AreEqual("d0", ((Register_v1) func.Signature.ReturnValue.Kind).Name);
         }


### PR DESCRIPTION
Return invalid instruction from d68020_cpscc - related to #35
Add info about different cooprocessor id's to d68020_cpscc
Renamed FunctionsByA6Offset to slightly more correct FunctionsByLibBaseOffset
Rename AmigaOSPlatform::LoadFuncs to LoadLibraryDef
Parametrize AmigaOSPlatform::LoadLibraryDef - one day we might want to load different library defs