### PR TITLE
WineSpec: Added Support for fixed-size integer types

### DIFF
--- a/src/Environments/Windows/WineSpecFileLoader.cs
+++ b/src/Environments/Windows/WineSpecFileLoader.cs
@@ -195,6 +195,24 @@ namespace Reko.Environments.Windows
             case "wstr":
                 type = PointerType_v1.Create(PrimitiveType_v1.WChar16(), 4);
                 break;
+			case "uint16":
+				type = PrimitiveType_v1.UInt16();
+				break;
+			case "uint32":
+				type = PrimitiveType_v1.UInt32();
+				break;
+			case "uint64":
+				type = PrimitiveType_v1.UInt64();
+				break;
+			case "int16":
+				type = PrimitiveType_v1.Int16();
+				break;
+			case "int32":
+				type = PrimitiveType_v1.Int32();
+				break;
+			case "int64":
+				type = PrimitiveType_v1.Int64();
+				break;
             default: throw new Exception("Unknown: " + tok.Value);
             }
             args.Add(new Argument_v1 { Type = type });


### PR DESCRIPTION
Hey Guys,
Some Wine Specs (e.g. the ntoskrnl.exe.spec) contain fixed-size types such as `int64` instead of `long`, `qword` etc.

This Pull-Request adds support for those types to the WineSpecLoader