### PR TITLE
Don't crash the Application when a Spec File is invalid.

### DIFF
--- a/src/Gui/Forms/MainFormInteractor.cs
+++ b/src/Gui/Forms/MainFormInteractor.cs
@@ -1,6 +1,6 @@
 #region License
 /* 
- * Copyright (C) 1999-2016 John Källén.
+ * Copyright (C) 1999-2016 John Kï¿½llï¿½n.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -298,8 +298,15 @@ namespace Reko.Gui.Forms
                 loader,
                 this.decompilerSvc.Decompiler.Project,
                 this.sc.RequireService<DecompilerEventListener>());
-            var metadata = projectLoader.LoadMetadataFile(fileName);
-            decompilerSvc.Decompiler.Project.MetadataFiles.Add(metadata);
+
+			try {
+            	var metadata = projectLoader.LoadMetadataFile(fileName);
+	            decompilerSvc.Decompiler.Project.MetadataFiles.Add(metadata);
+			}
+			catch (Exception e)
+			{
+				uiSvc.ShowError (e, "An error occured while parsing the metadata file {0}", fileName);
+			}
         }
 
         public bool AssembleFile()


### PR DESCRIPTION
Without this, the Application would crash when you specify an invalid Wine Spec File.
Instead it would be better to just warn the user.

Note: It might be desirable to remove the MetadataFile from the Project again to enable re-adding the file when the errors have been fixed. Since I wasn't sure on how this should be implemented, I didn't do that.

Note2: For some reason my new git client messes things up (UTF-8 and Intendation), sorry for that