### PR TITLE
Use CodeViewerService to display globals

### DIFF
--- a/src/Gui/Design/GlobalVariablesNodeDesigner.cs
+++ b/src/Gui/Design/GlobalVariablesNodeDesigner.cs
@@ -47,18 +47,8 @@ namespace Reko.Gui.Design
 
         public override void DoDefaultAction()
         {
-            var uiSvc = Services.RequireService<IDecompilerShellUiService>();
-            var windowType = typeof(CombinedCodeViewInteractor).Name;
-            var frame = uiSvc.FindDocumentWindow(windowType, segment);
-            if (frame == null)
-            {
-                var pane = new CombinedCodeViewInteractor();
-                var label = string.Format(Resources.SegmentGlobalsFmt, segment.Name);
-                frame = uiSvc.CreateDocumentWindow(windowType, segment, label, pane);
-            }
-            frame.Show();
             var program = Host.GetAncestorOfType<Program>(this);
-            ((CombinedCodeViewInteractor)frame.Pane).DisplayGlobals(program, segment);
+            Services.RequireService<ICodeViewerService>().DisplayGlobals(program, segment);
         }
     }
 }

--- a/src/Gui/ICodeViewerService.cs
+++ b/src/Gui/ICodeViewerService.cs
@@ -30,6 +30,7 @@ namespace Reko.Gui
     public interface ICodeViewerService
     {
         void DisplayProcedure(Program program, Procedure proc);
+        void DisplayGlobals(Program program, ImageSegment segment);
         void DisplayDataType(Program program, DataType dt);
     }
 }

--- a/src/Gui/Windows/CodeViewerServiceImpl.cs
+++ b/src/Gui/Windows/CodeViewerServiceImpl.cs
@@ -58,6 +58,20 @@ namespace Reko.Gui.Windows
 #endif
         }
 
+        public void DisplayGlobals(Program program, ImageSegment segment)
+        {
+            var windowType = typeof(CombinedCodeViewInteractor).Name;
+            var frame = ShellUiSvc.FindDocumentWindow(windowType, segment);
+            if (frame == null)
+            {
+                var pane = new CombinedCodeViewInteractor();
+                var label = string.Format(Resources.SegmentGlobalsFmt, segment.Name);
+                frame = ShellUiSvc.CreateDocumentWindow(windowType, segment, label, pane);
+            }
+            frame.Show();
+            ((CombinedCodeViewInteractor)frame.Pane).DisplayGlobals(program, segment);
+        }
+
         public void DisplayDataType(Program program, DataType dt)
         {
             if (dt == null)

--- a/src/UnitTests/Gui/Windows/CodeViewerServiceTests.cs
+++ b/src/UnitTests/Gui/Windows/CodeViewerServiceTests.cs
@@ -49,6 +49,64 @@ namespace Reko.UnitTests.Gui.Windows
             };
         }
 
+        [Test]
+        public void Cvp_CreateProcedureViewerIfNotVisible()
+        {
+            var m = new ProcedureBuilder();
+            m.Return();
+
+            var uiSvc = AddMockService<IDecompilerShellUiService>();
+            uiSvc.Expect(s => s.FindDocumentWindow(
+                    "CombinedCodeViewInteractor", m.Procedure))
+                .Return(null);
+            var windowPane = mr.Stub<CombinedCodeViewInteractor>();
+            var windowFrame = mr.StrictMock<IWindowFrame>();
+            windowFrame.Stub(f => f.Pane).Return(windowPane);
+            uiSvc.Expect(s => s.CreateDocumentWindow(
+                    Arg<string>.Is.Equal("CombinedCodeViewInteractor"),
+                Arg<string>.Is.Equal(m.Procedure),
+                Arg<string>.Is.Equal(m.Procedure.Name),
+                Arg<IWindowPane>.Is.Anything))
+                .Return(windowFrame);
+            windowFrame.Expect(s => s.Show());
+
+            mr.ReplayAll();
+
+            var codeViewerSvc = new CodeViewerServiceImpl(sc);
+            codeViewerSvc.DisplayProcedure(program, m.Procedure);
+
+            uiSvc.VerifyAllExpectations();
+        }
+
+        [Test]
+        public void Cvp_CreateGlobalsViewerIfNotVisible()
+        {
+            var segment = new ImageSegment(
+                ".seg", Address32.Ptr32(0x17), 0, AccessMode.ReadWrite);
+            var label = ".seg global variables";
+
+            var uiSvc = AddMockService<IDecompilerShellUiService>();
+            uiSvc.Expect(s => s.FindDocumentWindow(
+                    "CombinedCodeViewInteractor", segment))
+                .Return(null);
+            var windowPane = mr.Stub<CombinedCodeViewInteractor>();
+            var windowFrame = mr.StrictMock<IWindowFrame>();
+            windowFrame.Stub(f => f.Pane).Return(windowPane);
+            uiSvc.Expect(s => s.CreateDocumentWindow(
+                    Arg<string>.Is.Equal("CombinedCodeViewInteractor"),
+                Arg<string>.Is.Equal(segment),
+                Arg<string>.Is.Equal(label),
+                Arg<IWindowPane>.Is.Anything))
+                .Return(windowFrame);
+            windowFrame.Expect(s => s.Show());
+
+            mr.ReplayAll();
+
+            var codeViewerSvc = new CodeViewerServiceImpl(sc);
+            codeViewerSvc.DisplayGlobals(program, segment);
+
+            uiSvc.VerifyAllExpectations();
+        }
 
         private T AddMockService<T>() where T : class
         {


### PR DESCRIPTION
- Use CodeViewerService to display globals instead of direct call of CombinedCodeViewInteractor constructor
- Create unit tests for CodeViewerServiceImpl