### PR TITLE
X86: emit cast for div/idiv

### DIFF
--- a/src/Arch/X86/X86Rewriter.Alu.cs
+++ b/src/Arch/X86/X86Rewriter.Alu.cs
@@ -324,7 +324,7 @@ namespace Reko.Arch.X86
                 orw.AddrOf(orw.AluRegister(Registers.al))));
         }
 
-        private void RewriteDivide(BinaryOperator op, Domain domain)
+        private void RewriteDivide(Func<Expression, Expression, Expression> op, Domain domain)
         {
             if (instrCur.Operands != 1)
                 throw new ArgumentOutOfRangeException("Intel DIV/IDIV instructions only take one operand");
@@ -362,10 +362,10 @@ namespace Reko.Arch.X86
             emitter.Assign(tmp, regDividend);
             emitter.Assign(
                 regRemainder, 
-                new BinaryExpression(Operator.IMod, p, tmp, SrcOp(instrCur.op1)));
+                emitter.Cast(p, emitter.Mod(tmp, SrcOp(instrCur.op1))));
             emitter.Assign(
                 regQuotient, 
-                new BinaryExpression(op, p, tmp, SrcOp(instrCur.op1)));
+                emitter.Cast(p, op(tmp, SrcOp(instrCur.op1))));
             EmitCcInstr(regQuotient, X86Instruction.DefCc(instrCur.code));
         }
 

--- a/src/Arch/X86/X86Rewriter.cs
+++ b/src/Arch/X86/X86Rewriter.cs
@@ -131,7 +131,7 @@ namespace Reko.Arch.X86
                 case Opcode.daa: EmitDaaDas("__daa"); break;
                 case Opcode.das: EmitDaaDas("__das"); break;
                 case Opcode.dec: RewriteIncDec(-1); break;
-                case Opcode.div: RewriteDivide(Operator.UDiv, Domain.UnsignedInt); break;
+                case Opcode.div: RewriteDivide(emitter.UDiv, Domain.UnsignedInt); break;
                 case Opcode.enter: RewriteEnter(); break;
                 case Opcode.fabs: RewriteFabs(); break;
                 case Opcode.fadd: EmitCommonFpuInstruction(emitter.FAdd, false, false); break;
@@ -196,7 +196,7 @@ namespace Reko.Arch.X86
                 case Opcode.fxch: RewriteExchange(); break;
                 case Opcode.fyl2x: RewriteFyl2x(); break;
                 case Opcode.hlt: RewriteHlt(); break;
-                case Opcode.idiv: RewriteDivide(Operator.SDiv, Domain.SignedInt); break;
+                case Opcode.idiv: RewriteDivide(emitter.SDiv, Domain.SignedInt); break;
                 case Opcode.@in: RewriteIn(); break;
                 case Opcode.imul: RewriteMultiply(Operator.SMul, Domain.SignedInt); break;
                 case Opcode.inc: RewriteIncDec(1); break;

--- a/src/UnitTests/Arch/Intel/X86RewriterTests.cs
+++ b/src/UnitTests/Arch/Intel/X86RewriterTests.cs
@@ -879,8 +879,8 @@ namespace Reko.UnitTests.Arch.Intel
             AssertCode(
                 "0|L--|0C00:0000(2): 4 instructions",
                 "1|L--|v5 = dx_ax",
-                "2|L--|dx = v5 % cx",
-                "3|L--|ax = v5 /u cx",
+                "2|L--|dx = (uint16) (v5 % cx)",
+                "3|L--|ax = (uint16) (v5 /u cx)",
                 "4|L--|SCZO = cond(ax)");
         }
 
@@ -894,8 +894,8 @@ namespace Reko.UnitTests.Arch.Intel
             AssertCode(
                     "0|L--|0C00:0000(2): 4 instructions",
                     "1|L--|v5 = dx_ax",
-                    "2|L--|dx = v5 % cx",
-                    "3|L--|ax = v5 / cx",
+                    "2|L--|dx = (int16) (v5 % cx)",
+                    "3|L--|ax = (int16) (v5 / cx)",
                     "4|L--|SCZO = cond(ax)");
         }
 
@@ -1433,8 +1433,8 @@ namespace Reko.UnitTests.Arch.Intel
             AssertCode(
                   "0|L--|10000000(4): 4 instructions",
                   "1|L--|v5 = edx_eax",
-                  "2|L--|edx = v5 % Mem0[esp + 0x00000004:word32]",
-                  "3|L--|eax = v5 / Mem0[esp + 0x00000004:word32]",
+                  "2|L--|edx = (int32) (v5 % Mem0[esp + 0x00000004:word32])",
+                  "3|L--|eax = (int32) (v5 / Mem0[esp + 0x00000004:word32])",
                   "4|L--|SCZO = cond(eax)");
         }
     }

--- a/src/tests/Intel/RwDivideTests.exp
+++ b/src/tests/Intel/RwDivideTests.exp
@@ -9,14 +9,14 @@ l0C00_0000:
 	eax = 0x00000064
 	edx_eax = (int64) eax
 	v7 = edx_eax
-	edx = v7 % ebx
-	eax = v7 / ebx
+	edx = (int32) (v7 % ebx)
+	eax = (int32) (v7 / ebx)
 	SCZO = cond(eax)
 	cx = Mem0[ds:si:word16]
 	ax = Mem0[ds:si + 0x0002:word16]
 	dx = Mem0[ds:si + 0x0004:word16]
 	v15 = dx_ax
-	dx = v15 % cx
-	ax = v15 /u cx
+	dx = (uint16) (v15 % cx)
+	ax = (uint16) (v15 /u cx)
 	SCZO = cond(ax)
 fn0C00_0000_exit:

--- a/subjects/PE-x86/VCExeSample/VCExeSample.c
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.c
@@ -82,15 +82,15 @@ void loop_test9(real32 rArg04, real64 rArg0)
 
 void const_div_test10(word32 dwArg04)
 {
-	Eq_207 eax_16 = 0x0A;
-	Eq_209 ecx_19 = 0x03;
+	uint32 eax_16 = 0x0A;
+	uint32 ecx_19 = 0x03;
 	if (dwArg04 != 0x00)
 	{
-		eax_16.u1 = 0x03;
-		ecx_19.u1 = 0x01;
+		eax_16 = 0x03;
+		ecx_19 = 0x01;
 	}
-	globals->t40301C = ecx_19;
-	globals->t403020 = eax_16;
+	globals->dw40301C = ecx_19;
+	globals->dw403020 = eax_16;
 	return;
 }
 

--- a/subjects/PE-x86/VCExeSample/VCExeSample.dis
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.dis
@@ -374,8 +374,8 @@ l004012A0:
 // SymbolicIn: esp:fp
 
 l004012B4:
-	eax_16 = 0x0000000000000003
-	ecx_19 = 0x0000000000000001
+	eax_16 = 0x00000003
+	ecx_19 = 0x00000001
 // DataOut: eax ecx
 // DataOut (flags): 
 // SymbolicIn: esp:fp - 0x00000004 ebp:fp - 0x00000004 eax:0x0000000A ecx:0x00000003 edx:<invalid> -4(fp):ebp

--- a/subjects/PE-x86/VCExeSample/VCExeSample.globals.c
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.globals.c
@@ -16,7 +16,7 @@ real32 g_r4020EC = 1000.1F;
 real64 g_r4020F0 = 321.0;
 real64 g_r4020F8 = 123.0;
 cdecl_class_ptr g_gbl_c = null;
-Eq_209 g_t40301C = ;
-Eq_207 g_t403020 = ;
+uint32 g_dw40301C = 0x00000000;
+uint32 g_dw403020 = 0x00000000;
 thiscall_class * g_gbl_thiscall = null;
 

--- a/subjects/PE-x86/VCExeSample/VCExeSample.h
+++ b/subjects/PE-x86/VCExeSample/VCExeSample.h
@@ -4,7 +4,7 @@
 
 /*
 // Equivalence classes ////////////
-Eq_1: (struct "Globals" (4020C0 (str char) str4020C0) (4020C8 (str char) str4020C8) (4020D4 (str char) str4020D4) (4020D8 (str char) str4020D8) (4020DC (str char) str4020DC) (4020E0 (str char) str4020E0) (4020E4 real32 r4020E4) (4020E8 real32 r4020E8) (4020EC real32 r4020EC) (4020F0 real64 r4020F0) (4020F8 real64 r4020F8) (403018 cdecl_class_ptr gbl_c) (40301C Eq_209 t40301C) (403020 Eq_207 t403020) (403024 (ptr thiscall_class) gbl_thiscall))
+Eq_1: (struct "Globals" (4020C0 (str char) str4020C0) (4020C8 (str char) str4020C8) (4020D4 (str char) str4020D4) (4020D8 (str char) str4020D8) (4020DC (str char) str4020DC) (4020E0 (str char) str4020E0) (4020E4 real32 r4020E4) (4020E8 real32 r4020E8) (4020EC real32 r4020EC) (4020F0 real64 r4020F0) (4020F8 real64 r4020F8) (403018 cdecl_class_ptr gbl_c) (40301C uint32 dw40301C) (403020 uint32 dw403020) (403024 (ptr thiscall_class) gbl_thiscall))
 	globals_t (in globals : (ptr (struct "Globals")))
 Eq_5: (fn void ((ptr char), int32, (ptr char), real32))
 	T_5 (in test1 : ptr32)
@@ -165,16 +165,6 @@ Eq_200: (fn void ((ptr thiscall_class), real64))
 	T_200 (in Mem39[Mem39[Mem39[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
 Eq_201: thiscall_class
 	T_201 (in 0x00403024 : ptr32)
-Eq_207: (union "Eq_207" (word32 u0) (uipr64 u1))
-	T_207 (in eax_16 : Eq_207)
-	T_208 (in 0x0000000A : word32)
-	T_217 (in Mem21[0x00403020:word32] : word32)
-	T_218 (in 0x0000000000000003 : uipr64)
-Eq_209: (union "Eq_209" (word32 u0) (uipr64 u1))
-	T_209 (in ecx_19 : Eq_209)
-	T_210 (in 0x00000003 : word32)
-	T_215 (in Mem20[0x0040301C:word32] : word32)
-	T_219 (in 0x0000000000000001 : uipr64)
 // Type Variables ////////////
 globals_t: (in globals : (ptr (struct "Globals")))
   Class: Eq_1
@@ -1000,21 +990,21 @@ T_206: (in dwArg04 : word32)
   Class: Eq_206
   DataType: word32
   OrigDataType: word32
-T_207: (in eax_16 : Eq_207)
+T_207: (in eax_16 : uint32)
   Class: Eq_207
-  DataType: Eq_207
-  OrigDataType: uipr64
+  DataType: uint32
+  OrigDataType: uint32
 T_208: (in 0x0000000A : word32)
   Class: Eq_207
-  DataType: word32
+  DataType: uint32
   OrigDataType: word32
-T_209: (in ecx_19 : Eq_209)
+T_209: (in ecx_19 : uint32)
   Class: Eq_209
-  DataType: Eq_209
-  OrigDataType: uipr64
+  DataType: uint32
+  OrigDataType: uint32
 T_210: (in 0x00000003 : word32)
   Class: Eq_209
-  DataType: word32
+  DataType: uint32
   OrigDataType: word32
 T_211: (in dwArg04 : word32)
   Class: Eq_211
@@ -1030,28 +1020,28 @@ T_213: (in dwArg04 == 0x00000000 : bool)
   OrigDataType: bool
 T_214: (in 0x0040301C : ptr32)
   Class: Eq_214
-  DataType: (ptr Eq_209)
+  DataType: (ptr uint32)
   OrigDataType: (ptr (struct (0 T_215 t0000)))
 T_215: (in Mem20[0x0040301C:word32] : word32)
   Class: Eq_209
-  DataType: Eq_209
+  DataType: uint32
   OrigDataType: word32
 T_216: (in 0x00403020 : word32)
   Class: Eq_216
-  DataType: (ptr Eq_207)
+  DataType: (ptr uint32)
   OrigDataType: (ptr (struct (0 T_217 t0000)))
 T_217: (in Mem21[0x00403020:word32] : word32)
   Class: Eq_207
-  DataType: Eq_207
+  DataType: uint32
   OrigDataType: word32
-T_218: (in 0x0000000000000003 : uipr64)
+T_218: (in 0x00000003 : uint32)
   Class: Eq_207
-  DataType: uipr64
-  OrigDataType: uipr64
-T_219: (in 0x0000000000000001 : uipr64)
+  DataType: uint32
+  OrigDataType: uint32
+T_219: (in 0x00000001 : uint32)
   Class: Eq_209
-  DataType: uipr64
-  OrigDataType: uipr64
+  DataType: uint32
+  OrigDataType: uint32
 */
 typedef struct Globals {
 	char str4020C0[];	// 4020C0
@@ -1066,8 +1056,8 @@ typedef struct Globals {
 	real64 r4020F0;	// 4020F0
 	real64 r4020F8;	// 4020F8
 	cdecl_class_ptr gbl_c;	// 403018
-	Eq_209 t40301C;	// 40301C
-	Eq_207 t403020;	// 403020
+	uint32 dw40301C;	// 40301C
+	uint32 dw403020;	// 403020
 	thiscall_class * gbl_thiscall;	// 403024
 } Eq_1;
 
@@ -1214,14 +1204,4 @@ typedef void (Eq_199)(thiscall_class * this, real64 rArg04);
 typedef void (Eq_200)(thiscall_class *, real64);
 
 typedef thiscall_class Eq_201;
-
-typedef union Eq_207 {
-	word32 u0;
-	uipr64 u1;
-} Eq_207;
-
-typedef union Eq_209 {
-	word32 u0;
-	uipr64 u1;
-} Eq_209;
 

--- a/subjects/PE-x86/pySample/pySample.c
+++ b/subjects/PE-x86/pySample/pySample.c
@@ -26,7 +26,7 @@ PyObject * fn100010A0(PyObject * ptrArg04, PyObject * ptrArg08)
 {
 	PyObject * eax_20 = PyArg_ParseTuple(ptrArg08, "ii:div", fp - 0x08, fp - 0x04);
 	if (eax_20 != null)
-		return Py_BuildValue("i", (int64) dwLoc08 / dwLoc04);
+		return Py_BuildValue("i", (int32) ((int64) dwLoc08 / dwLoc04));
 	else
 		return eax_20;
 }
@@ -62,7 +62,7 @@ void initpySample()
 word32 fn100011E9(word32 dwArg08)
 {
 	word32 eax_123;
-	Eq_138 ebp_203 = 0x00;
+	Eq_139 ebp_203 = 0x00;
 	if (dwArg08 == 0x00)
 	{
 		if (globals->dw10003070 <= 0x00)
@@ -75,10 +75,10 @@ word32 fn100011E9(word32 dwArg08)
 	globals->dw100033A4 = *adjust_fdiv;
 	if (dwArg08 == 0x01)
 	{
-		Eq_138 edi_82 = fs->ptr0018->t0004;
+		Eq_139 edi_82 = fs->ptr0018->t0004;
 		while (true)
 		{
-			Eq_138 eax_93 = InterlockedCompareExchange(&globals->t100033AC, edi_82, 0x00);
+			Eq_139 eax_93 = InterlockedCompareExchange(&globals->t100033AC, edi_82, 0x00);
 			if (eax_93 == 0x00)
 				break;
 			if (eax_93 == edi_82)
@@ -120,7 +120,7 @@ word32 fn100011E9(word32 dwArg08)
 				word32 ebx_184;
 				word32 esi_185;
 				word32 edi_186;
-				struct Eq_391 * fs_187;
+				struct Eq_392 * fs_187;
 				globals->ptr100033B8();
 			}
 		}
@@ -155,7 +155,7 @@ word32 fn100011E9(word32 dwArg08)
 					byte Z_295;
 					word32 ecx_296;
 					word32 esi_298;
-					struct Eq_331 * fs_300;
+					struct Eq_332 * fs_300;
 					eax_285();
 				}
 			}
@@ -179,15 +179,15 @@ word32 fn100011E9(word32 dwArg08)
 
 word32 fn10001388(LPVOID ecx, DWORD edx,  * ebx, ptr32 esi, word32 edi)
 {
-	struct Eq_400 * ebp_10 = fn100017E8(ebx, esi, edi, dwLoc0C, 0x100021E8, 0x10);
+	struct Eq_401 * ebp_10 = fn100017E8(ebx, esi, edi, dwLoc0C, 0x100021E8, 0x10);
 	ui32 ebx_158 = ebp_10->dw0008;
 	*(ebp_10 - 0x1C) = 0x01;
 	*(ebp_10 - 0x04) = 0x00;
 	globals->t10003008 = edx;
 	*(ebp_10 - 0x04) = 0x01;
 	ptr32 esp_175 = fp - 0x08;
-	Eq_395 edi_12 = ecx;
-	Eq_197 esi_14 = edx;
+	Eq_396 edi_12 = ecx;
+	Eq_198 esi_14 = edx;
 	if (edx == 0x00 && globals->dw10003070 == 0x00)
 	{
 		*(ebp_10 - 0x1C) = 0x00;
@@ -318,19 +318,19 @@ word32 fn100016D0(word32 dwArg04)
 {
 	if (dwArg04->w0000 == 23117)
 	{
-		struct Eq_764 * eax_21 = dwArg04 + dwArg04->dw003C / 0x0040;
+		struct Eq_765 * eax_21 = dwArg04 + dwArg04->dw003C / 0x0040;
 		if (eax_21->dw0000 == 0x4550)
 			return (word32) (eax_21->w0018 == 0x010B);
 	}
 	return 0x00;
 }
 
-Eq_781 * fn10001700(word32 dwArg04, word32 dwArg08)
+Eq_782 * fn10001700(word32 dwArg04, word32 dwArg08)
 {
-	struct Eq_784 * ecx_6 = dwArg04 + dwArg04->dw003C / 0x0040;
+	struct Eq_785 * ecx_6 = dwArg04 + dwArg04->dw003C / 0x0040;
 	uint32 esi_14 = (word32) ecx_6->w0006;
 	uint32 edx_15 = 0x00;
-	struct Eq_781 * eax_22 = (ecx_6 + ((word32) ecx_6->w0014 + 0x18) / 22)->w0006 + 0x03;
+	struct Eq_782 * eax_22 = (ecx_6 + ((word32) ecx_6->w0014 + 0x18) / 22)->w0006 + 0x03;
 	if (true)
 	{
 		do
@@ -349,14 +349,14 @@ Eq_781 * fn10001700(word32 dwArg04, word32 dwArg08)
 ui32 fn10001742( * ebx, ptr32 esi, word32 edi, ptr32 & ediOut)
 {
 	ui32 eax_31;
-	struct Eq_400 * ebp_10 = fn100017E8(ebx, esi, edi, dwLoc0C, 0x10002230, 0x08);
+	struct Eq_401 * ebp_10 = fn100017E8(ebx, esi, edi, dwLoc0C, 0x10002230, 0x08);
 	*(ebp_10 - 0x04) = *(ebp_10 - 0x04) & 0x00;
 	*(fp - 0x0C) = 0x10000000;
 	if (fn100016D0(dwArg00) != 0x00)
 	{
 		*(fp - 0x0C) = ebp_10->dw0008 - 0x10000000;
 		*(fp - 0x10) = 0x10000000;
-		struct Eq_881 * eax_54 = fn10001700(dwArg00, dwArg04);
+		struct Eq_882 * eax_54 = fn10001700(dwArg00, dwArg04);
 		if (eax_54 != null)
 		{
 			eax_31 = ~(eax_54->dw0024 >> 0x1F) & 0x01;
@@ -382,7 +382,7 @@ word32 fn100017C6(word32 dwArg04, word32 dwArg08)
 ptr32 fn100017E8( * ebx, ptr32 esi, word32 edi, word32 dwArg00, word32 dwArg04, word32 dwArg08)
 {
 	ptr32 esp_14 = fp - 0x08 - dwArg08;
-	*(esp_14 - 0x04) = (Eq_138 (**)(LONG *, Eq_138, Eq_138)) ebx;
+	*(esp_14 - 0x04) = (Eq_139 (**)(LONG *, Eq_139, Eq_139)) ebx;
 	*(esp_14 - 0x08) = esi;
 	*(esp_14 - 0x0C) = edi;
 	*(esp_14 - 0x10) = globals->dw10003000 ^ fp + 0x08;
@@ -391,7 +391,7 @@ ptr32 fn100017E8( * ebx, ptr32 esi, word32 edi, word32 dwArg00, word32 dwArg04, 
 	return fp + 0x08;
 }
 
-word32 fn1000182D(Eq_400 * ebp, word32 dwArg00, word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10)
+word32 fn1000182D(Eq_401 * ebp, word32 dwArg00, word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10)
 {
 	fs->dw0000 = *(ebp - 0x10);
 	ebp->dw0000 = dwArg00;

--- a/subjects/PE-x86/pySample/pySample.dis
+++ b/subjects/PE-x86/pySample/pySample.dis
@@ -103,7 +103,7 @@ l100010A0:
 // LocalsOut: fp(32) Local -0004(32) Local -0008(32)
 
 l100010C8:
-	return Py_BuildValue(0x1000214C, (int64) dwLoc08 / dwLoc04)
+	return Py_BuildValue(0x1000214C, (int32) ((int64) dwLoc08 / dwLoc04))
 // DataOut:
 // DataOut (flags): 
 // SymbolicIn: esp:fp - 0x00000008 edx:ptrArg08 eax:<invalid> ecx:fp - 0x00000008 -24(fp):ptrArg08 -20(fp):0x10002158 -16(fp):fp - 0x00000008 -12(fp):fp - 0x00000004 4(fp):ptrArg04 8(fp):ptrArg08

--- a/subjects/PE-x86/pySample/pySample.globals.c
+++ b/subjects/PE-x86/pySample/pySample.globals.c
@@ -4,10 +4,10 @@
 
 #include "pySample.h"
 
-Eq_283 g_t10002098 = null;
-Eq_284 g_t1000209C = null;
-Eq_228 g_t100020A0 = null;
-Eq_229 g_t100020A8 = null;
+Eq_284 g_t10002098 = null;
+Eq_285 g_t1000209C = null;
+Eq_229 g_t100020A0 = null;
+Eq_230 g_t100020A8 = null;
 <anonymous> * g_ptr100020CC = null;
 char g_str100020E0[] = "fdiv(a, b) = a / b";
 char g_str100020F4[] = "fdiv";
@@ -27,7 +27,7 @@ char g_str1000216C[] = ":unused";
 char g_str10002174[] = "pySample";
 ui32 g_dw10003000 = 0xBB40E64E;
 ui32 g_dw10003004 = 0x44BF19B1;
-Eq_197 g_t10003008 = 0xFFFFFFFF;
+Eq_198 g_t10003008 = 0xFFFFFFFF;
 PyMethodDef g_methods[5] = 
 	{
 		
@@ -69,7 +69,7 @@ PyMethodDef g_methods[5] =
 int32 g_dw10003070 = 0;
 word32 g_dw100033A4 = 0x00000000;
 word32 g_dw100033A8 = 0x00000000;
-Eq_174 g_t100033AC = 0;
+Eq_175 g_t100033AC = 0;
 void * g_ptr100033B0 = null;
 void * g_ptr100033B4 = null;
 <anonymous> * g_ptr100033B8 = null;

--- a/subjects/PE-x86/pySample/pySample.h
+++ b/subjects/PE-x86/pySample/pySample.h
@@ -4,7 +4,7 @@
 
 /*
 // Equivalence classes ////////////
-Eq_1: (struct "Globals" (10002098 Eq_283 t10002098) (1000209C Eq_284 t1000209C) (100020A0 Eq_228 t100020A0) (100020A8 Eq_229 t100020A8) (100020CC (ptr code) ptr100020CC) (100020E0 (str char) str100020E0) (100020F4 (str char) str100020F4) (100020FC (str char) str100020FC) (10002110 (str char) str10002110) (10002114 (str char) str10002114) (10002128 (str char) str10002128) (1000212C (str char) str1000212C) (10002140 (str char) str10002140) (10002144 (str char) str10002144) (1000214C (str char) str1000214C) (10002150 (str char) str10002150) (10002158 (str char) str10002158) (10002160 (str char) str10002160) (10002168 (str char) str10002168) (1000216C (str char) str1000216C) (10002174 (str char) str10002174) (10003000 ui32 dw10003000) (10003004 ui32 dw10003004) (10003008 Eq_197 t10003008) (10003010 (arr PyMethodDef 5) methods) (10003070 int32 dw10003070) (100033A4 word32 dw100033A4) (100033A8 word32 dw100033A8) (100033AC Eq_174 t100033AC) (100033B0 (ptr void) ptr100033B0) (100033B4 (ptr void) ptr100033B4) (100033B8 (ptr code) ptr100033B8))
+Eq_1: (struct "Globals" (10002098 Eq_284 t10002098) (1000209C Eq_285 t1000209C) (100020A0 Eq_229 t100020A0) (100020A8 Eq_230 t100020A8) (100020CC (ptr code) ptr100020CC) (100020E0 (str char) str100020E0) (100020F4 (str char) str100020F4) (100020FC (str char) str100020FC) (10002110 (str char) str10002110) (10002114 (str char) str10002114) (10002128 (str char) str10002128) (1000212C (str char) str1000212C) (10002140 (str char) str10002140) (10002144 (str char) str10002144) (1000214C (str char) str1000214C) (10002150 (str char) str10002150) (10002158 (str char) str10002158) (10002160 (str char) str10002160) (10002168 (str char) str10002168) (1000216C (str char) str1000216C) (10002174 (str char) str10002174) (10003000 ui32 dw10003000) (10003004 ui32 dw10003004) (10003008 Eq_198 t10003008) (10003010 (arr PyMethodDef 5) methods) (10003070 int32 dw10003070) (100033A4 word32 dw100033A4) (100033A8 word32 dw100033A8) (100033AC Eq_175 t100033AC) (100033B0 (ptr void) ptr100033B0) (100033B4 (ptr void) ptr100033B4) (100033B8 (ptr code) ptr100033B8))
 	globals_t (in globals : (ptr (struct "Globals")))
 Eq_2: PyObject
 	T_2 (in eax : (ptr Eq_2))
@@ -19,17 +19,17 @@ Eq_2: PyObject
 	T_52 (in eax_20 : (ptr Eq_2))
 	T_63 (in PyArg_ParseTuple(ptrArg08, "ii:div", fp - 0x00000008, fp - 0x00000004) : int32)
 	T_64 (in 0x00000000 : word32)
-	T_74 (in Py_BuildValue("i", (int64) dwLoc08 / dwLoc04) : (ptr PyObject))
-	T_75 (in eax_20 : (ptr Eq_2))
-	T_86 (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", fp - 0x00000008, fp - 0x00000004) : int32)
-	T_87 (in 0x00000000 : word32)
-	T_97 (in Py_BuildValue("f", (real64) rLoc08 / rLoc04) : (ptr PyObject))
+	T_75 (in Py_BuildValue("i", (int32) ((int64) dwLoc08 / dwLoc04)) : (ptr PyObject))
+	T_76 (in eax_20 : (ptr Eq_2))
+	T_87 (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", fp - 0x00000008, fp - 0x00000004) : int32)
+	T_88 (in 0x00000000 : word32)
+	T_98 (in Py_BuildValue("f", (real64) rLoc08 / rLoc04) : (ptr PyObject))
 Eq_3: PyObject
 	T_3 (in ptrArg04 : (ptr Eq_3))
 Eq_4: PyObject
 	T_4 (in ptrArg08 : (ptr Eq_4))
 	T_8 (in ptrArg04 : (ptr PyObject))
-	T_104 (in args : (ptr PyObject))
+	T_105 (in args : (ptr PyObject))
 Eq_6: (fn (ptr Eq_2) ((ptr Eq_4), (ptr char), (ptr int32), (ptr int32)))
 	T_6 (in PyArg_ParseTuple : ptr32)
 	T_7 (in signature of PyArg_ParseTuple : void)
@@ -48,275 +48,275 @@ Eq_53: (fn (ptr Eq_2) ((ptr Eq_4), (ptr char), (ptr int32), (ptr int32)))
 Eq_66: (fn (ptr Eq_2) ((ptr char), int32))
 	T_66 (in Py_BuildValue : ptr32)
 	T_67 (in signature of Py_BuildValue : void)
-Eq_76: (fn (ptr Eq_2) ((ptr Eq_4), (ptr char), (ptr real32), (ptr real32)))
-	T_76 (in PyArg_ParseTuple : ptr32)
-	T_77 (in signature of PyArg_ParseTuple : void)
-Eq_89: (fn (ptr Eq_2) ((ptr char), real64))
-	T_89 (in Py_BuildValue : ptr32)
-	T_90 (in signature of Py_BuildValue : void)
-Eq_95: (union "Eq_95" (real32 u0) (real64 u1))
-	T_95 (in rLoc04 : real32)
-Eq_98: PyObject
-	T_98 (in eax : (ptr Eq_98))
-	T_101 (in eax_15 : (ptr Eq_98))
-	T_106 (in PyArg_ParseTuple(args, ":unused") : int32)
-	T_107 (in 0x00000000 : word32)
-	T_121 (in &_Py_NoneStruct : word32)
+Eq_77: (fn (ptr Eq_2) ((ptr Eq_4), (ptr char), (ptr real32), (ptr real32)))
+	T_77 (in PyArg_ParseTuple : ptr32)
+	T_78 (in signature of PyArg_ParseTuple : void)
+Eq_90: (fn (ptr Eq_2) ((ptr char), real64))
+	T_90 (in Py_BuildValue : ptr32)
+	T_91 (in signature of Py_BuildValue : void)
+Eq_96: (union "Eq_96" (real32 u0) (real64 u1))
+	T_96 (in rLoc04 : real32)
 Eq_99: PyObject
-	T_99 (in self : (ptr Eq_99))
+	T_99 (in eax : (ptr Eq_99))
+	T_102 (in eax_15 : (ptr Eq_99))
+	T_107 (in PyArg_ParseTuple(args, ":unused") : int32)
+	T_108 (in 0x00000000 : word32)
+	T_122 (in &_Py_NoneStruct : word32)
 Eq_100: PyObject
-	T_100 (in args : (ptr Eq_100))
-Eq_102: (fn (ptr Eq_98) ((ptr Eq_4), (ptr char)))
-	T_102 (in PyArg_ParseTuple : ptr32)
-	T_103 (in signature of PyArg_ParseTuple : void)
-Eq_109: PyObject
-	T_109 (in eax_24 : (ptr Eq_109))
-	T_111 (in &_Py_NoneStruct : word32)
+	T_100 (in self : (ptr Eq_100))
+Eq_101: PyObject
+	T_101 (in args : (ptr Eq_101))
+Eq_103: (fn (ptr Eq_99) ((ptr Eq_4), (ptr char)))
+	T_103 (in PyArg_ParseTuple : ptr32)
+	T_104 (in signature of PyArg_ParseTuple : void)
 Eq_110: PyObject
-	T_110 (in _Py_NoneStruct : PyObject)
-	T_120 (in _Py_NoneStruct : PyObject)
-Eq_122: (fn (ptr Eq_134) ((ptr char), (ptr Eq_125), (ptr char), (ptr Eq_127), int32))
-	T_122 (in Py_InitModule4 : ptr32)
-	T_123 (in signature of Py_InitModule4 : void)
-Eq_125: PyMethodDef
-	T_125 (in ptrArg08 : (ptr PyMethodDef))
-	T_130 (in 0x10003010 : word32)
-Eq_127: PyObject
-	T_127 (in ptrArg10 : (ptr PyObject))
-	T_132 (in 0x00000000 : word32)
-Eq_134: PyObject
-	T_134 (in Py_InitModule4("pySample", globals->methods, null, null, 0x000003EF) : (ptr PyObject))
-Eq_138: LONG
-	T_138 (in ebp_203 : Eq_138)
-	T_139 (in 0x00000000 : word32)
-	T_164 (in edi_82 : Eq_138)
-	T_170 (in Mem45[Mem45[fs:0x00000018:word32] + 0x00000004:word32] : word32)
-	T_171 (in eax_93 : Eq_138)
-	T_175 (in Exchange : LONG)
-	T_176 (in Comperand : LONG)
-	T_178 (in 0x00000000 : word32)
-	T_179 (in InterlockedCompareExchange(&globals->t100033AC, edi_82, 0x00000000) : LONG)
-	T_180 (in 0x00000000 : word32)
-	T_185 (in 0x00000001 : word32)
-	T_186 (in 0x00000000 : word32)
-	T_187 (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) : LONG)
-	T_188 (in 0x00000000 : word32)
-	T_238 (in 0x00000001 : word32)
-	T_245 (in 0x00000000 : word32)
-	T_248 (in Mem252[esp_251 + 0x00000000:word32] : word32)
-	T_261 (in Value : LONG)
-	T_268 (in Mem255[esp_251 + 0x00000000:LONG] : LONG)
-	T_269 (in InterlockedExchange(*(esp_251 - 0x00000004), *esp_251) : LONG)
-	T_291 (in 0x00000000 : word32)
-	T_338 (in InterlockedExchange(&globals->t100033AC, ebp_203) : LONG)
-Eq_165: (segment "Eq_165" (18 (ptr Eq_167) ptr0018))
-	T_165 (in fs : selector)
-Eq_167: (struct "Eq_167" (4 Eq_138 t0004))
-	T_167 (in Mem45[fs:0x00000018:word32] : word32)
-Eq_172: (fn Eq_138 ((ptr Eq_174), Eq_138, Eq_138))
-	T_172 (in InterlockedCompareExchange : ptr32)
-	T_173 (in signature of InterlockedCompareExchange : void)
-	T_183 (in InterlockedCompareExchange : ptr32)
-	T_348 (in ebx : (ptr Eq_172))
-	T_352 (in InterlockedCompareExchange : ptr32)
-	T_397 (in ebx : (ptr Eq_172))
-	T_403 (in ebx : (ptr Eq_172))
-	T_749 (in ebx : word32)
-	T_934 (in Mem17[esp_14 - 0x00000004 + 0x00000000:word32] : word32)
-Eq_174: LONG
-	T_174 (in Destination : (ptr LONG))
-	T_177 (in 0x100033AC : ptr32)
-	T_184 (in 0x100033AC : ptr32)
-Eq_195: (fn void (Eq_197))
-	T_195 (in Sleep : ptr32)
-	T_196 (in signature of Sleep : void)
-	T_239 (in Sleep : ptr32)
-Eq_197: DWORD
-	T_197 (in dwMilliseconds : DWORD)
-	T_198 (in 0x000003E8 : word32)
-	T_240 (in 0x000003E8 : word32)
-	T_396 (in edx : Eq_197)
-	T_430 (in Mem22[0x10003008:word32] : word32)
-	T_442 (in esi_14 : Eq_197)
-	T_443 (in 0x00000000 : word32)
-	T_445 (in 0x00000001 : word32)
-	T_503 (in 0x00000002 : word32)
-	T_515 (in Mem59[esp_56 - 0x00000004 + 0x00000000:word32] : word32)
-	T_535 (in 0x00000001 : word32)
-	T_553 (in Mem197[fp - 0x00000010 + 0x00000000:word32] : word32)
-	T_581 (in Mem185[esp_182 - 0x00000004 + 0x00000000:word32] : word32)
-	T_600 (in 0x00000000 : word32)
-	T_673 (in Mem83[esp_80 - 0x00000004 + 0x00000000:word32] : word32)
-	T_684 (in 0x00000003 : word32)
-	T_716 (in Mem102[esp_80 - 0x00000004 + 0x00000000:word32] : word32)
-	T_738 (in 0xFFFFFFFF : word32)
-	T_740 (in Mem2[0x10003008:word32] : word32)
-	T_743 (in dwReason : Eq_197)
-	T_745 (in 0x00000001 : word32)
-	T_1003 (in GetCurrentProcessId() : DWORD)
-	T_1007 (in GetCurrentThreadId() : DWORD)
-	T_1011 (in GetTickCount() : DWORD)
-Eq_205: (fn (ptr word32) ((ptr void)))
-	T_205 (in _decode_pointer : ptr32)
-	T_206 (in signature of _decode_pointer : void)
-	T_274 (in _decode_pointer : ptr32)
-Eq_213: (struct "Eq_213" (4 word32 dw0004) (C word32 dw000C))
-	T_213 (in fp : ptr32)
-Eq_218: (fn void (int32))
-	T_218 (in _amsg_exit : ptr32)
-	T_219 (in signature of _amsg_exit : void)
-	T_235 (in _amsg_exit : ptr32)
-Eq_226: (fn int32 ((ptr Eq_228), (ptr Eq_229)))
-	T_226 (in _initterm_e : ptr32)
-	T_227 (in signature of _initterm_e : void)
-Eq_228: PVFV
-	T_228 (in fStart : (ptr PVFV))
-	T_230 (in 0x100020A0 : word32)
+	T_110 (in eax_24 : (ptr Eq_110))
+	T_112 (in &_Py_NoneStruct : word32)
+Eq_111: PyObject
+	T_111 (in _Py_NoneStruct : PyObject)
+	T_121 (in _Py_NoneStruct : PyObject)
+Eq_123: (fn (ptr Eq_135) ((ptr char), (ptr Eq_126), (ptr char), (ptr Eq_128), int32))
+	T_123 (in Py_InitModule4 : ptr32)
+	T_124 (in signature of Py_InitModule4 : void)
+Eq_126: PyMethodDef
+	T_126 (in ptrArg08 : (ptr PyMethodDef))
+	T_131 (in 0x10003010 : word32)
+Eq_128: PyObject
+	T_128 (in ptrArg10 : (ptr PyObject))
+	T_133 (in 0x00000000 : word32)
+Eq_135: PyObject
+	T_135 (in Py_InitModule4("pySample", globals->methods, null, null, 0x000003EF) : (ptr PyObject))
+Eq_139: LONG
+	T_139 (in ebp_203 : Eq_139)
+	T_140 (in 0x00000000 : word32)
+	T_165 (in edi_82 : Eq_139)
+	T_171 (in Mem45[Mem45[fs:0x00000018:word32] + 0x00000004:word32] : word32)
+	T_172 (in eax_93 : Eq_139)
+	T_176 (in Exchange : LONG)
+	T_177 (in Comperand : LONG)
+	T_179 (in 0x00000000 : word32)
+	T_180 (in InterlockedCompareExchange(&globals->t100033AC, edi_82, 0x00000000) : LONG)
+	T_181 (in 0x00000000 : word32)
+	T_186 (in 0x00000001 : word32)
+	T_187 (in 0x00000000 : word32)
+	T_188 (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) : LONG)
+	T_189 (in 0x00000000 : word32)
+	T_239 (in 0x00000001 : word32)
+	T_246 (in 0x00000000 : word32)
+	T_249 (in Mem252[esp_251 + 0x00000000:word32] : word32)
+	T_262 (in Value : LONG)
+	T_269 (in Mem255[esp_251 + 0x00000000:LONG] : LONG)
+	T_270 (in InterlockedExchange(*(esp_251 - 0x00000004), *esp_251) : LONG)
+	T_292 (in 0x00000000 : word32)
+	T_339 (in InterlockedExchange(&globals->t100033AC, ebp_203) : LONG)
+Eq_166: (segment "Eq_166" (18 (ptr Eq_168) ptr0018))
+	T_166 (in fs : selector)
+Eq_168: (struct "Eq_168" (4 Eq_139 t0004))
+	T_168 (in Mem45[fs:0x00000018:word32] : word32)
+Eq_173: (fn Eq_139 ((ptr Eq_175), Eq_139, Eq_139))
+	T_173 (in InterlockedCompareExchange : ptr32)
+	T_174 (in signature of InterlockedCompareExchange : void)
+	T_184 (in InterlockedCompareExchange : ptr32)
+	T_349 (in ebx : (ptr Eq_173))
+	T_353 (in InterlockedCompareExchange : ptr32)
+	T_398 (in ebx : (ptr Eq_173))
+	T_404 (in ebx : (ptr Eq_173))
+	T_750 (in ebx : word32)
+	T_935 (in Mem17[esp_14 - 0x00000004 + 0x00000000:word32] : word32)
+Eq_175: LONG
+	T_175 (in Destination : (ptr LONG))
+	T_178 (in 0x100033AC : ptr32)
+	T_185 (in 0x100033AC : ptr32)
+Eq_196: (fn void (Eq_198))
+	T_196 (in Sleep : ptr32)
+	T_197 (in signature of Sleep : void)
+	T_240 (in Sleep : ptr32)
+Eq_198: DWORD
+	T_198 (in dwMilliseconds : DWORD)
+	T_199 (in 0x000003E8 : word32)
+	T_241 (in 0x000003E8 : word32)
+	T_397 (in edx : Eq_198)
+	T_431 (in Mem22[0x10003008:word32] : word32)
+	T_443 (in esi_14 : Eq_198)
+	T_444 (in 0x00000000 : word32)
+	T_446 (in 0x00000001 : word32)
+	T_504 (in 0x00000002 : word32)
+	T_516 (in Mem59[esp_56 - 0x00000004 + 0x00000000:word32] : word32)
+	T_536 (in 0x00000001 : word32)
+	T_554 (in Mem197[fp - 0x00000010 + 0x00000000:word32] : word32)
+	T_582 (in Mem185[esp_182 - 0x00000004 + 0x00000000:word32] : word32)
+	T_601 (in 0x00000000 : word32)
+	T_674 (in Mem83[esp_80 - 0x00000004 + 0x00000000:word32] : word32)
+	T_685 (in 0x00000003 : word32)
+	T_717 (in Mem102[esp_80 - 0x00000004 + 0x00000000:word32] : word32)
+	T_739 (in 0xFFFFFFFF : word32)
+	T_741 (in Mem2[0x10003008:word32] : word32)
+	T_744 (in dwReason : Eq_198)
+	T_746 (in 0x00000001 : word32)
+	T_1004 (in GetCurrentProcessId() : DWORD)
+	T_1008 (in GetCurrentThreadId() : DWORD)
+	T_1012 (in GetTickCount() : DWORD)
+Eq_206: (fn (ptr word32) ((ptr void)))
+	T_206 (in _decode_pointer : ptr32)
+	T_207 (in signature of _decode_pointer : void)
+	T_275 (in _decode_pointer : ptr32)
+Eq_214: (struct "Eq_214" (4 word32 dw0004) (C word32 dw000C))
+	T_214 (in fp : ptr32)
+Eq_219: (fn void (int32))
+	T_219 (in _amsg_exit : ptr32)
+	T_220 (in signature of _amsg_exit : void)
+	T_236 (in _amsg_exit : ptr32)
+Eq_227: (fn int32 ((ptr Eq_229), (ptr Eq_230)))
+	T_227 (in _initterm_e : ptr32)
+	T_228 (in signature of _initterm_e : void)
 Eq_229: PVFV
-	T_229 (in fEnd : (ptr PVFV))
-	T_231 (in 0x100020A8 : word32)
-Eq_258: (fn Eq_138 ((ptr Eq_260), Eq_138))
-	T_258 (in InterlockedExchange : ptr32)
-	T_259 (in signature of InterlockedExchange : void)
-	T_336 (in InterlockedExchange : ptr32)
-Eq_260: LONG
-	T_260 (in Target : (ptr LONG))
-	T_265 (in Mem255[esp_251 - 0x00000004 + 0x00000000:(ptr LONG)] : (ptr LONG))
-	T_337 (in 0x100033AC : ptr32)
-Eq_281: (fn void ((ptr Eq_283), (ptr Eq_284)))
-	T_281 (in _initterm : ptr32)
-	T_282 (in signature of _initterm : void)
-Eq_283: PVFV
-	T_283 (in fStart : (ptr PVFV))
-	T_285 (in 0x10002098 : word32)
+	T_229 (in fStart : (ptr PVFV))
+	T_231 (in 0x100020A0 : word32)
+Eq_230: PVFV
+	T_230 (in fEnd : (ptr PVFV))
+	T_232 (in 0x100020A8 : word32)
+Eq_259: (fn Eq_139 ((ptr Eq_261), Eq_139))
+	T_259 (in InterlockedExchange : ptr32)
+	T_260 (in signature of InterlockedExchange : void)
+	T_337 (in InterlockedExchange : ptr32)
+Eq_261: LONG
+	T_261 (in Target : (ptr LONG))
+	T_266 (in Mem255[esp_251 - 0x00000004 + 0x00000000:(ptr LONG)] : (ptr LONG))
+	T_338 (in 0x100033AC : ptr32)
+Eq_282: (fn void ((ptr Eq_284), (ptr Eq_285)))
+	T_282 (in _initterm : ptr32)
+	T_283 (in signature of _initterm : void)
 Eq_284: PVFV
-	T_284 (in fEnd : (ptr PVFV))
-	T_286 (in 0x1000209C : word32)
-Eq_306: (fn void ((ptr word32)))
-	T_306 (in free : ptr32)
-	T_307 (in signature of free : void)
-Eq_314: (fn (ptr void) ())
-	T_314 (in _encoded_null : ptr32)
-	T_315 (in signature of _encoded_null : void)
-Eq_331: (segment "Eq_331")
-	T_331 (in fs_300 : (ptr Eq_331))
-Eq_346: (fn word32 ((ptr Eq_172), ptr32, word32, ptr32))
-	T_346 (in fn10001742 : ptr32)
-	T_347 (in signature of fn10001742 : void)
-Eq_391: (segment "Eq_391")
-	T_391 (in fs_187 : (ptr Eq_391))
-Eq_395: LPVOID
-	T_395 (in ecx : Eq_395)
-	T_441 (in edi_12 : Eq_395)
-	T_510 (in Mem57[esp_56 + 0x00000000:word32] : word32)
-	T_548 (in Mem195[fp - 0x0000000C + 0x00000000:word32] : word32)
-	T_576 (in Mem183[esp_182 + 0x00000000:word32] : word32)
-	T_606 (in Mem128[esp_56 + 0x00000000:word32] : word32)
-	T_621 (in Mem136[esp_56 + 0x00000000:word32] : word32)
-	T_644 (in Mem148[esp_56 + 0x00000000:word32] : word32)
-	T_668 (in Mem81[esp_80 + 0x00000000:word32] : word32)
-	T_711 (in Mem100[esp_80 + 0x00000000:word32] : word32)
-	T_744 (in lpReserved : Eq_395)
-Eq_400: (struct "Eq_400" (0 word32 dw0000) (8 ui32 dw0008))
-	T_400 (in ebp_10 : (ptr Eq_400))
-	T_412 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x100021E8, 0x00000010) : word32)
-	T_486 (in ebp : (ptr Eq_400))
-	T_827 (in ebp_10 : (ptr Eq_400))
-	T_832 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10002230, 0x00000008) : word32)
-Eq_401: (fn (ptr Eq_400) ((ptr Eq_172), ptr32, word32, word32, word32, word32))
-	T_401 (in fn100017E8 : ptr32)
-	T_402 (in signature of fn100017E8 : void)
-	T_828 (in fn100017E8 : ptr32)
-Eq_475: (fn void ())
-	T_475 (in fn10001493 : ptr32)
-	T_476 (in signature of fn10001493 : void)
-Eq_484: (fn word32 ((ptr Eq_400), word32, word32, word32, word32, word32))
-	T_484 (in fn1000182D : ptr32)
-	T_485 (in signature of fn1000182D : void)
-	T_903 (in fn1000182D : ptr32)
-Eq_522: (fn word32 (word32, word32))
-	T_522 (in fn100017C6 : ptr32)
-	T_523 (in signature of fn100017C6 : void)
-	T_617 (in fn100017C6 : ptr32)
-Eq_588: (fn ui32 (word32))
-	T_588 (in fn100011E9 : ptr32)
-	T_589 (in signature of fn100011E9 : void)
-	T_633 (in fn100011E9 : ptr32)
-	T_680 (in fn100011E9 : ptr32)
-Eq_741: BOOL
-	T_741 (in eax : Eq_741)
-	T_752 (in fn10001388(lpReserved, dwReason, ebx, esi, edi) : word32)
-	T_922 (in DisableThreadLibraryCalls(dwArg04) : BOOL)
-	T_1018 (in QueryPerformanceCounter(fp - 0x00000014) : BOOL)
-Eq_742: HANDLE
-	T_742 (in hModule : Eq_742)
-Eq_747: (fn Eq_741 (Eq_395, Eq_197, (ptr Eq_172), ptr32, word32))
-	T_747 (in fn10001388 : ptr32)
-	T_748 (in signature of fn10001388 : void)
-Eq_753: (fn void ())
-	T_753 (in fn10001864 : ptr32)
-	T_754 (in signature of fn10001864 : void)
-Eq_758: (struct "Eq_758" (0 word16 w0000) (3C word32 dw003C))
-	T_758 (in dwArg04 : word32)
-Eq_764: (struct "Eq_764" (0 word32 dw0000) (18 word16 w0018))
-	T_764 (in eax_21 : (ptr Eq_764))
-	T_768 (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
-Eq_781: (struct "Eq_781" 0028 (0 word32 dw0000) (8 uint32 dw0008))
-	T_781 (in eax : (ptr Eq_781))
-	T_797 (in eax_22 : (ptr Eq_781))
-	T_806 (in (word32) ecx_6->w0014 + 0x00000018 + ecx_6 + 0x0000000C : word32)
-	T_808 (in 0x00000000 : word32)
-	T_812 (in eax_22 + 0x00000028 : word32)
-Eq_784: (struct "Eq_784" (6 word16 w0006) (14 word16 w0014))
-	T_784 (in ecx_6 : (ptr Eq_784))
-	T_789 (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
-Eq_785: (struct "Eq_785" (3C word32 dw003C))
-	T_785 (in dwArg04 : word32)
-Eq_852: (fn word32 (word32))
-	T_852 (in fn100016D0 : ptr32)
-	T_853 (in signature of fn100016D0 : void)
-Eq_868: (union "Eq_868" (ui32 u0) (ptr32 u1))
-	T_868 (in 0x10000000 : ptr32)
-Eq_881: (struct "Eq_881" (24 uint32 dw0024))
-	T_881 (in eax_54 : (ptr Eq_881))
-	T_885 (in fn10001700(dwArg00, dwArg04) : word32)
-	T_886 (in 0x00000000 : word32)
-Eq_882: (fn (ptr Eq_881) (word32, word32))
-	T_882 (in fn10001700 : ptr32)
-	T_883 (in signature of fn10001700 : void)
-Eq_918: (fn Eq_741 (Eq_920))
-	T_918 (in DisableThreadLibraryCalls : ptr32)
-	T_919 (in signature of DisableThreadLibraryCalls : void)
-Eq_920: HMODULE
-	T_920 (in hLibModule : HMODULE)
-	T_921 (in dwArg04 : word32)
-Eq_963: (segment "Eq_963" (0 ptr32 ptr0000))
-	T_963 (in fs : selector)
-Eq_973: (segment "Eq_973" (0 word32 dw0000))
-	T_973 (in fs : selector)
-Eq_974: (union "Eq_974" (ptr32 u0) ((memptr (ptr Eq_973) word32) u1))
-	T_974 (in 0x00000000 : ptr32)
-Eq_986: (fn void (Eq_988))
-	T_986 (in GetSystemTimeAsFileTime : ptr32)
-	T_987 (in signature of GetSystemTimeAsFileTime : void)
-Eq_988: LPFILETIME
-	T_988 (in lpSystemTimeAsFileTime : LPFILETIME)
-	T_991 (in fp - 0x0000000C : word32)
-Eq_1001: (fn Eq_197 ())
-	T_1001 (in GetCurrentProcessId : ptr32)
-	T_1002 (in signature of GetCurrentProcessId : void)
-Eq_1005: (fn Eq_197 ())
-	T_1005 (in GetCurrentThreadId : ptr32)
-	T_1006 (in signature of GetCurrentThreadId : void)
-Eq_1009: (fn Eq_197 ())
-	T_1009 (in GetTickCount : ptr32)
-	T_1010 (in signature of GetTickCount : void)
-Eq_1013: (fn Eq_741 ((ptr Eq_1015)))
-	T_1013 (in QueryPerformanceCounter : ptr32)
-	T_1014 (in signature of QueryPerformanceCounter : void)
-Eq_1015: LARGE_INTEGER
-	T_1015 (in lpPerformanceCount : (ptr LARGE_INTEGER))
-	T_1017 (in fp - 0x00000014 : word32)
+	T_284 (in fStart : (ptr PVFV))
+	T_286 (in 0x10002098 : word32)
+Eq_285: PVFV
+	T_285 (in fEnd : (ptr PVFV))
+	T_287 (in 0x1000209C : word32)
+Eq_307: (fn void ((ptr word32)))
+	T_307 (in free : ptr32)
+	T_308 (in signature of free : void)
+Eq_315: (fn (ptr void) ())
+	T_315 (in _encoded_null : ptr32)
+	T_316 (in signature of _encoded_null : void)
+Eq_332: (segment "Eq_332")
+	T_332 (in fs_300 : (ptr Eq_332))
+Eq_347: (fn word32 ((ptr Eq_173), ptr32, word32, ptr32))
+	T_347 (in fn10001742 : ptr32)
+	T_348 (in signature of fn10001742 : void)
+Eq_392: (segment "Eq_392")
+	T_392 (in fs_187 : (ptr Eq_392))
+Eq_396: LPVOID
+	T_396 (in ecx : Eq_396)
+	T_442 (in edi_12 : Eq_396)
+	T_511 (in Mem57[esp_56 + 0x00000000:word32] : word32)
+	T_549 (in Mem195[fp - 0x0000000C + 0x00000000:word32] : word32)
+	T_577 (in Mem183[esp_182 + 0x00000000:word32] : word32)
+	T_607 (in Mem128[esp_56 + 0x00000000:word32] : word32)
+	T_622 (in Mem136[esp_56 + 0x00000000:word32] : word32)
+	T_645 (in Mem148[esp_56 + 0x00000000:word32] : word32)
+	T_669 (in Mem81[esp_80 + 0x00000000:word32] : word32)
+	T_712 (in Mem100[esp_80 + 0x00000000:word32] : word32)
+	T_745 (in lpReserved : Eq_396)
+Eq_401: (struct "Eq_401" (0 word32 dw0000) (8 ui32 dw0008))
+	T_401 (in ebp_10 : (ptr Eq_401))
+	T_413 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x100021E8, 0x00000010) : word32)
+	T_487 (in ebp : (ptr Eq_401))
+	T_828 (in ebp_10 : (ptr Eq_401))
+	T_833 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10002230, 0x00000008) : word32)
+Eq_402: (fn (ptr Eq_401) ((ptr Eq_173), ptr32, word32, word32, word32, word32))
+	T_402 (in fn100017E8 : ptr32)
+	T_403 (in signature of fn100017E8 : void)
+	T_829 (in fn100017E8 : ptr32)
+Eq_476: (fn void ())
+	T_476 (in fn10001493 : ptr32)
+	T_477 (in signature of fn10001493 : void)
+Eq_485: (fn word32 ((ptr Eq_401), word32, word32, word32, word32, word32))
+	T_485 (in fn1000182D : ptr32)
+	T_486 (in signature of fn1000182D : void)
+	T_904 (in fn1000182D : ptr32)
+Eq_523: (fn word32 (word32, word32))
+	T_523 (in fn100017C6 : ptr32)
+	T_524 (in signature of fn100017C6 : void)
+	T_618 (in fn100017C6 : ptr32)
+Eq_589: (fn ui32 (word32))
+	T_589 (in fn100011E9 : ptr32)
+	T_590 (in signature of fn100011E9 : void)
+	T_634 (in fn100011E9 : ptr32)
+	T_681 (in fn100011E9 : ptr32)
+Eq_742: BOOL
+	T_742 (in eax : Eq_742)
+	T_753 (in fn10001388(lpReserved, dwReason, ebx, esi, edi) : word32)
+	T_923 (in DisableThreadLibraryCalls(dwArg04) : BOOL)
+	T_1019 (in QueryPerformanceCounter(fp - 0x00000014) : BOOL)
+Eq_743: HANDLE
+	T_743 (in hModule : Eq_743)
+Eq_748: (fn Eq_742 (Eq_396, Eq_198, (ptr Eq_173), ptr32, word32))
+	T_748 (in fn10001388 : ptr32)
+	T_749 (in signature of fn10001388 : void)
+Eq_754: (fn void ())
+	T_754 (in fn10001864 : ptr32)
+	T_755 (in signature of fn10001864 : void)
+Eq_759: (struct "Eq_759" (0 word16 w0000) (3C word32 dw003C))
+	T_759 (in dwArg04 : word32)
+Eq_765: (struct "Eq_765" (0 word32 dw0000) (18 word16 w0018))
+	T_765 (in eax_21 : (ptr Eq_765))
+	T_769 (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
+Eq_782: (struct "Eq_782" 0028 (0 word32 dw0000) (8 uint32 dw0008))
+	T_782 (in eax : (ptr Eq_782))
+	T_798 (in eax_22 : (ptr Eq_782))
+	T_807 (in (word32) ecx_6->w0014 + 0x00000018 + ecx_6 + 0x0000000C : word32)
+	T_809 (in 0x00000000 : word32)
+	T_813 (in eax_22 + 0x00000028 : word32)
+Eq_785: (struct "Eq_785" (6 word16 w0006) (14 word16 w0014))
+	T_785 (in ecx_6 : (ptr Eq_785))
+	T_790 (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
+Eq_786: (struct "Eq_786" (3C word32 dw003C))
+	T_786 (in dwArg04 : word32)
+Eq_853: (fn word32 (word32))
+	T_853 (in fn100016D0 : ptr32)
+	T_854 (in signature of fn100016D0 : void)
+Eq_869: (union "Eq_869" (ui32 u0) (ptr32 u1))
+	T_869 (in 0x10000000 : ptr32)
+Eq_882: (struct "Eq_882" (24 uint32 dw0024))
+	T_882 (in eax_54 : (ptr Eq_882))
+	T_886 (in fn10001700(dwArg00, dwArg04) : word32)
+	T_887 (in 0x00000000 : word32)
+Eq_883: (fn (ptr Eq_882) (word32, word32))
+	T_883 (in fn10001700 : ptr32)
+	T_884 (in signature of fn10001700 : void)
+Eq_919: (fn Eq_742 (Eq_921))
+	T_919 (in DisableThreadLibraryCalls : ptr32)
+	T_920 (in signature of DisableThreadLibraryCalls : void)
+Eq_921: HMODULE
+	T_921 (in hLibModule : HMODULE)
+	T_922 (in dwArg04 : word32)
+Eq_964: (segment "Eq_964" (0 ptr32 ptr0000))
+	T_964 (in fs : selector)
+Eq_974: (segment "Eq_974" (0 word32 dw0000))
+	T_974 (in fs : selector)
+Eq_975: (union "Eq_975" (ptr32 u0) ((memptr (ptr Eq_974) word32) u1))
+	T_975 (in 0x00000000 : ptr32)
+Eq_987: (fn void (Eq_989))
+	T_987 (in GetSystemTimeAsFileTime : ptr32)
+	T_988 (in signature of GetSystemTimeAsFileTime : void)
+Eq_989: LPFILETIME
+	T_989 (in lpSystemTimeAsFileTime : LPFILETIME)
+	T_992 (in fp - 0x0000000C : word32)
+Eq_1002: (fn Eq_198 ())
+	T_1002 (in GetCurrentProcessId : ptr32)
+	T_1003 (in signature of GetCurrentProcessId : void)
+Eq_1006: (fn Eq_198 ())
+	T_1006 (in GetCurrentThreadId : ptr32)
+	T_1007 (in signature of GetCurrentThreadId : void)
+Eq_1010: (fn Eq_198 ())
+	T_1010 (in GetTickCount : ptr32)
+	T_1011 (in signature of GetTickCount : void)
+Eq_1014: (fn Eq_742 ((ptr Eq_1016)))
+	T_1014 (in QueryPerformanceCounter : ptr32)
+	T_1015 (in signature of QueryPerformanceCounter : void)
+Eq_1016: LARGE_INTEGER
+	T_1016 (in lpPerformanceCount : (ptr LARGE_INTEGER))
+	T_1018 (in fp - 0x00000014 : word32)
 // Type Variables ////////////
 globals_t: (in globals : (ptr (struct "Globals")))
   Class: Eq_1
@@ -581,7 +581,7 @@ T_65: (in eax_20 != null : bool)
 T_66: (in Py_BuildValue : ptr32)
   Class: Eq_66
   DataType: (ptr Eq_66)
-  OrigDataType: (ptr (fn T_74 (T_69, T_73)))
+  OrigDataType: (ptr (fn T_75 (T_69, T_74)))
 T_67: (in signature of Py_BuildValue : void)
   Class: Eq_66
   DataType: (ptr Eq_66)
@@ -606,3904 +606,3908 @@ T_72: (in dwLoc04 : word32)
   Class: Eq_72
   DataType: int32
   OrigDataType: int32
-T_73: (in (int64) dwLoc08 / dwLoc04 : int32)
+T_73: (in (int64) dwLoc08 / dwLoc04 : word32)
+  Class: Eq_73
+  DataType: int32
+  OrigDataType: int32
+T_74: (in (int32) ((int64) dwLoc08 / dwLoc04) : int32)
   Class: Eq_68
   DataType: int32
   OrigDataType: int32
-T_74: (in Py_BuildValue("i", (int64) dwLoc08 / dwLoc04) : (ptr PyObject))
+T_75: (in Py_BuildValue("i", (int32) ((int64) dwLoc08 / dwLoc04)) : (ptr PyObject))
   Class: Eq_2
   DataType: (ptr Eq_2)
   OrigDataType: (ptr PyObject)
-T_75: (in eax_20 : (ptr Eq_2))
+T_76: (in eax_20 : (ptr Eq_2))
   Class: Eq_2
   DataType: (ptr Eq_2)
   OrigDataType: int32
-T_76: (in PyArg_ParseTuple : ptr32)
-  Class: Eq_76
-  DataType: (ptr Eq_76)
-  OrigDataType: (ptr (fn T_86 (T_4, T_80, T_83, T_85)))
-T_77: (in signature of PyArg_ParseTuple : void)
-  Class: Eq_76
-  DataType: (ptr Eq_76)
-  OrigDataType: 
-T_78: (in  : (ptr real32))
-  Class: Eq_78
-  DataType: (ptr real32)
+T_77: (in PyArg_ParseTuple : ptr32)
+  Class: Eq_77
+  DataType: (ptr Eq_77)
+  OrigDataType: (ptr (fn T_87 (T_4, T_81, T_84, T_86)))
+T_78: (in signature of PyArg_ParseTuple : void)
+  Class: Eq_77
+  DataType: (ptr Eq_77)
   OrigDataType: 
 T_79: (in  : (ptr real32))
   Class: Eq_79
   DataType: (ptr real32)
   OrigDataType: 
-T_80: (in 0x10002160 : word32)
+T_80: (in  : (ptr real32))
+  Class: Eq_80
+  DataType: (ptr real32)
+  OrigDataType: 
+T_81: (in 0x10002160 : word32)
   Class: Eq_9
   DataType: (ptr char)
   OrigDataType: (ptr char)
-T_81: (in fp : ptr32)
-  Class: Eq_81
+T_82: (in fp : ptr32)
+  Class: Eq_82
   DataType: ptr32
   OrigDataType: ptr32
-T_82: (in 0x00000008 : word32)
-  Class: Eq_82
+T_83: (in 0x00000008 : word32)
+  Class: Eq_83
   DataType: ui32
   OrigDataType: ui32
-T_83: (in fp - 0x00000008 : word32)
-  Class: Eq_78
-  DataType: (ptr real32)
-  OrigDataType: (ptr real32)
-T_84: (in 0x00000004 : word32)
-  Class: Eq_84
-  DataType: ui32
-  OrigDataType: ui32
-T_85: (in fp - 0x00000004 : word32)
+T_84: (in fp - 0x00000008 : word32)
   Class: Eq_79
   DataType: (ptr real32)
   OrigDataType: (ptr real32)
-T_86: (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", fp - 0x00000008, fp - 0x00000004) : int32)
+T_85: (in 0x00000004 : word32)
+  Class: Eq_85
+  DataType: ui32
+  OrigDataType: ui32
+T_86: (in fp - 0x00000004 : word32)
+  Class: Eq_80
+  DataType: (ptr real32)
+  OrigDataType: (ptr real32)
+T_87: (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", fp - 0x00000008, fp - 0x00000004) : int32)
   Class: Eq_2
   DataType: (ptr Eq_2)
   OrigDataType: int32
-T_87: (in 0x00000000 : word32)
+T_88: (in 0x00000000 : word32)
   Class: Eq_2
   DataType: (ptr Eq_2)
   OrigDataType: word32
-T_88: (in eax_20 != null : bool)
-  Class: Eq_88
+T_89: (in eax_20 != null : bool)
+  Class: Eq_89
   DataType: bool
   OrigDataType: bool
-T_89: (in Py_BuildValue : ptr32)
-  Class: Eq_89
-  DataType: (ptr Eq_89)
-  OrigDataType: (ptr (fn T_97 (T_92, T_96)))
-T_90: (in signature of Py_BuildValue : void)
-  Class: Eq_89
-  DataType: (ptr Eq_89)
+T_90: (in Py_BuildValue : ptr32)
+  Class: Eq_90
+  DataType: (ptr Eq_90)
+  OrigDataType: (ptr (fn T_98 (T_93, T_97)))
+T_91: (in signature of Py_BuildValue : void)
+  Class: Eq_90
+  DataType: (ptr Eq_90)
   OrigDataType: 
-T_91: (in  : real64)
-  Class: Eq_91
+T_92: (in  : real64)
+  Class: Eq_92
   DataType: real64
   OrigDataType: 
-T_92: (in 0x10002168 : word32)
+T_93: (in 0x10002168 : word32)
   Class: Eq_23
   DataType: (ptr char)
   OrigDataType: (ptr char)
-T_93: (in rLoc08 : real32)
-  Class: Eq_93
+T_94: (in rLoc08 : real32)
+  Class: Eq_94
   DataType: real32
   OrigDataType: real32
-T_94: (in (real64) rLoc08 : real64)
-  Class: Eq_94
-  DataType: real64
-  OrigDataType: real64
-T_95: (in rLoc04 : real32)
+T_95: (in (real64) rLoc08 : real64)
   Class: Eq_95
-  DataType: Eq_95
-  OrigDataType: (union (real32 u0) (real64 u1))
-T_96: (in (real64) rLoc08 / rLoc04 : real64)
-  Class: Eq_91
   DataType: real64
   OrigDataType: real64
-T_97: (in Py_BuildValue("f", (real64) rLoc08 / rLoc04) : (ptr PyObject))
+T_96: (in rLoc04 : real32)
+  Class: Eq_96
+  DataType: Eq_96
+  OrigDataType: (union (real32 u0) (real64 u1))
+T_97: (in (real64) rLoc08 / rLoc04 : real64)
+  Class: Eq_92
+  DataType: real64
+  OrigDataType: real64
+T_98: (in Py_BuildValue("f", (real64) rLoc08 / rLoc04) : (ptr PyObject))
   Class: Eq_2
   DataType: (ptr Eq_2)
   OrigDataType: (ptr PyObject)
-T_98: (in eax : (ptr Eq_98))
-  Class: Eq_98
-  DataType: (ptr Eq_98)
-  OrigDataType: (ptr PyObject)
-T_99: (in self : (ptr Eq_99))
+T_99: (in eax : (ptr Eq_99))
   Class: Eq_99
   DataType: (ptr Eq_99)
   OrigDataType: (ptr PyObject)
-T_100: (in args : (ptr Eq_100))
+T_100: (in self : (ptr Eq_100))
   Class: Eq_100
   DataType: (ptr Eq_100)
   OrigDataType: (ptr PyObject)
-T_101: (in eax_15 : (ptr Eq_98))
-  Class: Eq_98
-  DataType: (ptr Eq_98)
+T_101: (in args : (ptr Eq_101))
+  Class: Eq_101
+  DataType: (ptr Eq_101)
+  OrigDataType: (ptr PyObject)
+T_102: (in eax_15 : (ptr Eq_99))
+  Class: Eq_99
+  DataType: (ptr Eq_99)
   OrigDataType: int32
-T_102: (in PyArg_ParseTuple : ptr32)
-  Class: Eq_102
-  DataType: (ptr Eq_102)
-  OrigDataType: (ptr (fn T_106 (T_104, T_105)))
-T_103: (in signature of PyArg_ParseTuple : void)
-  Class: Eq_102
-  DataType: (ptr Eq_102)
+T_103: (in PyArg_ParseTuple : ptr32)
+  Class: Eq_103
+  DataType: (ptr Eq_103)
+  OrigDataType: (ptr (fn T_107 (T_105, T_106)))
+T_104: (in signature of PyArg_ParseTuple : void)
+  Class: Eq_103
+  DataType: (ptr Eq_103)
   OrigDataType: 
-T_104: (in args : (ptr PyObject))
+T_105: (in args : (ptr PyObject))
   Class: Eq_4
   DataType: (ptr Eq_4)
   OrigDataType: (ptr (union (PyObject u1)))
-T_105: (in 0x1000216C : word32)
+T_106: (in 0x1000216C : word32)
   Class: Eq_9
   DataType: (ptr char)
   OrigDataType: (ptr char)
-T_106: (in PyArg_ParseTuple(args, ":unused") : int32)
-  Class: Eq_98
-  DataType: (ptr Eq_98)
+T_107: (in PyArg_ParseTuple(args, ":unused") : int32)
+  Class: Eq_99
+  DataType: (ptr Eq_99)
   OrigDataType: int32
-T_107: (in 0x00000000 : word32)
-  Class: Eq_98
-  DataType: (ptr Eq_98)
+T_108: (in 0x00000000 : word32)
+  Class: Eq_99
+  DataType: (ptr Eq_99)
   OrigDataType: word32
-T_108: (in eax_15 != null : bool)
-  Class: Eq_108
+T_109: (in eax_15 != null : bool)
+  Class: Eq_109
   DataType: bool
   OrigDataType: bool
-T_109: (in eax_24 : (ptr Eq_109))
-  Class: Eq_109
-  DataType: (ptr Eq_109)
-  OrigDataType: (ptr (struct (0 T_114 t0000)))
-T_110: (in _Py_NoneStruct : PyObject)
+T_110: (in eax_24 : (ptr Eq_110))
   Class: Eq_110
-  DataType: Eq_110
+  DataType: (ptr Eq_110)
+  OrigDataType: (ptr (struct (0 T_115 t0000)))
+T_111: (in _Py_NoneStruct : PyObject)
+  Class: Eq_111
+  DataType: Eq_111
   OrigDataType: PyObject
-T_111: (in &_Py_NoneStruct : word32)
-  Class: Eq_109
-  DataType: (ptr Eq_109)
+T_112: (in &_Py_NoneStruct : word32)
+  Class: Eq_110
+  DataType: (ptr Eq_110)
   OrigDataType: (ptr PyObject)
-T_112: (in 0x00000000 : word32)
-  Class: Eq_112
-  DataType: word32
-  OrigDataType: word32
-T_113: (in eax_24 + 0x00000000 : word32)
+T_113: (in 0x00000000 : word32)
   Class: Eq_113
   DataType: word32
   OrigDataType: word32
-T_114: (in Mem0[eax_24 + 0x00000000:word32] : word32)
+T_114: (in eax_24 + 0x00000000 : word32)
   Class: Eq_114
   DataType: word32
   OrigDataType: word32
-T_115: (in 0x00000001 : word32)
+T_115: (in Mem0[eax_24 + 0x00000000:word32] : word32)
   Class: Eq_115
   DataType: word32
   OrigDataType: word32
-T_116: (in eax_24->ob_refcnt + 0x00000001 : word32)
-  Class: Eq_114
+T_116: (in 0x00000001 : word32)
+  Class: Eq_116
   DataType: word32
   OrigDataType: word32
-T_117: (in 0x00000000 : word32)
-  Class: Eq_117
+T_117: (in eax_24->ob_refcnt + 0x00000001 : word32)
+  Class: Eq_115
   DataType: word32
   OrigDataType: word32
-T_118: (in eax_24 + 0x00000000 : word32)
+T_118: (in 0x00000000 : word32)
   Class: Eq_118
+  DataType: word32
+  OrigDataType: word32
+T_119: (in eax_24 + 0x00000000 : word32)
+  Class: Eq_119
   DataType: (ptr word32)
   OrigDataType: (ptr word32)
-T_119: (in Mem27[eax_24 + 0x00000000:word32] : word32)
-  Class: Eq_114
+T_120: (in Mem27[eax_24 + 0x00000000:word32] : word32)
+  Class: Eq_115
   DataType: word32
   OrigDataType: word32
-T_120: (in _Py_NoneStruct : PyObject)
-  Class: Eq_110
-  DataType: Eq_110
+T_121: (in _Py_NoneStruct : PyObject)
+  Class: Eq_111
+  DataType: Eq_111
   OrigDataType: PyObject
-T_121: (in &_Py_NoneStruct : word32)
-  Class: Eq_98
-  DataType: (ptr Eq_98)
+T_122: (in &_Py_NoneStruct : word32)
+  Class: Eq_99
+  DataType: (ptr Eq_99)
   OrigDataType: (ptr PyObject)
-T_122: (in Py_InitModule4 : ptr32)
-  Class: Eq_122
-  DataType: (ptr Eq_122)
-  OrigDataType: (ptr (fn T_134 (T_129, T_130, T_131, T_132, T_133)))
-T_123: (in signature of Py_InitModule4 : void)
-  Class: Eq_122
-  DataType: (ptr Eq_122)
+T_123: (in Py_InitModule4 : ptr32)
+  Class: Eq_123
+  DataType: (ptr Eq_123)
+  OrigDataType: (ptr (fn T_135 (T_130, T_131, T_132, T_133, T_134)))
+T_124: (in signature of Py_InitModule4 : void)
+  Class: Eq_123
+  DataType: (ptr Eq_123)
   OrigDataType: 
-T_124: (in ptrArg04 : (ptr char))
-  Class: Eq_124
-  DataType: (ptr char)
-  OrigDataType: 
-T_125: (in ptrArg08 : (ptr PyMethodDef))
+T_125: (in ptrArg04 : (ptr char))
   Class: Eq_125
-  DataType: (ptr Eq_125)
-  OrigDataType: 
-T_126: (in ptrArg0C : (ptr char))
-  Class: Eq_126
   DataType: (ptr char)
   OrigDataType: 
-T_127: (in ptrArg10 : (ptr PyObject))
-  Class: Eq_127
-  DataType: (ptr Eq_127)
+T_126: (in ptrArg08 : (ptr PyMethodDef))
+  Class: Eq_126
+  DataType: (ptr Eq_126)
   OrigDataType: 
-T_128: (in dwArg14 : int32)
+T_127: (in ptrArg0C : (ptr char))
+  Class: Eq_127
+  DataType: (ptr char)
+  OrigDataType: 
+T_128: (in ptrArg10 : (ptr PyObject))
   Class: Eq_128
+  DataType: (ptr Eq_128)
+  OrigDataType: 
+T_129: (in dwArg14 : int32)
+  Class: Eq_129
   DataType: int32
   OrigDataType: 
-T_129: (in 0x10002174 : word32)
-  Class: Eq_124
-  DataType: (ptr char)
-  OrigDataType: (ptr char)
-T_130: (in 0x10003010 : word32)
+T_130: (in 0x10002174 : word32)
   Class: Eq_125
-  DataType: (ptr Eq_125)
-  OrigDataType: (ptr PyMethodDef)
-T_131: (in 0x00000000 : word32)
-  Class: Eq_126
   DataType: (ptr char)
   OrigDataType: (ptr char)
+T_131: (in 0x10003010 : word32)
+  Class: Eq_126
+  DataType: (ptr Eq_126)
+  OrigDataType: (ptr PyMethodDef)
 T_132: (in 0x00000000 : word32)
   Class: Eq_127
-  DataType: (ptr Eq_127)
-  OrigDataType: (ptr PyObject)
-T_133: (in 0x000003EF : word32)
+  DataType: (ptr char)
+  OrigDataType: (ptr char)
+T_133: (in 0x00000000 : word32)
   Class: Eq_128
+  DataType: (ptr Eq_128)
+  OrigDataType: (ptr PyObject)
+T_134: (in 0x000003EF : word32)
+  Class: Eq_129
   DataType: int32
   OrigDataType: int32
-T_134: (in Py_InitModule4("pySample", globals->methods, null, null, 0x000003EF) : (ptr PyObject))
-  Class: Eq_134
-  DataType: (ptr Eq_134)
-  OrigDataType: (ptr PyObject)
-T_135: (in eax : word32)
+T_135: (in Py_InitModule4("pySample", globals->methods, null, null, 0x000003EF) : (ptr PyObject))
   Class: Eq_135
-  DataType: word32
-  OrigDataType: word32
-T_136: (in dwArg08 : word32)
+  DataType: (ptr Eq_135)
+  OrigDataType: (ptr PyObject)
+T_136: (in eax : word32)
   Class: Eq_136
   DataType: word32
   OrigDataType: word32
-T_137: (in eax_123 : word32)
+T_137: (in dwArg08 : word32)
   Class: Eq_137
   DataType: word32
   OrigDataType: word32
-T_138: (in ebp_203 : Eq_138)
+T_138: (in eax_123 : word32)
   Class: Eq_138
-  DataType: Eq_138
+  DataType: word32
+  OrigDataType: word32
+T_139: (in ebp_203 : Eq_139)
+  Class: Eq_139
+  DataType: Eq_139
   OrigDataType: LONG
-T_139: (in 0x00000000 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_140: (in 0x00000000 : word32)
+  Class: Eq_139
+  DataType: Eq_139
   OrigDataType: word32
-T_140: (in dwArg08 : word32)
-  Class: Eq_140
+T_141: (in dwArg08 : word32)
+  Class: Eq_141
   DataType: word32
   OrigDataType: word32
-T_141: (in 0x00000000 : word32)
-  Class: Eq_140
+T_142: (in 0x00000000 : word32)
+  Class: Eq_141
   DataType: word32
   OrigDataType: word32
-T_142: (in dwArg08 != 0x00000000 : bool)
-  Class: Eq_142
+T_143: (in dwArg08 != 0x00000000 : bool)
+  Class: Eq_143
   DataType: bool
   OrigDataType: bool
-T_143: (in adjust_fdiv : ptr32)
-  Class: Eq_143
+T_144: (in adjust_fdiv : ptr32)
+  Class: Eq_144
   DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_147 t0000)))
-T_144: (in signature of adjust_fdiv : void)
-  Class: Eq_143
+  OrigDataType: (ptr (struct (0 T_148 t0000)))
+T_145: (in signature of adjust_fdiv : void)
+  Class: Eq_144
   DataType: (ptr word32)
   OrigDataType: 
-T_145: (in 0x00000000 : word32)
-  Class: Eq_145
+T_146: (in 0x00000000 : word32)
+  Class: Eq_146
   DataType: word32
   OrigDataType: word32
-T_146: (in adjust_fdiv + 0x00000000 : word32)
-  Class: Eq_146
+T_147: (in adjust_fdiv + 0x00000000 : word32)
+  Class: Eq_147
   DataType: ptr32
   OrigDataType: ptr32
-T_147: (in Mem0[adjust_fdiv + 0x00000000:word32] : word32)
-  Class: Eq_147
-  DataType: word32
-  OrigDataType: word32
-T_148: (in 0x100033A4 : ptr32)
+T_148: (in Mem0[adjust_fdiv + 0x00000000:word32] : word32)
   Class: Eq_148
+  DataType: word32
+  OrigDataType: word32
+T_149: (in 0x100033A4 : ptr32)
+  Class: Eq_149
   DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_149 t0000)))
-T_149: (in Mem45[0x100033A4:word32] : word32)
-  Class: Eq_147
+  OrigDataType: (ptr (struct (0 T_150 t0000)))
+T_150: (in Mem45[0x100033A4:word32] : word32)
+  Class: Eq_148
   DataType: word32
   OrigDataType: word32
-T_150: (in 0x00000001 : word32)
-  Class: Eq_140
+T_151: (in 0x00000001 : word32)
+  Class: Eq_141
   DataType: word32
   OrigDataType: word32
-T_151: (in dwArg08 != 0x00000001 : bool)
-  Class: Eq_151
-  DataType: bool
-  OrigDataType: bool
-T_152: (in 0x10003070 : ptr32)
+T_152: (in dwArg08 != 0x00000001 : bool)
   Class: Eq_152
-  DataType: (ptr int32)
-  OrigDataType: (ptr (struct (0 T_153 t0000)))
-T_153: (in Mem0[0x10003070:word32] : word32)
-  Class: Eq_153
-  DataType: int32
-  OrigDataType: int32
-T_154: (in 0x00000000 : word32)
-  Class: Eq_153
-  DataType: int32
-  OrigDataType: int32
-T_155: (in globals->dw10003070 <= 0x00000000 : bool)
-  Class: Eq_155
   DataType: bool
   OrigDataType: bool
-T_156: (in 0x00000000 : word32)
-  Class: Eq_137
-  DataType: word32
-  OrigDataType: word32
-T_157: (in 0x10003070 : ptr32)
-  Class: Eq_157
+T_153: (in 0x10003070 : ptr32)
+  Class: Eq_153
   DataType: (ptr int32)
-  OrigDataType: (ptr (struct (0 T_153 t0000)))
-T_158: (in Mem0[0x10003070:word32] : word32)
-  Class: Eq_153
+  OrigDataType: (ptr (struct (0 T_154 t0000)))
+T_154: (in Mem0[0x10003070:word32] : word32)
+  Class: Eq_154
   DataType: int32
-  OrigDataType: word32
-T_159: (in 0x00000001 : word32)
-  Class: Eq_159
-  DataType: word32
-  OrigDataType: word32
-T_160: (in globals->dw10003070 - 0x00000001 : word32)
-  Class: Eq_153
+  OrigDataType: int32
+T_155: (in 0x00000000 : word32)
+  Class: Eq_154
   DataType: int32
-  OrigDataType: word32
-T_161: (in Mem307[0x10003070:word32] : word32)
-  Class: Eq_153
-  DataType: int32
-  OrigDataType: word32
-T_162: (in 0x00000000 : word32)
-  Class: Eq_140
-  DataType: word32
-  OrigDataType: word32
-T_163: (in dwArg08 != 0x00000000 : bool)
-  Class: Eq_163
+  OrigDataType: int32
+T_156: (in globals->dw10003070 <= 0x00000000 : bool)
+  Class: Eq_156
   DataType: bool
   OrigDataType: bool
-T_164: (in edi_82 : Eq_138)
+T_157: (in 0x00000000 : word32)
   Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: (union (LONG u1))
-T_165: (in fs : selector)
-  Class: Eq_165
-  DataType: (ptr Eq_165)
-  OrigDataType: (ptr (segment (18 T_167 t0018)))
-T_166: (in 0x00000018 : word32)
-  Class: Eq_166
-  DataType: (memptr (ptr Eq_165) (ptr Eq_167))
-  OrigDataType: (memptr T_165 (struct (0 T_167 t0000)))
-T_167: (in Mem45[fs:0x00000018:word32] : word32)
-  Class: Eq_167
-  DataType: (ptr Eq_167)
-  OrigDataType: (ptr (struct (4 T_170 t0004)))
-T_168: (in 0x00000004 : word32)
-  Class: Eq_168
   DataType: word32
   OrigDataType: word32
-T_169: (in Mem45[fs:0x00000018:word32] + 0x00000004 : word32)
+T_158: (in 0x10003070 : ptr32)
+  Class: Eq_158
+  DataType: (ptr int32)
+  OrigDataType: (ptr (struct (0 T_154 t0000)))
+T_159: (in Mem0[0x10003070:word32] : word32)
+  Class: Eq_154
+  DataType: int32
+  OrigDataType: word32
+T_160: (in 0x00000001 : word32)
+  Class: Eq_160
+  DataType: word32
+  OrigDataType: word32
+T_161: (in globals->dw10003070 - 0x00000001 : word32)
+  Class: Eq_154
+  DataType: int32
+  OrigDataType: word32
+T_162: (in Mem307[0x10003070:word32] : word32)
+  Class: Eq_154
+  DataType: int32
+  OrigDataType: word32
+T_163: (in 0x00000000 : word32)
+  Class: Eq_141
+  DataType: word32
+  OrigDataType: word32
+T_164: (in dwArg08 != 0x00000000 : bool)
+  Class: Eq_164
+  DataType: bool
+  OrigDataType: bool
+T_165: (in edi_82 : Eq_139)
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: (union (LONG u1))
+T_166: (in fs : selector)
+  Class: Eq_166
+  DataType: (ptr Eq_166)
+  OrigDataType: (ptr (segment (18 T_168 t0018)))
+T_167: (in 0x00000018 : word32)
+  Class: Eq_167
+  DataType: (memptr (ptr Eq_166) (ptr Eq_168))
+  OrigDataType: (memptr T_166 (struct (0 T_168 t0000)))
+T_168: (in Mem45[fs:0x00000018:word32] : word32)
+  Class: Eq_168
+  DataType: (ptr Eq_168)
+  OrigDataType: (ptr (struct (4 T_171 t0004)))
+T_169: (in 0x00000004 : word32)
   Class: Eq_169
   DataType: word32
   OrigDataType: word32
-T_170: (in Mem45[Mem45[fs:0x00000018:word32] + 0x00000004:word32] : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_171: (in eax_93 : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: LONG
-T_172: (in InterlockedCompareExchange : ptr32)
-  Class: Eq_172
-  DataType: (ptr Eq_172)
-  OrigDataType: (ptr (fn T_179 (T_177, T_164, T_178)))
-T_173: (in signature of InterlockedCompareExchange : void)
-  Class: Eq_172
-  DataType: (ptr Eq_172)
-  OrigDataType: 
-T_174: (in Destination : (ptr LONG))
-  Class: Eq_174
-  DataType: (ptr Eq_174)
-  OrigDataType: 
-T_175: (in Exchange : LONG)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: 
-T_176: (in Comperand : LONG)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: 
-T_177: (in 0x100033AC : ptr32)
-  Class: Eq_174
-  DataType: (ptr Eq_174)
-  OrigDataType: (ptr LONG)
-T_178: (in 0x00000000 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: LONG
-T_179: (in InterlockedCompareExchange(&globals->t100033AC, edi_82, 0x00000000) : LONG)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: LONG
-T_180: (in 0x00000000 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_181: (in eax_93 != 0x00000000 : bool)
-  Class: Eq_181
-  DataType: bool
-  OrigDataType: bool
-T_182: (in 0x00000001 : word32)
-  Class: Eq_137
+T_170: (in Mem45[fs:0x00000018:word32] + 0x00000004 : word32)
+  Class: Eq_170
   DataType: word32
   OrigDataType: word32
-T_183: (in InterlockedCompareExchange : ptr32)
-  Class: Eq_172
-  DataType: (ptr Eq_172)
-  OrigDataType: (ptr (fn T_187 (T_184, T_185, T_186)))
-T_184: (in 0x100033AC : ptr32)
-  Class: Eq_174
-  DataType: (ptr Eq_174)
-  OrigDataType: (ptr LONG)
-T_185: (in 0x00000001 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: LONG
-T_186: (in 0x00000000 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: LONG
-T_187: (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) : LONG)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: LONG
-T_188: (in 0x00000000 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_171: (in Mem45[Mem45[fs:0x00000018:word32] + 0x00000004:word32] : word32)
+  Class: Eq_139
+  DataType: Eq_139
   OrigDataType: word32
-T_189: (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) != 0x00000000 : bool)
-  Class: Eq_189
+T_172: (in eax_93 : Eq_139)
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: LONG
+T_173: (in InterlockedCompareExchange : ptr32)
+  Class: Eq_173
+  DataType: (ptr Eq_173)
+  OrigDataType: (ptr (fn T_180 (T_178, T_165, T_179)))
+T_174: (in signature of InterlockedCompareExchange : void)
+  Class: Eq_173
+  DataType: (ptr Eq_173)
+  OrigDataType: 
+T_175: (in Destination : (ptr LONG))
+  Class: Eq_175
+  DataType: (ptr Eq_175)
+  OrigDataType: 
+T_176: (in Exchange : LONG)
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: 
+T_177: (in Comperand : LONG)
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: 
+T_178: (in 0x100033AC : ptr32)
+  Class: Eq_175
+  DataType: (ptr Eq_175)
+  OrigDataType: (ptr LONG)
+T_179: (in 0x00000000 : word32)
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: LONG
+T_180: (in InterlockedCompareExchange(&globals->t100033AC, edi_82, 0x00000000) : LONG)
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: LONG
+T_181: (in 0x00000000 : word32)
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: word32
+T_182: (in eax_93 != 0x00000000 : bool)
+  Class: Eq_182
   DataType: bool
   OrigDataType: bool
-T_190: (in eax_93 == edi_82 : bool)
+T_183: (in 0x00000001 : word32)
+  Class: Eq_138
+  DataType: word32
+  OrigDataType: word32
+T_184: (in InterlockedCompareExchange : ptr32)
+  Class: Eq_173
+  DataType: (ptr Eq_173)
+  OrigDataType: (ptr (fn T_188 (T_185, T_186, T_187)))
+T_185: (in 0x100033AC : ptr32)
+  Class: Eq_175
+  DataType: (ptr Eq_175)
+  OrigDataType: (ptr LONG)
+T_186: (in 0x00000001 : word32)
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: LONG
+T_187: (in 0x00000000 : word32)
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: LONG
+T_188: (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) : LONG)
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: LONG
+T_189: (in 0x00000000 : word32)
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: word32
+T_190: (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) != 0x00000000 : bool)
   Class: Eq_190
   DataType: bool
   OrigDataType: bool
-T_191: (in 0x100033A8 : ptr32)
+T_191: (in eax_93 == edi_82 : bool)
   Class: Eq_191
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_192 t0000)))
-T_192: (in Mem45[0x100033A8:word32] : word32)
-  Class: Eq_192
-  DataType: word32
-  OrigDataType: word32
-T_193: (in 0x00000000 : word32)
-  Class: Eq_192
-  DataType: word32
-  OrigDataType: word32
-T_194: (in globals->dw100033A8 == 0x00000000 : bool)
-  Class: Eq_194
   DataType: bool
   OrigDataType: bool
-T_195: (in Sleep : ptr32)
+T_192: (in 0x100033A8 : ptr32)
+  Class: Eq_192
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_193 t0000)))
+T_193: (in Mem45[0x100033A8:word32] : word32)
+  Class: Eq_193
+  DataType: word32
+  OrigDataType: word32
+T_194: (in 0x00000000 : word32)
+  Class: Eq_193
+  DataType: word32
+  OrigDataType: word32
+T_195: (in globals->dw100033A8 == 0x00000000 : bool)
   Class: Eq_195
-  DataType: (ptr Eq_195)
-  OrigDataType: (ptr (fn T_199 (T_198)))
-T_196: (in signature of Sleep : void)
-  Class: Eq_195
-  DataType: (ptr Eq_195)
+  DataType: bool
+  OrigDataType: bool
+T_196: (in Sleep : ptr32)
+  Class: Eq_196
+  DataType: (ptr Eq_196)
+  OrigDataType: (ptr (fn T_200 (T_199)))
+T_197: (in signature of Sleep : void)
+  Class: Eq_196
+  DataType: (ptr Eq_196)
   OrigDataType: 
-T_197: (in dwMilliseconds : DWORD)
-  Class: Eq_197
-  DataType: Eq_197
+T_198: (in dwMilliseconds : DWORD)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: 
-T_198: (in 0x000003E8 : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_199: (in 0x000003E8 : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: DWORD
-T_199: (in Sleep(0x000003E8) : void)
-  Class: Eq_199
-  DataType: void
-  OrigDataType: void
-T_200: (in 0x100033A8 : ptr32)
+T_200: (in Sleep(0x000003E8) : void)
   Class: Eq_200
+  DataType: void
+  OrigDataType: void
+T_201: (in 0x100033A8 : ptr32)
+  Class: Eq_201
   DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_201 t0000)))
-T_201: (in Mem45[0x100033A8:word32] : word32)
-  Class: Eq_192
+  OrigDataType: (ptr (struct (0 T_202 t0000)))
+T_202: (in Mem45[0x100033A8:word32] : word32)
+  Class: Eq_193
   DataType: word32
   OrigDataType: word32
-T_202: (in 0x00000002 : word32)
-  Class: Eq_192
+T_203: (in 0x00000002 : word32)
+  Class: Eq_193
   DataType: word32
   OrigDataType: word32
-T_203: (in globals->dw100033A8 == 0x00000002 : bool)
-  Class: Eq_203
+T_204: (in globals->dw100033A8 == 0x00000002 : bool)
+  Class: Eq_204
   DataType: bool
   OrigDataType: bool
-T_204: (in eax_232 : (ptr word32))
-  Class: Eq_204
+T_205: (in eax_232 : (ptr word32))
+  Class: Eq_205
   DataType: (ptr word32)
   OrigDataType: (ptr void)
-T_205: (in _decode_pointer : ptr32)
-  Class: Eq_205
-  DataType: (ptr Eq_205)
-  OrigDataType: (ptr (fn T_210 (T_209)))
-T_206: (in signature of _decode_pointer : void)
-  Class: Eq_205
-  DataType: (ptr Eq_205)
+T_206: (in _decode_pointer : ptr32)
+  Class: Eq_206
+  DataType: (ptr Eq_206)
+  OrigDataType: (ptr (fn T_211 (T_210)))
+T_207: (in signature of _decode_pointer : void)
+  Class: Eq_206
+  DataType: (ptr Eq_206)
   OrigDataType: 
-T_207: (in ptrArg04 : (ptr void))
-  Class: Eq_207
-  DataType: (ptr void)
-  OrigDataType: 
-T_208: (in 0x100033B4 : ptr32)
+T_208: (in ptrArg04 : (ptr void))
   Class: Eq_208
+  DataType: (ptr void)
+  OrigDataType: 
+T_209: (in 0x100033B4 : ptr32)
+  Class: Eq_209
   DataType: (ptr (ptr void))
-  OrigDataType: (ptr (struct (0 T_209 t0000)))
-T_209: (in Mem45[0x100033B4:word32] : word32)
-  Class: Eq_207
+  OrigDataType: (ptr (struct (0 T_210 t0000)))
+T_210: (in Mem45[0x100033B4:word32] : word32)
+  Class: Eq_208
   DataType: (ptr void)
   OrigDataType: (ptr void)
-T_210: (in _decode_pointer(globals->ptr100033B4) : (ptr void))
-  Class: Eq_204
+T_211: (in _decode_pointer(globals->ptr100033B4) : (ptr void))
+  Class: Eq_205
   DataType: (ptr word32)
   OrigDataType: (ptr void)
-T_211: (in ebx_233 : (ptr word32))
-  Class: Eq_204
+T_212: (in ebx_233 : (ptr word32))
+  Class: Eq_205
   DataType: (ptr word32)
   OrigDataType: (ptr void)
-T_212: (in esp_238 : ptr32)
-  Class: Eq_212
-  DataType: ptr32
-  OrigDataType: ptr32
-T_213: (in fp : ptr32)
+T_213: (in esp_238 : ptr32)
   Class: Eq_213
-  DataType: (ptr Eq_213)
-  OrigDataType: (ptr (struct (4 T_374 t0004) (C T_361 t000C)))
-T_214: (in 0x00000010 : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_214: (in fp : ptr32)
   Class: Eq_214
+  DataType: (ptr Eq_214)
+  OrigDataType: (ptr (struct (4 T_375 t0004) (C T_362 t000C)))
+T_215: (in 0x00000010 : word32)
+  Class: Eq_215
   DataType: ui32
   OrigDataType: ui32
-T_215: (in fp - 0x00000010 : word32)
-  Class: Eq_212
+T_216: (in fp - 0x00000010 : word32)
+  Class: Eq_213
   DataType: ptr32
   OrigDataType: ptr32
-T_216: (in 0x00000000 : word32)
-  Class: Eq_204
+T_217: (in 0x00000000 : word32)
+  Class: Eq_205
   DataType: (ptr word32)
   OrigDataType: word32
-T_217: (in eax_232 == null : bool)
-  Class: Eq_217
+T_218: (in eax_232 == null : bool)
+  Class: Eq_218
   DataType: bool
   OrigDataType: bool
-T_218: (in _amsg_exit : ptr32)
-  Class: Eq_218
-  DataType: (ptr Eq_218)
-  OrigDataType: (ptr (fn T_222 (T_221)))
-T_219: (in signature of _amsg_exit : void)
-  Class: Eq_218
-  DataType: (ptr Eq_218)
+T_219: (in _amsg_exit : ptr32)
+  Class: Eq_219
+  DataType: (ptr Eq_219)
+  OrigDataType: (ptr (fn T_223 (T_222)))
+T_220: (in signature of _amsg_exit : void)
+  Class: Eq_219
+  DataType: (ptr Eq_219)
   OrigDataType: 
-T_220: (in n : int32)
-  Class: Eq_220
+T_221: (in n : int32)
+  Class: Eq_221
   DataType: int32
   OrigDataType: 
-T_221: (in 0x0000001F : word32)
-  Class: Eq_220
+T_222: (in 0x0000001F : word32)
+  Class: Eq_221
   DataType: int32
   OrigDataType: int32
-T_222: (in _amsg_exit(0x0000001F) : void)
-  Class: Eq_222
+T_223: (in _amsg_exit(0x0000001F) : void)
+  Class: Eq_223
   DataType: void
   OrigDataType: void
-T_223: (in 0x00000001 : word32)
-  Class: Eq_192
+T_224: (in 0x00000001 : word32)
+  Class: Eq_193
   DataType: word32
   OrigDataType: word32
-T_224: (in 0x100033A8 : ptr32)
-  Class: Eq_224
+T_225: (in 0x100033A8 : ptr32)
+  Class: Eq_225
   DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_225 t0000)))
-T_225: (in Mem114[0x100033A8:word32] : word32)
-  Class: Eq_192
+  OrigDataType: (ptr (struct (0 T_226 t0000)))
+T_226: (in Mem114[0x100033A8:word32] : word32)
+  Class: Eq_193
   DataType: word32
   OrigDataType: word32
-T_226: (in _initterm_e : ptr32)
-  Class: Eq_226
-  DataType: (ptr Eq_226)
-  OrigDataType: (ptr (fn T_232 (T_230, T_231)))
-T_227: (in signature of _initterm_e : void)
-  Class: Eq_226
-  DataType: (ptr Eq_226)
+T_227: (in _initterm_e : ptr32)
+  Class: Eq_227
+  DataType: (ptr Eq_227)
+  OrigDataType: (ptr (fn T_233 (T_231, T_232)))
+T_228: (in signature of _initterm_e : void)
+  Class: Eq_227
+  DataType: (ptr Eq_227)
   OrigDataType: 
-T_228: (in fStart : (ptr PVFV))
-  Class: Eq_228
-  DataType: (ptr Eq_228)
-  OrigDataType: 
-T_229: (in fEnd : (ptr PVFV))
+T_229: (in fStart : (ptr PVFV))
   Class: Eq_229
   DataType: (ptr Eq_229)
   OrigDataType: 
-T_230: (in 0x100020A0 : word32)
-  Class: Eq_228
-  DataType: (ptr Eq_228)
-  OrigDataType: (ptr PVFV)
-T_231: (in 0x100020A8 : word32)
+T_230: (in fEnd : (ptr PVFV))
+  Class: Eq_230
+  DataType: (ptr Eq_230)
+  OrigDataType: 
+T_231: (in 0x100020A0 : word32)
   Class: Eq_229
   DataType: (ptr Eq_229)
   OrigDataType: (ptr PVFV)
-T_232: (in _initterm_e(&globals->t100020A0, &globals->t100020A8) : int32)
-  Class: Eq_232
+T_232: (in 0x100020A8 : word32)
+  Class: Eq_230
+  DataType: (ptr Eq_230)
+  OrigDataType: (ptr PVFV)
+T_233: (in _initterm_e(&globals->t100020A0, &globals->t100020A8) : int32)
+  Class: Eq_233
   DataType: int32
   OrigDataType: int32
-T_233: (in 0x00000000 : word32)
-  Class: Eq_232
+T_234: (in 0x00000000 : word32)
+  Class: Eq_233
   DataType: int32
   OrigDataType: word32
-T_234: (in _initterm_e(&globals->t100020A0, &globals->t100020A8) == 0x00000000 : bool)
-  Class: Eq_234
+T_235: (in _initterm_e(&globals->t100020A0, &globals->t100020A8) == 0x00000000 : bool)
+  Class: Eq_235
   DataType: bool
   OrigDataType: bool
-T_235: (in _amsg_exit : ptr32)
-  Class: Eq_218
-  DataType: (ptr Eq_218)
-  OrigDataType: (ptr (fn T_237 (T_236)))
-T_236: (in 0x0000001F : word32)
-  Class: Eq_220
+T_236: (in _amsg_exit : ptr32)
+  Class: Eq_219
+  DataType: (ptr Eq_219)
+  OrigDataType: (ptr (fn T_238 (T_237)))
+T_237: (in 0x0000001F : word32)
+  Class: Eq_221
   DataType: int32
   OrigDataType: int32
-T_237: (in _amsg_exit(0x0000001F) : void)
-  Class: Eq_222
+T_238: (in _amsg_exit(0x0000001F) : void)
+  Class: Eq_223
   DataType: void
   OrigDataType: void
-T_238: (in 0x00000001 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_239: (in 0x00000001 : word32)
+  Class: Eq_139
+  DataType: Eq_139
   OrigDataType: word32
-T_239: (in Sleep : ptr32)
-  Class: Eq_195
-  DataType: (ptr Eq_195)
-  OrigDataType: (ptr (fn T_241 (T_240)))
-T_240: (in 0x000003E8 : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_240: (in Sleep : ptr32)
+  Class: Eq_196
+  DataType: (ptr Eq_196)
+  OrigDataType: (ptr (fn T_242 (T_241)))
+T_241: (in 0x000003E8 : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: DWORD
-T_241: (in Sleep(0x000003E8) : void)
-  Class: Eq_199
+T_242: (in Sleep(0x000003E8) : void)
+  Class: Eq_200
   DataType: void
   OrigDataType: void
-T_242: (in esp_251 : (ptr Eq_138))
-  Class: Eq_242
-  DataType: (ptr Eq_138)
-  OrigDataType: (ptr (struct (0 T_138 t0000)))
-T_243: (in 0x00000004 : word32)
+T_243: (in esp_251 : (ptr Eq_139))
   Class: Eq_243
+  DataType: (ptr Eq_139)
+  OrigDataType: (ptr (struct (0 T_139 t0000)))
+T_244: (in 0x00000004 : word32)
+  Class: Eq_244
   DataType: ui32
   OrigDataType: ui32
-T_244: (in esp_238 - 0x00000004 : word32)
-  Class: Eq_242
-  DataType: (ptr Eq_138)
+T_245: (in esp_238 - 0x00000004 : word32)
+  Class: Eq_243
+  DataType: (ptr Eq_139)
   OrigDataType: ptr32
-T_245: (in 0x00000000 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
 T_246: (in 0x00000000 : word32)
-  Class: Eq_246
+  Class: Eq_139
+  DataType: Eq_139
+  OrigDataType: word32
+T_247: (in 0x00000000 : word32)
+  Class: Eq_247
   DataType: word32
   OrigDataType: word32
-T_247: (in esp_251 + 0x00000000 : word32)
-  Class: Eq_247
+T_248: (in esp_251 + 0x00000000 : word32)
+  Class: Eq_248
   DataType: ptr32
   OrigDataType: ptr32
-T_248: (in Mem252[esp_251 + 0x00000000:word32] : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_249: (in Mem252[esp_251 + 0x00000000:word32] : word32)
+  Class: Eq_139
+  DataType: Eq_139
   OrigDataType: word32
-T_249: (in 0x100033AC : ptr32)
-  Class: Eq_249
+T_250: (in 0x100033AC : ptr32)
+  Class: Eq_250
   DataType: ptr32
   OrigDataType: ptr32
-T_250: (in 0x00000004 : word32)
-  Class: Eq_250
+T_251: (in 0x00000004 : word32)
+  Class: Eq_251
   DataType: ui32
   OrigDataType: ui32
-T_251: (in esp_251 - 0x00000004 : word32)
-  Class: Eq_251
-  DataType: (ptr ptr32)
-  OrigDataType: (ptr (struct (0 T_254 t0000)))
-T_252: (in 0x00000000 : word32)
+T_252: (in esp_251 - 0x00000004 : word32)
   Class: Eq_252
-  DataType: word32
-  OrigDataType: word32
-T_253: (in esp_251 - 0x00000004 + 0x00000000 : word32)
+  DataType: (ptr ptr32)
+  OrigDataType: (ptr (struct (0 T_255 t0000)))
+T_253: (in 0x00000000 : word32)
   Class: Eq_253
-  DataType: ptr32
-  OrigDataType: ptr32
-T_254: (in Mem254[esp_251 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_249
-  DataType: ptr32
-  OrigDataType: word32
-T_255: (in 0x00000000 : word32)
-  Class: Eq_192
   DataType: word32
   OrigDataType: word32
-T_256: (in 0x100033A8 : ptr32)
-  Class: Eq_256
+T_254: (in esp_251 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_254
+  DataType: ptr32
+  OrigDataType: ptr32
+T_255: (in Mem254[esp_251 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_250
+  DataType: ptr32
+  OrigDataType: word32
+T_256: (in 0x00000000 : word32)
+  Class: Eq_193
+  DataType: word32
+  OrigDataType: word32
+T_257: (in 0x100033A8 : ptr32)
+  Class: Eq_257
   DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_257 t0000)))
-T_257: (in Mem255[0x100033A8:word32] : word32)
-  Class: Eq_192
+  OrigDataType: (ptr (struct (0 T_258 t0000)))
+T_258: (in Mem255[0x100033A8:word32] : word32)
+  Class: Eq_193
   DataType: word32
   OrigDataType: word32
-T_258: (in InterlockedExchange : ptr32)
-  Class: Eq_258
-  DataType: (ptr Eq_258)
-  OrigDataType: (ptr (fn T_269 (T_265, T_268)))
-T_259: (in signature of InterlockedExchange : void)
-  Class: Eq_258
-  DataType: (ptr Eq_258)
+T_259: (in InterlockedExchange : ptr32)
+  Class: Eq_259
+  DataType: (ptr Eq_259)
+  OrigDataType: (ptr (fn T_270 (T_266, T_269)))
+T_260: (in signature of InterlockedExchange : void)
+  Class: Eq_259
+  DataType: (ptr Eq_259)
   OrigDataType: 
-T_260: (in Target : (ptr LONG))
-  Class: Eq_260
-  DataType: (ptr Eq_260)
+T_261: (in Target : (ptr LONG))
+  Class: Eq_261
+  DataType: (ptr Eq_261)
   OrigDataType: 
-T_261: (in Value : LONG)
-  Class: Eq_138
-  DataType: Eq_138
+T_262: (in Value : LONG)
+  Class: Eq_139
+  DataType: Eq_139
   OrigDataType: 
-T_262: (in esp_251 - 0x00000004 : word32)
-  Class: Eq_262
-  DataType: (ptr (ptr Eq_260))
-  OrigDataType: (ptr (struct (0 T_265 t0000)))
-T_263: (in 0x00000000 : word32)
+T_263: (in esp_251 - 0x00000004 : word32)
   Class: Eq_263
+  DataType: (ptr (ptr Eq_261))
+  OrigDataType: (ptr (struct (0 T_266 t0000)))
+T_264: (in 0x00000000 : word32)
+  Class: Eq_264
   DataType: word32
   OrigDataType: word32
-T_264: (in esp_251 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_264
+T_265: (in esp_251 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_265
   DataType: ptr32
   OrigDataType: ptr32
-T_265: (in Mem255[esp_251 - 0x00000004 + 0x00000000:(ptr LONG)] : (ptr LONG))
-  Class: Eq_260
-  DataType: (ptr Eq_260)
+T_266: (in Mem255[esp_251 - 0x00000004 + 0x00000000:(ptr LONG)] : (ptr LONG))
+  Class: Eq_261
+  DataType: (ptr Eq_261)
   OrigDataType: (ptr LONG)
-T_266: (in 0x00000000 : word32)
-  Class: Eq_266
+T_267: (in 0x00000000 : word32)
+  Class: Eq_267
   DataType: word32
   OrigDataType: word32
-T_267: (in esp_251 + 0x00000000 : word32)
-  Class: Eq_267
+T_268: (in esp_251 + 0x00000000 : word32)
+  Class: Eq_268
   DataType: (ptr word32)
   OrigDataType: (ptr word32)
-T_268: (in Mem255[esp_251 + 0x00000000:LONG] : LONG)
-  Class: Eq_138
-  DataType: Eq_138
+T_269: (in Mem255[esp_251 + 0x00000000:LONG] : LONG)
+  Class: Eq_139
+  DataType: Eq_139
   OrigDataType: LONG
-T_269: (in InterlockedExchange(*(esp_251 - 0x00000004), *esp_251) : LONG)
-  Class: Eq_138
-  DataType: Eq_138
+T_270: (in InterlockedExchange(*(esp_251 - 0x00000004), *esp_251) : LONG)
+  Class: Eq_139
+  DataType: Eq_139
   OrigDataType: LONG
-T_270: (in esp_263 : ptr32)
-  Class: Eq_270
+T_271: (in esp_263 : ptr32)
+  Class: Eq_271
   DataType: ptr32
   OrigDataType: ptr32
-T_271: (in 0x00000010 : word32)
-  Class: Eq_271
+T_272: (in 0x00000010 : word32)
+  Class: Eq_272
   DataType: ui32
   OrigDataType: ui32
-T_272: (in fp - 0x00000010 : word32)
-  Class: Eq_270
+T_273: (in fp - 0x00000010 : word32)
+  Class: Eq_271
   DataType: ptr32
   OrigDataType: ptr32
-T_273: (in edi_264 : (ptr word32))
-  Class: Eq_204
+T_274: (in edi_264 : (ptr word32))
+  Class: Eq_205
   DataType: (ptr word32)
   OrigDataType: (ptr (struct 0004 (0 word32 dw0000)))
-T_274: (in _decode_pointer : ptr32)
-  Class: Eq_205
-  DataType: (ptr Eq_205)
-  OrigDataType: (ptr (fn T_277 (T_276)))
-T_275: (in 0x100033B0 : ptr32)
-  Class: Eq_275
+T_275: (in _decode_pointer : ptr32)
+  Class: Eq_206
+  DataType: (ptr Eq_206)
+  OrigDataType: (ptr (fn T_278 (T_277)))
+T_276: (in 0x100033B0 : ptr32)
+  Class: Eq_276
   DataType: (ptr (ptr void))
-  OrigDataType: (ptr (struct (0 T_276 t0000)))
-T_276: (in Mem45[0x100033B0:word32] : word32)
-  Class: Eq_207
+  OrigDataType: (ptr (struct (0 T_277 t0000)))
+T_277: (in Mem45[0x100033B0:word32] : word32)
+  Class: Eq_208
   DataType: (ptr void)
   OrigDataType: (ptr void)
-T_277: (in _decode_pointer(globals->ptr100033B0) : (ptr void))
-  Class: Eq_204
+T_278: (in _decode_pointer(globals->ptr100033B0) : (ptr void))
+  Class: Eq_205
   DataType: (ptr word32)
   OrigDataType: (ptr void)
-T_278: (in 0x00000004 : word32)
-  Class: Eq_278
+T_279: (in 0x00000004 : word32)
+  Class: Eq_279
   DataType: ui32
   OrigDataType: ui32
-T_279: (in edi_264 - 0x00000004 : word32)
-  Class: Eq_204
+T_280: (in edi_264 - 0x00000004 : word32)
+  Class: Eq_205
   DataType: (ptr word32)
   OrigDataType: ptr32
-T_280: (in edi_264 >= ebx_233 : bool)
-  Class: Eq_280
+T_281: (in edi_264 >= ebx_233 : bool)
+  Class: Eq_281
   DataType: bool
   OrigDataType: bool
-T_281: (in _initterm : ptr32)
-  Class: Eq_281
-  DataType: (ptr Eq_281)
-  OrigDataType: (ptr (fn T_287 (T_285, T_286)))
-T_282: (in signature of _initterm : void)
-  Class: Eq_281
-  DataType: (ptr Eq_281)
+T_282: (in _initterm : ptr32)
+  Class: Eq_282
+  DataType: (ptr Eq_282)
+  OrigDataType: (ptr (fn T_288 (T_286, T_287)))
+T_283: (in signature of _initterm : void)
+  Class: Eq_282
+  DataType: (ptr Eq_282)
   OrigDataType: 
-T_283: (in fStart : (ptr PVFV))
-  Class: Eq_283
-  DataType: (ptr Eq_283)
-  OrigDataType: 
-T_284: (in fEnd : (ptr PVFV))
+T_284: (in fStart : (ptr PVFV))
   Class: Eq_284
   DataType: (ptr Eq_284)
   OrigDataType: 
-T_285: (in 0x10002098 : word32)
-  Class: Eq_283
-  DataType: (ptr Eq_283)
-  OrigDataType: (ptr PVFV)
-T_286: (in 0x1000209C : word32)
+T_285: (in fEnd : (ptr PVFV))
+  Class: Eq_285
+  DataType: (ptr Eq_285)
+  OrigDataType: 
+T_286: (in 0x10002098 : word32)
   Class: Eq_284
   DataType: (ptr Eq_284)
   OrigDataType: (ptr PVFV)
-T_287: (in _initterm(&globals->t10002098, &globals->t1000209C) : void)
-  Class: Eq_287
+T_287: (in 0x1000209C : word32)
+  Class: Eq_285
+  DataType: (ptr Eq_285)
+  OrigDataType: (ptr PVFV)
+T_288: (in _initterm(&globals->t10002098, &globals->t1000209C) : void)
+  Class: Eq_288
   DataType: void
   OrigDataType: void
-T_288: (in 0x00000002 : word32)
-  Class: Eq_192
+T_289: (in 0x00000002 : word32)
+  Class: Eq_193
   DataType: word32
   OrigDataType: word32
-T_289: (in 0x100033A8 : ptr32)
-  Class: Eq_289
+T_290: (in 0x100033A8 : ptr32)
+  Class: Eq_290
   DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_290 t0000)))
-T_290: (in Mem132[0x100033A8:word32] : word32)
-  Class: Eq_192
+  OrigDataType: (ptr (struct (0 T_291 t0000)))
+T_291: (in Mem132[0x100033A8:word32] : word32)
+  Class: Eq_193
   DataType: word32
   OrigDataType: word32
-T_291: (in 0x00000000 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_292: (in 0x00000000 : word32)
+  Class: Eq_139
+  DataType: Eq_139
   OrigDataType: word32
-T_292: (in ebp_203 != 0x00000000 : bool)
-  Class: Eq_292
+T_293: (in ebp_203 != 0x00000000 : bool)
+  Class: Eq_293
   DataType: bool
   OrigDataType: bool
-T_293: (in 0x00000000 : word32)
-  Class: Eq_137
+T_294: (in 0x00000000 : word32)
+  Class: Eq_138
   DataType: word32
   OrigDataType: word32
-T_294: (in eax_285 : (ptr code))
-  Class: Eq_294
+T_295: (in eax_285 : (ptr code))
+  Class: Eq_295
   DataType: (ptr code)
   OrigDataType: (ptr code)
-T_295: (in 0x00000000 : word32)
-  Class: Eq_295
+T_296: (in 0x00000000 : word32)
+  Class: Eq_296
   DataType: word32
   OrigDataType: word32
-T_296: (in edi_264 + 0x00000000 : word32)
-  Class: Eq_296
+T_297: (in edi_264 + 0x00000000 : word32)
+  Class: Eq_297
   DataType: ptr32
   OrigDataType: ptr32
-T_297: (in Mem45[edi_264 + 0x00000000:word32] : word32)
-  Class: Eq_294
+T_298: (in Mem45[edi_264 + 0x00000000:word32] : word32)
+  Class: Eq_295
   DataType: (ptr code)
   OrigDataType: word32
-T_298: (in 0x00000000 : word32)
-  Class: Eq_294
+T_299: (in 0x00000000 : word32)
+  Class: Eq_295
   DataType: (ptr code)
   OrigDataType: word32
-T_299: (in eax_285 == null : bool)
-  Class: Eq_299
+T_300: (in eax_285 == null : bool)
+  Class: Eq_300
   DataType: bool
   OrigDataType: bool
-T_300: (in esp_278 : (ptr (ptr word32)))
-  Class: Eq_300
-  DataType: (ptr (ptr word32))
-  OrigDataType: (ptr (struct (0 T_204 t0000)))
-T_301: (in 0x00000004 : word32)
+T_301: (in esp_278 : (ptr (ptr word32)))
   Class: Eq_301
+  DataType: (ptr (ptr word32))
+  OrigDataType: (ptr (struct (0 T_205 t0000)))
+T_302: (in 0x00000004 : word32)
+  Class: Eq_302
   DataType: ui32
   OrigDataType: ui32
-T_302: (in esp_263 - 0x00000004 : word32)
-  Class: Eq_300
+T_303: (in esp_263 - 0x00000004 : word32)
+  Class: Eq_301
   DataType: (ptr (ptr word32))
   OrigDataType: ptr32
-T_303: (in 0x00000000 : word32)
-  Class: Eq_303
+T_304: (in 0x00000000 : word32)
+  Class: Eq_304
   DataType: word32
   OrigDataType: word32
-T_304: (in esp_278 + 0x00000000 : word32)
-  Class: Eq_304
+T_305: (in esp_278 + 0x00000000 : word32)
+  Class: Eq_305
   DataType: ptr32
   OrigDataType: ptr32
-T_305: (in Mem279[esp_278 + 0x00000000:word32] : word32)
-  Class: Eq_204
+T_306: (in Mem279[esp_278 + 0x00000000:word32] : word32)
+  Class: Eq_205
   DataType: (ptr word32)
   OrigDataType: word32
-T_306: (in free : ptr32)
-  Class: Eq_306
-  DataType: (ptr Eq_306)
-  OrigDataType: (ptr (fn T_312 (T_311)))
-T_307: (in signature of free : void)
-  Class: Eq_306
-  DataType: (ptr Eq_306)
+T_307: (in free : ptr32)
+  Class: Eq_307
+  DataType: (ptr Eq_307)
+  OrigDataType: (ptr (fn T_313 (T_312)))
+T_308: (in signature of free : void)
+  Class: Eq_307
+  DataType: (ptr Eq_307)
   OrigDataType: 
-T_308: (in ptrArg04 : (ptr void))
-  Class: Eq_204
+T_309: (in ptrArg04 : (ptr void))
+  Class: Eq_205
   DataType: (ptr word32)
   OrigDataType: 
-T_309: (in 0x00000000 : word32)
-  Class: Eq_309
+T_310: (in 0x00000000 : word32)
+  Class: Eq_310
   DataType: word32
   OrigDataType: word32
-T_310: (in esp_278 + 0x00000000 : word32)
-  Class: Eq_310
+T_311: (in esp_278 + 0x00000000 : word32)
+  Class: Eq_311
   DataType: (ptr word32)
   OrigDataType: (ptr word32)
-T_311: (in Mem279[esp_278 + 0x00000000:(ptr void)] : (ptr void))
-  Class: Eq_204
+T_312: (in Mem279[esp_278 + 0x00000000:(ptr void)] : (ptr void))
+  Class: Eq_205
   DataType: (ptr word32)
   OrigDataType: (ptr void)
-T_312: (in free(*esp_278) : void)
-  Class: Eq_312
+T_313: (in free(*esp_278) : void)
+  Class: Eq_313
   DataType: void
   OrigDataType: void
-T_313: (in eax_282 : (ptr void))
-  Class: Eq_207
+T_314: (in eax_282 : (ptr void))
+  Class: Eq_208
   DataType: (ptr void)
   OrigDataType: (ptr void)
-T_314: (in _encoded_null : ptr32)
-  Class: Eq_314
-  DataType: (ptr Eq_314)
-  OrigDataType: (ptr (fn T_316 ()))
-T_315: (in signature of _encoded_null : void)
-  Class: Eq_314
-  DataType: (ptr Eq_314)
+T_315: (in _encoded_null : ptr32)
+  Class: Eq_315
+  DataType: (ptr Eq_315)
+  OrigDataType: (ptr (fn T_317 ()))
+T_316: (in signature of _encoded_null : void)
+  Class: Eq_315
+  DataType: (ptr Eq_315)
   OrigDataType: 
-T_316: (in _encoded_null() : (ptr void))
-  Class: Eq_207
+T_317: (in _encoded_null() : (ptr void))
+  Class: Eq_208
   DataType: (ptr void)
   OrigDataType: (ptr void)
-T_317: (in 0x100033B0 : ptr32)
-  Class: Eq_317
+T_318: (in 0x100033B0 : ptr32)
+  Class: Eq_318
   DataType: (ptr (ptr void))
-  OrigDataType: (ptr (struct (0 T_318 t0000)))
-T_318: (in Mem283[0x100033B0:word32] : word32)
-  Class: Eq_207
+  OrigDataType: (ptr (struct (0 T_319 t0000)))
+T_319: (in Mem283[0x100033B0:word32] : word32)
+  Class: Eq_208
   DataType: (ptr void)
   OrigDataType: word32
-T_319: (in 0x100033B4 : ptr32)
-  Class: Eq_319
+T_320: (in 0x100033B4 : ptr32)
+  Class: Eq_320
   DataType: (ptr (ptr void))
-  OrigDataType: (ptr (struct (0 T_320 t0000)))
-T_320: (in Mem284[0x100033B4:word32] : word32)
-  Class: Eq_207
+  OrigDataType: (ptr (struct (0 T_321 t0000)))
+T_321: (in Mem284[0x100033B4:word32] : word32)
+  Class: Eq_208
   DataType: (ptr void)
   OrigDataType: word32
-T_321: (in 0x00000004 : word32)
-  Class: Eq_321
+T_322: (in 0x00000004 : word32)
+  Class: Eq_322
   DataType: int32
   OrigDataType: int32
-T_322: (in esp_278 + 0x00000004 : word32)
-  Class: Eq_212
+T_323: (in esp_278 + 0x00000004 : word32)
+  Class: Eq_213
   DataType: ptr32
   OrigDataType: ptr32
-T_323: (in eax_290 : word32)
-  Class: Eq_323
-  DataType: word32
-  OrigDataType: word32
-T_324: (in ebp_291 : word32)
+T_324: (in eax_290 : word32)
   Class: Eq_324
   DataType: word32
   OrigDataType: word32
-T_325: (in SZO_292 : byte)
+T_325: (in ebp_291 : word32)
   Class: Eq_325
-  DataType: byte
-  OrigDataType: byte
-T_326: (in C_293 : byte)
+  DataType: word32
+  OrigDataType: word32
+T_326: (in SZO_292 : byte)
   Class: Eq_326
   DataType: byte
   OrigDataType: byte
-T_327: (in SCZO_294 : byte)
+T_327: (in C_293 : byte)
   Class: Eq_327
   DataType: byte
   OrigDataType: byte
-T_328: (in Z_295 : byte)
+T_328: (in SCZO_294 : byte)
   Class: Eq_328
   DataType: byte
   OrigDataType: byte
-T_329: (in ecx_296 : word32)
+T_329: (in Z_295 : byte)
   Class: Eq_329
-  DataType: word32
-  OrigDataType: word32
-T_330: (in esi_298 : word32)
+  DataType: byte
+  OrigDataType: byte
+T_330: (in ecx_296 : word32)
   Class: Eq_330
   DataType: word32
   OrigDataType: word32
-T_331: (in fs_300 : (ptr Eq_331))
+T_331: (in esi_298 : word32)
   Class: Eq_331
-  DataType: (ptr Eq_331)
-  OrigDataType: (ptr (segment))
-T_332: (in 0x100033B8 : ptr32)
+  DataType: word32
+  OrigDataType: word32
+T_332: (in fs_300 : (ptr Eq_332))
   Class: Eq_332
+  DataType: (ptr Eq_332)
+  OrigDataType: (ptr (segment))
+T_333: (in 0x100033B8 : ptr32)
+  Class: Eq_333
   DataType: (ptr (ptr code))
-  OrigDataType: (ptr (struct (0 T_333 t0000)))
-T_333: (in Mem132[0x100033B8:word32] : word32)
-  Class: Eq_333
+  OrigDataType: (ptr (struct (0 T_334 t0000)))
+T_334: (in Mem132[0x100033B8:word32] : word32)
+  Class: Eq_334
   DataType: (ptr code)
   OrigDataType: word32
-T_334: (in 0x00000000 : word32)
-  Class: Eq_333
+T_335: (in 0x00000000 : word32)
+  Class: Eq_334
   DataType: (ptr code)
   OrigDataType: word32
-T_335: (in globals->ptr100033B8 == null : bool)
-  Class: Eq_335
+T_336: (in globals->ptr100033B8 == null : bool)
+  Class: Eq_336
   DataType: bool
   OrigDataType: bool
-T_336: (in InterlockedExchange : ptr32)
-  Class: Eq_258
-  DataType: (ptr Eq_258)
-  OrigDataType: (ptr (fn T_338 (T_337, T_138)))
-T_337: (in 0x100033AC : ptr32)
-  Class: Eq_260
-  DataType: (ptr Eq_260)
+T_337: (in InterlockedExchange : ptr32)
+  Class: Eq_259
+  DataType: (ptr Eq_259)
+  OrigDataType: (ptr (fn T_339 (T_338, T_139)))
+T_338: (in 0x100033AC : ptr32)
+  Class: Eq_261
+  DataType: (ptr Eq_261)
   OrigDataType: (ptr LONG)
-T_338: (in InterlockedExchange(&globals->t100033AC, ebp_203) : LONG)
-  Class: Eq_138
-  DataType: Eq_138
+T_339: (in InterlockedExchange(&globals->t100033AC, ebp_203) : LONG)
+  Class: Eq_139
+  DataType: Eq_139
   OrigDataType: LONG
-T_339: (in 0x10003070 : ptr32)
-  Class: Eq_339
+T_340: (in 0x10003070 : ptr32)
+  Class: Eq_340
   DataType: (ptr int32)
-  OrigDataType: (ptr (struct (0 T_153 t0000)))
-T_340: (in Mem132[0x10003070:word32] : word32)
-  Class: Eq_153
+  OrigDataType: (ptr (struct (0 T_154 t0000)))
+T_341: (in Mem132[0x10003070:word32] : word32)
+  Class: Eq_154
   DataType: int32
   OrigDataType: word32
-T_341: (in 0x00000001 : word32)
-  Class: Eq_341
+T_342: (in 0x00000001 : word32)
+  Class: Eq_342
   DataType: word32
   OrigDataType: word32
-T_342: (in globals->dw10003070 + 0x00000001 : word32)
-  Class: Eq_153
+T_343: (in globals->dw10003070 + 0x00000001 : word32)
+  Class: Eq_154
   DataType: int32
   OrigDataType: word32
-T_343: (in Mem157[0x10003070:word32] : word32)
-  Class: Eq_153
+T_344: (in Mem157[0x10003070:word32] : word32)
+  Class: Eq_154
   DataType: int32
   OrigDataType: word32
-T_344: (in edi_161 : word32)
-  Class: Eq_344
-  DataType: word32
-  OrigDataType: word32
-T_345: (in eax_162 : word32)
+T_345: (in edi_161 : word32)
   Class: Eq_345
   DataType: word32
   OrigDataType: word32
-T_346: (in fn10001742 : ptr32)
+T_346: (in eax_162 : word32)
   Class: Eq_346
-  DataType: (ptr Eq_346)
-  OrigDataType: (ptr (fn T_356 (T_352, T_353, T_354, T_355)))
-T_347: (in signature of fn10001742 : void)
-  Class: Eq_346
-  DataType: (ptr Eq_346)
+  DataType: word32
+  OrigDataType: word32
+T_347: (in fn10001742 : ptr32)
+  Class: Eq_347
+  DataType: (ptr Eq_347)
+  OrigDataType: (ptr (fn T_357 (T_353, T_354, T_355, T_356)))
+T_348: (in signature of fn10001742 : void)
+  Class: Eq_347
+  DataType: (ptr Eq_347)
   OrigDataType: 
-T_348: (in ebx : (ptr Eq_172))
-  Class: Eq_172
-  DataType: (ptr Eq_172)
+T_349: (in ebx : (ptr Eq_173))
+  Class: Eq_173
+  DataType: (ptr Eq_173)
   OrigDataType: word32
-T_349: (in esi : ptr32)
-  Class: Eq_349
-  DataType: ptr32
-  OrigDataType: word32
-T_350: (in edi : word32)
+T_350: (in esi : ptr32)
   Class: Eq_350
+  DataType: ptr32
+  OrigDataType: word32
+T_351: (in edi : word32)
+  Class: Eq_351
   DataType: word32
   OrigDataType: word32
-T_351: (in ediOut : ptr32)
-  Class: Eq_351
+T_352: (in ediOut : ptr32)
+  Class: Eq_352
   DataType: ptr32
   OrigDataType: ptr32
-T_352: (in InterlockedCompareExchange : ptr32)
-  Class: Eq_172
-  DataType: (ptr Eq_172)
+T_353: (in InterlockedCompareExchange : ptr32)
+  Class: Eq_173
+  DataType: (ptr Eq_173)
   OrigDataType: ptr32
-T_353: (in 0x100033AC : ptr32)
-  Class: Eq_349
-  DataType: ptr32
-  OrigDataType: ptr32
-T_354: (in 0x00000002 : word32)
+T_354: (in 0x100033AC : ptr32)
   Class: Eq_350
-  DataType: word32
-  OrigDataType: word32
-T_355: (in out edi_161 : ptr32)
-  Class: Eq_351
   DataType: ptr32
   OrigDataType: ptr32
-T_356: (in fn10001742(InterlockedCompareExchange, 0x100033AC, 0x00000002, out edi_161) : word32)
-  Class: Eq_345
+T_355: (in 0x00000002 : word32)
+  Class: Eq_351
   DataType: word32
   OrigDataType: word32
-T_357: (in 0x00000000 : word32)
-  Class: Eq_345
+T_356: (in out edi_161 : ptr32)
+  Class: Eq_352
+  DataType: ptr32
+  OrigDataType: ptr32
+T_357: (in fn10001742(InterlockedCompareExchange, 0x100033AC, 0x00000002, out edi_161) : word32)
+  Class: Eq_346
   DataType: word32
   OrigDataType: word32
-T_358: (in eax_162 == 0x00000000 : bool)
-  Class: Eq_358
+T_358: (in 0x00000000 : word32)
+  Class: Eq_346
+  DataType: word32
+  OrigDataType: word32
+T_359: (in eax_162 == 0x00000000 : bool)
+  Class: Eq_359
   DataType: bool
   OrigDataType: bool
-T_359: (in 0x0000000C : word32)
-  Class: Eq_359
-  DataType: word32
-  OrigDataType: word32
-T_360: (in fp + 0x0000000C : word32)
+T_360: (in 0x0000000C : word32)
   Class: Eq_360
-  DataType: ptr32
-  OrigDataType: ptr32
-T_361: (in Mem132[fp + 0x0000000C:word32] : word32)
-  Class: Eq_361
   DataType: word32
   OrigDataType: word32
-T_362: (in 0x00000014 : word32)
+T_361: (in fp + 0x0000000C : word32)
+  Class: Eq_361
+  DataType: ptr32
+  OrigDataType: ptr32
+T_362: (in Mem132[fp + 0x0000000C:word32] : word32)
   Class: Eq_362
-  DataType: ui32
-  OrigDataType: ui32
-T_363: (in fp - 0x00000014 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_363: (in 0x00000014 : word32)
   Class: Eq_363
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_366 t0000)))
-T_364: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_364: (in fp - 0x00000014 : word32)
   Class: Eq_364
-  DataType: word32
-  OrigDataType: word32
-T_365: (in fp - 0x00000014 + 0x00000000 : word32)
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_367 t0000)))
+T_365: (in 0x00000000 : word32)
   Class: Eq_365
-  DataType: ptr32
-  OrigDataType: ptr32
-T_366: (in Mem170[fp - 0x00000014 + 0x00000000:word32] : word32)
-  Class: Eq_361
   DataType: word32
   OrigDataType: word32
-T_367: (in 0x00000018 : word32)
-  Class: Eq_367
-  DataType: ui32
-  OrigDataType: ui32
-T_368: (in fp - 0x00000018 : word32)
+T_366: (in fp - 0x00000014 + 0x00000000 : word32)
+  Class: Eq_366
+  DataType: ptr32
+  OrigDataType: ptr32
+T_367: (in Mem170[fp - 0x00000014 + 0x00000000:word32] : word32)
+  Class: Eq_362
+  DataType: word32
+  OrigDataType: word32
+T_368: (in 0x00000018 : word32)
   Class: Eq_368
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_371 t0000)))
-T_369: (in 0x00000000 : word32)
-  Class: Eq_369
-  DataType: word32
-  OrigDataType: word32
-T_370: (in fp - 0x00000018 + 0x00000000 : word32)
-  Class: Eq_370
-  DataType: ptr32
-  OrigDataType: ptr32
-T_371: (in Mem172[fp - 0x00000018 + 0x00000000:word32] : word32)
-  Class: Eq_344
-  DataType: word32
-  OrigDataType: word32
-T_372: (in 0x00000004 : word32)
-  Class: Eq_372
-  DataType: word32
-  OrigDataType: word32
-T_373: (in fp + 0x00000004 : word32)
-  Class: Eq_373
-  DataType: ptr32
-  OrigDataType: ptr32
-T_374: (in Mem172[fp + 0x00000004:word32] : word32)
-  Class: Eq_374
-  DataType: word32
-  OrigDataType: word32
-T_375: (in 0x0000001C : word32)
-  Class: Eq_375
   DataType: ui32
   OrigDataType: ui32
-T_376: (in fp - 0x0000001C : word32)
-  Class: Eq_376
+T_369: (in fp - 0x00000018 : word32)
+  Class: Eq_369
   DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_379 t0000)))
-T_377: (in 0x00000000 : word32)
-  Class: Eq_377
+  OrigDataType: (ptr (struct (0 T_372 t0000)))
+T_370: (in 0x00000000 : word32)
+  Class: Eq_370
   DataType: word32
   OrigDataType: word32
-T_378: (in fp - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_378
+T_371: (in fp - 0x00000018 + 0x00000000 : word32)
+  Class: Eq_371
   DataType: ptr32
   OrigDataType: ptr32
-T_379: (in Mem175[fp - 0x0000001C + 0x00000000:word32] : word32)
+T_372: (in Mem172[fp - 0x00000018 + 0x00000000:word32] : word32)
+  Class: Eq_345
+  DataType: word32
+  OrigDataType: word32
+T_373: (in 0x00000004 : word32)
+  Class: Eq_373
+  DataType: word32
+  OrigDataType: word32
+T_374: (in fp + 0x00000004 : word32)
   Class: Eq_374
+  DataType: ptr32
+  OrigDataType: ptr32
+T_375: (in Mem172[fp + 0x00000004:word32] : word32)
+  Class: Eq_375
   DataType: word32
   OrigDataType: word32
-T_380: (in esp_176 : word32)
-  Class: Eq_380
+T_376: (in 0x0000001C : word32)
+  Class: Eq_376
+  DataType: ui32
+  OrigDataType: ui32
+T_377: (in fp - 0x0000001C : word32)
+  Class: Eq_377
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_380 t0000)))
+T_378: (in 0x00000000 : word32)
+  Class: Eq_378
   DataType: word32
   OrigDataType: word32
-T_381: (in eax_177 : word32)
+T_379: (in fp - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_379
+  DataType: ptr32
+  OrigDataType: ptr32
+T_380: (in Mem175[fp - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_375
+  DataType: word32
+  OrigDataType: word32
+T_381: (in esp_176 : word32)
   Class: Eq_381
   DataType: word32
   OrigDataType: word32
-T_382: (in ebp_178 : word32)
+T_382: (in eax_177 : word32)
   Class: Eq_382
   DataType: word32
   OrigDataType: word32
-T_383: (in SZO_179 : byte)
+T_383: (in ebp_178 : word32)
   Class: Eq_383
-  DataType: byte
-  OrigDataType: byte
-T_384: (in C_180 : byte)
+  DataType: word32
+  OrigDataType: word32
+T_384: (in SZO_179 : byte)
   Class: Eq_384
   DataType: byte
   OrigDataType: byte
-T_385: (in SCZO_181 : byte)
+T_385: (in C_180 : byte)
   Class: Eq_385
   DataType: byte
   OrigDataType: byte
-T_386: (in Z_182 : byte)
+T_386: (in SCZO_181 : byte)
   Class: Eq_386
   DataType: byte
   OrigDataType: byte
-T_387: (in ecx_183 : word32)
+T_387: (in Z_182 : byte)
   Class: Eq_387
-  DataType: word32
-  OrigDataType: word32
-T_388: (in ebx_184 : word32)
+  DataType: byte
+  OrigDataType: byte
+T_388: (in ecx_183 : word32)
   Class: Eq_388
   DataType: word32
   OrigDataType: word32
-T_389: (in esi_185 : word32)
+T_389: (in ebx_184 : word32)
   Class: Eq_389
   DataType: word32
   OrigDataType: word32
-T_390: (in edi_186 : word32)
+T_390: (in esi_185 : word32)
   Class: Eq_390
   DataType: word32
   OrigDataType: word32
-T_391: (in fs_187 : (ptr Eq_391))
+T_391: (in edi_186 : word32)
   Class: Eq_391
-  DataType: (ptr Eq_391)
-  OrigDataType: (ptr (segment))
-T_392: (in 0x100033B8 : ptr32)
+  DataType: word32
+  OrigDataType: word32
+T_392: (in fs_187 : (ptr Eq_392))
   Class: Eq_392
+  DataType: (ptr Eq_392)
+  OrigDataType: (ptr (segment))
+T_393: (in 0x100033B8 : ptr32)
+  Class: Eq_393
   DataType: (ptr (ptr code))
-  OrigDataType: (ptr (struct (0 T_393 t0000)))
-T_393: (in Mem175[0x100033B8:word32] : word32)
-  Class: Eq_333
+  OrigDataType: (ptr (struct (0 T_394 t0000)))
+T_394: (in Mem175[0x100033B8:word32] : word32)
+  Class: Eq_334
   DataType: (ptr code)
   OrigDataType: (ptr code)
-T_394: (in eax : word32)
-  Class: Eq_394
-  DataType: word32
-  OrigDataType: word32
-T_395: (in ecx : Eq_395)
+T_395: (in eax : word32)
   Class: Eq_395
-  DataType: Eq_395
-  OrigDataType: word32
-T_396: (in edx : Eq_197)
-  Class: Eq_197
-  DataType: Eq_197
-  OrigDataType: word32
-T_397: (in ebx : (ptr Eq_172))
-  Class: Eq_172
-  DataType: (ptr Eq_172)
-  OrigDataType: word32
-T_398: (in esi : ptr32)
-  Class: Eq_349
-  DataType: ptr32
-  OrigDataType: word32
-T_399: (in edi : word32)
-  Class: Eq_350
   DataType: word32
   OrigDataType: word32
-T_400: (in ebp_10 : (ptr Eq_400))
-  Class: Eq_400
-  DataType: (ptr Eq_400)
-  OrigDataType: (ptr (struct (8 T_416 t0008)))
-T_401: (in fn100017E8 : ptr32)
+T_396: (in ecx : Eq_396)
+  Class: Eq_396
+  DataType: Eq_396
+  OrigDataType: word32
+T_397: (in edx : Eq_198)
+  Class: Eq_198
+  DataType: Eq_198
+  OrigDataType: word32
+T_398: (in ebx : (ptr Eq_173))
+  Class: Eq_173
+  DataType: (ptr Eq_173)
+  OrigDataType: word32
+T_399: (in esi : ptr32)
+  Class: Eq_350
+  DataType: ptr32
+  OrigDataType: word32
+T_400: (in edi : word32)
+  Class: Eq_351
+  DataType: word32
+  OrigDataType: word32
+T_401: (in ebp_10 : (ptr Eq_401))
   Class: Eq_401
   DataType: (ptr Eq_401)
-  OrigDataType: (ptr (fn T_412 (T_397, T_398, T_399, T_409, T_410, T_411)))
-T_402: (in signature of fn100017E8 : void)
-  Class: Eq_401
-  DataType: (ptr Eq_401)
+  OrigDataType: (ptr (struct (8 T_417 t0008)))
+T_402: (in fn100017E8 : ptr32)
+  Class: Eq_402
+  DataType: (ptr Eq_402)
+  OrigDataType: (ptr (fn T_413 (T_398, T_399, T_400, T_410, T_411, T_412)))
+T_403: (in signature of fn100017E8 : void)
+  Class: Eq_402
+  DataType: (ptr Eq_402)
   OrigDataType: 
-T_403: (in ebx : (ptr Eq_172))
-  Class: Eq_172
-  DataType: (ptr Eq_172)
+T_404: (in ebx : (ptr Eq_173))
+  Class: Eq_173
+  DataType: (ptr Eq_173)
   OrigDataType: word32
-T_404: (in esi : ptr32)
-  Class: Eq_349
+T_405: (in esi : ptr32)
+  Class: Eq_350
   DataType: ptr32
   OrigDataType: word32
-T_405: (in edi : word32)
-  Class: Eq_350
+T_406: (in edi : word32)
+  Class: Eq_351
   DataType: word32
   OrigDataType: word32
-T_406: (in dwArg00 : word32)
-  Class: Eq_406
-  DataType: word32
-  OrigDataType: word32
-T_407: (in dwArg04 : word32)
+T_407: (in dwArg00 : word32)
   Class: Eq_407
   DataType: word32
   OrigDataType: word32
-T_408: (in dwArg08 : word32)
+T_408: (in dwArg04 : word32)
   Class: Eq_408
   DataType: word32
   OrigDataType: word32
-T_409: (in dwLoc0C : word32)
-  Class: Eq_406
+T_409: (in dwArg08 : word32)
+  Class: Eq_409
   DataType: word32
   OrigDataType: word32
-T_410: (in 0x100021E8 : word32)
+T_410: (in dwLoc0C : word32)
   Class: Eq_407
   DataType: word32
   OrigDataType: word32
-T_411: (in 0x00000010 : word32)
+T_411: (in 0x100021E8 : word32)
   Class: Eq_408
   DataType: word32
   OrigDataType: word32
-T_412: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x100021E8, 0x00000010) : word32)
-  Class: Eq_400
-  DataType: (ptr Eq_400)
+T_412: (in 0x00000010 : word32)
+  Class: Eq_409
+  DataType: word32
   OrigDataType: word32
-T_413: (in ebx_158 : ui32)
-  Class: Eq_413
+T_413: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x100021E8, 0x00000010) : word32)
+  Class: Eq_401
+  DataType: (ptr Eq_401)
+  OrigDataType: word32
+T_414: (in ebx_158 : ui32)
+  Class: Eq_414
   DataType: ui32
   OrigDataType: word32
-T_414: (in 0x00000008 : word32)
-  Class: Eq_414
-  DataType: word32
-  OrigDataType: word32
-T_415: (in ebp_10 + 0x00000008 : word32)
+T_415: (in 0x00000008 : word32)
   Class: Eq_415
   DataType: word32
   OrigDataType: word32
-T_416: (in Mem0[ebp_10 + 0x00000008:word32] : word32)
-  Class: Eq_413
-  DataType: ui32
-  OrigDataType: word32
-T_417: (in 0x00000001 : word32)
-  Class: Eq_417
+T_416: (in ebp_10 + 0x00000008 : word32)
+  Class: Eq_416
   DataType: word32
   OrigDataType: word32
-T_418: (in 0x0000001C : word32)
+T_417: (in Mem0[ebp_10 + 0x00000008:word32] : word32)
+  Class: Eq_414
+  DataType: ui32
+  OrigDataType: word32
+T_418: (in 0x00000001 : word32)
   Class: Eq_418
-  DataType: ui32
-  OrigDataType: ui32
-T_419: (in ebp_10 - 0x0000001C : word32)
+  DataType: word32
+  OrigDataType: word32
+T_419: (in 0x0000001C : word32)
   Class: Eq_419
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_422 t0000)))
-T_420: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_420: (in ebp_10 - 0x0000001C : word32)
   Class: Eq_420
-  DataType: word32
-  OrigDataType: word32
-T_421: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_423 t0000)))
+T_421: (in 0x00000000 : word32)
   Class: Eq_421
+  DataType: word32
+  OrigDataType: word32
+T_422: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_422
   DataType: ptr32
   OrigDataType: ptr32
-T_422: (in Mem19[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_417
+T_423: (in Mem19[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_418
   DataType: word32
   OrigDataType: word32
-T_423: (in 0x00000000 : word32)
-  Class: Eq_423
-  DataType: word32
-  OrigDataType: word32
-T_424: (in 0x00000004 : word32)
+T_424: (in 0x00000000 : word32)
   Class: Eq_424
-  DataType: ui32
-  OrigDataType: ui32
-T_425: (in ebp_10 - 0x00000004 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_425: (in 0x00000004 : word32)
   Class: Eq_425
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_428 t0000)))
-T_426: (in 0x00000000 : word32)
-  Class: Eq_426
-  DataType: word32
-  OrigDataType: word32
-T_427: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_427
-  DataType: ptr32
-  OrigDataType: ptr32
-T_428: (in Mem21[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_423
-  DataType: word32
-  OrigDataType: word32
-T_429: (in 0x10003008 : ptr32)
-  Class: Eq_429
-  DataType: (ptr Eq_197)
-  OrigDataType: (ptr (struct (0 T_430 t0000)))
-T_430: (in Mem22[0x10003008:word32] : word32)
-  Class: Eq_197
-  DataType: Eq_197
-  OrigDataType: word32
-T_431: (in 0x00000001 : word32)
-  Class: Eq_431
-  DataType: word32
-  OrigDataType: word32
-T_432: (in 0x00000004 : word32)
-  Class: Eq_432
   DataType: ui32
   OrigDataType: ui32
-T_433: (in ebp_10 - 0x00000004 : word32)
-  Class: Eq_433
+T_426: (in ebp_10 - 0x00000004 : word32)
+  Class: Eq_426
   DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_436 t0000)))
-T_434: (in 0x00000000 : word32)
+  OrigDataType: (ptr (struct (0 T_429 t0000)))
+T_427: (in 0x00000000 : word32)
+  Class: Eq_427
+  DataType: word32
+  OrigDataType: word32
+T_428: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_428
+  DataType: ptr32
+  OrigDataType: ptr32
+T_429: (in Mem21[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_424
+  DataType: word32
+  OrigDataType: word32
+T_430: (in 0x10003008 : ptr32)
+  Class: Eq_430
+  DataType: (ptr Eq_198)
+  OrigDataType: (ptr (struct (0 T_431 t0000)))
+T_431: (in Mem22[0x10003008:word32] : word32)
+  Class: Eq_198
+  DataType: Eq_198
+  OrigDataType: word32
+T_432: (in 0x00000001 : word32)
+  Class: Eq_432
+  DataType: word32
+  OrigDataType: word32
+T_433: (in 0x00000004 : word32)
+  Class: Eq_433
+  DataType: ui32
+  OrigDataType: ui32
+T_434: (in ebp_10 - 0x00000004 : word32)
   Class: Eq_434
-  DataType: word32
-  OrigDataType: word32
-T_435: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_437 t0000)))
+T_435: (in 0x00000000 : word32)
   Class: Eq_435
-  DataType: ptr32
-  OrigDataType: ptr32
-T_436: (in Mem23[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_431
   DataType: word32
   OrigDataType: word32
-T_437: (in esp_175 : ptr32)
-  Class: Eq_437
+T_436: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_436
   DataType: ptr32
   OrigDataType: ptr32
-T_438: (in fp : ptr32)
+T_437: (in Mem23[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_432
+  DataType: word32
+  OrigDataType: word32
+T_438: (in esp_175 : ptr32)
   Class: Eq_438
   DataType: ptr32
   OrigDataType: ptr32
-T_439: (in 0x00000008 : word32)
+T_439: (in fp : ptr32)
   Class: Eq_439
-  DataType: ui32
-  OrigDataType: ui32
-T_440: (in fp - 0x00000008 : word32)
-  Class: Eq_437
   DataType: ptr32
   OrigDataType: ptr32
-T_441: (in edi_12 : Eq_395)
-  Class: Eq_395
-  DataType: Eq_395
+T_440: (in 0x00000008 : word32)
+  Class: Eq_440
+  DataType: ui32
+  OrigDataType: ui32
+T_441: (in fp - 0x00000008 : word32)
+  Class: Eq_438
+  DataType: ptr32
+  OrigDataType: ptr32
+T_442: (in edi_12 : Eq_396)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: word32
-T_442: (in esi_14 : Eq_197)
-  Class: Eq_197
-  DataType: Eq_197
+T_443: (in esi_14 : Eq_198)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_443: (in 0x00000000 : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_444: (in 0x00000000 : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_444: (in edx != 0x00000000 : bool)
-  Class: Eq_444
+T_445: (in edx != 0x00000000 : bool)
+  Class: Eq_445
   DataType: bool
   OrigDataType: bool
-T_445: (in 0x00000001 : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_446: (in 0x00000001 : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_446: (in edx == 0x00000001 : bool)
-  Class: Eq_446
-  DataType: bool
-  OrigDataType: bool
-T_447: (in 0x10003070 : ptr32)
+T_447: (in edx == 0x00000001 : bool)
   Class: Eq_447
-  DataType: (ptr int32)
-  OrigDataType: (ptr (struct (0 T_448 t0000)))
-T_448: (in Mem23[0x10003070:word32] : word32)
-  Class: Eq_153
-  DataType: int32
-  OrigDataType: word32
-T_449: (in 0x00000000 : word32)
-  Class: Eq_153
-  DataType: int32
-  OrigDataType: word32
-T_450: (in globals->dw10003070 != 0x00000000 : bool)
-  Class: Eq_450
   DataType: bool
   OrigDataType: bool
-T_451: (in 0x00000000 : word32)
-  Class: Eq_451
-  DataType: word32
+T_448: (in 0x10003070 : ptr32)
+  Class: Eq_448
+  DataType: (ptr int32)
+  OrigDataType: (ptr (struct (0 T_449 t0000)))
+T_449: (in Mem23[0x10003070:word32] : word32)
+  Class: Eq_154
+  DataType: int32
   OrigDataType: word32
-T_452: (in 0x0000001C : word32)
+T_450: (in 0x00000000 : word32)
+  Class: Eq_154
+  DataType: int32
+  OrigDataType: word32
+T_451: (in globals->dw10003070 != 0x00000000 : bool)
+  Class: Eq_451
+  DataType: bool
+  OrigDataType: bool
+T_452: (in 0x00000000 : word32)
   Class: Eq_452
-  DataType: ui32
-  OrigDataType: ui32
-T_453: (in ebp_10 - 0x0000001C : word32)
+  DataType: word32
+  OrigDataType: word32
+T_453: (in 0x0000001C : word32)
   Class: Eq_453
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_456 t0000)))
-T_454: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_454: (in ebp_10 - 0x0000001C : word32)
   Class: Eq_454
-  DataType: word32
-  OrigDataType: word32
-T_455: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_457 t0000)))
+T_455: (in 0x00000000 : word32)
   Class: Eq_455
-  DataType: ptr32
-  OrigDataType: ptr32
-T_456: (in Mem217[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_451
   DataType: word32
   OrigDataType: word32
-T_457: (in 0x00000004 : word32)
-  Class: Eq_457
-  DataType: ui32
-  OrigDataType: ui32
-T_458: (in ebp_10 - 0x00000004 : word32)
+T_456: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_456
+  DataType: ptr32
+  OrigDataType: ptr32
+T_457: (in Mem217[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_452
+  DataType: word32
+  OrigDataType: word32
+T_458: (in 0x00000004 : word32)
   Class: Eq_458
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_461 t0000)))
-T_459: (in 0x00000000 : word32)
-  Class: Eq_459
-  DataType: word32
-  OrigDataType: word32
-T_460: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_460
-  DataType: ptr32
-  OrigDataType: ptr32
-T_461: (in Mem23[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_461
   DataType: ui32
   OrigDataType: ui32
-T_462: (in 0x00000000 : word32)
+T_459: (in ebp_10 - 0x00000004 : word32)
+  Class: Eq_459
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_462 t0000)))
+T_460: (in 0x00000000 : word32)
+  Class: Eq_460
+  DataType: word32
+  OrigDataType: word32
+T_461: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_461
+  DataType: ptr32
+  OrigDataType: ptr32
+T_462: (in Mem23[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
   Class: Eq_462
   DataType: ui32
   OrigDataType: ui32
-T_463: (in *(ebp_10 - 0x00000004) & 0x00000000 : word32)
+T_463: (in 0x00000000 : word32)
   Class: Eq_463
   DataType: ui32
   OrigDataType: ui32
-T_464: (in 0x00000004 : word32)
+T_464: (in *(ebp_10 - 0x00000004) & 0x00000000 : word32)
   Class: Eq_464
   DataType: ui32
   OrigDataType: ui32
-T_465: (in ebp_10 - 0x00000004 : word32)
+T_465: (in 0x00000004 : word32)
   Class: Eq_465
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_468 t0000)))
-T_466: (in 0x00000000 : word32)
-  Class: Eq_466
-  DataType: word32
-  OrigDataType: word32
-T_467: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_467
-  DataType: ptr32
-  OrigDataType: ptr32
-T_468: (in Mem35[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_463
-  DataType: ui32
-  OrigDataType: word32
-T_469: (in 0xFFFFFFFE : word32)
-  Class: Eq_469
-  DataType: word32
-  OrigDataType: word32
-T_470: (in 0x00000004 : word32)
-  Class: Eq_470
   DataType: ui32
   OrigDataType: ui32
-T_471: (in ebp_10 - 0x00000004 : word32)
-  Class: Eq_471
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_474 t0000)))
-T_472: (in 0x00000000 : word32)
-  Class: Eq_472
+T_466: (in ebp_10 - 0x00000004 : word32)
+  Class: Eq_466
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_469 t0000)))
+T_467: (in 0x00000000 : word32)
+  Class: Eq_467
   DataType: word32
   OrigDataType: word32
-T_473: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_473
+T_468: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_468
   DataType: ptr32
   OrigDataType: ptr32
-T_474: (in Mem38[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_469
+T_469: (in Mem35[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_464
+  DataType: ui32
+  OrigDataType: word32
+T_470: (in 0xFFFFFFFE : word32)
+  Class: Eq_470
   DataType: word32
   OrigDataType: word32
-T_475: (in fn10001493 : ptr32)
-  Class: Eq_475
-  DataType: (ptr Eq_475)
-  OrigDataType: (ptr (fn T_477 ()))
-T_476: (in signature of fn10001493 : void)
-  Class: Eq_475
-  DataType: (ptr Eq_475)
+T_471: (in 0x00000004 : word32)
+  Class: Eq_471
+  DataType: ui32
+  OrigDataType: ui32
+T_472: (in ebp_10 - 0x00000004 : word32)
+  Class: Eq_472
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_475 t0000)))
+T_473: (in 0x00000000 : word32)
+  Class: Eq_473
+  DataType: word32
+  OrigDataType: word32
+T_474: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_474
+  DataType: ptr32
+  OrigDataType: ptr32
+T_475: (in Mem38[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_470
+  DataType: word32
+  OrigDataType: word32
+T_476: (in fn10001493 : ptr32)
+  Class: Eq_476
+  DataType: (ptr Eq_476)
+  OrigDataType: (ptr (fn T_478 ()))
+T_477: (in signature of fn10001493 : void)
+  Class: Eq_476
+  DataType: (ptr Eq_476)
   OrigDataType: 
-T_477: (in fn10001493() : void)
-  Class: Eq_477
+T_478: (in fn10001493() : void)
+  Class: Eq_478
   DataType: void
   OrigDataType: void
-T_478: (in eax_39 : word32)
-  Class: Eq_394
+T_479: (in eax_39 : word32)
+  Class: Eq_395
   DataType: word32
   OrigDataType: word32
-T_479: (in 0x0000001C : word32)
-  Class: Eq_479
+T_480: (in 0x0000001C : word32)
+  Class: Eq_480
   DataType: ui32
   OrigDataType: ui32
-T_480: (in ebp_10 - 0x0000001C : word32)
-  Class: Eq_480
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_483 t0000)))
-T_481: (in 0x00000000 : word32)
+T_481: (in ebp_10 - 0x0000001C : word32)
   Class: Eq_481
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_484 t0000)))
+T_482: (in 0x00000000 : word32)
+  Class: Eq_482
   DataType: word32
   OrigDataType: word32
-T_482: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_482
+T_483: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_483
   DataType: ptr32
   OrigDataType: ptr32
-T_483: (in Mem38[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_394
+T_484: (in Mem38[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_395
   DataType: word32
   OrigDataType: word32
-T_484: (in fn1000182D : ptr32)
-  Class: Eq_484
-  DataType: (ptr Eq_484)
-  OrigDataType: (ptr (fn T_497 (T_400, T_492, T_493, T_494, T_495, T_496)))
-T_485: (in signature of fn1000182D : void)
-  Class: Eq_484
-  DataType: (ptr Eq_484)
+T_485: (in fn1000182D : ptr32)
+  Class: Eq_485
+  DataType: (ptr Eq_485)
+  OrigDataType: (ptr (fn T_498 (T_401, T_493, T_494, T_495, T_496, T_497)))
+T_486: (in signature of fn1000182D : void)
+  Class: Eq_485
+  DataType: (ptr Eq_485)
   OrigDataType: 
-T_486: (in ebp : (ptr Eq_400))
-  Class: Eq_400
-  DataType: (ptr Eq_400)
-  OrigDataType: (ptr (struct (0 T_979 t0000)))
-T_487: (in dwArg00 : word32)
-  Class: Eq_487
-  DataType: word32
-  OrigDataType: word32
-T_488: (in dwArg04 : word32)
+T_487: (in ebp : (ptr Eq_401))
+  Class: Eq_401
+  DataType: (ptr Eq_401)
+  OrigDataType: (ptr (struct (0 T_980 t0000)))
+T_488: (in dwArg00 : word32)
   Class: Eq_488
   DataType: word32
   OrigDataType: word32
-T_489: (in dwArg08 : word32)
-  Class: Eq_136
+T_489: (in dwArg04 : word32)
+  Class: Eq_489
   DataType: word32
   OrigDataType: word32
-T_490: (in dwArg0C : word32)
-  Class: Eq_490
+T_490: (in dwArg08 : word32)
+  Class: Eq_137
   DataType: word32
   OrigDataType: word32
-T_491: (in dwArg10 : word32)
+T_491: (in dwArg0C : word32)
   Class: Eq_491
   DataType: word32
   OrigDataType: word32
-T_492: (in 0x00000010 : word32)
-  Class: Eq_487
+T_492: (in dwArg10 : word32)
+  Class: Eq_492
   DataType: word32
   OrigDataType: word32
-T_493: (in dwArg00 : word32)
+T_493: (in 0x00000010 : word32)
   Class: Eq_488
   DataType: word32
   OrigDataType: word32
-T_494: (in dwArg04 : word32)
-  Class: Eq_136
+T_494: (in dwArg00 : word32)
+  Class: Eq_489
   DataType: word32
   OrigDataType: word32
-T_495: (in dwArg08 : word32)
-  Class: Eq_490
+T_495: (in dwArg04 : word32)
+  Class: Eq_137
   DataType: word32
   OrigDataType: word32
-T_496: (in dwArg0C : word32)
+T_496: (in dwArg08 : word32)
   Class: Eq_491
   DataType: word32
   OrigDataType: word32
-T_497: (in fn1000182D(ebp_10, 0x00000010, dwArg00, dwArg04, dwArg08, dwArg0C) : word32)
-  Class: Eq_497
+T_497: (in dwArg0C : word32)
+  Class: Eq_492
   DataType: word32
   OrigDataType: word32
-T_498: (in eax_165 : (ptr code))
+T_498: (in fn1000182D(ebp_10, 0x00000010, dwArg00, dwArg04, dwArg08, dwArg0C) : word32)
   Class: Eq_498
+  DataType: word32
+  OrigDataType: word32
+T_499: (in eax_165 : (ptr code))
+  Class: Eq_499
   DataType: (ptr code)
   OrigDataType: (ptr code)
-T_499: (in 0x100020CC : ptr32)
-  Class: Eq_499
+T_500: (in 0x100020CC : ptr32)
+  Class: Eq_500
   DataType: (ptr (ptr code))
-  OrigDataType: (ptr (struct (0 T_500 t0000)))
-T_500: (in Mem23[0x100020CC:word32] : word32)
-  Class: Eq_498
+  OrigDataType: (ptr (struct (0 T_501 t0000)))
+T_501: (in Mem23[0x100020CC:word32] : word32)
+  Class: Eq_499
   DataType: (ptr code)
   OrigDataType: word32
-T_501: (in 0x00000000 : word32)
-  Class: Eq_498
+T_502: (in 0x00000000 : word32)
+  Class: Eq_499
   DataType: (ptr code)
   OrigDataType: word32
-T_502: (in eax_165 == null : bool)
-  Class: Eq_502
+T_503: (in eax_165 == null : bool)
+  Class: Eq_503
   DataType: bool
   OrigDataType: bool
-T_503: (in 0x00000002 : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_504: (in 0x00000002 : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_504: (in edx != 0x00000002 : bool)
-  Class: Eq_504
-  DataType: bool
-  OrigDataType: bool
-T_505: (in esp_56 : (ptr Eq_395))
+T_505: (in edx != 0x00000002 : bool)
   Class: Eq_505
-  DataType: (ptr Eq_395)
-  OrigDataType: (ptr (struct (0 T_395 t0000)))
-T_506: (in 0x00000004 : word32)
+  DataType: bool
+  OrigDataType: bool
+T_506: (in esp_56 : (ptr Eq_396))
   Class: Eq_506
+  DataType: (ptr Eq_396)
+  OrigDataType: (ptr (struct (0 T_396 t0000)))
+T_507: (in 0x00000004 : word32)
+  Class: Eq_507
   DataType: ui32
   OrigDataType: ui32
-T_507: (in esp_175 - 0x00000004 : word32)
-  Class: Eq_505
-  DataType: (ptr Eq_395)
+T_508: (in esp_175 - 0x00000004 : word32)
+  Class: Eq_506
+  DataType: (ptr Eq_396)
   OrigDataType: ptr32
-T_508: (in 0x00000000 : word32)
-  Class: Eq_508
-  DataType: word32
-  OrigDataType: word32
-T_509: (in esp_56 + 0x00000000 : word32)
+T_509: (in 0x00000000 : word32)
   Class: Eq_509
+  DataType: word32
+  OrigDataType: word32
+T_510: (in esp_56 + 0x00000000 : word32)
+  Class: Eq_510
   DataType: ptr32
   OrigDataType: ptr32
-T_510: (in Mem57[esp_56 + 0x00000000:word32] : word32)
-  Class: Eq_395
-  DataType: Eq_395
+T_511: (in Mem57[esp_56 + 0x00000000:word32] : word32)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: word32
-T_511: (in 0x00000004 : word32)
-  Class: Eq_511
-  DataType: ui32
-  OrigDataType: ui32
-T_512: (in esp_56 - 0x00000004 : word32)
+T_512: (in 0x00000004 : word32)
   Class: Eq_512
-  DataType: (ptr Eq_197)
-  OrigDataType: (ptr (struct (0 T_515 t0000)))
-T_513: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_513: (in esp_56 - 0x00000004 : word32)
   Class: Eq_513
-  DataType: word32
-  OrigDataType: word32
-T_514: (in esp_56 - 0x00000004 + 0x00000000 : word32)
+  DataType: (ptr Eq_198)
+  OrigDataType: (ptr (struct (0 T_516 t0000)))
+T_514: (in 0x00000000 : word32)
   Class: Eq_514
+  DataType: word32
+  OrigDataType: word32
+T_515: (in esp_56 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_515
   DataType: ptr32
   OrigDataType: ptr32
-T_515: (in Mem59[esp_56 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_516: (in Mem59[esp_56 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_516: (in 0x00000008 : word32)
-  Class: Eq_516
-  DataType: ui32
-  OrigDataType: ui32
-T_517: (in esp_56 - 0x00000008 : word32)
+T_517: (in 0x00000008 : word32)
   Class: Eq_517
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_520 t0000)))
-T_518: (in 0x00000000 : word32)
-  Class: Eq_518
-  DataType: word32
-  OrigDataType: word32
-T_519: (in esp_56 - 0x00000008 + 0x00000000 : word32)
-  Class: Eq_519
-  DataType: ptr32
-  OrigDataType: ptr32
-T_520: (in Mem61[esp_56 - 0x00000008 + 0x00000000:word32] : word32)
-  Class: Eq_413
-  DataType: ui32
-  OrigDataType: word32
-T_521: (in eax_62 : word32)
-  Class: Eq_521
-  DataType: word32
-  OrigDataType: word32
-T_522: (in fn100017C6 : ptr32)
-  Class: Eq_522
-  DataType: (ptr Eq_522)
-  OrigDataType: (ptr (fn T_526 (T_493, T_494)))
-T_523: (in signature of fn100017C6 : void)
-  Class: Eq_522
-  DataType: (ptr Eq_522)
-  OrigDataType: 
-T_524: (in dwArg04 : word32)
-  Class: Eq_488
-  DataType: word32
-  OrigDataType: word32
-T_525: (in dwArg08 : word32)
-  Class: Eq_136
-  DataType: word32
-  OrigDataType: word32
-T_526: (in fn100017C6(dwArg00, dwArg04) : word32)
-  Class: Eq_521
-  DataType: word32
-  OrigDataType: word32
-T_527: (in 0x0000001C : word32)
-  Class: Eq_527
   DataType: ui32
   OrigDataType: ui32
-T_528: (in ebp_10 - 0x0000001C : word32)
+T_518: (in esp_56 - 0x00000008 : word32)
+  Class: Eq_518
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_521 t0000)))
+T_519: (in 0x00000000 : word32)
+  Class: Eq_519
+  DataType: word32
+  OrigDataType: word32
+T_520: (in esp_56 - 0x00000008 + 0x00000000 : word32)
+  Class: Eq_520
+  DataType: ptr32
+  OrigDataType: ptr32
+T_521: (in Mem61[esp_56 - 0x00000008 + 0x00000000:word32] : word32)
+  Class: Eq_414
+  DataType: ui32
+  OrigDataType: word32
+T_522: (in eax_62 : word32)
+  Class: Eq_522
+  DataType: word32
+  OrigDataType: word32
+T_523: (in fn100017C6 : ptr32)
+  Class: Eq_523
+  DataType: (ptr Eq_523)
+  OrigDataType: (ptr (fn T_527 (T_494, T_495)))
+T_524: (in signature of fn100017C6 : void)
+  Class: Eq_523
+  DataType: (ptr Eq_523)
+  OrigDataType: 
+T_525: (in dwArg04 : word32)
+  Class: Eq_489
+  DataType: word32
+  OrigDataType: word32
+T_526: (in dwArg08 : word32)
+  Class: Eq_137
+  DataType: word32
+  OrigDataType: word32
+T_527: (in fn100017C6(dwArg00, dwArg04) : word32)
+  Class: Eq_522
+  DataType: word32
+  OrigDataType: word32
+T_528: (in 0x0000001C : word32)
   Class: Eq_528
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_531 t0000)))
-T_529: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_529: (in ebp_10 - 0x0000001C : word32)
   Class: Eq_529
-  DataType: word32
-  OrigDataType: word32
-T_530: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_532 t0000)))
+T_530: (in 0x00000000 : word32)
   Class: Eq_530
-  DataType: ptr32
-  OrigDataType: ptr32
-T_531: (in Mem64[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_521
   DataType: word32
   OrigDataType: word32
-T_532: (in esp_142 : ptr32)
-  Class: Eq_532
+T_531: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_531
   DataType: ptr32
   OrigDataType: ptr32
-T_533: (in 0x00000004 : word32)
+T_532: (in Mem64[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_522
+  DataType: word32
+  OrigDataType: word32
+T_533: (in esp_142 : ptr32)
   Class: Eq_533
+  DataType: ptr32
+  OrigDataType: ptr32
+T_534: (in 0x00000004 : word32)
+  Class: Eq_534
   DataType: int32
   OrigDataType: int32
-T_534: (in esp_56 + 0x00000004 : word32)
-  Class: Eq_532
+T_535: (in esp_56 + 0x00000004 : word32)
+  Class: Eq_533
   DataType: ptr32
   OrigDataType: ptr32
-T_535: (in 0x00000001 : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_536: (in 0x00000001 : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_536: (in esi_14 != 0x00000001 : bool)
-  Class: Eq_536
-  DataType: bool
-  OrigDataType: bool
-T_537: (in 0x0000001C : word32)
+T_537: (in esi_14 != 0x00000001 : bool)
   Class: Eq_537
-  DataType: ui32
-  OrigDataType: ui32
-T_538: (in ebp_10 - 0x0000001C : word32)
-  Class: Eq_538
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_541 t0000)))
-T_539: (in 0x00000000 : word32)
-  Class: Eq_539
-  DataType: word32
-  OrigDataType: word32
-T_540: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_540
-  DataType: ptr32
-  OrigDataType: ptr32
-T_541: (in Mem23[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_541
-  DataType: word32
-  OrigDataType: word32
-T_542: (in 0x00000000 : word32)
-  Class: Eq_541
-  DataType: word32
-  OrigDataType: word32
-T_543: (in *(ebp_10 - 0x0000001C) == 0x00000000 : bool)
-  Class: Eq_543
   DataType: bool
   OrigDataType: bool
-T_544: (in 0x0000000C : word32)
+T_538: (in 0x0000001C : word32)
+  Class: Eq_538
+  DataType: ui32
+  OrigDataType: ui32
+T_539: (in ebp_10 - 0x0000001C : word32)
+  Class: Eq_539
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_542 t0000)))
+T_540: (in 0x00000000 : word32)
+  Class: Eq_540
+  DataType: word32
+  OrigDataType: word32
+T_541: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_541
+  DataType: ptr32
+  OrigDataType: ptr32
+T_542: (in Mem23[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_542
+  DataType: word32
+  OrigDataType: word32
+T_543: (in 0x00000000 : word32)
+  Class: Eq_542
+  DataType: word32
+  OrigDataType: word32
+T_544: (in *(ebp_10 - 0x0000001C) == 0x00000000 : bool)
   Class: Eq_544
-  DataType: ui32
-  OrigDataType: ui32
-T_545: (in fp - 0x0000000C : word32)
+  DataType: bool
+  OrigDataType: bool
+T_545: (in 0x0000000C : word32)
   Class: Eq_545
-  DataType: (ptr Eq_395)
-  OrigDataType: (ptr (struct (0 T_548 t0000)))
-T_546: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_546: (in fp - 0x0000000C : word32)
   Class: Eq_546
-  DataType: word32
-  OrigDataType: word32
-T_547: (in fp - 0x0000000C + 0x00000000 : word32)
+  DataType: (ptr Eq_396)
+  OrigDataType: (ptr (struct (0 T_549 t0000)))
+T_547: (in 0x00000000 : word32)
   Class: Eq_547
+  DataType: word32
+  OrigDataType: word32
+T_548: (in fp - 0x0000000C + 0x00000000 : word32)
+  Class: Eq_548
   DataType: ptr32
   OrigDataType: ptr32
-T_548: (in Mem195[fp - 0x0000000C + 0x00000000:word32] : word32)
-  Class: Eq_395
-  DataType: Eq_395
+T_549: (in Mem195[fp - 0x0000000C + 0x00000000:word32] : word32)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: word32
-T_549: (in 0x00000010 : word32)
-  Class: Eq_549
-  DataType: ui32
-  OrigDataType: ui32
-T_550: (in fp - 0x00000010 : word32)
+T_550: (in 0x00000010 : word32)
   Class: Eq_550
-  DataType: (ptr Eq_197)
-  OrigDataType: (ptr (struct (0 T_553 t0000)))
-T_551: (in 0x00000000 : word32)
-  Class: Eq_551
-  DataType: word32
-  OrigDataType: word32
-T_552: (in fp - 0x00000010 + 0x00000000 : word32)
-  Class: Eq_552
-  DataType: ptr32
-  OrigDataType: ptr32
-T_553: (in Mem197[fp - 0x00000010 + 0x00000000:word32] : word32)
-  Class: Eq_197
-  DataType: Eq_197
-  OrigDataType: word32
-T_554: (in 0x00000014 : word32)
-  Class: Eq_554
   DataType: ui32
   OrigDataType: ui32
-T_555: (in fp - 0x00000014 : word32)
-  Class: Eq_555
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_558 t0000)))
-T_556: (in 0x00000000 : word32)
-  Class: Eq_556
+T_551: (in fp - 0x00000010 : word32)
+  Class: Eq_551
+  DataType: (ptr Eq_198)
+  OrigDataType: (ptr (struct (0 T_554 t0000)))
+T_552: (in 0x00000000 : word32)
+  Class: Eq_552
   DataType: word32
   OrigDataType: word32
-T_557: (in fp - 0x00000014 + 0x00000000 : word32)
-  Class: Eq_557
+T_553: (in fp - 0x00000010 + 0x00000000 : word32)
+  Class: Eq_553
   DataType: ptr32
   OrigDataType: ptr32
-T_558: (in Mem199[fp - 0x00000014 + 0x00000000:word32] : word32)
-  Class: Eq_413
-  DataType: ui32
+T_554: (in Mem197[fp - 0x00000010 + 0x00000000:word32] : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_559: (in ecx_202 : word32)
-  Class: Eq_559
+T_555: (in 0x00000014 : word32)
+  Class: Eq_555
+  DataType: ui32
+  OrigDataType: ui32
+T_556: (in fp - 0x00000014 : word32)
+  Class: Eq_556
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_559 t0000)))
+T_557: (in 0x00000000 : word32)
+  Class: Eq_557
   DataType: word32
   OrigDataType: word32
-T_560: (in edx_204 : word32)
+T_558: (in fp - 0x00000014 + 0x00000000 : word32)
+  Class: Eq_558
+  DataType: ptr32
+  OrigDataType: ptr32
+T_559: (in Mem199[fp - 0x00000014 + 0x00000000:word32] : word32)
+  Class: Eq_414
+  DataType: ui32
+  OrigDataType: word32
+T_560: (in ecx_202 : word32)
   Class: Eq_560
   DataType: word32
   OrigDataType: word32
-T_561: (in eax_207 : word32)
+T_561: (in edx_204 : word32)
   Class: Eq_561
   DataType: word32
   OrigDataType: word32
-T_562: (in SZO_208 : byte)
+T_562: (in eax_207 : word32)
   Class: Eq_562
-  DataType: byte
-  OrigDataType: byte
-T_563: (in C_209 : byte)
+  DataType: word32
+  OrigDataType: word32
+T_563: (in SZO_208 : byte)
   Class: Eq_563
   DataType: byte
   OrigDataType: byte
-T_564: (in SCZO_210 : byte)
+T_564: (in C_209 : byte)
   Class: Eq_564
   DataType: byte
   OrigDataType: byte
-T_565: (in Z_211 : byte)
+T_565: (in SCZO_210 : byte)
   Class: Eq_565
   DataType: byte
   OrigDataType: byte
-T_566: (in 0x0000001C : word32)
+T_566: (in Z_211 : byte)
   Class: Eq_566
-  DataType: ui32
-  OrigDataType: ui32
-T_567: (in ebp_10 - 0x0000001C : word32)
+  DataType: byte
+  OrigDataType: byte
+T_567: (in 0x0000001C : word32)
   Class: Eq_567
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_570 t0000)))
-T_568: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_568: (in ebp_10 - 0x0000001C : word32)
   Class: Eq_568
-  DataType: word32
-  OrigDataType: word32
-T_569: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_571 t0000)))
+T_569: (in 0x00000000 : word32)
   Class: Eq_569
-  DataType: ptr32
-  OrigDataType: ptr32
-T_570: (in Mem212[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_561
   DataType: word32
   OrigDataType: word32
-T_571: (in esp_182 : (ptr Eq_395))
-  Class: Eq_571
-  DataType: (ptr Eq_395)
-  OrigDataType: (ptr (struct (0 T_576 t0000)))
-T_572: (in 0x00000004 : word32)
+T_570: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_570
+  DataType: ptr32
+  OrigDataType: ptr32
+T_571: (in Mem212[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_562
+  DataType: word32
+  OrigDataType: word32
+T_572: (in esp_182 : (ptr Eq_396))
   Class: Eq_572
+  DataType: (ptr Eq_396)
+  OrigDataType: (ptr (struct (0 T_577 t0000)))
+T_573: (in 0x00000004 : word32)
+  Class: Eq_573
   DataType: ui32
   OrigDataType: ui32
-T_573: (in esp_175 - 0x00000004 : word32)
-  Class: Eq_571
-  DataType: (ptr Eq_395)
+T_574: (in esp_175 - 0x00000004 : word32)
+  Class: Eq_572
+  DataType: (ptr Eq_396)
   OrigDataType: ptr32
-T_574: (in 0x00000000 : word32)
-  Class: Eq_574
-  DataType: word32
-  OrigDataType: word32
-T_575: (in esp_182 + 0x00000000 : word32)
+T_575: (in 0x00000000 : word32)
   Class: Eq_575
+  DataType: word32
+  OrigDataType: word32
+T_576: (in esp_182 + 0x00000000 : word32)
+  Class: Eq_576
   DataType: ptr32
   OrigDataType: ptr32
-T_576: (in Mem183[esp_182 + 0x00000000:word32] : word32)
-  Class: Eq_395
-  DataType: Eq_395
+T_577: (in Mem183[esp_182 + 0x00000000:word32] : word32)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: word32
-T_577: (in 0x00000004 : word32)
-  Class: Eq_577
-  DataType: ui32
-  OrigDataType: ui32
-T_578: (in esp_182 - 0x00000004 : word32)
+T_578: (in 0x00000004 : word32)
   Class: Eq_578
-  DataType: (ptr Eq_197)
-  OrigDataType: (ptr (struct (0 T_581 t0000)))
-T_579: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_579: (in esp_182 - 0x00000004 : word32)
   Class: Eq_579
-  DataType: word32
-  OrigDataType: word32
-T_580: (in esp_182 - 0x00000004 + 0x00000000 : word32)
+  DataType: (ptr Eq_198)
+  OrigDataType: (ptr (struct (0 T_582 t0000)))
+T_580: (in 0x00000000 : word32)
   Class: Eq_580
+  DataType: word32
+  OrigDataType: word32
+T_581: (in esp_182 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_581
   DataType: ptr32
   OrigDataType: ptr32
-T_581: (in Mem185[esp_182 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_582: (in Mem185[esp_182 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_582: (in 0x00000008 : word32)
-  Class: Eq_582
-  DataType: ui32
-  OrigDataType: ui32
-T_583: (in esp_182 - 0x00000008 : word32)
+T_583: (in 0x00000008 : word32)
   Class: Eq_583
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_586 t0000)))
-T_584: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_584: (in esp_182 - 0x00000008 : word32)
   Class: Eq_584
-  DataType: word32
-  OrigDataType: word32
-T_585: (in esp_182 - 0x00000008 + 0x00000000 : word32)
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_587 t0000)))
+T_585: (in 0x00000000 : word32)
   Class: Eq_585
+  DataType: word32
+  OrigDataType: word32
+T_586: (in esp_182 - 0x00000008 + 0x00000000 : word32)
+  Class: Eq_586
   DataType: ptr32
   OrigDataType: ptr32
-T_586: (in Mem187[esp_182 - 0x00000008 + 0x00000000:word32] : word32)
-  Class: Eq_413
+T_587: (in Mem187[esp_182 - 0x00000008 + 0x00000000:word32] : word32)
+  Class: Eq_414
   DataType: ui32
   OrigDataType: word32
-T_587: (in eax_188 : ui32)
-  Class: Eq_587
+T_588: (in eax_188 : ui32)
+  Class: Eq_588
   DataType: ui32
   OrigDataType: word32
-T_588: (in fn100011E9 : ptr32)
-  Class: Eq_588
-  DataType: (ptr Eq_588)
-  OrigDataType: (ptr (fn T_590 (T_494)))
-T_589: (in signature of fn100011E9 : void)
-  Class: Eq_588
-  DataType: (ptr Eq_588)
+T_589: (in fn100011E9 : ptr32)
+  Class: Eq_589
+  DataType: (ptr Eq_589)
+  OrigDataType: (ptr (fn T_591 (T_495)))
+T_590: (in signature of fn100011E9 : void)
+  Class: Eq_589
+  DataType: (ptr Eq_589)
   OrigDataType: 
-T_590: (in fn100011E9(dwArg04) : word32)
-  Class: Eq_587
-  DataType: ui32
-  OrigDataType: word32
-T_591: (in 0x0000001C : word32)
-  Class: Eq_591
-  DataType: ui32
-  OrigDataType: ui32
-T_592: (in ebp_10 - 0x0000001C : word32)
-  Class: Eq_592
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_595 t0000)))
-T_593: (in 0x00000000 : word32)
-  Class: Eq_593
-  DataType: word32
-  OrigDataType: word32
-T_594: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_594
-  DataType: ptr32
-  OrigDataType: ptr32
-T_595: (in Mem190[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_587
-  DataType: ui32
-  OrigDataType: word32
-T_596: (in 0x00000004 : word32)
-  Class: Eq_596
-  DataType: int32
-  OrigDataType: int32
-T_597: (in esp_182 + 0x00000004 : word32)
-  Class: Eq_437
-  DataType: ptr32
-  OrigDataType: ptr32
-T_598: (in 0x00000000 : word32)
-  Class: Eq_587
-  DataType: ui32
-  OrigDataType: word32
-T_599: (in eax_188 == 0x00000000 : bool)
-  Class: Eq_599
-  DataType: bool
-  OrigDataType: bool
-T_600: (in 0x00000000 : word32)
-  Class: Eq_197
-  DataType: Eq_197
-  OrigDataType: word32
-T_601: (in esi_14 == 0x00000000 : bool)
-  Class: Eq_601
-  DataType: bool
-  OrigDataType: bool
-T_602: (in 0x00000000 : word32)
-  Class: Eq_521
-  DataType: word32
-  OrigDataType: word32
-T_603: (in eax_62 != 0x00000000 : bool)
-  Class: Eq_603
-  DataType: bool
-  OrigDataType: bool
-T_604: (in 0x00000000 : word32)
-  Class: Eq_604
-  DataType: word32
-  OrigDataType: word32
-T_605: (in esp_56 + 0x00000000 : word32)
-  Class: Eq_605
-  DataType: (ptr word32)
-  OrigDataType: (ptr word32)
-T_606: (in Mem128[esp_56 + 0x00000000:word32] : word32)
-  Class: Eq_395
-  DataType: Eq_395
-  OrigDataType: word32
-T_607: (in 0x00000004 : word32)
-  Class: Eq_607
-  DataType: ui32
-  OrigDataType: ui32
-T_608: (in esp_56 - 0x00000004 : word32)
-  Class: Eq_608
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_611 t0000)))
-T_609: (in 0x00000000 : word32)
-  Class: Eq_609
-  DataType: word32
-  OrigDataType: word32
-T_610: (in esp_56 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_610
-  DataType: ptr32
-  OrigDataType: ptr32
-T_611: (in Mem130[esp_56 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_521
-  DataType: word32
-  OrigDataType: word32
-T_612: (in 0x00000008 : word32)
-  Class: Eq_612
-  DataType: ui32
-  OrigDataType: ui32
-T_613: (in esp_56 - 0x00000008 : word32)
-  Class: Eq_613
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_616 t0000)))
-T_614: (in 0x00000000 : word32)
-  Class: Eq_614
-  DataType: word32
-  OrigDataType: word32
-T_615: (in esp_56 - 0x00000008 + 0x00000000 : word32)
-  Class: Eq_615
-  DataType: ptr32
-  OrigDataType: ptr32
-T_616: (in Mem132[esp_56 - 0x00000008 + 0x00000000:word32] : word32)
-  Class: Eq_413
-  DataType: ui32
-  OrigDataType: word32
-T_617: (in fn100017C6 : ptr32)
-  Class: Eq_522
-  DataType: (ptr Eq_522)
-  OrigDataType: (ptr (fn T_618 (T_493, T_494)))
-T_618: (in fn100017C6(dwArg00, dwArg04) : word32)
-  Class: Eq_521
-  DataType: word32
-  OrigDataType: word32
-T_619: (in 0x00000000 : word32)
-  Class: Eq_619
-  DataType: word32
-  OrigDataType: word32
-T_620: (in esp_56 + 0x00000000 : word32)
-  Class: Eq_620
-  DataType: (ptr word32)
-  OrigDataType: (ptr word32)
-T_621: (in Mem136[esp_56 + 0x00000000:word32] : word32)
-  Class: Eq_395
-  DataType: Eq_395
-  OrigDataType: word32
-T_622: (in 0x00000000 : word32)
-  Class: Eq_622
-  DataType: word32
-  OrigDataType: word32
-T_623: (in 0x00000004 : word32)
-  Class: Eq_623
-  DataType: ui32
-  OrigDataType: ui32
-T_624: (in esp_56 - 0x00000004 : word32)
-  Class: Eq_624
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_627 t0000)))
-T_625: (in 0x00000000 : word32)
-  Class: Eq_625
-  DataType: word32
-  OrigDataType: word32
-T_626: (in esp_56 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_626
-  DataType: ptr32
-  OrigDataType: ptr32
-T_627: (in Mem138[esp_56 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_622
-  DataType: word32
-  OrigDataType: word32
-T_628: (in 0x00000008 : word32)
-  Class: Eq_628
-  DataType: ui32
-  OrigDataType: ui32
-T_629: (in esp_56 - 0x00000008 : word32)
-  Class: Eq_629
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_632 t0000)))
-T_630: (in 0x00000000 : word32)
-  Class: Eq_630
-  DataType: word32
-  OrigDataType: word32
-T_631: (in esp_56 - 0x00000008 + 0x00000000 : word32)
-  Class: Eq_631
-  DataType: ptr32
-  OrigDataType: ptr32
-T_632: (in Mem140[esp_56 - 0x00000008 + 0x00000000:word32] : word32)
-  Class: Eq_413
-  DataType: ui32
-  OrigDataType: word32
-T_633: (in fn100011E9 : ptr32)
+T_591: (in fn100011E9(dwArg04) : word32)
   Class: Eq_588
-  DataType: (ptr Eq_588)
-  OrigDataType: (ptr (fn T_634 (T_494)))
-T_634: (in fn100011E9(dwArg04) : word32)
-  Class: Eq_587
   DataType: ui32
   OrigDataType: word32
-T_635: (in 0x00000004 : word32)
-  Class: Eq_635
-  DataType: int32
-  OrigDataType: int32
-T_636: (in esp_56 + 0x00000004 : word32)
-  Class: Eq_532
+T_592: (in 0x0000001C : word32)
+  Class: Eq_592
+  DataType: ui32
+  OrigDataType: ui32
+T_593: (in ebp_10 - 0x0000001C : word32)
+  Class: Eq_593
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_596 t0000)))
+T_594: (in 0x00000000 : word32)
+  Class: Eq_594
+  DataType: word32
+  OrigDataType: word32
+T_595: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_595
   DataType: ptr32
   OrigDataType: ptr32
-T_637: (in eax_143 : (ptr code))
-  Class: Eq_498
+T_596: (in Mem190[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_588
+  DataType: ui32
+  OrigDataType: word32
+T_597: (in 0x00000004 : word32)
+  Class: Eq_597
+  DataType: int32
+  OrigDataType: int32
+T_598: (in esp_182 + 0x00000004 : word32)
+  Class: Eq_438
+  DataType: ptr32
+  OrigDataType: ptr32
+T_599: (in 0x00000000 : word32)
+  Class: Eq_588
+  DataType: ui32
+  OrigDataType: word32
+T_600: (in eax_188 == 0x00000000 : bool)
+  Class: Eq_600
+  DataType: bool
+  OrigDataType: bool
+T_601: (in 0x00000000 : word32)
+  Class: Eq_198
+  DataType: Eq_198
+  OrigDataType: word32
+T_602: (in esi_14 == 0x00000000 : bool)
+  Class: Eq_602
+  DataType: bool
+  OrigDataType: bool
+T_603: (in 0x00000000 : word32)
+  Class: Eq_522
+  DataType: word32
+  OrigDataType: word32
+T_604: (in eax_62 != 0x00000000 : bool)
+  Class: Eq_604
+  DataType: bool
+  OrigDataType: bool
+T_605: (in 0x00000000 : word32)
+  Class: Eq_605
+  DataType: word32
+  OrigDataType: word32
+T_606: (in esp_56 + 0x00000000 : word32)
+  Class: Eq_606
+  DataType: (ptr word32)
+  OrigDataType: (ptr word32)
+T_607: (in Mem128[esp_56 + 0x00000000:word32] : word32)
+  Class: Eq_396
+  DataType: Eq_396
+  OrigDataType: word32
+T_608: (in 0x00000004 : word32)
+  Class: Eq_608
+  DataType: ui32
+  OrigDataType: ui32
+T_609: (in esp_56 - 0x00000004 : word32)
+  Class: Eq_609
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_612 t0000)))
+T_610: (in 0x00000000 : word32)
+  Class: Eq_610
+  DataType: word32
+  OrigDataType: word32
+T_611: (in esp_56 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_611
+  DataType: ptr32
+  OrigDataType: ptr32
+T_612: (in Mem130[esp_56 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_522
+  DataType: word32
+  OrigDataType: word32
+T_613: (in 0x00000008 : word32)
+  Class: Eq_613
+  DataType: ui32
+  OrigDataType: ui32
+T_614: (in esp_56 - 0x00000008 : word32)
+  Class: Eq_614
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_617 t0000)))
+T_615: (in 0x00000000 : word32)
+  Class: Eq_615
+  DataType: word32
+  OrigDataType: word32
+T_616: (in esp_56 - 0x00000008 + 0x00000000 : word32)
+  Class: Eq_616
+  DataType: ptr32
+  OrigDataType: ptr32
+T_617: (in Mem132[esp_56 - 0x00000008 + 0x00000000:word32] : word32)
+  Class: Eq_414
+  DataType: ui32
+  OrigDataType: word32
+T_618: (in fn100017C6 : ptr32)
+  Class: Eq_523
+  DataType: (ptr Eq_523)
+  OrigDataType: (ptr (fn T_619 (T_494, T_495)))
+T_619: (in fn100017C6(dwArg00, dwArg04) : word32)
+  Class: Eq_522
+  DataType: word32
+  OrigDataType: word32
+T_620: (in 0x00000000 : word32)
+  Class: Eq_620
+  DataType: word32
+  OrigDataType: word32
+T_621: (in esp_56 + 0x00000000 : word32)
+  Class: Eq_621
+  DataType: (ptr word32)
+  OrigDataType: (ptr word32)
+T_622: (in Mem136[esp_56 + 0x00000000:word32] : word32)
+  Class: Eq_396
+  DataType: Eq_396
+  OrigDataType: word32
+T_623: (in 0x00000000 : word32)
+  Class: Eq_623
+  DataType: word32
+  OrigDataType: word32
+T_624: (in 0x00000004 : word32)
+  Class: Eq_624
+  DataType: ui32
+  OrigDataType: ui32
+T_625: (in esp_56 - 0x00000004 : word32)
+  Class: Eq_625
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_628 t0000)))
+T_626: (in 0x00000000 : word32)
+  Class: Eq_626
+  DataType: word32
+  OrigDataType: word32
+T_627: (in esp_56 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_627
+  DataType: ptr32
+  OrigDataType: ptr32
+T_628: (in Mem138[esp_56 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_623
+  DataType: word32
+  OrigDataType: word32
+T_629: (in 0x00000008 : word32)
+  Class: Eq_629
+  DataType: ui32
+  OrigDataType: ui32
+T_630: (in esp_56 - 0x00000008 : word32)
+  Class: Eq_630
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_633 t0000)))
+T_631: (in 0x00000000 : word32)
+  Class: Eq_631
+  DataType: word32
+  OrigDataType: word32
+T_632: (in esp_56 - 0x00000008 + 0x00000000 : word32)
+  Class: Eq_632
+  DataType: ptr32
+  OrigDataType: ptr32
+T_633: (in Mem140[esp_56 - 0x00000008 + 0x00000000:word32] : word32)
+  Class: Eq_414
+  DataType: ui32
+  OrigDataType: word32
+T_634: (in fn100011E9 : ptr32)
+  Class: Eq_589
+  DataType: (ptr Eq_589)
+  OrigDataType: (ptr (fn T_635 (T_495)))
+T_635: (in fn100011E9(dwArg04) : word32)
+  Class: Eq_588
+  DataType: ui32
+  OrigDataType: word32
+T_636: (in 0x00000004 : word32)
+  Class: Eq_636
+  DataType: int32
+  OrigDataType: int32
+T_637: (in esp_56 + 0x00000004 : word32)
+  Class: Eq_533
+  DataType: ptr32
+  OrigDataType: ptr32
+T_638: (in eax_143 : (ptr code))
+  Class: Eq_499
   DataType: (ptr code)
   OrigDataType: (ptr code)
-T_638: (in 0x100020CC : ptr32)
-  Class: Eq_638
+T_639: (in 0x100020CC : ptr32)
+  Class: Eq_639
   DataType: (ptr (ptr code))
-  OrigDataType: (ptr (struct (0 T_639 t0000)))
-T_639: (in Mem140[0x100020CC:word32] : word32)
-  Class: Eq_498
+  OrigDataType: (ptr (struct (0 T_640 t0000)))
+T_640: (in Mem140[0x100020CC:word32] : word32)
+  Class: Eq_499
   DataType: (ptr code)
   OrigDataType: word32
-T_640: (in 0x00000000 : word32)
-  Class: Eq_498
+T_641: (in 0x00000000 : word32)
+  Class: Eq_499
   DataType: (ptr code)
   OrigDataType: word32
-T_641: (in eax_143 == null : bool)
-  Class: Eq_641
+T_642: (in eax_143 == null : bool)
+  Class: Eq_642
   DataType: bool
   OrigDataType: bool
-T_642: (in 0x00000000 : word32)
-  Class: Eq_642
+T_643: (in 0x00000000 : word32)
+  Class: Eq_643
   DataType: word32
   OrigDataType: word32
-T_643: (in esp_56 + 0x00000000 : word32)
-  Class: Eq_643
+T_644: (in esp_56 + 0x00000000 : word32)
+  Class: Eq_644
   DataType: (ptr word32)
   OrigDataType: (ptr word32)
-T_644: (in Mem148[esp_56 + 0x00000000:word32] : word32)
-  Class: Eq_395
-  DataType: Eq_395
+T_645: (in Mem148[esp_56 + 0x00000000:word32] : word32)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: word32
-T_645: (in 0x00000000 : word32)
-  Class: Eq_645
-  DataType: word32
-  OrigDataType: word32
-T_646: (in 0x00000004 : word32)
+T_646: (in 0x00000000 : word32)
   Class: Eq_646
-  DataType: ui32
-  OrigDataType: ui32
-T_647: (in esp_56 - 0x00000004 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_647: (in 0x00000004 : word32)
   Class: Eq_647
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_650 t0000)))
-T_648: (in 0x00000000 : word32)
-  Class: Eq_648
-  DataType: word32
-  OrigDataType: word32
-T_649: (in esp_56 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_649
-  DataType: ptr32
-  OrigDataType: ptr32
-T_650: (in Mem150[esp_56 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_645
-  DataType: word32
-  OrigDataType: word32
-T_651: (in 0x00000008 : word32)
-  Class: Eq_651
   DataType: ui32
   OrigDataType: ui32
-T_652: (in esp_56 - 0x00000008 : word32)
-  Class: Eq_652
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_655 t0000)))
-T_653: (in 0x00000000 : word32)
-  Class: Eq_653
+T_648: (in esp_56 - 0x00000004 : word32)
+  Class: Eq_648
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_651 t0000)))
+T_649: (in 0x00000000 : word32)
+  Class: Eq_649
   DataType: word32
   OrigDataType: word32
-T_654: (in esp_56 - 0x00000008 + 0x00000000 : word32)
-  Class: Eq_654
+T_650: (in esp_56 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_650
   DataType: ptr32
   OrigDataType: ptr32
-T_655: (in Mem152[esp_56 - 0x00000008 + 0x00000000:word32] : word32)
-  Class: Eq_413
-  DataType: ui32
-  OrigDataType: word32
-T_656: (in ecx_155 : word32)
-  Class: Eq_656
+T_651: (in Mem150[esp_56 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_646
   DataType: word32
   OrigDataType: word32
-T_657: (in edx_157 : word32)
+T_652: (in 0x00000008 : word32)
+  Class: Eq_652
+  DataType: ui32
+  OrigDataType: ui32
+T_653: (in esp_56 - 0x00000008 : word32)
+  Class: Eq_653
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_656 t0000)))
+T_654: (in 0x00000000 : word32)
+  Class: Eq_654
+  DataType: word32
+  OrigDataType: word32
+T_655: (in esp_56 - 0x00000008 + 0x00000000 : word32)
+  Class: Eq_655
+  DataType: ptr32
+  OrigDataType: ptr32
+T_656: (in Mem152[esp_56 - 0x00000008 + 0x00000000:word32] : word32)
+  Class: Eq_414
+  DataType: ui32
+  OrigDataType: word32
+T_657: (in ecx_155 : word32)
   Class: Eq_657
   DataType: word32
   OrigDataType: word32
-T_658: (in eax_160 : word32)
+T_658: (in edx_157 : word32)
   Class: Eq_658
   DataType: word32
   OrigDataType: word32
-T_659: (in SZO_161 : byte)
+T_659: (in eax_160 : word32)
   Class: Eq_659
-  DataType: byte
-  OrigDataType: byte
-T_660: (in C_162 : byte)
+  DataType: word32
+  OrigDataType: word32
+T_660: (in SZO_161 : byte)
   Class: Eq_660
   DataType: byte
   OrigDataType: byte
-T_661: (in SCZO_163 : byte)
+T_661: (in C_162 : byte)
   Class: Eq_661
   DataType: byte
   OrigDataType: byte
-T_662: (in Z_164 : byte)
+T_662: (in SCZO_163 : byte)
   Class: Eq_662
   DataType: byte
   OrigDataType: byte
-T_663: (in esp_80 : (ptr Eq_395))
+T_663: (in Z_164 : byte)
   Class: Eq_663
-  DataType: (ptr Eq_395)
-  OrigDataType: (ptr (struct (0 T_395 t0000)))
-T_664: (in 0x00000004 : word32)
+  DataType: byte
+  OrigDataType: byte
+T_664: (in esp_80 : (ptr Eq_396))
   Class: Eq_664
+  DataType: (ptr Eq_396)
+  OrigDataType: (ptr (struct (0 T_396 t0000)))
+T_665: (in 0x00000004 : word32)
+  Class: Eq_665
   DataType: ui32
   OrigDataType: ui32
-T_665: (in esp_142 - 0x00000004 : word32)
-  Class: Eq_663
-  DataType: (ptr Eq_395)
+T_666: (in esp_142 - 0x00000004 : word32)
+  Class: Eq_664
+  DataType: (ptr Eq_396)
   OrigDataType: ptr32
-T_666: (in 0x00000000 : word32)
-  Class: Eq_666
-  DataType: word32
-  OrigDataType: word32
-T_667: (in esp_80 + 0x00000000 : word32)
+T_667: (in 0x00000000 : word32)
   Class: Eq_667
+  DataType: word32
+  OrigDataType: word32
+T_668: (in esp_80 + 0x00000000 : word32)
+  Class: Eq_668
   DataType: ptr32
   OrigDataType: ptr32
-T_668: (in Mem81[esp_80 + 0x00000000:word32] : word32)
-  Class: Eq_395
-  DataType: Eq_395
+T_669: (in Mem81[esp_80 + 0x00000000:word32] : word32)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: word32
-T_669: (in 0x00000004 : word32)
-  Class: Eq_669
-  DataType: ui32
-  OrigDataType: ui32
-T_670: (in esp_80 - 0x00000004 : word32)
+T_670: (in 0x00000004 : word32)
   Class: Eq_670
-  DataType: (ptr Eq_197)
-  OrigDataType: (ptr (struct (0 T_673 t0000)))
-T_671: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_671: (in esp_80 - 0x00000004 : word32)
   Class: Eq_671
-  DataType: word32
-  OrigDataType: word32
-T_672: (in esp_80 - 0x00000004 + 0x00000000 : word32)
+  DataType: (ptr Eq_198)
+  OrigDataType: (ptr (struct (0 T_674 t0000)))
+T_672: (in 0x00000000 : word32)
   Class: Eq_672
+  DataType: word32
+  OrigDataType: word32
+T_673: (in esp_80 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_673
   DataType: ptr32
   OrigDataType: ptr32
-T_673: (in Mem83[esp_80 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_674: (in Mem83[esp_80 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_674: (in 0x00000008 : word32)
-  Class: Eq_674
-  DataType: ui32
-  OrigDataType: ui32
-T_675: (in esp_80 - 0x00000008 : word32)
+T_675: (in 0x00000008 : word32)
   Class: Eq_675
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_678 t0000)))
-T_676: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_676: (in esp_80 - 0x00000008 : word32)
   Class: Eq_676
-  DataType: word32
-  OrigDataType: word32
-T_677: (in esp_80 - 0x00000008 + 0x00000000 : word32)
-  Class: Eq_677
-  DataType: ptr32
-  OrigDataType: ptr32
-T_678: (in Mem85[esp_80 - 0x00000008 + 0x00000000:word32] : word32)
-  Class: Eq_413
-  DataType: ui32
-  OrigDataType: word32
-T_679: (in eax_86 : ui32)
-  Class: Eq_587
-  DataType: ui32
-  OrigDataType: ui32
-T_680: (in fn100011E9 : ptr32)
-  Class: Eq_588
-  DataType: (ptr Eq_588)
-  OrigDataType: (ptr (fn T_681 (T_494)))
-T_681: (in fn100011E9(dwArg04) : word32)
-  Class: Eq_587
-  DataType: ui32
-  OrigDataType: word32
-T_682: (in 0x00000000 : word32)
-  Class: Eq_587
-  DataType: ui32
-  OrigDataType: word32
-T_683: (in eax_86 != 0x00000000 : bool)
-  Class: Eq_683
-  DataType: bool
-  OrigDataType: bool
-T_684: (in 0x00000003 : word32)
-  Class: Eq_197
-  DataType: Eq_197
-  OrigDataType: word32
-T_685: (in esi_14 != 0x00000003 : bool)
-  Class: Eq_685
-  DataType: bool
-  OrigDataType: bool
-T_686: (in 0x0000001C : word32)
-  Class: Eq_686
-  DataType: ui32
-  OrigDataType: ui32
-T_687: (in ebp_10 - 0x0000001C : word32)
-  Class: Eq_687
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_690 t0000)))
-T_688: (in 0x00000000 : word32)
-  Class: Eq_688
-  DataType: word32
-  OrigDataType: word32
-T_689: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_689
-  DataType: ptr32
-  OrigDataType: ptr32
-T_690: (in Mem85[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_690
-  DataType: word32
-  OrigDataType: word32
-T_691: (in 0x00000000 : word32)
-  Class: Eq_690
-  DataType: word32
-  OrigDataType: word32
-T_692: (in *(ebp_10 - 0x0000001C) == 0x00000000 : bool)
-  Class: Eq_692
-  DataType: bool
-  OrigDataType: bool
-T_693: (in 0x0000001C : word32)
-  Class: Eq_693
-  DataType: ui32
-  OrigDataType: ui32
-T_694: (in ebp_10 - 0x0000001C : word32)
-  Class: Eq_694
   DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_697 t0000)))
-T_695: (in 0x00000000 : word32)
-  Class: Eq_695
+  OrigDataType: (ptr (struct (0 T_679 t0000)))
+T_677: (in 0x00000000 : word32)
+  Class: Eq_677
   DataType: word32
   OrigDataType: word32
-T_696: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_696
+T_678: (in esp_80 - 0x00000008 + 0x00000000 : word32)
+  Class: Eq_678
   DataType: ptr32
   OrigDataType: ptr32
-T_697: (in Mem85[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_697
+T_679: (in Mem85[esp_80 - 0x00000008 + 0x00000000:word32] : word32)
+  Class: Eq_414
+  DataType: ui32
+  OrigDataType: word32
+T_680: (in eax_86 : ui32)
+  Class: Eq_588
   DataType: ui32
   OrigDataType: ui32
-T_698: (in *(ebp_10 - 0x0000001C) & eax_86 : word32)
+T_681: (in fn100011E9 : ptr32)
+  Class: Eq_589
+  DataType: (ptr Eq_589)
+  OrigDataType: (ptr (fn T_682 (T_495)))
+T_682: (in fn100011E9(dwArg04) : word32)
+  Class: Eq_588
+  DataType: ui32
+  OrigDataType: word32
+T_683: (in 0x00000000 : word32)
+  Class: Eq_588
+  DataType: ui32
+  OrigDataType: word32
+T_684: (in eax_86 != 0x00000000 : bool)
+  Class: Eq_684
+  DataType: bool
+  OrigDataType: bool
+T_685: (in 0x00000003 : word32)
+  Class: Eq_198
+  DataType: Eq_198
+  OrigDataType: word32
+T_686: (in esi_14 != 0x00000003 : bool)
+  Class: Eq_686
+  DataType: bool
+  OrigDataType: bool
+T_687: (in 0x0000001C : word32)
+  Class: Eq_687
+  DataType: ui32
+  OrigDataType: ui32
+T_688: (in ebp_10 - 0x0000001C : word32)
+  Class: Eq_688
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_691 t0000)))
+T_689: (in 0x00000000 : word32)
+  Class: Eq_689
+  DataType: word32
+  OrigDataType: word32
+T_690: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_690
+  DataType: ptr32
+  OrigDataType: ptr32
+T_691: (in Mem85[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_691
+  DataType: word32
+  OrigDataType: word32
+T_692: (in 0x00000000 : word32)
+  Class: Eq_691
+  DataType: word32
+  OrigDataType: word32
+T_693: (in *(ebp_10 - 0x0000001C) == 0x00000000 : bool)
+  Class: Eq_693
+  DataType: bool
+  OrigDataType: bool
+T_694: (in 0x0000001C : word32)
+  Class: Eq_694
+  DataType: ui32
+  OrigDataType: ui32
+T_695: (in ebp_10 - 0x0000001C : word32)
+  Class: Eq_695
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_698 t0000)))
+T_696: (in 0x00000000 : word32)
+  Class: Eq_696
+  DataType: word32
+  OrigDataType: word32
+T_697: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_697
+  DataType: ptr32
+  OrigDataType: ptr32
+T_698: (in Mem85[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
   Class: Eq_698
   DataType: ui32
   OrigDataType: ui32
-T_699: (in 0x0000001C : word32)
+T_699: (in *(ebp_10 - 0x0000001C) & eax_86 : word32)
   Class: Eq_699
   DataType: ui32
   OrigDataType: ui32
-T_700: (in ebp_10 - 0x0000001C : word32)
+T_700: (in 0x0000001C : word32)
   Class: Eq_700
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_703 t0000)))
-T_701: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_701: (in ebp_10 - 0x0000001C : word32)
   Class: Eq_701
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_704 t0000)))
+T_702: (in 0x00000000 : word32)
+  Class: Eq_702
   DataType: word32
   OrigDataType: word32
-T_702: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_702
+T_703: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_703
   DataType: ptr32
   OrigDataType: ptr32
-T_703: (in Mem119[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_698
+T_704: (in Mem119[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_699
   DataType: ui32
   OrigDataType: word32
-T_704: (in eax_95 : (ptr code))
-  Class: Eq_498
+T_705: (in eax_95 : (ptr code))
+  Class: Eq_499
   DataType: (ptr code)
   OrigDataType: (ptr code)
-T_705: (in 0x100020CC : ptr32)
-  Class: Eq_705
+T_706: (in 0x100020CC : ptr32)
+  Class: Eq_706
   DataType: (ptr (ptr code))
-  OrigDataType: (ptr (struct (0 T_706 t0000)))
-T_706: (in Mem85[0x100020CC:word32] : word32)
-  Class: Eq_498
+  OrigDataType: (ptr (struct (0 T_707 t0000)))
+T_707: (in Mem85[0x100020CC:word32] : word32)
+  Class: Eq_499
   DataType: (ptr code)
   OrigDataType: word32
-T_707: (in 0x00000000 : word32)
-  Class: Eq_498
+T_708: (in 0x00000000 : word32)
+  Class: Eq_499
   DataType: (ptr code)
   OrigDataType: word32
-T_708: (in eax_95 == null : bool)
-  Class: Eq_708
+T_709: (in eax_95 == null : bool)
+  Class: Eq_709
   DataType: bool
   OrigDataType: bool
-T_709: (in 0x00000000 : word32)
-  Class: Eq_709
+T_710: (in 0x00000000 : word32)
+  Class: Eq_710
   DataType: word32
   OrigDataType: word32
-T_710: (in esp_80 + 0x00000000 : word32)
-  Class: Eq_710
+T_711: (in esp_80 + 0x00000000 : word32)
+  Class: Eq_711
   DataType: (ptr word32)
   OrigDataType: (ptr word32)
-T_711: (in Mem100[esp_80 + 0x00000000:word32] : word32)
-  Class: Eq_395
-  DataType: Eq_395
+T_712: (in Mem100[esp_80 + 0x00000000:word32] : word32)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: word32
-T_712: (in 0x00000004 : word32)
-  Class: Eq_712
-  DataType: ui32
-  OrigDataType: ui32
-T_713: (in esp_80 - 0x00000004 : word32)
+T_713: (in 0x00000004 : word32)
   Class: Eq_713
-  DataType: (ptr Eq_197)
-  OrigDataType: (ptr (struct (0 T_716 t0000)))
-T_714: (in 0x00000000 : word32)
-  Class: Eq_714
-  DataType: word32
-  OrigDataType: word32
-T_715: (in esp_80 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_715
-  DataType: ptr32
-  OrigDataType: ptr32
-T_716: (in Mem102[esp_80 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_197
-  DataType: Eq_197
-  OrigDataType: word32
-T_717: (in 0x00000008 : word32)
-  Class: Eq_717
   DataType: ui32
   OrigDataType: ui32
-T_718: (in esp_80 - 0x00000008 : word32)
-  Class: Eq_718
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_721 t0000)))
-T_719: (in 0x00000000 : word32)
-  Class: Eq_719
+T_714: (in esp_80 - 0x00000004 : word32)
+  Class: Eq_714
+  DataType: (ptr Eq_198)
+  OrigDataType: (ptr (struct (0 T_717 t0000)))
+T_715: (in 0x00000000 : word32)
+  Class: Eq_715
   DataType: word32
   OrigDataType: word32
-T_720: (in esp_80 - 0x00000008 + 0x00000000 : word32)
-  Class: Eq_720
+T_716: (in esp_80 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_716
   DataType: ptr32
   OrigDataType: ptr32
-T_721: (in Mem104[esp_80 - 0x00000008 + 0x00000000:word32] : word32)
-  Class: Eq_413
-  DataType: ui32
+T_717: (in Mem102[esp_80 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_722: (in esp_105 : word32)
-  Class: Eq_722
+T_718: (in 0x00000008 : word32)
+  Class: Eq_718
+  DataType: ui32
+  OrigDataType: ui32
+T_719: (in esp_80 - 0x00000008 : word32)
+  Class: Eq_719
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_722 t0000)))
+T_720: (in 0x00000000 : word32)
+  Class: Eq_720
   DataType: word32
   OrigDataType: word32
-T_723: (in edi_106 : word32)
+T_721: (in esp_80 - 0x00000008 + 0x00000000 : word32)
+  Class: Eq_721
+  DataType: ptr32
+  OrigDataType: ptr32
+T_722: (in Mem104[esp_80 - 0x00000008 + 0x00000000:word32] : word32)
+  Class: Eq_414
+  DataType: ui32
+  OrigDataType: word32
+T_723: (in esp_105 : word32)
   Class: Eq_723
   DataType: word32
   OrigDataType: word32
-T_724: (in ecx_107 : word32)
+T_724: (in edi_106 : word32)
   Class: Eq_724
   DataType: word32
   OrigDataType: word32
-T_725: (in esi_108 : word32)
+T_725: (in ecx_107 : word32)
   Class: Eq_725
   DataType: word32
   OrigDataType: word32
-T_726: (in edx_109 : word32)
+T_726: (in esi_108 : word32)
   Class: Eq_726
   DataType: word32
   OrigDataType: word32
-T_727: (in ebx_110 : word32)
+T_727: (in edx_109 : word32)
   Class: Eq_727
   DataType: word32
   OrigDataType: word32
-T_728: (in eax_112 : word32)
+T_728: (in ebx_110 : word32)
   Class: Eq_728
   DataType: word32
   OrigDataType: word32
-T_729: (in SZO_113 : byte)
+T_729: (in eax_112 : word32)
   Class: Eq_729
-  DataType: byte
-  OrigDataType: byte
-T_730: (in C_114 : byte)
+  DataType: word32
+  OrigDataType: word32
+T_730: (in SZO_113 : byte)
   Class: Eq_730
   DataType: byte
   OrigDataType: byte
-T_731: (in SCZO_115 : byte)
+T_731: (in C_114 : byte)
   Class: Eq_731
   DataType: byte
   OrigDataType: byte
-T_732: (in Z_116 : byte)
+T_732: (in SCZO_115 : byte)
   Class: Eq_732
   DataType: byte
   OrigDataType: byte
-T_733: (in 0x0000001C : word32)
+T_733: (in Z_116 : byte)
   Class: Eq_733
+  DataType: byte
+  OrigDataType: byte
+T_734: (in 0x0000001C : word32)
+  Class: Eq_734
   DataType: ui32
   OrigDataType: ui32
-T_734: (in ebp_10 - 0x0000001C : word32)
-  Class: Eq_734
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_737 t0000)))
-T_735: (in 0x00000000 : word32)
+T_735: (in ebp_10 - 0x0000001C : word32)
   Class: Eq_735
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_738 t0000)))
+T_736: (in 0x00000000 : word32)
+  Class: Eq_736
   DataType: word32
   OrigDataType: word32
-T_736: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_736
+T_737: (in ebp_10 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_737
   DataType: ptr32
   OrigDataType: ptr32
-T_737: (in Mem117[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_728
+T_738: (in Mem117[ebp_10 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_729
   DataType: word32
   OrigDataType: word32
-T_738: (in 0xFFFFFFFF : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_739: (in 0xFFFFFFFF : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_739: (in 0x10003008 : ptr32)
-  Class: Eq_739
-  DataType: (ptr Eq_197)
-  OrigDataType: (ptr (struct (0 T_740 t0000)))
-T_740: (in Mem2[0x10003008:word32] : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_740: (in 0x10003008 : ptr32)
+  Class: Eq_740
+  DataType: (ptr Eq_198)
+  OrigDataType: (ptr (struct (0 T_741 t0000)))
+T_741: (in Mem2[0x10003008:word32] : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_741: (in eax : Eq_741)
-  Class: Eq_741
-  DataType: Eq_741
-  OrigDataType: BOOL
-T_742: (in hModule : Eq_742)
+T_742: (in eax : Eq_742)
   Class: Eq_742
   DataType: Eq_742
+  OrigDataType: BOOL
+T_743: (in hModule : Eq_743)
+  Class: Eq_743
+  DataType: Eq_743
   OrigDataType: HANDLE
-T_743: (in dwReason : Eq_197)
-  Class: Eq_197
-  DataType: Eq_197
+T_744: (in dwReason : Eq_198)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: DWORD
-T_744: (in lpReserved : Eq_395)
-  Class: Eq_395
-  DataType: Eq_395
+T_745: (in lpReserved : Eq_396)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: LPVOID
-T_745: (in 0x00000001 : word32)
-  Class: Eq_197
-  DataType: Eq_197
+T_746: (in 0x00000001 : word32)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: word32
-T_746: (in dwReason != 0x00000001 : bool)
-  Class: Eq_746
+T_747: (in dwReason != 0x00000001 : bool)
+  Class: Eq_747
   DataType: bool
   OrigDataType: bool
-T_747: (in fn10001388 : ptr32)
-  Class: Eq_747
-  DataType: (ptr Eq_747)
-  OrigDataType: (ptr (fn T_752 (T_744, T_743, T_749, T_750, T_751)))
-T_748: (in signature of fn10001388 : void)
-  Class: Eq_747
-  DataType: (ptr Eq_747)
+T_748: (in fn10001388 : ptr32)
+  Class: Eq_748
+  DataType: (ptr Eq_748)
+  OrigDataType: (ptr (fn T_753 (T_745, T_744, T_750, T_751, T_752)))
+T_749: (in signature of fn10001388 : void)
+  Class: Eq_748
+  DataType: (ptr Eq_748)
   OrigDataType: 
-T_749: (in ebx : word32)
-  Class: Eq_172
-  DataType: (ptr Eq_172)
+T_750: (in ebx : word32)
+  Class: Eq_173
+  DataType: (ptr Eq_173)
   OrigDataType: word32
-T_750: (in esi : word32)
-  Class: Eq_349
+T_751: (in esi : word32)
+  Class: Eq_350
   DataType: ptr32
   OrigDataType: word32
-T_751: (in edi : word32)
-  Class: Eq_350
+T_752: (in edi : word32)
+  Class: Eq_351
   DataType: word32
   OrigDataType: word32
-T_752: (in fn10001388(lpReserved, dwReason, ebx, esi, edi) : word32)
-  Class: Eq_741
-  DataType: Eq_741
+T_753: (in fn10001388(lpReserved, dwReason, ebx, esi, edi) : word32)
+  Class: Eq_742
+  DataType: Eq_742
   OrigDataType: word32
-T_753: (in fn10001864 : ptr32)
-  Class: Eq_753
-  DataType: (ptr Eq_753)
-  OrigDataType: (ptr (fn T_755 ()))
-T_754: (in signature of fn10001864 : void)
-  Class: Eq_753
-  DataType: (ptr Eq_753)
+T_754: (in fn10001864 : ptr32)
+  Class: Eq_754
+  DataType: (ptr Eq_754)
+  OrigDataType: (ptr (fn T_756 ()))
+T_755: (in signature of fn10001864 : void)
+  Class: Eq_754
+  DataType: (ptr Eq_754)
   OrigDataType: 
-T_755: (in fn10001864() : void)
-  Class: Eq_755
+T_756: (in fn10001864() : void)
+  Class: Eq_756
   DataType: void
   OrigDataType: void
-T_756: (in eax : word32)
-  Class: Eq_756
-  DataType: word32
-  OrigDataType: word32
-T_757: (in dwArg04 : word32)
-  Class: Eq_488
+T_757: (in eax : word32)
+  Class: Eq_757
   DataType: word32
   OrigDataType: word32
 T_758: (in dwArg04 : word32)
-  Class: Eq_758
-  DataType: (ptr Eq_758)
-  OrigDataType: (ptr (struct (0 T_761 t0000) (3C T_767 t003C)))
-T_759: (in 0x00000000 : word32)
-  Class: Eq_759
+  Class: Eq_489
   DataType: word32
   OrigDataType: word32
-T_760: (in dwArg04 + 0x00000000 : word32)
+T_759: (in dwArg04 : word32)
+  Class: Eq_759
+  DataType: (ptr Eq_759)
+  OrigDataType: (ptr (struct (0 T_762 t0000) (3C T_768 t003C)))
+T_760: (in 0x00000000 : word32)
   Class: Eq_760
   DataType: word32
   OrigDataType: word32
-T_761: (in Mem0[dwArg04 + 0x00000000:word16] : word16)
+T_761: (in dwArg04 + 0x00000000 : word32)
   Class: Eq_761
+  DataType: word32
+  OrigDataType: word32
+T_762: (in Mem0[dwArg04 + 0x00000000:word16] : word16)
+  Class: Eq_762
   DataType: word16
   OrigDataType: word16
-T_762: (in 0x5A4D : word16)
-  Class: Eq_761
+T_763: (in 0x5A4D : word16)
+  Class: Eq_762
   DataType: word16
   OrigDataType: word16
-T_763: (in dwArg04->w0000 == 0x5A4D : bool)
-  Class: Eq_763
+T_764: (in dwArg04->w0000 == 0x5A4D : bool)
+  Class: Eq_764
   DataType: bool
   OrigDataType: bool
-T_764: (in eax_21 : (ptr Eq_764))
-  Class: Eq_764
-  DataType: (ptr Eq_764)
-  OrigDataType: (ptr (struct (0 T_771 t0000) (18 T_777 t0018)))
-T_765: (in 0x0000003C : word32)
+T_765: (in eax_21 : (ptr Eq_765))
   Class: Eq_765
+  DataType: (ptr Eq_765)
+  OrigDataType: (ptr (struct (0 T_772 t0000) (18 T_778 t0018)))
+T_766: (in 0x0000003C : word32)
+  Class: Eq_766
   DataType: word32
   OrigDataType: word32
-T_766: (in dwArg04 + 0x0000003C : word32)
-  Class: Eq_766
+T_767: (in dwArg04 + 0x0000003C : word32)
+  Class: Eq_767
   DataType: ptr32
   OrigDataType: ptr32
-T_767: (in Mem0[dwArg04 + 0x0000003C:word32] : word32)
-  Class: Eq_767
+T_768: (in Mem0[dwArg04 + 0x0000003C:word32] : word32)
+  Class: Eq_768
   DataType: word32
   OrigDataType: word32
-T_768: (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
-  Class: Eq_764
-  DataType: (ptr Eq_764)
+T_769: (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
+  Class: Eq_765
+  DataType: (ptr Eq_765)
   OrigDataType: word32
-T_769: (in 0x00000000 : word32)
-  Class: Eq_769
-  DataType: word32
-  OrigDataType: word32
-T_770: (in eax_21 + 0x00000000 : word32)
+T_770: (in 0x00000000 : word32)
   Class: Eq_770
   DataType: word32
   OrigDataType: word32
-T_771: (in Mem0[eax_21 + 0x00000000:word32] : word32)
+T_771: (in eax_21 + 0x00000000 : word32)
   Class: Eq_771
   DataType: word32
   OrigDataType: word32
-T_772: (in 0x00004550 : word32)
-  Class: Eq_771
+T_772: (in Mem0[eax_21 + 0x00000000:word32] : word32)
+  Class: Eq_772
   DataType: word32
   OrigDataType: word32
-T_773: (in eax_21->dw0000 != 0x00004550 : bool)
-  Class: Eq_773
+T_773: (in 0x00004550 : word32)
+  Class: Eq_772
+  DataType: word32
+  OrigDataType: word32
+T_774: (in eax_21->dw0000 != 0x00004550 : bool)
+  Class: Eq_774
   DataType: bool
   OrigDataType: bool
-T_774: (in 0x00000000 : word32)
-  Class: Eq_756
+T_775: (in 0x00000000 : word32)
+  Class: Eq_757
   DataType: word32
   OrigDataType: word32
-T_775: (in 0x00000018 : word32)
-  Class: Eq_775
-  DataType: word32
-  OrigDataType: word32
-T_776: (in eax_21 + 0x00000018 : word32)
+T_776: (in 0x00000018 : word32)
   Class: Eq_776
+  DataType: word32
+  OrigDataType: word32
+T_777: (in eax_21 + 0x00000018 : word32)
+  Class: Eq_777
   DataType: ptr32
   OrigDataType: ptr32
-T_777: (in Mem0[eax_21 + 0x00000018:word16] : word16)
-  Class: Eq_777
+T_778: (in Mem0[eax_21 + 0x00000018:word16] : word16)
+  Class: Eq_778
   DataType: word16
   OrigDataType: word16
-T_778: (in 0x010B : word16)
-  Class: Eq_777
+T_779: (in 0x010B : word16)
+  Class: Eq_778
   DataType: word16
   OrigDataType: word16
-T_779: (in eax_21->w0018 == 0x010B : bool)
-  Class: Eq_779
+T_780: (in eax_21->w0018 == 0x010B : bool)
+  Class: Eq_780
   DataType: bool
   OrigDataType: bool
-T_780: (in (word32) (eax_21->w0018 == 0x010B) : word32)
-  Class: Eq_756
+T_781: (in (word32) (eax_21->w0018 == 0x010B) : word32)
+  Class: Eq_757
   DataType: word32
   OrigDataType: word32
-T_781: (in eax : (ptr Eq_781))
-  Class: Eq_781
-  DataType: (ptr Eq_781)
+T_782: (in eax : (ptr Eq_782))
+  Class: Eq_782
+  DataType: (ptr Eq_782)
   OrigDataType: word32
-T_782: (in dwArg04 : word32)
-  Class: Eq_488
+T_783: (in dwArg04 : word32)
+  Class: Eq_489
   DataType: word32
   OrigDataType: word32
-T_783: (in dwArg08 : word32)
-  Class: Eq_136
+T_784: (in dwArg08 : word32)
+  Class: Eq_137
   DataType: word32
   OrigDataType: word32
-T_784: (in ecx_6 : (ptr Eq_784))
-  Class: Eq_784
-  DataType: (ptr Eq_784)
-  OrigDataType: (ptr (struct (6 T_793 t0006) (14 T_800 t0014)))
-T_785: (in dwArg04 : word32)
+T_785: (in ecx_6 : (ptr Eq_785))
   Class: Eq_785
   DataType: (ptr Eq_785)
-  OrigDataType: (ptr (struct (3C T_788 t003C)))
-T_786: (in 0x0000003C : word32)
+  OrigDataType: (ptr (struct (6 T_794 t0006) (14 T_801 t0014)))
+T_786: (in dwArg04 : word32)
   Class: Eq_786
-  DataType: word32
-  OrigDataType: word32
-T_787: (in dwArg04 + 0x0000003C : word32)
+  DataType: (ptr Eq_786)
+  OrigDataType: (ptr (struct (3C T_789 t003C)))
+T_787: (in 0x0000003C : word32)
   Class: Eq_787
   DataType: word32
   OrigDataType: word32
-T_788: (in Mem0[dwArg04 + 0x0000003C:word32] : word32)
+T_788: (in dwArg04 + 0x0000003C : word32)
   Class: Eq_788
   DataType: word32
   OrigDataType: word32
-T_789: (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
-  Class: Eq_784
-  DataType: (ptr Eq_784)
-  OrigDataType: word32
-T_790: (in esi_14 : uint32)
-  Class: Eq_790
-  DataType: uint32
-  OrigDataType: uint32
-T_791: (in 0x00000006 : word32)
-  Class: Eq_791
+T_789: (in Mem0[dwArg04 + 0x0000003C:word32] : word32)
+  Class: Eq_789
   DataType: word32
   OrigDataType: word32
-T_792: (in ecx_6 + 0x00000006 : word32)
+T_790: (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
+  Class: Eq_785
+  DataType: (ptr Eq_785)
+  OrigDataType: word32
+T_791: (in esi_14 : uint32)
+  Class: Eq_791
+  DataType: uint32
+  OrigDataType: uint32
+T_792: (in 0x00000006 : word32)
   Class: Eq_792
   DataType: word32
   OrigDataType: word32
-T_793: (in Mem0[ecx_6 + 0x00000006:word16] : word16)
+T_793: (in ecx_6 + 0x00000006 : word32)
   Class: Eq_793
+  DataType: word32
+  OrigDataType: word32
+T_794: (in Mem0[ecx_6 + 0x00000006:word16] : word16)
+  Class: Eq_794
   DataType: word16
   OrigDataType: word16
-T_794: (in (word32) ecx_6->w0006 : word32)
-  Class: Eq_790
+T_795: (in (word32) ecx_6->w0006 : word32)
+  Class: Eq_791
   DataType: uint32
   OrigDataType: word32
-T_795: (in edx_15 : uint32)
-  Class: Eq_790
+T_796: (in edx_15 : uint32)
+  Class: Eq_791
   DataType: uint32
   OrigDataType: uint32
-T_796: (in 0x00000000 : word32)
-  Class: Eq_790
+T_797: (in 0x00000000 : word32)
+  Class: Eq_791
   DataType: uint32
   OrigDataType: word32
-T_797: (in eax_22 : (ptr Eq_781))
-  Class: Eq_781
-  DataType: (ptr Eq_781)
+T_798: (in eax_22 : (ptr Eq_782))
+  Class: Eq_782
+  DataType: (ptr Eq_782)
   OrigDataType: (ptr (struct 0028 (0 word32 dw0000) (8 uint32 dw0008)))
-T_798: (in 0x00000014 : word32)
-  Class: Eq_798
+T_799: (in 0x00000014 : word32)
+  Class: Eq_799
   DataType: word32
   OrigDataType: word32
-T_799: (in ecx_6 + 0x00000014 : word32)
-  Class: Eq_799
+T_800: (in ecx_6 + 0x00000014 : word32)
+  Class: Eq_800
   DataType: ptr32
   OrigDataType: ptr32
-T_800: (in Mem0[ecx_6 + 0x00000014:word16] : word16)
-  Class: Eq_800
+T_801: (in Mem0[ecx_6 + 0x00000014:word16] : word16)
+  Class: Eq_801
   DataType: word16
   OrigDataType: word16
-T_801: (in (word32) ecx_6->w0014 : word32)
-  Class: Eq_801
-  DataType: word32
-  OrigDataType: word32
-T_802: (in 0x00000018 : word32)
+T_802: (in (word32) ecx_6->w0014 : word32)
   Class: Eq_802
   DataType: word32
   OrigDataType: word32
-T_803: (in (word32) ecx_6->w0014 + 0x00000018 : word32)
+T_803: (in 0x00000018 : word32)
   Class: Eq_803
   DataType: word32
   OrigDataType: word32
-T_804: (in (word32) ecx_6->w0014 + 0x00000018 + ecx_6 : word32)
+T_804: (in (word32) ecx_6->w0014 + 0x00000018 : word32)
   Class: Eq_804
   DataType: word32
   OrigDataType: word32
-T_805: (in 0x0000000C : word32)
+T_805: (in (word32) ecx_6->w0014 + 0x00000018 + ecx_6 : word32)
   Class: Eq_805
   DataType: word32
   OrigDataType: word32
-T_806: (in (word32) ecx_6->w0014 + 0x00000018 + ecx_6 + 0x0000000C : word32)
-  Class: Eq_781
-  DataType: (ptr Eq_781)
-  OrigDataType: word32
-T_807: (in false : bool)
-  Class: Eq_807
-  DataType: bool
-  OrigDataType: bool
-T_808: (in 0x00000000 : word32)
-  Class: Eq_781
-  DataType: (ptr Eq_781)
-  OrigDataType: word32
-T_809: (in 0x00000001 : word32)
-  Class: Eq_809
+T_806: (in 0x0000000C : word32)
+  Class: Eq_806
   DataType: word32
   OrigDataType: word32
-T_810: (in edx_15 + 0x00000001 : word32)
-  Class: Eq_790
+T_807: (in (word32) ecx_6->w0014 + 0x00000018 + ecx_6 + 0x0000000C : word32)
+  Class: Eq_782
+  DataType: (ptr Eq_782)
+  OrigDataType: word32
+T_808: (in false : bool)
+  Class: Eq_808
+  DataType: bool
+  OrigDataType: bool
+T_809: (in 0x00000000 : word32)
+  Class: Eq_782
+  DataType: (ptr Eq_782)
+  OrigDataType: word32
+T_810: (in 0x00000001 : word32)
+  Class: Eq_810
+  DataType: word32
+  OrigDataType: word32
+T_811: (in edx_15 + 0x00000001 : word32)
+  Class: Eq_791
   DataType: uint32
   OrigDataType: word32
-T_811: (in 0x00000028 : word32)
-  Class: Eq_811
+T_812: (in 0x00000028 : word32)
+  Class: Eq_812
   DataType: word32
   OrigDataType: word32
-T_812: (in eax_22 + 0x00000028 : word32)
-  Class: Eq_781
-  DataType: (ptr Eq_781)
+T_813: (in eax_22 + 0x00000028 : word32)
+  Class: Eq_782
+  DataType: (ptr Eq_782)
   OrigDataType: word32
-T_813: (in edx_15 < esi_14 : bool)
-  Class: Eq_813
+T_814: (in edx_15 < esi_14 : bool)
+  Class: Eq_814
   DataType: bool
   OrigDataType: bool
-T_814: (in dwArg08 : word32)
-  Class: Eq_814
+T_815: (in dwArg08 : word32)
+  Class: Eq_815
   DataType: uint32
   OrigDataType: uint32
-T_815: (in 0x00000008 : word32)
-  Class: Eq_815
-  DataType: word32
-  OrigDataType: word32
-T_816: (in eax_22 + 0x00000008 : word32)
+T_816: (in 0x00000008 : word32)
   Class: Eq_816
   DataType: word32
   OrigDataType: word32
-T_817: (in Mem0[eax_22 + 0x00000008:word32] : word32)
+T_817: (in eax_22 + 0x00000008 : word32)
   Class: Eq_817
-  DataType: uint32
-  OrigDataType: uint32
-T_818: (in ecx_49 : uint32)
-  Class: Eq_814
-  DataType: uint32
-  OrigDataType: uint32
-T_819: (in eax_22->dw0008 + ecx_49 : word32)
-  Class: Eq_814
-  DataType: uint32
-  OrigDataType: uint32
-T_820: (in dwArg08 < eax_22->dw0008 + ecx_49 : bool)
-  Class: Eq_820
-  DataType: bool
-  OrigDataType: bool
-T_821: (in 0x00000000 : word32)
-  Class: Eq_821
   DataType: word32
   OrigDataType: word32
-T_822: (in eax_22 + 0x00000000 : word32)
+T_818: (in Mem0[eax_22 + 0x00000008:word32] : word32)
+  Class: Eq_818
+  DataType: uint32
+  OrigDataType: uint32
+T_819: (in ecx_49 : uint32)
+  Class: Eq_815
+  DataType: uint32
+  OrigDataType: uint32
+T_820: (in eax_22->dw0008 + ecx_49 : word32)
+  Class: Eq_815
+  DataType: uint32
+  OrigDataType: uint32
+T_821: (in dwArg08 < eax_22->dw0008 + ecx_49 : bool)
+  Class: Eq_821
+  DataType: bool
+  OrigDataType: bool
+T_822: (in 0x00000000 : word32)
   Class: Eq_822
+  DataType: word32
+  OrigDataType: word32
+T_823: (in eax_22 + 0x00000000 : word32)
+  Class: Eq_823
   DataType: ptr32
   OrigDataType: ptr32
-T_823: (in Mem0[eax_22 + 0x00000000:word32] : word32)
-  Class: Eq_814
+T_824: (in Mem0[eax_22 + 0x00000000:word32] : word32)
+  Class: Eq_815
   DataType: uint32
   OrigDataType: word32
-T_824: (in dwArg08 < ecx_49 : bool)
-  Class: Eq_824
+T_825: (in dwArg08 < ecx_49 : bool)
+  Class: Eq_825
   DataType: bool
   OrigDataType: bool
-T_825: (in eax : ui32)
-  Class: Eq_825
+T_826: (in eax : ui32)
+  Class: Eq_826
   DataType: ui32
   OrigDataType: word32
-T_826: (in eax_31 : ui32)
-  Class: Eq_825
+T_827: (in eax_31 : ui32)
+  Class: Eq_826
   DataType: ui32
   OrigDataType: ui32
-T_827: (in ebp_10 : (ptr Eq_400))
-  Class: Eq_400
-  DataType: (ptr Eq_400)
-  OrigDataType: (ptr (struct (8 T_867 t0008)))
-T_828: (in fn100017E8 : ptr32)
+T_828: (in ebp_10 : (ptr Eq_401))
   Class: Eq_401
   DataType: (ptr Eq_401)
-  OrigDataType: (ptr (fn T_832 (T_348, T_349, T_350, T_829, T_830, T_831)))
-T_829: (in dwLoc0C : word32)
-  Class: Eq_406
-  DataType: word32
-  OrigDataType: word32
-T_830: (in 0x10002230 : word32)
+  OrigDataType: (ptr (struct (8 T_868 t0008)))
+T_829: (in fn100017E8 : ptr32)
+  Class: Eq_402
+  DataType: (ptr Eq_402)
+  OrigDataType: (ptr (fn T_833 (T_349, T_350, T_351, T_830, T_831, T_832)))
+T_830: (in dwLoc0C : word32)
   Class: Eq_407
   DataType: word32
   OrigDataType: word32
-T_831: (in 0x00000008 : word32)
+T_831: (in 0x10002230 : word32)
   Class: Eq_408
   DataType: word32
   OrigDataType: word32
-T_832: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10002230, 0x00000008) : word32)
-  Class: Eq_400
-  DataType: (ptr Eq_400)
-  OrigDataType: word32
-T_833: (in 0x00000004 : word32)
-  Class: Eq_833
-  DataType: ui32
-  OrigDataType: ui32
-T_834: (in ebp_10 - 0x00000004 : word32)
-  Class: Eq_834
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_837 t0000)))
-T_835: (in 0x00000000 : word32)
-  Class: Eq_835
+T_832: (in 0x00000008 : word32)
+  Class: Eq_409
   DataType: word32
   OrigDataType: word32
-T_836: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
+T_833: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10002230, 0x00000008) : word32)
+  Class: Eq_401
+  DataType: (ptr Eq_401)
+  OrigDataType: word32
+T_834: (in 0x00000004 : word32)
+  Class: Eq_834
+  DataType: ui32
+  OrigDataType: ui32
+T_835: (in ebp_10 - 0x00000004 : word32)
+  Class: Eq_835
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_838 t0000)))
+T_836: (in 0x00000000 : word32)
   Class: Eq_836
   DataType: word32
   OrigDataType: word32
-T_837: (in Mem0[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
+T_837: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
   Class: Eq_837
-  DataType: ui32
-  OrigDataType: ui32
-T_838: (in 0x00000000 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_838: (in Mem0[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
   Class: Eq_838
   DataType: ui32
   OrigDataType: ui32
-T_839: (in *(ebp_10 - 0x00000004) & 0x00000000 : word32)
+T_839: (in 0x00000000 : word32)
   Class: Eq_839
   DataType: ui32
   OrigDataType: ui32
-T_840: (in 0x00000004 : word32)
+T_840: (in *(ebp_10 - 0x00000004) & 0x00000000 : word32)
   Class: Eq_840
   DataType: ui32
   OrigDataType: ui32
-T_841: (in ebp_10 - 0x00000004 : word32)
+T_841: (in 0x00000004 : word32)
   Class: Eq_841
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_844 t0000)))
-T_842: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_842: (in ebp_10 - 0x00000004 : word32)
   Class: Eq_842
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_845 t0000)))
+T_843: (in 0x00000000 : word32)
+  Class: Eq_843
   DataType: word32
   OrigDataType: word32
-T_843: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_843
+T_844: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_844
   DataType: ptr32
   OrigDataType: ptr32
-T_844: (in Mem13[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_839
+T_845: (in Mem13[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_840
   DataType: ui32
   OrigDataType: word32
-T_845: (in 0x10000000 : ptr32)
-  Class: Eq_845
-  DataType: ptr32
-  OrigDataType: ptr32
-T_846: (in fp : ptr32)
+T_846: (in 0x10000000 : ptr32)
   Class: Eq_846
   DataType: ptr32
   OrigDataType: ptr32
-T_847: (in 0x0000000C : word32)
+T_847: (in fp : ptr32)
   Class: Eq_847
-  DataType: ui32
-  OrigDataType: ui32
-T_848: (in fp - 0x0000000C : word32)
-  Class: Eq_848
-  DataType: (ptr ptr32)
-  OrigDataType: (ptr (struct (0 T_851 t0000)))
-T_849: (in 0x00000000 : word32)
-  Class: Eq_849
-  DataType: word32
-  OrigDataType: word32
-T_850: (in fp - 0x0000000C + 0x00000000 : word32)
-  Class: Eq_850
   DataType: ptr32
   OrigDataType: ptr32
-T_851: (in Mem18[fp - 0x0000000C + 0x00000000:word32] : word32)
-  Class: Eq_845
+T_848: (in 0x0000000C : word32)
+  Class: Eq_848
+  DataType: ui32
+  OrigDataType: ui32
+T_849: (in fp - 0x0000000C : word32)
+  Class: Eq_849
+  DataType: (ptr ptr32)
+  OrigDataType: (ptr (struct (0 T_852 t0000)))
+T_850: (in 0x00000000 : word32)
+  Class: Eq_850
+  DataType: word32
+  OrigDataType: word32
+T_851: (in fp - 0x0000000C + 0x00000000 : word32)
+  Class: Eq_851
+  DataType: ptr32
+  OrigDataType: ptr32
+T_852: (in Mem18[fp - 0x0000000C + 0x00000000:word32] : word32)
+  Class: Eq_846
   DataType: ptr32
   OrigDataType: word32
-T_852: (in fn100016D0 : ptr32)
-  Class: Eq_852
-  DataType: (ptr Eq_852)
-  OrigDataType: (ptr (fn T_855 (T_854)))
-T_853: (in signature of fn100016D0 : void)
-  Class: Eq_852
-  DataType: (ptr Eq_852)
+T_853: (in fn100016D0 : ptr32)
+  Class: Eq_853
+  DataType: (ptr Eq_853)
+  OrigDataType: (ptr (fn T_856 (T_855)))
+T_854: (in signature of fn100016D0 : void)
+  Class: Eq_853
+  DataType: (ptr Eq_853)
   OrigDataType: 
-T_854: (in dwArg00 : word32)
-  Class: Eq_488
+T_855: (in dwArg00 : word32)
+  Class: Eq_489
   DataType: word32
   OrigDataType: word32
-T_855: (in fn100016D0(dwArg00) : word32)
-  Class: Eq_855
+T_856: (in fn100016D0(dwArg00) : word32)
+  Class: Eq_856
   DataType: word32
   OrigDataType: word32
-T_856: (in 0x00000000 : word32)
-  Class: Eq_855
+T_857: (in 0x00000000 : word32)
+  Class: Eq_856
   DataType: word32
   OrigDataType: word32
-T_857: (in fn100016D0(dwArg00) == 0x00000000 : bool)
-  Class: Eq_857
+T_858: (in fn100016D0(dwArg00) == 0x00000000 : bool)
+  Class: Eq_858
   DataType: bool
   OrigDataType: bool
-T_858: (in 0xFFFFFFFE : word32)
-  Class: Eq_858
-  DataType: word32
-  OrigDataType: word32
-T_859: (in 0x00000004 : word32)
+T_859: (in 0xFFFFFFFE : word32)
   Class: Eq_859
-  DataType: ui32
-  OrigDataType: ui32
-T_860: (in ebp_10 - 0x00000004 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_860: (in 0x00000004 : word32)
   Class: Eq_860
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_863 t0000)))
-T_861: (in 0x00000000 : word32)
-  Class: Eq_861
-  DataType: word32
-  OrigDataType: word32
-T_862: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_862
-  DataType: ptr32
-  OrigDataType: ptr32
-T_863: (in Mem43[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_858
-  DataType: word32
-  OrigDataType: word32
-T_864: (in 0x00000000 : word32)
-  Class: Eq_825
-  DataType: ui32
-  OrigDataType: word32
-T_865: (in 0x00000008 : word32)
-  Class: Eq_865
-  DataType: word32
-  OrigDataType: word32
-T_866: (in ebp_10 + 0x00000008 : word32)
-  Class: Eq_866
-  DataType: ptr32
-  OrigDataType: ptr32
-T_867: (in Mem18[ebp_10 + 0x00000008:word32] : word32)
-  Class: Eq_413
   DataType: ui32
   OrigDataType: ui32
-T_868: (in 0x10000000 : ptr32)
-  Class: Eq_868
+T_861: (in ebp_10 - 0x00000004 : word32)
+  Class: Eq_861
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_864 t0000)))
+T_862: (in 0x00000000 : word32)
+  Class: Eq_862
+  DataType: word32
+  OrigDataType: word32
+T_863: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_863
+  DataType: ptr32
+  OrigDataType: ptr32
+T_864: (in Mem43[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_859
+  DataType: word32
+  OrigDataType: word32
+T_865: (in 0x00000000 : word32)
+  Class: Eq_826
   DataType: ui32
-  OrigDataType: (union (ui32 u0) (ptr32 u1))
-T_869: (in ebp_10->dw0008 - 0x10000000 : word32)
+  OrigDataType: word32
+T_866: (in 0x00000008 : word32)
+  Class: Eq_866
+  DataType: word32
+  OrigDataType: word32
+T_867: (in ebp_10 + 0x00000008 : word32)
+  Class: Eq_867
+  DataType: ptr32
+  OrigDataType: ptr32
+T_868: (in Mem18[ebp_10 + 0x00000008:word32] : word32)
+  Class: Eq_414
+  DataType: ui32
+  OrigDataType: ui32
+T_869: (in 0x10000000 : ptr32)
   Class: Eq_869
   DataType: ui32
-  OrigDataType: ui32
-T_870: (in 0x0000000C : word32)
+  OrigDataType: (union (ui32 u0) (ptr32 u1))
+T_870: (in ebp_10->dw0008 - 0x10000000 : word32)
   Class: Eq_870
   DataType: ui32
   OrigDataType: ui32
-T_871: (in fp - 0x0000000C : word32)
+T_871: (in 0x0000000C : word32)
   Class: Eq_871
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_874 t0000)))
-T_872: (in 0x00000000 : word32)
-  Class: Eq_872
-  DataType: word32
-  OrigDataType: word32
-T_873: (in fp - 0x0000000C + 0x00000000 : word32)
-  Class: Eq_873
-  DataType: ptr32
-  OrigDataType: ptr32
-T_874: (in Mem51[fp - 0x0000000C + 0x00000000:word32] : word32)
-  Class: Eq_869
-  DataType: ui32
-  OrigDataType: word32
-T_875: (in 0x10000000 : ptr32)
-  Class: Eq_875
-  DataType: ptr32
-  OrigDataType: ptr32
-T_876: (in 0x00000010 : word32)
-  Class: Eq_876
   DataType: ui32
   OrigDataType: ui32
-T_877: (in fp - 0x00000010 : word32)
-  Class: Eq_877
-  DataType: (ptr ptr32)
-  OrigDataType: (ptr (struct (0 T_880 t0000)))
-T_878: (in 0x00000000 : word32)
-  Class: Eq_878
+T_872: (in fp - 0x0000000C : word32)
+  Class: Eq_872
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_875 t0000)))
+T_873: (in 0x00000000 : word32)
+  Class: Eq_873
   DataType: word32
   OrigDataType: word32
-T_879: (in fp - 0x00000010 + 0x00000000 : word32)
-  Class: Eq_879
+T_874: (in fp - 0x0000000C + 0x00000000 : word32)
+  Class: Eq_874
   DataType: ptr32
   OrigDataType: ptr32
-T_880: (in Mem53[fp - 0x00000010 + 0x00000000:word32] : word32)
-  Class: Eq_875
+T_875: (in Mem51[fp - 0x0000000C + 0x00000000:word32] : word32)
+  Class: Eq_870
+  DataType: ui32
+  OrigDataType: word32
+T_876: (in 0x10000000 : ptr32)
+  Class: Eq_876
+  DataType: ptr32
+  OrigDataType: ptr32
+T_877: (in 0x00000010 : word32)
+  Class: Eq_877
+  DataType: ui32
+  OrigDataType: ui32
+T_878: (in fp - 0x00000010 : word32)
+  Class: Eq_878
+  DataType: (ptr ptr32)
+  OrigDataType: (ptr (struct (0 T_881 t0000)))
+T_879: (in 0x00000000 : word32)
+  Class: Eq_879
+  DataType: word32
+  OrigDataType: word32
+T_880: (in fp - 0x00000010 + 0x00000000 : word32)
+  Class: Eq_880
+  DataType: ptr32
+  OrigDataType: ptr32
+T_881: (in Mem53[fp - 0x00000010 + 0x00000000:word32] : word32)
+  Class: Eq_876
   DataType: ptr32
   OrigDataType: word32
-T_881: (in eax_54 : (ptr Eq_881))
-  Class: Eq_881
-  DataType: (ptr Eq_881)
-  OrigDataType: (ptr (struct (24 T_890 t0024)))
-T_882: (in fn10001700 : ptr32)
+T_882: (in eax_54 : (ptr Eq_882))
   Class: Eq_882
   DataType: (ptr Eq_882)
-  OrigDataType: (ptr (fn T_885 (T_854, T_884)))
-T_883: (in signature of fn10001700 : void)
-  Class: Eq_882
-  DataType: (ptr Eq_882)
+  OrigDataType: (ptr (struct (24 T_891 t0024)))
+T_883: (in fn10001700 : ptr32)
+  Class: Eq_883
+  DataType: (ptr Eq_883)
+  OrigDataType: (ptr (fn T_886 (T_855, T_885)))
+T_884: (in signature of fn10001700 : void)
+  Class: Eq_883
+  DataType: (ptr Eq_883)
   OrigDataType: 
-T_884: (in dwArg04 : word32)
-  Class: Eq_136
+T_885: (in dwArg04 : word32)
+  Class: Eq_137
   DataType: word32
   OrigDataType: word32
-T_885: (in fn10001700(dwArg00, dwArg04) : word32)
-  Class: Eq_881
-  DataType: (ptr Eq_881)
+T_886: (in fn10001700(dwArg00, dwArg04) : word32)
+  Class: Eq_882
+  DataType: (ptr Eq_882)
   OrigDataType: word32
-T_886: (in 0x00000000 : word32)
-  Class: Eq_881
-  DataType: (ptr Eq_881)
+T_887: (in 0x00000000 : word32)
+  Class: Eq_882
+  DataType: (ptr Eq_882)
   OrigDataType: word32
-T_887: (in eax_54 == null : bool)
-  Class: Eq_887
+T_888: (in eax_54 == null : bool)
+  Class: Eq_888
   DataType: bool
   OrigDataType: bool
-T_888: (in 0x00000024 : word32)
-  Class: Eq_888
-  DataType: word32
-  OrigDataType: word32
-T_889: (in eax_54 + 0x00000024 : word32)
+T_889: (in 0x00000024 : word32)
   Class: Eq_889
   DataType: word32
   OrigDataType: word32
-T_890: (in Mem53[eax_54 + 0x00000024:word32] : word32)
+T_890: (in eax_54 + 0x00000024 : word32)
   Class: Eq_890
-  DataType: uint32
-  OrigDataType: uint32
-T_891: (in 0x0000001F : word32)
-  Class: Eq_891
   DataType: word32
   OrigDataType: word32
-T_892: (in eax_54->dw0024 >> 0x0000001F : word32)
-  Class: Eq_892
+T_891: (in Mem53[eax_54 + 0x00000024:word32] : word32)
+  Class: Eq_891
   DataType: uint32
   OrigDataType: uint32
-T_893: (in ~(eax_54->dw0024 >> 0x0000001F) : word32)
+T_892: (in 0x0000001F : word32)
+  Class: Eq_892
+  DataType: word32
+  OrigDataType: word32
+T_893: (in eax_54->dw0024 >> 0x0000001F : word32)
   Class: Eq_893
   DataType: uint32
   OrigDataType: uint32
-T_894: (in 0x00000001 : word32)
+T_894: (in ~(eax_54->dw0024 >> 0x0000001F) : word32)
   Class: Eq_894
+  DataType: uint32
+  OrigDataType: uint32
+T_895: (in 0x00000001 : word32)
+  Class: Eq_895
   DataType: ui32
   OrigDataType: ui32
-T_895: (in ~(eax_54->dw0024 >> 0x0000001F) & 0x00000001 : word32)
-  Class: Eq_825
+T_896: (in ~(eax_54->dw0024 >> 0x0000001F) & 0x00000001 : word32)
+  Class: Eq_826
   DataType: ui32
   OrigDataType: ui32
-T_896: (in 0xFFFFFFFE : word32)
-  Class: Eq_896
-  DataType: word32
-  OrigDataType: word32
-T_897: (in 0x00000004 : word32)
+T_897: (in 0xFFFFFFFE : word32)
   Class: Eq_897
-  DataType: ui32
-  OrigDataType: ui32
-T_898: (in ebp_10 - 0x00000004 : word32)
-  Class: Eq_898
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_901 t0000)))
-T_899: (in 0x00000000 : word32)
-  Class: Eq_899
   DataType: word32
   OrigDataType: word32
-T_900: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
+T_898: (in 0x00000004 : word32)
+  Class: Eq_898
+  DataType: ui32
+  OrigDataType: ui32
+T_899: (in ebp_10 - 0x00000004 : word32)
+  Class: Eq_899
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_902 t0000)))
+T_900: (in 0x00000000 : word32)
   Class: Eq_900
+  DataType: word32
+  OrigDataType: word32
+T_901: (in ebp_10 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_901
   DataType: ptr32
   OrigDataType: ptr32
-T_901: (in Mem68[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_896
+T_902: (in Mem68[ebp_10 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_897
   DataType: word32
   OrigDataType: word32
-T_902: (in edi_37 : word32)
-  Class: Eq_902
+T_903: (in edi_37 : word32)
+  Class: Eq_903
   DataType: word32
   OrigDataType: word32
-T_903: (in fn1000182D : ptr32)
-  Class: Eq_484
-  DataType: (ptr Eq_484)
-  OrigDataType: (ptr (fn T_907 (T_827, T_904, T_854, T_884, T_905, T_906)))
-T_904: (in 0x00000008 : word32)
-  Class: Eq_487
+T_904: (in fn1000182D : ptr32)
+  Class: Eq_485
+  DataType: (ptr Eq_485)
+  OrigDataType: (ptr (fn T_908 (T_828, T_905, T_855, T_885, T_906, T_907)))
+T_905: (in 0x00000008 : word32)
+  Class: Eq_488
   DataType: word32
   OrigDataType: word32
-T_905: (in dwArg08 : word32)
-  Class: Eq_490
-  DataType: word32
-  OrigDataType: word32
-T_906: (in dwArg0C : word32)
+T_906: (in dwArg08 : word32)
   Class: Eq_491
   DataType: word32
   OrigDataType: word32
-T_907: (in fn1000182D(ebp_10, 0x00000008, dwArg00, dwArg04, dwArg08, dwArg0C) : word32)
-  Class: Eq_497
+T_907: (in dwArg0C : word32)
+  Class: Eq_492
   DataType: word32
   OrigDataType: word32
-T_908: (in *ediOut : word32)
-  Class: Eq_497
+T_908: (in fn1000182D(ebp_10, 0x00000008, dwArg00, dwArg04, dwArg08, dwArg0C) : word32)
+  Class: Eq_498
   DataType: word32
   OrigDataType: word32
-T_909: (in eax : word32)
-  Class: Eq_909
+T_909: (in *ediOut : word32)
+  Class: Eq_498
   DataType: word32
   OrigDataType: word32
-T_910: (in dwArg08 : word32)
+T_910: (in eax : word32)
   Class: Eq_910
   DataType: word32
   OrigDataType: word32
-T_911: (in 0x00000001 : word32)
-  Class: Eq_910
+T_911: (in dwArg08 : word32)
+  Class: Eq_911
   DataType: word32
   OrigDataType: word32
-T_912: (in dwArg08 != 0x00000001 : bool)
-  Class: Eq_912
+T_912: (in 0x00000001 : word32)
+  Class: Eq_911
+  DataType: word32
+  OrigDataType: word32
+T_913: (in dwArg08 != 0x00000001 : bool)
+  Class: Eq_913
   DataType: bool
   OrigDataType: bool
-T_913: (in 0x00000001 : word32)
-  Class: Eq_909
+T_914: (in 0x00000001 : word32)
+  Class: Eq_910
   DataType: word32
   OrigDataType: word32
-T_914: (in 0x100020CC : ptr32)
-  Class: Eq_914
+T_915: (in 0x100020CC : ptr32)
+  Class: Eq_915
   DataType: (ptr (ptr code))
-  OrigDataType: (ptr (struct (0 T_915 t0000)))
-T_915: (in Mem0[0x100020CC:word32] : word32)
-  Class: Eq_498
+  OrigDataType: (ptr (struct (0 T_916 t0000)))
+T_916: (in Mem0[0x100020CC:word32] : word32)
+  Class: Eq_499
   DataType: (ptr code)
   OrigDataType: word32
-T_916: (in 0x00000000 : word32)
-  Class: Eq_498
+T_917: (in 0x00000000 : word32)
+  Class: Eq_499
   DataType: (ptr code)
   OrigDataType: word32
-T_917: (in globals->ptr100020CC != null : bool)
-  Class: Eq_917
+T_918: (in globals->ptr100020CC != null : bool)
+  Class: Eq_918
   DataType: bool
   OrigDataType: bool
-T_918: (in DisableThreadLibraryCalls : ptr32)
-  Class: Eq_918
-  DataType: (ptr Eq_918)
-  OrigDataType: (ptr (fn T_922 (T_921)))
-T_919: (in signature of DisableThreadLibraryCalls : void)
-  Class: Eq_918
-  DataType: (ptr Eq_918)
+T_919: (in DisableThreadLibraryCalls : ptr32)
+  Class: Eq_919
+  DataType: (ptr Eq_919)
+  OrigDataType: (ptr (fn T_923 (T_922)))
+T_920: (in signature of DisableThreadLibraryCalls : void)
+  Class: Eq_919
+  DataType: (ptr Eq_919)
   OrigDataType: 
-T_920: (in hLibModule : HMODULE)
-  Class: Eq_920
-  DataType: Eq_920
+T_921: (in hLibModule : HMODULE)
+  Class: Eq_921
+  DataType: Eq_921
   OrigDataType: 
-T_921: (in dwArg04 : word32)
-  Class: Eq_920
-  DataType: Eq_920
+T_922: (in dwArg04 : word32)
+  Class: Eq_921
+  DataType: Eq_921
   OrigDataType: HMODULE
-T_922: (in DisableThreadLibraryCalls(dwArg04) : BOOL)
-  Class: Eq_741
-  DataType: Eq_741
+T_923: (in DisableThreadLibraryCalls(dwArg04) : BOOL)
+  Class: Eq_742
+  DataType: Eq_742
   OrigDataType: BOOL
-T_923: (in ebp : ptr32)
-  Class: Eq_923
-  DataType: ptr32
-  OrigDataType: word32
-T_924: (in esp_14 : ptr32)
+T_924: (in ebp : ptr32)
   Class: Eq_924
   DataType: ptr32
-  OrigDataType: ptr32
-T_925: (in fp : ptr32)
+  OrigDataType: word32
+T_925: (in esp_14 : ptr32)
   Class: Eq_925
   DataType: ptr32
   OrigDataType: ptr32
-T_926: (in 0x00000008 : word32)
+T_926: (in fp : ptr32)
   Class: Eq_926
-  DataType: ui32
-  OrigDataType: ui32
-T_927: (in fp - 0x00000008 : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_927: (in 0x00000008 : word32)
   Class: Eq_927
-  DataType: ptr32
-  OrigDataType: ptr32
-T_928: (in dwArg08 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_928: (in fp - 0x00000008 : word32)
   Class: Eq_928
-  DataType: ui32
-  OrigDataType: ui32
-T_929: (in fp - 0x00000008 - dwArg08 : word32)
-  Class: Eq_924
   DataType: ptr32
   OrigDataType: ptr32
-T_930: (in 0x00000004 : word32)
-  Class: Eq_930
+T_929: (in dwArg08 : word32)
+  Class: Eq_929
   DataType: ui32
   OrigDataType: ui32
-T_931: (in esp_14 - 0x00000004 : word32)
+T_930: (in fp - 0x00000008 - dwArg08 : word32)
+  Class: Eq_925
+  DataType: ptr32
+  OrigDataType: ptr32
+T_931: (in 0x00000004 : word32)
   Class: Eq_931
-  DataType: (ptr (ptr Eq_172))
-  OrigDataType: (ptr (struct (0 T_934 t0000)))
-T_932: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_932: (in esp_14 - 0x00000004 : word32)
   Class: Eq_932
-  DataType: word32
-  OrigDataType: word32
-T_933: (in esp_14 - 0x00000004 + 0x00000000 : word32)
+  DataType: (ptr (ptr Eq_173))
+  OrigDataType: (ptr (struct (0 T_935 t0000)))
+T_933: (in 0x00000000 : word32)
   Class: Eq_933
+  DataType: word32
+  OrigDataType: word32
+T_934: (in esp_14 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_934
   DataType: ptr32
   OrigDataType: ptr32
-T_934: (in Mem17[esp_14 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_172
-  DataType: (ptr Eq_172)
+T_935: (in Mem17[esp_14 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_173
+  DataType: (ptr Eq_173)
   OrigDataType: word32
-T_935: (in 0x00000008 : word32)
-  Class: Eq_935
-  DataType: ui32
-  OrigDataType: ui32
-T_936: (in esp_14 - 0x00000008 : word32)
+T_936: (in 0x00000008 : word32)
   Class: Eq_936
-  DataType: (ptr ptr32)
-  OrigDataType: (ptr (struct (0 T_939 t0000)))
-T_937: (in 0x00000000 : word32)
-  Class: Eq_937
-  DataType: word32
-  OrigDataType: word32
-T_938: (in esp_14 - 0x00000008 + 0x00000000 : word32)
-  Class: Eq_938
-  DataType: ptr32
-  OrigDataType: ptr32
-T_939: (in Mem20[esp_14 - 0x00000008 + 0x00000000:word32] : word32)
-  Class: Eq_349
-  DataType: ptr32
-  OrigDataType: word32
-T_940: (in 0x0000000C : word32)
-  Class: Eq_940
   DataType: ui32
   OrigDataType: ui32
-T_941: (in esp_14 - 0x0000000C : word32)
-  Class: Eq_941
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_944 t0000)))
-T_942: (in 0x00000000 : word32)
-  Class: Eq_942
+T_937: (in esp_14 - 0x00000008 : word32)
+  Class: Eq_937
+  DataType: (ptr ptr32)
+  OrigDataType: (ptr (struct (0 T_940 t0000)))
+T_938: (in 0x00000000 : word32)
+  Class: Eq_938
   DataType: word32
   OrigDataType: word32
-T_943: (in esp_14 - 0x0000000C + 0x00000000 : word32)
-  Class: Eq_943
+T_939: (in esp_14 - 0x00000008 + 0x00000000 : word32)
+  Class: Eq_939
   DataType: ptr32
   OrigDataType: ptr32
-T_944: (in Mem23[esp_14 - 0x0000000C + 0x00000000:word32] : word32)
+T_940: (in Mem20[esp_14 - 0x00000008 + 0x00000000:word32] : word32)
   Class: Eq_350
+  DataType: ptr32
+  OrigDataType: word32
+T_941: (in 0x0000000C : word32)
+  Class: Eq_941
+  DataType: ui32
+  OrigDataType: ui32
+T_942: (in esp_14 - 0x0000000C : word32)
+  Class: Eq_942
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_945 t0000)))
+T_943: (in 0x00000000 : word32)
+  Class: Eq_943
   DataType: word32
   OrigDataType: word32
-T_945: (in 0x10003000 : ptr32)
-  Class: Eq_945
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_946 t0000)))
-T_946: (in Mem23[0x10003000:word32] : word32)
+T_944: (in esp_14 - 0x0000000C + 0x00000000 : word32)
+  Class: Eq_944
+  DataType: ptr32
+  OrigDataType: ptr32
+T_945: (in Mem23[esp_14 - 0x0000000C + 0x00000000:word32] : word32)
+  Class: Eq_351
+  DataType: word32
+  OrigDataType: word32
+T_946: (in 0x10003000 : ptr32)
   Class: Eq_946
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_947 t0000)))
+T_947: (in Mem23[0x10003000:word32] : word32)
+  Class: Eq_947
   DataType: ui32
   OrigDataType: word32
-T_947: (in 0x00000008 : word32)
-  Class: Eq_947
+T_948: (in 0x00000008 : word32)
+  Class: Eq_948
   DataType: int32
   OrigDataType: int32
-T_948: (in fp + 0x00000008 : word32)
-  Class: Eq_948
+T_949: (in fp + 0x00000008 : word32)
+  Class: Eq_949
   DataType: ptr32
   OrigDataType: ptr32
-T_949: (in globals->dw10003000 ^ fp + 0x00000008 : word32)
-  Class: Eq_949
-  DataType: ui32
-  OrigDataType: ui32
-T_950: (in 0x00000010 : word32)
+T_950: (in globals->dw10003000 ^ fp + 0x00000008 : word32)
   Class: Eq_950
   DataType: ui32
   OrigDataType: ui32
-T_951: (in esp_14 - 0x00000010 : word32)
+T_951: (in 0x00000010 : word32)
   Class: Eq_951
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_954 t0000)))
-T_952: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_952: (in esp_14 - 0x00000010 : word32)
   Class: Eq_952
-  DataType: word32
-  OrigDataType: word32
-T_953: (in esp_14 - 0x00000010 + 0x00000000 : word32)
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_955 t0000)))
+T_953: (in 0x00000000 : word32)
   Class: Eq_953
-  DataType: ptr32
-  OrigDataType: ptr32
-T_954: (in Mem33[esp_14 - 0x00000010 + 0x00000000:word32] : word32)
-  Class: Eq_949
-  DataType: ui32
-  OrigDataType: word32
-T_955: (in dwArg00 : word32)
-  Class: Eq_955
   DataType: word32
   OrigDataType: word32
-T_956: (in 0x00000014 : word32)
+T_954: (in esp_14 - 0x00000010 + 0x00000000 : word32)
+  Class: Eq_954
+  DataType: ptr32
+  OrigDataType: ptr32
+T_955: (in Mem33[esp_14 - 0x00000010 + 0x00000000:word32] : word32)
+  Class: Eq_950
+  DataType: ui32
+  OrigDataType: word32
+T_956: (in dwArg00 : word32)
   Class: Eq_956
-  DataType: ui32
-  OrigDataType: ui32
-T_957: (in esp_14 - 0x00000014 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_957: (in 0x00000014 : word32)
   Class: Eq_957
-  DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_960 t0000)))
-T_958: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_958: (in esp_14 - 0x00000014 : word32)
   Class: Eq_958
-  DataType: word32
-  OrigDataType: word32
-T_959: (in esp_14 - 0x00000014 + 0x00000000 : word32)
-  Class: Eq_959
-  DataType: ptr32
-  OrigDataType: ptr32
-T_960: (in Mem38[esp_14 - 0x00000014 + 0x00000000:word32] : word32)
-  Class: Eq_955
-  DataType: word32
-  OrigDataType: word32
-T_961: (in 0x00000008 : word32)
-  Class: Eq_961
-  DataType: ui32
-  OrigDataType: ui32
-T_962: (in fp - 0x00000008 : word32)
-  Class: Eq_962
-  DataType: ptr32
-  OrigDataType: ptr32
-T_963: (in fs : selector)
-  Class: Eq_963
-  DataType: (ptr Eq_963)
-  OrigDataType: (ptr (segment (0 T_965 t0000)))
-T_964: (in 0x00000000 : word32)
-  Class: Eq_964
-  DataType: (memptr (ptr Eq_963) ptr32)
-  OrigDataType: (memptr T_963 (struct (0 T_965 t0000)))
-T_965: (in Mem43[fs:0x00000000:word32] : word32)
-  Class: Eq_962
-  DataType: ptr32
-  OrigDataType: word32
-T_966: (in fp + 0x00000008 : word32)
-  Class: Eq_923
-  DataType: ptr32
-  OrigDataType: ptr32
-T_967: (in edi : word32)
-  Class: Eq_967
-  DataType: word32
-  OrigDataType: word32
-T_968: (in 0x00000010 : word32)
-  Class: Eq_968
-  DataType: ui32
-  OrigDataType: ui32
-T_969: (in ebp - 0x00000010 : word32)
-  Class: Eq_969
   DataType: (ptr word32)
-  OrigDataType: (ptr (struct (0 T_972 t0000)))
-T_970: (in 0x00000000 : word32)
-  Class: Eq_970
+  OrigDataType: (ptr (struct (0 T_961 t0000)))
+T_959: (in 0x00000000 : word32)
+  Class: Eq_959
   DataType: word32
   OrigDataType: word32
-T_971: (in ebp - 0x00000010 + 0x00000000 : word32)
+T_960: (in esp_14 - 0x00000014 + 0x00000000 : word32)
+  Class: Eq_960
+  DataType: ptr32
+  OrigDataType: ptr32
+T_961: (in Mem38[esp_14 - 0x00000014 + 0x00000000:word32] : word32)
+  Class: Eq_956
+  DataType: word32
+  OrigDataType: word32
+T_962: (in 0x00000008 : word32)
+  Class: Eq_962
+  DataType: ui32
+  OrigDataType: ui32
+T_963: (in fp - 0x00000008 : word32)
+  Class: Eq_963
+  DataType: ptr32
+  OrigDataType: ptr32
+T_964: (in fs : selector)
+  Class: Eq_964
+  DataType: (ptr Eq_964)
+  OrigDataType: (ptr (segment (0 T_966 t0000)))
+T_965: (in 0x00000000 : word32)
+  Class: Eq_965
+  DataType: (memptr (ptr Eq_964) ptr32)
+  OrigDataType: (memptr T_964 (struct (0 T_966 t0000)))
+T_966: (in Mem43[fs:0x00000000:word32] : word32)
+  Class: Eq_963
+  DataType: ptr32
+  OrigDataType: word32
+T_967: (in fp + 0x00000008 : word32)
+  Class: Eq_924
+  DataType: ptr32
+  OrigDataType: ptr32
+T_968: (in edi : word32)
+  Class: Eq_968
+  DataType: word32
+  OrigDataType: word32
+T_969: (in 0x00000010 : word32)
+  Class: Eq_969
+  DataType: ui32
+  OrigDataType: ui32
+T_970: (in ebp - 0x00000010 : word32)
+  Class: Eq_970
+  DataType: (ptr word32)
+  OrigDataType: (ptr (struct (0 T_973 t0000)))
+T_971: (in 0x00000000 : word32)
   Class: Eq_971
   DataType: word32
   OrigDataType: word32
-T_972: (in Mem0[ebp - 0x00000010 + 0x00000000:word32] : word32)
+T_972: (in ebp - 0x00000010 + 0x00000000 : word32)
   Class: Eq_972
   DataType: word32
   OrigDataType: word32
-T_973: (in fs : selector)
+T_973: (in Mem0[ebp - 0x00000010 + 0x00000000:word32] : word32)
   Class: Eq_973
-  DataType: (ptr Eq_973)
-  OrigDataType: (ptr (segment (0 T_975 t0000)))
-T_974: (in 0x00000000 : ptr32)
+  DataType: word32
+  OrigDataType: word32
+T_974: (in fs : selector)
   Class: Eq_974
-  DataType: Eq_974
-  OrigDataType: (union (ptr32 u0) ((memptr T_973 (struct (0 word32 dw0000))) u1))
-T_975: (in Mem5[fs:0x00000000:word32] : word32)
-  Class: Eq_972
+  DataType: (ptr Eq_974)
+  OrigDataType: (ptr (segment (0 T_976 t0000)))
+T_975: (in 0x00000000 : ptr32)
+  Class: Eq_975
+  DataType: Eq_975
+  OrigDataType: (union (ptr32 u0) ((memptr T_974 (struct (0 word32 dw0000))) u1))
+T_976: (in Mem5[fs:0x00000000:word32] : word32)
+  Class: Eq_973
   DataType: word32
   OrigDataType: word32
-T_976: (in dwArg00 : word32)
-  Class: Eq_976
-  DataType: word32
-  OrigDataType: word32
-T_977: (in 0x00000000 : word32)
+T_977: (in dwArg00 : word32)
   Class: Eq_977
   DataType: word32
   OrigDataType: word32
-T_978: (in ebp + 0x00000000 : word32)
+T_978: (in 0x00000000 : word32)
   Class: Eq_978
+  DataType: word32
+  OrigDataType: word32
+T_979: (in ebp + 0x00000000 : word32)
+  Class: Eq_979
   DataType: ptr32
   OrigDataType: ptr32
-T_979: (in Mem25[ebp + 0x00000000:word32] : word32)
-  Class: Eq_976
+T_980: (in Mem25[ebp + 0x00000000:word32] : word32)
+  Class: Eq_977
   DataType: word32
   OrigDataType: word32
-T_980: (in dwArg08 : word32)
-  Class: Eq_967
+T_981: (in dwArg08 : word32)
+  Class: Eq_968
   DataType: word32
   OrigDataType: word32
-T_981: (in eax_8 : ui32)
-  Class: Eq_946
+T_982: (in eax_8 : ui32)
+  Class: Eq_947
   DataType: ui32
   OrigDataType: ui32
-T_982: (in 0x10003000 : ptr32)
-  Class: Eq_982
+T_983: (in 0x10003000 : ptr32)
+  Class: Eq_983
   DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_983 t0000)))
-T_983: (in Mem0[0x10003000:word32] : word32)
-  Class: Eq_946
+  OrigDataType: (ptr (struct (0 T_984 t0000)))
+T_984: (in Mem0[0x10003000:word32] : word32)
+  Class: Eq_947
   DataType: ui32
   OrigDataType: word32
-T_984: (in 0xBB40E64E : word32)
-  Class: Eq_946
+T_985: (in 0xBB40E64E : word32)
+  Class: Eq_947
   DataType: ui32
   OrigDataType: word32
-T_985: (in eax_8 == 0xBB40E64E : bool)
-  Class: Eq_985
+T_986: (in eax_8 == 0xBB40E64E : bool)
+  Class: Eq_986
   DataType: bool
   OrigDataType: bool
-T_986: (in GetSystemTimeAsFileTime : ptr32)
-  Class: Eq_986
-  DataType: (ptr Eq_986)
-  OrigDataType: (ptr (fn T_992 (T_991)))
-T_987: (in signature of GetSystemTimeAsFileTime : void)
-  Class: Eq_986
-  DataType: (ptr Eq_986)
+T_987: (in GetSystemTimeAsFileTime : ptr32)
+  Class: Eq_987
+  DataType: (ptr Eq_987)
+  OrigDataType: (ptr (fn T_993 (T_992)))
+T_988: (in signature of GetSystemTimeAsFileTime : void)
+  Class: Eq_987
+  DataType: (ptr Eq_987)
   OrigDataType: 
-T_988: (in lpSystemTimeAsFileTime : LPFILETIME)
-  Class: Eq_988
-  DataType: Eq_988
-  OrigDataType: 
-T_989: (in fp : ptr32)
+T_989: (in lpSystemTimeAsFileTime : LPFILETIME)
   Class: Eq_989
+  DataType: Eq_989
+  OrigDataType: 
+T_990: (in fp : ptr32)
+  Class: Eq_990
   DataType: ptr32
   OrigDataType: ptr32
-T_990: (in 0x0000000C : word32)
-  Class: Eq_990
+T_991: (in 0x0000000C : word32)
+  Class: Eq_991
   DataType: ui32
   OrigDataType: ui32
-T_991: (in fp - 0x0000000C : word32)
-  Class: Eq_988
-  DataType: Eq_988
+T_992: (in fp - 0x0000000C : word32)
+  Class: Eq_989
+  DataType: Eq_989
   OrigDataType: LPFILETIME
-T_992: (in GetSystemTimeAsFileTime(fp - 0x0000000C) : void)
-  Class: Eq_992
+T_993: (in GetSystemTimeAsFileTime(fp - 0x0000000C) : void)
+  Class: Eq_993
   DataType: void
   OrigDataType: void
-T_993: (in esi_58 : ui32)
-  Class: Eq_993
-  DataType: ui32
-  OrigDataType: ui32
-T_994: (in dwLoc08 : word32)
+T_994: (in esi_58 : ui32)
   Class: Eq_994
   DataType: ui32
   OrigDataType: ui32
-T_995: (in 0x00000000 : word32)
+T_995: (in dwLoc08 : word32)
   Class: Eq_995
   DataType: ui32
   OrigDataType: ui32
-T_996: (in dwLoc08 & 0x00000000 : word32)
+T_996: (in 0x00000000 : word32)
   Class: Eq_996
   DataType: ui32
   OrigDataType: ui32
-T_997: (in dwLoc0C : word32)
+T_997: (in dwLoc08 & 0x00000000 : word32)
   Class: Eq_997
   DataType: ui32
   OrigDataType: ui32
-T_998: (in 0x00000000 : word32)
+T_998: (in dwLoc0C : word32)
   Class: Eq_998
   DataType: ui32
   OrigDataType: ui32
-T_999: (in dwLoc0C & 0x00000000 : word32)
+T_999: (in 0x00000000 : word32)
   Class: Eq_999
   DataType: ui32
   OrigDataType: ui32
-T_1000: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 : word32)
+T_1000: (in dwLoc0C & 0x00000000 : word32)
   Class: Eq_1000
   DataType: ui32
   OrigDataType: ui32
-T_1001: (in GetCurrentProcessId : ptr32)
+T_1001: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 : word32)
   Class: Eq_1001
-  DataType: (ptr Eq_1001)
-  OrigDataType: (ptr (fn T_1003 ()))
-T_1002: (in signature of GetCurrentProcessId : void)
-  Class: Eq_1001
-  DataType: (ptr Eq_1001)
-  OrigDataType: 
-T_1003: (in GetCurrentProcessId() : DWORD)
-  Class: Eq_197
-  DataType: Eq_197
-  OrigDataType: DWORD
-T_1004: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() : word32)
-  Class: Eq_1004
   DataType: ui32
   OrigDataType: ui32
-T_1005: (in GetCurrentThreadId : ptr32)
+T_1002: (in GetCurrentProcessId : ptr32)
+  Class: Eq_1002
+  DataType: (ptr Eq_1002)
+  OrigDataType: (ptr (fn T_1004 ()))
+T_1003: (in signature of GetCurrentProcessId : void)
+  Class: Eq_1002
+  DataType: (ptr Eq_1002)
+  OrigDataType: 
+T_1004: (in GetCurrentProcessId() : DWORD)
+  Class: Eq_198
+  DataType: Eq_198
+  OrigDataType: DWORD
+T_1005: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() : word32)
   Class: Eq_1005
-  DataType: (ptr Eq_1005)
-  OrigDataType: (ptr (fn T_1007 ()))
-T_1006: (in signature of GetCurrentThreadId : void)
-  Class: Eq_1005
-  DataType: (ptr Eq_1005)
-  OrigDataType: 
-T_1007: (in GetCurrentThreadId() : DWORD)
-  Class: Eq_197
-  DataType: Eq_197
-  OrigDataType: DWORD
-T_1008: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() ^ GetCurrentThreadId() : word32)
-  Class: Eq_1008
   DataType: ui32
   OrigDataType: ui32
-T_1009: (in GetTickCount : ptr32)
-  Class: Eq_1009
-  DataType: (ptr Eq_1009)
-  OrigDataType: (ptr (fn T_1011 ()))
-T_1010: (in signature of GetTickCount : void)
-  Class: Eq_1009
-  DataType: (ptr Eq_1009)
+T_1006: (in GetCurrentThreadId : ptr32)
+  Class: Eq_1006
+  DataType: (ptr Eq_1006)
+  OrigDataType: (ptr (fn T_1008 ()))
+T_1007: (in signature of GetCurrentThreadId : void)
+  Class: Eq_1006
+  DataType: (ptr Eq_1006)
   OrigDataType: 
-T_1011: (in GetTickCount() : DWORD)
-  Class: Eq_197
-  DataType: Eq_197
+T_1008: (in GetCurrentThreadId() : DWORD)
+  Class: Eq_198
+  DataType: Eq_198
   OrigDataType: DWORD
-T_1012: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount() : word32)
-  Class: Eq_993
+T_1009: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() ^ GetCurrentThreadId() : word32)
+  Class: Eq_1009
   DataType: ui32
   OrigDataType: ui32
-T_1013: (in QueryPerformanceCounter : ptr32)
-  Class: Eq_1013
-  DataType: (ptr Eq_1013)
-  OrigDataType: (ptr (fn T_1018 (T_1017)))
-T_1014: (in signature of QueryPerformanceCounter : void)
-  Class: Eq_1013
-  DataType: (ptr Eq_1013)
+T_1010: (in GetTickCount : ptr32)
+  Class: Eq_1010
+  DataType: (ptr Eq_1010)
+  OrigDataType: (ptr (fn T_1012 ()))
+T_1011: (in signature of GetTickCount : void)
+  Class: Eq_1010
+  DataType: (ptr Eq_1010)
   OrigDataType: 
-T_1015: (in lpPerformanceCount : (ptr LARGE_INTEGER))
-  Class: Eq_1015
-  DataType: (ptr Eq_1015)
+T_1012: (in GetTickCount() : DWORD)
+  Class: Eq_198
+  DataType: Eq_198
+  OrigDataType: DWORD
+T_1013: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount() : word32)
+  Class: Eq_994
+  DataType: ui32
+  OrigDataType: ui32
+T_1014: (in QueryPerformanceCounter : ptr32)
+  Class: Eq_1014
+  DataType: (ptr Eq_1014)
+  OrigDataType: (ptr (fn T_1019 (T_1018)))
+T_1015: (in signature of QueryPerformanceCounter : void)
+  Class: Eq_1014
+  DataType: (ptr Eq_1014)
   OrigDataType: 
-T_1016: (in 0x00000014 : word32)
+T_1016: (in lpPerformanceCount : (ptr LARGE_INTEGER))
   Class: Eq_1016
+  DataType: (ptr Eq_1016)
+  OrigDataType: 
+T_1017: (in 0x00000014 : word32)
+  Class: Eq_1017
   DataType: ui32
   OrigDataType: ui32
-T_1017: (in fp - 0x00000014 : word32)
-  Class: Eq_1015
-  DataType: (ptr Eq_1015)
+T_1018: (in fp - 0x00000014 : word32)
+  Class: Eq_1016
+  DataType: (ptr Eq_1016)
   OrigDataType: (ptr LARGE_INTEGER)
-T_1018: (in QueryPerformanceCounter(fp - 0x00000014) : BOOL)
-  Class: Eq_741
-  DataType: Eq_741
+T_1019: (in QueryPerformanceCounter(fp - 0x00000014) : BOOL)
+  Class: Eq_742
+  DataType: Eq_742
   OrigDataType: BOOL
-T_1019: (in esi_68 : ui32)
-  Class: Eq_946
+T_1020: (in esi_68 : ui32)
+  Class: Eq_947
   DataType: ui32
   OrigDataType: ui32
-T_1020: (in dwLoc10 : word32)
-  Class: Eq_1020
-  DataType: word32
-  OrigDataType: word32
-T_1021: (in dwLoc14 : word32)
+T_1021: (in dwLoc10 : word32)
   Class: Eq_1021
   DataType: word32
   OrigDataType: word32
-T_1022: (in dwLoc10 ^ dwLoc14 : word32)
+T_1022: (in dwLoc14 : word32)
   Class: Eq_1022
-  DataType: ui32
-  OrigDataType: ui32
-T_1023: (in esi_58 ^ (dwLoc10 ^ dwLoc14) : word32)
-  Class: Eq_946
-  DataType: ui32
-  OrigDataType: ui32
-T_1024: (in 0xBB40E64E : word32)
-  Class: Eq_946
-  DataType: ui32
-  OrigDataType: word32
-T_1025: (in esi_68 != 0xBB40E64E : bool)
-  Class: Eq_1025
-  DataType: bool
-  OrigDataType: bool
-T_1026: (in 0xFFFF0000 : word32)
-  Class: Eq_1026
-  DataType: ui32
-  OrigDataType: ui32
-T_1027: (in eax_8 & 0xFFFF0000 : word32)
-  Class: Eq_1027
-  DataType: ui32
-  OrigDataType: ui32
-T_1028: (in 0x00000000 : word32)
-  Class: Eq_1027
-  DataType: ui32
-  OrigDataType: word32
-T_1029: (in (eax_8 & 0xFFFF0000) == 0x00000000 : bool)
-  Class: Eq_1029
-  DataType: bool
-  OrigDataType: bool
-T_1030: (in ~eax_8 : word32)
-  Class: Eq_1030
-  DataType: ui32
-  OrigDataType: ui32
-T_1031: (in 0x10003004 : ptr32)
-  Class: Eq_1031
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_1032 t0000)))
-T_1032: (in Mem94[0x10003004:word32] : word32)
-  Class: Eq_1030
-  DataType: ui32
-  OrigDataType: word32
-T_1033: (in 0xFFFF0000 : word32)
-  Class: Eq_1033
-  DataType: ui32
-  OrigDataType: ui32
-T_1034: (in esi_68 & 0xFFFF0000 : word32)
-  Class: Eq_1034
-  DataType: ui32
-  OrigDataType: ui32
-T_1035: (in 0x00000000 : word32)
-  Class: Eq_1034
-  DataType: ui32
-  OrigDataType: word32
-T_1036: (in (esi_68 & 0xFFFF0000) != 0x00000000 : bool)
-  Class: Eq_1036
-  DataType: bool
-  OrigDataType: bool
-T_1037: (in 0xBB40E64F : word32)
-  Class: Eq_946
-  DataType: ui32
-  OrigDataType: word32
-T_1038: (in 0x10003000 : ptr32)
-  Class: Eq_1038
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_1039 t0000)))
-T_1039: (in Mem76[0x10003000:word32] : word32)
-  Class: Eq_946
-  DataType: ui32
-  OrigDataType: word32
-T_1040: (in ~esi_68 : word32)
-  Class: Eq_1030
-  DataType: ui32
-  OrigDataType: ui32
-T_1041: (in 0x10003004 : ptr32)
-  Class: Eq_1041
-  DataType: (ptr ui32)
-  OrigDataType: (ptr (struct (0 T_1042 t0000)))
-T_1042: (in Mem78[0x10003004:word32] : word32)
-  Class: Eq_1030
-  DataType: ui32
-  OrigDataType: word32
-T_1043: (in 0x00000010 : word32)
-  Class: Eq_1043
   DataType: word32
   OrigDataType: word32
-T_1044: (in esi_68 << 0x00000010 : word32)
-  Class: Eq_1044
+T_1023: (in dwLoc10 ^ dwLoc14 : word32)
+  Class: Eq_1023
   DataType: ui32
   OrigDataType: ui32
-T_1045: (in esi_68 | esi_68 << 0x00000010 : word32)
-  Class: Eq_946
+T_1024: (in esi_58 ^ (dwLoc10 ^ dwLoc14) : word32)
+  Class: Eq_947
+  DataType: ui32
+  OrigDataType: ui32
+T_1025: (in 0xBB40E64E : word32)
+  Class: Eq_947
+  DataType: ui32
+  OrigDataType: word32
+T_1026: (in esi_68 != 0xBB40E64E : bool)
+  Class: Eq_1026
+  DataType: bool
+  OrigDataType: bool
+T_1027: (in 0xFFFF0000 : word32)
+  Class: Eq_1027
+  DataType: ui32
+  OrigDataType: ui32
+T_1028: (in eax_8 & 0xFFFF0000 : word32)
+  Class: Eq_1028
+  DataType: ui32
+  OrigDataType: ui32
+T_1029: (in 0x00000000 : word32)
+  Class: Eq_1028
+  DataType: ui32
+  OrigDataType: word32
+T_1030: (in (eax_8 & 0xFFFF0000) == 0x00000000 : bool)
+  Class: Eq_1030
+  DataType: bool
+  OrigDataType: bool
+T_1031: (in ~eax_8 : word32)
+  Class: Eq_1031
+  DataType: ui32
+  OrigDataType: ui32
+T_1032: (in 0x10003004 : ptr32)
+  Class: Eq_1032
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_1033 t0000)))
+T_1033: (in Mem94[0x10003004:word32] : word32)
+  Class: Eq_1031
+  DataType: ui32
+  OrigDataType: word32
+T_1034: (in 0xFFFF0000 : word32)
+  Class: Eq_1034
+  DataType: ui32
+  OrigDataType: ui32
+T_1035: (in esi_68 & 0xFFFF0000 : word32)
+  Class: Eq_1035
+  DataType: ui32
+  OrigDataType: ui32
+T_1036: (in 0x00000000 : word32)
+  Class: Eq_1035
+  DataType: ui32
+  OrigDataType: word32
+T_1037: (in (esi_68 & 0xFFFF0000) != 0x00000000 : bool)
+  Class: Eq_1037
+  DataType: bool
+  OrigDataType: bool
+T_1038: (in 0xBB40E64F : word32)
+  Class: Eq_947
+  DataType: ui32
+  OrigDataType: word32
+T_1039: (in 0x10003000 : ptr32)
+  Class: Eq_1039
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_1040 t0000)))
+T_1040: (in Mem76[0x10003000:word32] : word32)
+  Class: Eq_947
+  DataType: ui32
+  OrigDataType: word32
+T_1041: (in ~esi_68 : word32)
+  Class: Eq_1031
+  DataType: ui32
+  OrigDataType: ui32
+T_1042: (in 0x10003004 : ptr32)
+  Class: Eq_1042
+  DataType: (ptr ui32)
+  OrigDataType: (ptr (struct (0 T_1043 t0000)))
+T_1043: (in Mem78[0x10003004:word32] : word32)
+  Class: Eq_1031
+  DataType: ui32
+  OrigDataType: word32
+T_1044: (in 0x00000010 : word32)
+  Class: Eq_1044
+  DataType: word32
+  OrigDataType: word32
+T_1045: (in esi_68 << 0x00000010 : word32)
+  Class: Eq_1045
+  DataType: ui32
+  OrigDataType: ui32
+T_1046: (in esi_68 | esi_68 << 0x00000010 : word32)
+  Class: Eq_947
   DataType: ui32
   OrigDataType: ui32
 */
 typedef struct Globals {
-	Eq_283 t10002098;	// 10002098
-	Eq_284 t1000209C;	// 1000209C
-	Eq_228 t100020A0;	// 100020A0
-	Eq_229 t100020A8;	// 100020A8
+	Eq_284 t10002098;	// 10002098
+	Eq_285 t1000209C;	// 1000209C
+	Eq_229 t100020A0;	// 100020A0
+	Eq_230 t100020A8;	// 100020A8
 	<anonymous> * ptr100020CC;	// 100020CC
 	char str100020E0[];	// 100020E0
 	char str100020F4[];	// 100020F4
@@ -4523,12 +4527,12 @@ typedef struct Globals {
 	char str10002174[];	// 10002174
 	ui32 dw10003000;	// 10003000
 	ui32 dw10003004;	// 10003004
-	Eq_197 t10003008;	// 10003008
+	Eq_198 t10003008;	// 10003008
 	PyMethodDef methods[5];	// 10003010
 	int32 dw10003070;	// 10003070
 	word32 dw100033A4;	// 100033A4
 	word32 dw100033A8;	// 100033A8
-	Eq_174 t100033AC;	// 100033AC
+	Eq_175 t100033AC;	// 100033AC
 	void * ptr100033B0;	// 100033B0
 	void * ptr100033B4;	// 100033B4
 	<anonymous> * ptr100033B8;	// 100033B8
@@ -4552,180 +4556,180 @@ typedef PyObject * (Eq_53)(PyObject *, char *, int32 *, int32 *);
 
 typedef PyObject * (Eq_66)(char *, int32);
 
-typedef PyObject * (Eq_76)(PyObject *, char *, real32 *, real32 *);
+typedef PyObject * (Eq_77)(PyObject *, char *, real32 *, real32 *);
 
-typedef PyObject * (Eq_89)(char *, real64);
+typedef PyObject * (Eq_90)(char *, real64);
 
-typedef union Eq_95 {
+typedef union Eq_96 {
 	real32 u0;
 	real64 u1;
-} Eq_95;
-
-typedef PyObject Eq_98;
+} Eq_96;
 
 typedef PyObject Eq_99;
 
 typedef PyObject Eq_100;
 
-typedef PyObject * (Eq_102)(PyObject *, char *);
+typedef PyObject Eq_101;
 
-typedef PyObject Eq_109;
+typedef PyObject * (Eq_103)(PyObject *, char *);
 
 typedef PyObject Eq_110;
 
-typedef PyObject * (Eq_122)(char *, PyMethodDef *, char *, PyObject *, int32);
+typedef PyObject Eq_111;
 
-typedef PyMethodDef Eq_125;
+typedef PyObject * (Eq_123)(char *, PyMethodDef *, char *, PyObject *, int32);
 
-typedef PyObject Eq_127;
+typedef PyMethodDef Eq_126;
 
-typedef PyObject Eq_134;
+typedef PyObject Eq_128;
 
-typedef LONG Eq_138;
+typedef PyObject Eq_135;
 
-typedef struct Eq_165 {
-	struct Eq_167 * ptr0018;	// 18
-} Eq_165;
+typedef LONG Eq_139;
 
-typedef struct Eq_167 {
-	Eq_138 t0004;	// 4
-} Eq_167;
+typedef struct Eq_166 {
+	struct Eq_168 * ptr0018;	// 18
+} Eq_166;
 
-typedef LONG (Eq_172)(LONG *, LONG, LONG);
+typedef struct Eq_168 {
+	Eq_139 t0004;	// 4
+} Eq_168;
 
-typedef LONG Eq_174;
+typedef LONG (Eq_173)(LONG *, LONG, LONG);
 
-typedef void (Eq_195)(DWORD);
+typedef LONG Eq_175;
 
-typedef DWORD Eq_197;
+typedef void (Eq_196)(DWORD);
 
-typedef word32 * (Eq_205)(void);
+typedef DWORD Eq_198;
 
-typedef struct Eq_213 {
+typedef word32 * (Eq_206)(void);
+
+typedef struct Eq_214 {
 	word32 dw0004;	// 4
 	word32 dw000C;	// C
-} Eq_213;
+} Eq_214;
 
-typedef void (Eq_218)(int32);
+typedef void (Eq_219)(int32);
 
-typedef int32 (Eq_226)(PVFV *, PVFV *);
-
-typedef PVFV Eq_228;
+typedef int32 (Eq_227)(PVFV *, PVFV *);
 
 typedef PVFV Eq_229;
 
-typedef LONG (Eq_258)(LONG *, LONG);
+typedef PVFV Eq_230;
 
-typedef LONG Eq_260;
+typedef LONG (Eq_259)(LONG *, LONG);
 
-typedef void (Eq_281)(PVFV *, PVFV *);
+typedef LONG Eq_261;
 
-typedef PVFV Eq_283;
+typedef void (Eq_282)(PVFV *, PVFV *);
 
 typedef PVFV Eq_284;
 
-typedef void (Eq_306)(word32 *);
+typedef PVFV Eq_285;
 
-typedef void (Eq_314)();
+typedef void (Eq_307)(word32 *);
 
-typedef struct Eq_331 {
-} Eq_331;
+typedef void (Eq_315)();
 
-typedef word32 (Eq_346)( *, ptr32, word32, ptr32);
+typedef struct Eq_332 {
+} Eq_332;
 
-typedef struct Eq_391 {
-} Eq_391;
+typedef word32 (Eq_347)( *, ptr32, word32, ptr32);
 
-typedef LPVOID Eq_395;
+typedef struct Eq_392 {
+} Eq_392;
 
-typedef struct Eq_400 {
+typedef LPVOID Eq_396;
+
+typedef struct Eq_401 {
 	word32 dw0000;	// 0
 	ui32 dw0008;	// 8
-} Eq_400;
+} Eq_401;
 
-typedef Eq_400 * (Eq_401)( *, ptr32, word32, word32, word32, word32);
+typedef Eq_401 * (Eq_402)( *, ptr32, word32, word32, word32, word32);
 
-typedef void (Eq_475)();
+typedef void (Eq_476)();
 
-typedef word32 (Eq_484)(Eq_400 *, word32, word32, word32, word32, word32);
+typedef word32 (Eq_485)(Eq_401 *, word32, word32, word32, word32, word32);
 
-typedef word32 (Eq_522)(word32, word32);
+typedef word32 (Eq_523)(word32, word32);
 
-typedef ui32 (Eq_588)(word32);
+typedef ui32 (Eq_589)(word32);
 
-typedef BOOL Eq_741;
+typedef BOOL Eq_742;
 
-typedef HANDLE Eq_742;
+typedef HANDLE Eq_743;
 
-typedef BOOL (Eq_747)(LPVOID, DWORD,  *, ptr32, word32);
+typedef BOOL (Eq_748)(LPVOID, DWORD,  *, ptr32, word32);
 
-typedef void (Eq_753)();
+typedef void (Eq_754)();
 
-typedef struct Eq_758 {
+typedef struct Eq_759 {
 	word16 w0000;	// 0
 	word32 dw003C;	// 3C
-} Eq_758;
+} Eq_759;
 
-typedef struct Eq_764 {
+typedef struct Eq_765 {
 	word32 dw0000;	// 0
 	word16 w0018;	// 18
-} Eq_764;
+} Eq_765;
 
-typedef struct Eq_781 {	// size: 40 28
+typedef struct Eq_782 {	// size: 40 28
 	word32 dw0000;	// 0
 	uint32 dw0008;	// 8
-} Eq_781;
-
-typedef struct Eq_784 {
-	word16 w0006;	// 6
-	word16 w0014;	// 14
-} Eq_784;
+} Eq_782;
 
 typedef struct Eq_785 {
-	word32 dw003C;	// 3C
+	word16 w0006;	// 6
+	word16 w0014;	// 14
 } Eq_785;
 
-typedef word32 (Eq_852)(word32);
+typedef struct Eq_786 {
+	word32 dw003C;	// 3C
+} Eq_786;
 
-typedef union Eq_868 {
+typedef word32 (Eq_853)(word32);
+
+typedef union Eq_869 {
 	ui32 u0;
 	ptr32 u1;
-} Eq_868;
+} Eq_869;
 
-typedef struct Eq_881 {
+typedef struct Eq_882 {
 	uint32 dw0024;	// 24
-} Eq_881;
+} Eq_882;
 
-typedef Eq_881 * (Eq_882)(word32, word32);
+typedef Eq_882 * (Eq_883)(word32, word32);
 
-typedef BOOL (Eq_918)(HMODULE);
+typedef BOOL (Eq_919)(HMODULE);
 
-typedef HMODULE Eq_920;
+typedef HMODULE Eq_921;
 
-typedef struct Eq_963 {
+typedef struct Eq_964 {
 	ptr32 ptr0000;	// 0
-} Eq_963;
+} Eq_964;
 
-typedef struct Eq_973 {
+typedef struct Eq_974 {
 	word32 dw0000;	// 0
-} Eq_973;
-
-typedef union Eq_974 {
-	ptr32 u0;
-	word32 Eq_973::* u1;
 } Eq_974;
 
-typedef void (Eq_986)(LPFILETIME);
+typedef union Eq_975 {
+	ptr32 u0;
+	word32 Eq_974::* u1;
+} Eq_975;
 
-typedef LPFILETIME Eq_988;
+typedef void (Eq_987)(LPFILETIME);
 
-typedef DWORD (Eq_1001)();
+typedef LPFILETIME Eq_989;
 
-typedef DWORD (Eq_1005)();
+typedef DWORD (Eq_1002)();
 
-typedef DWORD (Eq_1009)();
+typedef DWORD (Eq_1006)();
 
-typedef BOOL (Eq_1013)(LARGE_INTEGER *);
+typedef DWORD (Eq_1010)();
 
-typedef LARGE_INTEGER Eq_1015;
+typedef BOOL (Eq_1014)(LARGE_INTEGER *);
+
+typedef LARGE_INTEGER Eq_1016;
 

--- a/subjects/regressions/reko-90/PP.c
+++ b/subjects/regressions/reko-90/PP.c
@@ -234,8 +234,8 @@ l0800_0338:
 	word16 ax_214 = fn0800_8BBB(bp_202, si_203, di_204, bp, out dx_210, out bp_211, out si_212, out di_213)
 	Mem216[ss:fp - 0x3A + 0x00:word16] = dx_210
 	Mem218[ss:fp - 0x3C + 0x00:word16] = ax_214
-	Mem227[ss:fp - 0x3E + 0x00:word16] = (uint32) (uint16) si_212 % 100
-	Mem236[ss:fp - 0x40 + 0x00:word16] = (uint32) (uint16) si_212 /u 100
+	Mem227[ss:fp - 0x3E + 0x00:word16] = (uint16) ((uint32) (uint16) si_212 % 100)
+	Mem236[ss:fp - 0x40 + 0x00:word16] = (uint16) ((uint32) (uint16) si_212 /u 100)
 	Mem239[ss:fp - 66 + 0x00:word16] = Mem236[ds_94:10737:word16]
 	Mem242[ss:fp - 0x44 + 0x00:word16] = Mem239[ds_94:0x29EF:word16]
 	Mem245[ss:fp - 0x46 + 0x00:word16] = Mem242[ds_94:10741:word16]
@@ -798,8 +798,8 @@ selector fn0800_0ABC(word16 bp, selector ds, word16 wArg02, word16 wArg04, word1
 	Mem43[ss:fp - 0x1A + 0x00:word16] = Mem40[ds:0x2A07:word16];
 	word16 di_46;
 	word16 ax_47 = fn0800_0B79(fp - 0x02, wArg02, di, wArg00, wArg02, wArg04, wArg06, out di_46);
-	Mem57[ss:fp - 0x14 + 0x00:word16] = (uint32) (uint16) ax_47 % 100;
-	Mem66[ss:fp - 22 + 0x00:word16] = (uint32) (uint16) ax_47 /u 100;
+	Mem57[ss:fp - 0x14 + 0x00:word16] = (uint16) ((uint32) (uint16) ax_47 % 100);
+	Mem66[ss:fp - 22 + 0x00:word16] = (uint16) ((uint32) (uint16) ax_47 /u 100);
 	Mem69[ss:fp - 0x18 + 0x00:word16] = Mem66[ds:0x2A05:word16];
 	Mem72[ss:fp - 0x1A + 0x00:word16] = Mem69[ds:0x2A03:word16];
 	Mem75[ss:fp - 0x1C + 0x00:word16] = Mem72[ds:0x2A09:word16];
@@ -893,9 +893,9 @@ word16 fn0800_0C08(word16 wArg02)
 	word16 cx_11 = 0x01;
 	while (true)
 	{
-		word32 dx_ax_17 = (uint32) (uint16) si_10;
-		si_10 = dx_ax_17 /u 0x02;
-		if (dx_ax_17 /u 0x02 == 0x00)
+		word16 ax_20 = (uint16) ((uint32) (uint16) si_10 /u 0x02);
+		si_10 = ax_20;
+		if (ax_20 == 0x00)
 			break;
 		cx_11 = cx_11 + 0x01;
 	}
@@ -10109,8 +10109,8 @@ word16 fn0800_8BD8(word16 cx, word16 bp, word16 si, word16 di, ptr16 & dxOut, pt
 		word32 dx_ax_181 = SEQ(dx_17, ax_100);
 		if (dx_17 == 0x00 || bx_19 == 0x00)
 		{
-			word16 dx_188 = dx_ax_181 % bx_19;
-			ax_100 = dx_ax_181 /u bx_19;
+			word16 dx_188 = (uint16) (dx_ax_181 % bx_19);
+			ax_100 = (uint16) (dx_ax_181 /u bx_19);
 			if ((cx & 0x02) != 0x00)
 				ax_100 = dx_188;
 			word16 dx_195;
@@ -10321,11 +10321,11 @@ l0800_8DF7:
 		do
 		{
 			word32 dx_ax_175 = (uint32) (uint16) cx_168;
-			word32 dx_ax_181 = SEQ(dx_ax_175 % wArg06, ax_103);
-			Mem190[ss:si_104 + 0x00:byte] = (byte) (dx_ax_181 % wArg06);
-			word16 ax_178 = dx_ax_175 /u wArg06;
+			word32 dx_ax_181 = SEQ((uint16) (dx_ax_175 % wArg06), ax_103);
+			Mem190[ss:si_104 + 0x00:byte] = (byte) (uint16) (dx_ax_181 % wArg06);
+			word16 ax_178 = (uint16) (dx_ax_175 /u wArg06);
 			cx_168 = ax_178;
-			ax_103 = dx_ax_181 /u wArg06;
+			ax_103 = (uint16) (dx_ax_181 /u wArg06);
 			si_104 = si_104 + 0x01;
 		} while (ax_178 == 0x00);
 l0800_8DD9:
@@ -10349,8 +10349,8 @@ l0800_8DD9:
 		}
 	}
 	word32 dx_ax_106 = (uint32) (uint16) ax_103;
-	Mem114[ss:si_104 + 0x00:byte] = (byte) (dx_ax_106 % wArg06);
-	ax_103 = dx_ax_106 /u wArg06;
+	Mem114[ss:si_104 + 0x00:byte] = (byte) (uint16) (dx_ax_106 % wArg06);
+	ax_103 = (uint16) (dx_ax_106 /u wArg06);
 	si_104 = si_104 + 0x01;
 	goto l0800_8DD9;
 }
@@ -11858,7 +11858,7 @@ word16 fn0800_ABA3(word16 bp, selector ds, word16 wArg02, word16 wArg04, word16 
 		if (dx_100 <=u 0x01 && (dx_100 <u 0x01 || true))
 		{
 			selector ds_174;
-			ax_116 = (uint32) (uint16) (ax_80 - fn0800_AAB3(dx_100, ds, DPB(ptrLoc14, wArg0A, 0), wArg0C, ax_80, DPB(ptrLoc0E, wArg02, 0), wArg04, out ds_174)) /u wArg06;
+			ax_116 = (uint16) ((uint32) (uint16) (ax_80 - fn0800_AAB3(dx_100, ds, DPB(ptrLoc14, wArg0A, 0), wArg0C, ax_80, DPB(ptrLoc0E, wArg02, 0), wArg04, out ds_174)) /u wArg06);
 		}
 		else
 		{
@@ -12017,7 +12017,7 @@ word16 fn0800_AD85(word16 bp, selector ds, word16 wArg02, word16 wArg04, word16 
 		if (dx_93 <=u 0x01 && (dx_93 <u 0x01 || true))
 		{
 			selector ds_181;
-			ax_145 = (uint32) (uint16) fn0800_B4BE(ds, DPB(ptrLoc14, wArg0A, 0), wArg0C, ax_94, DPB(ptrLoc0E, wArg02, 0), wArg04, out ds_181) /u wArg06;
+			ax_145 = (uint16) ((uint32) (uint16) fn0800_B4BE(ds, DPB(ptrLoc14, wArg0A, 0), wArg0C, ax_94, DPB(ptrLoc0E, wArg02, 0), wArg04, out ds_181) /u wArg06);
 			return ax_145;
 		}
 		word16 si_105 = 0x00;
@@ -13300,7 +13300,7 @@ word16 fn0800_C553(selector ds, word16 wArg02, word16 wArg04, word16 wArg06, byt
 			cx_116 = Mem0[ds:bx_66 + 9920:word16];
 		if (((byte) (wArg02 + 0x07B2) & 0x03) != 0x00)
 			cx_116 = cx_116 - 0x01;
-		word16 cx_96 = cx_116 - (uint32) ((uint16) (((wArg02 + 0x01 >> 0x02) + cx_116) + 0x0171)) % 0x07;
+		word16 cx_96 = cx_116 - (uint16) ((uint32) ((uint16) (((wArg02 + 0x01 >> 0x02) + cx_116) + 0x0171)) % 0x07);
 		if (wArg04 == 0x04)
 		{
 			if (wArg06 >u cx_96)

--- a/subjects/regressions/reko-90/PP.dis
+++ b/subjects/regressions/reko-90/PP.dis
@@ -457,8 +457,8 @@ l0800_0338:
 	word16 ax_214 = fn0800_8BBB(bp_202, si_203, di_204, bp, out dx_210, out bp_211, out si_212, out di_213)
 	Mem216[ss:fp - 0x003A:word16] = dx_210
 	Mem218[ss:fp - 0x003C:word16] = ax_214
-	Mem227[ss:fp - 0x003E:word16] = (uint32) (uint16) si_212 % 0x0064
-	Mem236[ss:fp - 0x0040:word16] = (uint32) (uint16) si_212 /u 0x0064
+	Mem227[ss:fp - 0x003E:word16] = (uint16) ((uint32) (uint16) si_212 % 0x0064)
+	Mem236[ss:fp - 0x0040:word16] = (uint16) ((uint32) (uint16) si_212 /u 0x0064)
 	Mem239[ss:fp - 0x0042:word16] = Mem236[ds_94:0x29F1:word16]
 	Mem242[ss:fp - 0x0044:word16] = Mem239[ds_94:0x29EF:word16]
 	Mem245[ss:fp - 0x0046:word16] = Mem242[ds_94:0x29F5:word16]
@@ -479,7 +479,7 @@ l0800_0338:
 main_exit:
 // DataOut:
 // DataOut (flags): 
-// SymbolicIn: sp:<invalid> bp:<invalid> ax:<invalid> bx:<invalid> dx:<invalid> si:<invalid> cx:<invalid> es:<invalid> ah:<invalid> dl:<invalid> cl:<invalid> ds:<invalid> al:<invalid> dh:<invalid> di:<invalid> bl:<invalid> bh:0x00 ch:<invalid> -84(fp):0x07EB -82(fp):ds -80(fp):<invalid> -78(fp):0x0008 -76(fp):0x05DC -74(fp):ds -72(fp):<invalid> -70(fp):<invalid> -68(fp):<invalid> -66(fp):<invalid> -64(fp):dx_ax /u 0x0064 -62(fp):dx_ax % 0x0064 -60(fp):0x0000 -58(fp):0x5180 -56(fp):0x0000 -54(fp):0x5180 -52(fp):0x0000 -50(fp):<invalid> -48(fp):0x5180 -46(fp):0x0000 -44(fp):0x0E10 -42(fp):0x0000 -40(fp):0x0000 -38(fp):0x0E10 -36(fp):0x0000 -34(fp):0x0E10 -32(fp):0x0000 -30(fp):<invalid> -28(fp):0x0E10 -26(fp):0x0000 -24(fp):0x003C -22(fp):0x0000 -20(fp):0x0000 -18(fp):0x003C -16(fp):<invalid> -14(fp):<invalid> -12(fp):<invalid> -10(fp):<invalid> -8(fp):si -6(fp):<invalid> -4(fp):<invalid> -2(fp):bp
+// SymbolicIn: sp:<invalid> bp:<invalid> ax:<invalid> bx:<invalid> dx:<invalid> si:<invalid> cx:<invalid> es:<invalid> ah:<invalid> dl:<invalid> cl:<invalid> ds:<invalid> al:<invalid> dh:<invalid> di:<invalid> bl:<invalid> bh:0x00 ch:<invalid> -84(fp):0x07EB -82(fp):ds -80(fp):<invalid> -78(fp):0x0008 -76(fp):0x05DC -74(fp):ds -72(fp):<invalid> -70(fp):<invalid> -68(fp):<invalid> -66(fp):<invalid> -64(fp):(uint16) (dx_ax /u 0x0064) -62(fp):(uint16) (dx_ax % 0x0064) -60(fp):0x0000 -58(fp):0x5180 -56(fp):0x0000 -54(fp):0x5180 -52(fp):0x0000 -50(fp):<invalid> -48(fp):0x5180 -46(fp):0x0000 -44(fp):0x0E10 -42(fp):0x0000 -40(fp):0x0000 -38(fp):0x0E10 -36(fp):0x0000 -34(fp):0x0E10 -32(fp):0x0000 -30(fp):<invalid> -28(fp):0x0E10 -26(fp):0x0000 -24(fp):0x003C -22(fp):0x0000 -20(fp):0x0000 -18(fp):0x003C -16(fp):<invalid> -14(fp):<invalid> -12(fp):<invalid> -10(fp):<invalid> -8(fp):si -6(fp):<invalid> -4(fp):<invalid> -2(fp):bp
 
 
 
@@ -1669,8 +1669,8 @@ l0800_0ABC:
 	Mem43[ss:fp - 0x001A:word16] = Mem40[ds:0x2A07:word16]
 	word16 di_46
 	word16 ax_47 = fn0800_0B79(fp - 0x0002, wArg02, di, wArg00, wArg02, wArg04, wArg06, out di_46)
-	Mem57[ss:fp - 0x0014:word16] = (uint32) (uint16) ax_47 % 0x0064
-	Mem66[ss:fp - 0x0016:word16] = (uint32) (uint16) ax_47 /u 0x0064
+	Mem57[ss:fp - 0x0014:word16] = (uint16) ((uint32) (uint16) ax_47 % 0x0064)
+	Mem66[ss:fp - 0x0016:word16] = (uint16) ((uint32) (uint16) ax_47 /u 0x0064)
 	Mem69[ss:fp - 0x0018:word16] = Mem66[ds:0x2A05:word16]
 	Mem72[ss:fp - 0x001A:word16] = Mem69[ds:0x2A03:word16]
 	Mem75[ss:fp - 0x001C:word16] = Mem72[ds:0x2A09:word16]
@@ -1887,31 +1887,31 @@ l0800_0C08:
 // LocalsOut: fp(16)
 
 l0800_0C15:
-	word32 dx_ax_17 = (uint32) (uint16) si_10
-	si_10 = dx_ax_17 /u 0x0002
-	branch dx_ax_17 /u 0x0002 != 0x0000 l0800_0C14
+	word16 ax_20 = (uint16) ((uint32) (uint16) si_10 /u 0x0002)
+	si_10 = ax_20
+	branch ax_20 != 0x0000 l0800_0C14
 // DataOut: cx ds si ss
 // DataOut (flags): 
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 si:<invalid> cx:<invalid> bx:0x0002 ax:dx_ax /u 0x0002 | dx_ax /u 0x0002 dx:dx_ax % 0x0002 -4(fp):si -2(fp):bp
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 si:<invalid> cx:<invalid> bx:0x0002 ax:(uint16) (dx_ax /u 0x0002) | (uint16) (dx_ax /u 0x0002) dx:(uint16) (dx_ax % 0x0002) -4(fp):si -2(fp):bp
 // LocalsOut: fp(16)
 
 l0800_0C14:
 	cx_11 = cx_11 + 0x0001
 // DataOut: cx ds si ss
 // DataOut (flags): 
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 si:dx_ax /u 0x0002 cx:<invalid> bx:0x0002 ax:dx_ax /u 0x0002 | dx_ax /u 0x0002 dx:dx_ax % 0x0002 -4(fp):si -2(fp):bp
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 si:(uint16) (dx_ax /u 0x0002) cx:<invalid> bx:0x0002 ax:(uint16) (dx_ax /u 0x0002) | (uint16) (dx_ax /u 0x0002) dx:(uint16) (dx_ax % 0x0002) -4(fp):si -2(fp):bp
 // LocalsOut: fp(16)
 
 l0800_0C24:
 	return cx_11
 // DataOut: ax ds ss
 // DataOut (flags): 
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 si:dx_ax /u 0x0002 cx:<invalid> bx:0x0002 ax:dx_ax /u 0x0002 | dx_ax /u 0x0002 dx:dx_ax % 0x0002 -4(fp):si -2(fp):bp
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 si:(uint16) (dx_ax /u 0x0002) cx:<invalid> bx:0x0002 ax:(uint16) (dx_ax /u 0x0002) | (uint16) (dx_ax /u 0x0002) dx:(uint16) (dx_ax % 0x0002) -4(fp):si -2(fp):bp
 
 fn0800_0C08_exit:
 // DataOut: ax
 // DataOut (flags): 
-// SymbolicIn: sp:fp bp:bp si:si cx:<invalid> bx:0x0002 ax:<invalid> dx:dx_ax % 0x0002 -4(fp):si -2(fp):bp
+// SymbolicIn: sp:fp bp:bp si:si cx:<invalid> bx:0x0002 ax:<invalid> dx:(uint16) (dx_ax % 0x0002) -4(fp):si -2(fp):bp
 
 
 
@@ -22493,8 +22493,8 @@ l0800_8BF3:
 // SymbolicIn: sp:v3 - 0x0006 bp:v3 - 0x0006 di:cx ax:<invalid> dx:<invalid> bx:<invalid> cx:<invalid>
 
 l0800_8C5C:
-	word16 dx_188 = dx_ax_181 % bx_19
-	ax_100 = dx_ax_181 /u bx_19
+	word16 dx_188 = (uint16) (dx_ax_181 % bx_19)
+	ax_100 = (uint16) (dx_ax_181 /u bx_19)
 	branch (cx & 0x0002) == 0x0000 l0800_8C65
 // DataOut: ax ds dx sp ss
 // DataOut (flags): 
@@ -23023,11 +23023,11 @@ l0800_8DBC:
 
 l0800_8DC1:
 	word32 dx_ax_175 = (uint32) (uint16) cx_168
-	word32 dx_ax_181 = SEQ(dx_ax_175 % wArg06, ax_103)
-	Mem190[ss:si_104:byte] = (byte) (dx_ax_181 % wArg06)
-	word16 ax_178 = dx_ax_175 /u wArg06
+	word32 dx_ax_181 = SEQ((uint16) (dx_ax_175 % wArg06), ax_103)
+	Mem190[ss:si_104:byte] = (byte) (uint16) (dx_ax_181 % wArg06)
+	word16 ax_178 = (uint16) (dx_ax_175 /u wArg06)
 	cx_168 = ax_178
-	ax_103 = dx_ax_181 /u wArg06
+	ax_103 = (uint16) (dx_ax_181 /u wArg06)
 	si_104 = si_104 + 0x0001
 	branch ax_178 == 0x0000 l0800_8DD9
 // DataOut: ax bl bx cx di ds es si ss
@@ -23044,8 +23044,8 @@ l0800_8DD9:
 
 l0800_8DD1:
 	word32 dx_ax_106 = (uint32) (uint16) ax_103
-	Mem114[ss:si_104:byte] = (byte) (dx_ax_106 % wArg06)
-	ax_103 = dx_ax_106 /u wArg06
+	Mem114[ss:si_104:byte] = (byte) (uint16) (dx_ax_106 % wArg06)
+	ax_103 = (uint16) (dx_ax_106 /u wArg06)
 	si_104 = si_104 + 0x0001
 // DataOut: ax bl bx di ds es si ss
 // DataOut (flags): 
@@ -27286,7 +27286,7 @@ l0800_AC26:
 
 l0800_ABD3:
 	selector ds_174
-	ax_116 = (uint32) (uint16) (ax_80 - fn0800_AAB3(dx_100, ds, DPB(ptrLoc14, wArg0A, 0), wArg0C, ax_80, DPB(ptrLoc0E, wArg02, 0), wArg04, out ds_174)) /u wArg06
+	ax_116 = (uint16) ((uint32) (uint16) (ax_80 - fn0800_AAB3(dx_100, ds, DPB(ptrLoc14, wArg0A, 0), wArg0C, ax_80, DPB(ptrLoc0E, wArg02, 0), wArg04, out ds_174)) /u wArg06)
 // DataOut: ax ds sp ss
 // DataOut (flags): 
 // SymbolicIn: sp:fp - 0x000A bp:fp - 0x0002 di:<invalid> bx:<invalid> cx:<invalid> ax:<invalid> dx:<invalid> -10(fp):di -8(fp):si -6(fp):<invalid> -4(fp):<invalid> -2(fp):bp
@@ -27727,7 +27727,7 @@ l0800_ADEA:
 
 l0800_ADB1:
 	selector ds_181
-	ax_145 = (uint32) (uint16) fn0800_B4BE(ds, DPB(ptrLoc14, wArg0A, 0), wArg0C, ax_94, DPB(ptrLoc0E, wArg02, 0), wArg04, out ds_181) /u wArg06
+	ax_145 = (uint16) ((uint32) (uint16) fn0800_B4BE(ds, DPB(ptrLoc14, wArg0A, 0), wArg0C, ax_94, DPB(ptrLoc0E, wArg02, 0), wArg04, out ds_181) /u wArg06)
 // DataOut: ax ds sp ss
 // DataOut (flags): 
 // SymbolicIn: sp:fp - 0x000A bp:fp - 0x0002 di:<invalid> bx:<invalid> cx:<invalid> ax:<invalid> dx:<invalid> -10(fp):di -8(fp):si -6(fp):<invalid> -4(fp):<invalid> -2(fp):bp
@@ -31574,7 +31574,7 @@ l0800_C5E4:
 // LocalsOut: fp(16) Stack +0002(16) Stack +0004(16) Stack +0006(16) Stack +0008(8)
 
 l0800_C5E5:
-	word16 cx_96 = cx_116 - (uint32) ((uint16) (((wArg02 + 0x0001 >> 0x0002) + cx_116) + 0x0171)) % 0x0007
+	word16 cx_96 = cx_116 - (uint16) ((uint32) ((uint16) (((wArg02 + 0x0001 >> 0x0002) + cx_116) + 0x0171)) % 0x0007)
 	branch wArg04 != 0x0004 l0800_C61A
 // DataOut: ax cx di ds ss
 // DataOut (flags): 
@@ -31585,74 +31585,74 @@ l0800_C61A:
 	branch wArg06 <u cx_96 l0800_C626
 // DataOut: di ds ss
 // DataOut (flags): Z
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:dx_ax % 0x0007 -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:(uint16) (dx_ax % 0x0007) -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
 // LocalsOut: fp(16) Stack +0008(8)
 
 l0800_C61E:
 	branch wArg06 != cx_96 l0800_C62B
 // DataOut: di ds ss
 // DataOut (flags): 
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:dx_ax % 0x0007 -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:(uint16) (dx_ax % 0x0007) -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
 // LocalsOut: fp(16) Stack +0008(8)
 
 l0800_C620:
 	branch bArg08 >u 0x01 l0800_C62B
 // DataOut: di ds ss
 // DataOut (flags): 
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:dx_ax % 0x0007 -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:(uint16) (dx_ax % 0x0007) -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
 // LocalsOut: fp(16)
 
 l0800_C60C:
 	branch wArg06 >u cx_96 l0800_C626
 // DataOut: di ds ss
 // DataOut (flags): Z
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:dx_ax % 0x0007 -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:(uint16) (dx_ax % 0x0007) -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
 // LocalsOut: fp(16) Stack +0008(8)
 
 l0800_C610:
 	branch wArg06 != cx_96 l0800_C62B
 // DataOut: di ds ss
 // DataOut (flags): 
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:dx_ax % 0x0007 -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:(uint16) (dx_ax % 0x0007) -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
 // LocalsOut: fp(16) Stack +0008(8)
 
 l0800_C612:
 	branch bArg08 <u 0x02 l0800_C62B
 // DataOut: di ds ss
 // DataOut (flags): 
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:dx_ax % 0x0007 -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:(uint16) (dx_ax % 0x0007) -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
 // LocalsOut: fp(16)
 
 l0800_C62B:
 	ax_34 = 0x0000
 // DataOut: ax di ds ss
 // DataOut (flags): 
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:<invalid> si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:dx_ax % 0x0007 -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:<invalid> si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:(uint16) (dx_ax % 0x0007) -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
 // LocalsOut: fp(16)
 
 l0800_C618:
 // DataOut: di ds ss
 // DataOut (flags): 
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:dx_ax % 0x0007 -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:0x0007 si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:(uint16) (dx_ax % 0x0007) -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
 // LocalsOut: fp(16)
 
 l0800_C626:
 	ax_34 = 0x0001
 // DataOut: ax di ds ss
 // DataOut (flags): 
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:<invalid> si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:dx_ax % 0x0007 -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:<invalid> si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:(uint16) (dx_ax % 0x0007) -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
 // LocalsOut: fp(16)
 
 l0800_C62D:
 	return ax_34
 // DataOut: ax di ds ss
 // DataOut (flags): 
-// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:<invalid> si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:dx_ax % 0x0007 -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
+// SymbolicIn: sp:fp - 0x0004 bp:fp - 0x0002 ax:<invalid> bx:<invalid> si:<invalid> cx:<invalid> Sequence dx:ax:<invalid> dx:(uint16) (dx_ax % 0x0007) -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
 
 fn0800_C553_exit:
 // DataOut: ax
 // DataOut (flags): 
-// SymbolicIn: sp:fp bp:bp ax:<invalid> bx:<invalid> si:si cx:<invalid> Sequence dx:ax:<invalid> dx:dx_ax % 0x0007 -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
+// SymbolicIn: sp:fp bp:bp ax:<invalid> bx:<invalid> si:si cx:<invalid> Sequence dx:ax:<invalid> dx:(uint16) (dx_ax % 0x0007) -4(fp):si -2(fp):bp 4(fp):<invalid> 6(fp):<invalid>
 
 
 


### PR DESCRIPTION
Emit cast for `div/idiv`. This is the fix for #282