### PR TITLE
Change default calling convention from stdapi to __cdecl on Win32Platform

### DIFF
--- a/src/Environments/Windows/Win32Platform.cs
+++ b/src/Environments/Windows/Win32Platform.cs
@@ -202,7 +202,7 @@ namespace Reko.Environments.Windows
 
         public override string DefaultCallingConvention
         {
-            get { return "stdapi"; }
+            get { return "__cdecl"; }
         }
 
         public override ExternalProcedure SignatureFromName(string fnName)


### PR DESCRIPTION
Change default calling convention from stdapi to __cdecl on Win32Platform