### PR TITLE
Regression tests: replace absolute paths with relative

### DIFF
--- a/subjects/CPM-80/CB80.dcproject
+++ b/subjects/CPM-80/CB80.dcproject
@@ -3,12 +3,12 @@
   <arch>z80</arch>
   <platform>cpm</platform>
   <input>
-    <filename>D:\dev\uxmal\reko\master\subjects\CPM-80\CB80.COM</filename>
-    <disassembly>D:\dev\uxmal\reko\master\subjects\CPM-80\CB80.asm</disassembly>
-    <intermediate-code>D:\dev\uxmal\reko\master\subjects\CPM-80\CB80.dis</intermediate-code>
-    <output>D:\dev\uxmal\reko\master\subjects\CPM-80\CB80.c</output>
-    <types-file>D:\dev\uxmal\reko\master\subjects\CPM-80\CB80.h</types-file>
-    <global-vars>D:\dev\uxmal\reko\master\subjects\CPM-80\CB80.globals.c</global-vars>
+    <filename>CB80.COM</filename>
+    <disassembly>CB80.asm</disassembly>
+    <intermediate-code>CB80.dis</intermediate-code>
+    <output>CB80.c</output>
+    <types-file>CB80.h</types-file>
+    <global-vars>CB80.globals.c</global-vars>
     <user>
       <address>0100</address>
       <processor name="z80" />

--- a/subjects/MZ-x86/BENCHFN.dcproject
+++ b/subjects/MZ-x86/BENCHFN.dcproject
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemata.jklnet.org/Decompiler/v2">
   <input>
-    <filename>D:\dev\uxmal\reko\master\subjects\MZ-x86\BENCHFN.EXE</filename>
+    <filename>BENCHFN.EXE</filename>
     <address>0800:0000</address>
     <procedure name="fn0800_0222">
       <address>0800:0222</address>
       <assume reg="ds" value="1000" />
     </procedure>
-    <disassembly>D:\dev\uxmal\reko\master\subjects\MZ-x86\BENCHFN.asm</disassembly>
-    <intermediate-code>D:\dev\uxmal\reko\master\subjects\MZ-x86\BENCHFN.dis</intermediate-code>
-    <output>D:\dev\uxmal\reko\master\subjects\MZ-x86\BENCHFN.c</output>
-    <types-file>D:\dev\uxmal\reko\master\subjects\MZ-x86\BENCHFN.h</types-file>
-    <global-vars>D:\dev\uxmal\reko\master\subjects\MZ-x86\BENCHFN.globals.c</global-vars>
+    <disassembly>BENCHFN.asm</disassembly>
+    <intermediate-code>BENCHFN.dis</intermediate-code>
+    <output>BENCHFN.c</output>
+    <types-file>BENCHFN.h</types-file>
+    <global-vars>BENCHFN.globals.c</global-vars>
     <options>
       <HeuristicScanning>false</HeuristicScanning>
     </options>

--- a/subjects/regressions/snowman-51/switch.dcproject
+++ b/subjects/regressions/snowman-51/switch.dcproject
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemata.jklnet.org/Decompiler/v2">
   <input>
-    <filename>D:\dev\uxmal\reko\master\subjects\regressions\snowman-51\switch.dll</filename>
+    <filename>switch.dll</filename>
     <address>10070000</address>
     <procedure name="get">
       <address>10071000</address>


### PR DESCRIPTION
There are several tests with absolute paths. So they don't work on my machine.
Replace absolute paths with relative to make regression tests work on
any machine