### PR TITLE
Replace BuildDataType method with TypeLibraryDeserializer

### DIFF
--- a/src/Core/Platform.cs
+++ b/src/Core/Platform.cs
@@ -55,6 +55,7 @@ namespace Reko.Core
         IEnumerable<Address> CreatePointerScanner(ImageMap imageMap, ImageReader rdr, IEnumerable<Address> address, PointerScannerFlags pointerScannerFlags);
         ProcedureSerializer CreateProcedureSerializer();
         ProcedureSerializer CreateProcedureSerializer(ISerializedTypeVisitor<DataType> typeLoader, string defaultConvention);
+        TypeLibraryDeserializer CreateTypeLibraryDeserializer();
         SymbolTable CreateSymbolTable();
 
         /// <summary>
@@ -178,6 +179,12 @@ namespace Reko.Core
             return CreateProcedureSerializer(typeLoader, DefaultCallingConvention);
         }
 
+        public TypeLibraryDeserializer CreateTypeLibraryDeserializer()
+        {
+            EnsureTypeLibraries(PlatformIdentifier);
+            return new TypeLibraryDeserializer(this, true, Metadata.Clone());
+        }
+
         /// <summary>
         /// Creates a procedure serializer that understands the calling conventions used on this
         /// processor and environment
@@ -219,8 +226,6 @@ namespace Reko.Core
         public IDictionary<string, DataType> GetTypedefs()
         {
             EnsureTypeLibraries(PlatformIdentifier);
-
-            var typedefs = new Dictionary<string, DataType>();
             return Metadata.Types;
         }
 

--- a/src/Core/Serialization/ArrayType_v1.cs
+++ b/src/Core/Serialization/ArrayType_v1.cs
@@ -36,12 +36,6 @@ namespace Reko.Core.Serialization
         [DefaultValue(0)]
         public int Length;
 
-        public override DataType BuildDataType(TypeFactory factory)
-        {
-            var et = ElementType.BuildDataType(factory);
-            return new ArrayType(et, Length);
-        }
-
         public override T Accept<T>(ISerializedTypeVisitor<T> visitor)
         {
             return visitor.VisitArray(this);

--- a/src/Core/Serialization/Code_v1.cs
+++ b/src/Core/Serialization/Code_v1.cs
@@ -28,11 +28,6 @@ namespace Reko.Core.Serialization
 {
     public class CodeType_v1 : SerializedType
     {
-        public override DataType BuildDataType(TypeFactory factory)
-        {
-            return factory.CreateCodeType();
-        }
-
         public override T Accept<T>(ISerializedTypeVisitor<T> visitor)
         {
             return visitor.VisitCode(this);

--- a/src/Core/Serialization/MemberPointer_v1.cs
+++ b/src/Core/Serialization/MemberPointer_v1.cs
@@ -36,10 +36,5 @@ namespace Reko.Core.Serialization
         {
             return visitor.VisitMemberPointer(this);
         }
-
-        public override DataType BuildDataType(TypeFactory factory)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/Core/Serialization/PointerType_v1.cs
+++ b/src/Core/Serialization/PointerType_v1.cs
@@ -46,11 +46,6 @@ namespace Reko.Core.Serialization
             return visitor.VisitPointer(this);
         }
 
-		public override DataType BuildDataType(TypeFactory factory)
-		{
-			return factory.CreatePointer(DataType.BuildDataType(factory), PointerSize);
-		}
-
 		public override string ToString()
 		{
 			return string.Format("ptr({0})", DataType);

--- a/src/Core/Serialization/PrimitiveType_v1.cs
+++ b/src/Core/Serialization/PrimitiveType_v1.cs
@@ -51,11 +51,6 @@ namespace Reko.Core.Serialization
             return visitor.VisitPrimitive(this);
         }
 
-		public override DataType BuildDataType(TypeFactory factory)
-		{
-			return factory.CreatePrimitiveType(Domain, ByteSize);
-		}
-
 		public override string ToString()
 		{
 			return string.Format("prim({0},{1})", Domain, ByteSize);

--- a/src/Core/Serialization/ProjectLoader.cs
+++ b/src/Core/Serialization/ProjectLoader.cs
@@ -237,7 +237,8 @@ namespace Reko.Core.Serialization
             }
             foreach (var kv in user.Globals)
             {
-                var dt = kv.Value.DataType.BuildDataType(program.TypeFactory);
+                var tlDeser = program.Platform.CreateTypeLibraryDeserializer();
+                var dt = kv.Value.DataType.Accept(tlDeser);
                 var item = new ImageMapItem((uint)dt.Size)
                 {
                     Address = kv.Key,
@@ -339,7 +340,8 @@ namespace Reko.Core.Serialization
             }
             foreach (var kv in user.Globals)
             {
-                var dt = kv.Value.DataType.BuildDataType(program.TypeFactory);
+                var tlDeser = program.Platform.CreateTypeLibraryDeserializer();
+                var dt = kv.Value.DataType.Accept(tlDeser);
                 var item = new ImageMapItem((uint)dt.Size)
                 {
                     Address = kv.Key,

--- a/src/Core/Serialization/SerializedEnumType.cs
+++ b/src/Core/Serialization/SerializedEnumType.cs
@@ -52,11 +52,6 @@ namespace Reko.Core.Serialization
             this.Name = p;
         }
 
-        public override DataType BuildDataType(TypeFactory factory)
-        {
-            return factory.CreateEnum(Size, Domain, Name, Values);
-        }
-
         public override T Accept<T>(ISerializedTypeVisitor<T> visitor)
         {
             return visitor.VisitEnum(this);

--- a/src/Core/Serialization/SerializedSignature.cs
+++ b/src/Core/Serialization/SerializedSignature.cs
@@ -58,11 +58,6 @@ namespace Reko.Core.Serialization
             return visitor.VisitSignature(this);
         }
 
-        public override Types.DataType BuildDataType(Types.TypeFactory factory)
-        {
-            throw new NotImplementedException();
-        }
-
         public override string ToString()
         {
             var sb = new StringBuilder();

--- a/src/Core/Serialization/SerializedStructType.cs
+++ b/src/Core/Serialization/SerializedStructType.cs
@@ -45,16 +45,6 @@ namespace Reko.Core.Serialization
             return visitor.VisitStructure(this);
         }
 
-		public override DataType BuildDataType(TypeFactory factory)
-		{
-			StructureType str = factory.CreateStructureType(null, 0);
-			foreach (StructField_v1 f in Fields)
-			{
-				str.Fields.Add(new StructureField(f.Offset, f.Type.BuildDataType(factory), f.Name));
-			}
-			return str;
-		}
-
 		public override string ToString()
 		{
 			StringBuilder sb = new StringBuilder();

--- a/src/Core/Serialization/SerializedTemplate.cs
+++ b/src/Core/Serialization/SerializedTemplate.cs
@@ -39,12 +39,6 @@ namespace Reko.Core.Serialization
             this.TypeArguments = typeArguments;
         }
 
-        public override DataType BuildDataType(TypeFactory factory)
-        {
-            //$TODO: type system needs to support this too.
-            throw new NotImplementedException();
-        }
-
         public override T Accept<T>(ISerializedTypeVisitor<T> visitor)
         {
             return visitor.VisitTemplate(this);

--- a/src/Core/Serialization/SerializedType.cs
+++ b/src/Core/Serialization/SerializedType.cs
@@ -38,7 +38,6 @@ namespace Reko.Core.Serialization
         {
         }
 
-        public abstract DataType BuildDataType(TypeFactory factory);
         public abstract T Accept<T>(ISerializedTypeVisitor<T> visitor);
 
         /// <summary>

--- a/src/Core/Serialization/SerializedTypeReference.cs
+++ b/src/Core/Serialization/SerializedTypeReference.cs
@@ -58,11 +58,6 @@ namespace Reko.Core.Serialization
             this.TypeName = typeName;
         }
 
-        public override Types.DataType BuildDataType(Types.TypeFactory factory)
-        {
-            throw new NotImplementedException();
-        }
-
         public override T Accept<T>(ISerializedTypeVisitor<T> visitor)
         {
             return visitor.VisitTypeReference(this);

--- a/src/Core/Serialization/SerializedTypedef.cs
+++ b/src/Core/Serialization/SerializedTypedef.cs
@@ -37,12 +37,6 @@ namespace Reko.Core.Serialization
 
         public SerializedType DataType;
 
-        public override DataType BuildDataType(TypeFactory factory)
-        {
-            var type = DataType.BuildDataType(factory);
-            throw new NotImplementedException();
-        }
-
         public override T Accept<T>(ISerializedTypeVisitor<T> visitor)
         {
             return visitor.VisitTypedef(this);

--- a/src/Core/Serialization/StringType_v2.cs
+++ b/src/Core/Serialization/StringType_v2.cs
@@ -37,21 +37,6 @@ namespace Reko.Core.Serialization
 
         public SerializedType CharType;
 
-        public override DataType BuildDataType(TypeFactory factory)
-        {
-            var ch = CharType.BuildDataType(factory);
-
-            if (Termination == null)
-                throw new NotImplementedException();
-            switch (Termination[0])
-            {
-            case 'z':
-                return StringType.NullTerminated(ch);
-            default:
-                throw new NotImplementedException();
-            }
-        }
-
         public override T Accept<T>(ISerializedTypeVisitor<T> visitor)
         {
             return visitor.VisitString(this);

--- a/src/Core/Serialization/UnionType_v1.cs
+++ b/src/Core/Serialization/UnionType_v1.cs
@@ -47,16 +47,6 @@ namespace Reko.Core.Serialization
             return visitor.VisitUnion(this);
         }
 
-        public override DataType BuildDataType(TypeFactory factory)
-        {
-            UnionType u = factory.CreateUnionType(Name, null);
-            foreach (var alt in Alternatives)
-            {
-                u.Alternatives.Add(new UnionAlternative(alt.Name, alt.Type.BuildDataType(factory), u.Alternatives.Count));
-            }
-            return u;
-        }
-
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();

--- a/src/Core/Serialization/VoidType_v1.cs
+++ b/src/Core/Serialization/VoidType_v1.cs
@@ -28,11 +28,6 @@ namespace Reko.Core.Serialization
 {
     public class VoidType_v1 :  SerializedType
     {
-        public override DataType BuildDataType(TypeFactory factory)
-        {
-            return VoidType.Instance;
-        }
-
         public override T Accept<T>(ISerializedTypeVisitor<T> visitor)
         {
             return visitor.VisitVoidType(this);

--- a/src/UnitTests/Core/Serialization/SerializedProjectTests.cs
+++ b/src/UnitTests/Core/Serialization/SerializedProjectTests.cs
@@ -23,6 +23,7 @@ using Reko.Core;
 using Reko.Core.Code;
 using Reko.Core.Serialization;
 using Reko.Core.Types;
+using Reko.UnitTests.Mocks;
 using Reko.Loading;
 using NUnit.Framework;
 using Rhino.Mocks;
@@ -43,6 +44,7 @@ namespace Reko.UnitTests.Core.Serialization
 	public class SerializedProjectTests
 	{
         private MockRepository mr;
+        private MockFactory mockFactory;
         private ServiceContainer sc;
         private ILoader loader;
         private IProcessorArchitecture arch;
@@ -51,6 +53,7 @@ namespace Reko.UnitTests.Core.Serialization
         public void Setup()
         {
             this.mr = new MockRepository();
+            this.mockFactory = new MockFactory(mr);
             this.sc = new ServiceContainer();
             sc.AddService<IFileSystemService>(new FileSystemServiceImpl('/'));
         }
@@ -250,6 +253,7 @@ namespace Reko.UnitTests.Core.Serialization
             var program = new Program
             {
                 Architecture = arch,
+                Platform = mockFactory.CreatePlatform(),
                 Image = image,
                 ImageMap = image.CreateImageMap(),
             };
@@ -508,7 +512,6 @@ namespace Reko.UnitTests.Core.Serialization
                 Debug.Print("{0}", sw.ToString());
             Assert.AreEqual(sExp, sw.ToString());
         }
-
 
     }
 }

--- a/src/UnitTests/Gui/Windows/CodeViewerPaneTests.cs
+++ b/src/UnitTests/Gui/Windows/CodeViewerPaneTests.cs
@@ -45,6 +45,7 @@ namespace Reko.UnitTests.Gui.Windows
 
         private CodeViewerPane codeViewer;
         private MockRepository mr;
+        private MockFactory mockFactory;
         private IDecompilerService decompilerSvc;
         private IDecompiler decompiler;
         private IUiPreferencesService uiPreferencesSvc;
@@ -53,23 +54,17 @@ namespace Reko.UnitTests.Gui.Windows
         private Program program;
         private Procedure proc;
         private IWindowFrame frame;
-        private SymbolTable symbolTable;
 
         [SetUp]
         public void Setup()
         {
             mr = new MockRepository();
-            var arch = new FakeArchitecture();
-            var platform = mr.Stub<IPlatform>();
-            platform.Stub(p => p.GetByteSizeFromCBasicType(CBasicType.Char)).Return(1);
-            platform.Stub(p => p.GetByteSizeFromCBasicType(CBasicType.Int)).Return(4);
-            platform.Stub(p => p.GetByteSizeFromCBasicType(CBasicType.Float)).Return(4);
-            platform.Stub(p => p.PointerType).Return(PrimitiveType.Pointer32);
-            symbolTable = new SymbolTable(platform);
+            mockFactory = new MockFactory(mr);
+            var platform = mockFactory.CreatePlatform(); ;
 
             program = new Program
             {
-                Architecture = arch,
+                Architecture = platform.Architecture,
                 Platform = platform,
             };
             codeViewer = new CodeViewerPane();
@@ -145,7 +140,6 @@ namespace Reko.UnitTests.Gui.Windows
         {
             Given_StubProcedure();
             Given_Program();
-            Given_SymbolTable();
             mr.ReplayAll();
 
             When_CodeViewCreated();
@@ -176,30 +170,12 @@ namespace Reko.UnitTests.Gui.Windows
             decompiler.Stub(d => d.Project).Return(project);
         }
 
-        private void Given_NamedTypes(Dictionary<string, SerializedType> types)
-        {
-            var arch = new FakeArchitecture();
-            var platform = mr.Stub<IPlatform>();
-            platform.Stub(p => p.CreateSymbolTable()).Return(new SymbolTable(platform, types));
-            program = new Program
-            {
-                Architecture = arch,
-                Platform = platform,
-            };
-        }
-
-        private void Given_SymbolTable()
-        {
-            this.program.Platform.Stub(p => p.CreateSymbolTable()).Return(symbolTable);
-        }
-
         [Test(Description = "When a previously uncustomized procedure is displayed, show its name in the "+
             "declaration box")]
         public void Cvp_SetProcedure_ShowFnName()
         {
             Given_Program();
             Given_StubProcedure();
-            Given_SymbolTable();
             mr.ReplayAll();
 
             When_CodeViewCreated();
@@ -213,7 +189,6 @@ namespace Reko.UnitTests.Gui.Windows
         {
             Given_Program();
             Given_StubProcedure();
-            Given_SymbolTable();
             mr.ReplayAll();
 
             When_CodeViewCreated();
@@ -229,7 +204,6 @@ namespace Reko.UnitTests.Gui.Windows
         {
             Given_Program();
             Given_StubProcedure();
-            Given_SymbolTable();
             mr.ReplayAll();
 
             When_CodeViewCreated();
@@ -245,7 +219,6 @@ namespace Reko.UnitTests.Gui.Windows
         {
             Given_Program();
             Given_StubProcedure();
-            Given_SymbolTable();
             mr.ReplayAll();
 
             When_CodeViewCreated();
@@ -260,7 +233,6 @@ namespace Reko.UnitTests.Gui.Windows
         public void Cvp_Accept_Declaration()
         {
             Given_Program();
-            Given_SymbolTable();
             Given_StubProcedure();
             mr.ReplayAll();
 
@@ -277,7 +249,6 @@ namespace Reko.UnitTests.Gui.Windows
         public void Cvp_Accept_Declaration_Returning_CharPtr()
         {
             Given_Program();
-            Given_SymbolTable();
             Given_StubProcedure();
             mr.ReplayAll();
 
@@ -298,7 +269,7 @@ namespace Reko.UnitTests.Gui.Windows
                 { "BYTE", new PrimitiveType_v1 { ByteSize = 1, Domain = PrimitiveType.Byte.Domain } },
             };
             Given_Program();
-            Given_NamedTypes(types);
+            mockFactory.Given_NamedTypes(types);
             Given_StubProcedure();
             mr.ReplayAll();
 


### PR DESCRIPTION
SerializedType::BuildDataType method seems to have the same purpose as TypeLibraryDeserializer.
I think it could be deleted and replaced with TypeLibraryDeserializer