### PR TITLE
X86 Rewriter rewrites fdivr incorrectly

### DIFF
--- a/src/Arch/X86/X86Rewriter.Fpu.cs
+++ b/src/Arch/X86/X86Rewriter.Fpu.cs
@@ -56,18 +56,12 @@ namespace Reko.Arch.X86
                 {
                     // implicit st(0) operand.
                     Identifier opLeft = FpuRegister(0);
-                    Expression opRight = SrcOp(instrCur.op1);
-                    if (fReversed)
-                    {
-                        EmitCopy(
-                            instrCur.op1, 
-                            op(opRight, MaybeCast(cast, opLeft)),
-                            CopyFlags.ForceBreak);
-                    }
-                    else
-                    {
-                        emitter.Assign(opLeft, op(opLeft, MaybeCast(cast, opRight)));
-                    }
+                    Expression opRight = MaybeCast(cast, SrcOp(instrCur.op1));
+                    emitter.Assign(
+                        opLeft,
+                        op(
+                            fReversed ? opRight : opLeft,
+                            fReversed ? opLeft : opRight));
                     break;
                 }
             case 2:

--- a/src/UnitTests/Arch/Intel/X86RewriterTests.cs
+++ b/src/UnitTests/Arch/Intel/X86RewriterTests.cs
@@ -1447,5 +1447,14 @@ namespace Reko.UnitTests.Arch.Intel
                 "0|L--|10000000(4): 1 instructions",
                 "1|L--|Mem0[edi - 0x0000007D + eax * 0x00000002:real80] = (real80) rArg0");
         }
+
+        [Test]
+        public void X86rw_fdivr()
+        {
+            Run32bitTest(0xDC, 0x3D, 0x78, 0x56, 0x34, 0x12); // fdivr [12345678]
+            AssertCode(
+                "0|L--|10000000(6): 1 instructions",
+                "1|L--|rArg0 = Mem0[0x12345678:real64] / rArg0");
+        }
     }
 }


### PR DESCRIPTION
`fdivr arg` was rewritten to `arg = arg / st(0)`. Should be `st(0) = arg / st(0)`