### PR TITLE
Fix DfaReg00316 unit test

### DIFF
--- a/src/UnitTests/Analysis/DataFlowAnalysisTests.cs
+++ b/src/UnitTests/Analysis/DataFlowAnalysisTests.cs
@@ -51,6 +51,7 @@ namespace Reko.UnitTests.Analysis
 
         protected override void RunTest(Program program, TextWriter writer)
 		{
+            SetCSignatures(program);
             IImportResolver importResolver = mr.Stub<IImportResolver>();
             importResolver.Replay();
 			dfa = new DataFlowAnalysis(program, importResolver, new FakeDecompilerEventListener());
@@ -59,8 +60,9 @@ namespace Reko.UnitTests.Analysis
 			{
 				ProcedureFlow flow = dfa.ProgramDataFlow[proc];
 				writer.Write("// ");
-				flow.Signature.Emit(proc.Name, FunctionType.EmitFlags.ArgumentKind|FunctionType.EmitFlags.LowLevelInfo, writer);
-				flow.Emit(program.Architecture, writer);
+                var sig = flow.Signature ?? proc.Signature;
+                sig.Emit(proc.Name, FunctionType.EmitFlags.ArgumentKind | FunctionType.EmitFlags.LowLevelInfo, writer);
+                flow.Emit(program.Architecture, writer);
 				proc.Write(false, writer);
 				writer.WriteLine();
 			}


### PR DESCRIPTION
Output for `DfaReg00316` was changed. `ecx_11`, `esp_9` and `SZO_12` were disappeared from indirect call defined ids list. Is it correct, John?