### PR TITLE
Add new test case to Mcdm_MoveForward

### DIFF
--- a/src/UnitTests/Gui/Windows/Controls/MixedCodeDataModelTests.cs
+++ b/src/UnitTests/Gui/Windows/Controls/MixedCodeDataModelTests.cs
@@ -206,6 +206,9 @@ namespace Reko.UnitTests.Gui.Windows.Controls
             delta = mcdm.MoveToLine(mcdm.CurrentPosition, 1);
             Assert.AreEqual("00042020", mcdm.CurrentPosition.ToString());
             Assert.AreEqual(0, delta);
+
+            mcdm.MoveToLine(mcdm.StartPosition, 2);
+            Assert.AreEqual("00042000", mcdm.CurrentPosition.ToString());
         }
 
         [Test]


### PR DESCRIPTION
I have added new test case to Mcdm_MoveForward. Now output is "00041000" for this test case. John, do you agree that correct output is "00042000"? Could you look at it?