### PR TITLE
TypeFormatter writes type reference without variable name

### DIFF
--- a/src/Core/Output/TypeFormatter.cs
+++ b/src/Core/Output/TypeFormatter.cs
@@ -323,6 +323,7 @@ namespace Reko.Core.Output
             if (mode == Mode.Writing)
             {
                 writer.Write(typeref.Name);
+                WriteName(true);
             }
             return writer;
         }

--- a/src/UnitTests/Core/TypeFormatterTests.cs
+++ b/src/UnitTests/Core/TypeFormatterTests.cs
@@ -280,5 +280,16 @@ struct a {
                 "} meeble";
             Assert.AreEqual(sExp, sw.ToString());
         }
-	}
+
+        [Test]
+        public void TyfoPtrToTypeReference()
+        {
+            var typeReference = new TypeReference("testDataType", PrimitiveType.Int32);
+            var ptr = new Pointer(typeReference, 4);
+            tyfo.Write(ptr, "var");
+
+            string sExp = "testDataType * var";
+            Assert.AreEqual(sExp, sw.ToString());
+        }
+    }
 }


### PR DESCRIPTION
If variable type is pointer to type reference then TypeFormatter shoud write it as "{type reference name} * {variable name}". But it writes "{type reference name}" instead.

This request should fix it. New unit test was added. 