### PR TITLE
Detach image map changed event if MixedCodeDataControl is disposed

### DIFF
--- a/src/Gui/Windows/Controls/MixedCodeDataControl.cs
+++ b/src/Gui/Windows/Controls/MixedCodeDataControl.cs
@@ -36,6 +36,8 @@ namespace Reko.Gui.Windows.Controls
             this.ProgramChanged += delegate { OnProgramChanged(); };
 
             OnProgramChanged();
+
+            this.Disposed += MixedCodeDataControl_Disposed;
         }
 
         public Program Program {
@@ -107,6 +109,12 @@ namespace Reko.Gui.Windows.Controls
                 BeginInvoke(new Action(RefreshModel));
             else
                 RefreshModel();
+        }
+
+        private void MixedCodeDataControl_Disposed(object sender, EventArgs e)
+        {
+            if (program != null)
+                program.ImageMap.MapChanged -= ImageMap_MapChanged;
         }
 
         public Address GetAnchorAddress()


### PR DESCRIPTION
This is not fix for #209. This is another bug. It is occurs when disposed MixedCodeDataControl tries to refresh model when image map was changed.
 e.g. open combined code view, then close it. Open other procedure in combined code view. Try to add new global variable. The System.ObjectDisposedException will be thrown.