### PR TITLE
Fix unit tests for IndirectCallRewriter

### DIFF
--- a/src/UnitTests/Analysis/IndirectCallRewriterTests.cs
+++ b/src/UnitTests/Analysis/IndirectCallRewriterTests.cs
@@ -100,7 +100,6 @@ namespace Reko.UnitTests.Analysis
         {
             this.sig = new FunctionType(
                 null,
-                null,
                 new Identifier(
                     "a", 
                     new Pointer(argType, 4),


### PR DESCRIPTION
Number of broken tests was reduced from 93 to 86