### PR TITLE
Unifier: keep name of structure field

### DIFF
--- a/src/Core/Types/StructureField.cs
+++ b/src/Core/Types/StructureField.cs
@@ -51,7 +51,7 @@ namespace Reko.Core.Types
         public override string Name { get { if (name == null) return GenerateDefaultName(); return name; }
             set { name = value; } }
 
-        public bool NameSet { get { return name != null; } }
+        public bool IsNameSet { get { return name != null; } }
 
         private string name;
 

--- a/src/Core/Types/StructureField.cs
+++ b/src/Core/Types/StructureField.cs
@@ -50,6 +50,9 @@ namespace Reko.Core.Types
 
         public override string Name { get { if (name == null) return GenerateDefaultName(); return name; }
             set { name = value; } }
+
+        public bool NameSet { get { return name != null; } }
+
         private string name;
 
         public int Offset { get; set; }

--- a/src/Core/Types/Unifier.cs
+++ b/src/Core/Types/Unifier.cs
@@ -506,8 +506,9 @@ namespace Reko.Core.Types
 				}
 				else
 				{
-                    DataType fieldType = Unify(fa.DataType, fb.DataType);
-					mem.Fields.Add(fa.Offset, fieldType);
+                    var fieldType = Unify(fa.DataType, fb.DataType);
+                    var fieldName = MakeFieldName(fa, fb);
+                    mem.Fields.Add(fa.Offset, fieldType, fieldName);
 					fa = null;
 					fb = null;
 				}
@@ -533,6 +534,17 @@ namespace Reko.Core.Types
             mem.ForceStructure = a.ForceStructure | b.ForceStructure;
 			return mem;
 		}
+
+        private string MakeFieldName(StructureField fa, StructureField fb)
+        {
+            if (fa.NameSet && fb.NameSet && fa.Name != fb.Name)
+                throw new NotSupportedException("Both structure fields have names");
+            if (fa.NameSet)
+                return fa.Name;
+            if (fb.NameSet)
+                return fb.Name;
+            return null;
+        }
 
 		public DataType UnifyPointer(Pointer ptrA, DataType b)
 		{

--- a/src/Core/Types/Unifier.cs
+++ b/src/Core/Types/Unifier.cs
@@ -537,11 +537,11 @@ namespace Reko.Core.Types
 
         private string MakeFieldName(StructureField fa, StructureField fb)
         {
-            if (fa.NameSet && fb.NameSet && fa.Name != fb.Name)
+            if (fa.IsNameSet && fb.IsNameSet && fa.Name != fb.Name)
                 throw new NotSupportedException("Both structure fields have names");
-            if (fa.NameSet)
+            if (fa.IsNameSet)
                 return fa.Name;
-            if (fb.NameSet)
+            if (fb.IsNameSet)
                 return fb.Name;
             return null;
         }

--- a/src/Core/Types/Unifier.cs
+++ b/src/Core/Types/Unifier.cs
@@ -507,7 +507,12 @@ namespace Reko.Core.Types
 				else
 				{
                     var fieldType = Unify(fa.DataType, fb.DataType);
-                    var fieldName = MakeFieldName(fa, fb);
+                    string fieldName;
+                    if (!TryMakeFieldName(fa, fb, out fieldName))
+                        throw new NotSupportedException(
+                            string.Format(
+                                "Failed to unify field '{0}' in structure '{1}' with field '{2}' in structure '{3}'.",
+                                fa.Name, a, fb.Name, b));
                     mem.Fields.Add(fa.Offset, fieldType, fieldName);
 					fa = null;
 					fb = null;
@@ -535,15 +540,16 @@ namespace Reko.Core.Types
 			return mem;
 		}
 
-        private string MakeFieldName(StructureField fa, StructureField fb)
+        private bool TryMakeFieldName(StructureField fa, StructureField fb, out string name)
         {
+            name = null;
             if (fa.IsNameSet && fb.IsNameSet && fa.Name != fb.Name)
-                throw new NotSupportedException("Both structure fields have names");
+                return false;
             if (fa.IsNameSet)
-                return fa.Name;
+                name = fa.Name;
             if (fb.IsNameSet)
-                return fb.Name;
-            return null;
+                name = fb.Name;
+            return true;
         }
 
 		public DataType UnifyPointer(Pointer ptrA, DataType b)

--- a/src/UnitTests/Typing/UnifierTests.cs
+++ b/src/UnitTests/Typing/UnifierTests.cs
@@ -237,6 +237,35 @@ namespace Reko.UnitTests.Typing
             Assert.AreEqual("bar89", st.Fields[0].Name);
         }
 
+        [Test]
+        public void UnifyStructNamedField_SameNames()
+        {
+            StructureType st1 = new StructureType { Fields = { { 8, PrimitiveType.Word32, "bar89" } } };
+            StructureType st2 = new StructureType { Fields = { { 8, PrimitiveType.Word32, "bar89" } } };
+            StructureType st = (StructureType)un.Unify(st1, st2);
+            Assert.AreEqual(1, st.Fields.Count);
+            Assert.AreEqual("bar89", st.Fields[0].Name);
+        }
+
+        [Test]
+        public void UnifyStructNamedField_DifferentNames()
+        {
+            StructureType st1 = new StructureType { Fields = { { 8, PrimitiveType.Word32, "bar89" } } };
+            StructureType st2 = new StructureType { Fields = { { 8, PrimitiveType.Word32, "foo89" } } };
+            try
+            {
+                un.Unify(st1, st2);
+            }
+            catch (NotSupportedException ex)
+            {
+                Assert.AreEqual(
+                    "Failed to unify field 'bar89' in structure '(struct (8 word32 bar89))' with field 'foo89' in structure '(struct (8 word32 foo89))'.",
+                    ex.Message);
+                return;
+            }
+            Assert.Fail("Should throw NotSupportedException");
+        }
+
         // Arrays with the same sized elements should unify just fine.
         [Test]
 		public void UnifyArrays()

--- a/src/UnitTests/Typing/UnifierTests.cs
+++ b/src/UnitTests/Typing/UnifierTests.cs
@@ -226,8 +226,19 @@ namespace Reko.UnitTests.Typing
 			Assert.AreEqual("foo", st.Name);
 		}
 
-		// Arrays with the same sized elements should unify just fine.
-		[Test]
+        // Ensures that if a named field of structure is unified with an unnamed one, the resulting structure keeps the field name.
+        [Test]
+        public void UnifyStructNamedField()
+        {
+            StructureType st1 = new StructureType { Fields = { { 8, PrimitiveType.Word32 } } };
+            StructureType st2 = new StructureType { Fields = { { 8, PrimitiveType.Word32, "bar89" } } };
+            StructureType st = (StructureType)un.Unify(st1, st2);
+            Assert.AreEqual(1, st.Fields.Count);
+            Assert.AreEqual("bar89", st.Fields[0].Name);
+        }
+
+        // Arrays with the same sized elements should unify just fine.
+        [Test]
 		public void UnifyArrays()
 		{
 			ArrayType a1 = new ArrayType(PrimitiveType.Word32, 0);


### PR DESCRIPTION
Now `Unifier` could lose name of global variable specified by user.
- Keep name of structure field
- Add unit test to verify it