### PR TITLE
Use C parser in procedure dialog

### DIFF
--- a/src/Decompiler/Analysis/UserSignatureBuilder.cs
+++ b/src/Decompiler/Analysis/UserSignatureBuilder.cs
@@ -82,7 +82,7 @@ namespace Reko.Analysis
         {
             if (!string.IsNullOrEmpty(userProc.CSignature))
             {
-                return ParseFunctionDeclaration(userProc.CSignature, proc.Frame);
+                return ParseFunctionDeclaration(userProc.CSignature);
             }
             return null;
         }
@@ -133,7 +133,7 @@ namespace Reko.Analysis
             return new Assignment(dst, param);
         }
 
-        public ProcedureBase_v1 ParseFunctionDeclaration(string fnDecl, Frame frame)
+        public ProcedureBase_v1 ParseFunctionDeclaration(string fnDecl)
         {
             try {
                 var lexer = new CLexer(new StringReader(fnDecl + ";"));

--- a/src/Gui/Windows/CodeViewerPane.cs
+++ b/src/Gui/Windows/CodeViewerPane.cs
@@ -245,7 +245,7 @@ namespace Reko.Gui.Windows
 
             // Attempt to parse the signature.
             var usb = new UserSignatureBuilder(program);
-            sProc = usb.ParseFunctionDeclaration(txtSignature, this.proc.Frame);
+            sProc = usb.ParseFunctionDeclaration(txtSignature);
             return sProc != null;
         }
 

--- a/src/Gui/Windows/Controls/DeclarationTextBox.cs
+++ b/src/Gui/Windows/Controls/DeclarationTextBox.cs
@@ -207,7 +207,7 @@ namespace Reko.Gui.Windows.Controls
 
             // Attempt to parse the signature.
             var usb = new UserSignatureBuilder(program);
-            sProc = usb.ParseFunctionDeclaration(txtSignature, program.Architecture.CreateFrame());
+            sProc = usb.ParseFunctionDeclaration(txtSignature);
             return sProc != null;
         }
 

--- a/src/Gui/Windows/Forms/ProcedureDialogInteractor.cs
+++ b/src/Gui/Windows/Forms/ProcedureDialogInteractor.cs
@@ -88,7 +88,7 @@ namespace Reko.Gui.Windows.Forms
             if (!string.IsNullOrEmpty(CSignature))
             {
                 var usb = new UserSignatureBuilder(program);
-                sProc = usb.ParseFunctionDeclaration(CSignature, program.Architecture.CreateFrame());
+                sProc = usb.ParseFunctionDeclaration(CSignature);
                 isValid = (sProc != null);
             } else
             {

--- a/src/Gui/Windows/Forms/ProcedureDialogInteractor.cs
+++ b/src/Gui/Windows/Forms/ProcedureDialogInteractor.cs
@@ -18,6 +18,7 @@
  */
 #endregion
 
+using Reko.Analysis;
 using Reko.Core;
 using Reko.Core.Serialization;
 using System;
@@ -33,17 +34,13 @@ namespace Reko.Gui.Windows.Forms
     {
         protected ProcedureDialog dlg;
 
-        private IProcessorArchitecture arch;
+        private Program program;
         private Procedure_v1 proc;
 
-        public ProcedureDialogInteractor(IProcessorArchitecture arch, Procedure_v1 proc)
+        public ProcedureDialogInteractor(Program program, Procedure_v1 proc)
         {
-            this.arch = arch;
+            this.program = program;
             this.proc = proc;
-            if (proc.Signature != null && proc.Signature.Arguments == null)
-            {
-                proc.Signature.Arguments = new Argument_v1[0];
-            }
         }
 
         public ProcedureDialog CreateDialog()
@@ -54,24 +51,26 @@ namespace Reko.Gui.Windows.Forms
             return dlg;
         }
 
-        public Procedure_v1 SerializedProcedure { get { return proc; } }
-
         private void PopulateFields()
         {
-            dlg.ProcedureName.Text = proc.Name.Trim();
-            if (proc.Signature != null)
-            {
-                dlg.Signature.Text = SignatureParser.UnparseSignature(proc.Signature, proc.Name);
-            }
+            dlg.Signature.Text = proc.CSignature;
+            dlg.ProcedureName.Text = proc.Name;
+            EnableProcedureName();
         }
 
-        public void ApplyChangesToProcedure(Program program, Procedure procedure)
+        private void EnableProcedureName()
         {
-            var ser = program.CreateProcedureSerializer();
-            var sp = new SignatureParser(arch);
-            sp.Parse(dlg.Signature.Text);
-            Debug.Assert(sp.IsValid);
-            procedure.Signature = ser.Deserialize(sp.Signature, procedure.Frame);
+            dlg.ProcedureName.Enabled = string.IsNullOrEmpty(dlg.Signature.Text) ?
+                true: false;
+        }
+
+        public void ApplyChanges()
+        {
+            var CSignature = dlg.Signature.Text.Trim();
+            if (string.IsNullOrEmpty(CSignature))
+                CSignature = null;
+            proc.CSignature = CSignature;
+            proc.Name = dlg.ProcedureName.Text;
         }
 
         private void EnableControls(bool signatureIsValid)
@@ -82,12 +81,26 @@ namespace Reko.Gui.Windows.Forms
 
         protected void Signature_TextChanged(object sender, EventArgs e)
         {
-            var parser = new SignatureParser(arch);
-            parser.Parse(dlg.Signature.Text);
-            EnableControls(parser.IsValid);
-            if (parser.IsValid)
+            // Attempt to parse the signature.
+            var CSignature = dlg.Signature.Text.Trim();
+            ProcedureBase_v1 sProc = null;
+            bool isValid;
+            if (!string.IsNullOrEmpty(CSignature))
             {
-                proc.Signature = parser.Signature;
+                var usb = new UserSignatureBuilder(program);
+                sProc = usb.ParseFunctionDeclaration(CSignature, program.Architecture.CreateFrame());
+                isValid = (sProc != null);
+            } else
+            {
+                CSignature = null;
+                isValid = true;
+            }
+            EnableControls(isValid);
+            if (isValid)
+            {
+                if (sProc != null)
+                    dlg.ProcedureName.Text = sProc.Name;
+                EnableProcedureName();
             }
         }
 

--- a/src/UnitTests/Analysis/UserSignatureBuilderTests.cs
+++ b/src/UnitTests/Analysis/UserSignatureBuilderTests.cs
@@ -87,7 +87,7 @@ namespace Reko.UnitTests.Analysis
             Given_Procedure(0x1000);
 
             var usb = new UserSignatureBuilder(program);
-            var sProc = usb.ParseFunctionDeclaration("int foo(char *)", proc.Frame);
+            var sProc = usb.ParseFunctionDeclaration("int foo(char *)");
 
             Assert.AreEqual(
                 "fn(arg(prim(SignedInt,4)),(arg(ptr(prim(Character,1))))",
@@ -103,7 +103,7 @@ namespace Reko.UnitTests.Analysis
             Given_Procedure(0x1000);
 
             var usb = new UserSignatureBuilder(program);
-            var sProc = usb.ParseFunctionDeclaration("BYTE foo(BYTE a, BYTE b)", proc.Frame);
+            var sProc = usb.ParseFunctionDeclaration("BYTE foo(BYTE a, BYTE b)");
 
             Assert.AreEqual(
                 "fn(arg(BYTE),(arg(a,BYTE),arg(b,BYTE))",
@@ -124,14 +124,14 @@ namespace Reko.UnitTests.Analysis
             program.EnvironmentMetadata.Types.Add(
                 "USRDEF1", PrimitiveType.Create(PrimitiveType.Int16.Domain, 2));
 
-            var sProc = usb.ParseFunctionDeclaration("BYTE foo(USRDEF1 a, BYTE b)", proc.Frame);
+            var sProc = usb.ParseFunctionDeclaration("BYTE foo(USRDEF1 a, BYTE b)");
 
             Assert.AreEqual(
                 "fn(arg(BYTE),(arg(a,USRDEF1),arg(b,BYTE))",
                 sProc.Signature.ToString());
 
             //should not accept undefined type USRDEF2
-            sProc = usb.ParseFunctionDeclaration("BYTE foo(USRDEF1 a, USRDEF2 b)", proc.Frame);
+            sProc = usb.ParseFunctionDeclaration("BYTE foo(USRDEF1 a, USRDEF2 b)");
             Assert.AreEqual(null, sProc);
 
             //define USRDEF2 so parser should accept it
@@ -139,7 +139,7 @@ namespace Reko.UnitTests.Analysis
             program.EnvironmentMetadata.Types.Add(
                "USRDEF2", PrimitiveType.Create(PrimitiveType.Int16.Domain, 2));
 
-            sProc = usb.ParseFunctionDeclaration("BYTE foo(USRDEF1 a, USRDEF2 b)", proc.Frame);
+            sProc = usb.ParseFunctionDeclaration("BYTE foo(USRDEF1 a, USRDEF2 b)");
 
             Assert.AreEqual(
                 "fn(arg(BYTE),(arg(a,USRDEF1),arg(b,USRDEF2))",

--- a/src/UnitTests/Gui/Windows/Forms/ProcedureDialogInteractorTests.cs
+++ b/src/UnitTests/Gui/Windows/Forms/ProcedureDialogInteractorTests.cs
@@ -102,7 +102,7 @@ namespace Reko.UnitTests.Gui.Windows.Forms
         private class TestProcedureDialogInteractor : ProcedureDialogInteractor
         {
             public TestProcedureDialogInteractor(Procedure_v1 proc)
-                : base(new X86ArchitectureFlat32(), proc)
+                : base(new Program(), proc)
             {
             }
 


### PR DESCRIPTION
- Use CParser instead of SignatureParser
- Fix broken ProcedureDialogInteractor tests
- Remove unused frame argument from  UserSignatureBuilder::ParseFunctionDeclaration