### PR TITLE
Implement type library loader

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -619,6 +619,7 @@
     <Compile Include="TreeMatching\TreeMatcher.cs" />
     <Compile Include="TypedServiceProvider.cs" />
     <Compile Include="TypeLibraryDeserializer.cs" />
+    <Compile Include="TypeLibraryLoader.cs" />
     <Compile Include="Types\ArrayType.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/Core/TypeLibraryLoader.cs
+++ b/src/Core/TypeLibraryLoader.cs
@@ -1,0 +1,51 @@
+﻿#region License
+/* 
+ * Copyright (C) 1999-2016 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using Reko.Core.Serialization;
+using System;
+using System.IO;
+
+namespace Reko.Core
+{
+    public class TypeLibraryLoader : MetadataLoader
+    {
+        private Stream stream;
+
+        public TypeLibraryLoader(IServiceProvider services, string filename, byte[]  bytes) : base(services, filename, bytes)
+        {
+            this.stream = new MemoryStream(bytes);
+        }
+
+        [Obsolete]
+        public override TypeLibrary Load(IPlatform platform)
+        {
+            return Load(platform, new TypeLibrary());
+        }
+
+        public override TypeLibrary Load(IPlatform platform, TypeLibrary dstLib)
+        {
+            var ser = SerializedLibrary.CreateSerializer();
+            var slib = (SerializedLibrary) ser.Deserialize(stream);
+            var tldser = new TypeLibraryDeserializer(platform, true, dstLib);
+            var tlib = tldser.Load(slib);
+            return tlib;
+        }
+    }
+}

--- a/src/UnitTests/Core/TypeLibraryDeserializerTests.cs
+++ b/src/UnitTests/Core/TypeLibraryDeserializerTests.cs
@@ -31,7 +31,7 @@ using System.Text;
 namespace Reko.UnitTests.Core
 {
     [TestFixture]
-    public class TypeLibraryLoaderTests
+    public class TypeLibraryDeserializerTests
     {
         private MockRepository mr;
         private IProcessorArchitecture arch;

--- a/src/UnitTests/Core/TypeLibraryLoaderTests.cs
+++ b/src/UnitTests/Core/TypeLibraryLoaderTests.cs
@@ -1,0 +1,137 @@
+﻿#region License
+/* 
+ * Copyright (C) 1999-2016 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using Reko.Arch.X86;
+using Reko.Environments.Windows;
+using Reko.Core;
+using Reko.UnitTests.Mocks;
+using NUnit.Framework;
+using Rhino.Mocks;
+using System.Text;
+
+namespace Reko.UnitTests.Core
+{
+    [TestFixture]
+    public class TypeLibraryLoaderTests
+    {
+        private TypeLibraryLoader tlldr;
+        private IPlatform platform;
+
+        private void CreateTypeLibraryLoader(string filename, string contents)
+        {
+            this.platform = new Win32Platform(null, new X86ArchitectureFlat32());
+            tlldr = new TypeLibraryLoader(null, filename, Encoding.ASCII.GetBytes(contents));
+        }
+
+        [Test]
+        public void TLLDR_Typedef()
+        {
+            var contents =
+@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<library xmlns=""http://schemata.jklnet.org/Decompiler"">
+  <Types>
+    <typedef name=""INT"">
+      <prim domain=""SignedInt"" size=""4"" />
+    </typedef>
+  </Types>
+</library>";
+            CreateTypeLibraryLoader("c:\\bar\\foo.xml", contents);
+            var lib = tlldr.Load(platform, new TypeLibrary());
+            Assert.AreEqual(1, lib.Types.Count);
+            Assert.AreEqual("int32", lib.Types["INT"].ToString());
+            Assert.AreEqual(0, lib.Signatures.Count);
+        }
+
+        [Test]
+        public void TLLDR_FunctionDecl()
+        {
+            var contents =
+@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<library xmlns=""http://schemata.jklnet.org/Decompiler"">
+  <Types />
+  <procedure name=""strlen"">
+    <signature convention=""__cdecl"">
+      <return>
+        <type>size_t</type>
+      </return>
+      <arg>
+        <ptr size=""4"">
+          <prim domain=""Character"" size=""1"" />
+        </ptr>
+      </arg>
+    </signature>
+  </procedure>
+</library>";
+            CreateTypeLibraryLoader("c:\\bar\\foo.xml", contents);
+            var lib = tlldr.Load(platform, new TypeLibrary());
+            Assert.AreEqual(0, lib.Types.Count);
+            Assert.AreEqual(1, lib.Signatures.Count);
+            var sExp =
+@"Register size_t ()(Stack (ptr char) arg0)
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
+";
+            Assert.AreEqual(sExp, lib.Signatures["strlen"].ToString()
+            );
+        }
+
+        [Test]
+        public void TLLDR_TypeReference()
+        {
+            var contents =
+@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<library xmlns=""http://schemata.jklnet.org/Decompiler"">
+  <Types>
+    <typedef name=""FOO"">
+      <struct name=""foo"" />
+    </typedef>
+    <struct name=""foo"">
+      <field offset=""0"" name=""x"">
+        <prim domain=""SignedInt"" size=""4"" />
+      </field>
+    </struct>
+  </Types>
+  <procedure name=""bar"">
+    <signature>
+      <return>
+        <prim domain=""SignedInt"" size=""4"" />
+      </return>
+      <arg name=""pfoo"">
+        <ptr size=""4"">
+          <type>FOO</type>
+        </ptr>
+      </arg>
+    </signature>
+  </procedure>
+</library>";
+            CreateTypeLibraryLoader("c:\\bar\\foo.xml", contents);
+            var lib = tlldr.Load(platform, new TypeLibrary());
+            Assert.AreEqual(1, lib.Types.Count);
+            Assert.AreEqual(1, lib.Signatures.Count);
+            Assert.AreEqual("(struct \"foo\" (0 int32 x))", lib.Types["FOO"].ToString());
+            var sExp =
+@"Register int32 ()(Stack (ptr FOO) pfoo)
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
+";
+            Assert.AreEqual(sExp, lib.Signatures["bar"].ToString()
+            );
+        }
+    }
+}
+

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -199,6 +199,7 @@
     <Compile Include="Core\StructureReaderTests.cs" />
     <Compile Include="Core\TestConditionTests.cs" />
     <Compile Include="Core\TypeLibraryDeserializerTests.cs" />
+    <Compile Include="Core\TypeLibraryLoaderTests.cs" />
     <Compile Include="DchexLoader.cs" />
     <Compile Include="Environments\AmigaOS\AmigaOSPlatformTests.cs" />
     <Compile Include="Environments\AmigaOS\FuncsFileParserTests.cs" />

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -198,7 +198,7 @@
     <Compile Include="Core\Serialization\UnpackerSignatureFileTests.cs" />
     <Compile Include="Core\StructureReaderTests.cs" />
     <Compile Include="Core\TestConditionTests.cs" />
-    <Compile Include="Core\TypeLibraryLoaderTests.cs" />
+    <Compile Include="Core\TypeLibraryDeserializerTests.cs" />
     <Compile Include="DchexLoader.cs" />
     <Compile Include="Environments\AmigaOS\AmigaOSPlatformTests.cs" />
     <Compile Include="Environments\AmigaOS\FuncsFileParserTests.cs" />


### PR DESCRIPTION
Implement type library loader as a child of MetadataLoader. It allows to add user-defined XML type library by File->Add metadata file menu item.(see #107)