### PR TITLE
Create ExdReferenceToUnknown unit test

### DIFF
--- a/src/Decompiler/Typing/ExpressionTypeDescender.cs
+++ b/src/Decompiler/Typing/ExpressionTypeDescender.cs
@@ -462,7 +462,6 @@ namespace Reko.Typing
 
         public bool VisitIdentifier(Identifier id, TypeVariable tv)
         {
-            MeetDataType(id, tv.DataType);
             return false;
         }
 

--- a/src/UnitTests/Typing/ExpressionTypeDescenderTests.cs
+++ b/src/UnitTests/Typing/ExpressionTypeDescenderTests.cs
@@ -240,5 +240,26 @@ namespace Reko.UnitTests.Typing
                     m.IAdd(m.ISub(p, m.Word32(4)), m.Word32(0))),
                 PrimitiveType.Word32);
         }
+
+        [Test]
+        public void ExdReferenceToUnknown()
+        {
+            var p = Id("p", PrimitiveType.Word32);
+            store.EnsureExpressionTypeVariable(factory, p);
+            p.TypeVariable.OriginalDataType = PointerTo(
+                new TypeReference("UNKNOWN_TYPE", new UnknownType()));
+            p.TypeVariable.DataType = PointerTo(
+                new TypeReference("UNKNOWN_TYPE", new UnknownType()));
+            RunTest(
+                m.Load(
+                    PrimitiveType.Word32,
+                    m.IAdd(p, m.Word32(4))),
+                PrimitiveType.Word32);
+            var ptr = p.TypeVariable.OriginalDataType as Pointer;
+            Assert.IsNotNull(ptr, "Should be pointer");
+            var tRef = ptr.Pointee as TypeReference;
+            Assert.IsNotNull(tRef, "Should be type reference");
+            Assert.AreEqual("(struct (4 T_5 t0004))", tRef.Referent.ToString());
+        }
     }
 }

--- a/src/tests/Typing/DtbReg00011.exp
+++ b/src/tests/Typing/DtbReg00011.exp
@@ -39,7 +39,7 @@ Eq_2: (ptr (fn T_4 ()))
 	T_3 (in signature of fn0C00_0004 : void)
 Eq_4: void
 	T_4 (in fn0C00_0004() : void)
-Eq_5: (union (ci16 u0) ((memptr T_24 (struct (0 T_27 t0000))) u1))
+Eq_5: (union (ci16 u1) ((memptr T_24 (struct (0 T_27 t0000))) u0))
 	T_5 (in bx_23 : word16)
 	T_6 (in 0x0FFF : word16)
 	T_29 (in bx_23 - 0x0001 : word16)
@@ -110,11 +110,11 @@ T_4: (in fn0C00_0004() : void)
   OrigDataType: void
 T_5: (in bx_23 : word16)
   Class: Eq_5
-  DataType: (union (ci16 u0) ((memptr T_24 (struct (0 T_27 t0000))) u1))
-  OrigDataType: (union (ci16 u0) ((memptr T_24 (struct (0 T_27 t0000))) u1))
+  DataType: (union (ci16 u1) ((memptr T_24 (struct (0 T_27 t0000))) u0))
+  OrigDataType: (union (ci16 u1) ((memptr T_24 (struct (0 T_27 t0000))) u0))
 T_6: (in 0x0FFF : word16)
   Class: Eq_5
-  DataType: (union (ci16 u0) ((memptr T_24 (struct (0 T_27 t0000))) u1))
+  DataType: (union (ci16 u1) ((memptr T_24 (struct (0 T_27 t0000))) u0))
   OrigDataType: word16
 T_7: (in bh_24 : byte)
   Class: Eq_7
@@ -206,7 +206,7 @@ T_28: (in 0x0001 : word16)
   OrigDataType: ui16
 T_29: (in bx_23 - 0x0001 : word16)
   Class: Eq_5
-  DataType: (union (ci16 u0) ((memptr T_24 (struct (0 T_27 t0000))) u1))
+  DataType: (union (ci16 u1) ((memptr T_24 (struct (0 T_27 t0000))) u0))
   OrigDataType: (memptr T_24 (struct (0 T_27 t0000)))
 T_30: (in SLICE(bx_23, byte, 8) : byte)
   Class: Eq_7
@@ -218,7 +218,7 @@ T_31: (in (byte) bx_23 : byte)
   OrigDataType: byte
 T_32: (in 0x0000 : word16)
   Class: Eq_5
-  DataType: (union (ci16 u0) ((memptr T_24 (struct (0 T_27 t0000))) u1))
+  DataType: (union (ci16 u1) ((memptr T_24 (struct (0 T_27 t0000))) u0))
   OrigDataType: ci16
 T_33: (in bx_23 >= 0x0000 : bool)
   Class: Eq_33

--- a/src/tests/Typing/ExdReferenceToUnknown.exp
+++ b/src/tests/Typing/ExdReferenceToUnknown.exp
@@ -7,7 +7,7 @@ globals_t: (in globals : (ptr (struct "Globals")))
 T_2: (in p : word32)
   Class: Eq_2
   DataType: (ptr UNKNOWN_TYPE)
-  OrigDataType: (ptr (union (UNKNOWN_TYPE u1)))
+  OrigDataType: (ptr UNKNOWN_TYPE)
 T_3: (in 0x00000004 : word32)
   Class: Eq_3
   DataType: word32

--- a/src/tests/Typing/ExdReferenceToUnknown.exp
+++ b/src/tests/Typing/ExdReferenceToUnknown.exp
@@ -1,0 +1,22 @@
+// Equivalence classes ////////////
+// Type Variables ////////////
+globals_t: (in globals : (ptr (struct "Globals")))
+  Class: Eq_1
+  DataType: 
+  OrigDataType: 
+T_2: (in p : word32)
+  Class: Eq_2
+  DataType: (ptr UNKNOWN_TYPE)
+  OrigDataType: (ptr (union (UNKNOWN_TYPE u1)))
+T_3: (in 0x00000004 : word32)
+  Class: Eq_3
+  DataType: word32
+  OrigDataType: word32
+T_4: (in p + 0x00000004 : word32)
+  Class: Eq_4
+  DataType: ptr32
+  OrigDataType: ptr32
+T_5: (in Mem0[p + 0x00000004:word32] : word32)
+  Class: Eq_5
+  DataType: word32
+  OrigDataType: word32

--- a/subjects/Elf-MIPS/redir.h
+++ b/subjects/Elf-MIPS/redir.h
@@ -30065,7 +30065,7 @@ T_7296: (in r4_165 : uint32)
 T_7297: (in hi_lo_142 : Eq_7297)
   Class: Eq_7297
   DataType: Eq_7297
-  OrigDataType: (union (uint32 u0) (uint64 u1))
+  OrigDataType: (union (uint32 u1) (uint64 u0))
 T_7298: (in dwLoc3C : word32)
   Class: Eq_7298
   DataType: uint32
@@ -34029,7 +34029,7 @@ T_8287: (in hi_lo_244 : Eq_8287)
 T_8288: (in dwLoc60 : word32)
   Class: Eq_8288
   DataType: Eq_8288
-  OrigDataType: (union (int32 u0) (uint32 u1))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_8289: (in 0x00 : byte)
   Class: Eq_8289
   DataType: byte
@@ -34073,7 +34073,7 @@ T_8298: (in dwLoc5C + -1 : word32)
 T_8299: (in dwLoc78 : word32)
   Class: Eq_8299
   DataType: Eq_8299
-  OrigDataType: (union (int32 u0) (uint32 u1))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_8300: (in 0x00 : byte)
   Class: Eq_8300
   DataType: byte

--- a/subjects/Elf-x86-64/ais3_crackme/ais3_crackme.h
+++ b/subjects/Elf-x86-64/ais3_crackme/ais3_crackme.h
@@ -710,7 +710,7 @@ T_156: (in rbp : word64)
 T_157: (in dwLoc04 : word32)
   Class: Eq_156
   DataType: Eq_156
-  OrigDataType: (union (ptr64 u0) (word32 u1))
+  OrigDataType: (union (ptr64 u1) (word32 u0))
 T_158: (in qwLoc04 : word64)
   Class: Eq_156
   DataType: Eq_156

--- a/subjects/Hunk-m68k/BENCHFN.h
+++ b/subjects/Hunk-m68k/BENCHFN.h
@@ -8437,7 +8437,7 @@ T_1497: (in a7_208->t0030 <= 0x70 : bool)
 T_1498: (in v103_1416 : Eq_1032)
   Class: Eq_1032
   DataType: Eq_1032
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_1499: (in 0x00000030 : word32)
   Class: Eq_1499
   DataType: word32
@@ -16745,7 +16745,7 @@ T_3574: (in d1 : Eq_3550)
 T_3575: (in d2 : Eq_825)
   Class: Eq_825
   DataType: Eq_825
-  OrigDataType: (union (int32 u0) (uint32 u1))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_3576: (in d1Out : Eq_3576)
   Class: Eq_3576
   DataType: Eq_3576
@@ -32253,7 +32253,7 @@ T_7451: (in Mem2205[a7_1137 + 44:byte] : byte)
 T_7452: (in v470_2206 : Eq_7452)
   Class: Eq_7452
   DataType: Eq_7452
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_7453: (in 44 : int32)
   Class: Eq_7453
   DataType: int32

--- a/subjects/Hunk-m68k/BENCHLNG.h
+++ b/subjects/Hunk-m68k/BENCHLNG.h
@@ -9924,7 +9924,7 @@ T_1803: (in a7_210->t0030 <= 0x70 : bool)
 T_1804: (in v103_1444 : Eq_1337)
   Class: Eq_1337
   DataType: Eq_1337
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_1805: (in 0x00000030 : word32)
   Class: Eq_1805
   DataType: word32
@@ -18368,7 +18368,7 @@ T_3914: (in d1 : Eq_1008)
 T_3915: (in d2 : Eq_95)
   Class: Eq_95
   DataType: Eq_95
-  OrigDataType: (union (int32 u0) (uint32 u1))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_3916: (in d1Out : Eq_3916)
   Class: Eq_3916
   DataType: Eq_3916
@@ -33220,7 +33220,7 @@ T_7627: (in Mem2206[a7_1138 + 44:byte] : byte)
 T_7628: (in v470_2207 : Eq_7628)
   Class: Eq_7628
   DataType: Eq_7628
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_7629: (in 44 : int32)
   Class: Eq_7629
   DataType: int32

--- a/subjects/Hunk-m68k/BENCHMUL.h
+++ b/subjects/Hunk-m68k/BENCHMUL.h
@@ -11191,7 +11191,7 @@ T_2154: (in a7_210->t0030 <= 0x70 : bool)
 T_2155: (in v103_1444 : Eq_1688)
   Class: Eq_1688
   DataType: Eq_1688
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_2156: (in 0x00000030 : word32)
   Class: Eq_2156
   DataType: word32
@@ -19635,7 +19635,7 @@ T_4265: (in d1 : Eq_4241)
 T_4266: (in d2 : Eq_764)
   Class: Eq_764
   DataType: Eq_764
-  OrigDataType: (union (int32 u0) (uint32 u1))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_4267: (in d1Out : Eq_4267)
   Class: Eq_4267
   DataType: Eq_4267
@@ -35223,7 +35223,7 @@ T_8162: (in Mem2206[a7_1138 + 44:byte] : byte)
 T_8163: (in v470_2207 : Eq_8163)
   Class: Eq_8163
   DataType: Eq_8163
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_8164: (in 44 : int32)
   Class: Eq_8164
   DataType: int32

--- a/subjects/Hunk-m68k/BYTEOPS.h
+++ b/subjects/Hunk-m68k/BYTEOPS.h
@@ -6719,7 +6719,7 @@ T_1341: (in a7_208->t0030 <= 0x70 : bool)
 T_1342: (in v103_1416 : Eq_876)
   Class: Eq_876
   DataType: Eq_876
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_1343: (in 0x00000030 : word32)
   Class: Eq_1343
   DataType: word32
@@ -14771,7 +14771,7 @@ T_3354: (in d1 : Eq_3330)
 T_3355: (in d2 : Eq_746)
   Class: Eq_746
   DataType: Eq_746
-  OrigDataType: (union (int32 u0) (uint32 u1))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_3356: (in d1Out : Eq_3356)
   Class: Eq_3356
   DataType: Eq_3356

--- a/subjects/Hunk-m68k/FIBO.h
+++ b/subjects/Hunk-m68k/FIBO.h
@@ -8451,7 +8451,7 @@ T_1504: (in a7_208->t0030 <= 0x70 : bool)
 T_1505: (in v103_1416 : Eq_1039)
   Class: Eq_1039
   DataType: Eq_1039
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_1506: (in 0x00000030 : word32)
   Class: Eq_1506
   DataType: word32
@@ -16763,7 +16763,7 @@ T_3582: (in d1 : Eq_3558)
 T_3583: (in d2 : Eq_784)
   Class: Eq_784
   DataType: Eq_784
-  OrigDataType: (union (int32 u0) (uint32 u1))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_3584: (in d1Out : Eq_3584)
   Class: Eq_3584
   DataType: Eq_3584
@@ -32263,7 +32263,7 @@ T_7457: (in Mem2205[a7_1137 + 44:byte] : byte)
 T_7458: (in v470_2206 : Eq_7458)
   Class: Eq_7458
   DataType: Eq_7458
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_7459: (in 44 : int32)
   Class: Eq_7459
   DataType: int32

--- a/subjects/Hunk-m68k/MAX.h
+++ b/subjects/Hunk-m68k/MAX.h
@@ -18276,7 +18276,7 @@ T_3974: (in Mem2205[a7_1137 + 44:byte] : byte)
 T_3975: (in v470_2206 : Eq_3975)
   Class: Eq_3975
   DataType: Eq_3975
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_3976: (in 44 : int32)
   Class: Eq_3976
   DataType: int32
@@ -26584,7 +26584,7 @@ T_6051: (in a7_210->t0030 <= 0x70 : bool)
 T_6052: (in v103_1444 : Eq_5585)
   Class: Eq_5585
   DataType: Eq_5585
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_6053: (in 0x00000030 : word32)
   Class: Eq_6053
   DataType: word32
@@ -33048,7 +33048,7 @@ T_7667: (in d1 : Eq_4525)
 T_7668: (in d2 : Eq_714)
   Class: Eq_714
   DataType: Eq_714
-  OrigDataType: (union (int32 u0) (uint32 u1))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_7669: (in d1Out : Eq_7669)
   Class: Eq_7669
   DataType: Eq_7669

--- a/subjects/Hunk-m68k/TESTLONG.h
+++ b/subjects/Hunk-m68k/TESTLONG.h
@@ -8454,7 +8454,7 @@ T_1454: (in a7_208->t0030 <= 0x70 : bool)
 T_1455: (in v103_1416 : Eq_989)
   Class: Eq_989
   DataType: Eq_989
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_1456: (in 0x00000030 : word32)
   Class: Eq_1456
   DataType: word32
@@ -16734,7 +16734,7 @@ T_3524: (in d1 : Eq_3500)
 T_3525: (in d2 : Eq_95)
   Class: Eq_95
   DataType: Eq_95
-  OrigDataType: (union (int32 u0) (uint32 u1))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_3526: (in d1Out : Eq_3526)
   Class: Eq_3526
   DataType: Eq_3526
@@ -32322,7 +32322,7 @@ T_7421: (in Mem2206[a7_1138 + 44:byte] : byte)
 T_7422: (in v470_2207 : Eq_7422)
   Class: Eq_7422
   DataType: Eq_7422
-  OrigDataType: (union (int32 u0) (byte u1))
+  OrigDataType: (union (int32 u1) (byte u0))
 T_7423: (in 44 : int32)
   Class: Eq_7423
   DataType: int32

--- a/subjects/PE-x86-64/varargs_test/varargs_test.h
+++ b/subjects/PE-x86-64/varargs_test/varargs_test.h
@@ -5139,7 +5139,7 @@ T_893: (in edi_103 < 0xFFFFFFFF : bool)
 T_894: (in rax_50 : word64)
   Class: Eq_894
   DataType: PVOID
-  OrigDataType: (union (PVOID u1))
+  OrigDataType: PVOID
 T_895: (in RtlLookupFunctionEntry : ptr64)
   Class: Eq_895
   DataType: (ptr (fn T_906 (T_869, T_902, T_905)))
@@ -7187,7 +7187,7 @@ T_1405: (in RtlCaptureContext(tLoc05C0) : void)
 T_1406: (in rax_37 : word64)
   Class: Eq_894
   DataType: PVOID
-  OrigDataType: (union (PVOID u1))
+  OrigDataType: PVOID
 T_1407: (in RtlLookupFunctionEntry : ptr64)
   Class: Eq_895
   DataType: (ptr (fn T_1415 (T_1408, T_1411, T_1414)))
@@ -7251,7 +7251,7 @@ T_1421: (in memset(ptrLoc05C4, dwLoc05BC, tLoc05B4) : (ptr void))
 T_1422: (in eax_73 : word32)
   Class: Eq_763
   DataType: BOOL
-  OrigDataType: (union (BOOL u1))
+  OrigDataType: BOOL
 T_1423: (in IsDebuggerPresent : ptr64)
   Class: Eq_1423
   DataType: (ptr (fn T_1425 ()))
@@ -7851,7 +7851,7 @@ T_1571: (in 0000000140002680 : ptr64)
 T_1572: (in rsi_12 : word64)
   Class: Eq_1570
   DataType: (union (uint64 u1) (ptr64 u0))
-  OrigDataType: (union (uint64 u0) (ptr64 u1))
+  OrigDataType: (union (uint64 u1) (ptr64 u0))
 T_1573: (in 0000000140002680 : ptr64)
   Class: Eq_1570
   DataType: ptr64
@@ -7959,7 +7959,7 @@ T_1598: (in 0000000140002690 : ptr64)
 T_1599: (in rsi_12 : word64)
   Class: Eq_1597
   DataType: (union (uint64 u1) (ptr64 u0))
-  OrigDataType: (union (uint64 u0) (ptr64 u1))
+  OrigDataType: (union (uint64 u1) (ptr64 u0))
 T_1600: (in 0000000140002690 : ptr64)
   Class: Eq_1597
   DataType: ptr64

--- a/subjects/PE-x86/pySample/pySample.h
+++ b/subjects/PE-x86/pySample/pySample.h
@@ -977,7 +977,7 @@ T_164: (in dwArg08 != 0x00000000 : bool)
 T_165: (in edi_82 : Eq_139)
   Class: Eq_139
   DataType: Eq_139
-  OrigDataType: (union (LONG u1))
+  OrigDataType: LONG
 T_166: (in fs : selector)
   Class: Eq_166
   DataType: (ptr Eq_166)

--- a/subjects/regressions/angr-148/test.h
+++ b/subjects/regressions/angr-148/test.h
@@ -686,7 +686,7 @@ T_152: (in rbp : word64)
 T_153: (in dwLoc04 : word32)
   Class: Eq_152
   DataType: Eq_152
-  OrigDataType: (union (ptr64 u0) (word32 u1))
+  OrigDataType: (union (ptr64 u1) (word32 u0))
 T_154: (in qwLoc04 : word64)
   Class: Eq_152
   DataType: Eq_152

--- a/subjects/regressions/reko-351/a.h
+++ b/subjects/regressions/reko-351/a.h
@@ -970,7 +970,7 @@ T_230: (in rArg0C : real64)
 T_231: (in tArg14 : Eq_231)
   Class: Eq_231
   DataType: Eq_231
-  OrigDataType: (union ((ptr (struct (0 T_254 t0000))) u0) ((ref int32) u2))
+  OrigDataType: (union ((ptr (struct (0 T_254 t0000))) u1) ((ref int32) u0))
 T_232: (in rLoc1C : real64)
   Class: Eq_232
   DataType: real64


### PR DESCRIPTION
- Create `ExdReferenceToUnknown` unit test
- Type descender: remove `MeetDataType` call from `VisitIdentifier`. Type variable of `id` is always the same as
`tv`. So avoid unnecessary self-meeting.