### PR TITLE
Fix stack delta deserialization on X86

### DIFF
--- a/src/Arch/X86/X86ProcedureSerializer.cs
+++ b/src/Arch/X86/X86ProcedureSerializer.cs
@@ -53,7 +53,11 @@ namespace Reko.Arch.X86
             if (d == null || d.Length == 0)
                 d = DefaultConvention;
             sig.StackDelta = Architecture.PointerType.Size;  //$BUG: far/near pointers?
-            if (d == "stdapi" || d == "__stdcall" || d == "pascal")
+            if (d == "stdapi" ||
+                d == "stdcall" ||
+                d == "__stdcall" ||
+                d == "__thiscall" ||
+                d == "pascal")
                 sig.StackDelta += StackOffset;
             sig.FpuStackDelta = FpuStackOffset;
             sig.ReturnAddressOnStack = Architecture.PointerType.Size;   //$BUG: x86 real mode?

--- a/src/Drivers/reko.config
+++ b/src/Drivers/reko.config
@@ -121,7 +121,6 @@
 
       <Environment Name="win32" Description="Windows (Win32)" Type="Reko.Environments.Windows.Win32Platform,Reko.Environments.Windows">
         <TypeLibraries>
-          <TypeLibrary Name="msvcrt2.xml" />
           <TypeLibrary Name="windows32.xml" />
           <TypeLibrary Name="commctrl.xml" />
           <TypeLibrary Name="msvcrt.xml" />

--- a/src/UnitTests/Arch/Intel/X86ProcedureSerializerTests.cs
+++ b/src/UnitTests/Arch/Intel/X86ProcedureSerializerTests.cs
@@ -227,6 +227,7 @@ namespace Reko.UnitTests.Arch.Intel
             Assert.AreEqual(2, sig.Parameters.Length);
             Assert.AreEqual("this", sig.Parameters[0].ToString());
             Assert.AreEqual("ecx", sig.Parameters[0].Storage.ToString());
+            Assert.AreEqual(8, sig.StackDelta);
         }
 
         [Test]
@@ -252,7 +253,7 @@ namespace Reko.UnitTests.Arch.Intel
         }
 
         [Test]
-        public void ProcSer_Load_stdcall()
+        public void ProcSer_Load_stdapi()
         {
             var ssig = new SerializedSignature
             {
@@ -271,6 +272,53 @@ namespace Reko.UnitTests.Arch.Intel
             var sig = ser.Deserialize(ssig, arch.CreateFrame());
             Assert.AreEqual(8, sig.StackDelta);
             Assert.AreEqual(4, ((StackArgumentStorage)sig.Parameters[0].Storage).StackOffset);
+            Assert.AreEqual(8, sig.StackDelta);
+        }
+
+        [Test]
+        public void ProcSer_Load_stdcall()
+        {
+            var ssig = new SerializedSignature
+            {
+                Convention = "stdcall",
+                Arguments = new Argument_v1[] {
+                    new Argument_v1
+                    {
+                        Name = "foo",
+                        Type = new PrimitiveType_v1 { Domain = Domain.SignedInt, ByteSize = 4 },
+                    }
+                }
+            };
+            Given_ProcedureSerializer(ssig.Convention);
+            mr.ReplayAll();
+
+            var sig = ser.Deserialize(ssig, arch.CreateFrame());
+            Assert.AreEqual(8, sig.StackDelta);
+            Assert.AreEqual(4, ((StackArgumentStorage)sig.Parameters[0].Storage).StackOffset);
+            Assert.AreEqual(8, sig.StackDelta);
+        }
+
+        [Test]
+        public void ProcSer_Load___stdcall()
+        {
+            var ssig = new SerializedSignature
+            {
+                Convention = "__stdcall",
+                Arguments = new Argument_v1[] {
+                    new Argument_v1
+                    {
+                        Name = "foo",
+                        Type = new PrimitiveType_v1 { Domain = Domain.SignedInt, ByteSize = 4 },
+                    }
+                }
+            };
+            Given_ProcedureSerializer(ssig.Convention);
+            mr.ReplayAll();
+
+            var sig = ser.Deserialize(ssig, arch.CreateFrame());
+            Assert.AreEqual(8, sig.StackDelta);
+            Assert.AreEqual(4, ((StackArgumentStorage)sig.Parameters[0].Storage).StackOffset);
+            Assert.AreEqual(8, sig.StackDelta);
         }
 
         [Test]
@@ -328,7 +376,7 @@ namespace Reko.UnitTests.Arch.Intel
             var sig = ser.Deserialize(ssig, arch.CreateFrame());
             var sExp =
 @"void memfn(Register (ptr (struct ""CWindow"")) this, Stack int32 XX, Stack int16 arg1)
-// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 12; fpuStackDelta: 0; fpuMaxParam: -1
 ";
             Assert.AreEqual(sExp, sig.ToString("memfn", FunctionType.EmitFlags.AllDetails));
             Assert.AreEqual(4, ((StackArgumentStorage)sig.Parameters[1].Storage).StackOffset);

--- a/subjects/regressions/snowman-74/int16.dis
+++ b/subjects/regressions/snowman-74/int16.dis
@@ -1,5 +1,5 @@
 int32 get(int32 dwArg04)
-// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ecx
 // LiveOut:


### PR DESCRIPTION
- Fix calculation of stack delta for `stdcall` and `__thiscall` calling
conventions
- Create unit tests to verify it.
- Ran regression tests
- Remove `msvcrt2.xml` entry from `reko.config`