### PR TITLE
NestedComplexTypeExtractor: do not transform user-defined structs and unions

### DIFF
--- a/src/Decompiler/Typing/NestedComplexTypeExtractor.cs
+++ b/src/Decompiler/Typing/NestedComplexTypeExtractor.cs
@@ -90,6 +90,9 @@ namespace Reko.Typing
 
 		public override DataType VisitStructure(StructureType str)
 		{
+            // Do not transform user-defined types
+            if (str.UserDefined)
+                return str;
             if (visitedTypes.Contains(str))
                 return str;
             visitedTypes.Add(str);
@@ -109,7 +112,10 @@ namespace Reko.Typing
 
 		public override DataType VisitUnion(UnionType ut)
 		{
-			if (insideComplexType)
+            // Do not transform user-defined types
+            if (ut.UserDefined)
+                return ut;
+            if (insideComplexType)
 			{
 				changed = true;
 				NestedComplexTypeExtractor nctr = new NestedComplexTypeExtractor(factory, store);

--- a/src/UnitTests/Typing/NestedComplexTypeExtractorTests.cs
+++ b/src/UnitTests/Typing/NestedComplexTypeExtractorTests.cs
@@ -62,6 +62,72 @@ namespace Reko.UnitTests.Typing
         }
 
         [Test]
+        public void ArrayOfUserDefinedStructures()
+        {
+            var s = new StructureType(null, 0, true);
+            s.Fields.Add(0, PrimitiveType.Word32);
+            s.Fields.Add(4, PrimitiveType.Real64);
+
+            ArrayType a = new ArrayType(s, 0);
+
+            TypeVariable tv = store.CreateTypeVariable(factory);
+            tv.Class.DataType = a;
+            Assert.AreEqual(1, store.UsedEquivalenceClasses.Count);
+
+            DataType dt = tv.Class.DataType.Accept(nct);
+
+            Assert.AreEqual(1, store.UsedEquivalenceClasses.Count);
+            Assert.AreEqual(
+                "(arr (struct (0 word32 dw0000) (4 real64 r0004)))",
+                store.UsedEquivalenceClasses[0].DataType.ToString());
+        }
+
+        [Test]
+        public void ArrayOfUnions()
+        {
+            var ut = new UnionType(null, null, false);
+            ut.AddAlternative(PrimitiveType.Word32);
+            ut.AddAlternative(PrimitiveType.Real64);
+
+            ArrayType a = new ArrayType(ut, 0);
+
+            TypeVariable tv = store.CreateTypeVariable(factory);
+            tv.Class.DataType = a;
+            Assert.AreEqual(1, store.UsedEquivalenceClasses.Count);
+
+            DataType dt = tv.Class.DataType.Accept(nct);
+
+            Assert.AreEqual(2, store.UsedEquivalenceClasses.Count);
+            Assert.AreEqual(
+                "(arr Eq_2)",
+                store.UsedEquivalenceClasses[0].DataType.ToString());
+            Assert.AreEqual(
+                "(union (real64 u1) (word32 u0))",
+                store.UsedEquivalenceClasses[1].DataType.ToString());
+        }
+
+        [Test]
+        public void ArrayOfUserDefinedUnions()
+        {
+            var ut = new UnionType(null, null, true);
+            ut.AddAlternative(PrimitiveType.Word32);
+            ut.AddAlternative(PrimitiveType.Real64);
+
+            ArrayType a = new ArrayType(ut, 0);
+
+            TypeVariable tv = store.CreateTypeVariable(factory);
+            tv.Class.DataType = a;
+            Assert.AreEqual(1, store.UsedEquivalenceClasses.Count);
+
+            DataType dt = tv.Class.DataType.Accept(nct);
+
+            Assert.AreEqual(1, store.UsedEquivalenceClasses.Count);
+            Assert.AreEqual(
+                "(arr (union (real64 u1) (word32 u0)))",
+                store.UsedEquivalenceClasses[0].DataType.ToString());
+        }
+
+        [Test]
         public void StructureContainingArray()
         {
             ArrayType a = new ArrayType(PrimitiveType.Int32, 4);
@@ -76,6 +142,5 @@ namespace Reko.UnitTests.Typing
             Assert.AreEqual(1, store.UsedEquivalenceClasses.Count);
             Assert.AreEqual("(struct (8 (arr int32 4) a0008))", store.UsedEquivalenceClasses[0].DataType.ToString()); 
         }
-
     }
 }


### PR DESCRIPTION
Apply the same changes as for DataTypeTransformer and TypeTransformer to NestedComplexTypeExtractor

Add unit tests to verify it