### PR TITLE
Do not enqueue procedure from user global marked as no-decompiled

### DIFF
--- a/src/Decompiler/Scanning/Scanner.cs
+++ b/src/Decompiler/Scanning/Scanner.cs
@@ -311,6 +311,8 @@ namespace Reko.Scanning
         {
             if (program.Procedures.ContainsKey(addr))
                 return; // Already scanned. Do nothing.
+            if (IsNoDecompiledProcedure(addr))
+                return;
             var proc = EnsureProcedure(addr, null);
             proc.Signature = (FunctionType)sig.Clone();
             queue.Enqueue(PriorityEntryPoint, new ProcedureWorkItem(this, program, addr, proc.Name));

--- a/src/UnitTests/Scanning/ScannerTests.cs
+++ b/src/UnitTests/Scanning/ScannerTests.cs
@@ -586,6 +586,31 @@ fn00001100_exit:
         }
 
         [Test]
+        public void Scanner_NoDecompiledProcedureFromUserGlobal()
+        {
+            Given_Program(Address.Ptr32(0x12314), new byte[20]);
+            program.User.Procedures.Add(
+                Address.Ptr32(0x12314),
+                new Procedure_v1()
+                {
+                    Decompile = false,
+                }
+            );
+
+            var sc = CreateScanner(program);
+            sc.EnqueueUserProcedure(
+                Address.Ptr32(0x12314),
+                FunctionType.Action());
+            sc.EnqueueUserProcedure(
+                Address.Ptr32(0x12324),
+                FunctionType.Action());
+            sc.ScanImage();
+
+            Assert.AreEqual(1, program.Procedures.Count);
+            Assert.AreEqual(0x12324, program.Procedures.Keys[0].Offset);
+        }
+
+        [Test]
         public void Scanner_EvenOdd()
         {
             var scan = CreateScanner(0x1000, 0x2000);


### PR DESCRIPTION
Create unit test for no-decompiled procedure from user global