### PR TITLE
ImageMap::RemoveItem: do not merge disjoined items

### DIFF
--- a/src/Core/ImageMap.cs
+++ b/src/Core/ImageMap.cs
@@ -230,7 +230,8 @@ namespace Reko.Core
             // Merge with previous item
             ImageMapItem prevItem;
             if (items.TryGetLowerBound((addr - 1), out prevItem) &&
-                prevItem.DataType is UnknownType)
+                prevItem.DataType is UnknownType &&
+                prevItem.EndAddress.Equals(item.Address))
             {
                 mergedItem = prevItem;
 
@@ -241,7 +242,8 @@ namespace Reko.Core
             // Merge with next item
             ImageMapItem nextItem;
             if (items.TryGetUpperBound((addr + 1), out nextItem) &&
-                nextItem.DataType is UnknownType)
+                nextItem.DataType is UnknownType &&
+                mergedItem.EndAddress.Equals(nextItem.Address))
             {
                 mergedItem.Size = (uint)(nextItem.EndAddress - mergedItem.Address);
                 items.Remove(nextItem.Address);

--- a/src/UnitTests/Core/ImageMapTests.cs
+++ b/src/UnitTests/Core/ImageMapTests.cs
@@ -240,6 +240,42 @@ namespace Reko.UnitTests.Core
         }
 
         [Test]
+        public void Im_RemoveItem_DoNotMergeDisjoinedItems()
+        {
+            var map = new ImageMap(addrBase, 0x0100);
+            var codeAddr = addrBase;
+            var dataAddr = addrBase + 0x1000;
+            var textAddr = addrBase + 0x2000;
+            map.AddSegment(codeAddr, "code", AccessMode.ReadWrite, 0x100);
+            map.AddSegment(dataAddr, "data", AccessMode.ReadWrite, 0x4);
+            map.AddSegment(textAddr, "text", AccessMode.ReadWrite, 0x100);
+            var curAddr = addrBase;
+
+            CreateImageMapItem(map, PrimitiveType.Int32, addrBase + 0x1000);
+
+            map.Dump();
+
+            CheckImageMapTypes(map, "<unknown>", "int32", "<unknown>");
+            CheckImageMapAddresses(map, "8000:0000", "8000:1000", "8000:2000");
+            CheckImageMapSizes(map, 0x100, 0x4, 0x100);
+
+            map.RemoveItem(codeAddr);
+            CheckImageMapTypes(map, "<unknown>", "int32", "<unknown>");
+            CheckImageMapAddresses(map, "8000:0000", "8000:1000", "8000:2000");
+            CheckImageMapSizes(map, 0x100, 0x4, 0x100);
+
+            map.RemoveItem(dataAddr);
+            CheckImageMapTypes(map, "<unknown>", "<unknown>", "<unknown>");
+            CheckImageMapAddresses(map, "8000:0000", "8000:1000", "8000:2000");
+            CheckImageMapSizes(map, 0x100, 0x4, 0x100);
+
+            map.RemoveItem(textAddr);
+            CheckImageMapTypes(map, "<unknown>", "<unknown>", "<unknown>");
+            CheckImageMapAddresses(map, "8000:0000", "8000:1000", "8000:2000");
+            CheckImageMapSizes(map, 0x100, 0x4, 0x100);
+        }
+
+        [Test]
         public void Im_FireChangeEvent()
         {
             var map = new ImageMap(addrBase, 0x100);


### PR DESCRIPTION
- ImageMap::RemoveItem: do not merge disjoined items
- Add unit test to verify it