### PR TITLE
[WIP] AmigaOS library selection support

### DIFF
--- a/src/Environments/AmigaOS.Design/AmigaOSProperties.Designer.cs
+++ b/src/Environments/AmigaOS.Design/AmigaOSProperties.Designer.cs
@@ -31,7 +31,10 @@
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
             this.lblKickstart = new System.Windows.Forms.Label();
-            this.comboBox1 = new System.Windows.Forms.ComboBox();
+            this.cmbKickstartVersions = new System.Windows.Forms.ComboBox();
+            this.lblUsedLibraries = new System.Windows.Forms.Label();
+            this.lstLoadedLibs = new System.Windows.Forms.ListView();
+            this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.SuspendLayout();
             // 
             // label1
@@ -63,19 +66,47 @@
             this.lblKickstart.TabIndex = 2;
             this.lblKickstart.Text = "Select &Kickstart version";
             // 
-            // comboBox1
+            // cmbKickstartVersions
             // 
-            this.comboBox1.FormattingEnabled = true;
-            this.comboBox1.Location = new System.Drawing.Point(148, 75);
-            this.comboBox1.Name = "comboBox1";
-            this.comboBox1.Size = new System.Drawing.Size(182, 21);
-            this.comboBox1.TabIndex = 3;
+            this.cmbKickstartVersions.FormattingEnabled = true;
+            this.cmbKickstartVersions.Location = new System.Drawing.Point(148, 75);
+            this.cmbKickstartVersions.Name = "cmbKickstartVersions";
+            this.cmbKickstartVersions.Size = new System.Drawing.Size(182, 21);
+            this.cmbKickstartVersions.TabIndex = 3;
+            this.cmbKickstartVersions.SelectedIndexChanged += new System.EventHandler(this.onSelectedItemChanged);
+            // 
+            // lblUsedLibraries
+            // 
+            this.lblUsedLibraries.AutoSize = true;
+            this.lblUsedLibraries.Location = new System.Drawing.Point(337, 58);
+            this.lblUsedLibraries.Name = "lblUsedLibraries";
+            this.lblUsedLibraries.Size = new System.Drawing.Size(47, 13);
+            this.lblUsedLibraries.TabIndex = 4;
+            this.lblUsedLibraries.Text = "Will use:";
+            // 
+            // lstLoadedLibs
+            // 
+            this.lstLoadedLibs.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.columnHeader1});
+            this.lstLoadedLibs.Location = new System.Drawing.Point(337, 75);
+            this.lstLoadedLibs.Name = "lstLoadedLibs";
+            this.lstLoadedLibs.Size = new System.Drawing.Size(187, 161);
+            this.lstLoadedLibs.TabIndex = 5;
+            this.lstLoadedLibs.UseCompatibleStateImageBehavior = false;
+            this.lstLoadedLibs.View = System.Windows.Forms.View.Details;
+            // 
+            // columnHeader1
+            // 
+            this.columnHeader1.Text = "Library";
+            this.columnHeader1.Width = 144;
             // 
             // AmigaOSProperties
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.comboBox1);
+            this.Controls.Add(this.lstLoadedLibs);
+            this.Controls.Add(this.lblUsedLibraries);
+            this.Controls.Add(this.cmbKickstartVersions);
             this.Controls.Add(this.lblKickstart);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
@@ -91,6 +122,9 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label lblKickstart;
-        private System.Windows.Forms.ComboBox comboBox1;
+        private System.Windows.Forms.ComboBox cmbKickstartVersions;
+        private System.Windows.Forms.Label lblUsedLibraries;
+        private System.Windows.Forms.ListView lstLoadedLibs;
+        private System.Windows.Forms.ColumnHeader columnHeader1;
     }
 }

--- a/src/Environments/AmigaOS.Design/AmigaOSProperties.cs
+++ b/src/Environments/AmigaOS.Design/AmigaOSProperties.cs
@@ -11,9 +11,28 @@ namespace Reko.Environments.AmigaOS.Design
 {
     public partial class AmigaOSProperties : UserControl
     {
-        public AmigaOSProperties()
+        private AmigaOSPropertiesInteractor myInteractor;
+        public AmigaOSProperties(AmigaOSPropertiesInteractor interactor)
         {
             InitializeComponent();
+            myInteractor = interactor;
+            List<int> klist = myInteractor.getAvailableKickstarts();
+            foreach(int kick_ver in klist)
+                this.cmbKickstartVersions.Items.Add(String.Format("Kickstart {0}",kick_ver));
+            this.cmbKickstartVersions.SelectedIndex = 0;
+        }
+        private void onSelectedItemChanged(object sender, EventArgs e)
+        {
+            ComboBox src_cmb = (ComboBox)sender;
+            int idx_in_list = src_cmb.SelectedIndex;
+            if (idx_in_list >= 0)
+            {
+                List<int> klist = myInteractor.getAvailableKickstarts();
+                List<String> libList = myInteractor.GetLibrariesForKickstart(klist.ElementAt(idx_in_list));
+                this.lstLoadedLibs.Items.Clear();
+                foreach(String lib in libList)
+                    this.lstLoadedLibs.Items.Add(lib); //$TODO: mark available library definition files ?
+            }
         }
     }
 }

--- a/src/Environments/AmigaOS.Design/AmigaOSPropertiesInteractor.cs
+++ b/src/Environments/AmigaOS.Design/AmigaOSPropertiesInteractor.cs
@@ -41,7 +41,7 @@ namespace Reko.Environments.AmigaOS.Design
 
         public Control CreateControl()
         {
-            Control = new AmigaOSProperties();
+            Control = new AmigaOSProperties(this);
             return Control;
         }
 
@@ -59,5 +59,14 @@ namespace Reko.Environments.AmigaOS.Design
             }
         }
 
+        internal List<int> getAvailableKickstarts()
+        {
+            return AmigaOSPlatform.MapKickstartToListOfLibraries.Keys.ToList();
+        }
+
+        internal List<string> GetLibrariesForKickstart(int v)
+        {
+            return platform.GetLibrarySetForKickstartVersion(v);
+        }
     }
 }

--- a/src/Environments/AmigaOS/AmigaOSPlatform.cs
+++ b/src/Environments/AmigaOS/AmigaOSPlatform.cs
@@ -44,7 +44,30 @@ namespace Reko.Environments.AmigaOS
     public class AmigaOSPlatform : Platform
     {
         private RtlInstructionMatcher a6Pattern;
-        private Dictionary<int, SystemService> funcs;
+        private Dictionary<int, SystemService> funcs; //$TODO: This should take a type of base pointer the reference is from ?
+        private static Dictionary<int, List<String>> mapKickstartToListOfLibraries = new Dictionary<int, List<String>>
+        {
+            {
+                33, new List<String>
+                {
+                    "exec_v33",
+                    "dos_v33"
+                }
+            },
+            {
+                34, new List<String>
+                {
+                    "exec_v34",
+                    "dos_v34"
+                }
+            }
+        }; //$TODO: Load available kickstart -> libraries mappings from disk ?
+
+        public static Dictionary<int, List<String>> MapKickstartToListOfLibraries {
+            get {
+                return mapKickstartToListOfLibraries;
+            }
+        }
 
         public AmigaOSPlatform(IServiceProvider services, IProcessorArchitecture arch)
             : base(services, arch, "amigaOS")
@@ -89,7 +112,57 @@ namespace Reko.Environments.AmigaOS
             SystemService svc;
             return funcs.TryGetValue(offset, out svc) ? svc : null;
         }
+        private String GetLibraryBaseName(String name_with_version) 
+        {
+            int idx_of_version_str = name_with_version.IndexOf("_v");
+            if (-1 == idx_of_version_str) // no version, assuming the base name of library is same as name_with_version
+                return name_with_version;
+            return name_with_version.Substring(0, idx_of_version_str);
+        }
+        /// <summary>
+        /// Gets the list of libraries for given kickstart version.
+        /// </summary>
+        /// <returns>The library list for kickstart version.</returns>
+        /// <remarks> This will always try to build maximum list of libraries, using older versions where possible </remarks>
+        /// <param name="ver">Kickstart version</param>
+        public List<String> GetLibrarySetForKickstartVersion(int ver)
+        {
+            //$TODO: needs cleanup ?
+            var result_list = new List<String>();
+            var selected_librarties = new Dictionary<String,String>();
 
+            var keys = mapKickstartToListOfLibraries.Keys.ToList();
+            keys.Sort ();
+
+            int idx_version_to_select = keys.BinarySearch(ver);
+            if (idx_version_to_select<0) 
+            {
+                int next_larger_idx = ~idx_version_to_select;
+                // if ver > highest available - use highest available
+                if (next_larger_idx == keys.Count)
+                    idx_version_to_select =  keys.Count - 1;
+                // if ver < lowest available - return empty list
+                else if (next_larger_idx == 0)
+                    return result_list;
+            }
+            for (int ver_idx = idx_version_to_select; ver_idx >= 0; --ver_idx) 
+            {
+                int try_version = keys.ElementAt(ver_idx);
+                foreach(String lib in mapKickstartToListOfLibraries[try_version]) 
+                {
+                    String base_libname = GetLibraryBaseName(lib);
+                    if (selected_librarties.ContainsKey(base_libname))
+                        continue;
+                    selected_librarties.Add(base_libname, lib);
+                }
+            }
+            return selected_librarties.Values.ToList();
+        }
+        public void SetKickstartVersion(int v)
+        {
+            List<String> lib_list = GetLibrarySetForKickstartVersion (v);
+
+        }
         public override string DefaultCallingConvention
         {
             get { return ""; }

--- a/src/UnitTests/Environments/AmigaOS/AmigaOSPlatformTests.cs
+++ b/src/UnitTests/Environments/AmigaOS/AmigaOSPlatformTests.cs
@@ -85,7 +85,22 @@ namespace Reko.UnitTests.Environments.AmigaOS
             Assert.AreEqual("d0", svc.Signature.Parameters[1].Storage.ToString());
             mr.VerifyAll();
         }
+        [Test]
+        public void AOS_LibrarySelection() 
+        {
+            mr.ReplayAll();
+            When_Create_Platform();
+            var libs_v0 = platform.GetLibrarySetForKickstartVersion(0);
+            var libs_v33 = platform.GetLibrarySetForKickstartVersion(33);
+            var libs_v34 = platform.GetLibrarySetForKickstartVersion(34);
+            var libs_v999 = platform.GetLibrarySetForKickstartVersion(999);
 
+            Assert.AreEqual(0, libs_v0.Count);
+            Assert.IsTrue (libs_v33.Contains ("exec_v33"));
+            Assert.IsTrue (libs_v34.Contains ("exec_v34"));
+            Assert.IsTrue (libs_v999.Contains ("exec_v34")); //TODO: should select version from highest availalbe kickstart version
+            mr.VerifyAll();
+        }
         private void Given_Func(string fileContents)
         {
             var stm = new MemoryStream(Encoding.ASCII.GetBytes(fileContents));


### PR DESCRIPTION
This is just a mostly GUI layer for now.
There are a few issues to resolve before this is complete:

* Unloading 'patterns'  - this would require that each 'applied' pattern records it's application location, so that when pattern is unloaded/changed all functions that contain given location are re-decompiled
* Splitting exec.funcs into exec_v33.funcs/exec_v34.funcs/ etc.  
* associating more information for applied functions i.e.
```AbortIO(ioRequest/a1)``` could be augmented by loading in file named exec_v33.rh, which defines exec library types and contains the following declaration ```[[reko::reg("D0")]] BYTE AbortIO([[reko::reg("A1")]] struct IORequest * iORequest);```