### PR TITLE
Hack for #316

### DIFF
--- a/src/Decompiler/Analysis/ExpressionPropagator.cs
+++ b/src/Decompiler/Analysis/ExpressionPropagator.cs
@@ -121,7 +121,20 @@ namespace Reko.Analysis
             else
             {
                 var fn = ci.Callee.Accept(this);
+                //$HACK: all registers should be trashed but it caused
+                // regression. e.g. "ebp" trashing makes local variables
+                // recognition impossible on x86. So just trash "eax"
+                TrashRegister("eax");
                 return new CallInstruction(fn.PropagatedExpression, ci.CallSite);
+            }
+        }
+
+        private void TrashRegister(string regName)
+        {
+            foreach (var reg in arch.GetRegisters())
+            {
+                if (reg.Name == regName)
+                    ctx.RegisterState[reg] = Constant.Invalid;
             }
         }
 

--- a/src/tests/Analysis/DfaReg00316.exp
+++ b/src/tests/Analysis/DfaReg00316.exp
@@ -1,0 +1,25 @@
+// Register int32 r316(Stack int32 a)
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
+// MayUse: 
+// LiveOut:
+// Trashed: SZO ah al ax ch cl cx eax ecx esp rax rcx rsp sp spl
+// Preserved:
+// Stack args: Stack +0004(32)
+// r316
+// Return size: 4
+int32 r316(int32 a)
+fn0C00_0000_entry:
+	// succ:  l0C00_0000
+l0C00_0000:
+	word32 ecx_6 = Mem0[a:word32]
+	word32 esp_9
+	word32 eax_10
+	word32 ecx_11
+	byte SZO_12
+	call Mem0[ecx_6 + 0x00000004:word32] (retsize: 4; depth: 8)
+		uses: dwLoc04_8,eax_4,ecx_6,esp_7
+		defs: eax_10,ecx_11,esp_9,SZO_12
+	return eax_10 + 0x00000001
+	// succ:  fn0C00_0000_exit
+fn0C00_0000_exit:
+

--- a/src/tests/Fragments/regressions/r00316.asm
+++ b/src/tests/Fragments/regressions/r00316.asm
@@ -1,0 +1,12 @@
+;;; r00316.asm
+
+.i386
+
+main proc
+        mov eax, [esp+4]
+        mov ecx, [eax]
+        push 0x0000000A
+        call dword ptr [ecx+4]
+        inc eax
+        ret
+main endp

--- a/subjects/PE-x86/VCExeSample/VCExeSample.c
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.c
@@ -44,8 +44,7 @@ void test5()
 
 void test6(cdecl_class * c, int32 a, int32 b)
 {
-	c->vtbl->sum(c, a, b);
-	c->vtbl->method04(c, c);
+	c->vtbl->method04(c, c->vtbl->sum(c, a, b));
 	return;
 }
 

--- a/subjects/PE-x86/VCExeSample/VCExeSample.dis
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.dis
@@ -192,8 +192,7 @@ test6_entry:
 // LocalsOut: fp(32) Stack +0004(32)
 
 l00401120:
-	Mem0[Mem0[c:word32] + 0x00000008:word32](c, a, b)
-	Mem0[Mem0[c:word32] + 0x00000004:word32](c, c)
+	Mem0[Mem0[c:word32] + 0x00000004:word32](c, Mem0[Mem0[c:word32] + 0x00000008:word32](c, a, b))
 	return
 // DataOut:
 // DataOut (flags): 

--- a/subjects/PE-x86/VCExeSample/VCExeSample.h
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.h
@@ -63,18 +63,18 @@ Eq_92: cdecl_class_vtbl
 	T_92 (in c + 0x00000000 : word32)
 Eq_93: cdecl_class_vtbl
 	T_93 (in Mem0[c + 0x00000000:word32] : word32)
-Eq_95: (fn int32 ((ptr cdecl_class), int32, int32))
-	T_95 (in Mem0[c + 0x00000000:word32] + 0x00000008 : word32)
-Eq_96: (fn int32 ((ptr cdecl_class), int32, int32))
-	T_96 (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000008:word32] : word32)
-Eq_101: cdecl_class_vtbl
-	T_101 (in c + 0x00000000 : word32)
-Eq_102: cdecl_class_vtbl
-	T_102 (in Mem0[c + 0x00000000:word32] : word32)
-Eq_104: (fn void ((ptr cdecl_class), int32))
-	T_104 (in Mem0[c + 0x00000000:word32] + 0x00000004 : word32)
-Eq_105: (fn void ((ptr cdecl_class), int32))
-	T_105 (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+Eq_95: (fn void ((ptr cdecl_class), int32))
+	T_95 (in Mem0[c + 0x00000000:word32] + 0x00000004 : word32)
+Eq_96: (fn void ((ptr cdecl_class), int32))
+	T_96 (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+Eq_98: cdecl_class_vtbl
+	T_98 (in c + 0x00000000 : word32)
+Eq_99: cdecl_class_vtbl
+	T_99 (in Mem0[c + 0x00000000:word32] : word32)
+Eq_101: (fn int32 ((ptr cdecl_class), int32, int32))
+	T_101 (in Mem0[c + 0x00000000:word32] + 0x00000008 : word32)
+Eq_102: (fn int32 ((ptr cdecl_class), int32, int32))
+	T_102 (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000008:word32] : word32)
 // Type Variables ////////////
 globals_t: (in globals : (ptr (struct "Globals")))
   Class: Eq_1
@@ -448,55 +448,55 @@ T_93: (in Mem0[c + 0x00000000:word32] : word32)
   Class: Eq_93
   DataType: (ptr Eq_93)
   OrigDataType: (ptr (union (cdecl_class_vtbl u1)))
-T_94: (in 0x00000008 : word32)
+T_94: (in 0x00000004 : word32)
   Class: Eq_94
   DataType: word32
   OrigDataType: word32
-T_95: (in Mem0[c + 0x00000000:word32] + 0x00000008 : word32)
+T_95: (in Mem0[c + 0x00000000:word32] + 0x00000004 : word32)
   Class: Eq_95
   DataType: (ptr (ptr Eq_95))
-  OrigDataType: (ptr (ptr (fn int32 ((ptr cdecl_class), int32, int32))))
-T_96: (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000008:word32] : word32)
+  OrigDataType: (ptr (ptr (fn void ((ptr cdecl_class), int32))))
+T_96: (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000004:word32] : word32)
   Class: Eq_96
   DataType: (ptr Eq_96)
-  OrigDataType: (ptr (fn int32 ((ptr cdecl_class), int32, int32)))
-T_97: (in a : int32)
+  OrigDataType: (ptr (fn void ((ptr cdecl_class), int32)))
+T_97: (in 0x00000000 : word32)
   Class: Eq_97
-  DataType: int32
-  OrigDataType: int32
-T_98: (in b : int32)
+  DataType: word32
+  OrigDataType: word32
+T_98: (in c + 0x00000000 : word32)
   Class: Eq_98
-  DataType: int32
-  OrigDataType: int32
-T_99: (in c->vtbl->sum(c, a, b) : int32)
+  DataType: (ptr (ptr Eq_98))
+  OrigDataType: (ptr (ptr cdecl_class_vtbl))
+T_99: (in Mem0[c + 0x00000000:word32] : word32)
   Class: Eq_99
-  DataType: int32
-  OrigDataType: int32
-T_100: (in 0x00000000 : word32)
+  DataType: (ptr Eq_99)
+  OrigDataType: (ptr (union (cdecl_class_vtbl u1)))
+T_100: (in 0x00000008 : word32)
   Class: Eq_100
   DataType: word32
   OrigDataType: word32
-T_101: (in c + 0x00000000 : word32)
+T_101: (in Mem0[c + 0x00000000:word32] + 0x00000008 : word32)
   Class: Eq_101
   DataType: (ptr (ptr Eq_101))
-  OrigDataType: (ptr (ptr cdecl_class_vtbl))
-T_102: (in Mem0[c + 0x00000000:word32] : word32)
+  OrigDataType: (ptr (ptr (fn int32 ((ptr cdecl_class), int32, int32))))
+T_102: (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000008:word32] : word32)
   Class: Eq_102
   DataType: (ptr Eq_102)
-  OrigDataType: (ptr (union (cdecl_class_vtbl u1)))
-T_103: (in 0x00000004 : word32)
+  OrigDataType: (ptr (fn int32 ((ptr cdecl_class), int32, int32)))
+T_103: (in a : int32)
   Class: Eq_103
-  DataType: word32
-  OrigDataType: word32
-T_104: (in Mem0[c + 0x00000000:word32] + 0x00000004 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_104: (in b : int32)
   Class: Eq_104
-  DataType: (ptr (ptr Eq_104))
-  OrigDataType: (ptr (ptr (fn void ((ptr cdecl_class), int32))))
-T_105: (in Mem0[Mem0[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+  DataType: int32
+  OrigDataType: int32
+T_105: (in c->vtbl->sum(c, a, b) : int32)
   Class: Eq_105
-  DataType: (ptr Eq_105)
-  OrigDataType: (ptr (fn T_106 ((ptr cdecl_class), int32)))
-T_106: (in c->vtbl->method04(c, c) : void)
+  DataType: int32
+  OrigDataType: int32
+T_106: (in c->vtbl->method04(c, c->vtbl->sum(c, a, b)) : void)
   Class: Eq_106
   DataType: void
   OrigDataType: void
@@ -567,15 +567,15 @@ typedef cdecl_class_vtbl Eq_92;
 
 typedef cdecl_class_vtbl Eq_93;
 
-typedef int32 (Eq_95)(cdecl_class * ptrArg04, int32 dwArg08, int32 dwArg0C);
+typedef void (Eq_95)(cdecl_class * ptrArg04, int32 dwArg08);
 
-typedef int32 (Eq_96)(cdecl_class *, int32, int32);
+typedef void (Eq_96)(cdecl_class * ptrArg04, int32 dwArg08);
 
-typedef cdecl_class_vtbl Eq_101;
+typedef cdecl_class_vtbl Eq_98;
 
-typedef cdecl_class_vtbl Eq_102;
+typedef cdecl_class_vtbl Eq_99;
 
-typedef void (Eq_104)(cdecl_class * ptrArg04, int32 dwArg08);
+typedef int32 (Eq_101)(cdecl_class * ptrArg04, int32 dwArg08, int32 dwArg0C);
 
-typedef void (Eq_105)(cdecl_class *, int32);
+typedef int32 (Eq_102)(cdecl_class *, int32, int32);
 


### PR DESCRIPTION
All registers should be trashed but it caused
regression. e.g. `ebp` trashing makes local variables
recognition impossible on `x86`. So just trash `eax`