### PR TITLE
ArrayAccess and Slice matching is not implemented

### DIFF
--- a/src/Core/Expressions/ExpressionMatcher.cs
+++ b/src/Core/Expressions/ExpressionMatcher.cs
@@ -131,6 +131,9 @@ namespace Reko.Core.Expressions
 
         bool ExpressionVisitor<bool>.VisitArrayAccess(ArrayAccess acc)
         {
+            var arrayP = p as ArrayAccess;
+            if (arrayP == null)
+                return false;
             throw new NotImplementedException();
         }
 
@@ -289,6 +292,9 @@ namespace Reko.Core.Expressions
 
         bool ExpressionVisitor<bool>.VisitSlice(Slice slice)
         {
+            var slicePat = p as Slice;
+            if (slicePat == null)
+                return false;
             throw new NotImplementedException();
         }
 

--- a/src/UnitTests/Evaluation/ExpressionMatcherTests.cs
+++ b/src/UnitTests/Evaluation/ExpressionMatcherTests.cs
@@ -121,6 +121,22 @@ namespace Reko.UnitTests.Evaluation
             Assert.AreEqual("ecx", matcher.CapturedExpression("q").ToString());
         }
 
+        [Test]
+        public void Emt_ArrayAccessMismatch()
+        {
+            var e = m.Array(PrimitiveType.Int32, Id("eax"), m.Word32(6));
+            Create(m.Word32(5));
+            Assert.IsFalse(matcher.Match(e));
+        }
+
+        [Test]
+        public void Emt_SliceMismatch()
+        {
+            var e = m.Slice(PrimitiveType.Int16, Id("eax"), 16);
+            Create(m.Word32(5));
+            Assert.IsFalse(matcher.Match(e));
+        }
+
         private Expression AnyC(string p)
         {
             return ExpressionMatcher.AnyConstant(p);


### PR DESCRIPTION
Create unit tests for `ExpressionMatcher`