### PR TITLE
implemented store conditional instructions, concretized unit tests

### DIFF
--- a/src/Arch/Mips/MipsDisassembler.cs
+++ b/src/Arch/Mips/MipsDisassembler.cs
@@ -327,13 +327,15 @@ namespace Reko.Arch.Mips
             new AOpRec(Opcode.ld, "R2,El"),
 
             new Version6OpRec(
-                new AOpRec(Opcode.sc, "R2,El"),
+                new AOpRec(Opcode.sc, "R2,Ew"),
                 new AOpRec(Opcode.illegal, "")),
             new AOpRec(Opcode.swc1, "F2,Ew"),
             null,
             null,
 
-            new AOpRec(Opcode.scd, "R2,El"),
+            new Version6OpRec(
+                new AOpRec(Opcode.scd, "R2,El"),
+                new AOpRec(Opcode.illegal, "")),
             null, 
             null, 
             new AOpRec(Opcode.sd, "R2,El"),

--- a/src/Arch/Mips/MipsRewriter.Alu.cs
+++ b/src/Arch/Mips/MipsRewriter.Alu.cs
@@ -95,6 +95,20 @@ namespace Reko.Arch.Mips
             emitter.Assign(opDst, host.PseudoProcedure("__load_linked_64", PrimitiveType.Word64, opSrc));
         }
 
+        private void RewriteStoreConditional32(MipsInstruction instr)
+        {
+            var opMem = RewriteOperand(instr.op2);
+            var opReg = RewriteOperand(instr.op1);
+            emitter.Assign(opReg, host.PseudoProcedure("__store_conditional_32", PrimitiveType.Word32, opMem, opReg));
+        }
+
+        private void RewriteStoreConditional64(MipsInstruction instr)
+        {
+            var opMem = RewriteOperand(instr.op2);
+            var opReg = RewriteOperand(instr.op1);
+            emitter.Assign(opReg, host.PseudoProcedure("__store_conditional_64", PrimitiveType.Word64, opMem, opReg));
+        }
+
         private void RewriteLui(MipsInstruction instr)
         {
             var immOp = (ImmediateOperand)instr.op2;

--- a/src/Arch/Mips/MipsRewriter.cs
+++ b/src/Arch/Mips/MipsRewriter.cs
@@ -183,8 +183,8 @@ namespace Reko.Arch.Mips
                 case Opcode.pref:
                     goto default;
                 case Opcode.sb: RewriteStore(instr); break;
-                case Opcode.sc:
-                case Opcode.scd:
+                case Opcode.sc: RewriteStoreConditional32(instr); break;
+                case Opcode.scd: RewriteStoreConditional64(instr); break;
                 case Opcode.sd:
                 case Opcode.sdl:
                 case Opcode.sdr:

--- a/src/UnitTests/Arch/Mips/MipsDisassemblerTests.cs
+++ b/src/UnitTests/Arch/Mips/MipsDisassemblerTests.cs
@@ -21,10 +21,6 @@
 using Reko.Arch.Mips;
 using Reko.Core;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Reko.Core.Machine;
 using Reko.Core.Types;
 using Reko.Core.Expressions;
@@ -61,7 +57,7 @@ namespace Reko.UnitTests.Arch.Mips
         private void VerifyRegisterOperand(MachineOperand op, RegisterStorage reg, PrimitiveType type)
         {
             Assert.IsAssignableFrom(typeof(RegisterOperand), op);
-            RegisterOperand opReg = op as RegisterOperand;
+            var opReg = op as RegisterOperand;
             Assert.AreEqual(reg, opReg.Register);
             Assert.AreEqual(type, opReg.Register.DataType);
             Assert.AreEqual(type, opReg.Width);
@@ -69,7 +65,7 @@ namespace Reko.UnitTests.Arch.Mips
         private void VerifyIndirectOperand(MachineOperand op, RegisterStorage reg, int offset, PrimitiveType type)
         {
             Assert.IsAssignableFrom(typeof(IndirectOperand), op);
-            IndirectOperand opReg = op as IndirectOperand;
+            var opReg = op as IndirectOperand;
             Assert.AreEqual(reg, opReg.Base);
             Assert.AreEqual(offset, opReg.Offset);
             Assert.AreEqual(type, opReg.Width);
@@ -77,7 +73,7 @@ namespace Reko.UnitTests.Arch.Mips
         private void VerifyImmediateOperand(MachineOperand op, Constant val, PrimitiveType type)
         {
             Assert.IsAssignableFrom(typeof(ImmediateOperand), op);
-            ImmediateOperand opReg = op as ImmediateOperand;
+            var opReg = op as ImmediateOperand;
             Assert.AreEqual(type, opReg.Width);
             Assert.AreEqual(type, opReg.Value.DataType);
             Assert.AreEqual(val.GetValue(), opReg.Value.GetValue());
@@ -85,7 +81,7 @@ namespace Reko.UnitTests.Arch.Mips
         private void VerifyAddressOperand(MachineOperand op, Address addr, PrimitiveType type)
         {
             Assert.IsAssignableFrom(typeof(AddressOperand), op);
-            AddressOperand opReg = op as AddressOperand;
+            var opReg = op as AddressOperand;
             Assert.AreEqual(type, opReg.Width);
             Assert.AreEqual(addr, opReg.Address);
         }
@@ -577,7 +573,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 01001 00000 11111 00000 001001");
             Assert.AreEqual("jalr\tra,r9", instr.ToString());
             Assert.AreEqual(Opcode.jalr, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "ra", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.ra, PrimitiveType.Word32);
             VerifyRegisterOperand(instr.op2, Registers.r9, PrimitiveType.Word32);
         }
 
@@ -588,7 +584,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("lb\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lb, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.SByte);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.SByte);
         }
 
         [Test]
@@ -598,7 +594,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("lbu\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lbu, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Byte);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Byte);
         }
 
         [Test]
@@ -608,7 +604,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("ld\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.ld, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word64);
         }
 
         [Test]
@@ -618,7 +614,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("ldl\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.ldl, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word64);
         }
 
         [Test]
@@ -628,7 +624,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("ldr\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.ldr, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word64);
         }
 
         [Test]
@@ -638,7 +634,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("lh\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lh, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Int16);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Int16);
         }
 
         [Test]
@@ -648,7 +644,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("lhu\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lhu, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word16);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word16);
         }
 
         [Test]
@@ -658,7 +654,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("lw\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lw, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word32);
         }
 
         [Test]
@@ -668,7 +664,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("lwu\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lwu, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word32);
         }
 
         [Test]
@@ -678,7 +674,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("lwl\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lwl, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word32);
         }
 
         [Test]
@@ -688,7 +684,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("lwr\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lwr, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word32);
         }
 
         [Test]
@@ -699,7 +695,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("ll\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.ll, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word32);
         }
 
         [Test]
@@ -709,7 +705,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("lld\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lld, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word64);
         }
 
         [Test]
@@ -722,7 +718,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("ll\tr3,-0004(r9)", instr.ToString());
             Assert.AreEqual(Opcode.ll, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x4, PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x4, PrimitiveType.Word32);
         }
 
         [Test]
@@ -734,7 +730,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("lld\tr3,-0004(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lld, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
-            VerifyIndirectOperand(instr.op2, "r9", -0x4, PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x4, PrimitiveType.Word64);
         }
 
         [Test]
@@ -865,7 +861,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("sb\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sb, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Byte);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Byte);
         }
 
         [Test]
@@ -875,7 +871,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("sd\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sd, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word64);
         }
 
         [Test]
@@ -885,7 +881,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("sdl\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sdl, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word64);
         }
 
         [Test]
@@ -895,7 +891,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("sdr\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sdr, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word64);
         }
 
         [Test]
@@ -905,7 +901,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("sh\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sh, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word16);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word16);
         }
 
         [Test]
@@ -915,7 +911,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("sw\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sw, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word32);
         }
 
         [Test]
@@ -925,7 +921,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("swl\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.swl, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word32);
         }
 
         [Test]
@@ -935,7 +931,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("swr\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.swr, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, Registers.r9, -0x38, PrimitiveType.Word32);
         }
         
         [Test]
@@ -945,7 +941,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("sc\tr21,-0038(r10)", instr.ToString());
             Assert.AreEqual(Opcode.sc, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r21, PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "r10", -0x38, PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, Registers.r10, -0x38, PrimitiveType.Word32);
         }
         [Test]
         public void MipsDis_scd()
@@ -954,7 +950,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("scd\tr21,-0038(r10)", instr.ToString());
             Assert.AreEqual(Opcode.scd, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r21, PrimitiveType.Word64);
-            VerifyIndirectOperand(instr.op2, "r10", -0x38, PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, Registers.r10, -0x38, PrimitiveType.Word64);
         }
 
         [Test]
@@ -1026,7 +1022,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("mtc1\tr12,f1", instr.ToString());
             Assert.AreEqual(Opcode.mtc1, instr.opcode);
             VerifyRegisterOperand(instr.op1, Registers.r12, PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "f1", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.f1, PrimitiveType.Word32);
         }
 
         [Test]
@@ -1035,8 +1031,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleWord(0xE7AC0030);
             Assert.AreEqual("swc1\tf12,0030(sp)", instr.ToString());
             Assert.AreEqual(Opcode.swc1, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "f12", PrimitiveType.Word32);
-            VerifyIndirectOperand(instr.op2, "sp", 0x30, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.f12, PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, Registers.sp, 0x30, PrimitiveType.Word32);
         }
 
         [Test]
@@ -1045,6 +1041,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleWord(0x462C003E);
             Assert.AreEqual("c.le.d\tcc0,f0,f12", instr.ToString());
             Assert.AreEqual(Opcode.c_le_d, instr.opcode);
+            VerifyRegisterOperand(instr.op1, Registers.cc0, PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op2, Registers.f0, PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op3, Registers.f12, PrimitiveType.Word64);
         }
 
         [Test]
@@ -1053,6 +1052,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleWord(0x4443F800);
             Assert.AreEqual("cfc1\tr3,FCSR", instr.ToString());
             Assert.AreEqual(Opcode.cfc1, instr.opcode);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.FCSR, PrimitiveType.Word32);
         }
 
         [Test]
@@ -1091,15 +1092,56 @@ namespace Reko.UnitTests.Arch.Mips
         }
 
         [Test]
-        public void MipsDis_instrs1()
+        public void MipsDis_ctc1()
         {
-            Assert.AreEqual("ctc1\tr1,FCSR", DisassembleWord(0x44C1F800).ToString());
-            Assert.AreEqual("cvt.w.d\tf0,f12", DisassembleWord(0x46206024).ToString());
-            Assert.AreEqual("ctc1\tr3,FCSR", DisassembleWord(0x44C3F800).ToString());
-            Assert.AreEqual("bc1f\tcc0,0010004C", DisassembleWord(0x45000012).ToString());
-            Assert.AreEqual("add.d\tf0,f12,f0", DisassembleWord(0x46206000).ToString());
-            Assert.AreEqual("cfc1\tr3,FCSR", DisassembleWord(0x4443F800).ToString());
-            Assert.AreEqual("cvt.w.d\tf2,f0", DisassembleWord(0x462000A4).ToString());
+            var instr = DisassembleWord(0x44C1F800);
+            Assert.AreEqual("ctc1\tr1,FCSR", instr.ToString());
+            Assert.AreEqual(Opcode.ctc1, instr.opcode);
+            VerifyRegisterOperand(instr.op1, Registers.r1, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.FCSR, PrimitiveType.Word32);
+
+            instr = DisassembleWord(0x44C3F800);
+            Assert.AreEqual("ctc1\tr3,FCSR", instr.ToString());
+            Assert.AreEqual(Opcode.ctc1, instr.opcode);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.FCSR, PrimitiveType.Word32);
+        }
+
+        [Test]
+        public void MipsDis_cvt_w_d()
+        {
+            var instr = DisassembleWord(0x46206024); 
+            Assert.AreEqual("cvt.w.d\tf0,f12", instr.ToString());
+            Assert.AreEqual(Opcode.cvt_w_d, instr.opcode);
+            VerifyRegisterOperand(instr.op1, Registers.f0, PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op2, Registers.f12, PrimitiveType.Word64);
+
+            instr = DisassembleWord(0x462000A4);
+            Assert.AreEqual("cvt.w.d\tf2,f0", instr.ToString());
+            Assert.AreEqual(Opcode.cvt_w_d, instr.opcode);
+            VerifyRegisterOperand(instr.op1, Registers.f2, PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op2, Registers.f0, PrimitiveType.Word64);
+        }
+
+        [Test]
+        public void MipsDis_bc1f()
+        {
+            var instr = DisassembleWord(0x45000012); 
+            Assert.AreEqual("bc1f\tcc0,0010004C", instr.ToString());
+            Assert.AreEqual(Opcode.bc1f, instr.opcode);
+            VerifyRegisterOperand(instr.op1, Registers.cc0, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.f0, PrimitiveType.Word32);
+        }
+
+        [Test]
+        public void MipsDis_add_d()
+        {
+            var instr = DisassembleWord(0x46206000); 
+            Assert.AreEqual("add.d\tf0,f12,f0", instr.ToString());
+            Assert.AreEqual(Opcode.add_d, instr.opcode);
+            VerifyRegisterOperand(instr.op1, Registers.f0, PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op2, Registers.f12, PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op2, Registers.f0, PrimitiveType.Word64);
         }
     }
 }

--- a/src/UnitTests/Arch/Mips/MipsDisassemblerTests.cs
+++ b/src/UnitTests/Arch/Mips/MipsDisassemblerTests.cs
@@ -58,19 +58,19 @@ namespace Reko.UnitTests.Arch.Mips
             arch.Name = "mipsv6-be-32";
         }
 
-        private void VerifyRegisterOperand(MachineOperand op, string reg_name, PrimitiveType type)
+        private void VerifyRegisterOperand(MachineOperand op, RegisterStorage reg, PrimitiveType type)
         {
             Assert.IsAssignableFrom(typeof(RegisterOperand), op);
             RegisterOperand opReg = op as RegisterOperand;
-            Assert.AreEqual(arch.GetRegister(reg_name), opReg.Register);
+            Assert.AreEqual(reg, opReg.Register);
             Assert.AreEqual(type, opReg.Register.DataType);
             Assert.AreEqual(type, opReg.Width);
         }
-        private void VerifyIndirectOperand(MachineOperand op, string base_reg_name, int offset, PrimitiveType type)
+        private void VerifyIndirectOperand(MachineOperand op, RegisterStorage reg, int offset, PrimitiveType type)
         {
             Assert.IsAssignableFrom(typeof(IndirectOperand), op);
             IndirectOperand opReg = op as IndirectOperand;
-            Assert.AreEqual(arch.GetRegister(base_reg_name), opReg.Base);
+            Assert.AreEqual(reg, opReg.Base);
             Assert.AreEqual(offset, opReg.Offset);
             Assert.AreEqual(type, opReg.Width);
         }
@@ -97,8 +97,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("001000 00001 00010 1111111111111000");
             Assert.AreEqual("addi\tr2,r1,-00000008", instr.ToString());
             Assert.AreEqual(Opcode.addi, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r2", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r1", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r2, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r1, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Int32(-8), PrimitiveType.Int32);
         }
 
@@ -108,8 +108,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("001001 00011 00110 1111111111111000");
             Assert.AreEqual("addiu\tr6,r3,-00000008", instr.ToString());
             Assert.AreEqual(Opcode.addiu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r6", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r6, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Int32(-8), PrimitiveType.Int32);
         }
 
@@ -119,9 +119,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00110 11110 00000 100001");
             Assert.AreEqual("addu\tr30,r3,r6", instr.ToString());
             Assert.AreEqual(Opcode.addu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r6", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r30, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r6, PrimitiveType.Word32);
         }
 
         [Test]
@@ -130,9 +130,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00110 11110 00000 100100");
             Assert.AreEqual("and\tr30,r3,r6", instr.ToString());
             Assert.AreEqual(Opcode.and, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r6", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r30, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r6, PrimitiveType.Word32);
         }
 
         [Test]
@@ -141,8 +141,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("001100 00011 00110 1111000000100100");
             Assert.AreEqual("andi\tr6,r3,0000F024", instr.ToString());
             Assert.AreEqual(Opcode.andi, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r6", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r6, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Word32(0xF024), PrimitiveType.Word32);
         }
 
@@ -152,8 +152,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000100 00011 00110 0000000000000001");
             Assert.AreEqual("beq\tr3,r6,00100008", instr.ToString());
             Assert.AreEqual(Opcode.beq, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r6", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r6, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op3, Address.Ptr32(0x100008), PrimitiveType.Pointer32);
         }
 
@@ -163,8 +163,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("010100 00011 00110 0000000000000001");
             Assert.AreEqual("beql\tr3,r6,00100008", instr.ToString());
             Assert.AreEqual(Opcode.beql, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r6", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r6, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op3, Address.Ptr32(0x100008), PrimitiveType.Pointer32);
         }
 
@@ -174,7 +174,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000001 00011 00001 1111111111111110");
             Assert.AreEqual("bgez\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bgez, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -184,7 +184,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000001 00011 10001 1111111111111110");
             Assert.AreEqual("bgezal\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bgezal, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -194,7 +194,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000001 00011 10011 1111111111111110");
             Assert.AreEqual("bgezall\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bgezall, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -204,7 +204,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000001 00011 00011 1111111111111110");
             Assert.AreEqual("bgezl\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bgezl, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -214,7 +214,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000111 00011 00000 1111111111111110");
             Assert.AreEqual("bgtz\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bgtz, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -224,7 +224,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("010111 00011 00000 1111111111111110");
             Assert.AreEqual("bgtzl\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bgtzl, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -234,7 +234,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000110 00011 00000 1111111111111110");
             Assert.AreEqual("blez\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.blez, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -244,7 +244,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("010110 00011 00000 1111111111111110");
             Assert.AreEqual("blezl\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.blezl, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -254,7 +254,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000001 00011 00000 1111111111111110");
             Assert.AreEqual("bltz\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bltz, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -264,7 +264,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000001 00011 10000 1111111111111110");
             Assert.AreEqual("bltzal\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bltzal, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -274,7 +274,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000001 00011 10010 1111111111111110");
             Assert.AreEqual("bltzall\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bltzall, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -284,7 +284,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000001 00011 00010 1111111111111110");
             Assert.AreEqual("bltzl\tr3,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bltzl, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -294,8 +294,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000101 00011 00010 1111111111111110");
             Assert.AreEqual("bne\tr3,r2,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bne, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r2", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r2, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op3, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -305,8 +305,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("010101 00011 00010 1111111111111110");
             Assert.AreEqual("bnel\tr3,r2,000FFFFC", instr.ToString());
             Assert.AreEqual(Opcode.bnel, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r2", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r2, PrimitiveType.Word32);
             VerifyAddressOperand(instr.op3, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
@@ -325,9 +325,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00010 11110 00000 101100");
             Assert.AreEqual("dadd\tr30,r3,r2", instr.ToString());
             Assert.AreEqual(Opcode.dadd, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r2", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r30, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r2, PrimitiveType.Word32);
         }
 
         [Test]
@@ -336,8 +336,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("011000 00011 00010 1111000000101100");
             Assert.AreEqual("daddi\tr2,r3,-00000FD4", instr.ToString());
             Assert.AreEqual(Opcode.daddi, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r2", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r2, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Int32(-0xFD4), PrimitiveType.Int32);
         }
 
@@ -347,8 +347,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("011001 00011 00010 1111000000101100");
             Assert.AreEqual("daddiu\tr2,r3,-00000FD4", instr.ToString());
             Assert.AreEqual(Opcode.daddiu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r2", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r2, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Int32(-0xFD4), PrimitiveType.Int32);
         }
 
@@ -358,9 +358,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00010 11110 00000 101101");
             Assert.AreEqual("daddu\tr30,r3,r2", instr.ToString());
             Assert.AreEqual(Opcode.daddu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r2", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r30, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r2, PrimitiveType.Word32);
         }
 
         [Test]
@@ -369,8 +369,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011110");
             Assert.AreEqual("ddiv\tr3,r5", instr.ToString());
             Assert.AreEqual(Opcode.ddiv, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -379,8 +379,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011111");
             Assert.AreEqual("ddivu\tr3,r5", instr.ToString());
             Assert.AreEqual(Opcode.ddivu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -389,8 +389,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011010");
             Assert.AreEqual("div\tr3,r5", instr.ToString());
             Assert.AreEqual(Opcode.div, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -399,8 +399,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011011");
             Assert.AreEqual("divu\tr3,r5", instr.ToString());
             Assert.AreEqual(Opcode.divu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -409,8 +409,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011100");
             Assert.AreEqual("dmult\tr3,r5", instr.ToString());
             Assert.AreEqual(Opcode.dmult, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -419,8 +419,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011101");
             Assert.AreEqual("dmultu\tr3,r5", instr.ToString());
             Assert.AreEqual(Opcode.dmultu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -429,8 +429,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00000 00101 00111 01001 111000");
             Assert.AreEqual("dsll\tr7,r5,09", instr.ToString());
             Assert.AreEqual(Opcode.dsll, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
         }
 
@@ -440,8 +440,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00000 00101 00111 01001 111100");
             Assert.AreEqual("dsll32\tr7,r5,09", instr.ToString());
             Assert.AreEqual(Opcode.dsll32, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
         }
 
@@ -451,9 +451,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00111 00000 010100");
             Assert.AreEqual("dsllv\tr7,r5,r3", instr.ToString());
             Assert.AreEqual(Opcode.dsllv, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r3, PrimitiveType.Word32);
         }
 
         [Test]
@@ -462,8 +462,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00000 00101 00111 01001 111011");
             Assert.AreEqual("dsra\tr7,r5,09", instr.ToString());
             Assert.AreEqual(Opcode.dsra, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
         }
 
@@ -473,8 +473,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00000 00101 00111 01001 111111");
             Assert.AreEqual("dsra32\tr7,r5,09", instr.ToString());
             Assert.AreEqual(Opcode.dsra32, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
         }
 
@@ -484,9 +484,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00111 00000 010111");
             Assert.AreEqual("dsrav\tr7,r5,r3", instr.ToString());
             Assert.AreEqual(Opcode.dsrav, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r3, PrimitiveType.Word32);
         }
 
         [Test]
@@ -495,8 +495,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00000 00101 00111 01001 111010");
             Assert.AreEqual("dsrl\tr7,r5,09", instr.ToString());
             Assert.AreEqual(Opcode.dsrl, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
         }
 
@@ -506,8 +506,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00000 00101 00111 01001 111110");
             Assert.AreEqual("dsrl32\tr7,r5,09", instr.ToString());
             Assert.AreEqual(Opcode.dsrl32, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
         }
 
@@ -517,9 +517,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00111 00000 010110");
             Assert.AreEqual("dsrlv\tr7,r5,r3", instr.ToString());
             Assert.AreEqual(Opcode.dsrlv, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r3, PrimitiveType.Word32);
         }
 
         [Test]
@@ -528,9 +528,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00010 11110 00000 101110");
             Assert.AreEqual("dsub\tr30,r3,r2", instr.ToString());
             Assert.AreEqual(Opcode.dsub, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r2", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r30, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r2, PrimitiveType.Word32);
         }
 
         [Test]
@@ -539,9 +539,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00010 11110 00000 101111");
             Assert.AreEqual("dsubu\tr30,r3,r2", instr.ToString());
             Assert.AreEqual(Opcode.dsubu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r2", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r30, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r2, PrimitiveType.Word32);
         }
 
         [Test]
@@ -568,7 +568,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 01001 000000000000000 001000");
             Assert.AreEqual("jr\tr9", instr.ToString());
             Assert.AreEqual(Opcode.jr, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r9", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r9, PrimitiveType.Word32);
         }
 
         [Test]
@@ -578,7 +578,7 @@ namespace Reko.UnitTests.Arch.Mips
             Assert.AreEqual("jalr\tra,r9", instr.ToString());
             Assert.AreEqual(Opcode.jalr, instr.opcode);
             VerifyRegisterOperand(instr.op1, "ra", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r9", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r9, PrimitiveType.Word32);
         }
 
         [Test]
@@ -587,7 +587,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("100000 01001 00011 1111111111001000");
             Assert.AreEqual("lb\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lb, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.SByte);
         }
 
@@ -597,7 +597,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("100100 01001 00011 1111111111001000");
             Assert.AreEqual("lbu\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lbu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Byte);
         }
 
@@ -607,7 +607,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("110111 01001 00011 1111111111001000");
             Assert.AreEqual("ld\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.ld, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
         }
 
@@ -617,7 +617,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("011010 01001 00011 1111111111001000");
             Assert.AreEqual("ldl\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.ldl, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
         }
 
@@ -627,7 +627,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("011011 01001 00011 1111111111001000");
             Assert.AreEqual("ldr\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.ldr, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
         }
 
@@ -637,7 +637,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("100001 01001 00011 1111111111001000");
             Assert.AreEqual("lh\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lh, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Int16);
         }
 
@@ -647,7 +647,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("100101 01001 00011 1111111111001000");
             Assert.AreEqual("lhu\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lhu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word16);
         }
 
@@ -657,7 +657,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("100011 01001 00011 1111111111001000");
             Assert.AreEqual("lw\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lw, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
         }
 
@@ -667,7 +667,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("100111 01001 00011 1111111111001000");
             Assert.AreEqual("lwu\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lwu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
         }
 
@@ -677,7 +677,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("100010 01001 00011 1111111111001000");
             Assert.AreEqual("lwl\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lwl, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
         }
 
@@ -687,7 +687,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("100110 01001 00011 1111111111001000");
             Assert.AreEqual("lwr\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lwr, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
         }
 
@@ -698,7 +698,7 @@ namespace Reko.UnitTests.Arch.Mips
             instr = DisassembleBits("110000 01001 00011 1111111111001000");
             Assert.AreEqual("ll\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.ll, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
         }
 
@@ -708,7 +708,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("110100 01001 00011 1111111111001000");
             Assert.AreEqual("lld\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lld, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
         }
 
@@ -721,7 +721,7 @@ namespace Reko.UnitTests.Arch.Mips
             instr = DisassembleBits("011111 01001 00011 111111100 0 110110");
             Assert.AreEqual("ll\tr3,-0004(r9)", instr.ToString());
             Assert.AreEqual(Opcode.ll, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x4, PrimitiveType.Word32);
         }
 
@@ -733,7 +733,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("011111 01001 00011 111111100 0 110111");
             Assert.AreEqual("lld\tr3,-0004(r9)", instr.ToString());
             Assert.AreEqual(Opcode.lld, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
             VerifyIndirectOperand(instr.op2, "r9", -0x4, PrimitiveType.Word64);
         }
 
@@ -743,7 +743,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("001111 00000 00011 1111111111001000");
             Assert.AreEqual("lui\tr3,-0038", instr.ToString());
             Assert.AreEqual(Opcode.lui, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op2, Constant.Int16(-0x38), PrimitiveType.Int16);
         }
 
@@ -753,7 +753,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00000 00000 01010 00000 010000");
             Assert.AreEqual("mfhi\tr10", instr.ToString());
             Assert.AreEqual(Opcode.mfhi, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r10, PrimitiveType.Word32);
         }
 
         [Test]
@@ -762,7 +762,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00000 00000 01010 00000 010010");
             Assert.AreEqual("mflo\tr10", instr.ToString());
             Assert.AreEqual(Opcode.mflo, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r10, PrimitiveType.Word32);
         }
 
         [Test]
@@ -771,7 +771,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 01010 00000 00000 00000 010001");
             Assert.AreEqual("mthi\tr10", instr.ToString());
             Assert.AreEqual(Opcode.mthi, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r10, PrimitiveType.Word32);
         }
 
         [Test]
@@ -780,7 +780,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 01010 00000 00000 00000 010011");
             Assert.AreEqual("mtlo\tr10", instr.ToString());
             Assert.AreEqual(Opcode.mtlo, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r10, PrimitiveType.Word32);
         }
 
         [Test]
@@ -789,9 +789,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00001 00101 01010 00000 001011");
             Assert.AreEqual("movn\tr10,r1,r5", instr.ToString());
             Assert.AreEqual(Opcode.movn, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r1", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r10, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r1, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -800,9 +800,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00001 00101 01010 00000 001010");
             Assert.AreEqual("movz\tr10,r1,r5", instr.ToString());
             Assert.AreEqual(Opcode.movz, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r1", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r10, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r1, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -811,8 +811,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011000");
             Assert.AreEqual("mult\tr3,r5", instr.ToString());
             Assert.AreEqual(Opcode.mult, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -821,8 +821,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011001");
             Assert.AreEqual("multu\tr3,r5", instr.ToString());
             Assert.AreEqual(Opcode.multu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -831,9 +831,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00111 00000 100101");
             Assert.AreEqual("or\tr7,r3,r5", instr.ToString());
             Assert.AreEqual(Opcode.or, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -842,9 +842,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00111 00000 100111");
             Assert.AreEqual("nor\tr7,r3,r5", instr.ToString());
             Assert.AreEqual(Opcode.nor, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -853,8 +853,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("001101 00011 00101 0011100000100111");
             Assert.AreEqual("ori\tr5,r3,00003827", instr.ToString());
             Assert.AreEqual(Opcode.ori, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r5", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r5, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Word32(0x3827), PrimitiveType.Word32);
         }
 
@@ -864,7 +864,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("101000 01001 00011 1111111111001000");
             Assert.AreEqual("sb\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sb, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Byte);
         }
 
@@ -874,7 +874,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("111111 01001 00011 1111111111001000");
             Assert.AreEqual("sd\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sd, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
         }
 
@@ -884,7 +884,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("101100 01001 00011 1111111111001000");
             Assert.AreEqual("sdl\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sdl, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
         }
 
@@ -894,7 +894,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("101101 01001 00011 1111111111001000");
             Assert.AreEqual("sdr\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sdr, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word64);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
         }
 
@@ -904,7 +904,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("101001 01001 00011 1111111111001000");
             Assert.AreEqual("sh\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sh, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word16);
         }
 
@@ -914,7 +914,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("101011 01001 00011 1111111111001000");
             Assert.AreEqual("sw\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.sw, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
         }
 
@@ -924,7 +924,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("101010 01001 00011 1111111111001000");
             Assert.AreEqual("swl\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.swl, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
         }
 
@@ -934,7 +934,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("101110 01001 00011 1111111111001000");
             Assert.AreEqual("swr\tr3,-0038(r9)", instr.ToString());
             Assert.AreEqual(Opcode.swr, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
         }
         
@@ -944,7 +944,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("111000 01010 10101 1111111111001000");
             Assert.AreEqual("sc\tr21,-0038(r10)", instr.ToString());
             Assert.AreEqual(Opcode.sc, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r21", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r21, PrimitiveType.Word32);
             VerifyIndirectOperand(instr.op2, "r10", -0x38, PrimitiveType.Word32);
         }
         [Test]
@@ -953,7 +953,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("111100 01010 10101 1111111111001000");
             Assert.AreEqual("scd\tr21,-0038(r10)", instr.ToString());
             Assert.AreEqual(Opcode.scd, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r21", PrimitiveType.Word64);
+            VerifyRegisterOperand(instr.op1, Registers.r21, PrimitiveType.Word64);
             VerifyIndirectOperand(instr.op2, "r10", -0x38, PrimitiveType.Word64);
         }
 
@@ -963,9 +963,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("000000 00011 00101 00111 00000 100110");
             Assert.AreEqual("xor\tr7,r3,r5", instr.ToString());
             Assert.AreEqual(Opcode.xor, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r7, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r5, PrimitiveType.Word32);
         }
 
         [Test]
@@ -974,8 +974,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("001110 00011 00101 0011100000100111");
             Assert.AreEqual("xori\tr5,r3,00003827", instr.ToString());
             Assert.AreEqual(Opcode.xori, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r5", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r5, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op3, Constant.Word32(0x3827), PrimitiveType.Word32);
         }
 
@@ -993,9 +993,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleWord(0x0144402B);
             Assert.AreEqual("sltu\tr8,r10,r4", instr.ToString());
             Assert.AreEqual(Opcode.sltu, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r8", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r10", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r4", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r8, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r10, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r4, PrimitiveType.Word32);
         }
 
         [Test]
@@ -1004,9 +1004,9 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleWord(0x01011004);
             Assert.AreEqual("sllv\tr2,r1,r8", instr.ToString());
             Assert.AreEqual(Opcode.sllv, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r2", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r1", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op3, "r8", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r2, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r1, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, Registers.r8, PrimitiveType.Word32);
         }
 
         [Test]
@@ -1015,8 +1015,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleWord(0x40024800);
             Assert.AreEqual("mfc0\tr2,r9", instr.ToString());
             Assert.AreEqual(Opcode.mfc0, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r2", PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, "r9", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r2, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, Registers.r9, PrimitiveType.Word32);
         }
 
         [Test]
@@ -1025,7 +1025,7 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleWord(0x448C0800);
             Assert.AreEqual("mtc1\tr12,f1", instr.ToString());
             Assert.AreEqual(Opcode.mtc1, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r12", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r12, PrimitiveType.Word32);
             VerifyRegisterOperand(instr.op2, "f1", PrimitiveType.Word32);
         }
 
@@ -1062,31 +1062,31 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleBits("011111 00000 00011 00000 00000 111011");
             Assert.AreEqual("rdhwr\tr3,00", instr.ToString()); // CPU number
             Assert.AreEqual(Opcode.rdhwr, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op2, Constant.Byte(0x0), PrimitiveType.Byte);
 
             instr = DisassembleBits("011111 00000 00011 00001 00000 111011");
             Assert.AreEqual("rdhwr\tr3,01", instr.ToString()); // SYNCI step size
             Assert.AreEqual(Opcode.rdhwr, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op2, Constant.Byte(0x1), PrimitiveType.Byte);
 
             instr = DisassembleBits("011111 00000 00011 00010 00000 111011");
             Assert.AreEqual("rdhwr\tr3,02", instr.ToString()); // Cycle counter
             Assert.AreEqual(Opcode.rdhwr, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op2, Constant.Byte(0x2), PrimitiveType.Byte);
 
             instr = DisassembleBits("011111 00000 00011 00011 00000 111011");
             Assert.AreEqual("rdhwr\tr3,03", instr.ToString()); // Cycle counter resolution
             Assert.AreEqual(Opcode.rdhwr, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op2, Constant.Byte(0x3), PrimitiveType.Byte);
 
             instr = DisassembleBits("011111 00000 00011 11101 00000 111011");
             Assert.AreEqual("rdhwr\tr3,1D", instr.ToString()); // OS-specific, thread local pointer on Linux
             Assert.AreEqual(Opcode.rdhwr, instr.opcode);
-            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.r3, PrimitiveType.Word32);
             VerifyImmediateOperand(instr.op2, Constant.Byte(0x1D), PrimitiveType.Byte);
         }
 

--- a/src/UnitTests/Arch/Mips/MipsDisassemblerTests.cs
+++ b/src/UnitTests/Arch/Mips/MipsDisassemblerTests.cs
@@ -25,6 +25,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Reko.Core.Machine;
+using Reko.Core.Types;
+using Reko.Core.Expressions;
 
 namespace Reko.UnitTests.Arch.Mips
 {
@@ -55,11 +58,48 @@ namespace Reko.UnitTests.Arch.Mips
             arch.Name = "mipsv6-be-32";
         }
 
+        private void VerifyRegisterOperand(MachineOperand op, string reg_name, PrimitiveType type)
+        {
+            Assert.IsAssignableFrom(typeof(RegisterOperand), op);
+            RegisterOperand opReg = op as RegisterOperand;
+            Assert.AreEqual(arch.GetRegister(reg_name), opReg.Register);
+            Assert.AreEqual(type, opReg.Register.DataType);
+            Assert.AreEqual(type, opReg.Width);
+        }
+        private void VerifyIndirectOperand(MachineOperand op, string base_reg_name, int offset, PrimitiveType type)
+        {
+            Assert.IsAssignableFrom(typeof(IndirectOperand), op);
+            IndirectOperand opReg = op as IndirectOperand;
+            Assert.AreEqual(arch.GetRegister(base_reg_name), opReg.Base);
+            Assert.AreEqual(offset, opReg.Offset);
+            Assert.AreEqual(type, opReg.Width);
+        }
+        private void VerifyImmediateOperand(MachineOperand op, Constant val, PrimitiveType type)
+        {
+            Assert.IsAssignableFrom(typeof(ImmediateOperand), op);
+            ImmediateOperand opReg = op as ImmediateOperand;
+            Assert.AreEqual(type, opReg.Width);
+            Assert.AreEqual(type, opReg.Value.DataType);
+            Assert.AreEqual(val.GetValue(), opReg.Value.GetValue());
+        }
+        private void VerifyAddressOperand(MachineOperand op, Address addr, PrimitiveType type)
+        {
+            Assert.IsAssignableFrom(typeof(AddressOperand), op);
+            AddressOperand opReg = op as AddressOperand;
+            Assert.AreEqual(type, opReg.Width);
+            Assert.AreEqual(addr, opReg.Address);
+        }
+
+
         [Test]
         public void MipsDis_addi()
         {
             var instr = DisassembleBits("001000 00001 00010 1111111111111000");
             Assert.AreEqual("addi\tr2,r1,-00000008", instr.ToString());
+            Assert.AreEqual(Opcode.addi, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r2", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r1", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Int32(-8), PrimitiveType.Int32);
         }
 
         [Test]
@@ -67,6 +107,10 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("001001 00011 00110 1111111111111000");
             Assert.AreEqual("addiu\tr6,r3,-00000008", instr.ToString());
+            Assert.AreEqual(Opcode.addiu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r6", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Int32(-8), PrimitiveType.Int32);
         }
 
         [Test]
@@ -74,6 +118,10 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00011 00110 11110 00000 100001");
             Assert.AreEqual("addu\tr30,r3,r6", instr.ToString());
+            Assert.AreEqual(Opcode.addu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r6", PrimitiveType.Word32);
         }
 
         [Test]
@@ -81,6 +129,10 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00011 00110 11110 00000 100100");
             Assert.AreEqual("and\tr30,r3,r6", instr.ToString());
+            Assert.AreEqual(Opcode.and, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r6", PrimitiveType.Word32);
         }
 
         [Test]
@@ -88,6 +140,10 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("001100 00011 00110 1111000000100100");
             Assert.AreEqual("andi\tr6,r3,0000F024", instr.ToString());
+            Assert.AreEqual(Opcode.andi, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r6", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Word32(0xF024), PrimitiveType.Word32);
         }
 
         [Test]
@@ -95,6 +151,10 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000100 00011 00110 0000000000000001");
             Assert.AreEqual("beq\tr3,r6,00100008", instr.ToString());
+            Assert.AreEqual(Opcode.beq, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r6", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op3, Address.Ptr32(0x100008), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -102,6 +162,10 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("010100 00011 00110 0000000000000001");
             Assert.AreEqual("beql\tr3,r6,00100008", instr.ToString());
+            Assert.AreEqual(Opcode.beql, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r6", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op3, Address.Ptr32(0x100008), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -109,6 +173,9 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000001 00011 00001 1111111111111110");
             Assert.AreEqual("bgez\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bgez, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -116,6 +183,9 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000001 00011 10001 1111111111111110");
             Assert.AreEqual("bgezal\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bgezal, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -123,6 +193,9 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000001 00011 10011 1111111111111110");
             Assert.AreEqual("bgezall\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bgezall, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -130,6 +203,9 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000001 00011 00011 1111111111111110");
             Assert.AreEqual("bgezl\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bgezl, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -137,6 +213,9 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000111 00011 00000 1111111111111110");
             Assert.AreEqual("bgtz\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bgtz, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -144,6 +223,9 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("010111 00011 00000 1111111111111110");
             Assert.AreEqual("bgtzl\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bgtzl, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -151,6 +233,9 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000110 00011 00000 1111111111111110");
             Assert.AreEqual("blez\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.blez, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -158,6 +243,9 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("010110 00011 00000 1111111111111110");
             Assert.AreEqual("blezl\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.blezl, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -165,15 +253,39 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000001 00011 00000 1111111111111110");
             Assert.AreEqual("bltz\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bltz, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
+        }
 
-            instr = DisassembleBits("000001 00011 10000 1111111111111110");
+        [Test]
+        public void MipsDis_bltzal()
+        {
+            var instr = DisassembleBits("000001 00011 10000 1111111111111110");
             Assert.AreEqual("bltzal\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bltzal, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
+        }
 
-            instr = DisassembleBits("000001 00011 10010 1111111111111110");
+        [Test]
+        public void MipsDis_bltzall()
+        {
+            var instr = DisassembleBits("000001 00011 10010 1111111111111110");
             Assert.AreEqual("bltzall\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bltzall, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
+        }
 
-            instr = DisassembleBits("000001 00011 00010 1111111111111110");
+        [Test]
+        public void MipsDis_bltzl()
+        {
+            var instr = DisassembleBits("000001 00011 00010 1111111111111110");
             Assert.AreEqual("bltzl\tr3,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bltzl, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -181,9 +293,21 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000101 00011 00010 1111111111111110");
             Assert.AreEqual("bne\tr3,r2,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bne, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r2", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op3, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
+        }
 
-            instr = DisassembleBits("010101 00011 00010 1111111111111110");
+        [Test]
+        public void MipsDis_bnel()
+        {
+            var instr = DisassembleBits("010101 00011 00010 1111111111111110");
             Assert.AreEqual("bnel\tr3,r2,000FFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.bnel, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r2", PrimitiveType.Word32);
+            VerifyAddressOperand(instr.op3, Address.Ptr32(0x000FFFFC), PrimitiveType.Pointer32);
         }
 
         [Test]
@@ -191,6 +315,8 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00011000101111111111 001101");
             Assert.AreEqual("break\t00018BFF", instr.ToString());
+            Assert.AreEqual(Opcode.@break, instr.opcode);
+            VerifyImmediateOperand(instr.op1, Constant.Word32(0x18BFF), PrimitiveType.Word32);
         }
 
         [Test]
@@ -198,15 +324,43 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00011 00010 11110 00000 101100");
             Assert.AreEqual("dadd\tr30,r3,r2", instr.ToString());
+            Assert.AreEqual(Opcode.dadd, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r2", PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("011000 00011 00010 1111000000101100");
+        [Test]
+        public void MipsDis_daddi()
+        {
+            var instr = DisassembleBits("011000 00011 00010 1111000000101100");
             Assert.AreEqual("daddi\tr2,r3,-00000FD4", instr.ToString());
+            Assert.AreEqual(Opcode.daddi, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r2", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Int32(-0xFD4), PrimitiveType.Int32);
+        }
 
-            instr = DisassembleBits("011001 00011 00010 1111000000101100");
+        [Test]
+        public void MipsDis_daddiu()
+        {
+            var instr = DisassembleBits("011001 00011 00010 1111000000101100");
             Assert.AreEqual("daddiu\tr2,r3,-00000FD4", instr.ToString());
+            Assert.AreEqual(Opcode.daddiu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r2", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Int32(-0xFD4), PrimitiveType.Int32);
+        }
 
-            instr = DisassembleBits("000000 00011 00010 11110 00000 101101");
+        [Test]
+        public void MipsDis_daddu()
+        {
+            var instr = DisassembleBits("000000 00011 00010 11110 00000 101101");
             Assert.AreEqual("daddu\tr30,r3,r2", instr.ToString());
+            Assert.AreEqual(Opcode.daddu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r2", PrimitiveType.Word32);
         }
 
         [Test]
@@ -214,9 +368,19 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011110");
             Assert.AreEqual("ddiv\tr3,r5", instr.ToString());
+            Assert.AreEqual(Opcode.ddiv, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("000000 00011 00101 00000 00000 011111");
+        [Test]
+        public void MipsDis_ddivu()
+        {
+            var instr = DisassembleBits("000000 00011 00101 00000 00000 011111");
             Assert.AreEqual("ddivu\tr3,r5", instr.ToString());
+            Assert.AreEqual(Opcode.ddivu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
         }
 
         [Test]
@@ -224,9 +388,19 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011010");
             Assert.AreEqual("div\tr3,r5", instr.ToString());
+            Assert.AreEqual(Opcode.div, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("000000 00011 00101 00000 00000 011011");
+        [Test]
+        public void MipsDis_divu()
+        {
+            var instr = DisassembleBits("000000 00011 00101 00000 00000 011011");
             Assert.AreEqual("divu\tr3,r5", instr.ToString());
+            Assert.AreEqual(Opcode.divu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
         }
 
         [Test]
@@ -234,9 +408,19 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011100");
             Assert.AreEqual("dmult\tr3,r5", instr.ToString());
+            Assert.AreEqual(Opcode.dmult, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("000000 00011 00101 00000 00000 011101");
+        [Test]
+        public void MipsDis_dmultu()
+        {
+            var instr = DisassembleBits("000000 00011 00101 00000 00000 011101");
             Assert.AreEqual("dmultu\tr3,r5", instr.ToString());
+            Assert.AreEqual(Opcode.dmultu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
         }
 
         [Test]
@@ -244,12 +428,32 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00000 00101 00111 01001 111000");
             Assert.AreEqual("dsll\tr7,r5,09", instr.ToString());
+            Assert.AreEqual(Opcode.dsll, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
+        }
 
-            instr = DisassembleBits("000000 00000 00101 00111 01001 111100");
+        [Test]
+        public void MipsDis_dsl32()
+        {
+            var instr = DisassembleBits("000000 00000 00101 00111 01001 111100");
             Assert.AreEqual("dsll32\tr7,r5,09", instr.ToString());
+            Assert.AreEqual(Opcode.dsll32, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
+        }
 
-            instr = DisassembleBits("000000 00011 00101 00111 00000 010100");
+        [Test]
+        public void MipsDis_dsllv()
+        {
+            var instr = DisassembleBits("000000 00011 00101 00111 00000 010100");
             Assert.AreEqual("dsllv\tr7,r5,r3", instr.ToString());
+            Assert.AreEqual(Opcode.dsllv, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r3", PrimitiveType.Word32);
         }
 
         [Test]
@@ -257,12 +461,32 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00000 00101 00111 01001 111011");
             Assert.AreEqual("dsra\tr7,r5,09", instr.ToString());
+            Assert.AreEqual(Opcode.dsra, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
+        }
 
-            instr = DisassembleBits("000000 00000 00101 00111 01001 111111");
+        [Test]
+        public void MipsDis_dsra32()
+        {
+            var instr = DisassembleBits("000000 00000 00101 00111 01001 111111");
             Assert.AreEqual("dsra32\tr7,r5,09", instr.ToString());
+            Assert.AreEqual(Opcode.dsra32, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
+        }
 
-            instr = DisassembleBits("000000 00011 00101 00111 00000 010111");
+        [Test]
+        public void MipsDis_dsrav()
+        {
+            var instr = DisassembleBits("000000 00011 00101 00111 00000 010111");
             Assert.AreEqual("dsrav\tr7,r5,r3", instr.ToString());
+            Assert.AreEqual(Opcode.dsrav, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r3", PrimitiveType.Word32);
         }
 
         [Test]
@@ -270,12 +494,32 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00000 00101 00111 01001 111010");
             Assert.AreEqual("dsrl\tr7,r5,09", instr.ToString());
+            Assert.AreEqual(Opcode.dsrl, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
+        }
 
-            instr = DisassembleBits("000000 00000 00101 00111 01001 111110");
+        [Test]
+        public void MipsDis_dsrl32()
+        {
+            var instr = DisassembleBits("000000 00000 00101 00111 01001 111110");
             Assert.AreEqual("dsrl32\tr7,r5,09", instr.ToString());
+            Assert.AreEqual(Opcode.dsrl32, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Byte(0x09), PrimitiveType.Byte);
+        }
 
-            instr = DisassembleBits("000000 00011 00101 00111 00000 010110");
+        [Test]
+        public void MipsDis_dsrlv()
+        {
+            var instr = DisassembleBits("000000 00011 00101 00111 00000 010110");
             Assert.AreEqual("dsrlv\tr7,r5,r3", instr.ToString());
+            Assert.AreEqual(Opcode.dsrlv, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r3", PrimitiveType.Word32);
         }
 
         [Test]
@@ -283,9 +527,21 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00011 00010 11110 00000 101110");
             Assert.AreEqual("dsub\tr30,r3,r2", instr.ToString());
+            Assert.AreEqual(Opcode.dsub, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r2", PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("000000 00011 00010 11110 00000 101111");
+        [Test]
+        public void MipsDis_dsubu()
+        {
+            var instr = DisassembleBits("000000 00011 00010 11110 00000 101111");
             Assert.AreEqual("dsubu\tr30,r3,r2", instr.ToString());
+            Assert.AreEqual(Opcode.dsubu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r30", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r2", PrimitiveType.Word32);
         }
 
         [Test]
@@ -293,56 +549,146 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000010 11111111111111111111111111");
             Assert.AreEqual("j\t0FFFFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.j, instr.opcode);
+            VerifyAddressOperand(instr.op1, Address.Ptr32(0x0FFFFFFC), PrimitiveType.Pointer32);
+        }
 
-            instr = DisassembleBits("000011 11111111111111111111111111");
+        [Test]
+        public void MipsDis_jal()
+        {
+            var instr = DisassembleBits("000011 11111111111111111111111111");
             Assert.AreEqual("jal\t0FFFFFFC", instr.ToString());
+            Assert.AreEqual(Opcode.jal, instr.opcode);
+            VerifyAddressOperand(instr.op1, Address.Ptr32(0x0FFFFFFC), PrimitiveType.Pointer32);
         }
 
         [Test]
         public void MipsDis_jr()
         {
-            var instr = DisassembleBits("000000 01001 00000 11111 00000 001001");
-            Assert.AreEqual("jalr\tra,r9", instr.ToString());
-
-            instr = DisassembleBits("000000 01001 000000000000000 001000");
+            var instr = DisassembleBits("000000 01001 000000000000000 001000");
             Assert.AreEqual("jr\tr9", instr.ToString());
+            Assert.AreEqual(Opcode.jr, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r9", PrimitiveType.Word32);
         }
 
         [Test]
-        public void MipsDis_loads()
+        public void MipsDis_jalr()
+        {
+            var instr = DisassembleBits("000000 01001 00000 11111 00000 001001");
+            Assert.AreEqual("jalr\tra,r9", instr.ToString());
+            Assert.AreEqual(Opcode.jalr, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "ra", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r9", PrimitiveType.Word32);
+        }
+
+        [Test]
+        public void MipsDis_lb()
         {
             var instr = DisassembleBits("100000 01001 00011 1111111111001000");
             Assert.AreEqual("lb\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.lb, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.SByte);
+        }
 
-            instr = DisassembleBits("100100 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_lbu()
+        {
+            var instr = DisassembleBits("100100 01001 00011 1111111111001000");
             Assert.AreEqual("lbu\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.lbu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Byte);
+        }
 
-            instr = DisassembleBits("110111 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_ld()
+        {
+            var instr = DisassembleBits("110111 01001 00011 1111111111001000");
             Assert.AreEqual("ld\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.ld, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+        }
 
-            instr = DisassembleBits("011010 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_ldl()
+        {
+            var instr = DisassembleBits("011010 01001 00011 1111111111001000");
             Assert.AreEqual("ldl\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.ldl, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+        }
 
-            instr = DisassembleBits("011011 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_ldr()
+        {
+            var instr = DisassembleBits("011011 01001 00011 1111111111001000");
             Assert.AreEqual("ldr\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.ldr, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+        }
 
-            instr = DisassembleBits("100001 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_lh()
+        {
+            var instr = DisassembleBits("100001 01001 00011 1111111111001000");
             Assert.AreEqual("lh\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.lh, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Int16);
+        }
 
-            instr = DisassembleBits("100101 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_lhu()
+        {
+            var instr = DisassembleBits("100101 01001 00011 1111111111001000");
             Assert.AreEqual("lhu\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.lhu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word16);
+        }
 
-            instr = DisassembleBits("100011 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_lw()
+        {
+            var instr = DisassembleBits("100011 01001 00011 1111111111001000");
             Assert.AreEqual("lw\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.lw, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("100111 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_lwu()
+        {
+            var instr = DisassembleBits("100111 01001 00011 1111111111001000");
             Assert.AreEqual("lwu\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.lwu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("100010 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_lwl()
+        {
+            var instr = DisassembleBits("100010 01001 00011 1111111111001000");
             Assert.AreEqual("lwl\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.lwl, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("100110 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_lwr()
+        {
+            var instr = DisassembleBits("100110 01001 00011 1111111111001000");
             Assert.AreEqual("lwr\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.lwr, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
         }
 
         [Test]
@@ -351,9 +697,19 @@ namespace Reko.UnitTests.Arch.Mips
             MipsInstruction instr;
             instr = DisassembleBits("110000 01001 00011 1111111111001000");
             Assert.AreEqual("ll\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.ll, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("110100 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_lld()
+        {
+            var instr = DisassembleBits("110100 01001 00011 1111111111001000");
             Assert.AreEqual("lld\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.lld, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
         }
 
         [Test]
@@ -364,9 +720,21 @@ namespace Reko.UnitTests.Arch.Mips
             MipsInstruction instr;
             instr = DisassembleBits("011111 01001 00011 111111100 0 110110");
             Assert.AreEqual("ll\tr3,-0004(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.ll, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x4, PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("011111 01001 00011 111111100 0 110111");
+        [Test]
+        public void MipsDis_lld_v6()
+        {
+            Given_Mips_v6_Architecture();
+
+            var instr = DisassembleBits("011111 01001 00011 111111100 0 110111");
             Assert.AreEqual("lld\tr3,-0004(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.lld, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, "r9", -0x4, PrimitiveType.Word64);
         }
 
         [Test]
@@ -374,32 +742,67 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("001111 00000 00011 1111111111001000");
             Assert.AreEqual("lui\tr3,-0038", instr.ToString());
+            Assert.AreEqual(Opcode.lui, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op2, Constant.Int16(-0x38), PrimitiveType.Int16);
         }
 
         [Test]
-        public void MipsDis_mtofromhilo()
+        public void MipsDis_mfhi()
         {
             var instr = DisassembleBits("000000 00000 00000 01010 00000 010000");
             Assert.AreEqual("mfhi\tr10", instr.ToString());
-
-            instr = DisassembleBits("000000 00000 00000 01010 00000 010010");
-            Assert.AreEqual("mflo\tr10", instr.ToString());
-
-            instr = DisassembleBits("000000 01010 00000 00000 00000 010001");
-            Assert.AreEqual("mthi\tr10", instr.ToString());
-
-            instr = DisassembleBits("000000 01010 00000 00000 00000 010011");
-            Assert.AreEqual("mtlo\tr10", instr.ToString());
+            Assert.AreEqual(Opcode.mfhi, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
         }
 
         [Test]
-        public void MipsDis_mov_z_nz()
+        public void MipsDis_mflo()
+        {
+            var instr = DisassembleBits("000000 00000 00000 01010 00000 010010");
+            Assert.AreEqual("mflo\tr10", instr.ToString());
+            Assert.AreEqual(Opcode.mflo, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
+        }
+
+        [Test]
+        public void MipsDis_mthi()
+        {
+            var instr = DisassembleBits("000000 01010 00000 00000 00000 010001");
+            Assert.AreEqual("mthi\tr10", instr.ToString());
+            Assert.AreEqual(Opcode.mthi, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
+        }
+
+        [Test]
+        public void MipsDis_mtlo()
+        {
+            var instr = DisassembleBits("000000 01010 00000 00000 00000 010011");
+            Assert.AreEqual("mtlo\tr10", instr.ToString());
+            Assert.AreEqual(Opcode.mtlo, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
+        }
+
+        [Test]
+        public void MipsDis_movnz()
         {
             var instr = DisassembleBits("000000 00001 00101 01010 00000 001011");
             Assert.AreEqual("movn\tr10,r1,r5", instr.ToString());
+            Assert.AreEqual(Opcode.movn, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r1", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r5", PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("000000 00001 00101 01010 00000 001010");
+        [Test]
+        public void MipsDis_movz()
+        {
+            var instr = DisassembleBits("000000 00001 00101 01010 00000 001010");
             Assert.AreEqual("movz\tr10,r1,r5", instr.ToString());
+            Assert.AreEqual(Opcode.movz, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r10", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r1", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r5", PrimitiveType.Word32);
         }
 
         [Test]
@@ -407,9 +810,19 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00011 00101 00000 00000 011000");
             Assert.AreEqual("mult\tr3,r5", instr.ToString());
+            Assert.AreEqual(Opcode.mult, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("000000 00011 00101 00000 00000 011001");
+        [Test]
+        public void MipsDis_multu()
+        {
+            var instr = DisassembleBits("000000 00011 00101 00000 00000 011001");
             Assert.AreEqual("multu\tr3,r5", instr.ToString());
+            Assert.AreEqual(Opcode.multu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r5", PrimitiveType.Word32);
         }
 
         [Test]
@@ -417,46 +830,131 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00011 00101 00111 00000 100101");
             Assert.AreEqual("or\tr7,r3,r5", instr.ToString());
-
-            instr = DisassembleBits("000000 00011 00101 00111 00000 100111");
-            Assert.AreEqual("nor\tr7,r3,r5", instr.ToString());
-
-            instr = DisassembleBits("001101 00011 00101 0011100000100111");
-            Assert.AreEqual("ori\tr5,r3,00003827", instr.ToString());
+            Assert.AreEqual(Opcode.or, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r5", PrimitiveType.Word32);
         }
 
         [Test]
-        public void MipsDis_stores()
+        public void MipsDis_nor()
+        {
+            var instr = DisassembleBits("000000 00011 00101 00111 00000 100111");
+            Assert.AreEqual("nor\tr7,r3,r5", instr.ToString());
+            Assert.AreEqual(Opcode.nor, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r5", PrimitiveType.Word32);
+        }
+
+        [Test]
+        public void MipsDis_ori()
+        {
+            var instr = DisassembleBits("001101 00011 00101 0011100000100111");
+            Assert.AreEqual("ori\tr5,r3,00003827", instr.ToString());
+            Assert.AreEqual(Opcode.ori, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Word32(0x3827), PrimitiveType.Word32);
+        }
+
+        [Test]
+        public void MipsDis_sb()
         {
             var instr = DisassembleBits("101000 01001 00011 1111111111001000");
             Assert.AreEqual("sb\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.sb, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Byte);
+        }
 
-            instr = DisassembleBits("111000 01001 00011 1111111111001000");
-            Assert.AreEqual("sc\tr3,-0038(r9)", instr.ToString());
-
-            instr = DisassembleBits("111100 01001 00011 1111111111001000");
-            Assert.AreEqual("scd\tr3,-0038(r9)", instr.ToString());
-
-            instr = DisassembleBits("111111 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_sd()
+        {
+            var instr = DisassembleBits("111111 01001 00011 1111111111001000");
             Assert.AreEqual("sd\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.sd, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+        }
 
-            instr = DisassembleBits("101100 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_sdl()
+        {
+            var instr = DisassembleBits("101100 01001 00011 1111111111001000");
             Assert.AreEqual("sdl\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.sdl, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+        }
 
-            instr = DisassembleBits("101101 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_sdr()
+        {
+            var instr = DisassembleBits("101101 01001 00011 1111111111001000");
             Assert.AreEqual("sdr\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.sdr, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word64);
+        }
 
-            instr = DisassembleBits("101001 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_sh()
+        {
+            var instr = DisassembleBits("101001 01001 00011 1111111111001000");
             Assert.AreEqual("sh\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.sh, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word16);
+        }
 
-            instr = DisassembleBits("101011 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_sw()
+        {
+            var instr = DisassembleBits("101011 01001 00011 1111111111001000");
             Assert.AreEqual("sw\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.sw, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("101010 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_swl()
+        {
+            var instr = DisassembleBits("101010 01001 00011 1111111111001000");
             Assert.AreEqual("swl\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.swl, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("101110 01001 00011 1111111111001000");
+        [Test]
+        public void MipsDis_swr()
+        {
+            var instr = DisassembleBits("101110 01001 00011 1111111111001000");
             Assert.AreEqual("swr\tr3,-0038(r9)", instr.ToString());
+            Assert.AreEqual(Opcode.swr, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r9", -0x38, PrimitiveType.Word32);
+        }
+        
+        [Test]
+        public void MipsDis_sc()
+        {
+            var instr = DisassembleBits("111000 01010 10101 1111111111001000");
+            Assert.AreEqual("sc\tr21,-0038(r10)", instr.ToString());
+            Assert.AreEqual(Opcode.sc, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r21", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "r10", -0x38, PrimitiveType.Word32);
+        }
+        [Test]
+        public void MipsDis_scd()
+        {
+            var instr = DisassembleBits("111100 01010 10101 1111111111001000");
+            Assert.AreEqual("scd\tr21,-0038(r10)", instr.ToString());
+            Assert.AreEqual(Opcode.scd, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r21", PrimitiveType.Word64);
+            VerifyIndirectOperand(instr.op2, "r10", -0x38, PrimitiveType.Word64);
         }
 
         [Test]
@@ -464,9 +962,21 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleBits("000000 00011 00101 00111 00000 100110");
             Assert.AreEqual("xor\tr7,r3,r5", instr.ToString());
+            Assert.AreEqual(Opcode.xor, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r7", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r5", PrimitiveType.Word32);
+        }
 
-            instr = DisassembleBits("001110 00011 00101 0011100000100111");
+        [Test]
+        public void MipsDis_xori()
+        {
+            var instr = DisassembleBits("001110 00011 00101 0011100000100111");
             Assert.AreEqual("xori\tr5,r3,00003827", instr.ToString());
+            Assert.AreEqual(Opcode.xori, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r5", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op3, Constant.Word32(0x3827), PrimitiveType.Word32);
         }
 
         [Test]
@@ -474,6 +984,7 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleWord(0); // nop
             Assert.AreEqual("nop", instr.ToString());
+            Assert.AreEqual(Opcode.nop, instr.opcode);
         }
 
         [Test]
@@ -481,6 +992,10 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleWord(0x0144402B);
             Assert.AreEqual("sltu\tr8,r10,r4", instr.ToString());
+            Assert.AreEqual(Opcode.sltu, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r8", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r10", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r4", PrimitiveType.Word32);
         }
 
         [Test]
@@ -488,6 +1003,10 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleWord(0x01011004);
             Assert.AreEqual("sllv\tr2,r1,r8", instr.ToString());
+            Assert.AreEqual(Opcode.sllv, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r2", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r1", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op3, "r8", PrimitiveType.Word32);
         }
 
         [Test]
@@ -495,6 +1014,9 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleWord(0x40024800);
             Assert.AreEqual("mfc0\tr2,r9", instr.ToString());
+            Assert.AreEqual(Opcode.mfc0, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r2", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "r9", PrimitiveType.Word32);
         }
 
         [Test]
@@ -502,6 +1024,9 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleWord(0x448C0800);
             Assert.AreEqual("mtc1\tr12,f1", instr.ToString());
+            Assert.AreEqual(Opcode.mtc1, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r12", PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op2, "f1", PrimitiveType.Word32);
         }
 
         [Test]
@@ -509,6 +1034,9 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleWord(0xE7AC0030);
             Assert.AreEqual("swc1\tf12,0030(sp)", instr.ToString());
+            Assert.AreEqual(Opcode.swc1, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "f12", PrimitiveType.Word32);
+            VerifyIndirectOperand(instr.op2, "sp", 0x30, PrimitiveType.Word32);
         }
 
         [Test]
@@ -516,6 +1044,7 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleWord(0x462C003E);
             Assert.AreEqual("c.le.d\tcc0,f0,f12", instr.ToString());
+            Assert.AreEqual(Opcode.c_le_d, instr.opcode);
         }
 
         [Test]
@@ -523,6 +1052,7 @@ namespace Reko.UnitTests.Arch.Mips
         {
             var instr = DisassembleWord(0x4443F800);
             Assert.AreEqual("cfc1\tr3,FCSR", instr.ToString());
+            Assert.AreEqual(Opcode.cfc1, instr.opcode);
         }
 
         [Test]
@@ -531,18 +1061,33 @@ namespace Reko.UnitTests.Arch.Mips
             // Test only the known ones, we'll have to see how this changes things later on with dynamic custom registers
             var instr = DisassembleBits("011111 00000 00011 00000 00000 111011");
             Assert.AreEqual("rdhwr\tr3,00", instr.ToString()); // CPU number
+            Assert.AreEqual(Opcode.rdhwr, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op2, Constant.Byte(0x0), PrimitiveType.Byte);
 
             instr = DisassembleBits("011111 00000 00011 00001 00000 111011");
             Assert.AreEqual("rdhwr\tr3,01", instr.ToString()); // SYNCI step size
+            Assert.AreEqual(Opcode.rdhwr, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op2, Constant.Byte(0x1), PrimitiveType.Byte);
 
             instr = DisassembleBits("011111 00000 00011 00010 00000 111011");
             Assert.AreEqual("rdhwr\tr3,02", instr.ToString()); // Cycle counter
+            Assert.AreEqual(Opcode.rdhwr, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op2, Constant.Byte(0x2), PrimitiveType.Byte);
 
             instr = DisassembleBits("011111 00000 00011 00011 00000 111011");
             Assert.AreEqual("rdhwr\tr3,03", instr.ToString()); // Cycle counter resolution
+            Assert.AreEqual(Opcode.rdhwr, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op2, Constant.Byte(0x3), PrimitiveType.Byte);
 
             instr = DisassembleBits("011111 00000 00011 11101 00000 111011");
             Assert.AreEqual("rdhwr\tr3,1D", instr.ToString()); // OS-specific, thread local pointer on Linux
+            Assert.AreEqual(Opcode.rdhwr, instr.opcode);
+            VerifyRegisterOperand(instr.op1, "r3", PrimitiveType.Word32);
+            VerifyImmediateOperand(instr.op2, Constant.Byte(0x1D), PrimitiveType.Byte);
         }
 
         [Test]

--- a/src/UnitTests/Arch/Mips/MipsDisassemblerTests.cs
+++ b/src/UnitTests/Arch/Mips/MipsDisassemblerTests.cs
@@ -1129,8 +1129,8 @@ namespace Reko.UnitTests.Arch.Mips
             var instr = DisassembleWord(0x45000012); 
             Assert.AreEqual("bc1f\tcc0,0010004C", instr.ToString());
             Assert.AreEqual(Opcode.bc1f, instr.opcode);
-            VerifyRegisterOperand(instr.op1, Registers.cc0, PrimitiveType.Word32);
-            VerifyRegisterOperand(instr.op2, Registers.f0, PrimitiveType.Word32);
+            VerifyRegisterOperand(instr.op1, Registers.cc0, PrimitiveType.Bool);
+            VerifyAddressOperand(instr.op2, Address.Ptr32(0x0010004C), PrimitiveType.Pointer32);
         }
 
         [Test]

--- a/src/UnitTests/Arch/Mips/MipsRewriterTests.cs
+++ b/src/UnitTests/Arch/Mips/MipsRewriterTests.cs
@@ -120,6 +120,23 @@ namespace Reko.UnitTests.Arch.Mips
         }
 
         [Test]
+        public void MipsRw_sc()
+        {
+            RunTest("111000 01010 10101 1111111111001000");
+            AssertCode(
+                "0|L--|00100000(4): 1 instructions",
+                "1|L--|r21 = __store_conditional_32(Mem0[r10 - 0x00000038:word32], r21)");
+        }
+        [Test]
+        public void MipsRw_scd()
+        {
+            RunTest("111100 01010 10101 1111111111001000");
+            AssertCode(
+                "0|L--|00100000(4): 1 instructions",
+                "1|L--|r21 = __store_conditional_64(Mem0[r10 - 0x00000038:word64], r21)");
+        }
+
+        [Test]
         public void MipsRw_ori_r0()
         {
             RunTest("001101 00000 00101 1111100000100111");


### PR DESCRIPTION
fixed MipsDisassembler bug

Take a look at the unit tests, these currently fail, however that is because we do not have a Mips64Architecture and have to split the failing instructions off from the MIPS32 instructions.

Similarly take a look at the last couple unit tests, can we figure out a way to make these special registers (cc0, FCSR, ...) also accessible for these kinds of checks?

Whether you wanna merge this or not despite the failing test cases is up to you, we can even merge everything but them and then figure out how to solve this after.