### PR TITLE
ApplicationBuilder: do not add return address to stack depth on entry

### DIFF
--- a/src/Core/ApplicationBuilder.cs
+++ b/src/Core/ApplicationBuilder.cs
@@ -201,7 +201,7 @@ namespace Reko.Core
         {
             if (ensureVariables)
                 return frame.EnsureStackVariable(
-                    stack.StackOffset - (site.StackDepthOnEntry + sigCallee.ReturnAddressOnStack),
+                    stack.StackOffset - site.StackDepthOnEntry,
                     stack.DataType);
             else 
                 return arch.CreateStackAccess(frame, stack.StackOffset, stack.DataType);


### PR DESCRIPTION
Do not add return address to stack depth on entry as it already was
included to stack depth on entry