### PR TITLE
680x0 disassembler bugfix: invalid cpBcc instructions no longer result in invalid M68kInstructions

### DIFF
--- a/src/Arch/M68k/M68kDisassembler.cs
+++ b/src/Arch/M68k/M68kDisassembler.cs
@@ -1362,10 +1362,11 @@ namespace Reko.Arch.M68k
         {
             var new_pc = dasm.rdr.Address;
             dasm.LIMIT_CPU_TYPES(M68020_PLUS);
+            Opcode opcode = g_cpcc[dasm.instruction & 0x3f];
             return new M68kInstruction
             {
-                code = g_cpcc[dasm.instruction & 0x3f],
-                op1 = new M68kAddressOperand(new_pc + dasm.rdr.ReadBeInt16())
+                code = opcode,
+                op1 = (opcode != Opcode.illegal) ? new M68kAddressOperand(new_pc + dasm.rdr.ReadBeInt16()) : null
             };
         }
 

--- a/src/UnitTests/Arch/M68k/M68kDisassemblerTests.cs
+++ b/src/UnitTests/Arch/M68k/M68kDisassemblerTests.cs
@@ -709,5 +709,14 @@ namespace Reko.UnitTests.Arch.M68k
         {
             RunTest("fbnge\t$100000E2", 0xF29C, 0x00E0);  
         }
+
+        [Test]
+        public void M68kdis_fbcc_illegalEncoding()
+        {
+            // This is an fbcc instruction, which uses an encoding
+            // which is not valid with a 68k FPU; it should
+            // decode to an illegal instruction
+            RunTest("illegal\t", 0xF2BC, 0x00E0);
+        }
     }
 }


### PR DESCRIPTION
Hi,

when disassembling a certain 68000 program ("p61con", The Player 6.1's module converter) I noticed that the GUI disassembler would throw an unhandled exception very quickly if I scrolled around a bit in the disassembly view window.

This change fixes a bug in one of the code paths which generate disassembled instructions. (The code that converted from disassembled instruction to string representation would trip itself up on it.) With the change in place I haven't noticed any unhandled exceptions when browsing that source code.

