### PR TITLE
Add unit tests for declaration text box

### DIFF
--- a/src/Gui/Forms/IDeclarationForm.cs
+++ b/src/Gui/Forms/IDeclarationForm.cs
@@ -1,6 +1,6 @@
 ﻿#region License
 /* 
- * Copyright (C) 1999-2016 John Källén.
+ * Copyright (C) 1999-2016 Pavel Tomin.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,25 +18,16 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows.Forms;
+using System.Drawing;
+using Reko.Gui.Controls;
 
-namespace Reko.Gui.Controls
+namespace Reko.Gui.Forms
 {
-    public interface ITextBox : IControl
+    public interface IDeclarationForm : IDialog
     {
-        event EventHandler TextChanged;
-        event KeyEventHandler KeyDown;
-        event EventHandler LostFocus;
-
-        bool Enabled { get; set; }
-        string Text { get; set; }
-
-        void SelectAll();
-
-        void Focus();
+        string HintText { get; set; }
+        ITextBox TextBox { get; }
+        void ShowAt(Point location);
+        void Hide();
     }
 }

--- a/src/Gui/Gui.csproj
+++ b/src/Gui/Gui.csproj
@@ -290,7 +290,12 @@
     <Compile Include="Windows\Controls\TextViewLayout.cs" />
     <Compile Include="Windows\Controls\TextViewPainter.cs" />
     <Compile Include="Windows\Controls\DeclarationTextBox.cs" />
-    <Compile Include="Windows\Forms\DeclarationForm.cs" />
+    <Compile Include="Windows\Forms\DeclarationForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Windows\Forms\DeclarationForm.Designer.cs">
+      <DependentUpon>DeclarationForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Windows\Forms\TextEncodingDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -583,6 +588,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Windows\Forms\CallSiteDialog.resx">
       <DependentUpon>CallSiteDialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Windows\Forms\DeclarationForm.resx">
+      <DependentUpon>DeclarationForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Windows\Forms\EditProjectDialog.resx">
       <DependentUpon>EditProjectDialog.cs</DependentUpon>

--- a/src/Gui/Gui.csproj
+++ b/src/Gui/Gui.csproj
@@ -289,7 +289,7 @@
     </Compile>
     <Compile Include="Windows\Controls\TextViewLayout.cs" />
     <Compile Include="Windows\Controls\TextViewPainter.cs" />
-    <Compile Include="Windows\Controls\DeclarationTextBox.cs" />
+    <Compile Include="Windows\Forms\DeclarationFormInteractor.cs" />
     <Compile Include="Windows\Forms\DeclarationForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/src/Gui/Gui.csproj
+++ b/src/Gui/Gui.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Design\ProgramResourceInstanceDesigner.cs" />
     <Compile Include="Forms\CallSiteInteractor.cs" />
     <Compile Include="Forms\IAssumedRegisterValuesDialog.cs" />
+    <Compile Include="Forms\IDeclarationForm.cs" />
     <Compile Include="Forms\IResourceEditor.cs" />
     <Compile Include="Forms\ResourceEditorInteractor.cs" />
     <Compile Include="ICallGraphViewService.cs" />
@@ -289,6 +290,7 @@
     <Compile Include="Windows\Controls\TextViewLayout.cs" />
     <Compile Include="Windows\Controls\TextViewPainter.cs" />
     <Compile Include="Windows\Controls\DeclarationTextBox.cs" />
+    <Compile Include="Windows\Forms\DeclarationForm.cs" />
     <Compile Include="Windows\Forms\TextEncodingDialog.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/src/Gui/IDialogFactory.cs
+++ b/src/Gui/IDialogFactory.cs
@@ -40,5 +40,6 @@ namespace Reko.Gui
         IUserPreferencesDialog CreateUserPreferencesDialog();
         IWorkerDialog CreateWorkerDialog();
         ITextEncodingDialog CreateTextEncodingDialog();
+        IDeclarationForm CreateDeclarationForm();
     }
 }

--- a/src/Gui/Windows/CombinedCodeViewInteractor.cs
+++ b/src/Gui/Windows/CombinedCodeViewInteractor.cs
@@ -27,6 +27,7 @@ using Reko.Core.Serialization;
 using Reko.Core.Types;
 using Reko.Gui.Forms;
 using Reko.Gui.Windows.Controls;
+using Reko.Gui.Windows.Forms;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
@@ -50,7 +51,7 @@ namespace Reko.Gui.Windows
         private NestedTextModel nestedTextModel;
         private GViewer gViewer;
 
-        private DeclarationTextBox declarationTextBox;
+        private DeclarationFormInteractor declarationFormInteractor;
 
         private ImageSegment segment;
         private bool showProcedures;
@@ -243,7 +244,7 @@ namespace Reko.Gui.Windows
             this.navInteractor = new NavigationInteractor<Address>();
             this.navInteractor.Attach(this.combinedCodeView);
 
-            declarationTextBox = new DeclarationTextBox(services);
+            declarationFormInteractor = new DeclarationFormInteractor(services);
 
             return combinedCodeView;
         }
@@ -390,7 +391,7 @@ namespace Reko.Gui.Windows
             }
             var anchorPt = combinedCodeView.MixedCodeDataView.GetAnchorTopPoint();
             var screenPoint = combinedCodeView.MixedCodeDataView.PointToScreen(anchorPt);
-            declarationTextBox.Show(screenPoint, program, addr);
+            declarationFormInteractor.Show(screenPoint, program, addr);
         }
 
         private void MixedCodeDataView_MouseDown(object sender, MouseEventArgs e)

--- a/src/Gui/Windows/CombinedCodeViewInteractor.cs
+++ b/src/Gui/Windows/CombinedCodeViewInteractor.cs
@@ -243,7 +243,7 @@ namespace Reko.Gui.Windows
             this.navInteractor = new NavigationInteractor<Address>();
             this.navInteractor.Attach(this.combinedCodeView);
 
-            declarationTextBox = new DeclarationTextBox(combinedCodeView, services);
+            declarationTextBox = new DeclarationTextBox(services);
 
             return combinedCodeView;
         }
@@ -390,8 +390,7 @@ namespace Reko.Gui.Windows
             }
             var anchorPt = combinedCodeView.MixedCodeDataView.GetAnchorTopPoint();
             var screenPoint = combinedCodeView.MixedCodeDataView.PointToScreen(anchorPt);
-            var clientPoint = combinedCodeView.PointToClient(screenPoint);
-            declarationTextBox.Show(clientPoint, program, addr);
+            declarationTextBox.Show(screenPoint, program, addr);
         }
 
         private void MixedCodeDataView_MouseDown(object sender, MouseEventArgs e)

--- a/src/Gui/Windows/Controls/DeclarationTextBox.cs
+++ b/src/Gui/Windows/Controls/DeclarationTextBox.cs
@@ -22,6 +22,8 @@ using Reko.Core;
 using Reko.Core.Types;
 using Reko.Core.Output;
 using Reko.Core.Serialization;
+using Reko.Gui.Windows.Forms;
+using Reko.Gui.Forms;
 using Reko.Analysis;
 using System;
 using System.IO;
@@ -31,12 +33,14 @@ using System.Windows.Forms;
 
 namespace Reko.Gui.Windows.Controls
 {
-    public class DeclarationTextBox : IDisposable
+    public class DeclarationTextBox
     {
         private IServiceProvider services;
 
-        private TextBox text;
-        private Label label;
+        private Control bgControl;// $TODO remove
+
+        private IDeclarationForm declarationForm;
+        private bool closing;
 
         private Program program;
         private Address address;
@@ -45,28 +49,19 @@ namespace Reko.Gui.Windows.Controls
 
         public DeclarationTextBox(Control bgControl, IServiceProvider services)
         {
-            Debug.Print(bgControl.GetType().FullName);
-            text = new TextBox
-            {
-                BorderStyle = BorderStyle.FixedSingle,
-                Parent = bgControl,
-                Visible = false,
-            };
-            label = new Label
-            {
-                ForeColor = SystemColors.ControlText,
-                BackColor = SystemColors.Info,
-                BorderStyle = BorderStyle.FixedSingle,
-                AutoSize = true,
-                Parent = bgControl,
-                Visible = false,
-            };
-
-            text.LostFocus += text_LostFocus;
-            text.TextChanged += text_TextChanged;
-            text.KeyDown += text_KeyDown;
-
             this.services = services;
+            this.bgControl = bgControl;
+        }
+
+        private void CreateDeclarationForm()
+        {
+            var dlgFactory = services.RequireService<IDialogFactory>();
+            this.declarationForm = dlgFactory.CreateDeclarationForm();
+            ((DeclarationForm)declarationForm).SetBgControl(bgControl);
+
+            declarationForm.TextBox.LostFocus += text_LostFocus;
+            declarationForm.TextBox.TextChanged += text_TextChanged;
+            declarationForm.TextBox.KeyDown += text_KeyDown;
         }
 
         private string LabelText()
@@ -84,7 +79,7 @@ namespace Reko.Gui.Windows.Controls
             {
                 case Keys.Enter:
                 case Keys.Escape:
-                    HideControls();
+                    SaveAndClose();
                     e.SuppressKeyPress = true;
                     e.Handled = true;
                     break;
@@ -96,16 +91,10 @@ namespace Reko.Gui.Windows.Controls
             this.program = program;
             this.address = address;
             this.editProcedure = program.Procedures.ContainsKey(address);
-            label.Text = LabelText();
-            label.Location = new Point(location.X, location.Y - text.Height - label.Height);
-            text.Text = GetDeclarationText();
-            text.Location = new Point(location.X, location.Y - text.Height);
-            text.Width = label.Width;
-            label.BringToFront();
-            text.Visible = true;
-            label.Visible = true;
-            text.BringToFront();
-            text.Focus();
+            CreateDeclarationForm();
+            declarationForm.HintText = LabelText();
+            declarationForm.TextBox.Text = GetDeclarationText();
+            declarationForm.ShowAt(location);
         }
 
         private string GetDeclarationText()
@@ -149,8 +138,19 @@ namespace Reko.Gui.Windows.Controls
 
         public void HideControls()
         {
-            text.Visible = false;
-            label.Visible = false;
+            declarationForm.Hide();
+            declarationForm.Dispose();
+            declarationForm = null;
+        }
+
+        private void SaveAndClose()
+        {
+            if (closing)
+                return;
+            closing = true;
+            ModifyDeclaration();
+            HideControls();
+            closing = false;
         }
 
         void text_TextChanged(object sender, EventArgs e)
@@ -160,41 +160,32 @@ namespace Reko.Gui.Windows.Controls
 
         void text_LostFocus(object sender, EventArgs e)
         {
-            HideControls();
-            ModifyDeclaration();
-        }
-
-        public void Dispose()
-        {
-            if (text != null) text.Dispose();
-            if (label != null) label.Dispose();
-            text = null;
-            label = null;
+            SaveAndClose();
         }
 
         private void EnableControls()
         {
             ProcedureBase_v1 sProc;
             GlobalDataItem_v2 global;
-            var procText = text.Text;
+            var procText = declarationForm.TextBox.Text;
             if (TryParseSignature(procText, out sProc))
             {
-                text.ForeColor = SystemColors.ControlText;
+                declarationForm.TextBox.ForeColor = SystemColors.ControlText;
                 return;
             }
             if (!editProcedure && TryParseGlobal(procText, out global))
             {
-                text.ForeColor = SystemColors.ControlText;
+                declarationForm.TextBox.ForeColor = SystemColors.ControlText;
                 return;
             }
             // If parser failed, perhaps it's simply a valid name? 
             if (UserSignatureBuilder.IsValidCIdentifier(procText))
             {
-                text.ForeColor = SystemColors.ControlText; ;
+                declarationForm.TextBox.ForeColor = SystemColors.ControlText; ;
                 return;
             }
             // Not valid name either, die.
-            text.ForeColor = Color.Red;
+            declarationForm.TextBox.ForeColor = Color.Red;
         }
 
         private bool TryParseSignature(string txtSignature, out ProcedureBase_v1 sProc)
@@ -227,7 +218,7 @@ namespace Reko.Gui.Windows.Controls
 
         private void ModifyDeclaration()
         {
-            var declText = text.Text.Trim();
+            var declText = declarationForm.TextBox.Text.Trim();
             Procedure proc;
             if (!program.Procedures.TryGetValue(address, out proc))
                 proc = null;

--- a/src/Gui/Windows/Controls/DeclarationTextBox.cs
+++ b/src/Gui/Windows/Controls/DeclarationTextBox.cs
@@ -22,12 +22,10 @@ using Reko.Core;
 using Reko.Core.Types;
 using Reko.Core.Output;
 using Reko.Core.Serialization;
-using Reko.Gui.Windows.Forms;
 using Reko.Gui.Forms;
 using Reko.Analysis;
 using System;
 using System.IO;
-using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -37,8 +35,6 @@ namespace Reko.Gui.Windows.Controls
     {
         private IServiceProvider services;
 
-        private Control bgControl;// $TODO remove
-
         private IDeclarationForm declarationForm;
         private bool closing;
 
@@ -47,17 +43,15 @@ namespace Reko.Gui.Windows.Controls
 
         private bool editProcedure;
 
-        public DeclarationTextBox(Control bgControl, IServiceProvider services)
+        public DeclarationTextBox(IServiceProvider services)
         {
             this.services = services;
-            this.bgControl = bgControl;
         }
 
         private void CreateDeclarationForm()
         {
             var dlgFactory = services.RequireService<IDialogFactory>();
             this.declarationForm = dlgFactory.CreateDeclarationForm();
-            ((DeclarationForm)declarationForm).SetBgControl(bgControl);
 
             declarationForm.TextBox.LostFocus += text_LostFocus;
             declarationForm.TextBox.TextChanged += text_TextChanged;

--- a/src/Gui/Windows/Forms/DeclarationForm.Designer.cs
+++ b/src/Gui/Windows/Forms/DeclarationForm.Designer.cs
@@ -1,0 +1,93 @@
+﻿#region License
+/* 
+ * Copyright (C) 1999-2016 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+namespace Reko.Gui.Windows.Forms
+{
+    partial class DeclarationForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label = new System.Windows.Forms.Label();
+            this.text = new System.Windows.Forms.TextBox();
+            this.SuspendLayout();
+            // 
+            // label
+            // 
+            this.label.AutoSize = true;
+            this.label.Location = new System.Drawing.Point(9, 9);
+            this.label.Name = "label";
+            this.label.Size = new System.Drawing.Size(29, 13);
+            this.label.TabIndex = 0;
+            this.label.Text = "label";
+            // 
+            // text
+            // 
+            this.text.Location = new System.Drawing.Point(12, 25);
+            this.text.Name = "text";
+            this.text.Size = new System.Drawing.Size(100, 20);
+            this.text.TabIndex = 1;
+            // 
+            // DeclarationForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
+            this.ClientSize = new System.Drawing.Size(284, 59);
+            this.ControlBox = false;
+            this.Controls.Add(this.text);
+            this.Controls.Add(this.label);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Name = "DeclarationForm";
+            this.Text = "Edit declaration";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label;
+        private System.Windows.Forms.TextBox text;
+    }
+}

--- a/src/Gui/Windows/Forms/DeclarationForm.cs
+++ b/src/Gui/Windows/Forms/DeclarationForm.cs
@@ -1,0 +1,103 @@
+﻿#region License
+/* 
+ * Copyright (C) 1999-2016 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Drawing;
+using System.Windows.Forms;
+using Reko.Gui.Controls;
+using Reko.Gui.Forms;
+
+namespace Reko.Gui.Windows.Forms
+{
+    public class DeclarationForm : IDeclarationForm
+    {
+        private TextBox text;
+        private Label label;
+
+        private ITextBox textWrapped;
+
+        public DeclarationForm()
+        {
+            text = new TextBox
+            {
+                BorderStyle = BorderStyle.FixedSingle,
+                Visible = false,
+            };
+            label = new Label
+            {
+                ForeColor = SystemColors.ControlText,
+                BackColor = SystemColors.Info,
+                BorderStyle = BorderStyle.FixedSingle,
+                AutoSize = true,
+                Visible = false,
+            };
+            textWrapped = new TextBoxWrapper(text);
+        }
+
+        // $TODO remove
+        public void SetBgControl(Control bgControl)
+        {
+            text.Parent = bgControl;
+            label.Parent = bgControl;
+        }
+
+        public string HintText {
+            get
+            {
+                return label.Text;
+            }
+            set
+            {
+                label.Text = value;
+            }
+        }
+
+        public virtual ITextBox TextBox { get { return textWrapped; } }
+
+
+        public void ShowAt(Point location)
+        {
+            label.Location = new Point(location.X, location.Y - text.Height - label.Height);
+            text.Location = new Point(location.X, location.Y - text.Height);
+            text.Width = label.Width;
+            label.BringToFront();
+            text.Visible = true;
+            label.Visible = true;
+            text.BringToFront();
+            text.Focus();
+        }
+
+        public void Hide()
+        {
+            label.Visible = false;
+            text.Visible = false;
+        }
+
+        public void Dispose()
+        {
+            if (text != null) text.Dispose();
+            if (label != null) label.Dispose();
+            text = null;
+            label = null;
+        }
+    }
+}

--- a/src/Gui/Windows/Forms/DeclarationForm.cs
+++ b/src/Gui/Windows/Forms/DeclarationForm.cs
@@ -18,9 +18,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Drawing;
 using System.Windows.Forms;
 using Reko.Gui.Controls;
@@ -28,39 +25,18 @@ using Reko.Gui.Forms;
 
 namespace Reko.Gui.Windows.Forms
 {
-    public class DeclarationForm : IDeclarationForm
+    public partial class DeclarationForm : Form, IDeclarationForm
     {
-        private TextBox text;
-        private Label label;
-
         private ITextBox textWrapped;
 
         public DeclarationForm()
         {
-            text = new TextBox
-            {
-                BorderStyle = BorderStyle.FixedSingle,
-                Visible = false,
-            };
-            label = new Label
-            {
-                ForeColor = SystemColors.ControlText,
-                BackColor = SystemColors.Info,
-                BorderStyle = BorderStyle.FixedSingle,
-                AutoSize = true,
-                Visible = false,
-            };
+            InitializeComponent();
             textWrapped = new TextBoxWrapper(text);
         }
 
-        // $TODO remove
-        public void SetBgControl(Control bgControl)
+        public string HintText
         {
-            text.Parent = bgControl;
-            label.Parent = bgControl;
-        }
-
-        public string HintText {
             get
             {
                 return label.Text;
@@ -76,28 +52,9 @@ namespace Reko.Gui.Windows.Forms
 
         public void ShowAt(Point location)
         {
-            label.Location = new Point(location.X, location.Y - text.Height - label.Height);
-            text.Location = new Point(location.X, location.Y - text.Height);
             text.Width = label.Width;
-            label.BringToFront();
-            text.Visible = true;
-            label.Visible = true;
-            text.BringToFront();
-            text.Focus();
-        }
-
-        public void Hide()
-        {
-            label.Visible = false;
-            text.Visible = false;
-        }
-
-        public void Dispose()
-        {
-            if (text != null) text.Dispose();
-            if (label != null) label.Dispose();
-            text = null;
-            label = null;
+            this.Show();
+            this.Location = new Point(location.X, location.Y - this.Height);
         }
     }
 }

--- a/src/Gui/Windows/Forms/DeclarationForm.resx
+++ b/src/Gui/Windows/Forms/DeclarationForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/Gui/Windows/Forms/DeclarationFormInteractor.cs
+++ b/src/Gui/Windows/Forms/DeclarationFormInteractor.cs
@@ -29,9 +29,9 @@ using System.IO;
 using System.Drawing;
 using System.Windows.Forms;
 
-namespace Reko.Gui.Windows.Controls
+namespace Reko.Gui.Windows.Forms
 {
-    public class DeclarationTextBox
+    public class DeclarationFormInteractor
     {
         private IServiceProvider services;
 
@@ -43,7 +43,7 @@ namespace Reko.Gui.Windows.Controls
 
         private bool editProcedure;
 
-        public DeclarationTextBox(IServiceProvider services)
+        public DeclarationFormInteractor(IServiceProvider services)
         {
             this.services = services;
         }

--- a/src/Gui/Windows/TextBoxWrapper.cs
+++ b/src/Gui/Windows/TextBoxWrapper.cs
@@ -20,9 +20,7 @@
 
 using Reko.Gui.Controls;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace Reko.Gui.Windows
@@ -41,6 +39,8 @@ namespace Reko.Gui.Windows
 
         public bool Enabled { get { return text.Enabled; } set { text.Enabled = value; } }
         public string Text { get { return text.Text; } set { text.Text = value;  } }
+        public Color BackColor { get { return text.BackColor; } set { text.BackColor = value; } }
+        public Color ForeColor { get { return text.ForeColor; } set { text.ForeColor = value; } }
 
         public void SelectAll() {
             text.SelectAll();
@@ -61,6 +61,12 @@ namespace Reko.Gui.Windows
         {
             add { text.TextChanged += value; }
             remove { text.TextChanged -= value; }
+        }
+
+        public event EventHandler LostFocus
+        {
+            add { text.LostFocus += value; }
+            remove { text.LostFocus -= value; }
         }
     }
 }

--- a/src/Gui/Windows/ToolStripTextBoxWrapper.cs
+++ b/src/Gui/Windows/ToolStripTextBoxWrapper.cs
@@ -20,10 +20,7 @@
 
 using Reko.Gui.Controls;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace Reko.Gui.Windows
@@ -39,6 +36,8 @@ namespace Reko.Gui.Windows
 
         public bool Enabled { get { return textbox.Enabled; } set { textbox.Enabled = value; } }
         public string Text { get { return textbox.Text; } set { textbox.Text = value; } }
+        public Color BackColor { get { return textbox.BackColor; } set { textbox.BackColor = value; } }
+        public Color ForeColor { get { return textbox.ForeColor; } set { textbox.ForeColor = value; } }
 
         public void SelectAll()
         {
@@ -60,6 +59,12 @@ namespace Reko.Gui.Windows
         {
             add { textbox.TextChanged += value; }
             remove { textbox.TextChanged -= value; }
+        }
+
+        public event EventHandler LostFocus
+        {
+            add { textbox.LostFocus += value; }
+            remove { textbox.LostFocus -= value; }
         }
     }
 }

--- a/src/Gui/Windows/WindowsFormsDialogFactory.cs
+++ b/src/Gui/Windows/WindowsFormsDialogFactory.cs
@@ -144,6 +144,11 @@ namespace Reko.Gui.Windows
         {
             return new TextEncodingDialog();
         }
+
+        public IDeclarationForm CreateDeclarationForm()
+        {
+            return new DeclarationForm();
+        }
     }
 }
 

--- a/src/UnitTests/Gui/Windows/Forms/DeclarationFormInteractorTests.cs
+++ b/src/UnitTests/Gui/Windows/Forms/DeclarationFormInteractorTests.cs
@@ -30,7 +30,7 @@ using Reko.Core.Serialization;
 using Reko.Gui;
 using Reko.Gui.Controls;
 using Reko.Gui.Forms;
-using Reko.Gui.Windows.Controls;
+using Reko.Gui.Windows.Forms;
 using System.ComponentModel.Design;
 using NUnit.Framework;
 
@@ -39,7 +39,7 @@ namespace Reko.UnitTests.Gui.Windows.Forms
     class DeclarationFormInteractorTests
     {
         MockRepository mr;
-        private DeclarationTextBox interactor;
+        private DeclarationFormInteractor interactor;
         private IDeclarationForm declarationForm;
         private FakeTextBox textBox;
         private Program program;
@@ -59,7 +59,7 @@ namespace Reko.UnitTests.Gui.Windows.Forms
             dlgFactory.Stub(f => f.CreateDeclarationForm()).Return(declarationForm);
             services.AddService<IDialogFactory>(dlgFactory);
             mr.ReplayAll();
-            interactor = new DeclarationTextBox(services);
+            interactor = new DeclarationFormInteractor(services);
             var mem = new MemoryArea(Address32.Ptr32(0x10), new byte[40]);
             var seg = new ImageSegment(".text", mem, AccessMode.ReadWrite);
             var imageMap = new ImageMap(Address32.Ptr32(0x05), seg);

--- a/src/UnitTests/Gui/Windows/Forms/DeclarationFormInteractorTests.cs
+++ b/src/UnitTests/Gui/Windows/Forms/DeclarationFormInteractorTests.cs
@@ -20,10 +20,7 @@
  
 using System;
 using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
-using Reko.Gui.Windows.Forms;
 using Rhino.Mocks;
 using Reko.Arch.X86;
 using Reko.Environments.Windows;
@@ -51,16 +48,18 @@ namespace Reko.UnitTests.Gui.Windows.Forms
         public void Setup()
         {
             mr = new MockRepository();
-            var bgControl = new TextBox();
             var services = new ServiceContainer();
-            declarationForm = mr.Stub<DeclarationForm>();
+            declarationForm = mr.Stub<IDeclarationForm>();
             textBox = new FakeTextBox();
             declarationForm.Stub(f => f.TextBox).Return(textBox);
+            declarationForm.Stub(f => f.ShowAt(new Point()));
+            declarationForm.Stub(f => f.Hide());
+            declarationForm.Stub(f => f.Dispose());
             var dlgFactory = mr.Stub<IDialogFactory>();
             dlgFactory.Stub(f => f.CreateDeclarationForm()).Return(declarationForm);
             services.AddService<IDialogFactory>(dlgFactory);
             mr.ReplayAll();
-            interactor = new DeclarationTextBox(bgControl, services);
+            interactor = new DeclarationTextBox(services);
             var mem = new MemoryArea(Address32.Ptr32(0x10), new byte[40]);
             var seg = new ImageSegment(".text", mem, AccessMode.ReadWrite);
             var imageMap = new ImageMap(Address32.Ptr32(0x05), seg);

--- a/src/UnitTests/Gui/Windows/Forms/DeclarationFormInteractorTests.cs
+++ b/src/UnitTests/Gui/Windows/Forms/DeclarationFormInteractorTests.cs
@@ -1,0 +1,189 @@
+﻿#region License
+/* 
+ * Copyright (C) 1999-2016 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+ 
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using Reko.Gui.Windows.Forms;
+using Rhino.Mocks;
+using Reko.Arch.X86;
+using Reko.Environments.Windows;
+using Reko.Core;
+using Reko.Core.Types;
+using Reko.Core.Serialization;
+using Reko.Gui;
+using Reko.Gui.Controls;
+using Reko.Gui.Forms;
+using Reko.Gui.Windows.Controls;
+using System.ComponentModel.Design;
+using NUnit.Framework;
+
+namespace Reko.UnitTests.Gui.Windows.Forms
+{
+    class DeclarationFormInteractorTests
+    {
+        MockRepository mr;
+        private DeclarationTextBox interactor;
+        private IDeclarationForm declarationForm;
+        private FakeTextBox textBox;
+        private Program program;
+
+        [SetUp]
+        public void Setup()
+        {
+            mr = new MockRepository();
+            var bgControl = new TextBox();
+            var services = new ServiceContainer();
+            declarationForm = mr.Stub<DeclarationForm>();
+            textBox = new FakeTextBox();
+            declarationForm.Stub(f => f.TextBox).Return(textBox);
+            var dlgFactory = mr.Stub<IDialogFactory>();
+            dlgFactory.Stub(f => f.CreateDeclarationForm()).Return(declarationForm);
+            services.AddService<IDialogFactory>(dlgFactory);
+            mr.ReplayAll();
+            interactor = new DeclarationTextBox(bgControl, services);
+            var mem = new MemoryArea(Address32.Ptr32(0x10), new byte[40]);
+            var seg = new ImageSegment(".text", mem, AccessMode.ReadWrite);
+            var imageMap = new ImageMap(Address32.Ptr32(0x05), seg);
+            var arch = new X86ArchitectureFlat32();
+            var platform = new Win32Platform(null, arch);
+            program = new Program(imageMap, arch, platform);
+        }
+
+        private void CloseForm()
+        {
+            textBox.FireLostFocus();
+        }
+
+        private void Given_ImageMapItem(uint addr, DataType dataType, string name)
+        {
+            var address = Address32.Ptr32(addr);
+            var item = new ImageMapItem
+            {
+                Address = address,
+                DataType = dataType,
+                Name = name,
+                Size = (uint)dataType.Size,
+            };
+            program.ImageMap.AddItem(address, item);
+        }
+
+        private void Given_ProcedureName(uint addr, string name)
+        {
+            var address = Address32.Ptr32(addr);
+            var proc = new Procedure(name, null);
+            program.Procedures[address] = proc;
+        }
+
+        private void Given_ProcedureSignature(uint addr, string CSignature)
+        {
+            var address = Address32.Ptr32(addr);
+            var sProc = new Procedure_v1()
+            {
+                CSignature = CSignature,
+            };
+            program.User.Procedures[address] = sProc;
+        }
+
+        [Test]
+        public void Dfi_CreateGlobalInt32()
+        {
+            interactor.Show(new Point(0, 0), program, Address32.Ptr32(0x13));
+            Assert.AreEqual("", declarationForm.TextBox.Text);
+            declarationForm.TextBox.Text = "int a(";
+            Assert.AreEqual(Color.Red, declarationForm.TextBox.ForeColor);
+            declarationForm.TextBox.Text = "int a";
+            Assert.AreEqual(SystemColors.ControlText, declarationForm.TextBox.ForeColor);
+            CloseForm();
+            Assert.AreEqual(1, program.User.Globals.Count);
+            Assert.AreEqual("00000013", program.User.Globals.Keys[0].ToString());
+            Assert.AreEqual("prim(SignedInt,4)", program.User.Globals.Values[0].DataType.ToString());
+            Assert.AreEqual("a", program.User.Globals.Values[0].Name);
+        }
+
+        [Test]
+        public void Dfi_EditGlobalReal64()
+        {
+            Given_ImageMapItem(0x14, PrimitiveType.Real64, "DB");
+            interactor.Show(new Point(0, 0), program, Address32.Ptr32(0x14));
+            Assert.AreEqual("double DB", declarationForm.TextBox.Text);
+        }
+
+        [Test]
+        public void Dfi_EditProcedureSignature()
+        {
+            Given_ProcedureSignature(0x16, "float test(float b)");
+            interactor.Show(new Point(0, 0), program, Address32.Ptr32(0x16));
+            Assert.AreEqual("float test(float b)", declarationForm.TextBox.Text);
+            declarationForm.TextBox.Text = "float test(floatb b)";
+            Assert.AreEqual(Color.Red, declarationForm.TextBox.ForeColor);
+        }
+
+        [Test]
+        public void Dfi_EditProcedureName()
+        {
+            Given_ProcedureName(0x15, "fn123");
+            interactor.Show(new Point(0, 0), program, Address32.Ptr32(0x15));
+            Assert.AreEqual("fn123", declarationForm.TextBox.Text);
+            declarationForm.TextBox.Text = "fn123456";
+            Assert.AreEqual(SystemColors.ControlText, declarationForm.TextBox.ForeColor);
+            CloseForm();
+            Assert.AreEqual(1, program.User.Procedures.Count);
+            Assert.AreEqual(1, program.Procedures.Count);
+            Assert.AreEqual("fn123456", program.User.Procedures.Values[0].Name);
+            Assert.AreEqual("fn123456", program.Procedures.Values[0].Name);
+        }
+
+        private class FakeTextBox : ITextBox
+        {
+            private string text;
+
+            public bool Enabled { get; set; }
+            public string Text
+            {
+                get { return text == null ? "" : text; }
+                set { text = value; TextChanged.Fire(this); }
+            }
+            public Color BackColor { get; set; }
+            public Color ForeColor { get; set; }
+
+            public void SelectAll()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Focus()
+            {
+                throw new NotImplementedException();
+            }
+
+            public event KeyEventHandler KeyDown;
+            public event EventHandler TextChanged;
+            public event EventHandler LostFocus;
+
+            public void FireLostFocus()
+            {
+                LostFocus.Fire(this);
+            }
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Gui\Windows\TextSpanFormatterTests.cs" />
     <Compile Include="Gui\Windows\Forms\OpenAsInteractorTests.cs" />
     <Compile Include="Gui\Windows\Forms\SearchDialogInteractorTests.cs" />
+    <Compile Include="Gui\Windows\Forms\DeclarationFormInteractorTests.cs" />
     <Compile Include="Gui\Windows\ProjectBrowserServiceTests.cs" />
     <Compile Include="Gui\Windows\WindowsFormsSettingsServiceTests.cs" />
     <Compile Include="ImageLoaders\Elf\ElfImageLoaderTests.cs" />


### PR DESCRIPTION
1. Modify DeclarationTextBox so that it uses dialog factory for creation of form (and rename it to DeclarationFormInteractor)
2. Create unit tests for DeclarationFormInteractor
3. Modify DeclarationForm view.
It was:

![sample2](https://cloud.githubusercontent.com/assets/13188041/14582784/ed08482c-0427-11e6-9245-d6e5260d8e67.jpg)

Now it is:

![sample1](https://cloud.githubusercontent.com/assets/13188041/14582785/00808c84-0428-11e6-8664-28afd9895074.jpg)
