### PR TITLE
Move data type deserialisation from SignaturGuesser to ImportResolver

### DIFF
--- a/src/Core/ImportReference.cs
+++ b/src/Core/ImportReference.cs
@@ -83,16 +83,7 @@ namespace Reko.Core
             IPlatform platform,
             AddressContext ctx)
         {
-            var global = resolver.ResolveImport(ModuleName, ImportName, platform);
-            if (global != null)
-                return global;
-            var t = platform.DataTypeFromImportName(ImportName);
-            //$REVIEW: the way imported symbols are resolved as 
-            // globals or functions needs a revisit.
-            if (t != null && !(t.Item2 is FunctionType))
-                return new Identifier(t.Item1, t.Item2, new MemoryStorage());
-            else
-                return null;
+            return resolver.ResolveImport(ModuleName, ImportName, platform);
         }
 
         public override ExternalProcedure ResolveImportedProcedure(
@@ -102,28 +93,13 @@ namespace Reko.Core
         {
             var ep = resolver.ResolveProcedure(ModuleName, ImportName, platform);
             if (ep != null)
-                return ep;
-            // Can we guess at the signature?
-            ep = platform.SignatureFromName(ImportName);
-            if (ep != null)
             {
-                if (!ep.Signature.ParametersValid)
-                {
-                    // We found a imported procedure but couldn't find its signature.
-                    // Perhaps it has been mangled, and we can use the stripped name.
-                    var epNew = resolver.ResolveProcedure(null, ep.Name, platform);
-                    if (epNew != null)
-                    {
-                        ep = epNew;
-                    }
-                }
                 if (!ep.Signature.ParametersValid)
                 {
                     ctx.Warn("Unable to guess parameters of {0}.", this);
                 }
                 return ep;
             }
-            
             ctx.Warn("Unable to resolve imported reference {0}.", this);
             return new ExternalProcedure(this.ToString(), null);
         }

--- a/src/Core/ImportResolver.cs
+++ b/src/Core/ImportResolver.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Reko.Core.Expressions;
+using Reko.Core.Serialization;
 using Reko.Core.Services;
 using Reko.Core.Types;
 using Reko.Core.Operators;
@@ -144,8 +145,14 @@ namespace Reko.Core
             var t = platform.DataTypeFromImportName(name);
             //$REVIEW: the way imported symbols are resolved as 
             // globals or functions needs a revisit.
-            if (t != null && !(t.Item2 is FunctionType))
-                return new Identifier(t.Item1, t.Item2, new MemoryStorage());
+            if (t != null && !(t.Item2 is SerializedSignature))
+            {
+                var dSer = program.CreateTypeLibraryDeserializer();
+                var dt = (t.Item2 == null) ?
+                    new UnknownType() :
+                    t.Item2.Accept(dSer);
+                return new Identifier(t.Item1, dt, new MemoryStorage());
+            }
             else
                 return null;
         }

--- a/src/Core/Platform.cs
+++ b/src/Core/Platform.cs
@@ -145,7 +145,7 @@ namespace Reko.Core
         bool TryParseAddress(string sAddress, out Address addr);
         Dictionary<string, object> SaveUserOptions();
         ExternalProcedure SignatureFromName(string importName);
-        Tuple<string, DataType, SerializedType> DataTypeFromImportName(string importName);
+        Tuple<string, SerializedType, SerializedType> DataTypeFromImportName(string importName);
     }
 
     /// <summary>
@@ -421,7 +421,7 @@ namespace Reko.Core
             return null;
         }
 
-        public virtual Tuple<string, DataType, SerializedType> DataTypeFromImportName(string importName)
+        public virtual Tuple<string, SerializedType, SerializedType> DataTypeFromImportName(string importName)
         {
             return null;
         }

--- a/src/Environments/Windows/SignatureGuesser.cs
+++ b/src/Environments/Windows/SignatureGuesser.cs
@@ -31,7 +31,7 @@ namespace Reko.Environments.Windows
 {
     public class SignatureGuesser
     {
-        public static Tuple<string, DataType, SerializedType> InferTypeFromName(string fnName, TypeLibraryDeserializer loader, IPlatform platform)
+        public static Tuple<string, SerializedType, SerializedType> InferTypeFromName(string fnName)
         {
             if (fnName[0] == '?')
             {
@@ -47,23 +47,7 @@ namespace Reko.Environments.Windows
                     Debug.Print("*** Error parsing {0}. {1}", fnName, ex.Message);
                     return null;
                 }
-                var sproc = field.Item2 as SerializedSignature;
-                if (sproc != null)
-                {
-                    var sser = platform.CreateProcedureSerializer(loader, sproc.Convention);
-                    var sig = sser.Deserialize(sproc, platform.Architecture.CreateFrame());    //$BUGBUG: catch dupes?
-                    return new Tuple<string, DataType, SerializedType>(
-                        field.Item1,
-                        sig,
-                        field.Item3);
-                }
-                else
-                {
-                    var dt = (field.Item2 == null) ?
-                        new UnknownType() :
-                        field.Item2.Accept(loader);
-                    return Tuple.Create(field.Item1, dt, field.Item3);
-                }
+                return field;
             }
             return null;
         }

--- a/src/Environments/Windows/Win32Platform.cs
+++ b/src/Environments/Windows/Win32Platform.cs
@@ -277,13 +277,10 @@ namespace Reko.Environments.Windows
                 this);
         }
 
-        public override Tuple<string, DataType, SerializedType> DataTypeFromImportName(string importName)
+        public override Tuple<string, SerializedType, SerializedType> DataTypeFromImportName(string importName)
         {
             EnsureTypeLibraries(PlatformIdentifier);
-            return SignatureGuesser.InferTypeFromName(
-                importName,
-                new TypeLibraryDeserializer(this, true, Metadata),
-                this);
+            return SignatureGuesser.InferTypeFromName(importName);
         }
     }
 }

--- a/src/ImageLoaders/Llvm/LLVMPlatform.cs
+++ b/src/ImageLoaders/Llvm/LLVMPlatform.cs
@@ -94,7 +94,7 @@ namespace Reko.ImageLoaders.LLVM
             throw new NotImplementedException();
         }
 
-        public Tuple<string, DataType, SerializedType> DataTypeFromImportName(string importName)
+        public Tuple<string, SerializedType, SerializedType> DataTypeFromImportName(string importName)
         {
             throw new NotImplementedException();
         }

--- a/src/UnitTests/Core/ImportResolverTests.cs
+++ b/src/UnitTests/Core/ImportResolverTests.cs
@@ -233,5 +233,22 @@ namespace Reko.UnitTests.Core
             var dt = impres.ResolveImport("foo", "bar", platform);
             Assert.AreEqual("&bar", dt.ToString());
         }
+
+        [Test]
+        public void Impres_VtblFromMsMangledName()
+        {
+            var proj = new Project();
+            var impres = new ImportResolver(proj, program, new FakeDecompilerEventListener());
+            platform.Stub(p => p.ResolveImportByName(null, null)).
+                IgnoreArguments().Return(null);
+            SerializedType nullType = null;
+            platform.Stub(p => p.DataTypeFromImportName("??_7Scope@@6B@")).
+                Return(Tuple.Create("`vftable'", nullType, nullType));
+
+            var id = impres.ResolveImport("foo", "??_7Scope@@6B@", platform);
+
+            Assert.AreEqual("`vftable'", id.ToString());
+            Assert.IsInstanceOf<UnknownType>(id.DataType);
+        }
     }
 }

--- a/src/UnitTests/Environments/Windows/Win32PlatformTests.cs
+++ b/src/UnitTests/Environments/Windows/Win32PlatformTests.cs
@@ -232,7 +232,8 @@ namespace Reko.UnitTests.Environments.Windows
             When_Creating_Win32_Platform();
 
             var type = win32.DataTypeFromImportName("??_7Scope@@6B@");
-            Assert.IsInstanceOf<UnknownType>(type.Item2);
+
+            Assert.IsNull(type.Item2);
         }
     }
 }


### PR DESCRIPTION
Only platform-defined types could be resolved by `SignatureGuesser` now.
Move data type deserialisation from `SignatureGuesser` to `ImportResolver` so that user-defined types could be resolved.