### PR TITLE
Remove obsolete Load method from MetadataLoader

### DIFF
--- a/src/Core/MetadataLoader.cs
+++ b/src/Core/MetadataLoader.cs
@@ -35,7 +35,6 @@ namespace Reko.Core
         {
         }
 
-       [Obsolete] public abstract TypeLibrary Load(IPlatform platform);
         public abstract TypeLibrary Load(IPlatform platform, TypeLibrary dstLib);
     }
 
@@ -44,11 +43,6 @@ namespace Reko.Core
         public NullMetadataLoader()
             : base(null, "", new byte[0])
         {
-        }
-
-        [Obsolete] public override TypeLibrary Load(IPlatform platform)
-        {
-            return new TypeLibrary();
         }
 
         public override TypeLibrary Load(IPlatform platform, TypeLibrary dstLib)

--- a/src/Core/TypeLibraryLoader.cs
+++ b/src/Core/TypeLibraryLoader.cs
@@ -33,12 +33,6 @@ namespace Reko.Core
             this.stream = new MemoryStream(bytes);
         }
 
-        [Obsolete]
-        public override TypeLibrary Load(IPlatform platform)
-        {
-            return Load(platform, new TypeLibrary());
-        }
-
         public override TypeLibrary Load(IPlatform platform, TypeLibrary dstLib)
         {
             var ser = SerializedLibrary.CreateSerializer();

--- a/src/Environments/Windows/ModuleDefinitionLoader.cs
+++ b/src/Environments/Windows/ModuleDefinitionLoader.cs
@@ -48,12 +48,6 @@ namespace Reko.Environments.Windows
             this.bufferedTok = null;
         }
 
-        [Obsolete]
-        public override TypeLibrary Load(IPlatform platform)
-        {
-            return Load(platform, new TypeLibrary());
-        }
-
         public override TypeLibrary Load(IPlatform platform, TypeLibrary dstLib)
         {
             this.platform = platform;

--- a/src/Environments/Windows/Win32MipsPlatform.cs
+++ b/src/Environments/Windows/Win32MipsPlatform.cs
@@ -146,15 +146,6 @@ namespace Reko.Environments.Windows
             }
         }
 
-        private TypeLibrary LoadTypelibrary(IConfigurationService cfgSvc, ITypeLibraryElement tl, LoaderElement ldr)
-        {
-            var type = Type.GetType(ldr.TypeName, true);
-            var filename = cfgSvc.GetInstallationRelativePath(tl.Name);
-            var bytes = File.ReadAllBytes(filename);
-            var loader = (MetadataLoader)Activator.CreateInstance(type, Services, filename, bytes);
-            return loader.Load(this);
-        }
-
         public override ExternalProcedure LookupProcedureByOrdinal(string moduleName, int ordinal)
         {
             throw new NotImplementedException();

--- a/src/Environments/Windows/WineSpecFileLoader.cs
+++ b/src/Environments/Windows/WineSpecFileLoader.cs
@@ -48,11 +48,6 @@ namespace Reko.Environments.Windows
             this.lexer = new Lexer(rdr);
         }
 
-        public override TypeLibrary Load(IPlatform platform)
-        {
-            return Load(platform, DefaultModuleName(filename), new TypeLibrary());
-        }
-
         public override TypeLibrary Load(IPlatform platform, TypeLibrary dstLib)
         {
             return Load(platform, DefaultModuleName(filename), dstLib);

--- a/src/UnitTests/Environments/Windows/ModuleDefinitionLoaderTests.cs
+++ b/src/UnitTests/Environments/Windows/ModuleDefinitionLoaderTests.cs
@@ -53,7 +53,7 @@ namespace Reko.UnitTests.Environments.Windows
         public void DFL_CommentLine()
         {
             CreateDefFileLoader("c:\\bar\\foo.def", "; hello\r\n");
-            TypeLibrary lib = dfl.Load(platform);
+            TypeLibrary lib = dfl.Load(platform, new TypeLibrary());
             Assert.AreEqual(0, lib.Types.Count);
             Assert.AreEqual(0, lib.Signatures.Count);
         }
@@ -65,7 +65,7 @@ namespace Reko.UnitTests.Environments.Windows
                 "c:\\bar\\foo.def",
                 "EXPORTS" + nl +
                 " _Foo@4 @4" + nl);
-            var lib = dfl.Load(platform);
+            var lib = dfl.Load(platform, new TypeLibrary());
             Assert.IsTrue(lib.Modules.ContainsKey("FOO.DLL"));
             var svc = lib.Modules["FOO.DLL"].ServicesByName["_Foo@4"];
             Assert.AreEqual("_Foo@4", svc.Name);
@@ -80,7 +80,7 @@ namespace Reko.UnitTests.Environments.Windows
                 "c:\\bar\\foo.def",
                 "EXPORTS" + nl +
                 " _Foo@4 @ 4" + nl);
-            var lib = dfl.Load(platform);
+            var lib = dfl.Load(platform, new TypeLibrary());
             var svc = lib.Modules["FOO.DLL"].ServicesByName["_Foo@4"];
             Assert.AreEqual("_Foo@4", svc.Name);
             Assert.AreEqual(4, svc.SyscallInfo.Vector);
@@ -94,7 +94,7 @@ namespace Reko.UnitTests.Environments.Windows
                 " LIBRARY bar" + nl +
                 "EXPORTS" + nl +
                 " _foo@12 @ 1" + nl);
-            var lib = dfl.Load(platform);
+            var lib = dfl.Load(platform, new TypeLibrary());
             Assert.IsTrue(lib.Modules.ContainsKey("bar"));
         }
     }

--- a/src/UnitTests/Environments/Windows/WineSpecFileLoaderTests.cs
+++ b/src/UnitTests/Environments/Windows/WineSpecFileLoaderTests.cs
@@ -20,6 +20,7 @@
 
 using NUnit.Framework;
 using Reko.Arch.X86;
+using Reko.Core;
 using Reko.Environments.Windows;
 using System;
 using System.Collections.Generic;
@@ -45,7 +46,7 @@ namespace Reko.UnitTests.Environments.Windows
         {
             CreateWineSpecFileLoader("foo.spec",
                 " # comment");
-            var lib = wsfl.Load(platform);
+            var lib = wsfl.Load(platform, new TypeLibrary());
             Assert.AreEqual(0, lib.Modules.Count);
         }
 
@@ -54,7 +55,7 @@ namespace Reko.UnitTests.Environments.Windows
         {
             CreateWineSpecFileLoader("foo.spec",
                 " 624 pascal SetFastQueue(long long) SetFastQueue16\n");
-            var lib = wsfl.Load(platform);
+            var lib = wsfl.Load(platform, new TypeLibrary());
             var mod = lib.Modules["FOO.DLL"];
             Assert.AreEqual(1, mod.ServicesByVector.Count);
             Assert.AreEqual(0, mod.ServicesByName.Count);
@@ -72,7 +73,7 @@ namespace Reko.UnitTests.Environments.Windows
                 " 2   pascal -ret16 ExitKernel() ExitKernel16\n" +
                 "3    pascal GetVersion() GetVersion16\n" +
                 "4   pascal -ret16 LocalInit(word word word) LocalInit16\n");
-            var lib = wsfl.Load(platform);
+            var lib = wsfl.Load(platform, new TypeLibrary());
             var mod = lib.Modules["FOO.DLL"];
             Assert.AreEqual(3, mod.ServicesByVector.Count);
             Assert.AreEqual(
@@ -91,7 +92,7 @@ namespace Reko.UnitTests.Environments.Windows
         {
             CreateWineSpecFileLoader("foo.spec",
                 " @ stdcall -arch=win32 -norelay SMapLS_IP_EBP_36()\r\n");
-            var lib = wsfl.Load(platform);
+            var lib = wsfl.Load(platform, new TypeLibrary());
             Assert.AreEqual(0, lib.Modules.Count);
         }
     }


### PR DESCRIPTION
Obsolete Load method was removed from MetadataLoader. Also unused LoadTypelibrary method was removed from Win32MipsPlatform