### PR TITLE
TypeTransformer: do not transform user-defined structs and unions

### DIFF
--- a/src/Decompiler/Typing/TypeTransformer.cs
+++ b/src/Decompiler/Typing/TypeTransformer.cs
@@ -60,7 +60,8 @@ namespace Reko.Typing
 			this.eventListener = eventListener;
 			this.unifier = new Unifier(factory);
 			this.comparer = new DataTypeComparer();
-		}
+            this.visitedTypes = new HashSet<DataType>();
+        }
 
 		public bool Changed
 		{

--- a/src/Decompiler/Typing/TypeTransformer.cs
+++ b/src/Decompiler/Typing/TypeTransformer.cs
@@ -353,6 +353,9 @@ namespace Reko.Typing
 
         public DataType VisitStructure(StructureType str)
 		{
+            // Do not transform user-defined types
+            if (str.UserDefined)
+                return str;
             if (visitedTypes.Contains(str))
                 return str;
             visitedTypes.Add(str);
@@ -382,6 +385,9 @@ namespace Reko.Typing
 
 		public DataType VisitUnion(UnionType ut)
 		{
+            // Do not transform user-defined types
+            if (ut.UserDefined)
+                return ut;
             foreach (var alt in ut.Alternatives.Values)
             {
                 alt.DataType = alt.DataType.Accept(this);

--- a/src/UnitTests/Typing/TypeTransformTests.cs
+++ b/src/UnitTests/Typing/TypeTransformTests.cs
@@ -369,5 +369,31 @@ namespace Reko.UnitTests.Typing
         {
             RunTest(Fragments.MemStore, "Typing/TtranMemStore.txt");
         }
+
+        [Test]
+        public void TtranUserStruct()
+        {
+            var t1 = new StructureType("T1", 4, true);
+            var t2 = new StructureType("T2", 0, true)
+            {
+                Fields = { { 0, t1 } }
+            };
+            var ttran = new TypeTransformer(factory, store, null);
+            var dt = t2.Accept(ttran);
+            Assert.AreSame(t2, dt, "Should not affect user-defined types");
+        }
+
+        [Test]
+        public void TtranNonUserStruct()
+        {
+            var t1 = new StructureType("T1", 4, true);
+            var t2 = new StructureType("T2", 0, false)
+            {
+                Fields = { { 0, t1 } }
+            };
+            var ttran = new TypeTransformer(factory, store, null);
+            var dt = t2.Accept(ttran);
+            Assert.AreSame(t1, dt, "Should reduce fields at offset 0 ");
+        }
     }
 }


### PR DESCRIPTION
I have modified DataTypeTransformer so that it does not transform user-defined structs and unions in a421e30. John, should be the same changes applied to TypeTransformer?