### PR TITLE
UserSignatureBuilder: do not overwrite data type of register

### DIFF
--- a/src/Decompiler/Analysis/UserSignatureBuilder.cs
+++ b/src/Decompiler/Analysis/UserSignatureBuilder.cs
@@ -122,7 +122,6 @@ namespace Reko.Analysis
                 else
                 {
                     var paramId = proc.Frame.EnsureIdentifier(param.Storage);
-                    paramId.DataType = param.DataType;
 
                     // Need to take an extra step with parameters being passed
                     // in a register. It's perfectly possible for a user to 

--- a/src/UnitTests/Analysis/UserSignatureBuilderTests.cs
+++ b/src/UnitTests/Analysis/UserSignatureBuilderTests.cs
@@ -22,6 +22,7 @@ using NUnit.Framework;
 using Reko.Analysis;
 using Reko.Core;
 using Reko.Core.CLanguage;
+using Reko.Core.Code;
 using Reko.Core.Expressions;
 using Reko.Core.Serialization;
 using Reko.Core.Types;
@@ -92,6 +93,25 @@ namespace Reko.UnitTests.Analysis
             Assert.AreEqual(
                 "fn(arg(prim(SignedInt,4)),(arg(ptr(prim(Character,1))))",
                 sProc.Signature.ToString());
+        }
+
+        [Test(Description = "Verifies that data type of register was not overwritten.")]
+        public void Usb_BuildSignature_KeepRegisterType()
+        {
+            Given_Procedure(0x1000);
+            Given_UserSignature(0x01000, "void test([[reko::arg(register,\"ecx\")]] float f)");
+
+            var usb = new UserSignatureBuilder(program);
+            usb.BuildSignature(Address.Ptr32(0x1000), proc);
+
+            var ass = proc.Statements
+                .Select(stm => stm.Instruction as Assignment)
+                .Where(instr => instr != null)
+                .Single();
+            Assert.AreEqual("ecx = f", ass.ToString());
+            // verify that data type of register was not overwritten
+            Assert.AreEqual("word32", ass.Dst.DataType.ToString());
+            Assert.AreEqual("real32", ass.Src.DataType.ToString());
         }
 
         [Test]


### PR DESCRIPTION
- Modify `UserSignatureBuilder`. Do not overwrite data type of register if it used for parameter passing. Overwriting data type of register caused incorrect types of ALL occurrences of this register identifier in procedure.
.- Add unit test to verify it