### PR TITLE
Create SsaProcedureBuilder and use it in ValuePropagationTests

### DIFF
--- a/src/UnitTests/Mocks/SsaProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/SsaProcedureBuilder.cs
@@ -1,0 +1,127 @@
+﻿#region License
+/* 
+ * Copyright (C) 1999-2017 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using Reko.Analysis;
+using Reko.Core;
+using Reko.Core.Code;
+using Reko.Core.Expressions;
+using Reko.Core.Types;
+using System.Collections.Generic;
+
+namespace Reko.UnitTests.Mocks
+{
+    /// <summary>
+    /// Supports the building of a procedure in Static Single Assignment form.
+    /// </summary>
+    /// <remarks>
+    /// Some unit tests require procedure to be in Static Single Assignment
+    /// form. This class gives possibility to build it without ssa transforming
+    /// </remarks>
+    public class SsaProcedureBuilder : ProcedureBuilder
+    {
+        public SsaState Ssa { get; private set; }
+
+        public SsaProcedureBuilder() : base()
+        {
+            this.Ssa = new SsaState(Procedure, null);
+        }
+
+        private Identifier Reg(string name, PrimitiveType pt)
+        {
+            var r = new RegisterStorage(name, Ssa.Identifiers.Count, 0, pt);
+            var id = new Identifier(r.Name, r.DataType, r);
+            var sid = new SsaIdentifier(id, id, null, null, false);
+            Ssa.Identifiers.Add(id, sid);
+            return sid.Identifier;
+        }
+
+        public Identifier Reg32(string name)
+        {
+            return Reg(name, PrimitiveType.Word32);
+        }
+
+        public Identifier Reg16(string name)
+        {
+            return Reg(name, PrimitiveType.Word16);
+        }
+
+
+        public Identifier Reg8(string name)
+        {
+            return Reg(name, PrimitiveType.Byte);
+        }
+
+        public override Statement Emit(Instruction instr)
+        {
+            var stm = base.Emit(instr);
+            var ass = instr as Assignment;
+            if (ass != null)
+            {
+                Ssa.Identifiers[ass.Dst].DefStatement = stm;
+                Ssa.Identifiers[ass.Dst].DefExpression = ass.Src;
+            }
+            var phiAss = instr as PhiAssignment;
+            if (phiAss != null)
+            {
+                Ssa.Identifiers[phiAss.Dst].DefStatement = stm;
+                Ssa.Identifiers[phiAss.Dst].DefExpression = phiAss.Src;
+            }
+            Ssa.AddUses(stm);
+            return stm;
+        }
+
+        private void AddMemIdToSsa(MemoryAccess access)
+        {
+            var idOld = access.MemoryId;
+            var idNew = new MemoryIdentifier(Ssa.Identifiers.Count, idOld.DataType);
+            access.MemoryId = idNew;
+            var sid = new SsaIdentifier(idNew, idOld, null, null, false);
+            Ssa.Identifiers.Add(idNew, sid);
+        }
+
+        public new MemoryAccess LoadDw(Expression ea)
+        {
+            var access = base.LoadDw(ea);
+            AddMemIdToSsa(access);
+            return access;
+        }
+
+        public new SegmentedAccess SegMem(DataType dt, Expression basePtr, Expression ptr)
+        {
+            var access = base.SegMem(dt, basePtr, ptr);
+            AddMemIdToSsa(access);
+            return access;
+        }
+
+        public Statement Call(
+            Expression e,
+            int retSizeOnstack,
+            ICollection<Identifier> uses,
+            ICollection<Identifier> definitions)
+        {
+            var ci = new CallInstruction(e, new CallSite(retSizeOnstack, 0));
+            foreach (var use in uses)
+                ci.Uses.Add(new UseInstruction(use));
+            foreach (var def in definitions)
+                ci.Definitions.Add(new DefInstruction(def));
+            return Emit(ci);
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="ImageLoaders\IntelHex\HexLoaderTests.cs" />
     <Compile Include="Mocks\FakeTypeDeserializer.cs" />
     <Compile Include="Core\Analysis\PyBuildValueFormatParserTests.cs" />
+    <Compile Include="Mocks\SsaProcedureBuilder.cs" />
     <Compile Include="Mocks\XmlnsHidingWriter.cs" />
     <Compile Include="OsPath.cs" />
     <Compile Include="Analysis\AliasStateTests.cs" />


### PR DESCRIPTION
Create `SsaProcedureBuilder` and use it in `ValuePropagationTests`
`SsaProcedureBuilder` supports the building of a procedure in Static Single Assignment form.
Some unit tests require procedure to be in Static Single Assignment form. This class gives possibility
to build it without `ssa` transforming