### PR TITLE
Scan global variables

### DIFF
--- a/src/Core/TypeLibraryDeserializer.cs
+++ b/src/Core/TypeLibraryDeserializer.cs
@@ -217,8 +217,7 @@ namespace Reko.Core
 
         public DataType VisitSignature(SerializedSignature signature)
         {
-            //$BUGBUG: what we want is to unify FunctionType and ProcedureSignature....
-            return new Pointer(new CodeType(), platform.PointerType.Size);
+            return new FunctionType(signature);
         }
 
         public DataType VisitStructure(SerializedStructType structure)

--- a/src/Core/Types/FunctionType.cs
+++ b/src/Core/Types/FunctionType.cs
@@ -18,6 +18,7 @@
  */
 #endregion
 
+using Reko.Core.Serialization;
 using System;
 using System.IO;
 using System.Linq;
@@ -32,6 +33,8 @@ namespace Reko.Core.Types
 		public DataType ReturnType;
 		public DataType [] ArgumentTypes;
 		public string [] ArgumentNames;
+
+        public SerializedSignature Signature { get; private set; }
 
 		public FunctionType(
 			string name,
@@ -58,6 +61,11 @@ namespace Reko.Core.Types
             this.ArgumentNames = sig.Parameters.Select(a => a.Name).ToArray();
         }
 
+        public FunctionType(SerializedSignature signature) : base()
+        {
+            this.Signature = signature;
+        }
+
         public override T Accept<T>(IDataTypeVisitor<T> v)
         {
             return v.VisitFunctionType(this);
@@ -74,7 +82,9 @@ namespace Reko.Core.Types
 				if (ArgumentNames != null)
 					names[i] = ArgumentNames[i];
 			}
-			return new FunctionType(Name, ret, types, names);
+            var ft = new FunctionType(Name, ret, types, names);
+            ft.Signature = Signature;
+            return ft;
 		}
 
 		public override int Size

--- a/src/Decompiler/Decompiler.cs
+++ b/src/Decompiler/Decompiler.cs
@@ -398,6 +398,13 @@ namespace Reko
             {
                 eventListener.ShowStatus("Rewriting reachable machine code.");
                 scanner = CreateScanner(program);
+                foreach (var global in program.User.Globals)
+                {
+                    var addr = global.Key;
+                    var tlDeser = program.CreateTypeLibraryDeserializer();
+                    var dt = global.Value.DataType.Accept(tlDeser);
+                    scanner.EnqueueUserGlobalData(addr, dt);
+                }
                 foreach (EntryPoint ep in program.EntryPoints)
                 {
                     scanner.EnqueueEntryPoint(ep);

--- a/src/Decompiler/Decompiler.csproj
+++ b/src/Decompiler/Decompiler.csproj
@@ -269,6 +269,7 @@
     <Compile Include="Scanning\Dfa\State.cs" />
     <Compile Include="Scanning\Dfa\TreeNode.cs" />
     <Compile Include="Scanning\Dfa\Automaton.cs" />
+    <Compile Include="Scanning\GlobalDataWorkItem.cs" />
     <Compile Include="Scanning\HeuristicBlock.cs" />
     <Compile Include="Scanning\HeuristicDisassembler.cs" />
     <Compile Include="Scanning\HeuristicProcedure.cs" />

--- a/src/Decompiler/Scanning/GlobalDataWorkItem.cs
+++ b/src/Decompiler/Scanning/GlobalDataWorkItem.cs
@@ -1,0 +1,167 @@
+﻿#region License
+/*
+ * Copyright (C) 1999-2016 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using Reko.Core;
+using Reko.Core.Types;
+using Reko.Core.Serialization;
+using System;
+using System.Diagnostics;
+
+
+namespace Reko.Scanning
+{
+    class GlobalDataWorkItem : WorkItem, IDataTypeVisitor<bool>
+    {
+        private IScanner scanner;
+        private Program program;
+        private Address addr;
+        private DataType dt;
+        private ImageReader rdr;
+
+        public GlobalDataWorkItem(IScanner scanner, Program program, Address addr, DataType dt)
+        {
+            this.scanner = scanner;
+            this.program = program;
+            this.addr = addr;
+            this.dt = dt;
+            this.rdr = program.CreateImageReader(addr);
+        }
+
+        public override void Process()
+        {
+            try
+            {
+                dt.Accept(this);
+            }
+            catch (AddressCorrelatedException aex)
+            {
+                scanner.Error(aex.Address, aex.Message);
+            }
+            catch (Exception ex)
+            {
+                scanner.Error(addr, ex.Message);
+            }
+        }
+
+        public bool VisitArray(ArrayType at)
+        {
+            Debug.Assert(at.Length != 0, "Expected sizes of arrays to have been determined by now");
+
+            for (int i = 0; i < at.Length; ++i)
+            {
+                at.ElementType.Accept(this);
+            }
+
+            return false;
+        }
+
+        public bool VisitEnum(EnumType e)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool VisitCode(CodeType c)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool VisitEquivalenceClass(EquivalenceClass eq)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool VisitFunctionType(FunctionType ft)
+        {
+            var addr = rdr.Address;
+            var up = new Procedure_v1
+            {
+                Address = addr.ToString(),
+                Signature = ft.Signature
+            };
+            scanner.EnqueueUserProcedure(up);
+
+            return false;
+        }
+
+        public bool VisitPrimitive(PrimitiveType pt)
+        {
+            rdr.Read(pt);
+            return false;
+        }
+
+        public bool VisitMemberPointer(MemberPointer memptr)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool VisitPointer(Pointer ptr)
+        {
+            var c = rdr.Read(PrimitiveType.Create(Domain.Pointer, ptr.Size));
+            var addr = Address.FromConstant(c);
+
+            if (!program.Image.IsValidAddress(addr))
+                return false;
+
+            scanner.EnqueueUserGlobalData(addr, ptr.Pointee);
+
+            return false;
+        }
+
+        public bool VisitString(StringType str)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool VisitStructure(StructureType str)
+        {
+            for (int i = 0; i < str.Fields.Count; ++i)
+            {
+                str.Fields[i].DataType.Accept(this);
+            }
+
+            return false;
+        }
+
+        public bool VisitTypeReference(TypeReference typeref)
+        {
+            return typeref.Referent.Accept(this);
+        }
+
+        public bool VisitTypeVariable(TypeVariable tv)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool VisitUnion(UnionType ut)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool VisitUnknownType(UnknownType ut)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool VisitVoidType(VoidType voidType)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/UnitTests/Scanning/ScannerTests.cs
+++ b/src/UnitTests/Scanning/ScannerTests.cs
@@ -137,7 +137,7 @@ namespace Reko.UnitTests.Scanning
             {
                 m => { m.Return(4, 0); }
             });
-            Given_Program(Address.Ptr32(0x12314));
+            Given_Program(Address.Ptr32(0x12314), new byte[1]);
             var project = new Project { Programs = { program } };
 
             var sc = new Scanner(
@@ -148,7 +148,7 @@ namespace Reko.UnitTests.Scanning
             sc.EnqueueEntryPoint(
                 new EntryPoint(
                     Address.Ptr32(0x12314),
-                    arch.CreateProcessorState()));
+                    program.Architecture.CreateProcessorState()));
             sc.ScanImage();
 
             Assert.AreEqual(1, program.Procedures.Count);
@@ -156,16 +156,23 @@ namespace Reko.UnitTests.Scanning
             Assert.IsTrue(program.CallGraph.EntryPoints.Contains(program.Procedures.Values[0]));
         }
 
-        private void Given_Program(Address address)
+        private void Given_Program(Address address, byte[] bytes)
         {
-            var image = new LoadedImage(address, new byte[1]);
+            var image = new LoadedImage(address, bytes);
             var imageMap = image.CreateImageMap();
+            var arch = new X86ArchitectureFlat32();
+            var platform = new FakePlatform(null, arch);
             this.program = new Program
             {
                 Architecture = arch,
                 Image = image,
                 ImageMap = imageMap,
-                Platform = new FakePlatform(null, arch)
+                Platform = platform
+            };
+            platform.Test_CreateProcedureSerializer = (t, d) =>
+            {
+                var typeLoader = new TypeLibraryDeserializer(platform, false, new TypeLibrary());
+                return new X86ProcedureSerializer((IntelArchitecture)program.Architecture, typeLoader, "");
             };
         }
 
@@ -612,6 +619,113 @@ fn00001200_exit:
 
             var r1 = proc.Frame.EnsureIdentifier(arch.GetRegister("r1"));
             Assert.AreEqual("0x00000DC0", scanner.Test_State.GetValue(r1).ToString());
+        }
+
+        [Test]
+        public void Scanner_GlobalData()
+        {
+            var bytes = new byte[] {
+                0x48, 0x00, 0x21, 0x43, 0x00, 0x00, 0x00, 0x01, 0x53, 0x00, 0x21, 0x43,
+                0x28, 0x00, 0x21, 0x43, 0x00, 0x00, 0x00, 0x02, 0x63, 0x00, 0x21, 0x43,
+                0x38, 0x00, 0x21, 0x43, 0x00, 0x00, 0x00, 0x03, 0x73, 0x00, 0x21, 0x43,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            };
+            Given_Program(Address.Ptr32(0x43210000), bytes);
+            var project = new Project { Programs = { program } };
+
+            var sc = new Scanner(
+                this.program,
+                null,
+                new ImportResolver(project),
+                this.sc
+            );
+
+            var sSig1 = new SerializedSignature()
+            {
+                ReturnValue = new Argument_v1(null, new PrimitiveType_v1(Domain.Integer, 4), null, false),
+            };
+            var sSig2 = new SerializedSignature()
+            {
+                ReturnValue = new Argument_v1(null, new PrimitiveType_v1(Domain.Character, 1), null, false),
+            };
+            var ft1 = new FunctionType(sSig1);
+            var ft2 = new FunctionType(sSig2);
+            var str = new StructureType();
+            var fields = new StructureField[] {
+                new StructureField(0, new Pointer(ft1, 4), "A"),
+                new StructureField(4, PrimitiveType.Int32, "B"),
+                new StructureField(8, new Pointer(ft2, 4), "C"),
+            };
+            str.Fields.AddRange(fields);
+            var elementType = new TypeReference("test", str);
+            var arrayType = new ArrayType(elementType, 3);
+
+            sc.EnqueueUserGlobalData(Address.Ptr32(0x43210000), arrayType);
+            sc.ScanImage();
+
+            var sExpSig1 =
+@"Register ui32 ()()
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
+";
+            var sExpSig2 =
+@"Register char ()()
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
+";
+            Assert.AreEqual(6, program.Procedures.Count);
+            Assert.AreEqual(sExpSig1, program.Procedures[Address.Ptr32(0x43210028)].Signature.ToString());
+            Assert.AreEqual(sExpSig1, program.Procedures[Address.Ptr32(0x43210038)].Signature.ToString());
+            Assert.AreEqual(sExpSig1, program.Procedures[Address.Ptr32(0x43210048)].Signature.ToString());
+            Assert.AreEqual(sExpSig2, program.Procedures[Address.Ptr32(0x43210053)].Signature.ToString());
+            Assert.AreEqual(sExpSig2, program.Procedures[Address.Ptr32(0x43210063)].Signature.ToString());
+            Assert.AreEqual(sExpSig2, program.Procedures[Address.Ptr32(0x43210073)].Signature.ToString());
+        }
+
+        [Test]
+        public void Scanner_GlobalDataRecursiveStructs()
+        {
+            var bytes = new byte[] {
+                0x17, 0x00, 0x21, 0x43, 0x00, 0x00, 0x21, 0x43,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            };
+            Given_Program(Address.Ptr32(0x43210000), bytes);
+            var project = new Project { Programs = { program } };
+
+            var sc = new Scanner(
+                this.program,
+                null,
+                new ImportResolver(project),
+                this.sc
+            );
+
+            var sSig = new SerializedSignature()
+            {
+                ReturnValue = new Argument_v1(null, new PrimitiveType_v1(Domain.Real, 4), null, false),
+            };
+            var ft = new FunctionType(sSig);
+            var str = new StructureType();
+            var fields = new StructureField[] {
+                new StructureField(0, new Pointer(ft,  4), "func"),
+                new StructureField(4, new Pointer(str, 4), "next"),
+            };
+            str.Fields.AddRange(fields);
+
+            sc.EnqueueUserGlobalData(Address.Ptr32(0x43210000), str);
+            sc.ScanImage();
+
+            var sExpSig =
+@"Register real32 ()()
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
+";
+            Assert.AreEqual(1, program.Procedures.Count);
+            Assert.AreEqual(sExpSig, program.Procedures[Address.Ptr32(0x43210017)].Signature.ToString());
         }
     }
 }


### PR DESCRIPTION
Create new class GlobalDataWorkItem as parent of WorkItem. It scans global memory and discovers new entry points.