### PR TITLE
Remove TypeLibrary ::Load and obsolete ITypeLibraryLoaderService::LoadLibrary

### DIFF
--- a/src/Core/TypeLibrary.cs
+++ b/src/Core/TypeLibrary.cs
@@ -80,30 +80,6 @@ namespace Reko.Core
 			}
 		}
 
-        public static TypeLibrary Load(IPlatform platform, string fileName, IFileSystemService fsSvc, TypeLibrary dstLib)
-		{
-            var prefix = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var libPath = Path.Combine(prefix, fileName);
-            if (!File.Exists(libPath))
-            {
-                libPath = Path.Combine(Directory.GetCurrentDirectory(), fileName);
-            }
-			XmlSerializer ser = SerializedLibrary.CreateSerializer();
-			SerializedLibrary slib;
-			using (Stream stm = fsSvc.CreateFileStream(libPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-			{
-				slib = (SerializedLibrary) ser.Deserialize(stm);
-			}
-            return Load(platform, slib, dstLib);
-		}
-
-        public static TypeLibrary Load(IPlatform platform, SerializedLibrary slib, TypeLibrary dstLib)
-        {
-            var tlldr = new TypeLibraryDeserializer(platform, true, dstLib);
-            var tlib = tlldr.Load(slib);
-            return tlib;
-        }
-
 		public ProcedureSignature Lookup(string procedureName)
 		{
 			ProcedureSignature sig;

--- a/src/ImageLoaders/Elf/ElfImageLoader.cs
+++ b/src/ImageLoaders/Elf/ElfImageLoader.cs
@@ -426,22 +426,6 @@ namespace Reko.ImageLoaders.Elf
             return cfgSvc.GetEnvironment(envName).Load(Services, arch);
         }
 
-        public IEnumerable<TypeLibrary> LoadTypeLibraries()
-        {
-            var dcSvc = Services.GetService<IConfigurationService>();
-            if (dcSvc == null)
-                return new TypeLibrary[0];
-            var env = dcSvc.GetEnvironment("elf-neutral");
-            if (env == null)
-                return new TypeLibrary[0];
-            var tlSvc = Services.RequireService<ITypeLibraryLoaderService>();
-            return ((IEnumerable)env.TypeLibraries)
-                    .OfType<ITypeLibraryElement>()
-                    .Where(tl => tl.Architecture == "ppc32")
-                    .Select(tl => tlSvc.LoadLibrary(platform, tl.Name))
-                    .Where(tl => tl != null);
-        }
-
         private ImageMapSegmentRenderer CreateRenderer64(Elf64_SHdr shdr)
         {
             switch (shdr.sh_type)

--- a/src/UnitTests/Arch/Intel/Rewrite32.cs
+++ b/src/UnitTests/Arch/Intel/Rewrite32.cs
@@ -48,7 +48,7 @@ namespace Reko.UnitTests.Arch.Intel
         {
             mr = new MockRepository();
             this.services = mr.Stub<IServiceProvider>();
-            var tlSvc = mr.Stub<ITypeLibraryLoaderService>();
+            var tlSvc = new TypeLibraryLoaderServiceImpl(services);
             var configSvc = mr.StrictMock<IConfigurationService>();
             var fsSvc = new FileSystemServiceImpl();
             var win32env = new OperatingEnvironmentElement
@@ -67,14 +67,7 @@ namespace Reko.UnitTests.Arch.Intel
             services.Stub(s => s.GetService(typeof(DecompilerEventListener))).Return(new FakeDecompilerEventListener());
             services.Stub(s => s.GetService(typeof(CancellationTokenSource))).Return(null);
             services.Stub(s => s.GetService(typeof(IFileSystemService))).Return(new FileSystemServiceImpl());
-            tlSvc.Stub(t => t.LoadLibrary(null, null, null)).IgnoreArguments()
-                .Do(new Func<IPlatform, string, TypeLibrary, TypeLibrary>((p, n, l) =>
-                {
-                    var lib = TypeLibrary.Load(p, Path.ChangeExtension(n, ".xml"), fsSvc, l);
-                    return lib;
-                }));
             services.Replay();
-            tlSvc.Replay();
             configSvc.Replay();
             arch = new IntelArchitecture(ProcessorMode.Protected32);
             win32 = new Reko.Environments.Windows.Win32Platform(services, arch);

--- a/src/UnitTests/Core/SignatureLibraryTests.cs
+++ b/src/UnitTests/Core/SignatureLibraryTests.cs
@@ -52,7 +52,8 @@ namespace Reko.UnitTests.Core
             };
             var arch = new IntelArchitecture(ProcessorMode.Protected32);
             var platform = new SysVPlatform(null, arch);
-            var lib = TypeLibrary.Load(platform, slib, new TypeLibrary());
+            var tldser = new TypeLibraryDeserializer(platform, true, new TypeLibrary());
+            var lib = tldser.Load(slib);
             Assert.AreEqual(PrimitiveType.Int32, lib.LookupType("int"));
         }
 	}


### PR DESCRIPTION
Load method was removed from TypeLibrary. New TypeLibraryLoader class should be used instead.
Obsolete LoadLibrary method was removed from ITypeLibraryLoaderService.
Also unused LoadTypeLibraries method was removed from ElfImageLoader