### PR TITLE
WineSpecLoader: Fixes loading of Metadata for non-DLL files

### DIFF
--- a/src/Environments/Windows/WineSpecFileLoader.cs
+++ b/src/Environments/Windows/WineSpecFileLoader.cs
@@ -203,7 +203,13 @@ namespace Reko.Environments.Windows
 
         private string DefaultModuleName(string filename)
         {
-            return Path.GetFileNameWithoutExtension(filename).ToUpper() + ".DLL";
+			string libName = Path.GetFileNameWithoutExtension (filename).ToUpper ();
+
+			if (Path.GetExtension (libName).Length > 0) {
+				return libName;
+			} else {
+				return libName + ".DLL";
+			}
         }
 
         private Token Peek()


### PR DESCRIPTION
Since there are some libraries which aren't dlls (ntoskrnl.exe, portcls.sys) the old method of defining the Module Name has failed on those.

Instead of blindly appending .dll we now check for the extension. If there is an extension, then it's no dll file and we should pick whatever extension was defined.