### PR TITLE
Fix for expression simplifier type ref

### DIFF
--- a/src/Decompiler/Evaluation/ExpressionSimplifier.cs
+++ b/src/Decompiler/Evaluation/ExpressionSimplifier.cs
@@ -329,7 +329,11 @@ namespace Reko.Evaluation
             if (exp == Constant.Invalid)
                 return exp;
 
-            var ptCast = cast.DataType as PrimitiveType;
+            var dtCast = cast.DataType;
+            var typeref = dtCast as TypeReference;
+            if (typeref != null)
+                dtCast = typeref.Referent;
+            var ptCast = dtCast as PrimitiveType;
             Constant c = exp as Constant;
             if (c != null)
             {
@@ -339,7 +343,7 @@ namespace Reko.Evaluation
                     if ((ptSrc.Domain & Domain.Integer) != 0)
                     {
                         Changed = true;
-                        return Constant.Create(cast.DataType, c.ToUInt64());
+                        return Constant.Create(ptCast, c.ToUInt64());
                     }
                     if (ptSrc.Domain == Domain.Real && 
                         ptCast.Domain == Domain.Real && 

--- a/src/UnitTests/Evaluation/ExpressionSimplifierTests.cs
+++ b/src/UnitTests/Evaluation/ExpressionSimplifierTests.cs
@@ -121,5 +121,13 @@ namespace Reko.UnitTests.Evaluation
             var expr = m.Cast(PrimitiveType.Real32, Constant.Real64(1.5));
             Assert.AreEqual("1.5F", expr.Accept(simplifier).ToString());
         }
+
+        [Test]
+        public void Exs_Cast_byte_typeref()
+        {
+            Given_ExpressionSimplifier();
+            var expr = m.Cast(new TypeReference("BYTE", PrimitiveType.Byte), Constant.Word32(0x11));
+            Assert.AreEqual("0x11", expr.Accept(simplifier).ToString());
+        }
     }
 }


### PR DESCRIPTION
- Apply the same fix as 1a0e1e2 and 7dcce04 to  ExpressionSimplifier.VisitCast
- Add unit test to verify it