### PR TITLE
Simplify consecutive casts (analysis-development)

### DIFF
--- a/src/Decompiler/Analysis/DataFlowAnalysis.cs
+++ b/src/Decompiler/Analysis/DataFlowAnalysis.cs
@@ -219,6 +219,9 @@ namespace Reko.Analysis
                 coa.Transform();
                 DeadCode.Eliminate(ssa);
 
+                var vp = new ValuePropagator(program.Architecture, ssa);
+                vp.Transform();
+
                 var liv = new LinearInductionVariableFinder(
                     ssa,
                     new BlockDominatorGraph(

--- a/src/UnitTests/Analysis/DataFlowAnalysisTests.cs
+++ b/src/UnitTests/Analysis/DataFlowAnalysisTests.cs
@@ -278,6 +278,24 @@ done:
         }
 
         [Test]
+        [Category(Categories.UnitTests)]
+        public void DfaCastCast()
+        {
+            var m = new ProcedureBuilder();
+            var r1 = m.Register(1);
+            r1.DataType = PrimitiveType.Real32;
+            var r2 = m.Register(2);
+            r2.DataType = PrimitiveType.Real32;
+            var cast = m.Cast(PrimitiveType.Real64, r1);
+            m.Assign(r2, cast);
+            var castCast = m.Cast(PrimitiveType.Real32, r2);
+            m.Store(m.Word32(0x123408), castCast);
+            m.Return();
+
+            RunFileTest(m, "Analysis/DfaCastCast.txt");
+        }
+
+        [Test]
         [Ignore("Fixing this resolves #318")]
         public void Dfa_318_IncrementedSegmentedPointerOffset()
         {

--- a/src/tests/Analysis/DfaCastCast.exp
+++ b/src/tests/Analysis/DfaCastCast.exp
@@ -1,0 +1,17 @@
+// void ProcedureBuilder(Register real32 r1)
+// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// MayUse:  r1:32
+// LiveOut:
+// Trashed: r2
+// Preserved:
+// ProcedureBuilder
+// Return size: 0
+void ProcedureBuilder(real32 r1)
+ProcedureBuilder_entry:
+	// succ:  l1
+l1:
+	Mem3[0x00123408:real32] = r1
+	return
+	// succ:  ProcedureBuilder_exit
+ProcedureBuilder_exit:
+


### PR DESCRIPTION
- Add unit test to verify collapsing of consecutive casts
- Call `ValuePropagator` after `Coalescer` to eliminate consecutive casts