### PR TITLE
Fix for issue #353

### DIFF
--- a/src/Environments/SysV/SysVPlatform.cs
+++ b/src/Environments/SysV/SysVPlatform.cs
@@ -55,6 +55,7 @@ namespace Reko.Environments.SysV
             switch (Architecture.Name)
             {
             case "mips-be-32":
+            case "mips-le-32":
                 return new MipsProcedureSerializer(Architecture, typeLoader, defaultConvention);
             case "ppc32":
                 return new PowerPcProcedureSerializer(Architecture, typeLoader, defaultConvention);

--- a/src/ImageLoaders/Elf/ElfImageLoader.cs
+++ b/src/ImageLoaders/Elf/ElfImageLoader.cs
@@ -147,12 +147,12 @@ namespace Reko.ImageLoaders.Elf
             if (fileClass == ELFCLASS64)
             {
                 var header64 = Elf64_EHdr.Load(rdr);
-                return new ElfLoader64(this, header64, RawImage, osAbi);
+                return new ElfLoader64(this, header64, RawImage, osAbi, endianness);
             }
             else
             {
                 var header32 = Elf32_EHdr.Load(rdr);
-                return new ElfLoader32(this, header32, RawImage);
+                return new ElfLoader32(this, header32, RawImage, endianness);
             }
         }
 

--- a/src/ImageLoaders/Elf/ElfLoader.cs
+++ b/src/ImageLoaders/Elf/ElfLoader.cs
@@ -50,8 +50,8 @@ namespace Reko.ImageLoaders.Elf
         public const int ELFOSABI_AROS = 15;    // Amiga Research OS 
         public const int ELFOSABI_FENIXOS = 16; // The FenixOS highly scalable multi-core OS 
         
-        public const int ELFDATA2LSB = 1;
-        public const int ELFDATA2MSB = 2;
+        public const byte ELFDATA2LSB = 1;
+        public const byte ELFDATA2MSB = 2;
 
         public const int ELFOSABI_CELL_LV2 = 0x66;     // PS/3 has this in its files
         public const uint SHF_WRITE = 0x1;

--- a/src/UnitTests/ImageLoaders/Elf/ElfLoader32Tests.cs
+++ b/src/UnitTests/ImageLoaders/Elf/ElfLoader32Tests.cs
@@ -133,10 +133,10 @@ namespace Reko.UnitTests.ImageLoaders.Elf
             };
         }
 
-        private void When_CreateLoader32()
+        private void When_CreateLoader32(bool big_endian)
         {
             this.eil = new ElfImageLoader(sc, "foo", this.bytes);
-            this.el32 = new ElfLoader32(eil, eih, this.bytes);
+            this.el32 = new ElfLoader32(eil, eih, this.bytes, big_endian ? ElfLoader.ELFDATA2MSB : ElfLoader.ELFDATA2LSB);
             el32.ProgramHeaders.AddRange(programHeaders);
             el32.Sections.AddRange(sections);
         }
@@ -153,7 +153,7 @@ namespace Reko.UnitTests.ImageLoaders.Elf
             Given_Section(".bss", 0x2008, "rw");
             mr.ReplayAll();
 
-            When_CreateLoader32();
+            When_CreateLoader32(false);
             var segmentMap = el32.LoadImageBytes(platform, this.bytes, Address.Ptr32(0x1000));
 
             ImageSegment segText;
@@ -239,7 +239,7 @@ namespace Reko.UnitTests.ImageLoaders.Elf
             Given_BE32_GOT(0x0000000, 0x00000000, 0x04000010, 0x04000000);
             mr.ReplayAll();
 
-            When_CreateLoader32();
+            When_CreateLoader32(true);
 
             el32.LocateGotPointers(program, syms);
             Assert.AreEqual("strcmp_GOT", syms[Address.Ptr32(0x10000008)].Name);

--- a/src/UnitTests/ImageLoaders/Elf/ElfLoader64Tests.cs
+++ b/src/UnitTests/ImageLoaders/Elf/ElfLoader64Tests.cs
@@ -118,10 +118,10 @@ namespace Reko.UnitTests.ImageLoaders.Elf
             };
         }
 
-        private void When_CreateLoader64()
+        private void When_CreateLoader64(bool big_endian)
         {
             this.eil = new ElfImageLoader(sc, "foo", this.bytes);
-            this.el64 = new ElfLoader64(eil, eih, this.bytes, 0);
+            this.el64 = new ElfLoader64(eil, eih, this.bytes, 0, big_endian ? ElfLoader.ELFDATA2MSB : ElfLoader.ELFDATA2LSB);
             el64.ProgramHeaders64.AddRange(programHeaders);
             el64.Sections.AddRange(sections);
         }
@@ -138,7 +138,7 @@ namespace Reko.UnitTests.ImageLoaders.Elf
             Given_Section(".bss", 0x2008, "rw");
             mr.ReplayAll();
 
-            When_CreateLoader64();
+            When_CreateLoader64(false);
             var segmentMap = el64.LoadImageBytes(platform, this.bytes, Address.Ptr64(0x1000));
 
             ImageSegment segText;


### PR DESCRIPTION
Correctly get MIPS architecture from machine value AND endianness (Issue #353)