### PR TITLE
Remove x86 arch dependencies from VariableTests and UseInstructionTests

### DIFF
--- a/src/UnitTests/Core/UseInstructionTests.cs
+++ b/src/UnitTests/Core/UseInstructionTests.cs
@@ -18,7 +18,6 @@
  */
 #endregion
 
-using Reko.Arch.X86;
 using Reko.Core;
 using Reko.Core.Code;
 using Reko.Core.Expressions;
@@ -43,8 +42,9 @@ namespace Reko.UnitTests.Core
 		[Test]
 		public void UseCreateWithArg()
 		{
+			var reg_edx = new RegisterStorage("edx",1,PrimitiveType.Word32);
 			var id2 = new Identifier("bar", PrimitiveType.Word32, new TemporaryStorage("bar", -1, PrimitiveType.Word32));
-			var r = new Identifier(Registers.edx.Name, Registers.edx.DataType, Registers.edx);
+			var r = new Identifier(reg_edx.Name, reg_edx.DataType, reg_edx);
 			var arg = new Identifier("barOut", PrimitiveType.Pointer32, new OutArgumentStorage(r));
 			var use2 = new UseInstruction(id2, arg);
 			Assert.AreSame(id2, use2.Expression);
@@ -54,11 +54,12 @@ namespace Reko.UnitTests.Core
 		[Test]
 		public void UseToString()
 		{
+			var reg_edx = new RegisterStorage("edx",1,PrimitiveType.Word32);
 			var id1 = new Identifier("foo", PrimitiveType.Word32, null);
 			var use = new UseInstruction(id1);
 			Assert.AreEqual("use foo", use.ToString());
 
-			var r = new Identifier(Registers.edx.Name, Registers.edx.DataType, Registers.edx);
+			var r = new Identifier(reg_edx.Name, reg_edx.DataType, reg_edx);
 			var arg = new Identifier("edxOut", PrimitiveType.Pointer32, new OutArgumentStorage(r));
 			use = new UseInstruction(id1, arg);
 			Assert.AreEqual("use foo (=> edxOut)" , use.ToString());

--- a/src/UnitTests/Core/VariableTests.cs
+++ b/src/UnitTests/Core/VariableTests.cs
@@ -18,7 +18,6 @@
  */
 #endregion
 
-using Reko.Arch.X86;
 using Reko.Core;
 using Reko.Core.Code;
 using Reko.Core.Expressions;
@@ -52,12 +51,10 @@ namespace Reko.UnitTests.Core
 		private Identifier argOff;
 		private Identifier argSeg;
 		private Identifier arg_alias;
-        private IntelArchitecture arch;
 
 		[SetUp]
 		public void Setup()
 		{
-            arch = new IntelArchitecture(ProcessorMode.Real);
 			f = new Frame(PrimitiveType.Word16);
 			argOff = f.EnsureStackArgument(4, PrimitiveType.Word16);
 			argSeg = f.EnsureStackArgument(6, PrimitiveType.SegmentSelector);


### PR DESCRIPTION
I'm using a pull request, since I'm not 100% sure if x86 usages were unintentional.