### PR TITLE
Add unit test for missed fstsw sequence

### DIFF
--- a/src/Arch/X86/X86Rewriter.Fpu.cs
+++ b/src/Arch/X86/X86Rewriter.Fpu.cs
@@ -411,6 +411,7 @@ namespace Reko.Arch.X86
                 case Opcode.jz:
                     if (mask == 0x40) { Branch(ConditionCode.NE, nextInstr.op1); return true; }
                     if (mask == 0x41) { Branch(ConditionCode.GT, nextInstr.op1); return true; }
+                    if (mask == 0x01) { Branch(ConditionCode.GE, nextInstr.op1); return true; }
                     break;
                 case Opcode.jnz:
                     if (mask == 0x40) { Branch(ConditionCode.EQ, nextInstr.op1); return true; }
@@ -419,7 +420,7 @@ namespace Reko.Arch.X86
                     break;
                 }
 
-                return false;
+                throw new AddressCorrelatedException(nextInstr.Address, "Unexpected {0} fstsw mask for {1} opcode .", mask, nextInstr.code);
             }
             return false;
         }

--- a/src/UnitTests/Arch/Intel/RewriteFpuInstructionTests.cs
+++ b/src/UnitTests/Arch/Intel/RewriteFpuInstructionTests.cs
@@ -102,7 +102,7 @@ namespace Reko.UnitTests.Arch.Intel
         }
 
         [Test]
-        public void X86Rw_fstsw_ax_40_je()
+        public void X86Rw_fstsw_ax_40_jne()
         {
             BuildTest(m =>
             {
@@ -116,6 +116,23 @@ namespace Reko.UnitTests.Arch.Intel
                 "1|L--|SCZO = FPUF",
                 "2|T--|if (Test(EQ,FPUF)) branch 00010000"
                 );            
+        }
+
+        [Test]
+        public void X86Rw_fstsw_ax_01_je()
+        {
+            BuildTest(m =>
+            {
+                m.Label("foo");
+                m.Fstsw(m.ax);
+                m.Test(m.ah, 0x01);
+                m.Jz("foo");
+            });
+            AssertCode(
+                "0|L--|00010000(8): 2 instructions",
+                "1|L--|SCZO = FPUF",
+                "2|T--|if (Test(GE,FPUF)) branch 00010000"
+                );
         }
     }
 }


### PR DESCRIPTION
Following sequence was missed during working under #348
```
fstsw ax
text ah, 01
je <address>
```