### PR TITLE
Crash fix: handle --entry commandline switch for cmdline driver correctly

### DIFF
--- a/src/Arch/M68k/M68kDisassembler.cs
+++ b/src/Arch/M68k/M68kDisassembler.cs
@@ -1362,10 +1362,11 @@ namespace Reko.Arch.M68k
         {
             var new_pc = dasm.rdr.Address;
             dasm.LIMIT_CPU_TYPES(M68020_PLUS);
+            Opcode opcode = g_cpcc[dasm.instruction & 0x3f];
             return new M68kInstruction
             {
-                code = g_cpcc[dasm.instruction & 0x3f],
-                op1 = new M68kAddressOperand(new_pc + dasm.rdr.ReadBeInt16())
+                code = opcode,
+                op1 = (opcode != Opcode.illegal) ? new M68kAddressOperand(new_pc + dasm.rdr.ReadBeInt16()) : null
             };
         }
 

--- a/src/Drivers/CmdLine/CmdLineDriver.cs
+++ b/src/Drivers/CmdLine/CmdLineDriver.cs
@@ -145,7 +145,7 @@ namespace Reko.CmdLine
                 ArchitectureName = (string)pArgs["--arch"],
                 PlatformName = (string)sEnv,
                 LoadAddress = (string)pArgs["--base"],
-                EntryPoint = new EntryPointElement { Address = (string)pArgs["--entry"] }
+                EntryPoint = null
             });
             dec.Project.Programs[0].EntryPoints.Add(
                 addrEntry,


### PR DESCRIPTION
Hi,

I'm new to this project. It appears to me that the commandline driver was broken about two weeks ago. Change ecf9829a249664ce933f26525c49668169e9660b contains a rearchitecting of the ILoader interface.

As part of this, the way that EntryPoint is specified has changed. It appears that the code flow in CmdLineDriver.cs first provides an EntryPoint to LoadRawImage() -- which will add an entry to the EntryPoints table -- and right after that it will explicitly add the same entrypoint (but with different parameters) to the same table.

- Running without the --entry cmdline parameter resulted in an unhandled exception when the code attempted to look up the non-existing variable pArgs["--entry"]
- Running with the --entry cmdline parameted resulted in an unhandled exception when the code attempted to add two entrypoints at the same address

The proposed fix here is to always let the cmdline driver add the entry point, as it has more information than LoadRawImage does about the user's processor architecture specification.

I have not run any unit tests / regression tests yet; not familiar with those.