### PR TITLE
Fix ComplexExpressionBuilder

### DIFF
--- a/src/Decompiler/Typing/ComplexExpressionBuilder.cs
+++ b/src/Decompiler/Typing/ComplexExpressionBuilder.cs
@@ -160,6 +160,12 @@ namespace Reko.Typing
         {
             if (enclosingPtr != null)
             {
+                var unary = expComplex as UnaryExpression;
+                if (unary != null && unary.Operator == Operator.AddrOf)
+                {
+                    dereferenceGenerated = true;
+                    return unary.Expression;
+                }
                 return expComplex;
             }
             var pointee = ptr.Pointee;

--- a/src/UnitTests/Typing/ComplexExpressionBuilderTests.cs
+++ b/src/UnitTests/Typing/ComplexExpressionBuilderTests.cs
@@ -173,7 +173,27 @@ namespace Reko.UnitTests.Typing
 			Assert.AreEqual("ptr->dw0000", ceb.BuildComplex(true).ToString());
 		}
 
-		[Test]
+        [Test]
+        public void CEB_BuildAddrOfPointer()
+        {
+            var id = new Identifier("id", PrimitiveType.Word32, null);
+            var addrOf = m.AddrOf(id);
+            CreateTv(addrOf, Ptr32(Ptr32(PrimitiveType.Int32)), Ptr32(PrimitiveType.Word32));
+            var ceb = CreateBuilder(PrimitiveType.Word32, null, addrOf);
+            Assert.AreEqual("&id", ceb.BuildComplex(false).ToString());
+        }
+
+        [Test]
+        public void CEB_BuildAddrOfPointerFetch()
+        {
+            var id = new Identifier("id", PrimitiveType.Word32, null);
+            var addrOf = m.AddrOf(id);
+            CreateTv(addrOf, Ptr32(Ptr32(PrimitiveType.Int32)), Ptr32(PrimitiveType.Word32));
+            var ceb = CreateBuilder(PrimitiveType.Word32, null, addrOf);
+            Assert.AreEqual("id", ceb.BuildComplex(true).ToString());
+        }
+
+        [Test]
         public void CEB_BuildUnionFetch()
         {
             var ptr = new Identifier("ptr", PrimitiveType.Word32, null);

--- a/subjects/Hunk-m68k/BENCHFN.c
+++ b/subjects/Hunk-m68k/BENCHFN.c
@@ -21,13 +21,13 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 		} while (d0_511 != 0x00);
 	}
 	*&globals->ptr3E70 = fp;
-	*&globals->ptr3E74 = (struct Eq_5 **) a6_8;
+	globals->ptr3E74 = a6_8;
 	struct Eq_26 * d0_19 = FindTask(0x00);
 	struct Eq_32 * d0_112 = OpenLibrary(0x12BC, 0x00);
 	if (d0_112 != null)
 	{
 		int32 d4_463;
-		*&globals->ptr3E78 = (struct Eq_32 **) d0_112;
+		globals->ptr3E78 = d0_112;
 		if (d0_19->ptr00AC == null)
 		{
 			d4_463 = 0x02;
@@ -68,8 +68,8 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 			if (d0_151 == null)
 			{
 				fn00001214(d0_19);
-				*&globals->ptr3E7C = (struct Eq_68 **) d0_151;
-				*&globals->ptr3E80 = (struct Eq_68 **) d0_151;
+				globals->ptr3E7C = d0_151;
+				globals->ptr3E80 = d0_151;
 				Mem404[0x00:word32] = 0x00;
 				dwLoc14_158 = d0_151;
 				ui32 d0_407 = d0_151->dw0024;
@@ -1381,7 +1381,7 @@ Eq_32 * fn000021FC(word32 dwArg04, word32 dwArg08, ptr32 & d1Out, ptr32 & a0Out)
 {
 	*d1Out = d1;
 	struct Eq_32 * d0_45;
-	struct Eq_3256 * a0_31 = *&globals->ptr3E74;
+	struct Eq_3256 * a0_31 = globals->ptr3E74;
 	*a0Out = a0_31;
 	if (a0_31->w0014 >= 0x27)
 	{
@@ -1473,7 +1473,7 @@ word32 fn00002320(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & d1Out,
 	*a1Out = a1;
 	*d1Out = d1;
 	word32 d0_30;
-	struct Eq_3455 * a0_19 = *&globals->ptr3E74;
+	struct Eq_3455 * a0_19 = globals->ptr3E74;
 	*a0Out = a0_19;
 	if (a0_19->w0014 >= 0x27)
 	{

--- a/subjects/Hunk-m68k/BENCHLNG.c
+++ b/subjects/Hunk-m68k/BENCHLNG.c
@@ -21,14 +21,14 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 		} while (d0_511 != 0x00);
 	}
 	*&globals->ptr3E20 = fp;
-	*&globals->ptr3E24 = (struct Eq_5 **) a6_8;
+	globals->ptr3E24 = a6_8;
 	struct Eq_26 * d0_19 = FindTask(0x00);
 	word32 a1_170 = 0x000012BC;
 	struct Eq_34 * d0_112 = OpenLibrary(0x12BC, 0x00);
 	if (d0_112 != null)
 	{
 		int32 d4_463;
-		*&globals->ptr3E28 = (struct Eq_34 **) d0_112;
+		globals->ptr3E28 = d0_112;
 		if (d0_19->ptr00AC == null)
 		{
 			d4_463 = 0x02;
@@ -69,8 +69,8 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 			if (d0_151 == null)
 			{
 				fn00001214(d0_19);
-				*&globals->ptr3E2C = (struct Eq_70 **) d0_151;
-				*&globals->ptr3E30 = (struct Eq_70 **) d0_151;
+				globals->ptr3E2C = d0_151;
+				globals->ptr3E30 = d0_151;
 				Mem404[0x00:word32] = 0x00;
 				dwLoc14_158 = d0_151;
 				ui32 d0_407 = d0_151[0x0024];
@@ -94,7 +94,7 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 				word32 d0_435 = ((word32[]) 0x08)[d0_407];
 				if (d0_435 != 0x00)
 					d0_19->dw00A4 = d0_435;
-				a6_161 = (struct Eq_120 *) *&globals->ptr3E24;
+				a6_161 = globals->ptr3E24;
 l000011F8:
 				a0_163 = d0_19->dw003A;
 				goto l00001202;
@@ -191,7 +191,7 @@ l00001148:
 			*&globals->dw3E34 = d0_229;
 			execPrivate5();
 			*&globals->dw3E38 = d0_229;
-			a6_161 = (struct Eq_120 *) *&globals->ptr3E24;
+			a6_161 = globals->ptr3E24;
 			dwLoc14_158 = d0_132 + 0x0010;
 			dwLoc18 = d3_234;
 			if (a6_161[0x0014] >= 0x24)
@@ -1567,7 +1567,7 @@ Eq_34 * fn0000232C(word32 dwArg04, word32 dwArg08, ptr32 & d1Out, ptr32 & a0Out)
 {
 	*d1Out = d1;
 	struct Eq_34 * d0_45;
-	struct Eq_3596 * a0_31 = *&globals->ptr3E24;
+	struct Eq_3596 * a0_31 = globals->ptr3E24;
 	*a0Out = a0_31;
 	if (a0_31->w0014 >= 0x27)
 	{
@@ -1659,7 +1659,7 @@ word32 fn00002450(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & d1Out,
 	*a1Out = a1;
 	*d1Out = d1;
 	word32 d0_30;
-	struct Eq_3795 * a0_19 = *&globals->ptr3E24;
+	struct Eq_3795 * a0_19 = globals->ptr3E24;
 	*a0Out = a0_19;
 	if (a0_19->w0014 >= 0x27)
 	{

--- a/subjects/Hunk-m68k/BENCHMUL.c
+++ b/subjects/Hunk-m68k/BENCHMUL.c
@@ -21,13 +21,13 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 		} while (d0_511 != 0x00);
 	}
 	*&globals->ptr40F8 = fp;
-	*&globals->ptr40FC = (struct Eq_5 **) a6_8;
+	globals->ptr40FC = a6_8;
 	struct Eq_26 * d0_19 = FindTask(0x00);
 	struct Eq_32 * d0_112 = OpenLibrary(0x12BC, 0x00);
 	if (d0_112 != null)
 	{
 		int32 d4_463;
-		*&globals->ptr4100 = (struct Eq_32 **) d0_112;
+		globals->ptr4100 = d0_112;
 		if (d0_19->ptr00AC == null)
 		{
 			d4_463 = 0x02;
@@ -68,8 +68,8 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 			if (d0_151 == null)
 			{
 				fn00001214(d0_19);
-				*&globals->ptr4104 = (struct Eq_68 **) d0_151;
-				*&globals->ptr4108 = (struct Eq_68 **) d0_151;
+				globals->ptr4104 = d0_151;
+				globals->ptr4108 = d0_151;
 				Mem404[0x00:word32] = 0x00;
 				dwLoc14_158 = d0_151;
 				ui32 d0_407 = d0_151->dw0024;
@@ -1493,7 +1493,7 @@ Eq_32 * fn00002484(word32 dwArg04, word32 dwArg08, ptr32 & d1Out, ptr32 & a0Out)
 {
 	*d1Out = d1;
 	struct Eq_32 * d0_45;
-	struct Eq_3947 * a0_31 = *&globals->ptr40FC;
+	struct Eq_3947 * a0_31 = globals->ptr40FC;
 	*a0Out = a0_31;
 	if (a0_31->w0014 >= 0x27)
 	{
@@ -1585,7 +1585,7 @@ word32 fn000025A8(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & d1Out,
 	*a1Out = a1;
 	*d1Out = d1;
 	word32 d0_30;
-	struct Eq_4146 * a0_19 = *&globals->ptr40FC;
+	struct Eq_4146 * a0_19 = globals->ptr40FC;
 	*a0Out = a0_19;
 	if (a0_19->w0014 >= 0x27)
 	{

--- a/subjects/Hunk-m68k/BYTEOPS.c
+++ b/subjects/Hunk-m68k/BYTEOPS.c
@@ -21,13 +21,13 @@ void fn00001000(int32 d0, byte * a0)
 		} while (d0_508 != 0x00);
 	}
 	*&globals->ptr2B88 = fp;
-	*&globals->ptr2B8C = (struct Eq_4 **) a6_8;
+	globals->ptr2B8C = a6_8;
 	struct Eq_25 * d0_19 = FindTask(0x00);
 	struct Eq_31 * d0_112 = OpenLibrary(0x12BC, 0x00);
 	if (d0_112 != null)
 	{
 		int32 d4_460;
-		*&globals->ptr2B90 = (struct Eq_31 **) d0_112;
+		globals->ptr2B90 = d0_112;
 		if (d0_19->ptr00AC == null)
 		{
 			d4_460 = 0x02;
@@ -69,8 +69,8 @@ void fn00001000(int32 d0, byte * a0)
 			if (d0_151 == null)
 			{
 				fn00001214(d0_19);
-				*&globals->ptr2B94 = (struct Eq_67 **) d0_151;
-				*&globals->ptr2B98 = (struct Eq_67 **) d0_151;
+				globals->ptr2B94 = d0_151;
+				globals->ptr2B98 = d0_151;
 				Mem403[0x00:word32] = 0x00;
 				dwLoc14_159 = d0_151;
 				ui32 d0_406 = d0_151->dw0024;
@@ -1295,7 +1295,7 @@ Eq_2989 fn00001FF4(word32 dwArg04, ptr32 & a0Out)
 Eq_31 * fn000021C4(word32 dwArg04, word32 dwArg08, ptr32 & a0Out)
 {
 	struct Eq_31 * d0_45;
-	struct Eq_3059 * a0_31 = *&globals->ptr2B8C;
+	struct Eq_3059 * a0_31 = globals->ptr2B8C;
 	*a0Out = a0_31;
 	if (a0_31->w0014 >= 0x27)
 	{
@@ -1381,7 +1381,7 @@ l00002296:
 Eq_31 * fn000022E8(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & a0Out)
 {
 	struct Eq_31 * d0_30;
-	struct Eq_3250 * a0_19 = *&globals->ptr2B8C;
+	struct Eq_3250 * a0_19 = globals->ptr2B8C;
 	*a0Out = a0_19;
 	if (a0_19->w0014 >= 0x27)
 		d0_30 = CreatePrivatePool(dwArg04, dwArg08, dwArg0C);

--- a/subjects/Hunk-m68k/FIBO.c
+++ b/subjects/Hunk-m68k/FIBO.c
@@ -21,13 +21,13 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 		} while (d0_513 != 0x00);
 	}
 	*&globals->ptr3E94 = fp;
-	*&globals->ptr3E98 = (struct Eq_5 **) a6_8;
+	globals->ptr3E98 = a6_8;
 	struct Eq_26 * d0_19 = FindTask(0x00);
 	struct Eq_32 * d0_112 = OpenLibrary(0x12BC, 0x00);
 	if (d0_112 != null)
 	{
 		int32 d4_465;
-		*&globals->ptr3E9C = (struct Eq_32 **) d0_112;
+		globals->ptr3E9C = d0_112;
 		if (d0_19->ptr00AC == null)
 		{
 			d4_465 = 0x02;
@@ -68,8 +68,8 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 			if (d0_151 == null)
 			{
 				fn00001214(d0_19);
-				*&globals->ptr3EA0 = (struct Eq_68 **) d0_151;
-				*&globals->ptr3EA4 = (struct Eq_68 **) d0_151;
+				globals->ptr3EA0 = d0_151;
+				globals->ptr3EA4 = d0_151;
 				Mem405[0x00:word32] = 0x00;
 				dwLoc14_158 = d0_151;
 				ui32 d0_408 = d0_151->dw0024;
@@ -1363,7 +1363,7 @@ Eq_32 * fn00002220(word32 dwArg04, word32 dwArg08, ptr32 & d1Out, ptr32 & a0Out)
 {
 	*d1Out = d1;
 	struct Eq_32 * d0_45;
-	struct Eq_3263 * a0_31 = *&globals->ptr3E98;
+	struct Eq_3263 * a0_31 = globals->ptr3E98;
 	*a0Out = a0_31;
 	if (a0_31->w0014 >= 0x27)
 	{
@@ -1455,7 +1455,7 @@ word32 fn00002344(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & d1Out,
 	*a1Out = a1;
 	*d1Out = d1;
 	word32 d0_30;
-	struct Eq_3462 * a0_19 = *&globals->ptr3E98;
+	struct Eq_3462 * a0_19 = globals->ptr3E98;
 	*a0Out = a0_19;
 	if (a0_19->w0014 >= 0x27)
 	{

--- a/subjects/Hunk-m68k/MATRIXMU.c
+++ b/subjects/Hunk-m68k/MATRIXMU.c
@@ -21,13 +21,13 @@ void fn00001000(int32 d0, byte * a0)
 		} while (d0_505 != 0x00);
 	}
 	*&globals->ptr1494 = fp;
-	*&globals->ptr1498 = (struct Eq_4 **) a6_8;
+	globals->ptr1498 = a6_8;
 	struct Eq_25 * d0_19 = FindTask(0x00);
 	struct Eq_31 * d0_112 = OpenLibrary(0x12BC, 0x00);
 	if (d0_112 != null)
 	{
 		int32 d4_457;
-		*&globals->ptr149C = (struct Eq_31 **) d0_112;
+		globals->ptr149C = d0_112;
 		if (d0_19->ptr00AC == null)
 		{
 			d4_457 = 0x02;
@@ -67,8 +67,8 @@ void fn00001000(int32 d0, byte * a0)
 			if (d0_151 == null)
 			{
 				fn00001214(d0_19);
-				*&globals->ptr14A0 = (struct Eq_67 **) d0_151;
-				*&globals->ptr14A4 = (struct Eq_67 **) d0_151;
+				globals->ptr14A0 = d0_151;
+				globals->ptr14A4 = d0_151;
 				Mem401[0x00:word32] = 0x00;
 				dwLoc14_159 = d0_151;
 				ui32 d0_404 = d0_151->dw0024;
@@ -187,7 +187,7 @@ l00001148:
 			*(int32 *) 5292 = d0_226;
 			dwLoc14_159 = &d0_132->ptr0010;
 			dwLoc18 = d3_231;
-			if (**&globals->ptr1498 >= 0x24)
+			if (globals->ptr1498->w0014 >= 0x24)
 			{
 				word32 v87_298 = d0_19->dw00E0;
 				*(word32 *) 0x14B0 = v87_298;

--- a/subjects/Hunk-m68k/MATRIXMU.h
+++ b/subjects/Hunk-m68k/MATRIXMU.h
@@ -1352,7 +1352,7 @@ T_288: (in 0x0024 : word16)
   Class: Eq_287
   DataType: cu16
   OrigDataType: cu16
-T_289: (in **&globals->ptr1498 < 0x0024 : bool)
+T_289: (in globals->ptr1498->w0014 < 0x0024 : bool)
   Class: Eq_289
   DataType: bool
   OrigDataType: bool

--- a/subjects/Hunk-m68k/MAX.c
+++ b/subjects/Hunk-m68k/MAX.c
@@ -21,13 +21,13 @@ void fn00001000(int32 d0, byte * a0)
 		} while (d0_511 != 0x00);
 	}
 	*&globals->ptr3D90 = fp;
-	*&globals->ptr3D94 = (struct Eq_4 **) a6_8;
+	globals->ptr3D94 = a6_8;
 	struct Eq_25 * d0_19 = FindTask(0x00);
 	struct Eq_31 * d0_112 = OpenLibrary(0x12BC, 0x00);
 	if (d0_112 != null)
 	{
 		int32 d4_463;
-		*&globals->ptr3D98 = (struct Eq_31 **) d0_112;
+		globals->ptr3D98 = d0_112;
 		if (d0_19->ptr00AC == null)
 		{
 			d4_463 = 0x02;
@@ -68,8 +68,8 @@ void fn00001000(int32 d0, byte * a0)
 			if (d0_151 == null)
 			{
 				fn00001214(d0_19);
-				*&globals->ptr3D9C = (struct Eq_67 **) d0_151;
-				*&globals->ptr3DA0 = (struct Eq_67 **) d0_151;
+				globals->ptr3D9C = d0_151;
+				globals->ptr3DA0 = d0_151;
 				Mem404[0x00:word32] = 0x00;
 				dwLoc14_158 = d0_151;
 				ui32 d0_407 = d0_151->dw0024;
@@ -1967,7 +1967,7 @@ Eq_31 * fn000028E8(word32 dwArg04, word32 dwArg08, ptr32 & d1Out, ptr32 & a0Out)
 {
 	*d1Out = d1;
 	struct Eq_31 * d0_45;
-	struct Eq_5007 * a0_31 = *&globals->ptr3D94;
+	struct Eq_5007 * a0_31 = globals->ptr3D94;
 	*a0Out = a0_31;
 	if (a0_31->w0014 >= 0x27)
 	{
@@ -2059,7 +2059,7 @@ word32 fn00002A0C(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & d1Out,
 	*a1Out = a1;
 	*d1Out = d1;
 	word32 d0_30;
-	struct Eq_5206 * a0_19 = *&globals->ptr3D94;
+	struct Eq_5206 * a0_19 = globals->ptr3D94;
 	*a0Out = a0_19;
 	if (a0_19->w0014 >= 0x27)
 	{

--- a/subjects/Hunk-m68k/STRLEN.c
+++ b/subjects/Hunk-m68k/STRLEN.c
@@ -21,13 +21,13 @@ void fn00001000(int32 d0, byte * a0)
 		} while (d0_505 != 0x00);
 	}
 	*&globals->ptr13C8 = fp;
-	*&globals->ptr13CC = (struct Eq_4 **) a6_8;
+	globals->ptr13CC = a6_8;
 	struct Eq_25 * d0_19 = FindTask(0x00);
 	struct Eq_31 * d0_112 = OpenLibrary(0x12BC, 0x00);
 	if (d0_112 != null)
 	{
 		int32 d4_457;
-		*&globals->ptr13D0 = (struct Eq_31 **) d0_112;
+		globals->ptr13D0 = d0_112;
 		if (d0_19->ptr00AC == null)
 		{
 			d4_457 = 0x02;
@@ -67,8 +67,8 @@ void fn00001000(int32 d0, byte * a0)
 			if (d0_151 == null)
 			{
 				fn00001214(d0_19);
-				*&globals->ptr13D4 = (struct Eq_67 **) d0_151;
-				*&globals->ptr13D8 = (struct Eq_67 **) d0_151;
+				globals->ptr13D4 = d0_151;
+				globals->ptr13D8 = d0_151;
 				Mem401[0x00:word32] = 0x00;
 				dwLoc14_159 = d0_151;
 				ui32 d0_404 = d0_151->dw0024;
@@ -187,7 +187,7 @@ l00001148:
 			*(int32 *) 5088 = d0_226;
 			dwLoc14_159 = &d0_132->ptr0010;
 			dwLoc18 = d3_231;
-			if (**&globals->ptr13CC >= 0x24)
+			if (globals->ptr13CC->w0014 >= 0x24)
 			{
 				word32 v87_298 = d0_19->dw00E0;
 				*(word32 *) 0x13E4 = v87_298;

--- a/subjects/Hunk-m68k/STRLEN.h
+++ b/subjects/Hunk-m68k/STRLEN.h
@@ -1318,7 +1318,7 @@ T_288: (in 0x0024 : word16)
   Class: Eq_287
   DataType: cu16
   OrigDataType: cu16
-T_289: (in **&globals->ptr13CC < 0x0024 : bool)
+T_289: (in globals->ptr13CC->w0014 < 0x0024 : bool)
   Class: Eq_289
   DataType: bool
   OrigDataType: bool

--- a/subjects/Hunk-m68k/TESTLONG.c
+++ b/subjects/Hunk-m68k/TESTLONG.c
@@ -21,14 +21,14 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 		} while (d0_511 != 0x00);
 	}
 	*&globals->ptr3D70 = fp;
-	*&globals->ptr3D74 = (struct Eq_5 **) a6_8;
+	globals->ptr3D74 = a6_8;
 	struct Eq_26 * d0_19 = FindTask(0x00);
 	word32 a1_170 = 0x000012BC;
 	struct Eq_34 * d0_112 = OpenLibrary(0x12BC, 0x00);
 	if (d0_112 != null)
 	{
 		int32 d4_463;
-		*&globals->ptr3D78 = (struct Eq_34 **) d0_112;
+		globals->ptr3D78 = d0_112;
 		if (d0_19->ptr00AC == null)
 		{
 			d4_463 = 0x02;
@@ -69,8 +69,8 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 			if (d0_151 == null)
 			{
 				fn00001214(d0_19);
-				*&globals->ptr3D7C = (struct Eq_70 **) d0_151;
-				*&globals->ptr3D80 = (struct Eq_70 **) d0_151;
+				globals->ptr3D7C = d0_151;
+				globals->ptr3D80 = d0_151;
 				Mem404[0x00:word32] = 0x00;
 				dwLoc14_158 = d0_151;
 				ui32 d0_407 = d0_151[0x0024];
@@ -94,7 +94,7 @@ void fn00001000(int32 d0, int32 d7, byte * a0)
 				word32 d0_435 = ((word32[]) 0x08)[d0_407];
 				if (d0_435 != 0x00)
 					d0_19->dw00A4 = d0_435;
-				a6_161 = (struct Eq_120 *) *&globals->ptr3D74;
+				a6_161 = globals->ptr3D74;
 l000011F8:
 				a0_163 = d0_19->dw003A;
 				goto l00001202;
@@ -191,7 +191,7 @@ l00001148:
 			*&globals->dw3D84 = d0_229;
 			execPrivate5();
 			*&globals->dw3D88 = d0_229;
-			a6_161 = (struct Eq_120 *) *&globals->ptr3D74;
+			a6_161 = globals->ptr3D74;
 			dwLoc14_158 = d0_132 + 0x0010;
 			dwLoc18 = d3_234;
 			if (a6_161[0x0014] >= 0x24)
@@ -1353,7 +1353,7 @@ Eq_34 * fn00002184(word32 dwArg04, word32 dwArg08, ptr32 & d1Out, ptr32 & a0Out)
 {
 	*d1Out = d1;
 	struct Eq_34 * d0_45;
-	struct Eq_3206 * a0_31 = *&globals->ptr3D74;
+	struct Eq_3206 * a0_31 = globals->ptr3D74;
 	*a0Out = a0_31;
 	if (a0_31->w0014 >= 0x27)
 	{
@@ -1445,7 +1445,7 @@ word32 fn000022A8(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & d1Out,
 	*a1Out = a1;
 	*d1Out = d1;
 	word32 d0_30;
-	struct Eq_3405 * a0_19 = *&globals->ptr3D74;
+	struct Eq_3405 * a0_19 = globals->ptr3D74;
 	*a0Out = a0_19;
 	if (a0_19->w0014 >= 0x27)
 	{

--- a/subjects/PDP-11/space.c
+++ b/subjects/PDP-11/space.c
@@ -6,7 +6,7 @@
 
 word16 fn0216(word16 r4, ptr16 & r2Out, ptr16 & r3Out, ptr16 & r4Out)
 {
-	<anonymous> * r0_4 = *&globals->ptr1DAA;
+	<anonymous> * r0_4 = globals->ptr1DAA;
 	if (r0_4 != null)
 	{
 		word16 sp_297;
@@ -200,7 +200,7 @@ void fn0A62(Eq_496 * r0)
 Eq_520 * fn0AE0(Eq_520 * r3, Eq_521 r4, word16 wArg00, word16 wArg01, word16 wArg02, ptr16 wArg04, ptr16 wArg06, ptr16 & r4Out)
 {
 	Eq_528 wLoc04_11 = (word16) bArg00;
-	struct Eq_531 * r3_6 = *&globals->ptr5424;
+	struct Eq_531 * r3_6 = globals->ptr5424;
 	if (0x01 - wLoc04_11 != 0x00 && 0x08 - wLoc04_11 != 0x00)
 		wLoc04_11 = wLoc04_11;
 	byte NZVC_19 = cond(wArg01 - wArg00);
@@ -255,7 +255,7 @@ Eq_520 * fn0AE0(Eq_520 * r3, Eq_521 r4, word16 wArg00, word16 wArg01, word16 wAr
 Eq_496 * fn0B42(Eq_496 * r0, Eq_520 * r3, word16 wArg00, word16 wArg01, word16 wArg02, ptr16 ptrArg04, ptr16 ptrArg06, ptr16 & r3Out)
 {
 	Eq_616 wLoc04_11 = (word16) bArg00;
-	struct Eq_619 * r3_6 = *&globals->ptr5424;
+	struct Eq_619 * r3_6 = globals->ptr5424;
 	if (0x01 - wLoc04_11 != 0x00 && 0x08 - wLoc04_11 != 0x00)
 		wLoc04_11 = wLoc04_11;
 	<anonymous> ** sp_119;
@@ -284,7 +284,7 @@ l0BC6:
 		(*sp_119)();
 		*(sp_56 - 0x02) = r3_57;
 		*(sp_56 - 0x04) = r0_65;
-		struct Eq_713 * r3_71 = *&globals->ptr5424;
+		struct Eq_713 * r3_71 = globals->ptr5424;
 		r3_71->w0044 = r3_71->w0044 + (int16) r3_71->b0053;
 		r3_71->w005A = r3_71->w005A - 0x01;
 		sp_151 = sp_56 - 0x02;
@@ -429,7 +429,7 @@ Eq_520 * fn0EA6(Eq_520 * r3, word16 wArg00)
 ci16 fn0EF6(ci16 r0, Eq_1040 * r4, word16 * r5, word16 wArg00, byte bArg01, ptr16 & r2Out, ptr16 & r3Out, ptr16 & r4Out, ptr16 & r5Out)
 {
 	struct Eq_1048 * v11_10 = r4->ptr0000;
-	struct Eq_1052 * r3_13 = *&globals->ptr5424;
+	struct Eq_1052 * r3_13 = globals->ptr5424;
 	r3_13->w0000 = 0x00;
 	r3_13->ptr000E = fp - 0x07;
 	word16 v32_34 = *r5;
@@ -474,7 +474,7 @@ l0F2C:
 		word16 r2_107;
 		byte NZV_108;
 		r4->ptr0002();
-		struct Eq_1130 * r4_117 = *&globals->ptr5424;
+		struct Eq_1130 * r4_117 = globals->ptr5424;
 		*r4Out = r4_117;
 		r4_117->w0000 = wLoc04;
 		r4_117->w000E = wLoc02;
@@ -511,14 +511,14 @@ void fn0F9A()
 cui16 * * fn0FA2(Eq_496 * r0, cui16 * * r2, word16 wArg00, word16 wArg02, ptr16 ptrArg04, ptr16 ptrArg06, ptr16 & r3Out)
 {
 	**(r2 - 0x02) = *(r2 - 0x02);
-	struct Eq_1184 * r3_18 = *&globals->ptr5424;
+	struct Eq_1184 * r3_18 = globals->ptr5424;
 	r3_18->ptr0064 = fp + 0x08;
 	if (r3_18->w0014 != 0x00)
 		__syscall(0x899A);
 	r3_18->w0014 = 0x1020;
 	r3_18->w001C = wArg02;
 	struct Eq_794 * r0_47 = fn123A(r0);
-	struct Eq_1211 * r3_48 = *&globals->ptr5424;
+	struct Eq_1211 * r3_48 = globals->ptr5424;
 	r3_48->w001A = r3_48->w001C;
 	r3_48->w0018 = r3_48->w001C;
 	r3_48->w0012 = wArg00;
@@ -981,7 +981,7 @@ l2406:
 	*&globals->w2416 = *&globals->w2416 + 0x01
 	*&globals->w241A = -*&globals->w241A
 	*&globals->w241E = *&globals->w241E + 0x01
-	r0_116 = (struct Eq_496 *) *&globals->ptr54C2
+	r0_116 = globals->ptr54C2
 	branch r0_116 != null l2428
 	goto l1E52
 l2428:

--- a/subjects/regressions/reko-351/a.c
+++ b/subjects/regressions/reko-351/a.c
@@ -227,7 +227,7 @@ void _sin(real64 rArg04, real64 rArg0C, Eq_231 tArg14)
 
 void __do_global_ctors_aux()
 {
-	<anonymous> * a0_12 = *&globals->ptr8000270C;
+	<anonymous> * a0_12 = globals->ptr8000270C;
 	if (-0x01 - a0_12 != 0x00)
 	{
 		do


### PR DESCRIPTION
- Create unit tests for `ComplexExpressionBuilder`
- Modify `ComplexExpressionBuilder`: return `<expression>` instead of `*&<expression>`