### PR TITLE
Project loader: create unit test for global user data

### DIFF
--- a/src/UnitTests/Core/Serialization/ProjectLoaderTests.cs
+++ b/src/UnitTests/Core/Serialization/ProjectLoaderTests.cs
@@ -315,5 +315,39 @@ namespace Reko.UnitTests.Core.Serialization
 
             Assert.AreEqual(1, project.Programs.Count);
         }
+
+        [Test]
+        public void Prld_LoadGlobalUserData()
+        {
+            var sproject =
+    @"<?xml version=""1.0"" encoding=""utf-8""?>
+<project xmlns=""http://schemata.jklnet.org/Reko/v3"">
+  <input>
+    <user>
+      <global>
+        <Address>10000010</Address>
+        <arr length=""10"">
+          <type>refType</type>
+        </arr>
+        <Name>testVar</Name>
+      </global>
+    </user>
+  </input>
+</project>";
+            var ldr = mockFactory.CreateLoader();
+
+            var prld = new ProjectLoader(sc, ldr);
+            var project = prld.LoadProject(
+                @"c:\foo\global_user.proj",
+                new MemoryStream(Encoding.UTF8.GetBytes(sproject))
+            );
+
+            Assert.AreEqual(1, project.Programs.Count);
+            Assert.AreEqual(1, project.Programs[0].User.Globals.Count);
+            var globalVariable = project.Programs[0].User.Globals.Values[0];
+            Assert.AreEqual("10000010", globalVariable.Address);
+            Assert.AreEqual("testVar", globalVariable.Name);
+            Assert.AreEqual("arr(refType,10)", globalVariable.DataType.ToString());
+        }
     }
 }

--- a/src/UnitTests/Mocks/MockFactory.cs
+++ b/src/UnitTests/Mocks/MockFactory.cs
@@ -180,9 +180,14 @@ namespace Reko.UnitTests.Mocks
 
             loader = mr.Stub<ILoader>();
 
+            var program = CreateProgram();
+            var image = new LoadedImage(Address.Ptr32(0x10000000), new byte[1000]);
+            program.Image = image;
+            program.ImageMap = image.CreateImageMap();
+
             loader.Stub(
                 l => l.LoadExecutable(null, null, null)
-            ).IgnoreArguments().Return(CreateProgram());
+            ).IgnoreArguments().Return(program);
 
             loader.Stub(
                 l => l.LoadImageBytes(null, 0)


### PR DESCRIPTION
Now there is no test for loading global user data