### PR TITLE
ComplexExpressionBuilder: use FallbackExpression()

### DIFF
--- a/src/Decompiler/Typing/ComplexExpressionBuilder.cs
+++ b/src/Decompiler/Typing/ComplexExpressionBuilder.cs
@@ -329,7 +329,7 @@ namespace Reko.Typing
 
         public Expression VisitUnknownType(UnknownType ut)
         {
-            return expComplex;
+            return FallbackExpression();
         }
 
         public Expression VisitVoidType(VoidType voidType)

--- a/src/UnitTests/Typing/ComplexExpressionBuilderTests.cs
+++ b/src/UnitTests/Typing/ComplexExpressionBuilderTests.cs
@@ -204,6 +204,17 @@ namespace Reko.UnitTests.Typing
         }
 
         [Test]
+        public void CEB_BuildPointerToUnknown()
+        {
+            var id = new Identifier("id", PrimitiveType.Word32, null);
+            var index = new Identifier("index", PrimitiveType.Word32, null);
+            CreateTv(id, Ptr32(new UnknownType()), PrimitiveType.Word32);
+            var ceb = CreateBuilder(PrimitiveType.Word32, null, id, index, 0);
+            var e = ceb.BuildComplex(false);
+            Assert.AreEqual("(char *) id + index", e.ToString());
+        }
+
+        [Test]
         public void CEB_BuildUnionFetch()
         {
             var ptr = new Identifier("ptr", PrimitiveType.Word32, null);


### PR DESCRIPTION
Use `FallbackExpression()`  when we could not build appropriate C-like expression