### PR TITLE
Use StructureField.Offset when reading structure fields (#141)

### DIFF
--- a/src/Core/Output/GlobalDataWriter.cs
+++ b/src/Core/Output/GlobalDataWriter.cs
@@ -225,12 +225,15 @@ namespace Reko.Core.Output
             fmt.Terminate();
             fmt.Indentation += fmt.TabSize;
 
+            var structOffset = rdr.Offset;
             for (int i = 0; i < str.Fields.Count; ++i)
             {
                 fmt.Indent();
+                rdr.Offset = structOffset + str.Fields[i].Offset;
                 str.Fields[i].DataType.Accept(this);
                 fmt.Terminate(",");
             }
+            rdr.Offset = structOffset + str.GetInferredSize();
 
             fmt.Indentation -= fmt.TabSize;
             fmt.Indent();

--- a/src/Decompiler/Scanning/GlobalDataWorkItem.cs
+++ b/src/Decompiler/Scanning/GlobalDataWorkItem.cs
@@ -133,11 +133,13 @@ namespace Reko.Scanning
 
         public bool VisitStructure(StructureType str)
         {
+            var structOffset = rdr.Offset;
             for (int i = 0; i < str.Fields.Count; ++i)
             {
-                //$BUG: should be paying attention to StructureField.Offset here.
+                rdr.Offset = structOffset + str.Fields[i].Offset;
                 str.Fields[i].DataType.Accept(this);
             }
+            rdr.Offset = structOffset + str.GetInferredSize();
             return false;
         }
 

--- a/src/UnitTests/Scanning/ScannerTests.cs
+++ b/src/UnitTests/Scanning/ScannerTests.cs
@@ -737,7 +737,6 @@ fn00001200_exit:
         }
 
         [Test(Description = "Scanner should be able to handle structures with padding 'holes'")]
-        [Ignore("@ptomin: see if you can get this to work.")]
         public void Scanner_GlobalData_StructWithPadding()
         {
             var bytes = new byte[]
@@ -773,7 +772,7 @@ fn00001200_exit:
             scanner.ScanImage();
 
             Assert.AreEqual(1, program.Procedures.Count, "Scanner should have detected the pointer to function correctly.");
-            Assert.AreEqual(Address.Ptr32(0x43210017), program.Procedures.Keys.First());
+            Assert.AreEqual(Address.Ptr32(0x43210008), program.Procedures.Keys.First());
         }
     }
 }


### PR DESCRIPTION
Use StructureField.Offset when reading structure fields