### PR TITLE
Do not trash preserved registers (like 'ebp') when hell node processing

### DIFF
--- a/src/Decompiler/Analysis/DataFlowAnalysis.cs
+++ b/src/Decompiler/Analysis/DataFlowAnalysis.cs
@@ -256,7 +256,7 @@ namespace Reko.Analysis
             // not been visited, or are computed destinations  (e.g. vtables)
             // they will have no "ProcedureFlow" associated with them yet, in
             // which case the the SSA treats the call as a "hell node".
-            var sst = new SsaTransform(program.Architecture, proc, importResolver, this.ProgramDataFlow);
+            var sst = new SsaTransform(program, proc, importResolver, this.ProgramDataFlow);
             var ssa = sst.Transform();
 
             // Propagate condition codes and registers. At the end, the hope

--- a/src/Environments/Msdos/MsdosPlatform.cs
+++ b/src/Environments/Msdos/MsdosPlatform.cs
@@ -67,6 +67,7 @@ namespace Reko.Environments.Msdos
                 Registers.cx,
                 Registers.dx,
                 Registers.bx,
+                Registers.sp,
             };
         }
 

--- a/src/Environments/Windows/Win16Platform.cs
+++ b/src/Environments/Windows/Win16Platform.cs
@@ -61,6 +61,7 @@ namespace Reko.Environments.Windows
                 Registers.cx,
                 Registers.dx,
                 Registers.bx,
+                Registers.sp,
             };
         }
 

--- a/src/Environments/Windows/Win32Platform.cs
+++ b/src/Environments/Windows/Win32Platform.cs
@@ -106,6 +106,7 @@ namespace Reko.Environments.Windows
                 Registers.eax,
                 Registers.ecx,
                 Registers.edx,
+                Registers.esp,
             };
         }
 

--- a/src/UnitTests/Analysis/ConditionCodeEliminatorTests.cs
+++ b/src/UnitTests/Analysis/ConditionCodeEliminatorTests.cs
@@ -95,7 +95,7 @@ namespace Reko.UnitTests.Analysis
             DataFlowAnalysis dfa = new DataFlowAnalysis(program, importResolver, new FakeDecompilerEventListener());
             foreach (var proc in program.Procedures.Values)
             {
-                var sst = new SsaTransform(program.Architecture, proc, importResolver, new ProgramDataFlow());
+                var sst = new SsaTransform(program, proc, importResolver, new ProgramDataFlow());
                 var ssa = sst.Transform();
                 var larw = new LongAddRewriter2(program.Architecture, ssa);
                 larw.Transform();

--- a/src/UnitTests/Analysis/DeadCodeTests.cs
+++ b/src/UnitTests/Analysis/DeadCodeTests.cs
@@ -52,7 +52,11 @@ namespace Reko.UnitTests.Analysis
             var m = new ProcedureBuilder();
             builder(m);
 
-            var sst = new SsaTransform(m.Architecture, m.Procedure, null, programDataFlow);
+            var program = new Program()
+            {
+                Architecture = m.Architecture,
+            };
+            var sst = new SsaTransform(program, m.Procedure, null, programDataFlow);
             sst.Transform();
 
             DeadCode.Eliminate(sst.SsaState);

--- a/src/UnitTests/Analysis/DeclarationInserterTests.cs
+++ b/src/UnitTests/Analysis/DeclarationInserterTests.cs
@@ -58,7 +58,7 @@ namespace Reko.UnitTests.Analysis
 			this.doms = proc.CreateBlockDominatorGraph();
 
             SsaTransform sst = new SsaTransform(
-                null,
+                new Program(),
                 proc,
                 null,
                 new ProgramDataFlow());

--- a/src/UnitTests/Analysis/IndirectCallRewriterTests.cs
+++ b/src/UnitTests/Analysis/IndirectCallRewriterTests.cs
@@ -211,6 +211,16 @@ namespace Reko.UnitTests.Analysis
 
         protected override void RunTest(Program program, TextWriter fut)
         {
+            program.Platform = new FakePlatform(null, program.Architecture)
+            {
+                Test_CreateTrashedRegisters = () => 
+                    new HashSet<RegisterStorage>()
+                {
+                    (RegisterStorage)this.eax.Storage,
+                    (RegisterStorage)this.ecx.Storage,
+                    program.Architecture.StackRegister,
+                }
+            };
             InitProgram(program);
             IImportResolver importResolver = null;
             var eventListener = new FakeDecompilerEventListener();
@@ -220,7 +230,7 @@ namespace Reko.UnitTests.Analysis
             var proc = program.Procedures.Values[0];
             var usb = new UserSignatureBuilder(program);
             usb.ApplySignatureToProcedure(addr, proc.Signature, proc);
-            var sst = new SsaTransform(program.Architecture, proc, importResolver, programFlow);
+            var sst = new SsaTransform(program, proc, importResolver, programFlow);
             var ssa = sst.Transform();
             var vp = new ValuePropagator(program.Architecture, ssa);
             vp.Transform();

--- a/src/UnitTests/Analysis/LinearInductionVariableTests.cs
+++ b/src/UnitTests/Analysis/LinearInductionVariableTests.cs
@@ -61,8 +61,12 @@ namespace Reko.UnitTests.Analysis
             m.Label("b3");
             m.Return();
             this.dom = m.Procedure.CreateBlockDominatorGraph();
+            var program = new Program()
+            {
+                Architecture = m.Architecture,
+            };
             var sst = new SsaTransform(
-                m.Architecture,
+                program,
                 m.Procedure,
                 null,
                 new ProgramDataFlow());
@@ -336,7 +340,7 @@ namespace Reko.UnitTests.Analysis
 		{
             doms = proc.CreateBlockDominatorGraph();
             SsaTransform sst = new SsaTransform(
-                null,
+                new Program(),
                 proc,
                 null,
                 new ProgramDataFlow());

--- a/src/UnitTests/Analysis/LiveCopyInserterTests.cs
+++ b/src/UnitTests/Analysis/LiveCopyInserterTests.cs
@@ -176,12 +176,17 @@ namespace Reko.UnitTests.Analysis
 		private void Build(Procedure proc, IProcessorArchitecture arch)
 		{
             var platform = new DefaultPlatform(null, arch);
-			this.proc = proc;
+            var program = new Program()
+            {
+                Architecture = arch,
+                Platform = platform,
+            };
+            this.proc = proc;
             var importResolver = MockRepository.GenerateStub<IImportResolver>();
             importResolver.Replay();
 			var gr = proc.CreateBlockDominatorGraph();
             SsaTransform sst = new SsaTransform(
-                arch,
+                program,
                 proc,
                 null,
                 new ProgramDataFlow());

--- a/src/UnitTests/Analysis/LongAddRewriterTests.cs
+++ b/src/UnitTests/Analysis/LongAddRewriterTests.cs
@@ -37,6 +37,7 @@ namespace Reko.UnitTests.Analysis
         private Frame frame;
         private LongAddRewriter2 rw;
         private IProcessorArchitecture arch;
+        private Program program;
         private Identifier ax;
         private Identifier bx;
         private Identifier cx;
@@ -51,6 +52,11 @@ namespace Reko.UnitTests.Analysis
         public LongAddRewriterTests()
         {
             arch = new FakeArchitecture();
+            program = new Program()
+            {
+                Architecture = arch,
+                Platform = platform,
+            };
         }
 
         [SetUp]
@@ -93,7 +99,7 @@ namespace Reko.UnitTests.Analysis
             var eventListener = new FakeDecompilerEventListener();
             foreach (var proc in program.Procedures.Values)
             {
-                var sst = new SsaTransform(program.Architecture, proc, null, new ProgramDataFlow());
+                var sst = new SsaTransform(program, proc, null, new ProgramDataFlow());
                 sst.Transform();
                 var vp = new ValuePropagator(arch, sst.SsaState);
                 vp.Transform();
@@ -113,7 +119,7 @@ namespace Reko.UnitTests.Analysis
         private void RunTest(Action<ProcedureBuilder> builder)
         {
             builder(m);
-            var sst = new SsaTransform(arch, m.Procedure, null, new ProgramDataFlow());
+            var sst = new SsaTransform(program, m.Procedure, null, new ProgramDataFlow());
             sst.Transform();
             sst.RenameFrameAccesses = true;
             sst.Transform();

--- a/src/UnitTests/Analysis/RegisterPreservationTests.cs
+++ b/src/UnitTests/Analysis/RegisterPreservationTests.cs
@@ -87,7 +87,7 @@ namespace Reko.UnitTests.Analysis
                 // which case the the SSA treats the call as a "hell node".
                 var doms = proc.CreateBlockDominatorGraph();
                 var sst = new SsaTransform(
-                    program.Architecture,
+                    program,
                     proc,
                     importResolver,
                     dataFlow);

--- a/src/UnitTests/Analysis/SegmentedAccessClassifierTests.cs
+++ b/src/UnitTests/Analysis/SegmentedAccessClassifierTests.cs
@@ -37,7 +37,11 @@ namespace Reko.UnitTests.Analysis
 
 		private void Prepare(ProcedureBuilder mock)
 		{
-            var sst = new SsaTransform(mock.Architecture, mock.Procedure, null, new ProgramDataFlow());
+            var program = new Program()
+            {
+                Architecture = mock.Architecture,
+            };
+            var sst = new SsaTransform(program, mock.Procedure, null, new ProgramDataFlow());
             sst.Transform();
             ssa = sst.SsaState;
 		}

--- a/src/UnitTests/Analysis/SequenceIdentifierGeneratorTests.cs
+++ b/src/UnitTests/Analysis/SequenceIdentifierGeneratorTests.cs
@@ -48,7 +48,7 @@ namespace Reko.UnitTests.Analysis
         {
             var pb = new ProcedureBuilder();
             builder(pb);
-            var sst = new SsaTransform(null, pb.Procedure, importResolver, null);
+            var sst = new SsaTransform(new Program(), pb.Procedure, importResolver, null);
             sst.Transform();
 
             var seqgen = new SequenceIdentifierGenerator(sst);

--- a/src/UnitTests/Analysis/SsaLivenessTests.cs
+++ b/src/UnitTests/Analysis/SsaLivenessTests.cs
@@ -121,9 +121,14 @@ namespace Reko.UnitTests.Analysis
 		private void Build(Procedure proc, IProcessorArchitecture arch)
 		{
             var platform = new DefaultPlatform(null, arch);
-			this.proc = proc;
+            var program = new Program()
+            {
+                Architecture = arch,
+                Platform = platform,
+            };
+            this.proc = proc;
             var sst = new SsaTransform(
-                arch,
+                program,
                 proc,
                 null,
                 new ProgramDataFlow());

--- a/src/UnitTests/Analysis/SsaStateTests.cs
+++ b/src/UnitTests/Analysis/SsaStateTests.cs
@@ -48,7 +48,11 @@ namespace Reko.UnitTests.Analysis
             var pb = new ProcedureBuilder();
             builder(pb);
             var dflow = new ProgramDataFlow();
-            var sst = new SsaTransform(pb.Architecture, pb.Procedure, null, dflow);
+            var program = new Program()
+            {
+                Architecture = pb.Architecture,
+            };
+            var sst = new SsaTransform(program, pb.Procedure, null, dflow);
             this.ssa = sst.Transform();
         }
 

--- a/src/UnitTests/Analysis/StrengthReductionTests.cs
+++ b/src/UnitTests/Analysis/StrengthReductionTests.cs
@@ -48,7 +48,7 @@ namespace Reko.UnitTests.Analysis
             Procedure proc = BuildSimpleLoop();
 
             var dom = proc.CreateBlockDominatorGraph();
-            var sst = new SsaTransform(null, proc, null, new ProgramDataFlow());
+            var sst = new SsaTransform(new Program(), proc, null, new ProgramDataFlow());
             sst.Transform();
             var lif = new LinearInductionVariableFinder(sst.SsaState, dom);
             lif.Find();

--- a/src/UnitTests/Analysis/TrashedRegisterFinder2Tests.cs
+++ b/src/UnitTests/Analysis/TrashedRegisterFinder2Tests.cs
@@ -93,7 +93,7 @@ namespace Reko.UnitTests.Analysis
             importResolver.Replay();
 
             var dataFlow = new ProgramDataFlow(this.progBuilder.Program);
-            var sst = new SsaTransform(arch, proc, importResolver, dataFlow);
+            var sst = new SsaTransform(progBuilder.Program, proc, importResolver, dataFlow);
             sst.Transform();
             var vp = new ValuePropagator(arch, sst.SsaState);
             vp.Transform();

--- a/src/UnitTests/Analysis/UsedRegisterFinderTests.cs
+++ b/src/UnitTests/Analysis/UsedRegisterFinderTests.cs
@@ -85,7 +85,7 @@ namespace Reko.UnitTests.Analysis
             };
             var importResolver = MockRepository.GenerateStub<IImportResolver>();
             importResolver.Replay();
-            var sst = new SsaTransform(arch, proc, importResolver, new ProgramDataFlow());
+            var sst = new SsaTransform(progBuilder.Program, proc, importResolver, new ProgramDataFlow());
             sst.Transform();
             var vp = new ValuePropagator(arch, sst.SsaState);
             vp.Transform();

--- a/src/UnitTests/Analysis/ValuePropagationTests.cs
+++ b/src/UnitTests/Analysis/ValuePropagationTests.cs
@@ -43,6 +43,7 @@ namespace Reko.UnitTests.Analysis
 		SsaIdentifierCollection ssaIds;
         private MockRepository mr;
         private IProcessorArchitecture arch;
+        private Program program;
         private IImportResolver importResolver;
 
         [SetUp]
@@ -52,7 +53,11 @@ namespace Reko.UnitTests.Analysis
             mr = new MockRepository();
             arch = mr.Stub<IProcessorArchitecture>();
             importResolver = mr.Stub<IImportResolver>();
-		}
+            program = new Program()
+            {
+                Architecture = arch,
+            };
+        }
 
         private Identifier Reg32(string name)
         {
@@ -110,7 +115,7 @@ namespace Reko.UnitTests.Analysis
 			foreach (Procedure proc in program.Procedures.Values)
 			{
 				writer.WriteLine("= {0} ========================", proc.Name);
-                SsaTransform sst = new SsaTransform(program.Architecture, proc, importResolver, dfa.ProgramDataFlow);
+                SsaTransform sst = new SsaTransform(program, proc, importResolver, dfa.ProgramDataFlow);
                 sst.Transform();
 				SsaState ssa = sst.SsaState;
                 var cce = new ConditionCodeEliminator(ssa, program.Platform);
@@ -230,7 +235,7 @@ namespace Reko.UnitTests.Analysis
 		public void VpDbp()
 		{
 			Procedure proc = new DpbMock().Procedure;
-            var sst = new SsaTransform(arch, proc, importResolver, new ProgramDataFlow());
+            var sst = new SsaTransform(program, proc, importResolver, new ProgramDataFlow());
             sst.Transform();
             SsaState ssa = sst.SsaState;
 
@@ -301,7 +306,7 @@ namespace Reko.UnitTests.Analysis
             m.Return();
             var importResolver = mr.Stub<IImportResolver>();
             importResolver.Replay();
-            var sst = new SsaTransform(m.Architecture, m.Procedure, importResolver, new ProgramDataFlow());
+            var sst = new SsaTransform(program, m.Procedure, importResolver, new ProgramDataFlow());
             sst.Transform();
 
             var vp = new ValuePropagator(arch, sst.SsaState);
@@ -326,7 +331,7 @@ namespace Reko.UnitTests.Analysis
             var importResolver = mr.Stub<IImportResolver>();
             importResolver.Replay();
 
-            var sst = new SsaTransform(m.Architecture, m.Procedure, importResolver, new ProgramDataFlow());
+            var sst = new SsaTransform(program, m.Procedure, importResolver, new ProgramDataFlow());
             sst.Transform();
             ssaIds = sst.SsaState.Identifiers;
             var stms = m.Procedure.EntryBlock.Succ[0].Statements;
@@ -501,7 +506,7 @@ namespace Reko.UnitTests.Analysis
 			var gr = proc.CreateBlockDominatorGraph();
             var importResolver = MockRepository.GenerateStub<IImportResolver>();
             importResolver.Replay();
-			var sst = new SsaTransform(arch, proc, importResolver, new ProgramDataFlow());
+			var sst = new SsaTransform(program, proc, importResolver, new ProgramDataFlow());
             sst.Transform();
 			var ssa = sst.SsaState;
 
@@ -520,7 +525,7 @@ namespace Reko.UnitTests.Analysis
         {
             var proc = m.Procedure;
             var gr = proc.CreateBlockDominatorGraph();
-            var sst = new SsaTransform(arch, proc, importResolver, new ProgramDataFlow());
+            var sst = new SsaTransform(program, proc, importResolver, new ProgramDataFlow());
             var ssa = sst.SsaState;
             sst.Transform();
 

--- a/src/UnitTests/Evaluation/ConstDivisionImplementedByMultiplicationTests.cs
+++ b/src/UnitTests/Evaluation/ConstDivisionImplementedByMultiplicationTests.cs
@@ -52,7 +52,11 @@ namespace Reko.UnitTests.Evaluation
 
             var proc = m.Procedure;
             var flow = new ProgramDataFlow();
-            var sst = new SsaTransform(m.Architecture, proc, null, flow);
+            var program = new Program()
+            {
+                Architecture = m.Architecture,
+            };
+            var sst = new SsaTransform(program, proc, null, flow);
             sst.Transform();
 
             proc.Dump(true);

--- a/src/tests/Analysis/CceAsciiHex.exp
+++ b/src/tests/Analysis/CceAsciiHex.exp
@@ -1,42 +1,39 @@
 fp:fp
     def:  def fp
-    uses: call fn0C00_000A (retsize: 2;)	uses: al:al,ds:ds,sp:fp	defs: al:al_7,ds:ds_5,Flags:C_8
+    uses: call fn0C00_000A (retsize: 2;)	uses: al:al,sp:fp	defs: al:al_5,Flags:C_6
 sp_2: orig: sp
 sp_3: orig: sp
-    def:  call fn0C00_000A (retsize: 2;)	uses: al:al,ds:ds,sp:fp	defs: al:al_7,ds:ds_5,Flags:C_8
-ds:ds
-    def:  def ds
-    uses: call fn0C00_000A (retsize: 2;)	uses: al:al,ds:ds,sp:fp	defs: al:al_7,ds:ds_5,Flags:C_8
-ds_5: orig: ds
-    def:  call fn0C00_000A (retsize: 2;)	uses: al:al,ds:ds,sp:fp	defs: al:al_7,ds:ds_5,Flags:C_8
-    uses: Mem9[ds_5:0x0300:byte] = al_7
+    def:  call fn0C00_000A (retsize: 2;)	uses: al:al,sp:fp	defs: al:al_5,Flags:C_6
 al:al
     def:  def al
-    uses: call fn0C00_000A (retsize: 2;)	uses: al:al,ds:ds,sp:fp	defs: al:al_7,ds:ds_5,Flags:C_8
-al_7: orig: al
-    def:  call fn0C00_000A (retsize: 2;)	uses: al:al,ds:ds,sp:fp	defs: al:al_7,ds:ds_5,Flags:C_8
-    uses: Mem9[ds_5:0x0300:byte] = al_7
-C_8: orig: C
-    def:  call fn0C00_000A (retsize: 2;)	uses: al:al,ds:ds,sp:fp	defs: al:al_7,ds:ds_5,Flags:C_8
-    uses: branch C_8 l0C00_0009
-Mem9: orig: Mem0
-    def:  Mem9[ds_5:0x0300:byte] = al_7
+    uses: call fn0C00_000A (retsize: 2;)	uses: al:al,sp:fp	defs: al:al_5,Flags:C_6
+al_5: orig: al
+    def:  call fn0C00_000A (retsize: 2;)	uses: al:al,sp:fp	defs: al:al_5,Flags:C_6
+    uses: Mem8[ds:0x0300:byte] = al_5
+C_6: orig: C
+    def:  call fn0C00_000A (retsize: 2;)	uses: al:al,sp:fp	defs: al:al_5,Flags:C_6
+    uses: branch C_6 l0C00_0009
+ds:ds
+    def:  def ds
+    uses: Mem8[ds:0x0300:byte] = al_5
+Mem8: orig: Mem0
+    def:  Mem8[ds:0x0300:byte] = al_5
 // fn0C00_0000
 // Return size: 2
 define fn0C00_0000
 fn0C00_0000_entry:
 	def fp
-	def ds
 	def al
+	def ds
 	// succ:  l0C00_0000
 l0C00_0000:
 	call fn0C00_000A (retsize: 2;)
-		uses: al:al,ds:ds,sp:fp
-		defs: al:al_7,ds:ds_5,Flags:C_8
-	branch C_8 l0C00_0009
+		uses: al:al,sp:fp
+		defs: al:al_5,Flags:C_6
+	branch C_6 l0C00_0009
 	// succ:  l0C00_0005 l0C00_0009
 l0C00_0005:
-	Mem9[ds_5:0x0300:byte] = al_7
+	Mem8[ds:0x0300:byte] = al_5
 	// succ:  l0C00_0009
 l0C00_0009:
 	return

--- a/src/tests/Analysis/CceIsqrt.exp
+++ b/src/tests/Analysis/CceIsqrt.exp
@@ -1,36 +1,29 @@
 fp:fp
     def:  def fp
-    uses: call fn0C00_0008 (retsize: 2;)	uses: ds:ds,si:si,sp:fp	defs: ds:ds_5,si:si_7
+    uses: call fn0C00_0008 (retsize: 2;)	uses: sp:fp
 sp_2: orig: sp
 sp_3: orig: sp
-    def:  call fn0C00_0008 (retsize: 2;)	uses: ds:ds,si:si,sp:fp	defs: ds:ds_5,si:si_7
-ds:ds
-    def:  def ds
-    uses: call fn0C00_0008 (retsize: 2;)	uses: ds:ds,si:si,sp:fp	defs: ds:ds_5,si:si_7
-ds_5: orig: ds
-    def:  call fn0C00_0008 (retsize: 2;)	uses: ds:ds,si:si,sp:fp	defs: ds:ds_5,si:si_7
-    uses: Mem8[ds_5:0x0304:word16] = si_7
+    def:  call fn0C00_0008 (retsize: 2;)	uses: sp:fp
 si:si
     def:  def si
-    uses: call fn0C00_0008 (retsize: 2;)	uses: ds:ds,si:si,sp:fp	defs: ds:ds_5,si:si_7
-si_7: orig: si
-    def:  call fn0C00_0008 (retsize: 2;)	uses: ds:ds,si:si,sp:fp	defs: ds:ds_5,si:si_7
-    uses: Mem8[ds_5:0x0304:word16] = si_7
-Mem8: orig: Mem0
-    def:  Mem8[ds_5:0x0304:word16] = si_7
+    uses: Mem6[ds:0x0304:word16] = si
+ds:ds
+    def:  def ds
+    uses: Mem6[ds:0x0304:word16] = si
+Mem6: orig: Mem0
+    def:  Mem6[ds:0x0304:word16] = si
 // fn0C00_0000
 // Return size: 2
 define fn0C00_0000
 fn0C00_0000_entry:
 	def fp
-	def ds
 	def si
+	def ds
 	// succ:  l0C00_0000
 l0C00_0000:
 	call fn0C00_0008 (retsize: 2;)
-		uses: ds:ds,si:si,sp:fp
-		defs: ds:ds_5,si:si_7
-	Mem8[ds_5:0x0304:word16] = si_7
+		uses: sp:fp
+	Mem6[ds:0x0304:word16] = si
 	return
 	// succ:  fn0C00_0000_exit
 fn0C00_0000_exit:

--- a/src/tests/Analysis/SsaFactorial.exp
+++ b/src/tests/Analysis/SsaFactorial.exp
@@ -7,59 +7,51 @@ sp_2: orig: sp
 cx_3: orig: cx
     def:  cx_3 = 0x0064
     uses: Mem6[ss:sp_4:word16] = cx_3
-          call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss	defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
+          call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_4	defs: ax:ax_10,cx:cx_8,Flags:SCZO_11,sp:sp_7
 sp_4: orig: sp
     def:  sp_4 = sp_2 - 0x0002
     uses: Mem6[ss:sp_4:word16] = cx_3
-          call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss	defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
+          call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_4	defs: ax:ax_10,cx:cx_8,Flags:SCZO_11,sp:sp_7
 ss:ss
     def:  def ss
     uses: Mem6[ss:sp_4:word16] = cx_3
-          call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss	defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
 Mem6: orig: Mem0
     def:  Mem6[ss:sp_4:word16] = cx_3
 sp_7: orig: sp
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss	defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
-    uses: sp_15 = sp_7 + 0x0002
+    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_4	defs: ax:ax_10,cx:cx_8,Flags:SCZO_11,sp:sp_7
+    uses: sp_12 = sp_7 + 0x0002
 cx_8: orig: cx
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss	defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
+    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_4	defs: ax:ax_10,cx:cx_8,Flags:SCZO_11,sp:sp_7
     uses: use cx_8
-ss_9: orig: ss
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss	defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
-    uses: use ss_9
-ds:ds
-    def:  def ds
-    uses: call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss	defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
-ds_11: orig: ds
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss	defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
-    uses: Mem17[ds_11:0x0064:word16] = ax_13
-          use ds_11
 ax:ax
     def:  def ax
-    uses: call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss	defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
-ax_13: orig: ax
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss	defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
-    uses: Mem17[ds_11:0x0064:word16] = ax_13
-          use ax_13
-SCZO_14: orig: SCZO
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss	defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
-sp_15: orig: sp
-    def:  sp_15 = sp_7 + 0x0002
-    uses: SCZO_16 = cond(sp_15)
-          use sp_15
-SCZO_16: orig: SCZO
-    def:  SCZO_16 = cond(sp_15)
-    uses: use SCZO_16
-Mem17: orig: Mem0
-    def:  Mem17[ds_11:0x0064:word16] = ax_13
+    uses: call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_4	defs: ax:ax_10,cx:cx_8,Flags:SCZO_11,sp:sp_7
+ax_10: orig: ax
+    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_4	defs: ax:ax_10,cx:cx_8,Flags:SCZO_11,sp:sp_7
+    uses: Mem15[ds:0x0064:word16] = ax_10
+          use ax_10
+SCZO_11: orig: SCZO
+    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_4	defs: ax:ax_10,cx:cx_8,Flags:SCZO_11,sp:sp_7
+sp_12: orig: sp
+    def:  sp_12 = sp_7 + 0x0002
+    uses: SCZO_13 = cond(sp_12)
+          use sp_12
+SCZO_13: orig: SCZO
+    def:  SCZO_13 = cond(sp_12)
+    uses: use SCZO_13
+ds:ds
+    def:  def ds
+    uses: Mem15[ds:0x0064:word16] = ax_10
+Mem15: orig: Mem0
+    def:  Mem15[ds:0x0064:word16] = ax_10
 // fn0C00_0000
 // Return size: 2
 define fn0C00_0000
 fn0C00_0000_entry:
 	def fp
 	def ss
-	def ds
 	def ax
+	def ds
 	// succ:  l0C00_0000
 l0C00_0000:
 	sp_2 = fp
@@ -67,20 +59,18 @@ l0C00_0000:
 	sp_4 = sp_2 - 0x0002
 	Mem6[ss:sp_4:word16] = cx_3
 	call fn0C00_000F (retsize: 2;)
-		uses: ax:ax,cx:cx_3,ds:ds,sp:sp_4,ss:ss
-		defs: ax:ax_13,cx:cx_8,ds:ds_11,Flags:SCZO_14,sp:sp_7,ss:ss_9
-	sp_15 = sp_7 + 0x0002
-	SCZO_16 = cond(sp_15)
-	Mem17[ds_11:0x0064:word16] = ax_13
+		uses: ax:ax,cx:cx_3,sp:sp_4
+		defs: ax:ax_10,cx:cx_8,Flags:SCZO_11,sp:sp_7
+	sp_12 = sp_7 + 0x0002
+	SCZO_13 = cond(sp_12)
+	Mem15[ds:0x0064:word16] = ax_10
 	return
 	// succ:  fn0C00_0000_exit
 fn0C00_0000_exit:
-	use ax_13
+	use ax_10
 	use cx_8
-	use ds_11
-	use SCZO_16
-	use sp_15
-	use ss_9
+	use SCZO_13
+	use sp_12
 
 fp:fp
     def:  def fp
@@ -93,7 +83,7 @@ sp_3: orig: sp
     uses: Mem6[ss:sp_3:word16] = bp
           bp_7 = sp_3
           sp_12 = sp_3 - 0x0002
-          sp_31 = PHI(sp_23, sp_3)
+          sp_29 = PHI(sp_21, sp_3)
 bp:bp
     def:  def bp
     uses: Mem6[ss:sp_3:word16] = bp
@@ -102,16 +92,17 @@ ss:ss
     uses: Mem6[ss:sp_3:word16] = bp
           ax_8 = Mem6[ss:bp_7 + 0x0004:word16]
           Mem13[ss:sp_12:word16] = ax_9
-          call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss	defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
-          ss_30 = PHI(ss_16, ss)
+          dx_23 = Mem13[ss:bp_7 + 0x0004:word16]
+          bp_31 = Mem30[ss:sp_29:word16]
+          use ss
 Mem6: orig: Mem0
     def:  Mem6[ss:sp_3:word16] = bp
     uses: ax_8 = Mem6[ss:bp_7 + 0x0004:word16]
-          Mem32 = PHI(Mem13, Mem6)
+          Mem30 = PHI(Mem13, Mem6)
 bp_7: orig: bp
     def:  bp_7 = sp_3
     uses: ax_8 = Mem6[ss:bp_7 + 0x0004:word16]
-          call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss	defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
+          dx_23 = Mem13[ss:bp_7 + 0x0004:word16]
 ax_8: orig: ax
     def:  ax_8 = Mem6[ss:bp_7 + 0x0004:word16]
     uses: ax_9 = ax_8 - 0x0001
@@ -119,115 +110,104 @@ ax_9: orig: ax
     def:  ax_9 = ax_8 - 0x0001
     uses: SZO_10 = cond(ax_9)
           Mem13[ss:sp_12:word16] = ax_9
-          call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss	defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
+          call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,dx:dx,sp:sp_12	defs: ax:ax_15,dx:dx_17,Flags:SCZO_18,sp:sp_14
 SZO_10: orig: SZO
     def:  SZO_10 = cond(ax_9)
     uses: branch Test(EQ,SZO_10) l0C00_0026
-          S_37 = PHI(SCZO_29, SZO_10)
-          Z_40 = PHI(SCZO_29, SZO_10)
-          O_41 = PHI(SCZO_29, SZO_10)
+          S_35 = PHI(SCZO_27, SZO_10)
+          Z_38 = PHI(SCZO_27, SZO_10)
+          O_39 = PHI(SCZO_27, SZO_10)
 ax_11: orig: ax
     def:  ax_11 = 0x0001
-    uses: ax_35 = PHI(ax_28, ax_11)
+    uses: ax_33 = PHI(ax_26, ax_11)
 sp_12: orig: sp
     def:  sp_12 = sp_3 - 0x0002
     uses: Mem13[ss:sp_12:word16] = ax_9
-          call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss	defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
+          call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,dx:dx,sp:sp_12	defs: ax:ax_15,dx:dx_17,Flags:SCZO_18,sp:sp_14
 Mem13: orig: Mem0
     def:  Mem13[ss:sp_12:word16] = ax_9
-    uses: dx_25 = Mem13[ss_16:bp_15 + 0x0004:word16]
-          Mem32 = PHI(Mem13, Mem6)
+    uses: dx_23 = Mem13[ss:bp_7 + 0x0004:word16]
+          Mem30 = PHI(Mem13, Mem6)
 sp_14: orig: sp
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss	defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
-    uses: sp_21 = sp_14 + 0x0001
-bp_15: orig: bp
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss	defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
-    uses: dx_25 = Mem13[ss_16:bp_15 + 0x0004:word16]
-ss_16: orig: ss
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss	defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
-    uses: dx_25 = Mem13[ss_16:bp_15 + 0x0004:word16]
-          ss_30 = PHI(ss_16, ss)
-ax_17: orig: ax
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss	defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
-    uses: dx_ax_26 = dx_25 *s ax_17
+    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,dx:dx,sp:sp_12	defs: ax:ax_15,dx:dx_17,Flags:SCZO_18,sp:sp_14
+    uses: sp_19 = sp_14 + 0x0001
+ax_15: orig: ax
+    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,dx:dx,sp:sp_12	defs: ax:ax_15,dx:dx_17,Flags:SCZO_18,sp:sp_14
+    uses: dx_ax_24 = dx_23 *s ax_15
 dx:dx
     def:  def dx
-    uses: call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss	defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
-          dx_36 = PHI(dx_27, dx)
-dx_19: orig: dx
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss	defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
-SCZO_20: orig: SCZO
-    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss	defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
+    uses: call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,dx:dx,sp:sp_12	defs: ax:ax_15,dx:dx_17,Flags:SCZO_18,sp:sp_14
+          dx_34 = PHI(dx_25, dx)
+dx_17: orig: dx
+    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,dx:dx,sp:sp_12	defs: ax:ax_15,dx:dx_17,Flags:SCZO_18,sp:sp_14
+SCZO_18: orig: SCZO
+    def:  call fn0C00_000F (retsize: 2;)	uses: ax:ax_9,dx:dx,sp:sp_12	defs: ax:ax_15,dx:dx_17,Flags:SCZO_18,sp:sp_14
+sp_19: orig: sp
+    def:  sp_19 = sp_14 + 0x0001
+    uses: SZO_20 = cond(sp_19)
+          sp_21 = sp_19 + 0x0001
+SZO_20: orig: SZO
+    def:  SZO_20 = cond(sp_19)
 sp_21: orig: sp
-    def:  sp_21 = sp_14 + 0x0001
+    def:  sp_21 = sp_19 + 0x0001
     uses: SZO_22 = cond(sp_21)
-          sp_23 = sp_21 + 0x0001
+          sp_29 = PHI(sp_21, sp_3)
 SZO_22: orig: SZO
     def:  SZO_22 = cond(sp_21)
-sp_23: orig: sp
-    def:  sp_23 = sp_21 + 0x0001
-    uses: SZO_24 = cond(sp_23)
-          sp_31 = PHI(sp_23, sp_3)
-SZO_24: orig: SZO
-    def:  SZO_24 = cond(sp_23)
+dx_23: orig: dx
+    def:  dx_23 = Mem13[ss:bp_7 + 0x0004:word16]
+    uses: dx_ax_24 = dx_23 *s ax_15
+dx_ax_24: orig: dx_ax
+    def:  dx_ax_24 = dx_23 *s ax_15
+    uses: dx_25 = SLICE(dx_ax_24, word16, 16) (alias)
+          ax_26 = (word16) dx_ax_24 (alias)
+          SCZO_27 = cond(dx_ax_24)
 dx_25: orig: dx
-    def:  dx_25 = Mem13[ss_16:bp_15 + 0x0004:word16]
-    uses: dx_ax_26 = dx_25 *s ax_17
-dx_ax_26: orig: dx_ax
-    def:  dx_ax_26 = dx_25 *s ax_17
-    uses: dx_27 = SLICE(dx_ax_26, word16, 16) (alias)
-          ax_28 = (word16) dx_ax_26 (alias)
-          SCZO_29 = cond(dx_ax_26)
-dx_27: orig: dx
-    def:  dx_27 = SLICE(dx_ax_26, word16, 16) (alias)
-    uses: dx_36 = PHI(dx_27, dx)
-ax_28: orig: ax
-    def:  ax_28 = (word16) dx_ax_26 (alias)
-    uses: ax_35 = PHI(ax_28, ax_11)
-SCZO_29: orig: SCZO
-    def:  SCZO_29 = cond(dx_ax_26)
-    uses: S_37 = PHI(SCZO_29, SZO_10)
-          C_38 = PHI(SCZO_29, C)
-          Z_40 = PHI(SCZO_29, SZO_10)
-          O_41 = PHI(SCZO_29, SZO_10)
-ss_30: orig: ss
-    def:  ss_30 = PHI(ss_16, ss)
-    uses: bp_33 = Mem32[ss_30:sp_31:word16]
-          use ss_30
-sp_31: orig: sp
-    def:  sp_31 = PHI(sp_23, sp_3)
-    uses: bp_33 = Mem32[ss_30:sp_31:word16]
-          sp_34 = sp_31 + 0x0002
-Mem32: orig: Mem0
-    def:  Mem32 = PHI(Mem13, Mem6)
-    uses: bp_33 = Mem32[ss_30:sp_31:word16]
-bp_33: orig: bp
-    def:  bp_33 = Mem32[ss_30:sp_31:word16]
-    uses: use bp_33
-sp_34: orig: sp
-    def:  sp_34 = sp_31 + 0x0002
-    uses: use sp_34
-ax_35: orig: ax
-    def:  ax_35 = PHI(ax_28, ax_11)
-    uses: use ax_35
-dx_36: orig: dx
-    def:  dx_36 = PHI(dx_27, dx)
-    uses: use dx_36
-S_37: orig: S
-    def:  S_37 = PHI(SCZO_29, SZO_10)
-    uses: use C_38 | O_41 | S_37 | Z_40
-C_38: orig: C
-    def:  C_38 = PHI(SCZO_29, C)
-    uses: use C_38 | O_41 | S_37 | Z_40
+    def:  dx_25 = SLICE(dx_ax_24, word16, 16) (alias)
+    uses: dx_34 = PHI(dx_25, dx)
+ax_26: orig: ax
+    def:  ax_26 = (word16) dx_ax_24 (alias)
+    uses: ax_33 = PHI(ax_26, ax_11)
+SCZO_27: orig: SCZO
+    def:  SCZO_27 = cond(dx_ax_24)
+    uses: S_35 = PHI(SCZO_27, SZO_10)
+          C_36 = PHI(SCZO_27, C)
+          Z_38 = PHI(SCZO_27, SZO_10)
+          O_39 = PHI(SCZO_27, SZO_10)
+sp_29: orig: sp
+    def:  sp_29 = PHI(sp_21, sp_3)
+    uses: bp_31 = Mem30[ss:sp_29:word16]
+          sp_32 = sp_29 + 0x0002
+Mem30: orig: Mem0
+    def:  Mem30 = PHI(Mem13, Mem6)
+    uses: bp_31 = Mem30[ss:sp_29:word16]
+bp_31: orig: bp
+    def:  bp_31 = Mem30[ss:sp_29:word16]
+    uses: use bp_31
+sp_32: orig: sp
+    def:  sp_32 = sp_29 + 0x0002
+    uses: use sp_32
+ax_33: orig: ax
+    def:  ax_33 = PHI(ax_26, ax_11)
+    uses: use ax_33
+dx_34: orig: dx
+    def:  dx_34 = PHI(dx_25, dx)
+    uses: use dx_34
+S_35: orig: S
+    def:  S_35 = PHI(SCZO_27, SZO_10)
+    uses: use C_36 | O_39 | S_35 | Z_38
+C_36: orig: C
+    def:  C_36 = PHI(SCZO_27, C)
+    uses: use C_36 | O_39 | S_35 | Z_38
 C:Flags
     def:  def C
-    uses: C_38 = PHI(SCZO_29, C)
-Z_40: orig: Z
-    def:  Z_40 = PHI(SCZO_29, SZO_10)
-    uses: use C_38 | O_41 | S_37 | Z_40
-O_41: orig: O
-    def:  O_41 = PHI(SCZO_29, SZO_10)
-    uses: use C_38 | O_41 | S_37 | Z_40
+    uses: C_36 = PHI(SCZO_27, C)
+Z_38: orig: Z
+    def:  Z_38 = PHI(SCZO_27, SZO_10)
+    uses: use C_36 | O_39 | S_35 | Z_38
+O_39: orig: O
+    def:  O_39 = PHI(SCZO_27, SZO_10)
+    uses: use C_36 | O_39 | S_35 | Z_38
 // fn0C00_000F
 // Return size: 2
 define fn0C00_000F
@@ -252,41 +232,40 @@ l0C00_0018:
 	sp_12 = sp_3 - 0x0002
 	Mem13[ss:sp_12:word16] = ax_9
 	call fn0C00_000F (retsize: 2;)
-		uses: ax:ax_9,bp:bp_7,dx:dx,sp:sp_12,ss:ss
-		defs: ax:ax_17,bp:bp_15,dx:dx_19,Flags:SCZO_20,sp:sp_14,ss:ss_16
-	sp_21 = sp_14 + 0x0001
+		uses: ax:ax_9,dx:dx,sp:sp_12
+		defs: ax:ax_15,dx:dx_17,Flags:SCZO_18,sp:sp_14
+	sp_19 = sp_14 + 0x0001
+	SZO_20 = cond(sp_19)
+	sp_21 = sp_19 + 0x0001
 	SZO_22 = cond(sp_21)
-	sp_23 = sp_21 + 0x0001
-	SZO_24 = cond(sp_23)
-	dx_25 = Mem13[ss_16:bp_15 + 0x0004:word16]
-	dx_ax_26 = dx_25 *s ax_17
-	dx_27 = SLICE(dx_ax_26, word16, 16) (alias)
-	ax_28 = (word16) dx_ax_26 (alias)
-	SCZO_29 = cond(dx_ax_26)
+	dx_23 = Mem13[ss:bp_7 + 0x0004:word16]
+	dx_ax_24 = dx_23 *s ax_15
+	dx_25 = SLICE(dx_ax_24, word16, 16) (alias)
+	ax_26 = (word16) dx_ax_24 (alias)
+	SCZO_27 = cond(dx_ax_24)
 	goto l0C00_0029
 	// succ:  l0C00_0029
 l0C00_0026:
 	ax_11 = 0x0001
 	// succ:  l0C00_0029
 l0C00_0029:
-	O_41 = PHI(SCZO_29, SZO_10)
-	Z_40 = PHI(SCZO_29, SZO_10)
-	C_38 = PHI(SCZO_29, C)
-	S_37 = PHI(SCZO_29, SZO_10)
-	dx_36 = PHI(dx_27, dx)
-	ax_35 = PHI(ax_28, ax_11)
-	Mem32 = PHI(Mem13, Mem6)
-	sp_31 = PHI(sp_23, sp_3)
-	ss_30 = PHI(ss_16, ss)
-	bp_33 = Mem32[ss_30:sp_31:word16]
-	sp_34 = sp_31 + 0x0002
+	O_39 = PHI(SCZO_27, SZO_10)
+	Z_38 = PHI(SCZO_27, SZO_10)
+	C_36 = PHI(SCZO_27, C)
+	S_35 = PHI(SCZO_27, SZO_10)
+	dx_34 = PHI(dx_25, dx)
+	ax_33 = PHI(ax_26, ax_11)
+	Mem30 = PHI(Mem13, Mem6)
+	sp_29 = PHI(sp_21, sp_3)
+	bp_31 = Mem30[ss:sp_29:word16]
+	sp_32 = sp_29 + 0x0002
 	return
 	// succ:  fn0C00_000F_exit
 fn0C00_000F_exit:
-	use ax_35
-	use bp_33
-	use dx_36
-	use C_38 | O_41 | S_37 | Z_40
-	use sp_34
-	use ss_30
+	use ax_33
+	use bp_31
+	use dx_34
+	use C_36 | O_39 | S_35 | Z_38
+	use sp_32
+	use ss
 

--- a/src/tests/Analysis/SsaFactorialReg.exp
+++ b/src/tests/Analysis/SsaFactorialReg.exp
@@ -3,53 +3,48 @@ fp:fp
     uses: sp_2 = fp
 sp_2: orig: sp
     def:  sp_2 = fp
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_2	defs: ax:ax_9,cx:cx_5,ds:ds_7,sp:sp_4
+    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_2	defs: ax:ax_7,cx:cx_5,sp:sp_4
 cx_3: orig: cx
     def:  cx_3 = 0x0005
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_2	defs: ax:ax_9,cx:cx_5,ds:ds_7,sp:sp_4
+    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_2	defs: ax:ax_7,cx:cx_5,sp:sp_4
 sp_4: orig: sp
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_2	defs: ax:ax_9,cx:cx_5,ds:ds_7,sp:sp_4
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_2	defs: ax:ax_7,cx:cx_5,sp:sp_4
     uses: use sp_4
 cx_5: orig: cx
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_2	defs: ax:ax_9,cx:cx_5,ds:ds_7,sp:sp_4
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_2	defs: ax:ax_7,cx:cx_5,sp:sp_4
     uses: use cx_5
-ds:ds
-    def:  def ds
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_2	defs: ax:ax_9,cx:cx_5,ds:ds_7,sp:sp_4
-ds_7: orig: ds
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_2	defs: ax:ax_9,cx:cx_5,ds:ds_7,sp:sp_4
-    uses: Mem10[ds_7:0x0064:word16] = ax_9
-          use ds_7
 ax:ax
     def:  def ax
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_2	defs: ax:ax_9,cx:cx_5,ds:ds_7,sp:sp_4
-ax_9: orig: ax
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,ds:ds,sp:sp_2	defs: ax:ax_9,cx:cx_5,ds:ds_7,sp:sp_4
-    uses: Mem10[ds_7:0x0064:word16] = ax_9
-          use ax_9
-Mem10: orig: Mem0
-    def:  Mem10[ds_7:0x0064:word16] = ax_9
+    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_2	defs: ax:ax_7,cx:cx_5,sp:sp_4
+ax_7: orig: ax
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_3,sp:sp_2	defs: ax:ax_7,cx:cx_5,sp:sp_4
+    uses: Mem9[ds:0x0064:word16] = ax_7
+          use ax_7
+ds:ds
+    def:  def ds
+    uses: Mem9[ds:0x0064:word16] = ax_7
+Mem9: orig: Mem0
+    def:  Mem9[ds:0x0064:word16] = ax_7
 // fn0C00_0000
 // Return size: 2
 define fn0C00_0000
 fn0C00_0000_entry:
 	def fp
-	def ds
 	def ax
+	def ds
 	// succ:  l0C00_0000
 l0C00_0000:
 	sp_2 = fp
 	cx_3 = 0x0005
 	call fn0C00_000B (retsize: 2;)
-		uses: ax:ax,cx:cx_3,ds:ds,sp:sp_2
-		defs: ax:ax_9,cx:cx_5,ds:ds_7,sp:sp_4
-	Mem10[ds_7:0x0064:word16] = ax_9
+		uses: ax:ax,cx:cx_3,sp:sp_2
+		defs: ax:ax_7,cx:cx_5,sp:sp_4
+	Mem9[ds:0x0064:word16] = ax_7
 	return
 	// succ:  fn0C00_0000_exit
 fn0C00_0000_exit:
-	use ax_9
+	use ax_7
 	use cx_5
-	use ds_7
 	use sp_4
 
 fp:fp
@@ -61,119 +56,109 @@ sp_2: orig: sp
 sp_3: orig: sp
     def:  sp_3 = sp_2 - 0x0002
     uses: Mem6[ss:sp_3:word16] = si
-          call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss	defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
-          sp_25 = PHI(sp_13, sp_3)
+          call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,sp:sp_3	defs: ax:ax_16,cx:cx_14,Flags:SCZO_17,sp:sp_13
+          sp_23 = PHI(sp_13, sp_3)
 si:si
     def:  def si
     uses: Mem6[ss:sp_3:word16] = si
 ss:ss
     def:  def ss
     uses: Mem6[ss:sp_3:word16] = si
-          call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss	defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
-          ss_24 = PHI(ss_15, ss)
+          si_25 = Mem6[ss:sp_23:word16]
+          use ss
 Mem6: orig: Mem0
     def:  Mem6[ss:sp_3:word16] = si
-    uses: si_27 = Mem6[ss_24:sp_25:word16]
+    uses: si_25 = Mem6[ss:sp_23:word16]
 cx:cx
     def:  def cx
     uses: SCZO_8 = cond(cx - 0x0001)
           si_10 = cx
           cx_11 = cx - 0x0001
-          cx_30 = PHI(cx_16, cx)
+          cx_28 = PHI(cx_14, cx)
 SCZO_8: orig: SCZO
     def:  SCZO_8 = cond(cx - 0x0001)
     uses: branch Test(LE,SCZO_8) l0C00_001C
-          S_33 = PHI(SCZO_23, SCZO_8)
-          C_34 = PHI(SCZO_23, SCZO_8)
-          Z_35 = PHI(SCZO_23, SCZO_8)
-          O_36 = PHI(SCZO_23, SCZO_8)
+          S_31 = PHI(SCZO_21, SCZO_8)
+          C_32 = PHI(SCZO_21, SCZO_8)
+          Z_33 = PHI(SCZO_21, SCZO_8)
+          O_34 = PHI(SCZO_21, SCZO_8)
 ax_9: orig: ax
     def:  ax_9 = 0x0001
-    uses: ax_29 = PHI(ax_22, ax_9)
+    uses: ax_27 = PHI(ax_20, ax_9)
 si_10: orig: si
     def:  si_10 = cx
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss	defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
+    uses: dx_ax_18 = si_10 *s ax_16
 cx_11: orig: cx
     def:  cx_11 = cx - 0x0001
     uses: SZO_12 = cond(cx_11)
-          call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss	defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
+          call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,sp:sp_3	defs: ax:ax_16,cx:cx_14,Flags:SCZO_17,sp:sp_13
 SZO_12: orig: SZO
     def:  SZO_12 = cond(cx_11)
 sp_13: orig: sp
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss	defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
-    uses: sp_25 = PHI(sp_13, sp_3)
-si_14: orig: si
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss	defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
-    uses: dx_ax_20 = si_14 *s ax_18
-ss_15: orig: ss
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss	defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
-    uses: ss_24 = PHI(ss_15, ss)
-cx_16: orig: cx
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss	defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
-    uses: cx_30 = PHI(cx_16, cx)
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,sp:sp_3	defs: ax:ax_16,cx:cx_14,Flags:SCZO_17,sp:sp_13
+    uses: sp_23 = PHI(sp_13, sp_3)
+cx_14: orig: cx
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,sp:sp_3	defs: ax:ax_16,cx:cx_14,Flags:SCZO_17,sp:sp_13
+    uses: cx_28 = PHI(cx_14, cx)
 ax:ax
     def:  def ax
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss	defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
-ax_18: orig: ax
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss	defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
-    uses: dx_ax_20 = si_14 *s ax_18
-SCZO_19: orig: SCZO
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss	defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
-dx_ax_20: orig: dx_ax
-    def:  dx_ax_20 = si_14 *s ax_18
-    uses: dx_21 = SLICE(dx_ax_20, word16, 16) (alias)
-          ax_22 = (word16) dx_ax_20 (alias)
-          SCZO_23 = cond(dx_ax_20)
-dx_21: orig: dx
-    def:  dx_21 = SLICE(dx_ax_20, word16, 16) (alias)
-    uses: dx_31 = PHI(dx_21, dx)
-ax_22: orig: ax
-    def:  ax_22 = (word16) dx_ax_20 (alias)
-    uses: ax_29 = PHI(ax_22, ax_9)
-SCZO_23: orig: SCZO
-    def:  SCZO_23 = cond(dx_ax_20)
-    uses: S_33 = PHI(SCZO_23, SCZO_8)
-          C_34 = PHI(SCZO_23, SCZO_8)
-          Z_35 = PHI(SCZO_23, SCZO_8)
-          O_36 = PHI(SCZO_23, SCZO_8)
-ss_24: orig: ss
-    def:  ss_24 = PHI(ss_15, ss)
-    uses: si_27 = Mem6[ss_24:sp_25:word16]
-          use ss_24
-sp_25: orig: sp
-    def:  sp_25 = PHI(sp_13, sp_3)
-    uses: si_27 = Mem6[ss_24:sp_25:word16]
-          sp_28 = sp_25 + 0x0002
-si_27: orig: si
-    def:  si_27 = Mem6[ss_24:sp_25:word16]
-    uses: use si_27
-sp_28: orig: sp
-    def:  sp_28 = sp_25 + 0x0002
-    uses: use sp_28
-ax_29: orig: ax
-    def:  ax_29 = PHI(ax_22, ax_9)
-    uses: use ax_29
-cx_30: orig: cx
-    def:  cx_30 = PHI(cx_16, cx)
-    uses: use cx_30
-dx_31: orig: dx
-    def:  dx_31 = PHI(dx_21, dx)
-    uses: use dx_31
+    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,sp:sp_3	defs: ax:ax_16,cx:cx_14,Flags:SCZO_17,sp:sp_13
+ax_16: orig: ax
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,sp:sp_3	defs: ax:ax_16,cx:cx_14,Flags:SCZO_17,sp:sp_13
+    uses: dx_ax_18 = si_10 *s ax_16
+SCZO_17: orig: SCZO
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,cx:cx_11,sp:sp_3	defs: ax:ax_16,cx:cx_14,Flags:SCZO_17,sp:sp_13
+dx_ax_18: orig: dx_ax
+    def:  dx_ax_18 = si_10 *s ax_16
+    uses: dx_19 = SLICE(dx_ax_18, word16, 16) (alias)
+          ax_20 = (word16) dx_ax_18 (alias)
+          SCZO_21 = cond(dx_ax_18)
+dx_19: orig: dx
+    def:  dx_19 = SLICE(dx_ax_18, word16, 16) (alias)
+    uses: dx_29 = PHI(dx_19, dx)
+ax_20: orig: ax
+    def:  ax_20 = (word16) dx_ax_18 (alias)
+    uses: ax_27 = PHI(ax_20, ax_9)
+SCZO_21: orig: SCZO
+    def:  SCZO_21 = cond(dx_ax_18)
+    uses: S_31 = PHI(SCZO_21, SCZO_8)
+          C_32 = PHI(SCZO_21, SCZO_8)
+          Z_33 = PHI(SCZO_21, SCZO_8)
+          O_34 = PHI(SCZO_21, SCZO_8)
+sp_23: orig: sp
+    def:  sp_23 = PHI(sp_13, sp_3)
+    uses: si_25 = Mem6[ss:sp_23:word16]
+          sp_26 = sp_23 + 0x0002
+si_25: orig: si
+    def:  si_25 = Mem6[ss:sp_23:word16]
+    uses: use si_25
+sp_26: orig: sp
+    def:  sp_26 = sp_23 + 0x0002
+    uses: use sp_26
+ax_27: orig: ax
+    def:  ax_27 = PHI(ax_20, ax_9)
+    uses: use ax_27
+cx_28: orig: cx
+    def:  cx_28 = PHI(cx_14, cx)
+    uses: use cx_28
+dx_29: orig: dx
+    def:  dx_29 = PHI(dx_19, dx)
+    uses: use dx_29
 dx:dx
     def:  def dx
-    uses: dx_31 = PHI(dx_21, dx)
-S_33: orig: S
-    def:  S_33 = PHI(SCZO_23, SCZO_8)
-    uses: use C_34 | O_36 | S_33 | Z_35
-C_34: orig: C
-    def:  C_34 = PHI(SCZO_23, SCZO_8)
-    uses: use C_34 | O_36 | S_33 | Z_35
-Z_35: orig: Z
-    def:  Z_35 = PHI(SCZO_23, SCZO_8)
-    uses: use C_34 | O_36 | S_33 | Z_35
-O_36: orig: O
-    def:  O_36 = PHI(SCZO_23, SCZO_8)
-    uses: use C_34 | O_36 | S_33 | Z_35
+    uses: dx_29 = PHI(dx_19, dx)
+S_31: orig: S
+    def:  S_31 = PHI(SCZO_21, SCZO_8)
+    uses: use C_32 | O_34 | S_31 | Z_33
+C_32: orig: C
+    def:  C_32 = PHI(SCZO_21, SCZO_8)
+    uses: use C_32 | O_34 | S_31 | Z_33
+Z_33: orig: Z
+    def:  Z_33 = PHI(SCZO_21, SCZO_8)
+    uses: use C_32 | O_34 | S_31 | Z_33
+O_34: orig: O
+    def:  O_34 = PHI(SCZO_21, SCZO_8)
+    uses: use C_32 | O_34 | S_31 | Z_33
 // fn0C00_000B
 // Return size: 2
 define fn0C00_000B
@@ -197,37 +182,36 @@ l0C00_0011:
 	cx_11 = cx - 0x0001
 	SZO_12 = cond(cx_11)
 	call fn0C00_000B (retsize: 2;)
-		uses: ax:ax,cx:cx_11,si:si_10,sp:sp_3,ss:ss
-		defs: ax:ax_18,cx:cx_16,Flags:SCZO_19,si:si_14,sp:sp_13,ss:ss_15
-	dx_ax_20 = si_14 *s ax_18
-	dx_21 = SLICE(dx_ax_20, word16, 16) (alias)
-	ax_22 = (word16) dx_ax_20 (alias)
-	SCZO_23 = cond(dx_ax_20)
+		uses: ax:ax,cx:cx_11,sp:sp_3
+		defs: ax:ax_16,cx:cx_14,Flags:SCZO_17,sp:sp_13
+	dx_ax_18 = si_10 *s ax_16
+	dx_19 = SLICE(dx_ax_18, word16, 16) (alias)
+	ax_20 = (word16) dx_ax_18 (alias)
+	SCZO_21 = cond(dx_ax_18)
 	goto l0C00_001F
 	// succ:  l0C00_001F
 l0C00_001C:
 	ax_9 = 0x0001
 	// succ:  l0C00_001F
 l0C00_001F:
-	O_36 = PHI(SCZO_23, SCZO_8)
-	Z_35 = PHI(SCZO_23, SCZO_8)
-	C_34 = PHI(SCZO_23, SCZO_8)
-	S_33 = PHI(SCZO_23, SCZO_8)
-	dx_31 = PHI(dx_21, dx)
-	cx_30 = PHI(cx_16, cx)
-	ax_29 = PHI(ax_22, ax_9)
-	sp_25 = PHI(sp_13, sp_3)
-	ss_24 = PHI(ss_15, ss)
-	si_27 = Mem6[ss_24:sp_25:word16]
-	sp_28 = sp_25 + 0x0002
+	O_34 = PHI(SCZO_21, SCZO_8)
+	Z_33 = PHI(SCZO_21, SCZO_8)
+	C_32 = PHI(SCZO_21, SCZO_8)
+	S_31 = PHI(SCZO_21, SCZO_8)
+	dx_29 = PHI(dx_19, dx)
+	cx_28 = PHI(cx_14, cx)
+	ax_27 = PHI(ax_20, ax_9)
+	sp_23 = PHI(sp_13, sp_3)
+	si_25 = Mem6[ss:sp_23:word16]
+	sp_26 = sp_23 + 0x0002
 	return
 	// succ:  fn0C00_000B_exit
 fn0C00_000B_exit:
-	use ax_29
-	use cx_30
-	use dx_31
-	use C_34 | O_36 | S_33 | Z_35
-	use si_27
-	use sp_28
-	use ss_24
+	use ax_27
+	use cx_28
+	use dx_29
+	use C_32 | O_34 | S_31 | Z_33
+	use si_25
+	use sp_26
+	use ss
 

--- a/src/tests/Analysis/VpChainTest.exp
+++ b/src/tests/Analysis/VpChainTest.exp
@@ -4,43 +4,40 @@ fp:fp
     uses: sp_2 = fp
 sp_2: orig: sp
     def:  sp_2 = fp
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:dx_3,sp:sp_2	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
+    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,dx:dx_3,sp:sp_2	defs: ax:ax_7,dx:dx_5,sp:sp_4
 dx_3: orig: dx
     def:  dx_3 = 0x001E
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:dx_3,sp:sp_2	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
+    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,dx:dx_3,sp:sp_2	defs: ax:ax_7,dx:dx_5,sp:sp_4
 sp_4: orig: sp
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:dx_3,sp:sp_2	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,dx:dx_3,sp:sp_2	defs: ax:ax_7,dx:dx_5,sp:sp_4
 dx_5: orig: dx
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:dx_3,sp:sp_2	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-ds:ds
-    def:  def ds
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:dx_3,sp:sp_2	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-ds_7: orig: ds
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:dx_3,sp:sp_2	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-    uses: Mem10[ds_7:0x012C:word16] = ax_9
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,dx:dx_3,sp:sp_2	defs: ax:ax_7,dx:dx_5,sp:sp_4
 ax:ax
     def:  def ax
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:dx_3,sp:sp_2	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-ax_9: orig: ax
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:dx_3,sp:sp_2	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-    uses: Mem10[ds_7:0x012C:word16] = ax_9
-Mem10: orig: Mem0
-    def:  Mem10[ds_7:0x012C:word16] = ax_9
+    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,dx:dx_3,sp:sp_2	defs: ax:ax_7,dx:dx_5,sp:sp_4
+ax_7: orig: ax
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,dx:dx_3,sp:sp_2	defs: ax:ax_7,dx:dx_5,sp:sp_4
+    uses: Mem9[ds:0x012C:word16] = ax_7
+ds:ds
+    def:  def ds
+    uses: Mem9[ds:0x012C:word16] = ax_7
+Mem9: orig: Mem0
+    def:  Mem9[ds:0x012C:word16] = ax_7
 // fn0C00_0000
 // Return size: 2
 define fn0C00_0000
 fn0C00_0000_entry:
 	def fp
-	def ds
 	def ax
+	def ds
 	// succ:  l0C00_0000
 l0C00_0000:
 	sp_2 = fp
 	dx_3 = 0x001E
 	call fn0C00_000B (retsize: 2;)
-		uses: ax:ax,ds:ds,dx:dx_3,sp:sp_2
-		defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-	Mem10[ds_7:0x012C:word16] = ax_9
+		uses: ax:ax,dx:dx_3,sp:sp_2
+		defs: ax:ax_7,dx:dx_5,sp:sp_4
+	Mem9[ds:0x012C:word16] = ax_7
 	return
 	// succ:  fn0C00_0000_exit
 fn0C00_0000_exit:
@@ -48,44 +45,41 @@ fn0C00_0000_exit:
 fp:fp
     def:  def fp
     uses: sp_2 = fp
-          call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:0x001E,sp:fp	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
+          call fn0C00_000B (retsize: 2;)	uses: ax:ax,dx:0x001E,sp:fp	defs: ax:ax_7,dx:dx_5,sp:sp_4
 sp_2: orig: sp
     def:  sp_2 = fp
 dx_3: orig: dx
     def:  dx_3 = 0x001E
 sp_4: orig: sp
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:0x001E,sp:fp	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,dx:0x001E,sp:fp	defs: ax:ax_7,dx:dx_5,sp:sp_4
 dx_5: orig: dx
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:0x001E,sp:fp	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-ds:ds
-    def:  def ds
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:0x001E,sp:fp	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-ds_7: orig: ds
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:0x001E,sp:fp	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-    uses: Mem10[ds_7:0x012C:word16] = ax_9
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,dx:0x001E,sp:fp	defs: ax:ax_7,dx:dx_5,sp:sp_4
 ax:ax
     def:  def ax
-    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:0x001E,sp:fp	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-ax_9: orig: ax
-    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,ds:ds,dx:0x001E,sp:fp	defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-    uses: Mem10[ds_7:0x012C:word16] = ax_9
-Mem10: orig: Mem0
-    def:  Mem10[ds_7:0x012C:word16] = ax_9
+    uses: call fn0C00_000B (retsize: 2;)	uses: ax:ax,dx:0x001E,sp:fp	defs: ax:ax_7,dx:dx_5,sp:sp_4
+ax_7: orig: ax
+    def:  call fn0C00_000B (retsize: 2;)	uses: ax:ax,dx:0x001E,sp:fp	defs: ax:ax_7,dx:dx_5,sp:sp_4
+    uses: Mem9[ds:0x012C:word16] = ax_7
+ds:ds
+    def:  def ds
+    uses: Mem9[ds:0x012C:word16] = ax_7
+Mem9: orig: Mem0
+    def:  Mem9[ds:0x012C:word16] = ax_7
 // fn0C00_0000
 // Return size: 2
 define fn0C00_0000
 fn0C00_0000_entry:
 	def fp
-	def ds
 	def ax
+	def ds
 	// succ:  l0C00_0000
 l0C00_0000:
 	sp_2 = fp
 	dx_3 = 0x001E
 	call fn0C00_000B (retsize: 2;)
-		uses: ax:ax,ds:ds,dx:0x001E,sp:fp
-		defs: ax:ax_9,ds:ds_7,dx:dx_5,sp:sp_4
-	Mem10[ds_7:0x012C:word16] = ax_9
+		uses: ax:ax,dx:0x001E,sp:fp
+		defs: ax:ax_7,dx:dx_5,sp:sp_4
+	Mem9[ds:0x012C:word16] = ax_7
 	return
 	// succ:  fn0C00_0000_exit
 fn0C00_0000_exit:

--- a/src/tests/Analysis/VpStringInstructions.exp
+++ b/src/tests/Analysis/VpStringInstructions.exp
@@ -4,7 +4,7 @@ fp:fp
     uses: sp_2 = fp
 sp_2: orig: sp
     def:  sp_2 = fp
-    uses: call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si_20,sp:sp_2	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
+    uses: call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:sp_2	defs: ax:ax_26,eax:eax_24,sp:sp_22
 eax:eax
     def:  def eax
     uses: eax_4 = eax + eax * 0x00000004
@@ -24,7 +24,6 @@ ds:ds
           Mem17[ds:0x0308:word16] = ax_14
           ax_18 = Mem17[ds:si_16:word16]
           Mem21[ds:0x030A:word16] = ax_19
-          call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si_20,sp:sp_2	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
 Mem6: orig: Mem0
     def:  Mem6[ds:0x02FC:word32] = eax_4
     uses: eax_8 = Mem6[ds:si:word32]
@@ -74,29 +73,24 @@ ax_19: orig: ax
           eax_23 = DPB(eax, ax_19, 0) (alias)
 si_20: orig: si
     def:  si_20 = si_16 + 0x0002
-    uses: call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si_20,sp:sp_2	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
 Mem21: orig: Mem0
     def:  Mem21[ds:0x030A:word16] = ax_19
 sp_22: orig: sp
-    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si_20,sp:sp_2	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
+    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:sp_2	defs: ax:ax_26,eax:eax_24,sp:sp_22
 eax_23: orig: eax
     def:  eax_23 = DPB(eax, ax_19, 0) (alias)
-    uses: call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si_20,sp:sp_2	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
+    uses: call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:sp_2	defs: ax:ax_26,eax:eax_24,sp:sp_22
 eax_24: orig: eax
-    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si_20,sp:sp_2	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
-    uses: ax_27 = (word16) eax_24 (alias)
-ds_25: orig: ds
-    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si_20,sp:sp_2	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
-si_26: orig: si
-    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si_20,sp:sp_2	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
+    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:sp_2	defs: ax:ax_26,eax:eax_24,sp:sp_22
+    uses: ax_25 = (word16) eax_24 (alias)
+ax_25: orig: ax
+    def:  ax_25 = (word16) eax_24 (alias)
+    uses: call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:sp_2	defs: ax:ax_26,eax:eax_24,sp:sp_22
+          ax_27 = DPB(ax_25, ax_26, 0) (alias)
+ax_26: orig: ax
+    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:sp_2	defs: ax:ax_26,eax:eax_24,sp:sp_22
 ax_27: orig: ax
-    def:  ax_27 = (word16) eax_24 (alias)
-    uses: call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si_20,sp:sp_2	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
-          ax_29 = DPB(ax_27, ax_28, 0) (alias)
-ax_28: orig: ax
-    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si_20,sp:sp_2	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
-ax_29: orig: ax
-    def:  ax_29 = DPB(ax_27, ax_28, 0) (alias)
+    def:  ax_27 = DPB(ax_25, ax_26, 0) (alias)
 // fn0C00_0000
 // Return size: 2
 define fn0C00_0000
@@ -126,10 +120,10 @@ l0C00_0000:
 	si_20 = si_16 + 0x0002
 	Mem21[ds:0x030A:word16] = ax_19
 	call fn0C00_0026 (retsize: 2;)
-		uses: ax:ax_27,ds:ds,eax:eax_23,si:si_20,sp:sp_2
-		defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
-	ax_27 = (word16) eax_24 (alias)
-	ax_29 = DPB(ax_27, ax_28, 0) (alias)
+		uses: ax:ax_25,eax:eax_23,sp:sp_2
+		defs: ax:ax_26,eax:eax_24,sp:sp_22
+	ax_25 = (word16) eax_24 (alias)
+	ax_27 = DPB(ax_25, ax_26, 0) (alias)
 	return
 	// succ:  fn0C00_0000_exit
 fn0C00_0000_exit:
@@ -137,7 +131,7 @@ fn0C00_0000_exit:
 fp:fp
     def:  def fp
     uses: sp_2 = fp
-          call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si + 0x000C,sp:fp	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
+          call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:fp	defs: ax:ax_26,eax:eax_24,sp:sp_22
 sp_2: orig: sp
     def:  sp_2 = fp
 eax:eax
@@ -158,7 +152,6 @@ ds:ds
           Mem17[ds:0x0308:word16] = ax_14
           ax_18 = Mem17[ds:si + 0x000A:word16]
           Mem21[ds:0x030A:word16] = ax_19
-          call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si + 0x000C,sp:fp	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
 Mem6: orig: Mem0
     def:  Mem6[ds:0x02FC:word32] = eax * 0x00000005
     uses: eax_8 = Mem6[ds:si:word32]
@@ -172,7 +165,6 @@ si:si
           si_16 = si + 0x000A
           ax_18 = Mem17[ds:si + 0x000A:word16]
           si_20 = si + 0x000C
-          call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si + 0x000C,sp:fp	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
 eax_8: orig: eax
     def:  eax_8 = Mem6[ds:si:word32]
     uses: Mem10[ds:0x0300:word32] = eax_8
@@ -212,25 +204,21 @@ si_20: orig: si
 Mem21: orig: Mem0
     def:  Mem21[ds:0x030A:word16] = ax_19
 sp_22: orig: sp
-    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si + 0x000C,sp:fp	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
+    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:fp	defs: ax:ax_26,eax:eax_24,sp:sp_22
 eax_23: orig: eax
     def:  eax_23 = DPB(eax, ax_19, 0) (alias)
-    uses: call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si + 0x000C,sp:fp	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
+    uses: call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:fp	defs: ax:ax_26,eax:eax_24,sp:sp_22
 eax_24: orig: eax
-    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si + 0x000C,sp:fp	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
-    uses: ax_27 = (word16) eax_24 (alias)
-ds_25: orig: ds
-    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si + 0x000C,sp:fp	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
-si_26: orig: si
-    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si + 0x000C,sp:fp	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
+    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:fp	defs: ax:ax_26,eax:eax_24,sp:sp_22
+    uses: ax_25 = (word16) eax_24 (alias)
+ax_25: orig: ax
+    def:  ax_25 = (word16) eax_24 (alias)
+    uses: call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:fp	defs: ax:ax_26,eax:eax_24,sp:sp_22
+          ax_27 = DPB(ax_25, ax_26, 0) (alias)
+ax_26: orig: ax
+    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_25,eax:eax_23,sp:fp	defs: ax:ax_26,eax:eax_24,sp:sp_22
 ax_27: orig: ax
-    def:  ax_27 = (word16) eax_24 (alias)
-    uses: call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si + 0x000C,sp:fp	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
-          ax_29 = DPB(ax_27, ax_28, 0) (alias)
-ax_28: orig: ax
-    def:  call fn0C00_0026 (retsize: 2;)	uses: ax:ax_27,ds:ds,eax:eax_23,si:si + 0x000C,sp:fp	defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
-ax_29: orig: ax
-    def:  ax_29 = DPB(ax_27, ax_28, 0) (alias)
+    def:  ax_27 = DPB(ax_25, ax_26, 0) (alias)
 // fn0C00_0000
 // Return size: 2
 define fn0C00_0000
@@ -260,10 +248,10 @@ l0C00_0000:
 	si_20 = si + 0x000C
 	Mem21[ds:0x030A:word16] = ax_19
 	call fn0C00_0026 (retsize: 2;)
-		uses: ax:ax_27,ds:ds,eax:eax_23,si:si + 0x000C,sp:fp
-		defs: ax:ax_28,ds:ds_25,eax:eax_24,si:si_26,sp:sp_22
-	ax_27 = (word16) eax_24 (alias)
-	ax_29 = DPB(ax_27, ax_28, 0) (alias)
+		uses: ax:ax_25,eax:eax_23,sp:fp
+		defs: ax:ax_26,eax:eax_24,sp:sp_22
+	ax_25 = (word16) eax_24 (alias)
+	ax_27 = DPB(ax_25, ax_26, 0) (alias)
 	return
 	// succ:  fn0C00_0000_exit
 fn0C00_0000_exit:

--- a/src/tests/Analysis/VpSuccessiveDecs.exp
+++ b/src/tests/Analysis/VpSuccessiveDecs.exp
@@ -4,27 +4,24 @@ fp:fp
     uses: sp_2 = fp
 sp_2: orig: sp
     def:  sp_2 = fp
-    uses: call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:sp_2	defs: ax:ax_7,ds:ds_8,sp:sp_6
+    uses: call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,sp:sp_2	defs: ax:ax_7,sp:sp_6
 ds:ds
     def:  def ds
     uses: ax_5 = Mem0[ds:0x0300:word16]
-          call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:sp_2	defs: ax:ax_7,ds:ds_8,sp:sp_6
+          Mem8[ds:0x0302:word16] = ax_7
 Mem0:Global memory
     def:  def Mem0
     uses: ax_5 = Mem0[ds:0x0300:word16]
 ax_5: orig: ax
     def:  ax_5 = Mem0[ds:0x0300:word16]
-    uses: call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:sp_2	defs: ax:ax_7,ds:ds_8,sp:sp_6
+    uses: call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,sp:sp_2	defs: ax:ax_7,sp:sp_6
 sp_6: orig: sp
-    def:  call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:sp_2	defs: ax:ax_7,ds:ds_8,sp:sp_6
+    def:  call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,sp:sp_2	defs: ax:ax_7,sp:sp_6
 ax_7: orig: ax
-    def:  call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:sp_2	defs: ax:ax_7,ds:ds_8,sp:sp_6
-    uses: Mem9[ds_8:0x0302:word16] = ax_7
-ds_8: orig: ds
-    def:  call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:sp_2	defs: ax:ax_7,ds:ds_8,sp:sp_6
-    uses: Mem9[ds_8:0x0302:word16] = ax_7
-Mem9: orig: Mem0
-    def:  Mem9[ds_8:0x0302:word16] = ax_7
+    def:  call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,sp:sp_2	defs: ax:ax_7,sp:sp_6
+    uses: Mem8[ds:0x0302:word16] = ax_7
+Mem8: orig: Mem0
+    def:  Mem8[ds:0x0302:word16] = ax_7
 // fn0C00_0000
 // Return size: 2
 define fn0C00_0000
@@ -37,9 +34,9 @@ l0C00_0000:
 	sp_2 = fp
 	ax_5 = Mem0[ds:0x0300:word16]
 	call fn0C00_000C (retsize: 2;)
-		uses: ax:ax_5,ds:ds,sp:sp_2
-		defs: ax:ax_7,ds:ds_8,sp:sp_6
-	Mem9[ds_8:0x0302:word16] = ax_7
+		uses: ax:ax_5,sp:sp_2
+		defs: ax:ax_7,sp:sp_6
+	Mem8[ds:0x0302:word16] = ax_7
 	return
 	// succ:  fn0C00_0000_exit
 fn0C00_0000_exit:
@@ -47,29 +44,26 @@ fn0C00_0000_exit:
 fp:fp
     def:  def fp
     uses: sp_2 = fp
-          call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:fp	defs: ax:ax_7,ds:ds_8,sp:sp_6
+          call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,sp:fp	defs: ax:ax_7,sp:sp_6
 sp_2: orig: sp
     def:  sp_2 = fp
 ds:ds
     def:  def ds
     uses: ax_5 = Mem0[ds:0x0300:word16]
-          call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:fp	defs: ax:ax_7,ds:ds_8,sp:sp_6
+          Mem8[ds:0x0302:word16] = ax_7
 Mem0:Global memory
     def:  def Mem0
     uses: ax_5 = Mem0[ds:0x0300:word16]
 ax_5: orig: ax
     def:  ax_5 = Mem0[ds:0x0300:word16]
-    uses: call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:fp	defs: ax:ax_7,ds:ds_8,sp:sp_6
+    uses: call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,sp:fp	defs: ax:ax_7,sp:sp_6
 sp_6: orig: sp
-    def:  call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:fp	defs: ax:ax_7,ds:ds_8,sp:sp_6
+    def:  call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,sp:fp	defs: ax:ax_7,sp:sp_6
 ax_7: orig: ax
-    def:  call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:fp	defs: ax:ax_7,ds:ds_8,sp:sp_6
-    uses: Mem9[ds_8:0x0302:word16] = ax_7
-ds_8: orig: ds
-    def:  call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,ds:ds,sp:fp	defs: ax:ax_7,ds:ds_8,sp:sp_6
-    uses: Mem9[ds_8:0x0302:word16] = ax_7
-Mem9: orig: Mem0
-    def:  Mem9[ds_8:0x0302:word16] = ax_7
+    def:  call fn0C00_000C (retsize: 2;)	uses: ax:ax_5,sp:fp	defs: ax:ax_7,sp:sp_6
+    uses: Mem8[ds:0x0302:word16] = ax_7
+Mem8: orig: Mem0
+    def:  Mem8[ds:0x0302:word16] = ax_7
 // fn0C00_0000
 // Return size: 2
 define fn0C00_0000
@@ -82,9 +76,9 @@ l0C00_0000:
 	sp_2 = fp
 	ax_5 = Mem0[ds:0x0300:word16]
 	call fn0C00_000C (retsize: 2;)
-		uses: ax:ax_5,ds:ds,sp:fp
-		defs: ax:ax_7,ds:ds_8,sp:sp_6
-	Mem9[ds_8:0x0302:word16] = ax_7
+		uses: ax:ax_5,sp:fp
+		defs: ax:ax_7,sp:sp_6
+	Mem8[ds:0x0302:word16] = ax_7
 	return
 	// succ:  fn0C00_0000_exit
 fn0C00_0000_exit:


### PR DESCRIPTION
- Use `Platform.CreateTrashedRegisters()` to get trashed register when hell node processing
- Add stack register to list of trashed registers on `win32` and `msdos`
- Output for 7 unit tests was changed. These tests uses `msdos` platform. Some of 86 already broken tests could be affected too, of course.