### PR TITLE
Add unit tests for IdConstant to catch problem with type references

### DIFF
--- a/src/UnitTests/Evaluation/IdConstantTests.cs
+++ b/src/UnitTests/Evaluation/IdConstantTests.cs
@@ -64,5 +64,37 @@ namespace Reko.UnitTests.Evaluation
 			Expression e = ic.Transform();
 			Assert.AreEqual("selector", e.DataType.ToString());
 		}
-	}
+
+        [Test]
+        public void ConstantReferenceInt()
+        {
+            var dword = new TypeReference("DWORD", PrimitiveType.Int32);
+            Identifier edx = new Identifier("edx", dword, Registers.edx);
+
+            var ctx = new SymbolicEvaluationContext(null, null);
+            ctx.SetValue(edx, Constant.Int32(321));
+
+            IdConstant ic = new IdConstant(ctx, new Unifier(null));
+            Assert.IsTrue(ic.Match(edx));
+            Expression e = ic.Transform();
+            Assert.AreEqual("321", e.ToString());
+            Assert.AreEqual("int32", e.DataType.ToString());
+        }
+
+        [Test]
+        public void ConstantReferencePointerToInt()
+        {
+            var intptr = new TypeReference("INTPTR", new Pointer(PrimitiveType.Int32, 4));
+            Identifier edx = new Identifier("edx", intptr, Registers.edx);
+
+            var ctx = new SymbolicEvaluationContext(null, null);
+            ctx.SetValue(edx, Constant.Int32(0x567));
+
+            IdConstant ic = new IdConstant(ctx, new Unifier(null));
+            Assert.IsTrue(ic.Match(edx));
+            Expression e = ic.Transform();
+            Assert.AreEqual("00000567", e.ToString());
+            Assert.AreEqual("(ptr int32)", e.DataType.ToString());
+        }
+    }
 }


### PR DESCRIPTION
IdConstant fails to transform identifiers with reference type. I have created unit tests to catch it. John, could you look at it?