### PR TITLE
Create varargs format scanner

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -227,6 +227,7 @@
     <Compile Include="Expressions\UnaryExpression.cs" />
     <Compile Include="FieldAttribute.cs" />
     <Compile Include="ImageSymbol.cs" />
+    <Compile Include="IVarargsFormatParser.cs" />
     <Compile Include="Lib\PatternCollector.cs" />
     <Compile Include="Lib\PerfectHash.cs" />
     <Compile Include="Lib\SuffixArray.cs" />

--- a/src/Core/IVarargsFormatParser.cs
+++ b/src/Core/IVarargsFormatParser.cs
@@ -1,0 +1,31 @@
+﻿#region License
+/* 
+ * Copyright (C) 1999-2016 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+ 
+using System.Collections.Generic;
+using Reko.Core.Types;
+
+namespace Reko.Core
+{
+    public interface IVarargsFormatParser
+    {
+        List<DataType> ArgumentTypes { get; }
+        void Parse();
+    }
+}

--- a/src/Core/ImportResolver.cs
+++ b/src/Core/ImportResolver.cs
@@ -80,7 +80,11 @@ namespace Reko.Core
                 FunctionType sig;
                 if (program.EnvironmentMetadata.Signatures.TryGetValue(importName, out sig))
                 {
-                    return new ExternalProcedure(importName, sig);
+                    var chr = platform.LookupCharacteristicsByName(importName);
+                    if (chr != null)
+                        return new ExternalProcedure(importName, sig, chr);
+                    else
+                        return new ExternalProcedure(importName, sig);
                 }
             }
 

--- a/src/Core/Platform.cs
+++ b/src/Core/Platform.cs
@@ -127,6 +127,7 @@ namespace Reko.Core
         ExternalProcedure LookupProcedureByName(string moduleName, string procName);
         ExternalProcedure LookupProcedureByOrdinal(string moduleName, int ordinal);
         Identifier LookupGlobalByName(string moduleName, string globalName);
+        ProcedureCharacteristics LookupCharacteristicsByName(string procName);
         Address MakeAddressFromConstant(Constant c);
         Address MakeAddressFromLinear(ulong uAddr);
         bool TryParseAddress(string sAddress, out Address addr);
@@ -393,6 +394,14 @@ namespace Reko.Core
         public virtual Identifier LookupGlobalByName(string moduleName, string globalName)
         {
             return null;
+        }
+
+        public virtual ProcedureCharacteristics LookupCharacteristicsByName(string procName)
+        {
+            EnsureTypeLibraries(PlatformIdentifier);
+            return CharacteristicsLibs.Select(cl => cl.Lookup(procName))
+                .Where(c => c != null)
+                .FirstOrDefault();
         }
     }
 

--- a/src/Core/Types/FunctionType.cs
+++ b/src/Core/Types/FunctionType.cs
@@ -104,7 +104,7 @@ namespace Reko.Core.Types
             var sig = (FunctionType)Clone();
             sig.Parameters = Parameters.
                 Where(a => a.Name != "...").
-                Union(parameters).
+                Concat(parameters).
                 ToArray();
             return sig;
         }

--- a/src/Core/Types/FunctionType.cs
+++ b/src/Core/Types/FunctionType.cs
@@ -90,6 +90,25 @@ namespace Reko.Core.Types
             return ft;
 		}
 
+        public bool IsVarargs()
+        {
+            var last = Parameters != null ? Parameters.LastOrDefault() : null;
+            return last != null && last.Name == "...";
+        }
+
+        public FunctionType ReplaceVarargs(params Identifier[] parameters)
+        {
+            if (!IsVarargs())
+                throw new NotSupportedException(
+                    "Signature should contain varargs");
+            var sig = (FunctionType)Clone();
+            sig.Parameters = Parameters.
+                Where(a => a.Name != "...").
+                Union(parameters).
+                ToArray();
+            return sig;
+        }
+
         /// <summary>
         /// The size of the return address if pushed on stack.
         /// </summary>

--- a/src/Decompiler/Decompiler.csproj
+++ b/src/Decompiler/Decompiler.csproj
@@ -293,6 +293,7 @@
     <Compile Include="Scanning\StringSearch.cs" />
     <Compile Include="Scanning\KmpStringSearch.cs" />
     <Compile Include="Scanning\ProcedureWorkItem.cs" />
+    <Compile Include="Scanning\VarargsFormatScanner.cs" />
     <Compile Include="Scanning\VectorWorkItem.cs" />
     <Compile Include="Loading\Loader.cs" />
     <Compile Include="Scanning\EscapedAccessRewriter.cs">

--- a/src/Decompiler/Scanning/VarargsFormatScanner.cs
+++ b/src/Decompiler/Scanning/VarargsFormatScanner.cs
@@ -157,6 +157,7 @@ namespace Reko.Scanning
                 false,
                 platform.Architecture.WordWidth.Size,
                 platform.GetByteSizeFromCBasicType(CBasicType.Long),
+                platform.GetByteSizeFromCBasicType(CBasicType.Double),
                 platform.PointerType.Size);
             varargsParser.Parse();
             return varargsParser.ArgumentTypes;

--- a/src/Decompiler/Scanning/VarargsFormatScanner.cs
+++ b/src/Decompiler/Scanning/VarargsFormatScanner.cs
@@ -1,0 +1,188 @@
+﻿#region License
+/* 
+ * Copyright (C) 1999-2016 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Reko.Core;
+using Reko.Core.CLanguage;
+using Reko.Core.Code;
+using Reko.Core.Expressions;
+using Reko.Core.Serialization;
+using Reko.Core.Types;
+using Reko.Evaluation;
+
+namespace Reko.Scanning
+{
+    /// <summary>
+    /// Try to read varargs format, then to parse it, get arguments types and
+    /// build application instruction.
+    /// </summary>
+    class VarargsFormatScanner
+    {
+        private Program program;
+        private IProcessorArchitecture arch;
+        private Frame frame;
+        private ExpressionSimplifier eval;
+        private FunctionType sig;
+
+        public VarargsFormatScanner(
+            Program program,
+            Frame frame,
+            EvaluationContext ctx)
+        {
+            this.program = program;
+            this.arch = program.Architecture;
+            this.frame = frame;
+            this.eval = new ExpressionSimplifier(ctx);
+        }
+
+        public Instruction BuildInstruction(Expression callee, CallSite site)
+        {
+            var pc = callee as ProcedureConstant;
+            if (pc != null)
+                pc.Procedure.Signature = this.sig;
+            var ab = CreateApplicationBuilder(callee, this.sig, site);
+            return ab.CreateInstruction();
+        }
+
+        public bool TryScan(FunctionType sig, ProcedureCharacteristics chr)
+        {
+            if (
+                sig == null || !sig.IsVarargs() ||
+                chr == null || !VarargsParserSet(chr)
+            )
+            {
+                this.sig = null;
+                return false;
+            }
+            var format = ReadVarargsFormat(sig);
+            var argTypes = ParseVarargsFormat(chr, format, program.Platform);
+            this.sig = ReplaceVarargs(sig, argTypes);
+            return true;
+        }
+
+        private ApplicationBuilder CreateApplicationBuilder(
+            Expression callee,
+            FunctionType sig,
+            CallSite site)
+        {
+            var ab = new ApplicationBuilder(
+                arch,
+                frame,
+                site,
+                callee,
+                sig,
+                false);
+            return ab;
+        }
+
+        private Expression GetValue(Expression op)
+        {
+            return op.Accept<Expression>(eval);
+        }
+
+        private string ReadVarargsFormat(FunctionType sig)
+        {
+            var formatIndex = sig.Parameters.Length - 2;
+            if (formatIndex < 0)
+                throw new ApplicationException(
+                    string.Format("Varargs: should be at least 2 parameters"));
+            var formatParam = sig.Parameters[formatIndex];
+            var stackStorage = formatParam.Storage as StackStorage;
+            if (stackStorage == null)
+                throw new NotSupportedException(
+                    string.Format(
+                        "The {0} parameter of {1} wasn't a stack access.",
+                         formatParam.Name,
+                         sig.Name));
+            var stackAccess = arch.CreateStackAccess(
+                frame,
+                stackStorage.StackOffset,
+                stackStorage.DataType);
+            var c = GetValue(stackAccess) as Constant;
+            if (c == null || !c.IsValid)
+                throw new ApplicationException(
+                    string.Format("Varargs: invalid format constant"));
+            return ReadCString(c);
+        }
+
+        private string ReadCString(Constant cAddr)
+        {
+            var addr = program.Platform.MakeAddressFromConstant(cAddr);
+            if (!program.SegmentMap.IsValidAddress(addr))
+                throw new ApplicationException(
+                    string.Format("Varargs: invalid address: {0}", addr));
+            var rdr = program.CreateImageReader(addr);
+            var c = rdr.ReadCString(PrimitiveType.Char, program.TextEncoding);
+            return c.ToString();
+        }
+
+        private bool VarargsParserSet(ProcedureCharacteristics chr)
+        {
+            return !string.IsNullOrEmpty(chr.VarargsParserClass);
+        }
+
+        private IEnumerable<DataType> ParseVarargsFormat(
+            ProcedureCharacteristics chr,
+            string format,
+            IPlatform platform)
+        {
+            var type = Type.GetType(chr.VarargsParserClass);
+            if (type == null)
+                throw new TypeLoadException(
+                    string.Format(
+                        "Unable to load {0} varargs parser.",
+                        chr.VarargsParserClass));
+            var varargsParser = (IVarargsFormatParser)Activator.CreateInstance(
+                type,
+                format,
+                false,
+                platform.Architecture.WordWidth.Size,
+                platform.GetByteSizeFromCBasicType(CBasicType.Long),
+                platform.PointerType.Size);
+            varargsParser.Parse();
+            return varargsParser.ArgumentTypes;
+        }
+
+        private FunctionType ReplaceVarargs(
+            FunctionType sig,
+            IEnumerable<DataType> argumentTypes)
+        {
+            var varargs = sig.Parameters.Last();
+            var varargsStorage = varargs.Storage as StackStorage;
+            if (varargsStorage == null)
+                throw new NotSupportedException(
+                    string.Format(
+                        "The {0} parameter of {1} wasn't a stack access.",
+                        varargs.Name,
+                        sig.Name));
+            var stackOffset = varargsStorage.StackOffset;
+            var args = argumentTypes.Select(dt =>
+            {
+                var stg = new StackArgumentStorage(stackOffset, dt);
+                stackOffset += dt.Size;
+                return new Identifier(null, dt, stg);
+            });
+
+            return sig.ReplaceVarargs(args.ToArray());
+        }
+    }
+}

--- a/src/Decompiler/Scanning/VarargsFormatScanner.cs
+++ b/src/Decompiler/Scanning/VarargsFormatScanner.cs
@@ -35,7 +35,7 @@ namespace Reko.Scanning
     /// Try to read varargs format, then to parse it, get arguments types and
     /// build application instruction.
     /// </summary>
-    class VarargsFormatScanner
+    public class VarargsFormatScanner
     {
         private Program program;
         private IProcessorArchitecture arch;

--- a/src/Decompiler/Scanning/VarargsFormatScanner.cs
+++ b/src/Decompiler/Scanning/VarargsFormatScanner.cs
@@ -106,6 +106,9 @@ namespace Reko.Scanning
                 throw new ApplicationException(
                     string.Format("Varargs: should be at least 2 parameters"));
             var formatParam = sig.Parameters[formatIndex];
+            // $TODO: what about non-x86 architectures, like Sparc or PowerPC,
+            // there can be varargs functions where the first N parameters are
+            // passed in registers and the remaining are passed on the stack.
             var stackStorage = formatParam.Storage as StackStorage;
             if (stackStorage == null)
                 throw new NotSupportedException(

--- a/src/Environments/Windows/MsPrintfFormatParser.Tests.cs
+++ b/src/Environments/Windows/MsPrintfFormatParser.Tests.cs
@@ -35,7 +35,7 @@ namespace Reko.Environments.Windows
 
         private void ParseChar32(string formatString)
         {
-            this.parser = new MsPrintfFormatParser(formatString, false, 4, 4, 4);
+            this.parser = new MsPrintfFormatParser(formatString, false, 4, 4, 4, 4);
             parser.Parse();
         }
 

--- a/src/Environments/Windows/MsPrintfFormatParser.cs
+++ b/src/Environments/Windows/MsPrintfFormatParser.cs
@@ -34,15 +34,23 @@ namespace Reko.Environments.Windows
         private bool wideChars;
         private int wordSize;
         private int longSize;
+        private int doubleSize;
         private int pointerSize;
 
-        public MsPrintfFormatParser(string format, bool wideChars, int wordSize, int longSize, int pointerSize)
+        public MsPrintfFormatParser(
+            string format,
+            bool wideChars,
+            int wordSize,
+            int longSize,
+            int doubleSize,
+            int pointerSize)
         {
             this.ArgumentTypes = new List<DataType>();
             this.wideChars = wideChars;
             this.format = format;
             this.wordSize = wordSize;
             this.longSize = longSize;
+            this.doubleSize = doubleSize;
             this.pointerSize = pointerSize;
         }
 
@@ -140,6 +148,7 @@ namespace Reko.Environments.Windows
             case 'F':
             case 'g':
             case 'G':
+                byteSize = this.doubleSize;
                 domain = Domain.Real;
                 break;
             case 'p':

--- a/src/Environments/Windows/MsPrintfFormatParser.cs
+++ b/src/Environments/Windows/MsPrintfFormatParser.cs
@@ -18,6 +18,7 @@
  */
 #endregion
 
+using Reko.Core;
 using Reko.Core.Types;
 using System;
 using System.Collections.Generic;
@@ -26,7 +27,7 @@ using System.Text;
 
 namespace Reko.Environments.Windows
 {
-    public class MsPrintfFormatParser
+    public class MsPrintfFormatParser : IVarargsFormatParser
     {
         private int i;
         private string format;

--- a/src/Environments/Windows/msvcrt.xml
+++ b/src/Environments/Windows/msvcrt.xml
@@ -153,7 +153,9 @@
       <ptr><prim domain="Character" size="1" /></ptr>
       <stack size="4"/>
     </arg>
-    <!-- TODO: what about varargs? -->
+    <arg name="...">
+      <stack />
+    </arg>
     </signature>
   </procedure>
   <procedure name="sprintf">

--- a/src/UnitTests/Scanning/VarargsFormatScannerTests.cs
+++ b/src/UnitTests/Scanning/VarargsFormatScannerTests.cs
@@ -1,0 +1,213 @@
+﻿#region License
+/* 
+ * Copyright (C) 1999-2016 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using NUnit.Framework;
+using System.Text;
+using Reko.Arch.X86;
+using Reko.Arch.PowerPC;
+using Reko.Core;
+using Reko.Core.Code;
+using Reko.Core.Expressions;
+using Reko.Core.Serialization;
+using Reko.Core.Types;
+using Reko.Scanning;
+using Reko.UnitTests.Mocks;
+
+namespace Reko.UnitTests.Scanning
+{
+    [TestFixture]
+    class VarargsFormatScannerTests
+    {
+        private ProcedureBuilder m;
+        private X86ArchitectureFlat32 x86;
+        private PowerPcArchitecture32 ppc;
+        private Program program;
+        private ProcessorState state;
+        private VarargsFormatScanner vafs;
+        private ProcedureCharacteristics printfChr;
+        private FunctionType x86PrintfSig;
+        private FunctionType x86SprintfSig;
+        private FunctionType ppcPrintfSig;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.x86 = new X86ArchitectureFlat32();
+            this.ppc = new PowerPcArchitecture32();
+            this.m = new ProcedureBuilder();
+            this.printfChr = new ProcedureCharacteristics()
+            {
+                VarargsParserClass =
+                    "Reko.Environments.Windows.MsPrintfFormatParser," +
+                    "Reko.Environments.Windows"
+            };
+            this.x86PrintfSig = new FunctionType(
+                null,
+                null,
+                StackId(null,   4, CStringType()),
+                StackId("...",  8, new UnknownType()));
+            this.x86SprintfSig = new FunctionType(
+                null,
+                null,
+                StackId(null,   4, CStringType()),
+                StackId(null,   8, CStringType()),
+                StackId("...", 12, new UnknownType()));
+            this.ppcPrintfSig = new FunctionType(
+                null,
+                null,
+                RegId(null,  ppc, "r3", CStringType()),
+                RegId("...", ppc, "r4", new UnknownType()));
+        }
+
+        private SegmentMap CreateSegmentMap(uint uiAddr, uint size)
+        {
+            var mem = new MemoryArea(Address.Ptr32(uiAddr), new byte[size]);
+            var seg = new ImageSegment(".data", mem, AccessMode.ReadWrite);
+            return new SegmentMap(Address.Ptr32(uiAddr), seg);
+        }
+
+        private VarargsFormatScanner CreateVaScanner(Program program)
+        {
+            this.state = program.Architecture.CreateProcessorState();
+            var frame = program.Architecture.CreateFrame();
+            return new VarargsFormatScanner(program, frame, state);
+        }
+
+        private void WriteString(Program program, uint uiAddr, string str)
+        {
+            var imgW = program.CreateImageWriter(Address.Ptr32(uiAddr));
+            imgW.WriteString(str, Encoding.ASCII);
+        }
+
+        private DataType CStringType()
+        {
+            return new Pointer(PrimitiveType.Char, 4);
+        }
+
+        private Identifier StackId(string name, int offset, DataType dt)
+        {
+            return new Identifier(
+                name,
+                dt,
+                new StackArgumentStorage(offset, dt));
+        }
+
+        private Identifier RegId(
+            string name,
+            IProcessorArchitecture arch,
+            string reg,
+            DataType dt)
+        {
+            return new Identifier(
+                name,
+                dt,
+                arch.GetRegister(reg));
+        }
+
+        private void Given_VaScanner(IProcessorArchitecture arch)
+        {
+            var platform = new DefaultPlatform(null, arch);
+            var segmentMap = CreateSegmentMap(0, 128);
+            this.program = new Program(segmentMap, arch, platform);
+            this.vafs = CreateVaScanner(program);
+        }
+
+        private void Given_StackString(int stackOffset, string str)
+        {
+            uint uiAddr = 0x13;
+            var sp = m.Register(program.Architecture.StackRegister);
+            var stackAccess = m.IAdd(sp, stackOffset);
+            state.SetValueEa(stackAccess, Constant.Word32(uiAddr));
+            WriteString(program, uiAddr, str);
+        }
+
+        private void Given_RegString(string reg, string str)
+        {
+            uint uiAddr = 0x13;
+            var r = program.Architecture.GetRegister(reg);
+            state.SetRegister(r, Constant.Word32(uiAddr));
+            WriteString(program, uiAddr, str);
+        }
+
+        [Test]
+        public void Vafs_NoVarargs()
+        {
+            Given_VaScanner(x86);
+            var emptyChr = new ProcedureCharacteristics();
+            var emptySig = new FunctionType();
+            Assert.IsFalse(vafs.TryScan(null, null));
+            Assert.IsFalse(vafs.TryScan(emptySig, null));
+            Assert.IsFalse(vafs.TryScan(null, emptyChr));
+            Assert.IsFalse(vafs.TryScan(emptySig, emptyChr));
+            Assert.IsFalse(vafs.TryScan(x86PrintfSig, null));
+            Assert.IsFalse(vafs.TryScan(x86PrintfSig, emptyChr));
+            Assert.IsFalse(vafs.TryScan(null, printfChr));
+            Assert.IsFalse(vafs.TryScan(emptySig, printfChr));
+        }
+
+        [Test]
+        public void Vafs_X86Printf()
+        {
+            Given_VaScanner(x86);
+            Given_StackString(4, "%d %f");
+            Assert.IsTrue(vafs.TryScan(x86PrintfSig, printfChr));
+            var c = Constant.Word32(666);
+            var instr = vafs.BuildInstruction(c, new CallSite(4, 0));
+            Assert.AreEqual(
+                "0x0000029A(Mem0[esp:(ptr char)], Mem0[esp + 4:int32], " +
+                           "Mem0[esp + 8:real64])",
+                instr.ToString());
+        }
+
+        [Test]
+        public void Vafs_X86Sprintf()
+        {
+            Given_VaScanner(x86);
+            Given_StackString(8, "%c");
+            Assert.IsTrue(vafs.TryScan(x86SprintfSig, printfChr));
+            var ep = new ExternalProcedure("sprintf", x86SprintfSig);
+            var pc = new ProcedureConstant(new CodeType(), ep);
+            var instr = vafs.BuildInstruction(pc, new CallSite(4, 0));
+            Assert.AreEqual(
+                "sprintf(Mem0[esp:(ptr char)], Mem0[esp + 4:(ptr char)], " +
+                        "Mem0[esp + 8:char])",
+                instr.ToString());
+            var appl = (Application)((SideEffect)instr).Expression;
+            var sig = ((ProcedureConstant)appl.Procedure).Procedure.Signature;
+            Assert.AreEqual(
+                "(fn void ((ptr char), (ptr char), char))",
+                sig.ToString());
+        }
+
+        [Test]
+        [Ignore("Varargs scanning has not implemented on PowerPc")]
+        public void Vafs_PpcPrintf()
+        {
+            Given_VaScanner(ppc);
+            Given_RegString("r3", "%d%d");
+            Assert.IsTrue(vafs.TryScan(ppcPrintfSig, printfChr));
+            var c = Constant.Word32(0x123);
+            var instr = vafs.BuildInstruction(c, new CallSite(4, 0));
+            Assert.AreEqual(
+                "0x00000123(r3, r4, r5)",
+                instr.ToString());
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -492,6 +492,7 @@
     <Compile Include="Scanning\ScannerTests.cs" />
     <Compile Include="Scanning\ShingledScannerTests.cs" />
     <Compile Include="Scanning\StringFinderTests.cs" />
+    <Compile Include="Scanning\VarargsFormatScannerTests.cs" />
     <Compile Include="Scanning\VectorBuilderTests.cs" />
     <Compile Include="Structure\AbsynCodeGeneratorTests.cs" />
     <Compile Include="Structure\AbsynStatementEmitterTests.cs" />

--- a/subjects/PE-x86/VCExeSample/VCExeSample.c
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.c
@@ -12,7 +12,7 @@ int32 main(int32 argc, char * * argv)
 
 void test1(char * arg1, int32 arg2, char * arg3, real32 arg4)
 {
-	printf("%s %d %s %f");
+	printf("%s %d %s %f", arg1, arg2, arg3, (real64) arg4);
 	return;
 }
 

--- a/subjects/PE-x86/VCExeSample/VCExeSample.dis
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.dis
@@ -33,15 +33,15 @@ void test1(char * arg1, int32 arg2, char * arg3, real32 arg4)
 // LiveOut:
 // Trashed: SCZO ah al ax ch cl cx dh dl dx eax ecx edx rax rcx rdx
 // Preserved: ebp esp
-// Stack args: Stack +0010(32)
+// Stack args: Stack +0004(32) Stack +0008(32) Stack +000C(32) Stack +0010(32)
 test1_entry:
 // DataOut:
 // DataOut (flags): 
 // SymbolicIn: esp:fp
-// LocalsOut: fp(32) Stack +0010(32)
+// LocalsOut: fp(32) Stack +0004(32) Stack +0008(32) Stack +000C(32) Stack +0010(32)
 
 l00401030:
-	printf(0x004020C8)
+	printf(0x004020C8, arg1, arg2, arg3, (real64) arg4)
 	return
 // DataOut:
 // DataOut (flags): 

--- a/subjects/PE-x86/VCExeSample/VCExeSample.globals.c
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.globals.c
@@ -13,5 +13,5 @@ char g_str4020E0[] = "5";
 real32 g_r4020E4 = 8.567F;
 real32 g_r4020E8 = 4.123F;
 real32 g_r4020EC = 1000.1F;
-Eq_53 g_gbl_c = ;
+Eq_58 g_gbl_c = ;
 

--- a/subjects/PE-x86/VCExeSample/VCExeSample.h
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.h
@@ -4,47 +4,47 @@
 
 /*
 // Equivalence classes ////////////
-Eq_1: (struct "Globals" (4020C0 (str char) str4020C0) (4020C8 (str char) str4020C8) (4020D4 (str char) str4020D4) (4020D8 (str char) str4020D8) (4020DC (str char) str4020DC) (4020E0 (str char) str4020E0) (4020E4 real32 r4020E4) (4020E8 real32 r4020E8) (4020EC real32 r4020EC) (403018 Eq_53 gbl_c))
+Eq_1: (struct "Globals" (4020C0 (str char) str4020C0) (4020C8 (str char) str4020C8) (4020D4 (str char) str4020D4) (4020D8 (str char) str4020D8) (4020DC (str char) str4020DC) (4020E0 (str char) str4020E0) (4020E4 real32 r4020E4) (4020E8 real32 r4020E8) (4020EC real32 r4020EC) (403018 Eq_58 gbl_c))
 	globals_t (in globals : (ptr (struct "Globals")))
 Eq_5: (fn void ((ptr char), int32, (ptr char), real32))
 	T_5 (in test1 : ptr32)
 	T_6 (in signature of test1 : void)
-	T_26 (in test1 : ptr32)
-	T_36 (in test1 : ptr32)
-Eq_20: (fn int32 ((ptr char)))
+	T_31 (in test1 : ptr32)
+	T_41 (in test1 : ptr32)
+Eq_20: (fn int32 ((ptr char), (ptr char), int32, (ptr char), real64))
 	T_20 (in printf : ptr32)
 	T_21 (in signature of printf : void)
-Eq_43: cdecl_class
-	T_43 (in c : (ptr Eq_43))
-Eq_45: cdecl_class_vtbl
-	T_45 (in c + 0x00000000 : word32)
-Eq_46: cdecl_class_vtbl
-	T_46 (in Mem0[c + 0x00000000:word32] : word32)
-Eq_48: (fn void ((ptr cdecl_class), int32))
-	T_48 (in Mem0[c + 0x00000000:word32] + 0x00000004 : word32)
-Eq_49: (fn void ((ptr Eq_43), int32))
-	T_49 (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000004:word32] : word32)
-Eq_53: (union "Eq_53" ((ptr cdecl_class) u0) (cdecl_class_ptr u1))
-	T_53 (in Mem0[0x00403018:word32] : word32)
-	T_61 (in Mem0[0x00403018:word32] : word32)
-	T_64 (in Mem0[0x00403018:word32] : word32)
-	T_72 (in Mem0[0x00403018:word32] : word32)
-Eq_55: cdecl_class_vtbl
-	T_55 (in Mem0[0x00403018:word32] + 0x00000000 : word32)
-Eq_56: cdecl_class_vtbl
-	T_56 (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] : word32)
-Eq_58: (fn void ((ptr cdecl_class)))
-	T_58 (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000000 : word32)
-Eq_59: (fn void (Eq_53))
-	T_59 (in Mem0[Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
-Eq_66: cdecl_class_vtbl
-	T_66 (in Mem0[0x00403018:word32] + 0x00000000 : word32)
-Eq_67: cdecl_class_vtbl
-	T_67 (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] : word32)
-Eq_69: (fn void ((ptr cdecl_class), int32))
-	T_69 (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000004 : word32)
-Eq_70: (union "Eq_70" ((fn void ((ptr cdecl_class), int32)) u0) ((fn void (Eq_53, word32, real32)) u1))
-	T_70 (in Mem0[Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
+Eq_48: cdecl_class
+	T_48 (in c : (ptr Eq_48))
+Eq_50: cdecl_class_vtbl
+	T_50 (in c + 0x00000000 : word32)
+Eq_51: cdecl_class_vtbl
+	T_51 (in Mem0[c + 0x00000000:word32] : word32)
+Eq_53: (fn void ((ptr cdecl_class), int32))
+	T_53 (in Mem0[c + 0x00000000:word32] + 0x00000004 : word32)
+Eq_54: (fn void ((ptr Eq_48), int32))
+	T_54 (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+Eq_58: (union "Eq_58" ((ptr cdecl_class) u0) (cdecl_class_ptr u1))
+	T_58 (in Mem0[0x00403018:word32] : word32)
+	T_66 (in Mem0[0x00403018:word32] : word32)
+	T_69 (in Mem0[0x00403018:word32] : word32)
+	T_77 (in Mem0[0x00403018:word32] : word32)
+Eq_60: cdecl_class_vtbl
+	T_60 (in Mem0[0x00403018:word32] + 0x00000000 : word32)
+Eq_61: cdecl_class_vtbl
+	T_61 (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] : word32)
+Eq_63: (fn void ((ptr cdecl_class)))
+	T_63 (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000000 : word32)
+Eq_64: (fn void (Eq_58))
+	T_64 (in Mem0[Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
+Eq_71: cdecl_class_vtbl
+	T_71 (in Mem0[0x00403018:word32] + 0x00000000 : word32)
+Eq_72: cdecl_class_vtbl
+	T_72 (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] : word32)
+Eq_74: (fn void ((ptr cdecl_class), int32))
+	T_74 (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000004 : word32)
+Eq_75: (union "Eq_75" ((fn void ((ptr cdecl_class), int32)) u0) ((fn void (Eq_58, word32, real32)) u1))
+	T_75 (in Mem0[Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
 // Type Variables ////////////
 globals_t: (in globals : (ptr (struct "Globals")))
   Class: Eq_1
@@ -125,7 +125,7 @@ T_19: (in 0x00000000 : word32)
 T_20: (in printf : ptr32)
   Class: Eq_20
   DataType: (ptr Eq_20)
-  OrigDataType: (ptr (fn T_24 (T_23)))
+  OrigDataType: (ptr (fn T_29 (T_27, T_7, T_8, T_9, T_28)))
 T_21: (in signature of printf : void)
   Class: Eq_20
   DataType: (ptr Eq_20)
@@ -134,220 +134,240 @@ T_22: (in ptrArg04 : (ptr char))
   Class: Eq_22
   DataType: (ptr char)
   OrigDataType: 
-T_23: (in 0x004020C8 : word32)
+T_23: (in  : 32)
+  Class: Eq_7
+  DataType: (ptr char)
+  OrigDataType: 
+T_24: (in  : int32)
+  Class: Eq_8
+  DataType: int32
+  OrigDataType: 
+T_25: (in  : 32)
+  Class: Eq_9
+  DataType: (ptr char)
+  OrigDataType: 
+T_26: (in  : real64)
+  Class: Eq_26
+  DataType: real64
+  OrigDataType: 
+T_27: (in 0x004020C8 : word32)
   Class: Eq_22
   DataType: (ptr char)
   OrigDataType: (ptr char)
-T_24: (in printf("%s %d %s %f") : int32)
-  Class: Eq_24
+T_28: (in (real64) arg4 : real64)
+  Class: Eq_26
+  DataType: real64
+  OrigDataType: real64
+T_29: (in printf("%s %d %s %f", arg1, arg2, arg3, (real64) arg4) : int32)
+  Class: Eq_29
   DataType: int32
   OrigDataType: int32
-T_25: (in dwArg04 : word32)
-  Class: Eq_25
+T_30: (in dwArg04 : word32)
+  Class: Eq_30
   DataType: word32
   OrigDataType: word32
-T_26: (in test1 : ptr32)
+T_31: (in test1 : ptr32)
   Class: Eq_5
   DataType: (ptr Eq_5)
-  OrigDataType: (ptr (fn T_32 (T_27, T_28, T_29, T_31)))
-T_27: (in 0x004020D8 : word32)
+  OrigDataType: (ptr (fn T_37 (T_32, T_33, T_34, T_36)))
+T_32: (in 0x004020D8 : word32)
   Class: Eq_7
   DataType: (ptr char)
   OrigDataType: (ptr char)
-T_28: (in 0x00000002 : word32)
+T_33: (in 0x00000002 : word32)
   Class: Eq_8
   DataType: int32
   OrigDataType: int32
-T_29: (in 0x004020D4 : word32)
+T_34: (in 0x004020D4 : word32)
   Class: Eq_9
   DataType: (ptr char)
   OrigDataType: (ptr char)
-T_30: (in 0x004020E8 : ptr32)
-  Class: Eq_30
+T_35: (in 0x004020E8 : ptr32)
+  Class: Eq_35
   DataType: (ptr real32)
-  OrigDataType: (ptr (struct (0 T_31 t0000)))
-T_31: (in Mem0[0x004020E8:real32] : real32)
+  OrigDataType: (ptr (struct (0 T_36 t0000)))
+T_36: (in Mem0[0x004020E8:real32] : real32)
   Class: Eq_10
   DataType: real32
   OrigDataType: real32
-T_32: (in test1("1", 0x00000002, "3", globals->r4020E8) : void)
+T_37: (in test1("1", 0x00000002, "3", globals->r4020E8) : void)
   Class: Eq_18
   DataType: void
   OrigDataType: void
-T_33: (in dwArg04 : word32)
-  Class: Eq_33
+T_38: (in dwArg04 : word32)
+  Class: Eq_38
   DataType: word32
   OrigDataType: word32
-T_34: (in 0x00000000 : word32)
-  Class: Eq_33
+T_39: (in 0x00000000 : word32)
+  Class: Eq_38
   DataType: word32
   OrigDataType: word32
-T_35: (in dwArg04 != 0x00000000 : bool)
-  Class: Eq_35
+T_40: (in dwArg04 != 0x00000000 : bool)
+  Class: Eq_40
   DataType: bool
   OrigDataType: bool
-T_36: (in test1 : ptr32)
+T_41: (in test1 : ptr32)
   Class: Eq_5
   DataType: (ptr Eq_5)
-  OrigDataType: (ptr (fn T_42 (T_37, T_38, T_39, T_41)))
-T_37: (in 0x004020E0 : word32)
+  OrigDataType: (ptr (fn T_47 (T_42, T_43, T_44, T_46)))
+T_42: (in 0x004020E0 : word32)
   Class: Eq_7
   DataType: (ptr char)
   OrigDataType: (ptr char)
-T_38: (in 0x00000006 : word32)
+T_43: (in 0x00000006 : word32)
   Class: Eq_8
   DataType: int32
   OrigDataType: int32
-T_39: (in 0x004020DC : word32)
+T_44: (in 0x004020DC : word32)
   Class: Eq_9
   DataType: (ptr char)
   OrigDataType: (ptr char)
-T_40: (in 0x004020E4 : ptr32)
-  Class: Eq_40
+T_45: (in 0x004020E4 : ptr32)
+  Class: Eq_45
   DataType: (ptr real32)
-  OrigDataType: (ptr (struct (0 T_41 t0000)))
-T_41: (in Mem0[0x004020E4:real32] : real32)
+  OrigDataType: (ptr (struct (0 T_46 t0000)))
+T_46: (in Mem0[0x004020E4:real32] : real32)
   Class: Eq_10
   DataType: real32
   OrigDataType: real32
-T_42: (in test1("5", 0x00000006, "7", globals->r4020E4) : void)
+T_47: (in test1("5", 0x00000006, "7", globals->r4020E4) : void)
   Class: Eq_18
   DataType: void
   OrigDataType: void
-T_43: (in c : (ptr Eq_43))
-  Class: Eq_43
-  DataType: (ptr Eq_43)
-  OrigDataType: (ptr cdecl_class)
-T_44: (in 0x00000000 : word32)
-  Class: Eq_44
-  DataType: word32
-  OrigDataType: word32
-T_45: (in c + 0x00000000 : word32)
-  Class: Eq_45
-  DataType: (ptr (ptr Eq_45))
-  OrigDataType: (ptr (ptr cdecl_class_vtbl))
-T_46: (in Mem0[c + 0x00000000:word32] : word32)
-  Class: Eq_46
-  DataType: (ptr Eq_46)
-  OrigDataType: (ptr cdecl_class_vtbl)
-T_47: (in 0x00000004 : word32)
-  Class: Eq_47
-  DataType: word32
-  OrigDataType: word32
-T_48: (in Mem0[c + 0x00000000:word32] + 0x00000004 : word32)
+T_48: (in c : (ptr Eq_48))
   Class: Eq_48
-  DataType: (ptr (ptr Eq_48))
-  OrigDataType: (ptr (ptr (fn void ((ptr cdecl_class), int32))))
-T_49: (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+  DataType: (ptr Eq_48)
+  OrigDataType: (ptr cdecl_class)
+T_49: (in 0x00000000 : word32)
   Class: Eq_49
-  DataType: (ptr Eq_49)
-  OrigDataType: (ptr (fn T_51 (T_43, T_50)))
-T_50: (in 0x000003E8 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_50: (in c + 0x00000000 : word32)
   Class: Eq_50
+  DataType: (ptr (ptr Eq_50))
+  OrigDataType: (ptr (ptr cdecl_class_vtbl))
+T_51: (in Mem0[c + 0x00000000:word32] : word32)
+  Class: Eq_51
+  DataType: (ptr Eq_51)
+  OrigDataType: (ptr cdecl_class_vtbl)
+T_52: (in 0x00000004 : word32)
+  Class: Eq_52
+  DataType: word32
+  OrigDataType: word32
+T_53: (in Mem0[c + 0x00000000:word32] + 0x00000004 : word32)
+  Class: Eq_53
+  DataType: (ptr (ptr Eq_53))
+  OrigDataType: (ptr (ptr (fn void ((ptr cdecl_class), int32))))
+T_54: (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+  Class: Eq_54
+  DataType: (ptr Eq_54)
+  OrigDataType: (ptr (fn T_56 (T_48, T_55)))
+T_55: (in 0x000003E8 : word32)
+  Class: Eq_55
   DataType: int32
   OrigDataType: int32
-T_51: (in c->vtbl->method04(c, 0x000003E8) : void)
-  Class: Eq_51
-  DataType: void
-  OrigDataType: void
-T_52: (in 0x00403018 : ptr32)
-  Class: Eq_52
-  DataType: (ptr Eq_53)
-  OrigDataType: (ptr (struct (0 T_53 t0000)))
-T_53: (in Mem0[0x00403018:word32] : word32)
-  Class: Eq_53
-  DataType: Eq_53
-  OrigDataType: cdecl_class_ptr
-T_54: (in 0x00000000 : word32)
-  Class: Eq_54
-  DataType: word32
-  OrigDataType: word32
-T_55: (in Mem0[0x00403018:word32] + 0x00000000 : word32)
-  Class: Eq_55
-  DataType: (ptr (ptr Eq_55))
-  OrigDataType: (ptr (ptr cdecl_class_vtbl))
-T_56: (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] : word32)
+T_56: (in c->vtbl->method04(c, 0x000003E8) : void)
   Class: Eq_56
-  DataType: (ptr Eq_56)
-  OrigDataType: (ptr cdecl_class_vtbl)
-T_57: (in 0x00000000 : word32)
-  Class: Eq_57
-  DataType: word32
-  OrigDataType: word32
-T_58: (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000000 : word32)
-  Class: Eq_58
-  DataType: (ptr (ptr Eq_58))
-  OrigDataType: (ptr (ptr (fn void ((ptr cdecl_class)))))
-T_59: (in Mem0[Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
-  Class: Eq_59
-  DataType: (ptr Eq_59)
-  OrigDataType: (ptr (fn T_62 (T_61)))
-T_60: (in 0x00403018 : word32)
-  Class: Eq_60
-  DataType: (ptr Eq_53)
-  OrigDataType: (ptr (struct (0 T_61 t0000)))
-T_61: (in Mem0[0x00403018:word32] : word32)
-  Class: Eq_53
-  DataType: Eq_53
-  OrigDataType: (union ((ptr cdecl_class) u1) (cdecl_class_ptr u0))
-T_62: (in (**globals->gbl_c)(globals->gbl_c) : void)
-  Class: Eq_62
   DataType: void
   OrigDataType: void
-T_63: (in 0x00403018 : ptr32)
-  Class: Eq_63
-  DataType: (ptr Eq_53)
-  OrigDataType: (ptr (struct (0 T_64 t0000)))
-T_64: (in Mem0[0x00403018:word32] : word32)
-  Class: Eq_53
-  DataType: Eq_53
+T_57: (in 0x00403018 : ptr32)
+  Class: Eq_57
+  DataType: (ptr Eq_58)
+  OrigDataType: (ptr (struct (0 T_58 t0000)))
+T_58: (in Mem0[0x00403018:word32] : word32)
+  Class: Eq_58
+  DataType: Eq_58
   OrigDataType: cdecl_class_ptr
-T_65: (in 0x00000000 : word32)
-  Class: Eq_65
+T_59: (in 0x00000000 : word32)
+  Class: Eq_59
   DataType: word32
   OrigDataType: word32
-T_66: (in Mem0[0x00403018:word32] + 0x00000000 : word32)
-  Class: Eq_66
-  DataType: (ptr (ptr Eq_66))
+T_60: (in Mem0[0x00403018:word32] + 0x00000000 : word32)
+  Class: Eq_60
+  DataType: (ptr (ptr Eq_60))
   OrigDataType: (ptr (ptr cdecl_class_vtbl))
-T_67: (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] : word32)
-  Class: Eq_67
-  DataType: (ptr Eq_67)
+T_61: (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] : word32)
+  Class: Eq_61
+  DataType: (ptr Eq_61)
   OrigDataType: (ptr cdecl_class_vtbl)
-T_68: (in 0x00000004 : word32)
-  Class: Eq_68
+T_62: (in 0x00000000 : word32)
+  Class: Eq_62
   DataType: word32
   OrigDataType: word32
-T_69: (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000004 : word32)
-  Class: Eq_69
-  DataType: (ptr (ptr Eq_69))
-  OrigDataType: (ptr (ptr (fn void ((ptr cdecl_class), int32))))
-T_70: (in Mem0[Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
-  Class: Eq_70
-  DataType: (ptr Eq_70)
-  OrigDataType: (ptr (union ((fn void ((ptr cdecl_class), int32)) u0) ((fn void (Eq_53, word32, real32)) u1)))
-T_71: (in 0x00403018 : word32)
-  Class: Eq_71
-  DataType: (ptr Eq_53)
-  OrigDataType: (ptr (struct (0 T_72 t0000)))
-T_72: (in Mem0[0x00403018:word32] : word32)
-  Class: Eq_53
-  DataType: Eq_53
+T_63: (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000000 : word32)
+  Class: Eq_63
+  DataType: (ptr (ptr Eq_63))
+  OrigDataType: (ptr (ptr (fn void ((ptr cdecl_class)))))
+T_64: (in Mem0[Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
+  Class: Eq_64
+  DataType: (ptr Eq_64)
+  OrigDataType: (ptr (fn T_67 (T_66)))
+T_65: (in 0x00403018 : word32)
+  Class: Eq_65
+  DataType: (ptr Eq_58)
+  OrigDataType: (ptr (struct (0 T_66 t0000)))
+T_66: (in Mem0[0x00403018:word32] : word32)
+  Class: Eq_58
+  DataType: Eq_58
+  OrigDataType: (union ((ptr cdecl_class) u1) (cdecl_class_ptr u0))
+T_67: (in (**globals->gbl_c)(globals->gbl_c) : void)
+  Class: Eq_67
+  DataType: void
+  OrigDataType: void
+T_68: (in 0x00403018 : ptr32)
+  Class: Eq_68
+  DataType: (ptr Eq_58)
+  OrigDataType: (ptr (struct (0 T_69 t0000)))
+T_69: (in Mem0[0x00403018:word32] : word32)
+  Class: Eq_58
+  DataType: Eq_58
   OrigDataType: cdecl_class_ptr
-T_73: (in 0x000003E7 : word32)
+T_70: (in 0x00000000 : word32)
+  Class: Eq_70
+  DataType: word32
+  OrigDataType: word32
+T_71: (in Mem0[0x00403018:word32] + 0x00000000 : word32)
+  Class: Eq_71
+  DataType: (ptr (ptr Eq_71))
+  OrigDataType: (ptr (ptr cdecl_class_vtbl))
+T_72: (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] : word32)
+  Class: Eq_72
+  DataType: (ptr Eq_72)
+  OrigDataType: (ptr cdecl_class_vtbl)
+T_73: (in 0x00000004 : word32)
   Class: Eq_73
   DataType: word32
   OrigDataType: word32
-T_74: (in 0x004020EC : ptr32)
+T_74: (in Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000004 : word32)
   Class: Eq_74
-  DataType: (ptr real32)
-  OrigDataType: (ptr (struct (0 T_75 t0000)))
-T_75: (in Mem0[0x004020EC:real32] : real32)
+  DataType: (ptr (ptr Eq_74))
+  OrigDataType: (ptr (ptr (fn void ((ptr cdecl_class), int32))))
+T_75: (in Mem0[Mem0[Mem0[0x00403018:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
   Class: Eq_75
+  DataType: (ptr Eq_75)
+  OrigDataType: (ptr (union ((fn void ((ptr cdecl_class), int32)) u0) ((fn void (Eq_58, word32, real32)) u1)))
+T_76: (in 0x00403018 : word32)
+  Class: Eq_76
+  DataType: (ptr Eq_58)
+  OrigDataType: (ptr (struct (0 T_77 t0000)))
+T_77: (in Mem0[0x00403018:word32] : word32)
+  Class: Eq_58
+  DataType: Eq_58
+  OrigDataType: cdecl_class_ptr
+T_78: (in 0x000003E7 : word32)
+  Class: Eq_78
+  DataType: word32
+  OrigDataType: word32
+T_79: (in 0x004020EC : ptr32)
+  Class: Eq_79
+  DataType: (ptr real32)
+  OrigDataType: (ptr (struct (0 T_80 t0000)))
+T_80: (in Mem0[0x004020EC:real32] : real32)
+  Class: Eq_80
   DataType: real32
   OrigDataType: real32
-T_76: (in (**globals->gbl_c)(globals->gbl_c, 0x000003E7, globals->r4020EC) : void)
-  Class: Eq_76
+T_81: (in (**globals->gbl_c)(globals->gbl_c, 0x000003E7, globals->r4020EC) : void)
+  Class: Eq_81
   DataType: void
   OrigDataType: void
 */
@@ -361,44 +381,44 @@ typedef struct Globals {
 	real32 r4020E4;	// 4020E4
 	real32 r4020E8;	// 4020E8
 	real32 r4020EC;	// 4020EC
-	Eq_53 gbl_c;	// 403018
+	Eq_58 gbl_c;	// 403018
 } Eq_1;
 
 typedef void (Eq_5)(char *, int32, char *, real32);
 
-typedef int32 (Eq_20)(char *);
+typedef int32 (Eq_20)(char *, char *, int32, char *, real64);
 
-typedef cdecl_class Eq_43;
+typedef cdecl_class Eq_48;
 
-typedef cdecl_class_vtbl Eq_45;
+typedef cdecl_class_vtbl Eq_50;
 
-typedef cdecl_class_vtbl Eq_46;
+typedef cdecl_class_vtbl Eq_51;
 
-typedef void (Eq_48)(cdecl_class * ptrArg04, int32 dwArg08);
+typedef void (Eq_53)(cdecl_class * ptrArg04, int32 dwArg08);
 
-typedef void (Eq_49)(cdecl_class *, int32);
+typedef void (Eq_54)(cdecl_class *, int32);
 
-typedef union Eq_53 {
+typedef union Eq_58 {
 	cdecl_class * u0;
 	cdecl_class_ptr u1;
-} Eq_53;
+} Eq_58;
 
-typedef cdecl_class_vtbl Eq_55;
+typedef cdecl_class_vtbl Eq_60;
 
-typedef cdecl_class_vtbl Eq_56;
+typedef cdecl_class_vtbl Eq_61;
 
-typedef void (Eq_58)(cdecl_class * ptrArg04);
+typedef void (Eq_63)(cdecl_class * ptrArg04);
 
-typedef void (Eq_59)(Eq_53);
+typedef void (Eq_64)(Eq_58);
 
-typedef cdecl_class_vtbl Eq_66;
+typedef cdecl_class_vtbl Eq_71;
 
-typedef cdecl_class_vtbl Eq_67;
+typedef cdecl_class_vtbl Eq_72;
 
-typedef void (Eq_69)(cdecl_class * ptrArg04, int32 dwArg08);
+typedef void (Eq_74)(cdecl_class * ptrArg04, int32 dwArg08);
 
-typedef union Eq_70 {
+typedef union Eq_75 {
 	void u0(cdecl_class * ptrArg04, int32 dwArg08);
-	void u1(Eq_53, word32, real32);
-} Eq_70;
+	void u1(Eq_58, word32, real32);
+} Eq_75;
 


### PR DESCRIPTION
Create scanner for varargs format (new `VarargsFormatScanner` class). It scans and parses format and then builds application instruction with new signature. It uses children of new `IVarargsFormatParser` inerface (currently only `MsPrintfFormatParser`) to parse format
Also I have modified `MsPrintfFormatParser` so that it parses "f" as double rather than float.