### PR TITLE
Move signature deserialisation from SignatureGuesser to ImportResolver

### DIFF
--- a/src/Arch/X86/X86ProcedureSerializer.cs
+++ b/src/Arch/X86/X86ProcedureSerializer.cs
@@ -116,7 +116,9 @@ namespace Reko.Arch.X86
                 fpuDelta -= FpuStackOffset;
             }
             FpuStackOffset = fpuDelta;
-            var sig = new FunctionType(ret, args.ToArray());
+            var sig = ss.ParametersValid ?
+                new FunctionType(ret, args.ToArray()) :
+                new FunctionType();
             sig.IsInstanceMetod = ss.IsInstanceMethod;
             ApplyConvention(ss, sig);
             return sig;

--- a/src/Core/ImportResolver.cs
+++ b/src/Core/ImportResolver.cs
@@ -66,9 +66,11 @@ namespace Reko.Core
             if (ep != null)
                 return ep;
             // Can we guess at the signature?
-            ep = platform.SignatureFromName(importName);
-            if (ep != null)
+            var sProc = platform.SignatureFromName(importName);
+            if (sProc != null)
             {
+                var loader = program.CreateTypeLibraryDeserializer();
+                ep = loader.LoadExternalProcedure(sProc);
                 if (!ep.Signature.ParametersValid)
                 {
                     // We found a imported procedure but couldn't find its signature.

--- a/src/Core/Platform.cs
+++ b/src/Core/Platform.cs
@@ -144,7 +144,7 @@ namespace Reko.Core
         Address MakeAddressFromLinear(ulong uAddr);
         bool TryParseAddress(string sAddress, out Address addr);
         Dictionary<string, object> SaveUserOptions();
-        ExternalProcedure SignatureFromName(string importName);
+        ProcedureBase_v1 SignatureFromName(string importName);
         Tuple<string, SerializedType, SerializedType> DataTypeFromImportName(string importName);
     }
 
@@ -416,7 +416,7 @@ namespace Reko.Core
         /// </summary>
         /// <param name="fnName"></param>
         /// <returns>null if there is no way to guess a ProcedureSignature from the name.</returns>
-        public virtual ExternalProcedure SignatureFromName(string fnName)
+        public virtual ProcedureBase_v1 SignatureFromName(string fnName)
         {
             return null;
         }

--- a/src/Core/Serialization/ProcedureSerializer.cs
+++ b/src/Core/Serialization/ProcedureSerializer.cs
@@ -69,7 +69,10 @@ namespace Reko.Core.Serialization
         {
             SerializedSignature ssig = new SerializedSignature();
             if (!sig.ParametersValid)
+            {
+                ssig.ParametersValid = false;
                 return ssig;
+            }
             ArgumentSerializer argSer = new ArgumentSerializer(Architecture);
             ssig.ReturnValue = argSer.Serialize(sig.ReturnValue);
             ssig.Arguments = new Argument_v1[sig.Parameters.Length];

--- a/src/Core/Serialization/SerializedSignature.cs
+++ b/src/Core/Serialization/SerializedSignature.cs
@@ -61,6 +61,10 @@ namespace Reko.Core.Serialization
         [DefaultValue(0)]
         public int FpuStackDelta;
 
+        [XmlAttribute("parametersValid")]
+        [DefaultValue(true)]
+        public bool ParametersValid = true;
+
         public override T Accept<T>(ISerializedTypeVisitor<T> visitor)
         {
             return visitor.VisitSignature(this);

--- a/src/Core/TypeLibraryDeserializer.cs
+++ b/src/Core/TypeLibraryDeserializer.cs
@@ -180,7 +180,18 @@ namespace Reko.Core
         {
             return sType.Accept(this);
         }
-        
+
+        public ExternalProcedure LoadExternalProcedure(ProcedureBase_v1 sProc)
+        {
+            var sSig = sProc.Signature;
+            var sser = platform.CreateProcedureSerializer(this, this.defaultConvention);
+            var sig = sser.Deserialize(sSig, platform.Architecture.CreateFrame());    //$BUGBUG: catch dupes?
+            return new ExternalProcedure(sProc.Name, sig)
+            {
+                EnclosingType = sSig.EnclosingType
+            };
+        }
+
         public void ReadDefaults(SerializedLibraryDefaults defaults)
         {
             if (defaults == null)

--- a/src/Decompiler/Scanning/Scanner.cs
+++ b/src/Decompiler/Scanning/Scanner.cs
@@ -470,9 +470,11 @@ namespace Reko.Scanning
                 }
                 else if (sym.Name != null)
                 {
-                    var exp = program.Platform.SignatureFromName(sym.Name);
-                    if (exp != null)
+                    var sProc = program.Platform.SignatureFromName(sym.Name);
+                    if (sProc != null)
                     {
+                        var loader = Program.CreateTypeLibraryDeserializer();
+                        var exp = loader.LoadExternalProcedure(sProc);
                         proc.Name = exp.Name;
                         proc.Signature = exp.Signature;
                         proc.EnclosingType = exp.EnclosingType;

--- a/src/Decompiler/Scanning/ScannerBase.cs
+++ b/src/Decompiler/Scanning/ScannerBase.cs
@@ -70,9 +70,11 @@ namespace Reko.Scanning
             }
             if (procedureName != null)
             {
-                var exp = Program.Platform.SignatureFromName(procedureName);
-                if (exp != null)
+                var sProc = Program.Platform.SignatureFromName(procedureName);
+                if (sProc != null)
                 {
+                    var loader = Program.CreateTypeLibraryDeserializer();
+                    var exp = loader.LoadExternalProcedure(sProc);
                     proc.Name = exp.Name;
                     proc.Signature = exp.Signature;
                     proc.EnclosingType = exp.EnclosingType;

--- a/src/Environments/SysV/SysVPlatform.cs
+++ b/src/Environments/SysV/SysVPlatform.cs
@@ -199,7 +199,7 @@ namespace Reko.Environments.SysV
             return proc;
         }
 
-        public override ExternalProcedure SignatureFromName(string fnName)
+        public override ProcedureBase_v1 SignatureFromName(string fnName)
         {
             StructField_v1 field = null;
             try
@@ -217,12 +217,10 @@ namespace Reko.Environments.SysV
             var sproc = field.Type as SerializedSignature;
             if (sproc != null)
             {
-                var loader = new TypeLibraryDeserializer(this, false, Metadata);
-                var sser = this.CreateProcedureSerializer(loader, sproc.Convention);
-                var sig = sser.Deserialize(sproc, this.Architecture.CreateFrame());    //$BUGBUG: catch dupes?
-                return new ExternalProcedure(field.Name, sig)
+                return new Procedure_v1
                 {
-                    EnclosingType = sproc.EnclosingType
+                    Name = field.Name,
+                    Signature = sproc,
                 };
             }
             return null;

--- a/src/Environments/Windows/ModuleDefinitionLoader.cs
+++ b/src/Environments/Windows/ModuleDefinitionLoader.cs
@@ -126,7 +126,10 @@ namespace Reko.Environments.Windows
 
         private ExternalProcedure ParseSignature(string entryName, TypeLibraryDeserializer loader)
         {
-            return SignatureGuesser.SignatureFromName(entryName, loader, platform);
+            var sProc = SignatureGuesser.SignatureFromName(entryName, platform);
+            if (sProc == null)
+                return null;
+            return loader.LoadExternalProcedure(sProc);
         }
 
         private bool PeekAndDiscard(TokenType type)

--- a/src/Environments/Windows/Win16Platform.cs
+++ b/src/Environments/Windows/Win16Platform.cs
@@ -130,10 +130,9 @@ namespace Reko.Environments.Windows
             }
         }
 
-        public override ExternalProcedure SignatureFromName(string fnName)
+        public override ProcedureBase_v1 SignatureFromName(string fnName)
         {
-            var tlsvc = new TypeLibraryDeserializer(this, false, Metadata);
-            var sig = SignatureGuesser.SignatureFromName(fnName, tlsvc, this);
+            var sig = SignatureGuesser.SignatureFromName(fnName, this);
             return sig;
         }
     }

--- a/src/Environments/Windows/Win32Platform.cs
+++ b/src/Environments/Windows/Win32Platform.cs
@@ -268,13 +268,10 @@ namespace Reko.Environments.Windows
             get { return "__cdecl"; }
         }
 
-        public override ExternalProcedure SignatureFromName(string fnName)
+        public override ProcedureBase_v1 SignatureFromName(string fnName)
         {
             EnsureTypeLibraries(PlatformIdentifier); 
-            return SignatureGuesser.SignatureFromName(
-                fnName, 
-                new TypeLibraryDeserializer(this, true, Metadata),
-                this);
+            return SignatureGuesser.SignatureFromName(fnName, this);
         }
 
         public override Tuple<string, SerializedType, SerializedType> DataTypeFromImportName(string importName)

--- a/src/Environments/Windows/Win_x86_64_Platform.cs
+++ b/src/Environments/Windows/Win_x86_64_Platform.cs
@@ -176,12 +176,9 @@ namespace Reko.Environments.Windows
                 return null;
         }
 
-        public override ExternalProcedure SignatureFromName(string fnName)
+        public override ProcedureBase_v1 SignatureFromName(string fnName)
         {
-            return SignatureGuesser.SignatureFromName(
-                fnName,
-                new TypeLibraryDeserializer(this, true, Metadata),
-                this);
+            return SignatureGuesser.SignatureFromName(fnName, this);
         }
     }
 }

--- a/src/Environments/Windows/X86_64ProcedureSerializer.cs
+++ b/src/Environments/Windows/X86_64ProcedureSerializer.cs
@@ -94,6 +94,8 @@ namespace Reko.Environments.Windows
             if (d == null || d.Length == 0)
                 d = DefaultConvention;
             sig.StackDelta = Architecture.PointerType.Size;
+            if (ssig.StackDelta != 0)
+                sig.StackDelta = ssig.StackDelta;
             sig.ReturnAddressOnStack = Architecture.PointerType.Size;
         }
 

--- a/src/Environments/Windows/X86_64ProcedureSerializer.cs
+++ b/src/Environments/Windows/X86_64ProcedureSerializer.cs
@@ -133,7 +133,9 @@ namespace Reko.Environments.Windows
                     args.Add(arg);
                 }
             }
-            var sig = new FunctionType(ret, args.ToArray());
+            var sig = ss.ParametersValid ?
+                new FunctionType(ret, args.ToArray()) :
+                new FunctionType();
             sig.IsInstanceMetod = ss.IsInstanceMethod;
             ApplyConvention(ss, sig);
             return sig;

--- a/src/ImageLoaders/Llvm/LLVMPlatform.cs
+++ b/src/ImageLoaders/Llvm/LLVMPlatform.cs
@@ -194,7 +194,7 @@ namespace Reko.ImageLoaders.LLVM
             throw new NotImplementedException();
         }
 
-        public ExternalProcedure SignatureFromName(string importName)
+        public ProcedureBase_v1 SignatureFromName(string importName)
         {
             throw new NotImplementedException();
         }

--- a/src/UnitTests/Environments/Windows/Win32PlatformTests.cs
+++ b/src/UnitTests/Environments/Windows/Win32PlatformTests.cs
@@ -161,7 +161,12 @@ namespace Reko.UnitTests.Environments.Windows
             var fnName = "_foo@4";
             When_Creating_Win32_Platform();
 
-            var ep = win32.SignatureFromName(fnName);
+            var sProc = win32.SignatureFromName(fnName);
+            var loader = new TypeLibraryDeserializer(
+                win32,
+                false,
+                new TypeLibrary());
+            var ep = loader.LoadExternalProcedure(sProc);
 
             var sigExp =
 @"void foo()


### PR DESCRIPTION
Data type deserialisation was moved from `SignatureGuesser` to `ImportResolver` in 2aedc38 (see #458).
The same thing should be done for signature deserialisation
