### PR TITLE
Fix rewriting of floating point compare statements

### DIFF
--- a/src/tests/Analysis/CceFstswGe.exp
+++ b/src/tests/Analysis/CceFstswGe.exp
@@ -5,13 +5,13 @@ ds:ds
     def:  def ds
     uses: Mem8[ds:di:word16] = 0x0001
           Mem10[ds:di:word16] = 0x0000
-          branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
+          branch 0.0 > Mem0[ds:si:real64] l0C00_0010
 si:si
     def:  def si
-    uses: branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
+    uses: branch 0.0 > Mem0[ds:si:real64] l0C00_0010
 Mem0:Global memory
     def:  def Mem0
-    uses: branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
+    uses: branch 0.0 > Mem0[ds:si:real64] l0C00_0010
 FPUF_6: orig: FPUF
 SCZO_7: orig: SCZO
 Mem8: orig: Mem0
@@ -32,7 +32,7 @@ fn0C00_0000_entry:
 	def di
 	// succ:  l0C00_0000
 l0C00_0000:
-	branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
+	branch 0.0 > Mem0[ds:si:real64] l0C00_0010
 	// succ:  l0C00_000B l0C00_0010
 l0C00_000B:
 	Mem8[ds:di:word16] = 0x0001

--- a/src/tests/Analysis/CceFstswGt.exp
+++ b/src/tests/Analysis/CceFstswGt.exp
@@ -5,13 +5,13 @@ ds:ds
     def:  def ds
     uses: Mem8[ds:di:word16] = 0x0001
           Mem10[ds:di:word16] = 0x0000
-          branch 0.0 <= Mem0[ds:si:real64] l0C00_0010
+          branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
 si:si
     def:  def si
-    uses: branch 0.0 <= Mem0[ds:si:real64] l0C00_0010
+    uses: branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
 Mem0:Global memory
     def:  def Mem0
-    uses: branch 0.0 <= Mem0[ds:si:real64] l0C00_0010
+    uses: branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
 FPUF_6: orig: FPUF
 SCZO_7: orig: SCZO
 Mem8: orig: Mem0
@@ -32,7 +32,7 @@ fn0C00_0000_entry:
 	def di
 	// succ:  l0C00_0000
 l0C00_0000:
-	branch 0.0 <= Mem0[ds:si:real64] l0C00_0010
+	branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
 	// succ:  l0C00_000B l0C00_0010
 l0C00_000B:
 	Mem8[ds:di:word16] = 0x0001

--- a/src/tests/Analysis/CceFstswLe.exp
+++ b/src/tests/Analysis/CceFstswLe.exp
@@ -5,13 +5,13 @@ ds:ds
     def:  def ds
     uses: Mem8[ds:di:word16] = 0x0001
           Mem10[ds:di:word16] = 0x0000
-          branch 0.0 > Mem0[ds:si:real64] l0C00_0010
+          branch 0.0 < Mem0[ds:si:real64] l0C00_0010
 si:si
     def:  def si
-    uses: branch 0.0 > Mem0[ds:si:real64] l0C00_0010
+    uses: branch 0.0 < Mem0[ds:si:real64] l0C00_0010
 Mem0:Global memory
     def:  def Mem0
-    uses: branch 0.0 > Mem0[ds:si:real64] l0C00_0010
+    uses: branch 0.0 < Mem0[ds:si:real64] l0C00_0010
 FPUF_6: orig: FPUF
 SCZO_7: orig: SCZO
 Mem8: orig: Mem0
@@ -32,7 +32,7 @@ fn0C00_0000_entry:
 	def di
 	// succ:  l0C00_0000
 l0C00_0000:
-	branch 0.0 > Mem0[ds:si:real64] l0C00_0010
+	branch 0.0 < Mem0[ds:si:real64] l0C00_0010
 	// succ:  l0C00_000B l0C00_0010
 l0C00_000B:
 	Mem8[ds:di:word16] = 0x0001

--- a/src/tests/Analysis/CceFstswLt.exp
+++ b/src/tests/Analysis/CceFstswLt.exp
@@ -5,13 +5,13 @@ ds:ds
     def:  def ds
     uses: Mem8[ds:di:word16] = 0x0001
           Mem10[ds:di:word16] = 0x0000
-          branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
+          branch 0.0 <= Mem0[ds:si:real64] l0C00_0010
 si:si
     def:  def si
-    uses: branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
+    uses: branch 0.0 <= Mem0[ds:si:real64] l0C00_0010
 Mem0:Global memory
     def:  def Mem0
-    uses: branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
+    uses: branch 0.0 <= Mem0[ds:si:real64] l0C00_0010
 FPUF_6: orig: FPUF
 SCZO_7: orig: SCZO
 Mem8: orig: Mem0
@@ -32,7 +32,7 @@ fn0C00_0000_entry:
 	def di
 	// succ:  l0C00_0000
 l0C00_0000:
-	branch 0.0 >= Mem0[ds:si:real64] l0C00_0010
+	branch 0.0 <= Mem0[ds:si:real64] l0C00_0010
 	// succ:  l0C00_000B l0C00_0010
 l0C00_000B:
 	Mem8[ds:di:word16] = 0x0001

--- a/src/tests/Analysis/CceFstswTestAx.exp
+++ b/src/tests/Analysis/CceFstswTestAx.exp
@@ -2,16 +2,16 @@ fp:fp
 sp_1: orig: sp
 rArg0:FPU stack
     def:  def rArg0
-    uses: branch rArg0 < Mem0[ds:bx:real32] l0C00_000C
+    uses: branch rArg0 > Mem0[ds:bx:real32] l0C00_000C
 ds:ds
     def:  def ds
-    uses: branch rArg0 < Mem0[ds:bx:real32] l0C00_000C
+    uses: branch rArg0 > Mem0[ds:bx:real32] l0C00_000C
 bx:bx
     def:  def bx
-    uses: branch rArg0 < Mem0[ds:bx:real32] l0C00_000C
+    uses: branch rArg0 > Mem0[ds:bx:real32] l0C00_000C
 Mem0:Global memory
     def:  def Mem0
-    uses: branch rArg0 < Mem0[ds:bx:real32] l0C00_000C
+    uses: branch rArg0 > Mem0[ds:bx:real32] l0C00_000C
 FPUF_6: orig: FPUF
 SCZO_7: orig: SCZO
 ecx:ecx
@@ -33,7 +33,7 @@ fn0C00_0000_entry:
 	def Mem0
 	// succ:  l0C00_0000
 l0C00_0000:
-	branch rArg0 < Mem0[ds:bx:real32] l0C00_000C
+	branch rArg0 > Mem0[ds:bx:real32] l0C00_000C
 	// succ:  l0C00_0009 l0C00_000C
 l0C00_0009:
 	// succ:  l0C00_000C

--- a/src/tests/Analysis/DfaFstsw.exp
+++ b/src/tests/Analysis/DfaFstsw.exp
@@ -10,7 +10,7 @@ void fn0C00_0000(word16 bx, word16 si, selector ds, real64 rArg0)
 fn0C00_0000_entry:
 	// succ:  l0C00_0000
 l0C00_0000:
-	branch rArg0 >= Mem0[ds:bx:real32] l0C00_000D
+	branch rArg0 <= Mem0[ds:bx:real32] l0C00_000D
 	// succ:  l0C00_0009 l0C00_000D
 l0C00_0009:
 	Mem8[ds:si:word16] = 0x0004

--- a/subjects/PE-x86/VCExeSample/VCExeSample.c
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.c
@@ -50,7 +50,7 @@ void test6(Eq_63 c, int32 a, int32 b)
 
 void test7(real64 rArg04)
 {
-	if (1.0 > rArg04)
+	if (1.0 < rArg04)
 		globals->gbl_thiscall->vtbl->set_double(globals->gbl_thiscall, rArg04);
 	globals->gbl_thiscall->vtbl->modify_double(globals->gbl_thiscall, 0x0D, rArg04);
 	return;
@@ -59,7 +59,7 @@ void test7(real64 rArg04)
 void nested_if_blocks_test8(real64 rArg04, real64 rArg0)
 {
 	globals->gbl_thiscall->vtbl->modify_double(globals->gbl_thiscall, ~0x00, rArg04);
-	if (globals->r4020F8 != rArg04 && globals->r4020F0 < rArg04)
+	if (globals->r4020F8 != rArg04 && globals->r4020F0 > rArg04)
 		globals->gbl_thiscall->vtbl->set_double(globals->gbl_thiscall, rArg04);
 	test6(globals->gbl_c, 0x06, 0x07);
 	return;
@@ -71,7 +71,7 @@ void loop_test9(real32 rArg04, real64 rArg0)
 	while (true)
 	{
 		globals->gbl_thiscall->vtbl->modify_double(globals->gbl_thiscall, dwLoc08_12, (real64) rArg04);
-		if (rArg0 >= (real64) dwLoc08_12)
+		if (rArg0 <= (real64) dwLoc08_12)
 			break;
 		rArg0 = (real64) rArg04;
 		globals->gbl_thiscall->vtbl->set_double(globals->gbl_thiscall, rArg0);

--- a/subjects/PE-x86/VCExeSample/VCExeSample.dis
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.dis
@@ -220,7 +220,7 @@ test7_entry:
 // LocalsOut: fp(32) Stack +0004(64)
 
 l00401160:
-	branch 1.0 <= rArg04 l00401189
+	branch 1.0 >= rArg04 l00401189
 // DataOut: esp
 // DataOut (flags): 
 // SymbolicIn: esp:fp
@@ -269,7 +269,7 @@ l004011B0:
 // LocalsOut: Stack +0004(64)
 
 l004011E2:
-	branch Mem0[0x004020F0:real64] >= rArg04 l0040120D
+	branch Mem0[0x004020F0:real64] <= rArg04 l0040120D
 // DataOut: esp
 // DataOut (flags): 
 // SymbolicIn: esp:<invalid> ebp:fp - 0x00000004 eax:<invalid> edx:<invalid> ecx:<invalid> -16(fp):0xFFFFFFFF -12(fp):rLoc1 -4(fp):ebp
@@ -317,7 +317,7 @@ l00401230:
 
 l00401248:
 	Mem21[Mem21[Mem21[0x0040301C:word32]:word32] + 0x00000004:word32](Mem21[0x0040301C:word32], dwLoc08_12, (real64) rArg04)
-	branch rArg0 >= (real64) dwLoc08_12 l00401294
+	branch rArg0 <= (real64) dwLoc08_12 l00401294
 // DataOut: esp
 // DataOut (flags): 
 // SymbolicIn: esp:<invalid> ebp:fp - 0x00000004 ecx:<invalid> edx:<invalid> eax:<invalid> -28(fp):0x00000000 -24(fp):rLoc2 -16(fp):rLoc1 -8(fp):<invalid> -4(fp):ebp

--- a/subjects/PE-x86/VCExeSample/VCExeSample.h
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.h
@@ -602,7 +602,7 @@ T_109: (in rArg04 : real64)
   Class: Eq_108
   DataType: real64
   OrigDataType: real64
-T_110: (in 1.0 <= rArg04 : bool)
+T_110: (in 1.0 >= rArg04 : bool)
   Class: Eq_110
   DataType: bool
   OrigDataType: bool
@@ -806,7 +806,7 @@ T_160: (in Mem0[0x004020F0:real64] : real64)
   Class: Eq_147
   DataType: real64
   OrigDataType: real64
-T_161: (in globals->r4020F0 >= rArg04 : bool)
+T_161: (in globals->r4020F0 <= rArg04 : bool)
   Class: Eq_161
   DataType: bool
   OrigDataType: bool
@@ -926,7 +926,7 @@ T_190: (in (real64) dwLoc08_12 : real64)
   Class: Eq_174
   DataType: real64
   OrigDataType: real64
-T_191: (in rArg0 >= (real64) dwLoc08_12 : bool)
+T_191: (in rArg0 <= (real64) dwLoc08_12 : bool)
   Class: Eq_191
   DataType: bool
   OrigDataType: bool


### PR DESCRIPTION
Possible fix of floating point compare statements rewriting. I have also added explanation comment.
5 `Cce` tests and 1 `Dfa` test seem to be incorrect. I have fixed it. Hope they are correct now.