### PR TITLE
ProjectLoader: refactoring of LoadMetadataFile(string filename)

### DIFF
--- a/src/Core/Serialization/ProjectLoader.cs
+++ b/src/Core/Serialization/ProjectLoader.cs
@@ -421,19 +421,14 @@ namespace Reko.Core.Serialization
         public MetadataFile LoadMetadataFile(string filename)
         {
             var platform = DeterminePlatform(filename);
-            LoadMetadataFile(platform, filename);
-            return new MetadataFile
-            {
-                Filename = filename,
-            };
-        }
-
-        private void LoadMetadataFile(IPlatform platform, string filename)
-        {
             foreach (var program in project.Programs)
             {
                 program.LoadMetadataFile(loader, filename);
             }
+            return new MetadataFile
+            {
+                Filename = filename,
+            };
         }
 
         private IPlatform DeterminePlatform(string filename)


### PR DESCRIPTION
LoadMetadataFile was refactored. Now platform obtained from DeterminePlatform is unused. But let it be in master branch if you see some reason for that.