### PR TITLE
Incorrect call conventions parsing

### DIFF
--- a/src/Core/CLanguage/NamedDataTypeExtractor.cs
+++ b/src/Core/CLanguage/NamedDataTypeExtractor.cs
@@ -279,7 +279,15 @@ namespace Reko.Core.CLanguage
         
         public Func<NamedDataType,NamedDataType> VisitCallConvention(CallConventionDeclarator conv)
         {
+            ApplyCallConvention(conv.Convention);
             return (nt) => conv.Declarator.Accept(this)(nt);
+        }
+
+        private void ApplyCallConvention(CTokenType convention)
+        {
+            if (callingConvention != CTokenType.None)
+                throw new FormatException(string.Format("Unexpected extra calling convention specifier '{0}'.", callingConvention));
+            callingConvention = convention;
         }
 
         public SerializedType VisitSimpleType(SimpleTypeSpec simpleType)
@@ -532,9 +540,7 @@ namespace Reko.Core.CLanguage
             case CTokenType.__Cdecl:
             case CTokenType.__Fastcall:
             case CTokenType.__Stdcall:
-                if (callingConvention != CTokenType.None)
-                    throw new FormatException(string.Format("Unexpected extra calling convention specifier '{0}'.", callingConvention));
-                callingConvention = storageClassSpec.Type;
+                ApplyCallConvention(storageClassSpec.Type);
                 break;
             }
             return dt;       //$TODO make use of CDECL.

--- a/src/UnitTests/Analysis/UserSignatureBuilderTests.cs
+++ b/src/UnitTests/Analysis/UserSignatureBuilderTests.cs
@@ -114,6 +114,18 @@ namespace Reko.UnitTests.Analysis
             Assert.AreEqual("real32", ass.Src.DataType.ToString());
         }
 
+        [Test(Description = "Verifies stack delta of stdcall function.")]
+        public void Usb_BuildSignature_Stdcall()
+        {
+            Given_Procedure(0x1000);
+            Given_UserSignature(0x01000, "char * __stdcall test(int i, float f, double d)");
+
+            var usb = new UserSignatureBuilder(program);
+            usb.BuildSignature(Address.Ptr32(0x1000), proc);
+
+            Assert.AreEqual(20, proc.Signature.StackDelta);
+        }
+
         [Test]
         public void Usb_ParseFunctionDeclaration_PlatfromTypes()
         {

--- a/src/UnitTests/Core/CLanguage/NamedDataTypeExtractorTests.cs
+++ b/src/UnitTests/Core/CLanguage/NamedDataTypeExtractorTests.cs
@@ -124,6 +124,30 @@ namespace Reko.UnitTests.Core.CLanguage
             Assert.AreEqual("prim(UnsignedInt,2)", nt.DataType.ToString());
         }
 
+        [Test(Description = "Verifies call convention.")]
+        public void NamedDataTypeExtractor_ptrchar_stdcall_fn()
+        {
+            Run(new[] { SType(CTokenType.Char) },
+                new PointerDeclarator()
+                {
+                    Pointee = new CallConventionDeclarator()
+                    {
+                        Convention = CTokenType.__Stdcall,
+                        Declarator = new FunctionDeclarator()
+                        {
+                            Declarator = new IdDeclarator()
+                            {
+                                Name = "test"
+                            },
+                            Parameters = new List<ParamDecl>()
+                        }
+                    }
+                });
+            Assert.AreEqual(
+                "fn(__stdcall,arg(ptr(prim(Character,1))),()",
+                nt.DataType.ToString());
+        }
+
         [Test(Description = "If no reko attributes are present, don't explicitly state the kind, but let the ABI rules decide.")]
         public void NamedDataTypeExtractor_GetArgumentKindFromAttributes_OtherAttrs()
         {

--- a/src/tools/c2xml/UnitTests/XmlConverterTests.cs
+++ b/src/tools/c2xml/UnitTests/XmlConverterTests.cs
@@ -727,7 +727,7 @@ namespace Reko.Tools.C2Xml.UnitTests
   <Types>
     <typedef name=""PRTL_RUN_ONCE_INIT_FN"">
       <ptr size=""4"">
-        <fn>
+        <fn convention=""__stdcall"">
           <return>
             <prim domain=""SignedInt"" size=""4"" />
           </return>


### PR DESCRIPTION
- Create unit tests to verify call conventions parsing
- `NamedDataTypeExtractor`: fix applying call convention
- Fix broken unit test