### PR TITLE
CombinedCodeViewInteractor::copy: do not drop the last character

### DIFF
--- a/src/Gui/Windows/CombinedCodeViewInteractor.cs
+++ b/src/Gui/Windows/CombinedCodeViewInteractor.cs
@@ -33,6 +33,7 @@ using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Windows.Forms;
 
 namespace Reko.Gui.Windows
@@ -344,7 +345,8 @@ namespace Reko.Gui.Windows
 
             var ms = new MemoryStream();
             FocusedTextView.Selection.Save(ms, DataFormats.UnicodeText);
-            Clipboard.SetData(DataFormats.UnicodeText, ms);
+            var text = new string(Encoding.Unicode.GetChars(ms.ToArray()));
+            Clipboard.SetData(DataFormats.UnicodeText, text);
         }
 
         public bool ChooseTextEncoding()


### PR DESCRIPTION
It does not drop the last character after this commit. I do not know why.

