### PR TITLE
Enable StructWithPadding + Replace array length assertion + Add null check for procedure

### DIFF
--- a/src/Core/Output/GlobalDataWriter.cs
+++ b/src/Core/Output/GlobalDataWriter.cs
@@ -124,7 +124,13 @@ namespace Reko.Core.Output
 
         public CodeFormatter VisitArray(ArrayType at)
         {
-            Debug.Assert(at.Length != 0, "Expected sizes of arrays to have been determined by now");
+            if (at.Length == 0)
+            {
+                var dc = services.RequireService<DecompilerEventListener>();
+                dc.Warn(
+                    dc.CreateAddressNavigator(program, rdr.Address),
+                    "Expected sizes of arrays to have been determined by now");
+            }
             var fmt = codeFormatter.InnerFormatter;
             fmt.Terminate();
             fmt.Indent();

--- a/src/Gui/Commands/Cmd_EditSignature.cs
+++ b/src/Gui/Commands/Cmd_EditSignature.cs
@@ -62,7 +62,8 @@ namespace Reko.Gui.Commands
                 {
                     i.ApplyChanges();
                     program.User.Procedures[address] = sProc;
-                    procedure.Name = sProc.Name;
+                    if (procedure != null)
+                        procedure.Name = sProc.Name;
                 }
             }
         }

--- a/src/UnitTests/Scanning/GlobalDataWorkItemTests.cs
+++ b/src/UnitTests/Scanning/GlobalDataWorkItemTests.cs
@@ -166,7 +166,6 @@ namespace Reko.UnitTests.Scanning
         }
 
         [Test(Description = "Scanner should be able to handle structures with padding 'holes'")]
-        [Ignore("Disabled until #141 has been fixed")]
         public void Gdwi_StructWithPadding()
         {
             var bytes = new byte[]
@@ -192,7 +191,7 @@ namespace Reko.UnitTests.Scanning
                 // two-byte gap here.
                 new StructureField(4, new Pointer(ft, 4), "pfn")
             });
-            Expect_ScannerGlobalData(0x43210008, str);
+            Expect_ScannerGlobalData(0x43210008, ft);
             mr.ReplayAll();
 
             var gdwi = new GlobalDataWorkItem(scanner, program, program.ImageMap.BaseAddress, str);


### PR DESCRIPTION
3 little fixes:
 - GlobalDataWorkItemTests: enable StructWithPadding test
 - GlobalDataWriter: replace array length assertion with decompiler warning
 - Cmd_EditSignature: add null pointer check for procedure