### PR TITLE
TextView: remove override of OnPaintBackground method

### DIFF
--- a/src/Gui/Windows/Controls/TextView.cs
+++ b/src/Gui/Windows/Controls/TextView.cs
@@ -276,12 +276,6 @@ namespace Reko.Gui.Windows.Controls
             GetStyleStack().PopStyle();
         }
 
-        // Disable background painting to avoid the horrible flicker.
-        // We draw our own background anyway.
-        protected override void OnPaintBackground(PaintEventArgs pevent)
-        {
-        }
-
         public TextPointer GetStartSelection()
         {
             if (layout.ComparePositions(cursorPos, anchorPos) <= 0)


### PR DESCRIPTION
... to avoid drawing of black rectangle at the end
![sample1](https://cloud.githubusercontent.com/assets/13188041/14410409/60f7cd46-ff48-11e5-9ae7-90a32dc352ba.jpg)

John, you have added overriding of OnPaintBackground in 6f3c6e8e. Mentioned reason is avoiding flicker. But there is no flicker after removing it. And there is no black rectangle at the end of TextView