### PR TITLE
Fix SlibReadRealModeIntServices test

### DIFF
--- a/src/UnitTests/Core/Serialization/SerializedLibraryTests.cs
+++ b/src/UnitTests/Core/Serialization/SerializedLibraryTests.cs
@@ -85,7 +85,7 @@ namespace Reko.UnitTests.Core.Serialization
 			{
 				lib = (SerializedLibrary) ser.Deserialize(stm);
 			}
-			Assert.AreEqual(88, lib.Procedures.Count);
+			Assert.AreEqual(89, lib.Procedures.Count);
 		}
 
         [Test]


### PR DESCRIPTION
SlibReadRealModeIntServices was broken after creation msdos rename file service.
Number of services was increased from 88 to 89. So this test should be modified