### PR TITLE
SignatureGuesser throws NullReferenceException

### DIFF
--- a/src/Environments/Windows/SignatureGuesser.cs
+++ b/src/Environments/Windows/SignatureGuesser.cs
@@ -59,7 +59,9 @@ namespace Reko.Environments.Windows
                 }
                 else
                 {
-                    var dt = field.Item2.Accept(loader);
+                    var dt = (field.Item2 == null) ?
+                        new UnknownType() :
+                        field.Item2.Accept(loader);
                     return Tuple.Create(field.Item1, dt, field.Item3);
                 }
             }

--- a/src/UnitTests/Environments/Windows/Win32PlatformTests.cs
+++ b/src/UnitTests/Environments/Windows/Win32PlatformTests.cs
@@ -223,5 +223,16 @@ namespace Reko.UnitTests.Environments.Windows
             Assert.AreEqual("__int64",  win32.GetPrimitiveTypeName(PrimitiveType.Int64, "C"));
             Assert.AreEqual("unsigned __int64",  win32.GetPrimitiveTypeName(PrimitiveType.UInt64, "C"));
         }
+
+        [Test]
+        public void Win32_VtblFromMsMangledName()
+        {
+            Given_TypeLibraryLoaderService();
+            Given_Configuration_With_Win32_Element();
+            When_Creating_Win32_Platform();
+
+            var type = win32.DataTypeFromImportName("??_7Scope@@6B@");
+            Assert.IsInstanceOf<UnknownType>(type.Item2);
+        }
     }
 }


### PR DESCRIPTION
Microsoft mangled name parser is really great thing. It allows to process a lot of external global variables and signatures without user help.
But `SignatureGuesser` throws exception for virtual tables.