### PR TITLE
Make IndirectCallRewriter works on VCExeSample

### DIFF
--- a/src/Decompiler/Analysis/DataFlowAnalysis.cs
+++ b/src/Decompiler/Analysis/DataFlowAnalysis.cs
@@ -1,6 +1,6 @@
 #region License
 /* 
- * Copyright (C) 1999-2016 John Källén.
+ * Copyright (C) 1999-2016 John KÃ¤llÃ©n.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -277,7 +277,7 @@ namespace Reko.Analysis
             sst.Transform();
 
             var icrw = new IndirectCallRewriter(program, ssa, eventListener);
-            while (icrw.Rewrite())
+            while (!eventListener.IsCanceled() && icrw.Rewrite())
             {
                 vp.Transform();
                 sst.RenameFrameAccesses = true;

--- a/src/Decompiler/Analysis/DataFlowAnalysis.cs
+++ b/src/Decompiler/Analysis/DataFlowAnalysis.cs
@@ -276,6 +276,14 @@ namespace Reko.Analysis
             sst.RenameFrameAccesses = true;
             sst.Transform();
 
+            var icrw = new IndirectCallRewriter(program, ssa, eventListener);
+            while (icrw.Rewrite())
+            {
+                vp.Transform();
+                sst.RenameFrameAccesses = true;
+                sst.Transform();
+            }
+
             // By placing use statements in the exit block, we will collect
             // reaching definitions in the use statements.
             sst.AddUsesToExitBlock();

--- a/src/Decompiler/Analysis/IndirectCallRewriter.cs
+++ b/src/Decompiler/Analysis/IndirectCallRewriter.cs
@@ -133,7 +133,11 @@ namespace Reko.Analysis
                 return;
             var retSize = call.CallSite.SizeOfReturnAddressOnStack;
             var offset = stackDelta - retSize;
-            var src = emiter.IAdd(usedSpExp, Constant.Word32(offset));
+            Expression src;
+            if (offset == 0)
+                src = usedSpExp;
+            else
+                src = emiter.IAdd(usedSpExp, Constant.Word32(offset));
             // Generate a statement that adjusts the stack pointer according to
             // the calling convention.
             var ass = new Assignment(defSpId, src);

--- a/src/Decompiler/Analysis/IndirectCallRewriter.cs
+++ b/src/Decompiler/Analysis/IndirectCallRewriter.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using Reko.Core;
 using Reko.Core.Code;
 using Reko.Core.Expressions;
+using Reko.Core.Operators;
 using Reko.Core.Services;
 using Reko.Core.Types;
 
@@ -47,6 +48,9 @@ namespace Reko.Analysis
         private IndirectCallExpander expander;
         private SsaIdentifierTransformer ssaIdTransformer;
         private DecompilerEventListener eventListener;
+        private ExpressionEmitter emiter;
+        private bool changed;
+
 
         public IndirectCallRewriter(
             Program program,
@@ -60,10 +64,12 @@ namespace Reko.Analysis
             this.expander = new IndirectCallExpander(ssa);
             this.ssaIdTransformer = new SsaIdentifierTransformer(ssa);
             this.eventListener = eventListener;
+            this.emiter = new ExpressionEmitter();
         }
 
-        public void Rewrite()
+        public bool Rewrite()
         {
+            changed = false;
             foreach (Statement stm in proc.Statements.ToList())
             {
                 CallInstruction ci = stm.Instruction as CallInstruction;
@@ -83,6 +89,7 @@ namespace Reko.Analysis
                     }
                 }
             }
+            return changed;
         }
 
         private void RewriteCall(Statement stm, CallInstruction call)
@@ -95,14 +102,57 @@ namespace Reko.Analysis
             var ft = pt.Pointee as FunctionType;
             if (ft == null)
                 return;
-            var returnId = ft.ReturnValue.DataType is VoidType ?
-                null : ft.ReturnValue;
-            var sigCallee = new FunctionType(returnId, ft.Parameters);
+            AdjustStack(stm, call, ft.StackDelta);
             var ab = new FrameApplicationBuilder(
                  program.Architecture, proc.Frame, call.CallSite,
-                 call.Callee, true);
-            stm.Instruction = ab.CreateInstruction(sigCallee, null);
+                 call.Callee, false);
+            stm.Instruction = ab.CreateInstruction(ft, null);
             ssaIdTransformer.Transform(stm, call);
+            changed = true;
+        }
+
+        private void AdjustStack(
+            Statement stm,
+            CallInstruction call,
+            int stackDelta)
+        {
+            var defSpBinding = call.Definitions.Where(
+                u => u.Storage == program.Architecture.StackRegister)
+                .FirstOrDefault();
+            if (defSpBinding == null)
+                return;
+            var defSpId = defSpBinding.Expression as Identifier;
+            if (defSpId == null)
+                return;
+            var usedSpExp = call.Uses.Where(
+                u => u.Storage == program.Architecture.StackRegister)
+                .Select(u => u.Expression)
+                .FirstOrDefault();
+            if (usedSpExp == null)
+                return;
+            var retSize = call.CallSite.SizeOfReturnAddressOnStack;
+            var offset = stackDelta - retSize;
+            var src = emiter.IAdd(usedSpExp, Constant.Word32(offset));
+            var ass = new Assignment(defSpId, src);
+            var defSid = ssa.Identifiers[defSpId];
+            var stackStm = InsertStatement(stm, ass);
+            defSid.DefExpression = src;
+            defSid.DefStatement = stackStm;
+            call.Definitions.Remove(defSpBinding);
+            Use(stackStm, src);
+        }
+
+        private void Use(Statement stm, Expression e)
+        {
+            e.Accept(new ExpressionUseAdder(stm, ssa.Identifiers));
+        }
+
+        private Statement InsertStatement(Statement stm, Instruction instr)
+        {
+            var block = stm.Block;
+            var iPos = block.Statements.IndexOf(stm);
+            var linAddr = stm.LinearAddress;
+            return block.Statements.Insert(iPos + 1, linAddr, instr);
         }
     }
 
@@ -176,11 +226,13 @@ namespace Reko.Analysis
         private Frame frame;
         private Statement stm;
         private CallInstruction call;
+        private ArgumentTransformer argumentTransformer;
 
         public SsaIdentifierTransformer(SsaState ssa)
         {
             this.ssa = ssa;
             this.frame = ssa.Procedure.Frame;
+            this.argumentTransformer = new ArgumentTransformer(this);
         }
 
         public void Transform(Statement stm, CallInstruction call)
@@ -212,13 +264,7 @@ namespace Reko.Analysis
 
         private Expression TransformArgument(Expression arg)
         {
-            var id = arg as Identifier;
-            if (id == null)
-                return arg;
-            var usedId = FindUsedId(call, id.Storage);
-            if (usedId != null)
-                usedId.Accept(this);
-            return usedId ?? InvalidArgument();
+            return arg.Accept(argumentTransformer);
         }
 
         private Expression InvalidArgument()
@@ -265,6 +311,32 @@ namespace Reko.Analysis
                 .Where(u => u.Storage.Equals(storage))
                 .Select(u => u.Expression)
                 .FirstOrDefault();
+        }
+
+        class ArgumentTransformer : InstructionTransformer
+        {
+            SsaIdentifierTransformer outer;
+
+            public ArgumentTransformer(SsaIdentifierTransformer outer)
+            {
+                this.outer = outer;
+            }
+
+            public override Expression VisitIdentifier(Identifier id)
+            {
+                if (id is MemoryIdentifier)
+                {
+                    var sid = outer.ssa.Identifiers.Add(
+                        id, outer.stm, null, false);
+                    sid.DefStatement = null;
+                    sid.Uses.Add(outer.stm);
+                    return sid.Identifier;
+                }
+                var usedId = outer.FindUsedId(outer.call, id.Storage);
+                if (usedId != null)
+                    usedId.Accept(outer);
+                return usedId ?? outer.InvalidArgument();
+            }
         }
     }
 }

--- a/src/Decompiler/Analysis/IndirectCallRewriter.cs
+++ b/src/Decompiler/Analysis/IndirectCallRewriter.cs
@@ -116,6 +116,7 @@ namespace Reko.Analysis
             CallInstruction call,
             int stackDelta)
         {
+            // Locate the post-call definition of the stack pointer, if any
             var defSpBinding = call.Definitions.Where(
                 u => u.Storage == program.Architecture.StackRegister)
                 .FirstOrDefault();
@@ -133,6 +134,8 @@ namespace Reko.Analysis
             var retSize = call.CallSite.SizeOfReturnAddressOnStack;
             var offset = stackDelta - retSize;
             var src = emiter.IAdd(usedSpExp, Constant.Word32(offset));
+            // Generate a statement that adjusts the stack pointer according to
+            // the calling convention.
             var ass = new Assignment(defSpId, src);
             var defSid = ssa.Identifiers[defSpId];
             var stackStm = InsertStatement(stm, ass);

--- a/src/Decompiler/Analysis/IndirectCallRewriter.cs
+++ b/src/Decompiler/Analysis/IndirectCallRewriter.cs
@@ -102,7 +102,7 @@ namespace Reko.Analysis
             var ft = pt.Pointee as FunctionType;
             if (ft == null)
                 return;
-            AdjustStack(stm, call, ft.StackDelta);
+            AdjustStackPointerAfterCall(stm, call, ft.StackDelta);
             var ab = new FrameApplicationBuilder(
                  program.Architecture, proc.Frame, call.CallSite,
                  call.Callee, false);
@@ -111,7 +111,7 @@ namespace Reko.Analysis
             changed = true;
         }
 
-        private void AdjustStack(
+        private void AdjustStackPointerAfterCall(
             Statement stm,
             CallInstruction call,
             int stackDelta)

--- a/src/Decompiler/Analysis/TrashedRegisterFinder2.cs
+++ b/src/Decompiler/Analysis/TrashedRegisterFinder2.cs
@@ -147,6 +147,8 @@ namespace Reko.Analysis
         private Expression GetReachingExpression(SsaIdentifier sid, ISet<PhiAssignment> activePhis)
         {
             var sidOrig = sid;
+            if (sid.DefStatement == null)
+                return Constant.Invalid;
             var defInstr = sid.DefStatement.Instruction;
             if (defInstr is DefInstruction &&
                 sid.DefStatement.Block == ssa.Procedure.EntryBlock)

--- a/src/UnitTests/Analysis/IndirectCallRewriterTests.cs
+++ b/src/UnitTests/Analysis/IndirectCallRewriterTests.cs
@@ -28,6 +28,7 @@ using Reko.UnitTests.Mocks;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Reko.UnitTests.Analysis
 {
@@ -125,7 +126,15 @@ namespace Reko.UnitTests.Analysis
             Identifier returnValue,
             params Identifier[] parameters)
         {
-            return Ptr32(new FunctionType(returnValue, parameters));
+            var storages = parameters.Select(p => p.Storage as StackStorage)
+                .Where(stg => stg != null);
+            var stackDelta = storages.Count() == 0 ? 4 :
+                storages.Max(stg => stg.StackOffset + stg.DataType.Size);
+            var ft = new FunctionType(returnValue, parameters)
+            {
+                StackDelta = stackDelta,
+            };
+            return Ptr32(ft);
         }
 
         private Identifier VoidId()

--- a/src/tests/Analysis/IcrwInvalidArguments.exp
+++ b/src/tests/Analysis/IcrwInvalidArguments.exp
@@ -1,14 +1,15 @@
 a:Stack +0004
     def:  def a
     uses: a_10 = a
-          eax_8 = Mem3[ecx_6:word32](ecx_6, a)
 fp:fp
     def:  def fp
     uses: r63_4 = fp
+          r63_7 = fp + 0x00000004
+          eax_8 = Mem3[ecx_6:word32](ecx_6, Mem11[fp:int32])
 Mem3: orig: Mem0
     uses: eax_5 = a_10
           ecx_6 = Mem3[eax_5:word32]
-          eax_8 = Mem3[ecx_6:word32](ecx_6, a)
+          eax_8 = Mem3[ecx_6:word32](ecx_6, Mem11[fp:int32])
 r63_4: orig: r63
     def:  r63_4 = fp
 eax_5: orig: eax
@@ -16,15 +17,18 @@ eax_5: orig: eax
     uses: ecx_6 = Mem3[eax_5:word32]
 ecx_6: orig: ecx
     def:  ecx_6 = Mem3[eax_5:word32]
-    uses: eax_8 = Mem3[ecx_6:word32](ecx_6, a)
-          eax_8 = Mem3[ecx_6:word32](ecx_6, a)
+    uses: eax_8 = Mem3[ecx_6:word32](ecx_6, Mem11[fp:int32])
+          eax_8 = Mem3[ecx_6:word32](ecx_6, Mem11[fp:int32])
 r63_7: orig: r63
+    def:  r63_7 = fp + 0x00000004
 eax_8: orig: eax
-    def:  eax_8 = Mem3[ecx_6:word32](ecx_6, a)
+    def:  eax_8 = Mem3[ecx_6:word32](ecx_6, Mem11[fp:int32])
 ecx_9: orig: ecx
 a_10: orig: a
     def:  a_10 = a
     uses: eax_5 = a_10
+Mem11: orig: Mem0
+    uses: eax_8 = Mem3[ecx_6:word32](ecx_6, Mem11[fp:int32])
 // ProcedureBuilder
 // Return size: 0
 void ProcedureBuilder(struct <anonymous> * a)
@@ -37,7 +41,8 @@ l1:
 	r63_4 = fp
 	eax_5 = a_10
 	ecx_6 = Mem3[eax_5:word32]
-	eax_8 = Mem3[ecx_6:word32](ecx_6, a)
+	eax_8 = Mem3[ecx_6:word32](ecx_6, Mem11[fp:int32])
+	r63_7 = fp + 0x00000004
 	return
 	// succ:  ProcedureBuilder_exit
 ProcedureBuilder_exit:

--- a/src/tests/Analysis/IcrwNoArguments.exp
+++ b/src/tests/Analysis/IcrwNoArguments.exp
@@ -4,6 +4,7 @@ a:Stack +0004
 fp:fp
     def:  def fp
     uses: r63_4 = fp
+          r63_7 = fp + 0x00000000
 Mem3: orig: Mem0
     uses: eax_5 = a_10
           ecx_6 = Mem3[eax_5:word32]
@@ -17,6 +18,7 @@ ecx_6: orig: ecx
     def:  ecx_6 = Mem3[eax_5:word32]
     uses: Mem3[ecx_6:word32]()
 r63_7: orig: r63
+    def:  r63_7 = fp + 0x00000000
 eax_8: orig: eax
 ecx_9: orig: ecx
 a_10: orig: a
@@ -35,6 +37,7 @@ l1:
 	eax_5 = a_10
 	ecx_6 = Mem3[eax_5:word32]
 	Mem3[ecx_6:word32]()
+	r63_7 = fp + 0x00000000
 	return
 	// succ:  ProcedureBuilder_exit
 ProcedureBuilder_exit:

--- a/src/tests/Analysis/IcrwNoArguments.exp
+++ b/src/tests/Analysis/IcrwNoArguments.exp
@@ -4,7 +4,7 @@ a:Stack +0004
 fp:fp
     def:  def fp
     uses: r63_4 = fp
-          r63_7 = fp + 0x00000000
+          r63_7 = fp
 Mem3: orig: Mem0
     uses: eax_5 = a_10
           ecx_6 = Mem3[eax_5:word32]
@@ -18,7 +18,7 @@ ecx_6: orig: ecx
     def:  ecx_6 = Mem3[eax_5:word32]
     uses: Mem3[ecx_6:word32]()
 r63_7: orig: r63
-    def:  r63_7 = fp + 0x00000000
+    def:  r63_7 = fp
 eax_8: orig: eax
 ecx_9: orig: ecx
 a_10: orig: a
@@ -37,7 +37,7 @@ l1:
 	eax_5 = a_10
 	ecx_6 = Mem3[eax_5:word32]
 	Mem3[ecx_6:word32]()
-	r63_7 = fp + 0x00000000
+	r63_7 = fp
 	return
 	// succ:  ProcedureBuilder_exit
 ProcedureBuilder_exit:

--- a/src/tests/Analysis/IcrwOneArgument.exp
+++ b/src/tests/Analysis/IcrwOneArgument.exp
@@ -5,6 +5,8 @@ fp:fp
     def:  def fp
     uses: r63_4 = fp
           r63_7 = fp - 0x00000004
+          r63_9 = fp - 0x00000004 + 0x00000004
+          Mem8[ecx_6 + 0x00000004:word32](Mem14[fp - 0x00000004:int32])
 Mem3: orig: Mem0
     uses: eax_5 = a_12
           ecx_6 = Mem3[eax_5:word32]
@@ -15,12 +17,13 @@ eax_5: orig: eax
     uses: ecx_6 = Mem3[eax_5:word32]
 ecx_6: orig: ecx
     def:  ecx_6 = Mem3[eax_5:word32]
-    uses: Mem8[ecx_6 + 0x00000004:word32](dwLoc04_13)
+    uses: Mem8[ecx_6 + 0x00000004:word32](Mem14[fp - 0x00000004:int32])
 r63_7: orig: r63
     def:  r63_7 = fp - 0x00000004
 Mem8: orig: Mem0
-    uses: Mem8[ecx_6 + 0x00000004:word32](dwLoc04_13)
+    uses: Mem8[ecx_6 + 0x00000004:word32](Mem14[fp - 0x00000004:int32])
 r63_9: orig: r63
+    def:  r63_9 = fp - 0x00000004 + 0x00000004
 eax_10: orig: eax
 ecx_11: orig: ecx
 a_12: orig: a
@@ -28,7 +31,8 @@ a_12: orig: a
     uses: eax_5 = a_12
 dwLoc04_13: orig: dwLoc04
     def:  dwLoc04_13 = 0x0000000A
-    uses: Mem8[ecx_6 + 0x00000004:word32](dwLoc04_13)
+Mem14: orig: Mem0
+    uses: Mem8[ecx_6 + 0x00000004:word32](Mem14[fp - 0x00000004:int32])
 // ProcedureBuilder
 // Return size: 0
 void ProcedureBuilder(struct <anonymous> * a)
@@ -43,7 +47,8 @@ l1:
 	ecx_6 = Mem3[eax_5:word32]
 	r63_7 = fp - 0x00000004
 	dwLoc04_13 = 0x0000000A
-	Mem8[ecx_6 + 0x00000004:word32](dwLoc04_13)
+	Mem8[ecx_6 + 0x00000004:word32](Mem14[fp - 0x00000004:int32])
+	r63_9 = fp - 0x00000004 + 0x00000004
 	return
 	// succ:  ProcedureBuilder_exit
 ProcedureBuilder_exit:

--- a/src/tests/Analysis/IcrwOneArgumentPassEcx.exp
+++ b/src/tests/Analysis/IcrwOneArgumentPassEcx.exp
@@ -5,6 +5,8 @@ fp:fp
     def:  def fp
     uses: r63_4 = fp
           r63_7 = fp - 0x00000004
+          r63_9 = fp - 0x00000004 + 0x00000004
+          eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, Mem14[fp - 0x00000004:int32])
 Mem3: orig: Mem0
     uses: eax_5 = a_12
           ecx_6 = Mem3[eax_5:word32]
@@ -15,22 +17,24 @@ eax_5: orig: eax
     uses: ecx_6 = Mem3[eax_5:word32]
 ecx_6: orig: ecx
     def:  ecx_6 = Mem3[eax_5:word32]
-    uses: eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, dwLoc04_13)
-          eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, dwLoc04_13)
+    uses: eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, Mem14[fp - 0x00000004:int32])
+          eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, Mem14[fp - 0x00000004:int32])
 r63_7: orig: r63
     def:  r63_7 = fp - 0x00000004
 Mem8: orig: Mem0
-    uses: eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, dwLoc04_13)
+    uses: eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, Mem14[fp - 0x00000004:int32])
 r63_9: orig: r63
+    def:  r63_9 = fp - 0x00000004 + 0x00000004
 eax_10: orig: eax
-    def:  eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, dwLoc04_13)
+    def:  eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, Mem14[fp - 0x00000004:int32])
 ecx_11: orig: ecx
 a_12: orig: a
     def:  a_12 = a
     uses: eax_5 = a_12
 dwLoc04_13: orig: dwLoc04
     def:  dwLoc04_13 = 0x0000000A
-    uses: eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, dwLoc04_13)
+Mem14: orig: Mem0
+    uses: eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, Mem14[fp - 0x00000004:int32])
 // ProcedureBuilder
 // Return size: 0
 void ProcedureBuilder(struct <anonymous> * a)
@@ -45,7 +49,8 @@ l1:
 	ecx_6 = Mem3[eax_5:word32]
 	r63_7 = fp - 0x00000004
 	dwLoc04_13 = 0x0000000A
-	eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, dwLoc04_13)
+	eax_10 = Mem8[ecx_6 + 0x00000004:word32](ecx_6, Mem14[fp - 0x00000004:int32])
+	r63_9 = fp - 0x00000004 + 0x00000004
 	return
 	// succ:  ProcedureBuilder_exit
 ProcedureBuilder_exit:

--- a/src/tests/Analysis/IcrwTwoArguments.exp
+++ b/src/tests/Analysis/IcrwTwoArguments.exp
@@ -6,6 +6,9 @@ fp:fp
     uses: r63_4 = fp
           r63_7 = fp - 0x00000004
           r63_9 = fp - 0x00000008
+          r63_11 = fp - 0x00000008 + 0x00000008
+          Mem10[ecx_6 + 0x00000008:word32](Mem17[fp - 0x00000008:int32], Mem18[fp - 0x00000008 + 4:int32])
+          Mem10[ecx_6 + 0x00000008:word32](Mem17[fp - 0x00000008:int32], Mem18[fp - 0x00000008 + 4:int32])
 Mem3: orig: Mem0
     uses: eax_5 = a_14
           ecx_6 = Mem3[eax_5:word32]
@@ -16,15 +19,16 @@ eax_5: orig: eax
     uses: ecx_6 = Mem3[eax_5:word32]
 ecx_6: orig: ecx
     def:  ecx_6 = Mem3[eax_5:word32]
-    uses: Mem10[ecx_6 + 0x00000008:word32](dwLoc08_16, dwLoc04_15)
+    uses: Mem10[ecx_6 + 0x00000008:word32](Mem17[fp - 0x00000008:int32], Mem18[fp - 0x00000008 + 4:int32])
 r63_7: orig: r63
     def:  r63_7 = fp - 0x00000004
 Mem8: orig: Mem0
 r63_9: orig: r63
     def:  r63_9 = fp - 0x00000008
 Mem10: orig: Mem0
-    uses: Mem10[ecx_6 + 0x00000008:word32](dwLoc08_16, dwLoc04_15)
+    uses: Mem10[ecx_6 + 0x00000008:word32](Mem17[fp - 0x00000008:int32], Mem18[fp - 0x00000008 + 4:int32])
 r63_11: orig: r63
+    def:  r63_11 = fp - 0x00000008 + 0x00000008
 eax_12: orig: eax
 ecx_13: orig: ecx
 a_14: orig: a
@@ -32,10 +36,12 @@ a_14: orig: a
     uses: eax_5 = a_14
 dwLoc04_15: orig: dwLoc04
     def:  dwLoc04_15 = 0x0000000B
-    uses: Mem10[ecx_6 + 0x00000008:word32](dwLoc08_16, dwLoc04_15)
 dwLoc08_16: orig: dwLoc08
     def:  dwLoc08_16 = 0x0000000A
-    uses: Mem10[ecx_6 + 0x00000008:word32](dwLoc08_16, dwLoc04_15)
+Mem17: orig: Mem0
+    uses: Mem10[ecx_6 + 0x00000008:word32](Mem17[fp - 0x00000008:int32], Mem18[fp - 0x00000008 + 4:int32])
+Mem18: orig: Mem0
+    uses: Mem10[ecx_6 + 0x00000008:word32](Mem17[fp - 0x00000008:int32], Mem18[fp - 0x00000008 + 4:int32])
 // ProcedureBuilder
 // Return size: 0
 void ProcedureBuilder(struct <anonymous> * a)
@@ -52,7 +58,8 @@ l1:
 	dwLoc04_15 = 0x0000000B
 	r63_9 = fp - 0x00000008
 	dwLoc08_16 = 0x0000000A
-	Mem10[ecx_6 + 0x00000008:word32](dwLoc08_16, dwLoc04_15)
+	Mem10[ecx_6 + 0x00000008:word32](Mem17[fp - 0x00000008:int32], Mem18[fp - 0x00000008 + 4:int32])
+	r63_11 = fp - 0x00000008 + 0x00000008
 	return
 	// succ:  ProcedureBuilder_exit
 ProcedureBuilder_exit:


### PR DESCRIPTION
Make `IndirectCallRewriter` works on `VCExeSample`
- Call `IndirectCallRewriter` at data flow analysis stage.
- Add stack adjustment statement after rewritten call
- Do not ensure variables. Create direct memory access instead. It allows to avoid dependency on stack depth on function entry
- `TrashedRegisterFinder2`: check if definition statement is `null`
- Fix broken tests 