### PR TITLE
IndirectCallExpander: use DefStatement rather than DefExpression to expand identifies

### DIFF
--- a/src/Decompiler/Analysis/IndirectCallRewriter.cs
+++ b/src/Decompiler/Analysis/IndirectCallRewriter.cs
@@ -209,8 +209,13 @@ namespace Reko.Analysis
             SsaIdentifier sid;
             if (ssa.Identifiers.TryGetValue(id, out sid))
             {
-                if (sid.DefExpression != null)
-                    return Expand(sid.DefExpression);
+                Assignment ass;
+                if (sid.DefStatement != null &&
+                    sid.DefStatement.Instruction.As(out ass) &&
+                    ass.Dst == id)
+                {
+                    return Expand(ass.Src);
+                }
             }
             return id;
         }


### PR DESCRIPTION
Use `DefStatement` rather than `DefExpression` to expand identifies