### PR TITLE
ConditionCodeElimenator::ComparisonFromConditionCode: process type references

### DIFF
--- a/src/Decompiler/Analysis/ConditionCodeEliminator.cs
+++ b/src/Decompiler/Analysis/ConditionCodeEliminator.cs
@@ -264,14 +264,18 @@ namespace Reko.Analysis
 			}
 
 			Expression e;
-			if (bin.Operator == Operator.ISub || bin.Operator == Operator.FSub)
-			{
-				e = new BinaryExpression(cmpOp, PrimitiveType.Bool, bin.Left, bin.Right);
-			}
-			else
-			{
-				e = new BinaryExpression(cmpOp, PrimitiveType.Bool, bin, Constant.Zero(bin.Left.DataType));
-			}		
+            if (bin.Operator == Operator.ISub || bin.Operator == Operator.FSub)
+            {
+                e = new BinaryExpression(cmpOp, PrimitiveType.Bool, bin.Left, bin.Right);
+            }
+            else
+            {
+                var dt = bin.Left.DataType;
+                var typeref = dt as TypeReference;
+                if (typeref != null)
+                    dt = typeref.Referent;
+                e = new BinaryExpression(cmpOp, PrimitiveType.Bool, bin, Constant.Zero(dt));
+            }
 			return e;
 		}
 

--- a/src/UnitTests/Analysis/ConditionCodeEliminatorTests.cs
+++ b/src/UnitTests/Analysis/ConditionCodeEliminatorTests.cs
@@ -371,6 +371,23 @@ done:
 			Assert.AreEqual("RltOperator", b.Operator.GetType().Name);
 		}
 
+        [Test]
+        public void TypeReferenceComparisonFromConditionCode()
+        {
+            ConditionCodeEliminator cce = new ConditionCodeEliminator(
+                null,
+                new DefaultPlatform(null, new FakeArchitecture()));
+            var w16 = new TypeReference("W16", PrimitiveType.Word16);
+            BinaryExpression bin = new BinaryExpression(
+                Operator.IAdd,
+                w16,
+                new Identifier("a", w16, null),
+                new Identifier("b", w16, null));
+            BinaryExpression b = (BinaryExpression)cce.ComparisonFromConditionCode(ConditionCode.LT, bin, false);
+            Assert.AreEqual("a + b < 0x0000", b.ToString());
+            Assert.AreEqual("LtOperator", b.Operator.GetType().Name);
+        }
+
         private Identifier MockReg(ProcedureBuilder m, int i)
         {
             return m.Frame.EnsureRegister(FakeArchitecture.GetMachineRegister(i));


### PR DESCRIPTION
- Apply the same fix as 7dcce04 to ConditionCodeElimenator
- Add unit test to verify it