### PR TITLE
Reko does not show warning for not found import procedure which name started with underscore

### DIFF
--- a/src/Core/ImportReference.cs
+++ b/src/Core/ImportReference.cs
@@ -107,7 +107,11 @@ namespace Reko.Core
             // Can we guess at the signature?
             ep = platform.SignatureFromName(ImportName);
             if (ep != null)
+            {
+                if (!ep.Signature.ParametersValid)
+                    ctx.Warn("Unable to guess parameters of {0}.", this);
                 return ep;
+            }
             
             ctx.Warn("Unable to resolve imported reference {0}.", this);
             return new ExternalProcedure(this.ToString(), null);

--- a/src/UnitTests/Arch/Intel/Rewrite32.cs
+++ b/src/UnitTests/Arch/Intel/Rewrite32.cs
@@ -42,11 +42,13 @@ namespace Reko.UnitTests.Arch.Intel
         private Win32Platform win32;
         private IntelArchitecture arch;
         private IServiceProvider services;
+        private FakeDecompilerEventListener eventListener;
 
         [SetUp]
         public void Setup()
         {
             mr = new MockRepository();
+            eventListener = new FakeDecompilerEventListener();
             this.services = mr.Stub<IServiceProvider>();
             var tlSvc = new TypeLibraryLoaderServiceImpl(services);
             var configSvc = mr.StrictMock<IConfigurationService>();
@@ -63,7 +65,7 @@ namespace Reko.UnitTests.Arch.Intel
                 .Do(new Func<string[], string>(s => string.Join("/", s)));
             services.Stub(s => s.GetService(typeof(ITypeLibraryLoaderService))).Return(tlSvc);
             services.Stub(s => s.GetService(typeof(IConfigurationService))).Return(configSvc);
-            services.Stub(s => s.GetService(typeof(DecompilerEventListener))).Return(new FakeDecompilerEventListener());
+            services.Stub(s => s.GetService(typeof(DecompilerEventListener))).Return(eventListener);
             services.Stub(s => s.GetService(typeof(CancellationTokenSource))).Return(null);
             services.Stub(s => s.GetService(typeof(IFileSystemService))).Return(new FileSystemServiceImpl());
             services.Stub(s => s.GetService(typeof(IDiagnosticsService))).Return(new FakeDiagnosticsService());
@@ -133,7 +135,16 @@ namespace Reko.UnitTests.Arch.Intel
 			RunTest("Fragments/switch32.asm", "Intel/RwSwitch32.txt");
 		}
 
-		private void RunTest(string sourceFile, string outputFile)
+        [Test]
+        public void RwNotFoundImport()
+        {
+            RunTest("Fragments/import32/not_found_import.asm", "Intel/RwNotFoundImport.txt");
+            Assert.AreEqual(
+                "WarningDiagnostic - 10000014 - Unable to guess parameters of msvcrt!_not_found_import.",
+                eventListener.LastDiagnostic);
+        }
+
+        private void RunTest(string sourceFile, string outputFile)
 		{
 			Program program;
             var asm = new X86TextAssembler(services, new X86ArchitectureFlat32());
@@ -149,7 +160,7 @@ namespace Reko.UnitTests.Arch.Intel
             var project = new Project { Programs = { program } };
             Scanner scan = new Scanner(
                 program,
-                new ImportResolver(project, program, new FakeDecompilerEventListener()),
+                new ImportResolver(project, program, eventListener),
                 services);
             foreach (var ep in asm.EntryPoints)
             {

--- a/src/tests/Fragments/import32/not_found_import.asm
+++ b/src/tests/Fragments/import32/not_found_import.asm
@@ -1,0 +1,14 @@
+
+.i386
+main proc
+	mov edi,0x10001212
+	fld qword ptr [edi+0x04]
+	fld qword ptr [edi+0x0C]
+	call dword ptr [_not_found_import]
+	mov [edi+0x14],eax
+	call dword ptr [_not_found_import]
+	mov [edi+0x1C],eax
+	ret
+main endp
+
+_not_found_import	.import '_not_found_import','msvcrt.dll'

--- a/src/tests/Intel/RwNotFoundImport.exp
+++ b/src/tests/Intel/RwNotFoundImport.exp
@@ -1,0 +1,28 @@
+// fn10000000
+// Return size: 4
+// Mem0:Global memory
+// fp:fp
+// esp:esp
+// edi:edi
+// rLoc1:FPU stack
+// rLoc2:FPU stack
+// eax:eax
+// return address size: 4
+void fn10000000()
+fn10000000_entry:
+	// succ:  l10000000
+l10000000:
+	esp = fp
+	edi = 0x10001212
+	rLoc1 = Mem0[edi + 0x00000004:real64]
+	rLoc2 = Mem0[edi + 0x0000000C:real64]
+	call not_found_import (retsize: 4; FPU: 2;)
+	esp = esp + 0xFFFFFFFC
+	Mem0[edi + 0x00000014:word32] = eax
+	call not_found_import (retsize: 4; FPU: 2;)
+	esp = esp + 0xFFFFFFFC
+	Mem0[edi + 0x0000001C:word32] = eax
+	return
+	// succ:  fn10000000_exit
+fn10000000_exit:
+


### PR DESCRIPTION
`Reko` does not show warning for not found import procedure which name started with underscore

