### PR TITLE
WIP: MSBuild support for VS for Mac/Linux (Mono)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 solution: src/Reko-decompiler.sln
 install:
   - nuget restore src/Reko-decompiler.sln
-  - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
+  - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory src/testrunner
 
 script:
   - msbuild /p:Configuration=TravisRelease src/Reko-decompiler.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
 
 script:
-  - xbuild /p:Configuration=TravisRelease src/Reko-decompiler.sln
+  - msbuild /p:Configuration=TravisRelease src/Reko-decompiler.sln
   - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe ./src/tools/c2xml/bin/TravisRelease/c2xml.exe -exclude=UserInterface,FailedTests
   - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe ./src/UnitTests/bin/TravisRelease/Reko.UnitTests.dll -exclude=UserInterface,FailedTests
   - cd subjects; python regressionTests.py --check-output --configuration=TravisRelease

--- a/README.md
+++ b/README.md
@@ -26,37 +26,11 @@ To build reko, start by cloning https://github.com/uxmal/reko. You
 can use an IDE or the command line to build the solution file
 `Reko-decompiler.sln`. If you are an IDE user, use Visual
 Studio 2013 or later, or MonoDevelop version 5.10 or later. If you
-wish to build using the command line, use the commands
+wish to build using the command line, use the command:
 
 ```cmd
 msbuild Reko-decompiler.sln
 ```
-
-on Windows machines or
-
-```sh
-xbuild Reko-decompiler.sln
-```
-
-on machines with the Mono toolchain. All external dependencies
-needed to build are included in the `external` directory.
-
-**Note**: some users have reported difficulties with certain
-Linux distributions that don't support the 4.0 CLR framework
-(see issue #251 for details). One workaround that has been
-identified is to specify the CLR target framework explicitly
-at the xbuild command line:
-
-```sh
-xbuild /p:TargetFrameworkVersion="v4.5"  Reko-decompiler.sln
-```
-
-You may be able to work around the problem reported in issue #251
-by downloading the appropriate Mono CLR binaries from
-git://github.com/mono/reference-assemblies.git
-
-**Note**: please let us know if you still are not able to compile,
-so we can help you fix the issue.
 
 ### Warnings and errors related to WiX
 


### PR DESCRIPTION
This PR introduces the use of the new MSBuild system, but cannot be merged until https://developercommunity.visualstudio.com/content/problem/54843/error-msb4019-microsoftwebapplicationtargets-was-n.html is resolved.