### PR TITLE
Fix path for nunit.framework.dll in Windows.csproj

### DIFF
--- a/src/Environments/Windows/Windows.csproj
+++ b/src/Environments/Windows/Windows.csproj
@@ -66,7 +66,7 @@
   <ItemGroup>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\tabbed-gui\external\NUnit-2.6.3\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\external\NUnit-2.6.3\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Windows.csproj contains following Nunit assembly link path:

........\tabbed-gui\external\NUnit-2.6.3\nunit.framework.dll

If reko source directory is other than "tabbed-gui" (it is "reko" by default) then compilation error occurs. 