### PR TITLE
Remove "Parameters" tab from "Edit Procedure" dialog

### DIFF
--- a/src/Gui/Windows/Forms/ProcedureDialog.Designer.cs
+++ b/src/Gui/Windows/Forms/ProcedureDialog.Designer.cs
@@ -52,31 +52,19 @@ namespace Reko.Gui.Windows.Forms
             this.btnCancel = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
             this.txtName = new System.Windows.Forms.TextBox();
-            this.listArguments = new System.Windows.Forms.ListView();
-            this.propArgument = new System.Windows.Forms.PropertyGrid();
-            this.textBox2 = new System.Windows.Forms.TextBox();
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabProcedure = new System.Windows.Forms.TabPage();
             this.label4 = new System.Windows.Forms.Label();
             this.txtSignature = new System.Windows.Forms.TextBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.chkTerminates = new System.Windows.Forms.CheckBox();
             this.checkBox1 = new System.Windows.Forms.CheckBox();
             this.chkMalloc = new System.Windows.Forms.CheckBox();
             this.label3 = new System.Windows.Forms.Label();
             this.txtComment = new System.Windows.Forms.TextBox();
-            this.tabParameters = new System.Windows.Forms.TabPage();
-            this.label2 = new System.Windows.Forms.Label();
-            this.btnRemoveArgument = new System.Windows.Forms.Button();
-            this.btnAddArgument = new System.Windows.Forms.Button();
-            this.chkTerminates = new System.Windows.Forms.CheckBox();
-            this.splitContainer1.Panel1.SuspendLayout();
-            this.splitContainer1.Panel2.SuspendLayout();
-            this.splitContainer1.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabProcedure.SuspendLayout();
             this.groupBox1.SuspendLayout();
-            this.tabParameters.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnOK
@@ -112,65 +100,16 @@ namespace Reko.Gui.Windows.Forms
             // 
             // txtName
             // 
-            this.txtName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtName.Location = new System.Drawing.Point(6, 28);
             this.txtName.Name = "txtName";
             this.txtName.Size = new System.Drawing.Size(394, 20);
             this.txtName.TabIndex = 1;
             // 
-            // listArguments
-            // 
-            this.listArguments.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.listArguments.Location = new System.Drawing.Point(0, 0);
-            this.listArguments.Name = "listArguments";
-            this.listArguments.Size = new System.Drawing.Size(164, 230);
-            this.listArguments.TabIndex = 4;
-            this.listArguments.UseCompatibleStateImageBehavior = false;
-            this.listArguments.View = System.Windows.Forms.View.List;
-            // 
-            // propArgument
-            // 
-            this.propArgument.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.propArgument.Location = new System.Drawing.Point(0, 0);
-            this.propArgument.Name = "propArgument";
-            this.propArgument.Size = new System.Drawing.Size(233, 230);
-            this.propArgument.TabIndex = 6;
-            this.propArgument.ToolbarVisible = false;
-            // 
-            // textBox2
-            // 
-            this.textBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBox2.Enabled = false;
-            this.textBox2.Location = new System.Drawing.Point(0, 288);
-            this.textBox2.Multiline = true;
-            this.textBox2.Name = "textBox2";
-            this.textBox2.Size = new System.Drawing.Size(401, 90);
-            this.textBox2.TabIndex = 7;
-            // 
-            // splitContainer1
-            // 
-            this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
-            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer1.Name = "splitContainer1";
-            // 
-            // splitContainer1.Panel1
-            // 
-            this.splitContainer1.Panel1.Controls.Add(this.listArguments);
-            // 
-            // splitContainer1.Panel2
-            // 
-            this.splitContainer1.Panel2.Controls.Add(this.propArgument);
-            this.splitContainer1.Size = new System.Drawing.Size(401, 230);
-            this.splitContainer1.SplitterDistance = 164;
-            this.splitContainer1.TabIndex = 9;
-            // 
             // tabControl1
             // 
             this.tabControl1.Controls.Add(this.tabProcedure);
-            this.tabControl1.Controls.Add(this.tabParameters);
             this.tabControl1.Location = new System.Drawing.Point(1, 3);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
@@ -223,6 +162,16 @@ namespace Reko.Gui.Windows.Forms
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "C&haracteristics";
             // 
+            // chkTerminates
+            // 
+            this.chkTerminates.AutoSize = true;
+            this.chkTerminates.Location = new System.Drawing.Point(7, 67);
+            this.chkTerminates.Name = "chkTerminates";
+            this.chkTerminates.Size = new System.Drawing.Size(211, 17);
+            this.chkTerminates.TabIndex = 8;
+            this.chkTerminates.Text = "Procedure terminates process or thread";
+            this.chkTerminates.UseVisualStyleBackColor = true;
+            // 
             // checkBox1
             // 
             this.checkBox1.AutoSize = true;
@@ -251,7 +200,6 @@ namespace Reko.Gui.Windows.Forms
             this.label3.Size = new System.Drawing.Size(54, 13);
             this.label3.TabIndex = 4;
             this.label3.Text = "&Comment:";
-            this.label3.Click += new System.EventHandler(this.label3_Click);
             // 
             // txtComment
             // 
@@ -260,59 +208,6 @@ namespace Reko.Gui.Windows.Forms
             this.txtComment.Name = "txtComment";
             this.txtComment.Size = new System.Drawing.Size(395, 45);
             this.txtComment.TabIndex = 5;
-            this.txtComment.TextChanged += new System.EventHandler(this.txtComment_TextChanged);
-            // 
-            // tabParameters
-            // 
-            this.tabParameters.Controls.Add(this.label2);
-            this.tabParameters.Controls.Add(this.btnRemoveArgument);
-            this.tabParameters.Controls.Add(this.btnAddArgument);
-            this.tabParameters.Controls.Add(this.textBox2);
-            this.tabParameters.Controls.Add(this.splitContainer1);
-            this.tabParameters.Location = new System.Drawing.Point(4, 22);
-            this.tabParameters.Name = "tabParameters";
-            this.tabParameters.Padding = new System.Windows.Forms.Padding(3);
-            this.tabParameters.Size = new System.Drawing.Size(407, 384);
-            this.tabParameters.TabIndex = 0;
-            this.tabParameters.Text = "Parameters";
-            this.tabParameters.UseVisualStyleBackColor = true;
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 272);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(48, 13);
-            this.label2.TabIndex = 12;
-            this.label2.Text = "Previe&w:";
-            // 
-            // btnRemoveArgument
-            // 
-            this.btnRemoveArgument.Location = new System.Drawing.Point(81, 236);
-            this.btnRemoveArgument.Name = "btnRemoveArgument";
-            this.btnRemoveArgument.Size = new System.Drawing.Size(75, 23);
-            this.btnRemoveArgument.TabIndex = 11;
-            this.btnRemoveArgument.Text = "&Remove";
-            this.btnRemoveArgument.UseVisualStyleBackColor = true;
-            // 
-            // btnAddArgument
-            // 
-            this.btnAddArgument.Location = new System.Drawing.Point(0, 236);
-            this.btnAddArgument.Name = "btnAddArgument";
-            this.btnAddArgument.Size = new System.Drawing.Size(75, 23);
-            this.btnAddArgument.TabIndex = 10;
-            this.btnAddArgument.Text = "&Add";
-            this.btnAddArgument.UseVisualStyleBackColor = true;
-            // 
-            // chkTerminates
-            // 
-            this.chkTerminates.AutoSize = true;
-            this.chkTerminates.Location = new System.Drawing.Point(7, 67);
-            this.chkTerminates.Name = "chkTerminates";
-            this.chkTerminates.Size = new System.Drawing.Size(211, 17);
-            this.chkTerminates.TabIndex = 8;
-            this.chkTerminates.Text = "Procedure terminates process or thread";
-            this.chkTerminates.UseVisualStyleBackColor = true;
             // 
             // ProcedureDialog
             // 
@@ -331,16 +226,11 @@ namespace Reko.Gui.Windows.Forms
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Edit Procedure";
-            this.splitContainer1.Panel1.ResumeLayout(false);
-            this.splitContainer1.Panel2.ResumeLayout(false);
-            this.splitContainer1.ResumeLayout(false);
             this.tabControl1.ResumeLayout(false);
             this.tabProcedure.ResumeLayout(false);
             this.tabProcedure.PerformLayout();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
-            this.tabParameters.ResumeLayout(false);
-            this.tabParameters.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -351,16 +241,8 @@ namespace Reko.Gui.Windows.Forms
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.TextBox txtName;
-        private System.Windows.Forms.ListView listArguments;
-        private System.Windows.Forms.PropertyGrid propArgument;
-        private System.Windows.Forms.TextBox textBox2;
-        private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.TabControl tabControl1;
         private System.Windows.Forms.TabPage tabProcedure;
-        private System.Windows.Forms.TabPage tabParameters;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.Button btnRemoveArgument;
-        private System.Windows.Forms.Button btnAddArgument;
         private System.Windows.Forms.TextBox txtComment;
         private System.Windows.Forms.CheckBox chkMalloc;
         private System.Windows.Forms.Label label3;

--- a/src/Gui/Windows/Forms/ProcedureDialog.cs
+++ b/src/Gui/Windows/Forms/ProcedureDialog.cs
@@ -45,35 +45,6 @@ namespace Reko.Gui.Windows.Forms
             get { return txtSignature; }
         }
 
-
-        public ListView ArgumentList
-        {
-            get { return listArguments; }
-        }
-
-        public PropertyGrid ArgumentProperties
-        {
-            get { return propArgument; }
-        }
-
-        public TabControl TabControl
-        {
-            get { return tabControl1; }
-        }
-
         public Button OkButton { get { return btnOK; } }
-
-
-        private void txtComment_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
-        private void label3_Click(object sender, EventArgs e)
-        {
-
-        }
-
-
     }
 }

--- a/src/Gui/Windows/Forms/ProcedureDialogInteractor.cs
+++ b/src/Gui/Windows/Forms/ProcedureDialogInteractor.cs
@@ -50,7 +50,6 @@ namespace Reko.Gui.Windows.Forms
         {
             dlg = new ProcedureDialog();
             PopulateFields();
-            dlg.ArgumentList.SelectedIndexChanged += ArgumentList_SelectedIndexChanged;
             dlg.Signature.TextChanged += Signature_TextChanged;
             return dlg;
         }
@@ -63,24 +62,6 @@ namespace Reko.Gui.Windows.Forms
             if (proc.Signature != null)
             {
                 dlg.Signature.Text = SignatureParser.UnparseSignature(proc.Signature, proc.Name);
-                PopulateSignatureFields(proc.Signature);
-            }
-        }
-
-
-
-        private string StringizeSignature(SerializedSignature sig, string name)
-        {
-            return SignatureParser.UnparseSignature(sig, name);
-        }
-
-        private void PopulateSignatureFields(SerializedSignature sig)
-        {
-            if (sig.ReturnValue != null)
-            {
-                ListViewItem item = new ListViewItem("<Return value>"); 
-                item.Tag = sig.ReturnValue;
-                dlg.ArgumentList.Items.Add(item);
             }
         }
 
@@ -97,18 +78,6 @@ namespace Reko.Gui.Windows.Forms
         {
             dlg.OkButton.Enabled = signatureIsValid;
             dlg.Signature.ForeColor = signatureIsValid ? SystemColors.WindowText : Color.Red;
-        }
-
-        protected void ArgumentList_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (dlg.ArgumentList.SelectedItems.Count != 0)
-            {
-                dlg.ArgumentProperties.SelectedObjects = new object[] {
-                    dlg.ArgumentList.SelectedItems[0].Tag
-                };
-            }
-            else
-                dlg.ArgumentProperties.SelectedObjects = new object[0];
         }
 
         protected void Signature_TextChanged(object sender, EventArgs e)

--- a/src/UnitTests/Gui/Windows/Forms/ProcedureDialogInteractorTests.cs
+++ b/src/UnitTests/Gui/Windows/Forms/ProcedureDialogInteractorTests.cs
@@ -55,53 +55,6 @@ namespace Reko.UnitTests.Gui.Windows.Forms
         }
 
         [Test]
-        public void ReturnValue()
-        {
-            proc.Name = "x";
-            proc.Signature = new SerializedSignature();
-            proc.Signature.Arguments = new Argument_v1[0];
-            CreateReturnValue(proc.Signature);
-            //proc.Signature.Arguments = new SerializedArgument[1];
-            //proc.Signature.Arguments[0] = new SerializedArgument();
-            //proc.Signature.Arguments[0].Name = "arg0";
-            //proc.Signature.Arguments[0].Kind = new SerializedStackVariable(4);
-            //proc.Signature.Arguments[0].Type = "int32";
-
-            using (ProcedureDialog dlg = interactor.CreateDialog())
-            {
-                dlg.Show();
-                Assert.AreEqual(1, dlg.ArgumentList.Items.Count);
-                Assert.AreEqual("<Return value>", dlg.ArgumentList.Items[0].Text);
-            }
-        }
-
-        private static void CreateReturnValue(SerializedSignature sig)
-        {
-            sig.ReturnValue = new Argument_v1();
-            sig.ReturnValue.Kind = new Register_v1("eax");
-            sig.ReturnValue.Type = new TypeReference_v1("int32");
-        }
-
-        [Test]
-        public void SelectReturnValue()
-        {
-            proc.Name = "x";
-            proc.Signature = new SerializedSignature();
-            proc.Signature.Arguments = new Argument_v1[0];
-            CreateReturnValue(proc.Signature);
-            using (ProcedureDialog dlg = interactor.CreateDialog())
-            {
-                dlg.Show();
-                interactor.UserSwitchTab(1);
-                interactor.UserSelectedItem(dlg.ArgumentList, 0);
-
-                ListViewItem item = dlg.ArgumentList.Items[0];
-                Assert.AreEqual("<Return value>", item.Text);
-                Assert.AreSame(item.Tag, dlg.ArgumentProperties.SelectedObject);
-            }
-        }
-
-        [Test]
         public void PopulateWithEmptySignature()
         {
             proc.Name = "foo";
@@ -153,21 +106,10 @@ namespace Reko.UnitTests.Gui.Windows.Forms
             {
             }
 
-            public void UserSelectedItem(ListView listView, int p)
-            {
-                listView.Items[0].Selected = true;
-                base.ArgumentList_SelectedIndexChanged(listView, EventArgs.Empty);
-            }
-
             internal void UserChangeSignatureText( string text)
             {
                 dlg.Signature.Text = text;
                 base.Signature_TextChanged(dlg.Signature, EventArgs.Empty);
-            }
-
-            internal void UserSwitchTab(int p)
-            {
-                dlg.TabControl.SelectedIndex = p;
             }
         }
     }


### PR DESCRIPTION
You wrote:
> Let's use the Edit Properties dialog. The "Parameters" tab is obsolete, however, and should be removed.

Done