### PR TITLE
Modify DataType.ResolveAs<T> to process type references

### DIFF
--- a/src/Core/Types/DataType.cs
+++ b/src/Core/Types/DataType.cs
@@ -59,6 +59,15 @@ namespace Reko.Core.Types
         public T ResolveAs<T>() where T : DataType
         {
             DataType dt = this;
+            // Special case: ResolveAs<TypeReference> or ResolveAs<DataType>
+            if ((dt is TypeReference) && (dt is T))
+                return dt as T;
+            TypeReference typeRef = dt as TypeReference;
+            while (typeRef != null)
+            {
+                dt = typeRef.Referent;
+                typeRef = dt as TypeReference;
+            }
             TypeVariable tv = dt as TypeVariable;
             while (tv != null)
             {

--- a/src/Decompiler/Analysis/ConditionCodeEliminator.cs
+++ b/src/Decompiler/Analysis/ConditionCodeEliminator.cs
@@ -469,11 +469,8 @@ namespace Reko.Analysis
             }
             else
             {
-                var dt = bin.Left.DataType;
-                var typeref = dt as TypeReference;
-                if (typeref != null)
-                    dt = typeref.Referent;
-                e = new BinaryExpression(cmpOp, PrimitiveType.Bool, bin, Constant.Zero(dt));
+                var pt = bin.Left.DataType.ResolveAs<PrimitiveType>();
+                e = new BinaryExpression(cmpOp, PrimitiveType.Bool, bin, Constant.Zero(pt));
             }
 			return e;
 		}

--- a/src/Decompiler/Evaluation/ExpressionSimplifier.cs
+++ b/src/Decompiler/Evaluation/ExpressionSimplifier.cs
@@ -329,11 +329,7 @@ namespace Reko.Evaluation
             if (exp == Constant.Invalid)
                 return exp;
 
-            var dtCast = cast.DataType;
-            var typeref = dtCast as TypeReference;
-            if (typeref != null)
-                dtCast = typeref.Referent;
-            var ptCast = dtCast as PrimitiveType;
+            var ptCast = cast.DataType.ResolveAs<PrimitiveType>();
             Constant c = exp as Constant;
             if (c != null)
             {

--- a/src/Decompiler/Evaluation/IdConstant.cs
+++ b/src/Decompiler/Evaluation/IdConstant.cs
@@ -59,9 +59,6 @@ namespace Reko.Evaluation
             if (!cSrc.IsValid)
                 return cSrc;
             DataType dt = unifier.Unify(cSrc.DataType, idDst.DataType);
-            var typeref = dt as TypeReference;
-            if (typeref != null)
-                dt = typeref.Referent;
             var pt = dt.ResolveAs<PrimitiveType>();
             if (pt != null)
                 return Constant.Create(pt, cSrc.ToInt64());

--- a/src/tests/Typing/ExaTypeReferenceToPointer.exp
+++ b/src/tests/Typing/ExaTypeReferenceToPointer.exp
@@ -18,5 +18,5 @@ T_4: (in psz + 0x00000000 : LPSTR)
   OrigDataType: LPSTR
 T_5: (in Mem0[psz + 0x00000000:byte] : byte)
   Class: Eq_5
-  DataType: byte
-  OrigDataType: byte
+  DataType: char
+  OrigDataType: char


### PR DESCRIPTION
Finally I have modified ResolveAs to process type references so that it breaks only one unit test. John please review it.
I also have fixed the broken unit test (ExaTypeReferenceToPointer)
```
T_5: (in Mem0[psz + 0x00000000:byte] : byte)
   Class: Eq_5
   DataType: byte
  OrigDataType: byte
```
was replaced with
```
T_5: (in Mem0[psz + 0x00000000:byte] : byte)
   Class: Eq_5
   DataType: char
  OrigDataType: char
```
`psz` is a string value. So `char` data type is more correctly for this expression than `byte`