### PR TITLE
Schwartz algorithm refines switches with irregular case exits incorrectly

### DIFF
--- a/src/Decompiler/Structure/StructureAnalysis.cs
+++ b/src/Decompiler/Structure/StructureAnalysis.cs
@@ -610,7 +610,7 @@ all other cases, together they constitute a Switch[].
             Region follow = null;
             foreach (var s in regionGraph.Successors(n))
             {
-                if (regionGraph.Predecessors(s).Count != 1)
+                if (regionGraph.Predecessors(s).Where(p => (p != n)).Any())
                     return null;
                 var ss = SingleSuccessor(s);
                 if (s.Type != RegionType.Tail)

--- a/src/Decompiler/Structure/StructureAnalysis.cs
+++ b/src/Decompiler/Structure/StructureAnalysis.cs
@@ -758,8 +758,12 @@ doing future pattern matches.
             regionGraph.RemoveEdge(vEdge.From, vEdge.To);
             if (regionGraph.Predecessors(vEdge.To).Count == 0 && vEdge.To != entry)
             {
-                //$BUGBUG: this causes losing of some code blocks
-                RemoveRegion(vEdge.To);
+                eventListener.Error(
+                    eventListener.CreateProcedureNavigator(program, proc),
+                    string.Format(
+                        "Removing edge ({0}, {1}) caused losing of some code blocks",
+                        vEdge.From.Block.Name,
+                        vEdge.To.Block.Name));
 
 
                 Probe();

--- a/src/Decompiler/Structure/StructureAnalysis.cs
+++ b/src/Decompiler/Structure/StructureAnalysis.cs
@@ -50,7 +50,6 @@ namespace Reko.Structure
         private DominatorGraph<Region> doms;
         private DominatorGraph<Region> postDoms;
         private Queue<Tuple<Region, ISet<Region>>> unresolvedCycles;
-        private Queue<Tuple<Region, ISet<Region>>> unresolvedNoncycles;
         private DecompilerEventListener eventListener;
 
         public StructureAnalysis(DecompilerEventListener listener, Program program, Procedure proc)
@@ -125,7 +124,6 @@ namespace Reko.Structure
                 oldCount = regionGraph.Nodes.Count;
                 this.doms = new DominatorGraph<Region>(this.regionGraph, result.Item2);
                 this.unresolvedCycles = new Queue<Tuple<Region, ISet<Region>>>();
-                this.unresolvedNoncycles = new Queue<Tuple<Region, ISet<Region>>>();
                 var postOrder = new DfsIterator<Region>(regionGraph).PostOrder(entry).ToList();
 
                 bool didReduce = false;
@@ -628,7 +626,6 @@ all other cases, together they constitute a Switch[].
             ISet<Region> unstructuredPreds = regionGraph.Predecessors(s).Where(p => p != n).ToHashSet();
             if (unstructuredPreds.Count == 0)
                 return false;
-            this.unresolvedNoncycles.Enqueue(Tuple.Create(n, unstructuredPreds));
             return true;
         }
 

--- a/src/Decompiler/Structure/StructureAnalysis.cs
+++ b/src/Decompiler/Structure/StructureAnalysis.cs
@@ -956,6 +956,9 @@ are added during loop refinement, which we discuss next.
                     return true;
                 }
             }
+            // Should be condition. Switches should not match a cyclic pattern
+            if (n.Type != RegionType.Condition)
+                return didReduce;
             foreach (var s in succs)
             {
                 if (SingleSuccessor(s) == n && SinglePredecessor(s) == n)

--- a/src/UnitTests/Structure/ProcedureStructurerTests.cs
+++ b/src/UnitTests/Structure/ProcedureStructurerTests.cs
@@ -630,6 +630,46 @@ target_2:
             RunTest(sExp, m.Procedure);
         }
 
+        [Test]
+        public void ProcStr_Switch_Fallthru_IrregularCaseExits()
+        {
+            var r1 = m.Reg32("r1", 1);
+
+            m.Label("head");
+            m.Switch(r1, "case_0", "case_1");
+
+            m.Label("case_0");
+            m.BranchIf(m.Fn("done"), "done");
+            m.Assign(r1, 2);
+            // Fallthru
+
+            m.Label("case_1");
+            m.Assign(r1, 1);
+            m.Goto("done");
+
+            m.Label("done");
+            m.Return(r1);
+
+            var sExp =
+@"    switch (r1)
+    {
+    case 0x00:
+        if (!done())
+        {
+            r1 = 0x02;
+            goto case_1;
+        }
+        break;
+    case 0x01:
+case_1:
+        r1 = 0x01;
+        break;
+    }
+    return r1;
+";
+            RunTest(sExp, m.Procedure);
+        }
+
         [Test(Description="A do-while with a nested if-then-else")]
         public void ProcStr_DoWhile_NestedIfElse()
         {

--- a/subjects/Elf-x86-64/ls.c
+++ b/subjects/Elf-x86-64/ls.c
@@ -3148,9 +3148,9 @@ l0000000000404A70:
 l0000000000404A78:
 	if (SZO_161)
 	{
-		if (al_100 != 0x00 && al_100 != 0x3A)
-			goto l0000000000404B60;
-		goto l0000000000404B4D;
+		if (al_100 == 0x00 || al_100 == 0x3A)
+			break;
+		goto l0000000000404B60;
 	}
 	if (al_100 != 0x5C)
 	{
@@ -3195,7 +3195,13 @@ l0000000000404B60:
 l0000000000404B29:
 	word32 eax_200 = (word32) Mem0[rax_106 + 0x00:byte];
 	byte al_202 = (byte) eax_200;
-	if (al_202 >u 0x78)
+	if (al_202 <=u 0x78)
+	{
+		rcx = DPB(rcx, (word32) al_202, 0);
+		rax_106 = 0x06;
+		eax_211 = 0x06;
+	}
+	else
 	{
 		r11_117 = (uint64) eax_200;
 		r11d_118 = (word32) r11_117;
@@ -3205,20 +3211,10 @@ l0000000000404B29:
 		r9_105 = r9_105 + 0x01;
 		rax_106 = 0x00;
 		eax_211 = 0x00;
-		goto l0000000000404BB0;
 	}
-	rcx = DPB(rcx, (word32) al_202, 0);
-	rax_106 = 0x06;
-	eax_211 = 0x06;
-	switch (rcx)
-	{
-	case 0x00:
-l0000000000404BB0:
-		r8_103 = r8_103 + 0x01;
-		if (eax_211 <=u 0x04)
-			goto l0000000000404A06;
-		break;
-	}
+	r8_103 = r8_103 + 0x01;
+	if (eax_211 <=u 0x04)
+		goto l0000000000404A06;
 l0000000000404A38:
 	Mem76[r15 + 0x00:word64] = r9_105;
 	Mem77[r14 + 0x00:word64] = r8_103;
@@ -13185,686 +13181,6 @@ word64 fn000000000040D8A0(word64 rcx, word64 rdx, word64 rsi, word64 rdi, word64
 	word32 ecx_1052;
 	__ctype_get_mb_cur_max();
 	byte al_101 = (byte) (uint64) ((word32) (uint64) ((word32) (uint64) ebx_64 >>u 0x01) & 0x01);
-	if (r14d_57 >u 0x08)
-		abort();
-	word64 rbx_1036;
-	word64 rax_108 = (uint64) r14d_57;
-	word64 r11_109 = rsi;
-	byte r11b_1015 = (byte) rsi;
-	word32 r11d_1016 = (word32) rsi;
-	switch (r14d_57)
-	{
-	case 0x00:
-		r14_1024 = 0x00;
-		rbx_1036 = 0x00;
-		break;
-	case 0x01:
-		rsi_1039 = 0x01;
-		rbx_1036 = 0x00;
-		break;
-	case 0x02:
-		if (al_101 == 0x00)
-		{
-			if (rsi != 0x00)
-			{
-				Mem1837[rdi + 0x00:byte] = 0x27;
-				rsi_1039 = 0x01;
-				rbx_1036 = 0x01;
-			}
-			else
-			{
-				rsi_1039 = 0x01;
-				rbx_1036 = 0x01;
-			}
-		}
-		else
-		{
-			rsi_1039 = 0x01;
-			rbx_1036 = 0x00;
-		}
-		break;
-	case 0x03:
-		if (al_101 == 0x00)
-			goto l000000000040DF5B;
-		goto l000000000040E428;
-	case 0x04:
-		rsi_1039 = 0x01;
-		rbx_1036 = 0x00;
-		break;
-	case 0x05:
-		r14_1024 = 0x00;
-		rbx_1036 = 0x00;
-		break;
-	case 0x06:
-	case 0x07:
-	case 0x08:
-		if (r14d_57 != 0x08)
-		{
-			word32 ebx_1968;
-			word64 rsp_1969;
-			word64 r8_1970;
-			word64 r12_1971;
-			word64 r13_1972;
-			word64 r15_1973;
-			word64 rax_1974 = fn000000000040D7B0((word32) (uint64) (word32) (uint64) r8d, 4284405, r8_80, r13_1332, r15_1025, fs_1009, out ebx_1968, out rsp_1969, out r8_1970, out r12_1971, out r13_1972, out r15_1973);
-			Mem1978[rsp_1969 + 0x70:word64] = rax_1974;
-			rsi_1039 = (uint64) ebx_1968;
-			word32 ebx_1979;
-			word64 r8_1981;
-			rax_108 = fn000000000040D7B0((word32) rsi_1039, 4287978, r8_1970, r13_1972, r15_1973, fs_1009, out ebx_1979, out rsp_1041, out r8_1981, out r12_1022, out r13_1332, out r15_1025);
-			r11_109 = Mem1978[rsp_1041 + 0x20:word64];
-			Mem1989[rsp_1041 + 0x68:word64] = rax_108;
-		}
-		rbx_1036 = 0x00;
-		if (Mem0[rsp_1041 + 0x33:byte] == 0x00)
-		{
-			word64 rdx_1931 = Mem0[rsp_1041 + 0x70:word64];
-			word32 eax_1935 = (word32) Mem0[rdx_1931 + 0x00:byte];
-			rax_108 = DPB(rax_108, eax_1935, 0);
-			byte al_1937 = (byte) eax_1935;
-			if (al_1937 != 0x00)
-			{
-				word64 rcx_1941 = Mem0[rsp_1041 + 0x28:word64];
-				ecx_1052 = (word32) rcx_1941;
-				do
-				{
-					if (rbx_1036 <u r11_109)
-						Mem1961[rcx_1941 + rbx_1036:byte] = al_1937;
-					rbx_1036 = rbx_1036 + 0x01;
-					word32 eax_1955 = (word32) Mem0[rdx_1931 + rbx_1036:byte];
-					rax_108 = DPB(rax_108, eax_1955, 0);
-					al_1937 = (byte) eax_1955;
-				} while (al_1937 != 0x00);
-			}
-		}
-		word64 rbp_1919 = Mem0[rsp_1041 + 0x68:word64];
-		Mem1920[rsp_1041 + 0x38:word64] = r11_109;
-		word64 rax_1923 = DPB(rax_108, strlen(rbp_1919), 0);
-		Mem1924[rsp_1041 + 0x60:word64] = rbp_1919;
-		Mem1927[rsp_1041 + 0x20:byte] = 0x01;
-		r11_109 = Mem1927[rsp_1041 + 0x38:word64];
-		r14_1024 = rax_1923;
-		r11b_1015 = (byte) r11_109;
-		r11d_1016 = (word32) r11_109;
-		break;
-	}
-l000000000040D960:
-	Mem209[rsp_1041 + 0x38:byte] = (byte) (uint64) ((word32) Mem0[rsp_1041 + 0x33:byte] ^ 0x01);
-	word64 rax_1031 = (uint64) ((word32) Mem209[rsp_1041 + 0x20:byte] ^ 0x01);
-	Mem216[rsp_1041 + 0x95:byte] = (byte) rax_1031;
-	word64 r9_1020;
-	*r9Out = r14_1024;
-	word64 rbp_1003 = 0x00;
-	*r14Out = r11_109;
-	word64 r8_1019;
-	*r8Out = r13_1332;
-l000000000040D986:
-	word64 rax_292;
-	byte al_1795 = rbp_1003 != r15_1025;
-	word64 rax_1720 = DPB(rax_1031, al_1795, 0);
-	if (r15_1025 == ~0x00)
-	{
-l000000000040DB76:
-		byte al_537 = Mem216[r8_1019 + rbp_1003:byte] != 0x00;
-		rax_1720 = DPB(rax_1720, al_537, 0);
-		if (al_537 == 0x00)
-			goto l000000000040DB86;
-		goto l000000000040D9A8;
-	}
-l000000000040D9A0:
-	if (al_1795 == 0x00)
-	{
-l000000000040DB86:
-		r11_109 = r14_1024;
-		*r11Out = r11_109;
-		r11b_1015 = (byte) r14_1024;
-		r11d_1016 = (word32) r14_1024;
-		r13_1332 = r8_1019;
-		*r13Out = r13_1332;
-		if (rbx_1036 != 0x00 || (Mem216[rsp_1041 + 0x34:word32] != 0x02 || Mem216[rsp_1041 + 0x33:byte] == 0x00))
-		{
-			if (Mem216[rsp_1041 + 0x33:byte] == 0x00 && Mem216[rsp_1041 + 0x60:word64] != 0x00)
-			{
-				word64 rdx_456 = Mem216[rsp_1041 + 0x60:word64];
-				byte al_462 = (byte) (word32) Mem216[rdx_456 + 0x00:byte];
-				if (al_462 != 0x00)
-				{
-					word64 rcx_466 = Mem216[rsp_1041 + 0x28:word64];
-					ecx_1052 = (word32) rcx_466;
-					word64 rdx_469 = rdx_456 - rbx_1036;
-					do
-					{
-						if (r14_1024 >u rbx_1036)
-							Mem492[rcx_466 + rbx_1036:byte] = al_462;
-						rbx_1036 = rbx_1036 + 0x01;
-						al_462 = (byte) (word32) Mem216[rdx_469 + rbx_1036:byte];
-					} while (al_462 != 0x00);
-				}
-			}
-			rax_292 = rbx_1036;
-			if (rbx_1036 <u r14_1024)
-				Mem453[Mem216[rsp_1041 + 0x28:word64] + rbx_1036:byte] = 0x00;
-l000000000040DC86:
-			if ((Mem216[rsp_1041 + 0xB8:word64] ^ Mem216[fs_1009:0x28:word64]) == 0x00)
-			{
-				word64 rsp_314 = Mem216[rsp_1041 + 0xD8:word64];
-				word64 rbp_316;
-				*rbpOut = Mem216[rsp_314 + 0x08:word64];
-				word64 rsp_322;
-				*rspOut = rsp_314 + 0x20;
-				return rax_292;
-			}
-			__stack_chk_fail();
-l000000000040E428:
-			Mem155[rsp_1041 + 0x20:byte] = 0x01;
-			Mem157[rsp_1041 + 0x60:word64] = 4284395;
-			rsi_1039 = 0x01;
-			rbx_1036 = 0x00;
-			goto l000000000040D960;
-		}
-		goto l000000000040DC46;
-	}
-l000000000040D9A8:
-	word64 r13_1725;
-	byte cl_585 = r9_1020 != 0x00;
-	ecx_1052 = DPB(ecx_1052, cl_585, 0);
-	if (r9_1020 != 0x00 && Mem216[rsp_1041 + 0x20:byte] != 0x00)
-	{
-		rax_1720 = rbp_1003 + r9_1020;
-		if (r15_1025 >=u rax_1720)
-		{
-			rsi_1039 = Mem216[rsp_1041 + 0x60:word64];
-			Mem1741[rsp_1041 + 0x50:word32] = ecx_1052;
-			Mem1742[rsp_1041 + 0x48:word64] = r8_1019;
-			Mem1744[rsp_1041 + 0x40:word64] = r9_1020;
-			r13_1725 = r8_1019 + rbp_1003;
-			word32 eax_1745 = memcmp(r13_1725, rsi_1039, r9_1020);
-			rax_1720 = DPB(rax_1720, eax_1745, 0);
-			*r9Out = Mem1744[rsp_1041 + 0x40:word64];
-			r8_1019 = Mem1744[rsp_1041 + 0x48:word64];
-			*r8Out = r8_1019;
-			if (eax_1745 == 0x00)
-			{
-				if (Mem1744[rsp_1041 + 0x33:byte] != 0x00)
-					goto l000000000040DC40;
-				rbx_1036 = 0x01;
-			}
-			else
-			{
-				r11b_1015 = 0x00;
-				r11d_1016 = 0x00;
-			}
-l000000000040DA20:
-			word32 r12d_1012 = (word32) Mem216[r13_1725 + 0x00:byte];
-			byte r12b_1013 = (byte) r12d_1012;
-			r12_1022 = DPB(r12_1022, r12d_1012, 0);
-			*r12Out = r12_1022;
-			if (r12b_1013 <=u 0x7E)
-			{
-				rax_1031 = DPB(rax_1720, (word32) r12b_1013, 0);
-				if (Mem216[rsp_1041 + 0x20:byte] != 0x00)
-				{
-					if (Mem216[rsp_1041 + 0x33:byte] != 0x00)
-						goto l000000000040DC40;
-					if (rbx_1036 <u r14_1024)
-						Mem999[Mem216[rsp_1041 + 0x28:word64] + rbx_1036:byte] = 0x5C;
-					rax_1031 = rbx_1036 + 0x01;
-					if (r15_1025 >u rbp_1003 + 0x01)
-					{
-						rsi_1039 = DPB(rsi_1039, (word32) Mem216[r8_1019 + 0x01 + rbp_1003:byte], 0);
-						if ((byte) (rsi_1039 - 0x30) <=u 0x09)
-						{
-							if (r14_1024 >u rax_1031)
-							{
-								rsi_1039 = Mem216[rsp_1041 + 0x28:word64];
-								Mem997[rsi_1039 + rax_1031:byte] = 0x30;
-							}
-							if (r14_1024 >u rbx_1036 + 0x02)
-								Mem995[Mem216[rsp_1041 + 0x28:word64] + 0x02 + rbx_1036:byte] = 0x30;
-							rax_1031 = rbx_1036 + 0x03;
-						}
-					}
-					rbx_1036 = rax_1031;
-					rsp_1041 = 0x30;
-l000000000040DB09:
-					word64 rdi_886 = Mem216[rsp_1041 + 88:word64];
-					if (rdi_886 != 0x00)
-					{
-						ecx_1052 = (word32) (uint64) r12d_1012;
-						word64 rdx_892 = (uint64) r12d_1012;
-						rax_1031 = (uint64) (0x01 << (byte) ((uint64) (ecx_1052 & 0x1F)));
-						if ((rdi_886[DPB(rdx_892, (word32) ((byte) rdx_892 >>u 0x05), 0) * 0x04] & (word32) rax_1031) != 0x00)
-						{
-l000000000040DB33:
-							if (Mem216[rsp_1041 + 0x33:byte] == 0x00)
-							{
-								if (rbx_1036 <u r14_1024)
-								{
-									rax_1031 = Mem216[rsp_1041 + 0x28:word64];
-									Mem805[rax_1031 + rbx_1036:byte] = 0x5C;
-								}
-								rbx_1036 = rbx_1036 + 0x01;
-l000000000040DB50:
-								rbp_1003 = rbp_1003 + 0x01;
-								goto l000000000040DB54;
-							}
-							goto l000000000040DC40;
-						}
-					}
-l000000000040DB2E:
-					if (r11b_1015 == 0x00)
-						goto l000000000040DB50;
-					goto l000000000040DB33;
-				}
-				if ((Mem216[rsp_1041 + 0x90:byte] & 0x01) != 0x00)
-				{
-					rbp_1003 = rbp_1003 + 0x01;
-					goto l000000000040D986;
-				}
-l000000000040DAF8:
-				if (Mem216[rsp_1041 + 0x38:byte] != 0x00 && Mem216[rsp_1041 + 0x95:byte] != 0x00)
-					goto l000000000040DB2E;
-				goto l000000000040DB09;
-			}
-			byte dl_1181;
-			word32 esi_1014;
-			byte dl_1028;
-			if (Mem216[rsp_1041 + 0x78:word64] == 0x01)
-			{
-				Mem1203[rsp_1041 + 0x50:word64] = r8_1019;
-				Mem1204[rsp_1041 + 0x48:word64] = r9_1020;
-				Mem1205[rsp_1041 + 0x40:word32] = r11d_1016;
-				word64 rdi_1207;
-				word64 rcx_1209;
-				word32 r14d_1211;
-				word32 r8d_1212;
-				word64 r13_1215;
-				word64 rdx_1216;
-				word32 ebx_1218;
-				word32 r9d_1219;
-				byte SCZO_1220;
-				word64 rax_1221;
-				word32 eax_1223;
-				byte SZO_1224;
-				byte C_1225;
-				byte al_1226;
-				byte CZ_1227;
-				word64 r11_1228;
-				byte Z_1230;
-				word32 edi_1231;
-				word64 r9_1232;
-				word32 ebp_1233;
-				word64 r8_1234;
-				byte cl_1235;
-				word32 edx_1239;
-				byte dl_1240;
-				byte r11b_1241;
-				word32 esp_1242;
-				word32 r11d_1243;
-				word16 dx_1244;
-				word64 r10_1246;
-				byte dil_1247;
-				byte sil_1248;
-				__ctype_b_loc();
-				word64 r11_1252 = (uint64) Mem1205[rsp_1041 + 0x40:word32];
-				word32 edx_1259 = (word32) Mem1205[rax_1221 + 0x00:word64][DPB(rdx_1216, (word32) r12b_1013, 0) * 0x02];
-				r11b_1015 = (byte) r11_1252;
-				r11d_1016 = (word32) r11_1252;
-				*r9Out = Mem1205[rsp_1041 + 0x48:word64];
-				*r8Out = Mem1205[rsp_1041 + 0x50:word64];
-				rax_1031 = 0x01;
-				dl_1181 = (byte) (uint64) ((word32) (uint64) (DPB(edx_1259, (word16) edx_1259 >>u 0x0E, 0) ^ 0x01) & 0x01);
-			}
-			else
-			{
-				Mem1276[rsp_1041 + 0xB0:word64] = 0x00;
-				if (r15_1025 == ~0x00)
-				{
-					Mem1707[rsp_1041 + 0x50:word64] = r9_1020;
-					Mem1708[rsp_1041 + 0x48:word32] = r11d_1016;
-					Mem1709[rsp_1041 + 0x40:word64] = r8_1019;
-					word64 rax_1711 = DPB(rax_1720, strlen(r8_1019), 0);
-					r9_1020 = Mem1709[rsp_1041 + 0x50:word64];
-					r15_1025 = rax_1711;
-					r11b_1015 = (byte) (uint64) Mem1709[rsp_1041 + 0x48:word32];
-				}
-				Mem1291[rsp_1041 + 0x80:word64] = rbx_1036;
-				Mem1292[rsp_1041 + 0x96:byte] = r12b_1013;
-				Mem1293[rsp_1041 + 0x98:word64] = r13_1725;
-				Mem1296[rsp_1041 + 0x48:word64] = rbp_1003;
-				Mem1297[rsp_1041 + 0x88:word64] = r9_1020;
-				Mem1301[rsp_1041 + 151:byte] = r11b_1015;
-				Mem1302[rsp_1041 + 0x50:word64] = r14_1024;
-				Mem1304[rsp_1041 + 0x40:word64] = r15_1025;
-				do
-				{
-					word64 r15_1325;
-					word64 rcx_1326;
-					word32 r14d_1328;
-					word32 r8d_1329;
-					word64 r14_1330;
-					word64 rbp_1331;
-					word64 rdx_1333;
-					word64 rbx_1334;
-					word32 ebx_1335;
-					word32 r9d_1336;
-					byte SCZO_1337;
-					word64 rax_1338;
-					word32 eax_1340;
-					byte SZO_1341;
-					byte C_1342;
-					byte al_1343;
-					byte CZ_1344;
-					word64 r11_1345;
-					byte Z_1347;
-					word32 edi_1348;
-					word64 r9_1349;
-					word32 ebp_1350;
-					word64 r8_1351;
-					byte cl_1352;
-					word32 r12d_1354;
-					byte r12b_1355;
-					word32 edx_1356;
-					byte dl_1357;
-					byte r11b_1358;
-					word32 esp_1359;
-					word32 r11d_1360;
-					word16 dx_1361;
-					word64 r12_1362;
-					word64 r10_1363;
-					byte dil_1364;
-					byte sil_1365;
-					word64 rdi_1324;
-					mbrtowc();
-					if (rax_1338 == 0x00)
-					{
-						r11d_1016 = (word32) Mem1304[rsp_1041 + 151:byte];
-						r12d_1012 = (word32) Mem1304[rsp_1041 + 0x96:byte];
-						rax_1031 = rbx_1334;
-						rbp_1003 = Mem1304[rsp_1041 + 0x48:word64];
-						*r9Out = Mem1304[rsp_1041 + 0x88:word64];
-						r11b_1015 = (byte) r11d_1016;
-						*r8Out = r13_1332;
-						rbx_1036 = Mem1304[rsp_1041 + 0x80:word64];
-						r12b_1013 = (byte) r12d_1012;
-						*r12Out = DPB(r12_1362, r12d_1012, 0);
-						dl_1181 = (byte) (uint64) ((word32) (uint64) r12d_1354 ^ 0x01);
-						*r14Out = Mem1304[rsp_1041 + 0x50:word64];
-						*r15Out = Mem1304[rsp_1041 + 0x40:word64];
-						goto l000000000040E22D;
-					}
-					if (rax_1338 == ~0x00)
-					{
-						r12d_1012 = (word32) Mem1304[rsp_1041 + 0x96:byte];
-						r11d_1016 = (word32) Mem1304[rsp_1041 + 151:byte];
-						rax_1031 = rbx_1334;
-						rbp_1003 = Mem1304[rsp_1041 + 0x48:word64];
-						*r9Out = Mem1304[rsp_1041 + 0x88:word64];
-						r12b_1013 = (byte) r12d_1012;
-						*r12Out = DPB(r12_1362, r12d_1012, 0);
-						r11b_1015 = (byte) r11d_1016;
-						*r8Out = r13_1332;
-						rbx_1036 = Mem1304[rsp_1041 + 0x80:word64];
-						*r14Out = Mem1304[rsp_1041 + 0x50:word64];
-						dl_1181 = 0x01;
-						*r15Out = Mem1304[rsp_1041 + 0x40:word64];
-						goto l000000000040E22D;
-					}
-					if (rax_1338 == ~0x01)
-					{
-						r12d_1012 = (word32) Mem1304[rsp_1041 + 0x96:byte];
-						r11d_1016 = (word32) Mem1304[rsp_1041 + 151:byte];
-						r15_1025 = Mem1304[rsp_1041 + 0x40:word64];
-						*r15Out = r15_1025;
-						rsi_1039 = r14_1330;
-						rax_1031 = rbx_1334;
-						*r8Out = r13_1332;
-						rbp_1003 = Mem1304[rsp_1041 + 0x48:word64];
-						*r9Out = Mem1304[rsp_1041 + 0x88:word64];
-						r12b_1013 = (byte) r12d_1012;
-						*r12Out = DPB(r12_1362, r12d_1012, 0);
-						r11b_1015 = (byte) r11d_1016;
-						rbx_1036 = Mem1304[rsp_1041 + 0x80:word64];
-						*r14Out = Mem1304[rsp_1041 + 0x50:word64];
-						word64 r13_1631 = Mem1304[rsp_1041 + 0x98:word64];
-						if (r15_1025 >u r14_1330)
-						{
-							if (Mem1304[rdx_1333 + 0x00:byte] != 0x00)
-							{
-								do
-									rax_1031 = rax_1031 + 0x01;
-								while (r15_1025 >u rbp_1003 + rax_1031 && Mem1304[r13_1631 + rax_1031:byte] != 0x00);
-							}
-						}
-						dl_1181 = 0x01;
-						goto l000000000040E22D;
-					}
-					if (Mem1304[rsp_1041 + 0x33:byte] != 0x00 && (Mem1304[rsp_1041 + 0x34:word32] == 0x02 && rax_1338 != 0x01))
-					{
-						word64 rdx_1561 = 0x01;
-						r15_1568 = r15_1325;
-						do
-						{
-							word64 r15_1568;
-							rdi_1324 = DPB(rdi_1324, (word32) Mem1304[r15_1568 + rdx_1561:byte], 0);
-							ecx_1052 = rdi_1324 - 0x5B;
-							byte cl_1583 = (byte) (rdi_1324 - 0x5B);
-							if (cl_1583 <=u 33)
-							{
-								r15_1568 = 0x2B;
-								if ((0x01 << cl_1583 & rdi_1324) != 0x00)
-								{
-									r11_109 = Mem1304[rsp_1041 + 0x50:word64];
-									r11b_1015 = (byte) r11_109;
-									r11d_1016 = (word32) r11_109;
-									r15_1025 = Mem1304[rsp_1041 + 0x40:word64];
-l000000000040DC46:
-									word64 rax_360 = Mem216[rsp_1041 + 0x68:word64];
-									word32 r9d_362 = (word32) (uint64) Mem216[rsp_1041 + 0x90:word32];
-									word64 r8_364 = (uint64) Mem216[rsp_1041 + 0x34:word32];
-									word64 rdi_366 = Mem216[rsp_1041 + 0x28:word64];
-									Mem368[rsp_1041 + 0x00:word64] = 0x00;
-									Mem370[rsp_1041 + 0x10:word64] = rax_360;
-									Mem376[rsp_1041 + 0x08:word64] = Mem370[rsp_1041 + 0x70:word64];
-									word64 rbp_379;
-									word64 r8_380;
-									word64 r9_381;
-									rax_292 = fn000000000040D8A0(r15_1025, r13_1332, r11_109, rdi_366, r8_364, (word32) (uint64) (r9d_362 & ~0x02), fs_1009, qwArg18, qwArg20, qwArg28, out rsp_1041, out rbp_379, out r8_380, out r9_381, out r11_109, out r12_1022, out r13_1332, out r14_1024, out r15_1025);
-									goto l000000000040DC86;
-								}
-							}
-							rdx_1561 = rdx_1561 + 0x01;
-						} while (rdx_1561 != rax_1338);
-					}
-					word64 rsp_1427;
-					word64 rdi_1428;
-					word64 r15_1429;
-					word64 rcx_1430;
-					word64 rsi_1431;
-					word32 r14d_1432;
-					word32 r8d_1433;
-					word64 r14_1434;
-					word64 rbp_1435;
-					word64 r13_1436;
-					word64 rdx_1437;
-					word64 rbx_1438;
-					word32 ebx_1439;
-					word32 r9d_1440;
-					byte SCZO_1441;
-					word64 rax_1442;
-					selector fs_1443;
-					word32 eax_1444;
-					byte SZO_1445;
-					byte C_1446;
-					byte al_1447;
-					byte CZ_1448;
-					word64 r11_1449;
-					word32 esi_1450;
-					byte Z_1451;
-					word32 edi_1452;
-					word64 r9_1453;
-					word32 ebp_1454;
-					word64 r8_1455;
-					byte cl_1456;
-					word32 ecx_1457;
-					word32 r12d_1458;
-					byte r12b_1459;
-					word32 edx_1460;
-					byte dl_1461;
-					byte r11b_1462;
-					word32 esp_1463;
-					word32 r11d_1464;
-					word16 dx_1465;
-					word64 r12_1466;
-					word64 r10_1467;
-					byte dil_1468;
-					byte sil_1469;
-					iswprint();
-					word64 rdi_1479;
-					word64 r15_1480;
-					word64 rcx_1481;
-					word64 rsi_1482;
-					word32 r14d_1483;
-					word32 r8d_1484;
-					word64 r14_1485;
-					word64 rbp_1486;
-					word64 r13_1487;
-					word64 rdx_1488;
-					word64 rbx_1489;
-					word32 ebx_1490;
-					word32 r9d_1491;
-					byte SCZO_1492;
-					word64 rax_1493;
-					word32 eax_1495;
-					byte SZO_1496;
-					byte C_1497;
-					byte al_1498;
-					byte CZ_1499;
-					word64 r11_1500;
-					word32 esi_1501;
-					byte Z_1502;
-					word32 edi_1503;
-					word64 r9_1504;
-					word32 ebp_1505;
-					word64 r8_1506;
-					byte cl_1507;
-					word32 r12d_1509;
-					byte r12b_1510;
-					word32 edx_1511;
-					byte dl_1512;
-					byte r11b_1513;
-					word32 esp_1514;
-					word32 r11d_1515;
-					word16 dx_1516;
-					word64 r12_1517;
-					word64 r10_1518;
-					byte dil_1519;
-					byte sil_1520;
-					mbsinit();
-				} while (0x00 == 0x00);
-				rsi_1039 = (uint64) r12d_1509;
-				r11d_1016 = (word32) Mem1304[rsp_1041 + 151:byte];
-				r12d_1012 = (word32) Mem1304[rsp_1041 + 0x96:byte];
-				esi_1014 = (word32) rsi_1039;
-				r11b_1015 = (byte) r11d_1016;
-				r12b_1013 = (byte) r12d_1012;
-				*r12Out = DPB(r12_1517, r12d_1012, 0);
-				rax_1031 = rbx_1489;
-				rbp_1003 = Mem1304[rsp_1041 + 0x48:word64];
-				*r9Out = Mem1304[rsp_1041 + 0x88:word64];
-				rbx_1036 = Mem1304[rsp_1041 + 0x80:word64];
-				*r14Out = Mem1304[rsp_1041 + 0x50:word64];
-				*r15Out = Mem1304[rsp_1041 + 0x40:word64];
-				*r8Out = r13_1487;
-				dl_1181 = (byte) (uint64) ((word32) (uint64) esi_1014 ^ 0x01);
-l000000000040E22D:
-				if (rax_1031 >u 0x01)
-				{
-					dl_1028 = dl_1181 & Mem1304[rsp_1041 + 0x20:byte];
-l000000000040DE6B:
-					word64 rcx_1050 = Mem216[rsp_1041 + 0x28:word64];
-					rax_1031 = rax_1031 + rbp_1003;
-					byte dil_1049 = (byte) (word32) Mem216[rsp_1041 + 0x33:byte];
-					ecx_1052 = (word32) rcx_1050;
-					while (true)
-					{
-						if (dl_1028 == 0x00)
-						{
-							if (r11b_1015 != 0x00)
-							{
-								if (rbx_1036 <u r14_1024)
-									Mem1110[rcx_1050 + rbx_1036:byte] = 0x5C;
-								rbx_1036 = rbx_1036 + 0x01;
-								r11b_1015 = 0x00;
-								r11d_1016 = 0x00;
-							}
-						}
-						else
-						{
-							if (dil_1049 != 0x00)
-							{
-l000000000040DC40:
-								r11_109 = r14_1024;
-								r11b_1015 = (byte) r14_1024;
-								r11d_1016 = (word32) r14_1024;
-								r13_1332 = r8_1019;
-								goto l000000000040DC46;
-							}
-							if (rbx_1036 <u r14_1024)
-								Mem1155[rcx_1050 + rbx_1036:byte] = 0x5C;
-							if (r14_1024 >u rbx_1036 + 0x01)
-							{
-								word64 rsi_1150 = (uint64) (DPB(esi_1014, (byte) (uint64) r12d_1012 >>u 0x06, 0) + 0x30);
-								Mem1154[rcx_1050 + 0x01 + rbx_1036:byte] = (byte) rsi_1150;
-								esi_1014 = (word32) rsi_1150;
-							}
-							rsi_1039 = rbx_1036 + 0x02;
-							if (r14_1024 >u rsi_1039)
-							{
-								rsi_1039 = (uint64) ((word32) (uint64) (DPB(esi_1014, (byte) (uint64) r12d_1012 >>u 0x03, 0) & 0x07) + 0x30);
-								Mem1145[rcx_1050 + 0x02 + rbx_1036:byte] = (byte) rsi_1039;
-								esi_1014 = (word32) rsi_1039;
-							}
-							r12_1022 = (uint64) ((word32) (uint64) (r12d_1012 & 0x07) + 0x30);
-							*r12Out = r12_1022;
-							rbx_1036 = rbx_1036 + 0x03;
-							r12b_1013 = (byte) r12_1022;
-						}
-						rbp_1003 = rbp_1003 + 0x01;
-						if (rax_1031 <=u rbp_1003)
-						{
-l000000000040DB54:
-							if (rbx_1036 <u r14_1024)
-							{
-								rax_1031 = Mem216[rsp_1041 + 0x28:word64];
-								Mem710[rax_1031 + rbx_1036:byte] = r12b_1013;
-							}
-							al_1795 = rbp_1003 != r15_1025;
-							rbx_1036 = rbx_1036 + 0x01;
-							rax_1720 = DPB(rax_1031, al_1795, 0);
-							if (r15_1025 == ~0x00)
-								goto l000000000040DB76;
-							goto l000000000040D9A0;
-						}
-						if (rbx_1036 <u r14_1024)
-							Mem1097[rcx_1050 + rbx_1036:byte] = r12b_1013;
-						r12d_1012 = (word32) Mem216[r8_1019 + rbp_1003:byte];
-						r12b_1013 = (byte) r12d_1012;
-						*r12Out = DPB(r12_1022, r12d_1012, 0);
-						rbx_1036 = rbx_1036 + 0x01;
-					}
-				}
-			}
-			dl_1028 = dl_1181 & Mem216[rsp_1041 + 0x20:byte];
-			if (dl_1028 == 0x00)
-				goto l000000000040DAF8;
-			goto l000000000040DE6B;
-		}
-	}
-	r13_1725 = r8_1019 + rbp_1003;
-	r11b_1015 = 0x00;
-	r11d_1016 = 0x00;
-	goto l000000000040DA20;
 }
 
 // 000000000040E450: Register word64 fn000000000040E450(Register word64 rcx, Register word64 rdx, Register word64 rsi, Register word64 rdi, Register word64 r11, Register selector fs, Register out ptr64 ebxOut, Register out ptr64 rspOut, Register out ptr64 rbpOut, Register out ptr64 r8Out, Register out ptr64 r9Out, Register out ptr64 r11Out, Register out ptr64 r12Out, Register out ptr64 r13Out, Register out ptr64 r14Out, Register out ptr64 r15Out)
@@ -14362,111 +13678,102 @@ l000000000040EDA1:
 						dil_643 = (byte) (word32) Mem0[rbx_139 + 0x00:byte];
 					}
 					word64 r8_712;
-					if (dil_643 >u 122)
-					{
-						r8_712 = rbx_139;
-						goto l000000000040F39F;
-					}
-					else
+					if (dil_643 <=u 122)
 					{
 						r8_712 = r11_1012 - 0x01;
 						dil_643 = (byte) (word32) Mem0[rbx_139 - 0x01 + 0x00:byte];
-						switch (DPB(rdx_679, (word32) dil_643, 0))
-						{
-						case 0x00:
-l000000000040F39F:
-							word64 r15_719;
-							if (dil_643 == 0x25)
-							{
-								*r15Out = r8_712;
-								rcx = 0x01;
-								cl = 0x01;
-							}
-							else
-							{
-								word64 rax_898 = r8_712 - 0x01;
-								word32 ecx_903 = 0x01;
-								do
-								{
-									*r15Out = rax_898;
-									rax_898 = rax_898 - 0x01;
-									ecx_903 = (word32) (uint64) (ecx_903 + 0x01);
-								} while (Mem0[rax_898 + 0x01:byte] != 0x25);
-								rcx = (int64) ecx_903;
-								cl = (byte) rcx;
-							}
-							word64 r8_720 = r8_712;
-							*r8Out = r8_720;
-							word64 rax_727 = 0x00;
-							byte al_729 = 0x00;
-							if (ebp_678 >= 0x00)
-							{
-								rax_727 = (uint64) ebp_678;
-								al_729 = (byte) ebp_678;
-							}
-							rax_215 = DPB(rax_727, (int16) al_729, 0);
-							rbx_139 = rax_215;
-							if (rcx >=u rax_215)
-								rbx_139 = rcx;
-							if (rbx_139 >=u r14_1029 - r13_1021)
-								goto l000000000040EE98;
-							break;
-						}
-						if (r12_1020 != 0x00)
-						{
-							if (rax_215 >u rcx)
-							{
-								Mem847[rsp_138 + 0x30:word64] = rcx;
-								Mem848[rsp_138 + 0x28:word32] = r9d;
-								Mem853[rsp_138 + 0x18:word64] = r8_712;
-								word64 rbp_849 = (int64) ebp_678 - rcx;
-								if (r11d != 0x30)
-								{
-									rax_215 = memset(r12_1020, 0x20, rbp_849);
-									r9 = (uint64) Mem853[rsp_138 + 0x28:word32];
-									*r9Out = r9;
-									r12_1020 = r12_1020 + rbp_849;
-									rcx = Mem853[rsp_138 + 0x30:word64];
-									r9d = (word32) r9;
-									r9b_629 = (byte) r9;
-									r8_720 = Mem853[rsp_138 + 0x18:word64];
-								}
-								else
-								{
-									rax_215 = memset(r12_1020, 0x30, rbp_849);
-									r9 = (uint64) Mem853[rsp_138 + 0x28:word32];
-									*r9Out = r9;
-									r12_1020 = r12_1020 + rbp_849;
-									r8_720 = Mem853[rsp_138 + 0x18:word64];
-									r9d = (word32) r9;
-									r9b_629 = (byte) r9;
-									rcx = Mem853[rsp_138 + 0x30:word64];
-								}
-							}
-							Mem804[rsp_138 + 0x28:word64] = r8_720;
-							Mem808[rsp_138 + 0x18:word64] = rcx;
-							if (r9b_629 != 0x00)
-							{
-								word32 ebp_828;
-								rax_215 = fn000000000040EC80(rax_215, rcx, r15_719, r12_1020, qwLoc04, out rsp_138, out ebp_828, out r12_1020);
-								rcx = Mem808[rsp_138 + 0x18:word64];
-								cl = (byte) rcx;
-								word64 r8_837;
-								*r8Out = Mem808[rsp_138 + 0x28:word64];
-							}
-							else
-							{
-								rax_215 = memcpy(r12_1020, r15_719, rcx);
-								rcx = Mem808[rsp_138 + 0x18:word64];
-								word64 r8_842;
-								*r8Out = Mem808[rsp_138 + 0x28:word64];
-								cl = (byte) rcx;
-							}
-							*r12Out = r12_1020 + rcx;
-						}
-						*r13Out = r13_1021 + rbx_139;
-						goto l000000000040ED74;
 					}
+					else
+						r8_712 = rbx_139;
+					word64 r15_719;
+					if (dil_643 == 0x25)
+					{
+						*r15Out = r8_712;
+						rcx = 0x01;
+						cl = 0x01;
+					}
+					else
+					{
+						word64 rax_898 = r8_712 - 0x01;
+						word32 ecx_903 = 0x01;
+						do
+						{
+							*r15Out = rax_898;
+							rax_898 = rax_898 - 0x01;
+							ecx_903 = (word32) (uint64) (ecx_903 + 0x01);
+						} while (Mem0[rax_898 + 0x01:byte] != 0x25);
+						rcx = (int64) ecx_903;
+						cl = (byte) rcx;
+					}
+					word64 r8_720 = r8_712;
+					*r8Out = r8_720;
+					word64 rax_727 = 0x00;
+					byte al_729 = 0x00;
+					if (ebp_678 >= 0x00)
+					{
+						rax_727 = (uint64) ebp_678;
+						al_729 = (byte) ebp_678;
+					}
+					rax_215 = DPB(rax_727, (int16) al_729, 0);
+					rbx_139 = rax_215;
+					if (rcx >=u rax_215)
+						rbx_139 = rcx;
+					if (rbx_139 >=u r14_1029 - r13_1021)
+						goto l000000000040EE98;
+					if (r12_1020 != 0x00)
+					{
+						if (rax_215 >u rcx)
+						{
+							Mem847[rsp_138 + 0x30:word64] = rcx;
+							Mem848[rsp_138 + 0x28:word32] = r9d;
+							Mem853[rsp_138 + 0x18:word64] = r8_712;
+							word64 rbp_849 = (int64) ebp_678 - rcx;
+							if (r11d != 0x30)
+							{
+								rax_215 = memset(r12_1020, 0x20, rbp_849);
+								r9 = (uint64) Mem853[rsp_138 + 0x28:word32];
+								*r9Out = r9;
+								r12_1020 = r12_1020 + rbp_849;
+								rcx = Mem853[rsp_138 + 0x30:word64];
+								r9d = (word32) r9;
+								r9b_629 = (byte) r9;
+								r8_720 = Mem853[rsp_138 + 0x18:word64];
+							}
+							else
+							{
+								rax_215 = memset(r12_1020, 0x30, rbp_849);
+								r9 = (uint64) Mem853[rsp_138 + 0x28:word32];
+								*r9Out = r9;
+								r12_1020 = r12_1020 + rbp_849;
+								r8_720 = Mem853[rsp_138 + 0x18:word64];
+								r9d = (word32) r9;
+								r9b_629 = (byte) r9;
+								rcx = Mem853[rsp_138 + 0x30:word64];
+							}
+						}
+						Mem804[rsp_138 + 0x28:word64] = r8_720;
+						Mem808[rsp_138 + 0x18:word64] = rcx;
+						if (r9b_629 != 0x00)
+						{
+							word32 ebp_828;
+							rax_215 = fn000000000040EC80(rax_215, rcx, r15_719, r12_1020, qwLoc04, out rsp_138, out ebp_828, out r12_1020);
+							rcx = Mem808[rsp_138 + 0x18:word64];
+							cl = (byte) rcx;
+							word64 r8_837;
+							*r8Out = Mem808[rsp_138 + 0x28:word64];
+						}
+						else
+						{
+							rax_215 = memcpy(r12_1020, r15_719, rcx);
+							rcx = Mem808[rsp_138 + 0x18:word64];
+							word64 r8_842;
+							*r8Out = Mem808[rsp_138 + 0x28:word64];
+							cl = (byte) rcx;
+						}
+						*r12Out = r12_1020 + rcx;
+					}
+					*r13Out = r13_1021 + rbx_139;
+					goto l000000000040ED74;
 				}
 			}
 			if (r14_1029 - r13_1021 <=u 0x01)
@@ -15082,9 +14389,11 @@ l0000000000410FD5:
 			switch (DPB(rdx_317, (word32) dl_320, 0))
 			{
 			case 0x00:
-				if (rbx_213 <=u rax_314)
-					goto l0000000000411210;
-				goto l0000000000411283;
+				if (rbx_213 >u rax_314)
+					goto l0000000000411283;
+				rbx_213 = rbx_213 << 0x0A;
+				edx_333 = 0x00;
+				goto l0000000000411038;
 			case 0x01:
 			case 0x02:
 			case 0x04:
@@ -15148,7 +14457,7 @@ l0000000000411028:
 					edx_333 = (word32) (uint64) (edx_333 | r8d_402);
 					esi_395 = (word32) rsi_298;
 				} while (esi_395 == 0x00);
-				break;
+				goto l0000000000411038;
 			case 0x05:
 			case 0x25:
 				rsi_298 = (int64) eax_315;
@@ -15170,22 +14479,38 @@ l0000000000411028:
 					edx_333 = (word32) (uint64) (edx_333 | r8d_402);
 					edi_463 = (word32) (uint64) (edi_463 - 0x01);
 				} while (edi_463 != 0x00);
-				break;
+				goto l0000000000411038;
 			case 0x09:
 			case 0x29:
 				rdi_529 = (int64) eax_315;
 				rsi_298 = ~0x00;
-				if (rbx_213 >u (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_529))
-					goto l00000000004111B5;
-				goto l0000000000411193;
+				if (rbx_213 <=u (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_529))
+					goto l0000000000411193;
+				rbx_213 = ~0x00;
+				edx_333 = 0x01;
+				goto l0000000000411038;
 			case 11:
 			case 0x2B:
 				rdi_529 = (int64) eax_315;
 				rsi_298 = ~0x00;
 				word64 rax_567 = (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_529);
 				if (rbx_213 <=u rax_567)
-					goto l0000000000411186;
-				goto l00000000004112A3;
+				{
+					rbx_213 = rbx_213 *s rdi_529;
+					if (rax_567 <u rbx_213)
+						goto l00000000004112A3;
+l0000000000411193:
+					rsi_298 = ~0x00;
+					rbx_213 = rbx_213 *s rdi_529;
+					edx_333 = 0x00;
+				}
+				else
+				{
+l00000000004112A3:
+					edx_333 = 0x01;
+					rbx_213 = ~0x00;
+				}
+				goto l0000000000411038;
 			case 0x0E:
 				rsi_298 = (int64) eax_315;
 				word64 rax_594 = (uint64) (0xFFFFFFFFFFFFFFFF /u rsi_298);
@@ -15206,7 +14531,7 @@ l0000000000411028:
 					edx_333 = (word32) (uint64) (edx_333 | r8d_402);
 					edi_598 = (word32) (uint64) (edi_598 - 0x01);
 				} while (edi_598 == 0x00);
-				break;
+				goto l0000000000411038;
 			case 0x12:
 			case 0x32:
 				rsi_298 = (int64) eax_315;
@@ -15228,7 +14553,7 @@ l0000000000411028:
 					edx_333 = (word32) (uint64) (edx_333 | r8d_402);
 					edi_666 = (word32) (uint64) (edi_666 - 0x01);
 				} while (edi_666 != 0x00);
-				break;
+				goto l0000000000411038;
 			case 0x17:
 				word64 rdi_723 = (int64) eax_315;
 				word64 rax_730 = (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_723);
@@ -15250,7 +14575,7 @@ l0000000000411028:
 					edx_333 = (word32) (uint64) (edx_333 | r8d_402);
 					esi_734 = (word32) rsi_298;
 				} while (esi_734 == 0x00);
-				break;
+				goto l0000000000411038;
 			case 0x18:
 				word64 rdi_791 = (int64) eax_315;
 				word64 rax_798 = (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_791);
@@ -15272,30 +14597,40 @@ l0000000000411028:
 					edx_333 = (word32) (uint64) (edx_333 | r8d_402);
 					esi_802 = (word32) rsi_298;
 				} while (esi_802 == 0x00);
-				break;
+				goto l0000000000411038;
 			case 0x20:
-				if (rbx_213 <=u rax_314)
-					goto l0000000000411077;
-				goto l0000000000411283;
+				if (rbx_213 >u rax_314)
+					goto l0000000000411283;
+				rbx_213 = rbx_213 << 0x09;
+				edx_333 = 0x00;
+				goto l0000000000411038;
 			case 33:
 				edx_333 = 0x00;
-				break;
+				goto l0000000000411038;
 			case 0x35:
 				if (rbx_213 >= 0x00)
-					goto l000000000041105D;
-				goto l0000000000411283;
-			}
+				{
+					rbx_213 = rbx_213 * 0x02;
+					edx_333 = 0x00;
+				}
+				else
+				{
+l0000000000411283:
+					rbx_213 = ~0x00;
+					edx_333 = 0x01;
+				}
 l0000000000411038:
-			rbp_240 = (uint64) (ebp_238 | edx_333);
-			Mem352[r15_51 + 0x00:word64] = r14_211 + (int64) ecx_310;
-			ebp_238 = (word32) rbp_240;
-			word32 eax_350 = (word32) (uint64) ((word32) (uint64) ebp_238 | 0x02);
-			if (Mem352[rsi_298 + 0x00:byte] != 0x00)
-			{
-				ebp_238 = eax_350;
-				rbp_240 = DPB(rbp_240, eax_350, 0);
+				rbp_240 = (uint64) (ebp_238 | edx_333);
+				Mem352[r15_51 + 0x00:word64] = r14_211 + (int64) ecx_310;
+				ebp_238 = (word32) rbp_240;
+				word32 eax_350 = (word32) (uint64) ((word32) (uint64) ebp_238 | 0x02);
+				if (Mem352[rsi_298 + 0x00:byte] != 0x00)
+				{
+					ebp_238 = eax_350;
+					rbp_240 = DPB(rbp_240, eax_350, 0);
+				}
+				goto l0000000000410F4F;
 			}
-			goto l0000000000410F4F;
 		}
 		if (al_901 != 66)
 			goto l0000000000410FCB;
@@ -15549,9 +14884,11 @@ l00000000004114AD:
 			case 0x00:
 				word64 r8_442 = 0xFFFFFFFF;
 				*r8Out = r8_442;
-				if (rbx_1057 <=u rax_382)
-					goto l00000000004116E8;
-				goto l000000000041175B;
+				if (rbx_1057 >u rax_382)
+					goto l000000000041175B;
+				rbx_1057 = rbx_1057 << 0x0A;
+				edx_403 = 0x00;
+				goto l0000000000411510;
 			case 0x01:
 			case 0x02:
 			case 0x04:
@@ -15617,7 +14954,7 @@ l0000000000411500:
 					edx_403 = (word32) (uint64) (edx_403 | r8d_284);
 					esi_466 = (word32) rsi_366;
 				} while (esi_466 == 0x00);
-				break;
+				goto l0000000000411510;
 			case 0x05:
 			case 0x25:
 				rsi_366 = (int64) eax_383;
@@ -15641,22 +14978,38 @@ l0000000000411500:
 					edx_403 = (word32) (uint64) (edx_403 | r8d_284);
 					edi_534 = (word32) (uint64) (edi_534 - 0x01);
 				} while (edi_534 != 0x00);
-				break;
+				goto l0000000000411510;
 			case 0x09:
 			case 0x29:
 				rdi_600 = (int64) eax_383;
 				rsi_366 = ~0x00;
-				if (rbx_1057 >u (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_600))
-					goto l000000000041168D;
-				goto l000000000041166B;
+				if (rbx_1057 <=u (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_600))
+					goto l000000000041166B;
+				rbx_1057 = ~0x00;
+				edx_403 = 0x01;
+				goto l0000000000411510;
 			case 11:
 			case 0x2B:
 				rdi_600 = (int64) eax_383;
 				rsi_366 = ~0x00;
 				word64 rax_638 = (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_600);
 				if (rbx_1057 <=u rax_638)
-					goto l000000000041165E;
-				goto l000000000041177B;
+				{
+					rbx_1057 = rbx_1057 *s rdi_600;
+					if (rax_638 <u rbx_1057)
+						goto l000000000041177B;
+l000000000041166B:
+					rsi_366 = ~0x00;
+					rbx_1057 = rbx_1057 *s rdi_600;
+					edx_403 = 0x00;
+				}
+				else
+				{
+l000000000041177B:
+					edx_403 = 0x01;
+					rbx_1057 = ~0x00;
+				}
+				goto l0000000000411510;
 			case 0x0E:
 				rsi_366 = (int64) eax_383;
 				word64 rax_665 = (uint64) (0xFFFFFFFFFFFFFFFF /u rsi_366);
@@ -15679,7 +15032,7 @@ l0000000000411500:
 					edx_403 = (word32) (uint64) (edx_403 | r8d_284);
 					edi_669 = (word32) (uint64) (edi_669 - 0x01);
 				} while (edi_669 == 0x00);
-				break;
+				goto l0000000000411510;
 			case 0x12:
 			case 0x32:
 				rsi_366 = (int64) eax_383;
@@ -15703,7 +15056,7 @@ l0000000000411500:
 					edx_403 = (word32) (uint64) (edx_403 | r8d_284);
 					edi_737 = (word32) (uint64) (edi_737 - 0x01);
 				} while (edi_737 != 0x00);
-				break;
+				goto l0000000000411510;
 			case 0x17:
 				word64 rdi_794 = (int64) eax_383;
 				word64 rax_801 = (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_794);
@@ -15727,7 +15080,7 @@ l0000000000411500:
 					edx_403 = (word32) (uint64) (edx_403 | r8d_284);
 					esi_805 = (word32) rsi_366;
 				} while (esi_805 == 0x00);
-				break;
+				goto l0000000000411510;
 			case 0x18:
 				word64 rdi_862 = (int64) eax_383;
 				word64 rax_869 = (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_862);
@@ -15751,34 +15104,44 @@ l0000000000411500:
 					edx_403 = (word32) (uint64) (edx_403 | r8d_284);
 					esi_873 = (word32) rsi_366;
 				} while (esi_873 == 0x00);
-				break;
+				goto l0000000000411510;
 			case 0x20:
 				word64 r8_930 = 0xFFFFFFFF;
 				*r8Out = r8_930;
-				if (rbx_1057 <=u rax_382)
-					goto l000000000041154F;
-				goto l000000000041175B;
+				if (rbx_1057 >u rax_382)
+					goto l000000000041175B;
+				rbx_1057 = rbx_1057 << 0x09;
+				edx_403 = 0x00;
+				goto l0000000000411510;
 			case 33:
 				edx_403 = 0x00;
-				break;
+				goto l0000000000411510;
 			case 0x35:
 				if (rbx_1057 >= 0x00)
-					goto l0000000000411535;
-				goto l000000000041175B;
-			}
+				{
+					rbx_1057 = rbx_1057 * 0x02;
+					edx_403 = 0x00;
+				}
+				else
+				{
+l000000000041175B:
+					rbx_1057 = ~0x00;
+					edx_403 = 0x01;
+				}
 l0000000000411510:
-			rbp_1009 = (uint64) (ebp_1010 | edx_403);
-			word64 r14_413 = r14_278 + (int64) ecx_378;
-			*r14Out = r14_413;
-			Mem421[r15_255 + 0x00:word64] = r14_413;
-			ebp_1010 = (word32) rbp_1009;
-			word32 eax_419 = (word32) (uint64) ((word32) (uint64) ebp_1010 | 0x02);
-			if (Mem421[rsi_366 + 0x00:byte] != 0x00)
-			{
-				ebp_1010 = eax_419;
-				rbp_1009 = DPB(rbp_1009, eax_419, 0);
+				rbp_1009 = (uint64) (ebp_1010 | edx_403);
+				word64 r14_413 = r14_278 + (int64) ecx_378;
+				*r14Out = r14_413;
+				Mem421[r15_255 + 0x00:word64] = r14_413;
+				ebp_1010 = (word32) rbp_1009;
+				word32 eax_419 = (word32) (uint64) ((word32) (uint64) ebp_1010 | 0x02);
+				if (Mem421[rsi_366 + 0x00:byte] != 0x00)
+				{
+					ebp_1010 = eax_419;
+					rbp_1009 = DPB(rbp_1009, eax_419, 0);
+				}
+				goto l0000000000411422;
 			}
-			goto l0000000000411422;
 		}
 		if (al_973 != 66)
 			goto l00000000004114A3;

--- a/subjects/Elf-x86-64/ls.c
+++ b/subjects/Elf-x86-64/ls.c
@@ -13181,6 +13181,697 @@ word64 fn000000000040D8A0(word64 rcx, word64 rdx, word64 rsi, word64 rdi, word64
 	word32 ecx_1052;
 	__ctype_get_mb_cur_max();
 	byte al_101 = (byte) (uint64) ((word32) (uint64) ((word32) (uint64) ebx_64 >>u 0x01) & 0x01);
+	if (r14d_57 >u 0x08)
+		abort();
+	word64 rbx_1036;
+	word64 rax_108 = (uint64) r14d_57;
+	word64 r11_109 = rsi;
+	byte r11b_1015 = (byte) rsi;
+	word32 r11d_1016 = (word32) rsi;
+	switch (r14d_57)
+	{
+	case 0x00:
+		r14_1024 = 0x00;
+		rbx_1036 = 0x00;
+		break;
+	case 0x01:
+		rsi_1039 = 0x01;
+		rbx_1036 = 0x00;
+		break;
+	case 0x02:
+		if (al_101 == 0x00)
+		{
+			if (rsi != 0x00)
+			{
+				Mem1837[rdi + 0x00:byte] = 0x27;
+				rsi_1039 = 0x01;
+				rbx_1036 = 0x01;
+			}
+			else
+			{
+				rsi_1039 = 0x01;
+				rbx_1036 = 0x01;
+			}
+		}
+		else
+		{
+			rsi_1039 = 0x01;
+			rbx_1036 = 0x00;
+		}
+		break;
+	case 0x03:
+		if (al_101 != 0x00)
+			goto l000000000040E428;
+		if (rsi != 0x00)
+		{
+			Mem1863[rdi + 0x00:byte] = 0x22;
+			rsi_1039 = 0x01;
+			rbx_1036 = 0x01;
+		}
+		else
+		{
+			rsi_1039 = 0x01;
+			rbx_1036 = 0x01;
+		}
+		break;
+	case 0x04:
+		rsi_1039 = 0x01;
+		rbx_1036 = 0x00;
+		break;
+	case 0x05:
+		r14_1024 = 0x00;
+		rbx_1036 = 0x00;
+		break;
+	case 0x06:
+	case 0x07:
+	case 0x08:
+		if (r14d_57 != 0x08)
+		{
+			word32 ebx_1968;
+			word64 rsp_1969;
+			word64 r8_1970;
+			word64 r12_1971;
+			word64 r13_1972;
+			word64 r15_1973;
+			word64 rax_1974 = fn000000000040D7B0((word32) (uint64) (word32) (uint64) r8d, 4284405, r8_80, r13_1332, r15_1025, fs_1009, out ebx_1968, out rsp_1969, out r8_1970, out r12_1971, out r13_1972, out r15_1973);
+			Mem1978[rsp_1969 + 0x70:word64] = rax_1974;
+			rsi_1039 = (uint64) ebx_1968;
+			word32 ebx_1979;
+			word64 r8_1981;
+			rax_108 = fn000000000040D7B0((word32) rsi_1039, 4287978, r8_1970, r13_1972, r15_1973, fs_1009, out ebx_1979, out rsp_1041, out r8_1981, out r12_1022, out r13_1332, out r15_1025);
+			r11_109 = Mem1978[rsp_1041 + 0x20:word64];
+			Mem1989[rsp_1041 + 0x68:word64] = rax_108;
+		}
+		rbx_1036 = 0x00;
+		if (Mem0[rsp_1041 + 0x33:byte] == 0x00)
+		{
+			word64 rdx_1931 = Mem0[rsp_1041 + 0x70:word64];
+			word32 eax_1935 = (word32) Mem0[rdx_1931 + 0x00:byte];
+			rax_108 = DPB(rax_108, eax_1935, 0);
+			byte al_1937 = (byte) eax_1935;
+			if (al_1937 != 0x00)
+			{
+				word64 rcx_1941 = Mem0[rsp_1041 + 0x28:word64];
+				ecx_1052 = (word32) rcx_1941;
+				do
+				{
+					if (rbx_1036 <u r11_109)
+						Mem1961[rcx_1941 + rbx_1036:byte] = al_1937;
+					rbx_1036 = rbx_1036 + 0x01;
+					word32 eax_1955 = (word32) Mem0[rdx_1931 + rbx_1036:byte];
+					rax_108 = DPB(rax_108, eax_1955, 0);
+					al_1937 = (byte) eax_1955;
+				} while (al_1937 != 0x00);
+			}
+		}
+		word64 rbp_1919 = Mem0[rsp_1041 + 0x68:word64];
+		Mem1920[rsp_1041 + 0x38:word64] = r11_109;
+		word64 rax_1923 = DPB(rax_108, strlen(rbp_1919), 0);
+		Mem1924[rsp_1041 + 0x60:word64] = rbp_1919;
+		Mem1927[rsp_1041 + 0x20:byte] = 0x01;
+		r11_109 = Mem1927[rsp_1041 + 0x38:word64];
+		r14_1024 = rax_1923;
+		r11b_1015 = (byte) r11_109;
+		r11d_1016 = (word32) r11_109;
+		break;
+	}
+l000000000040D960:
+	Mem209[rsp_1041 + 0x38:byte] = (byte) (uint64) ((word32) Mem0[rsp_1041 + 0x33:byte] ^ 0x01);
+	word64 rax_1031 = (uint64) ((word32) Mem209[rsp_1041 + 0x20:byte] ^ 0x01);
+	Mem216[rsp_1041 + 0x95:byte] = (byte) rax_1031;
+	word64 r9_1020;
+	*r9Out = r14_1024;
+	word64 rbp_1003 = 0x00;
+	*r14Out = r11_109;
+	word64 r8_1019;
+	*r8Out = r13_1332;
+l000000000040D986:
+	word64 rax_292;
+	byte al_1795 = rbp_1003 != r15_1025;
+	word64 rax_1720 = DPB(rax_1031, al_1795, 0);
+	if (r15_1025 == ~0x00)
+	{
+l000000000040DB76:
+		byte al_537 = Mem216[r8_1019 + rbp_1003:byte] != 0x00;
+		rax_1720 = DPB(rax_1720, al_537, 0);
+		if (al_537 == 0x00)
+			goto l000000000040DB86;
+		goto l000000000040D9A8;
+	}
+l000000000040D9A0:
+	if (al_1795 == 0x00)
+	{
+l000000000040DB86:
+		r11_109 = r14_1024;
+		*r11Out = r11_109;
+		r11b_1015 = (byte) r14_1024;
+		r11d_1016 = (word32) r14_1024;
+		r13_1332 = r8_1019;
+		*r13Out = r13_1332;
+		if (rbx_1036 != 0x00 || (Mem216[rsp_1041 + 0x34:word32] != 0x02 || Mem216[rsp_1041 + 0x33:byte] == 0x00))
+		{
+			if (Mem216[rsp_1041 + 0x33:byte] == 0x00 && Mem216[rsp_1041 + 0x60:word64] != 0x00)
+			{
+				word64 rdx_456 = Mem216[rsp_1041 + 0x60:word64];
+				byte al_462 = (byte) (word32) Mem216[rdx_456 + 0x00:byte];
+				if (al_462 != 0x00)
+				{
+					word64 rcx_466 = Mem216[rsp_1041 + 0x28:word64];
+					ecx_1052 = (word32) rcx_466;
+					word64 rdx_469 = rdx_456 - rbx_1036;
+					do
+					{
+						if (r14_1024 >u rbx_1036)
+							Mem492[rcx_466 + rbx_1036:byte] = al_462;
+						rbx_1036 = rbx_1036 + 0x01;
+						al_462 = (byte) (word32) Mem216[rdx_469 + rbx_1036:byte];
+					} while (al_462 != 0x00);
+				}
+			}
+			rax_292 = rbx_1036;
+			if (rbx_1036 <u r14_1024)
+				Mem453[Mem216[rsp_1041 + 0x28:word64] + rbx_1036:byte] = 0x00;
+l000000000040DC86:
+			if ((Mem216[rsp_1041 + 0xB8:word64] ^ Mem216[fs_1009:0x28:word64]) == 0x00)
+			{
+				word64 rsp_314 = Mem216[rsp_1041 + 0xD8:word64];
+				word64 rbp_316;
+				*rbpOut = Mem216[rsp_314 + 0x08:word64];
+				word64 rsp_322;
+				*rspOut = rsp_314 + 0x20;
+				return rax_292;
+			}
+			__stack_chk_fail();
+l000000000040E428:
+			Mem155[rsp_1041 + 0x20:byte] = 0x01;
+			Mem157[rsp_1041 + 0x60:word64] = 4284395;
+			rsi_1039 = 0x01;
+			rbx_1036 = 0x00;
+			goto l000000000040D960;
+		}
+		goto l000000000040DC46;
+	}
+l000000000040D9A8:
+	word64 r13_1725;
+	byte cl_585 = r9_1020 != 0x00;
+	ecx_1052 = DPB(ecx_1052, cl_585, 0);
+	if (r9_1020 != 0x00 && Mem216[rsp_1041 + 0x20:byte] != 0x00)
+	{
+		rax_1720 = rbp_1003 + r9_1020;
+		if (r15_1025 >=u rax_1720)
+		{
+			rsi_1039 = Mem216[rsp_1041 + 0x60:word64];
+			Mem1741[rsp_1041 + 0x50:word32] = ecx_1052;
+			Mem1742[rsp_1041 + 0x48:word64] = r8_1019;
+			Mem1744[rsp_1041 + 0x40:word64] = r9_1020;
+			r13_1725 = r8_1019 + rbp_1003;
+			word32 eax_1745 = memcmp(r13_1725, rsi_1039, r9_1020);
+			rax_1720 = DPB(rax_1720, eax_1745, 0);
+			*r9Out = Mem1744[rsp_1041 + 0x40:word64];
+			r8_1019 = Mem1744[rsp_1041 + 0x48:word64];
+			*r8Out = r8_1019;
+			if (eax_1745 == 0x00)
+			{
+				if (Mem1744[rsp_1041 + 0x33:byte] != 0x00)
+					goto l000000000040DC40;
+				rbx_1036 = 0x01;
+			}
+			else
+			{
+				r11b_1015 = 0x00;
+				r11d_1016 = 0x00;
+			}
+l000000000040DA20:
+			word32 r12d_1012 = (word32) Mem216[r13_1725 + 0x00:byte];
+			byte r12b_1013 = (byte) r12d_1012;
+			r12_1022 = DPB(r12_1022, r12d_1012, 0);
+			*r12Out = r12_1022;
+			if (r12b_1013 <=u 0x7E)
+			{
+				rax_1031 = DPB(rax_1720, (word32) r12b_1013, 0);
+				if (Mem216[rsp_1041 + 0x20:byte] != 0x00)
+				{
+					if (Mem216[rsp_1041 + 0x33:byte] != 0x00)
+						goto l000000000040DC40;
+					if (rbx_1036 <u r14_1024)
+						Mem999[Mem216[rsp_1041 + 0x28:word64] + rbx_1036:byte] = 0x5C;
+					rax_1031 = rbx_1036 + 0x01;
+					if (r15_1025 >u rbp_1003 + 0x01)
+					{
+						rsi_1039 = DPB(rsi_1039, (word32) Mem216[r8_1019 + 0x01 + rbp_1003:byte], 0);
+						if ((byte) (rsi_1039 - 0x30) <=u 0x09)
+						{
+							if (r14_1024 >u rax_1031)
+							{
+								rsi_1039 = Mem216[rsp_1041 + 0x28:word64];
+								Mem997[rsi_1039 + rax_1031:byte] = 0x30;
+							}
+							if (r14_1024 >u rbx_1036 + 0x02)
+								Mem995[Mem216[rsp_1041 + 0x28:word64] + 0x02 + rbx_1036:byte] = 0x30;
+							rax_1031 = rbx_1036 + 0x03;
+						}
+					}
+					rbx_1036 = rax_1031;
+					rsp_1041 = 0x30;
+l000000000040DB09:
+					word64 rdi_886 = Mem216[rsp_1041 + 88:word64];
+					if (rdi_886 != 0x00)
+					{
+						ecx_1052 = (word32) (uint64) r12d_1012;
+						word64 rdx_892 = (uint64) r12d_1012;
+						rax_1031 = (uint64) (0x01 << (byte) ((uint64) (ecx_1052 & 0x1F)));
+						if ((rdi_886[DPB(rdx_892, (word32) ((byte) rdx_892 >>u 0x05), 0) * 0x04] & (word32) rax_1031) != 0x00)
+						{
+l000000000040DB33:
+							if (Mem216[rsp_1041 + 0x33:byte] == 0x00)
+							{
+								if (rbx_1036 <u r14_1024)
+								{
+									rax_1031 = Mem216[rsp_1041 + 0x28:word64];
+									Mem805[rax_1031 + rbx_1036:byte] = 0x5C;
+								}
+								rbx_1036 = rbx_1036 + 0x01;
+l000000000040DB50:
+								rbp_1003 = rbp_1003 + 0x01;
+								goto l000000000040DB54;
+							}
+							goto l000000000040DC40;
+						}
+					}
+l000000000040DB2E:
+					if (r11b_1015 == 0x00)
+						goto l000000000040DB50;
+					goto l000000000040DB33;
+				}
+				if ((Mem216[rsp_1041 + 0x90:byte] & 0x01) != 0x00)
+				{
+					rbp_1003 = rbp_1003 + 0x01;
+					goto l000000000040D986;
+				}
+l000000000040DAF8:
+				if (Mem216[rsp_1041 + 0x38:byte] != 0x00 && Mem216[rsp_1041 + 0x95:byte] != 0x00)
+					goto l000000000040DB2E;
+				goto l000000000040DB09;
+			}
+			byte dl_1181;
+			word32 esi_1014;
+			byte dl_1028;
+			if (Mem216[rsp_1041 + 0x78:word64] == 0x01)
+			{
+				Mem1203[rsp_1041 + 0x50:word64] = r8_1019;
+				Mem1204[rsp_1041 + 0x48:word64] = r9_1020;
+				Mem1205[rsp_1041 + 0x40:word32] = r11d_1016;
+				word64 rdi_1207;
+				word64 rcx_1209;
+				word32 r14d_1211;
+				word32 r8d_1212;
+				word64 r13_1215;
+				word64 rdx_1216;
+				word32 ebx_1218;
+				word32 r9d_1219;
+				byte SCZO_1220;
+				word64 rax_1221;
+				word32 eax_1223;
+				byte SZO_1224;
+				byte C_1225;
+				byte al_1226;
+				byte CZ_1227;
+				word64 r11_1228;
+				byte Z_1230;
+				word32 edi_1231;
+				word64 r9_1232;
+				word32 ebp_1233;
+				word64 r8_1234;
+				byte cl_1235;
+				word32 edx_1239;
+				byte dl_1240;
+				byte r11b_1241;
+				word32 esp_1242;
+				word32 r11d_1243;
+				word16 dx_1244;
+				word64 r10_1246;
+				byte dil_1247;
+				byte sil_1248;
+				__ctype_b_loc();
+				word64 r11_1252 = (uint64) Mem1205[rsp_1041 + 0x40:word32];
+				word32 edx_1259 = (word32) Mem1205[rax_1221 + 0x00:word64][DPB(rdx_1216, (word32) r12b_1013, 0) * 0x02];
+				r11b_1015 = (byte) r11_1252;
+				r11d_1016 = (word32) r11_1252;
+				*r9Out = Mem1205[rsp_1041 + 0x48:word64];
+				*r8Out = Mem1205[rsp_1041 + 0x50:word64];
+				rax_1031 = 0x01;
+				dl_1181 = (byte) (uint64) ((word32) (uint64) (DPB(edx_1259, (word16) edx_1259 >>u 0x0E, 0) ^ 0x01) & 0x01);
+			}
+			else
+			{
+				Mem1276[rsp_1041 + 0xB0:word64] = 0x00;
+				if (r15_1025 == ~0x00)
+				{
+					Mem1707[rsp_1041 + 0x50:word64] = r9_1020;
+					Mem1708[rsp_1041 + 0x48:word32] = r11d_1016;
+					Mem1709[rsp_1041 + 0x40:word64] = r8_1019;
+					word64 rax_1711 = DPB(rax_1720, strlen(r8_1019), 0);
+					r9_1020 = Mem1709[rsp_1041 + 0x50:word64];
+					r15_1025 = rax_1711;
+					r11b_1015 = (byte) (uint64) Mem1709[rsp_1041 + 0x48:word32];
+				}
+				Mem1291[rsp_1041 + 0x80:word64] = rbx_1036;
+				Mem1292[rsp_1041 + 0x96:byte] = r12b_1013;
+				Mem1293[rsp_1041 + 0x98:word64] = r13_1725;
+				Mem1296[rsp_1041 + 0x48:word64] = rbp_1003;
+				Mem1297[rsp_1041 + 0x88:word64] = r9_1020;
+				Mem1301[rsp_1041 + 151:byte] = r11b_1015;
+				Mem1302[rsp_1041 + 0x50:word64] = r14_1024;
+				Mem1304[rsp_1041 + 0x40:word64] = r15_1025;
+				do
+				{
+					word64 r15_1325;
+					word64 rcx_1326;
+					word32 r14d_1328;
+					word32 r8d_1329;
+					word64 r14_1330;
+					word64 rbp_1331;
+					word64 rdx_1333;
+					word64 rbx_1334;
+					word32 ebx_1335;
+					word32 r9d_1336;
+					byte SCZO_1337;
+					word64 rax_1338;
+					word32 eax_1340;
+					byte SZO_1341;
+					byte C_1342;
+					byte al_1343;
+					byte CZ_1344;
+					word64 r11_1345;
+					byte Z_1347;
+					word32 edi_1348;
+					word64 r9_1349;
+					word32 ebp_1350;
+					word64 r8_1351;
+					byte cl_1352;
+					word32 r12d_1354;
+					byte r12b_1355;
+					word32 edx_1356;
+					byte dl_1357;
+					byte r11b_1358;
+					word32 esp_1359;
+					word32 r11d_1360;
+					word16 dx_1361;
+					word64 r12_1362;
+					word64 r10_1363;
+					byte dil_1364;
+					byte sil_1365;
+					word64 rdi_1324;
+					mbrtowc();
+					if (rax_1338 == 0x00)
+					{
+						r11d_1016 = (word32) Mem1304[rsp_1041 + 151:byte];
+						r12d_1012 = (word32) Mem1304[rsp_1041 + 0x96:byte];
+						rax_1031 = rbx_1334;
+						rbp_1003 = Mem1304[rsp_1041 + 0x48:word64];
+						*r9Out = Mem1304[rsp_1041 + 0x88:word64];
+						r11b_1015 = (byte) r11d_1016;
+						*r8Out = r13_1332;
+						rbx_1036 = Mem1304[rsp_1041 + 0x80:word64];
+						r12b_1013 = (byte) r12d_1012;
+						*r12Out = DPB(r12_1362, r12d_1012, 0);
+						dl_1181 = (byte) (uint64) ((word32) (uint64) r12d_1354 ^ 0x01);
+						*r14Out = Mem1304[rsp_1041 + 0x50:word64];
+						*r15Out = Mem1304[rsp_1041 + 0x40:word64];
+						goto l000000000040E22D;
+					}
+					if (rax_1338 == ~0x00)
+					{
+						r12d_1012 = (word32) Mem1304[rsp_1041 + 0x96:byte];
+						r11d_1016 = (word32) Mem1304[rsp_1041 + 151:byte];
+						rax_1031 = rbx_1334;
+						rbp_1003 = Mem1304[rsp_1041 + 0x48:word64];
+						*r9Out = Mem1304[rsp_1041 + 0x88:word64];
+						r12b_1013 = (byte) r12d_1012;
+						*r12Out = DPB(r12_1362, r12d_1012, 0);
+						r11b_1015 = (byte) r11d_1016;
+						*r8Out = r13_1332;
+						rbx_1036 = Mem1304[rsp_1041 + 0x80:word64];
+						*r14Out = Mem1304[rsp_1041 + 0x50:word64];
+						dl_1181 = 0x01;
+						*r15Out = Mem1304[rsp_1041 + 0x40:word64];
+						goto l000000000040E22D;
+					}
+					if (rax_1338 == ~0x01)
+					{
+						r12d_1012 = (word32) Mem1304[rsp_1041 + 0x96:byte];
+						r11d_1016 = (word32) Mem1304[rsp_1041 + 151:byte];
+						r15_1025 = Mem1304[rsp_1041 + 0x40:word64];
+						*r15Out = r15_1025;
+						rsi_1039 = r14_1330;
+						rax_1031 = rbx_1334;
+						*r8Out = r13_1332;
+						rbp_1003 = Mem1304[rsp_1041 + 0x48:word64];
+						*r9Out = Mem1304[rsp_1041 + 0x88:word64];
+						r12b_1013 = (byte) r12d_1012;
+						*r12Out = DPB(r12_1362, r12d_1012, 0);
+						r11b_1015 = (byte) r11d_1016;
+						rbx_1036 = Mem1304[rsp_1041 + 0x80:word64];
+						*r14Out = Mem1304[rsp_1041 + 0x50:word64];
+						word64 r13_1631 = Mem1304[rsp_1041 + 0x98:word64];
+						if (r15_1025 >u r14_1330)
+						{
+							if (Mem1304[rdx_1333 + 0x00:byte] != 0x00)
+							{
+								do
+									rax_1031 = rax_1031 + 0x01;
+								while (r15_1025 >u rbp_1003 + rax_1031 && Mem1304[r13_1631 + rax_1031:byte] != 0x00);
+							}
+						}
+						dl_1181 = 0x01;
+						goto l000000000040E22D;
+					}
+					if (Mem1304[rsp_1041 + 0x33:byte] != 0x00 && (Mem1304[rsp_1041 + 0x34:word32] == 0x02 && rax_1338 != 0x01))
+					{
+						word64 rdx_1561 = 0x01;
+						r15_1568 = r15_1325;
+						do
+						{
+							word64 r15_1568;
+							rdi_1324 = DPB(rdi_1324, (word32) Mem1304[r15_1568 + rdx_1561:byte], 0);
+							ecx_1052 = rdi_1324 - 0x5B;
+							byte cl_1583 = (byte) (rdi_1324 - 0x5B);
+							if (cl_1583 <=u 33)
+							{
+								r15_1568 = 0x2B;
+								if ((0x01 << cl_1583 & rdi_1324) != 0x00)
+								{
+									r11_109 = Mem1304[rsp_1041 + 0x50:word64];
+									r11b_1015 = (byte) r11_109;
+									r11d_1016 = (word32) r11_109;
+									r15_1025 = Mem1304[rsp_1041 + 0x40:word64];
+l000000000040DC46:
+									word64 rax_360 = Mem216[rsp_1041 + 0x68:word64];
+									word32 r9d_362 = (word32) (uint64) Mem216[rsp_1041 + 0x90:word32];
+									word64 r8_364 = (uint64) Mem216[rsp_1041 + 0x34:word32];
+									word64 rdi_366 = Mem216[rsp_1041 + 0x28:word64];
+									Mem368[rsp_1041 + 0x00:word64] = 0x00;
+									Mem370[rsp_1041 + 0x10:word64] = rax_360;
+									Mem376[rsp_1041 + 0x08:word64] = Mem370[rsp_1041 + 0x70:word64];
+									word64 rbp_379;
+									word64 r8_380;
+									word64 r9_381;
+									rax_292 = fn000000000040D8A0(r15_1025, r13_1332, r11_109, rdi_366, r8_364, (word32) (uint64) (r9d_362 & ~0x02), fs_1009, qwArg18, qwArg20, qwArg28, out rsp_1041, out rbp_379, out r8_380, out r9_381, out r11_109, out r12_1022, out r13_1332, out r14_1024, out r15_1025);
+									goto l000000000040DC86;
+								}
+							}
+							rdx_1561 = rdx_1561 + 0x01;
+						} while (rdx_1561 != rax_1338);
+					}
+					word64 rsp_1427;
+					word64 rdi_1428;
+					word64 r15_1429;
+					word64 rcx_1430;
+					word64 rsi_1431;
+					word32 r14d_1432;
+					word32 r8d_1433;
+					word64 r14_1434;
+					word64 rbp_1435;
+					word64 r13_1436;
+					word64 rdx_1437;
+					word64 rbx_1438;
+					word32 ebx_1439;
+					word32 r9d_1440;
+					byte SCZO_1441;
+					word64 rax_1442;
+					selector fs_1443;
+					word32 eax_1444;
+					byte SZO_1445;
+					byte C_1446;
+					byte al_1447;
+					byte CZ_1448;
+					word64 r11_1449;
+					word32 esi_1450;
+					byte Z_1451;
+					word32 edi_1452;
+					word64 r9_1453;
+					word32 ebp_1454;
+					word64 r8_1455;
+					byte cl_1456;
+					word32 ecx_1457;
+					word32 r12d_1458;
+					byte r12b_1459;
+					word32 edx_1460;
+					byte dl_1461;
+					byte r11b_1462;
+					word32 esp_1463;
+					word32 r11d_1464;
+					word16 dx_1465;
+					word64 r12_1466;
+					word64 r10_1467;
+					byte dil_1468;
+					byte sil_1469;
+					iswprint();
+					word64 rdi_1479;
+					word64 r15_1480;
+					word64 rcx_1481;
+					word64 rsi_1482;
+					word32 r14d_1483;
+					word32 r8d_1484;
+					word64 r14_1485;
+					word64 rbp_1486;
+					word64 r13_1487;
+					word64 rdx_1488;
+					word64 rbx_1489;
+					word32 ebx_1490;
+					word32 r9d_1491;
+					byte SCZO_1492;
+					word64 rax_1493;
+					word32 eax_1495;
+					byte SZO_1496;
+					byte C_1497;
+					byte al_1498;
+					byte CZ_1499;
+					word64 r11_1500;
+					word32 esi_1501;
+					byte Z_1502;
+					word32 edi_1503;
+					word64 r9_1504;
+					word32 ebp_1505;
+					word64 r8_1506;
+					byte cl_1507;
+					word32 r12d_1509;
+					byte r12b_1510;
+					word32 edx_1511;
+					byte dl_1512;
+					byte r11b_1513;
+					word32 esp_1514;
+					word32 r11d_1515;
+					word16 dx_1516;
+					word64 r12_1517;
+					word64 r10_1518;
+					byte dil_1519;
+					byte sil_1520;
+					mbsinit();
+				} while (0x00 == 0x00);
+				rsi_1039 = (uint64) r12d_1509;
+				r11d_1016 = (word32) Mem1304[rsp_1041 + 151:byte];
+				r12d_1012 = (word32) Mem1304[rsp_1041 + 0x96:byte];
+				esi_1014 = (word32) rsi_1039;
+				r11b_1015 = (byte) r11d_1016;
+				r12b_1013 = (byte) r12d_1012;
+				*r12Out = DPB(r12_1517, r12d_1012, 0);
+				rax_1031 = rbx_1489;
+				rbp_1003 = Mem1304[rsp_1041 + 0x48:word64];
+				*r9Out = Mem1304[rsp_1041 + 0x88:word64];
+				rbx_1036 = Mem1304[rsp_1041 + 0x80:word64];
+				*r14Out = Mem1304[rsp_1041 + 0x50:word64];
+				*r15Out = Mem1304[rsp_1041 + 0x40:word64];
+				*r8Out = r13_1487;
+				dl_1181 = (byte) (uint64) ((word32) (uint64) esi_1014 ^ 0x01);
+l000000000040E22D:
+				if (rax_1031 >u 0x01)
+				{
+					dl_1028 = dl_1181 & Mem1304[rsp_1041 + 0x20:byte];
+l000000000040DE6B:
+					word64 rcx_1050 = Mem216[rsp_1041 + 0x28:word64];
+					rax_1031 = rax_1031 + rbp_1003;
+					byte dil_1049 = (byte) (word32) Mem216[rsp_1041 + 0x33:byte];
+					ecx_1052 = (word32) rcx_1050;
+					while (true)
+					{
+						if (dl_1028 == 0x00)
+						{
+							if (r11b_1015 != 0x00)
+							{
+								if (rbx_1036 <u r14_1024)
+									Mem1110[rcx_1050 + rbx_1036:byte] = 0x5C;
+								rbx_1036 = rbx_1036 + 0x01;
+								r11b_1015 = 0x00;
+								r11d_1016 = 0x00;
+							}
+						}
+						else
+						{
+							if (dil_1049 != 0x00)
+							{
+l000000000040DC40:
+								r11_109 = r14_1024;
+								r11b_1015 = (byte) r14_1024;
+								r11d_1016 = (word32) r14_1024;
+								r13_1332 = r8_1019;
+								goto l000000000040DC46;
+							}
+							if (rbx_1036 <u r14_1024)
+								Mem1155[rcx_1050 + rbx_1036:byte] = 0x5C;
+							if (r14_1024 >u rbx_1036 + 0x01)
+							{
+								word64 rsi_1150 = (uint64) (DPB(esi_1014, (byte) (uint64) r12d_1012 >>u 0x06, 0) + 0x30);
+								Mem1154[rcx_1050 + 0x01 + rbx_1036:byte] = (byte) rsi_1150;
+								esi_1014 = (word32) rsi_1150;
+							}
+							rsi_1039 = rbx_1036 + 0x02;
+							if (r14_1024 >u rsi_1039)
+							{
+								rsi_1039 = (uint64) ((word32) (uint64) (DPB(esi_1014, (byte) (uint64) r12d_1012 >>u 0x03, 0) & 0x07) + 0x30);
+								Mem1145[rcx_1050 + 0x02 + rbx_1036:byte] = (byte) rsi_1039;
+								esi_1014 = (word32) rsi_1039;
+							}
+							r12_1022 = (uint64) ((word32) (uint64) (r12d_1012 & 0x07) + 0x30);
+							*r12Out = r12_1022;
+							rbx_1036 = rbx_1036 + 0x03;
+							r12b_1013 = (byte) r12_1022;
+						}
+						rbp_1003 = rbp_1003 + 0x01;
+						if (rax_1031 <=u rbp_1003)
+						{
+l000000000040DB54:
+							if (rbx_1036 <u r14_1024)
+							{
+								rax_1031 = Mem216[rsp_1041 + 0x28:word64];
+								Mem710[rax_1031 + rbx_1036:byte] = r12b_1013;
+							}
+							al_1795 = rbp_1003 != r15_1025;
+							rbx_1036 = rbx_1036 + 0x01;
+							rax_1720 = DPB(rax_1031, al_1795, 0);
+							if (r15_1025 == ~0x00)
+								goto l000000000040DB76;
+							goto l000000000040D9A0;
+						}
+						if (rbx_1036 <u r14_1024)
+							Mem1097[rcx_1050 + rbx_1036:byte] = r12b_1013;
+						r12d_1012 = (word32) Mem216[r8_1019 + rbp_1003:byte];
+						r12b_1013 = (byte) r12d_1012;
+						*r12Out = DPB(r12_1022, r12d_1012, 0);
+						rbx_1036 = rbx_1036 + 0x01;
+					}
+				}
+			}
+			dl_1028 = dl_1181 & Mem216[rsp_1041 + 0x20:byte];
+			if (dl_1028 == 0x00)
+				goto l000000000040DAF8;
+			goto l000000000040DE6B;
+		}
+	}
+	r13_1725 = r8_1019 + rbp_1003;
+	r11b_1015 = 0x00;
+	r11d_1016 = 0x00;
+	goto l000000000040DA20;
 }
 
 // 000000000040E450: Register word64 fn000000000040E450(Register word64 rcx, Register word64 rdx, Register word64 rsi, Register word64 rdi, Register word64 r11, Register selector fs, Register out ptr64 ebxOut, Register out ptr64 rspOut, Register out ptr64 rbpOut, Register out ptr64 r8Out, Register out ptr64 r9Out, Register out ptr64 r11Out, Register out ptr64 r12Out, Register out ptr64 r13Out, Register out ptr64 r14Out, Register out ptr64 r15Out)
@@ -14510,7 +15201,7 @@ l00000000004112A3:
 					edx_333 = 0x01;
 					rbx_213 = ~0x00;
 				}
-				goto l0000000000411038;
+				break;
 			case 0x0E:
 				rsi_298 = (int64) eax_315;
 				word64 rax_594 = (uint64) (0xFFFFFFFFFFFFFFFF /u rsi_298);
@@ -14531,7 +15222,7 @@ l00000000004112A3:
 					edx_333 = (word32) (uint64) (edx_333 | r8d_402);
 					edi_598 = (word32) (uint64) (edi_598 - 0x01);
 				} while (edi_598 == 0x00);
-				goto l0000000000411038;
+				break;
 			case 0x12:
 			case 0x32:
 				rsi_298 = (int64) eax_315;
@@ -14553,7 +15244,7 @@ l00000000004112A3:
 					edx_333 = (word32) (uint64) (edx_333 | r8d_402);
 					edi_666 = (word32) (uint64) (edi_666 - 0x01);
 				} while (edi_666 != 0x00);
-				goto l0000000000411038;
+				break;
 			case 0x17:
 				word64 rdi_723 = (int64) eax_315;
 				word64 rax_730 = (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_723);
@@ -14575,7 +15266,7 @@ l00000000004112A3:
 					edx_333 = (word32) (uint64) (edx_333 | r8d_402);
 					esi_734 = (word32) rsi_298;
 				} while (esi_734 == 0x00);
-				goto l0000000000411038;
+				break;
 			case 0x18:
 				word64 rdi_791 = (int64) eax_315;
 				word64 rax_798 = (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_791);
@@ -14597,16 +15288,16 @@ l00000000004112A3:
 					edx_333 = (word32) (uint64) (edx_333 | r8d_402);
 					esi_802 = (word32) rsi_298;
 				} while (esi_802 == 0x00);
-				goto l0000000000411038;
+				break;
 			case 0x20:
 				if (rbx_213 >u rax_314)
 					goto l0000000000411283;
 				rbx_213 = rbx_213 << 0x09;
 				edx_333 = 0x00;
-				goto l0000000000411038;
+				break;
 			case 33:
 				edx_333 = 0x00;
-				goto l0000000000411038;
+				break;
 			case 0x35:
 				if (rbx_213 >= 0x00)
 				{
@@ -14619,18 +15310,19 @@ l0000000000411283:
 					rbx_213 = ~0x00;
 					edx_333 = 0x01;
 				}
-l0000000000411038:
-				rbp_240 = (uint64) (ebp_238 | edx_333);
-				Mem352[r15_51 + 0x00:word64] = r14_211 + (int64) ecx_310;
-				ebp_238 = (word32) rbp_240;
-				word32 eax_350 = (word32) (uint64) ((word32) (uint64) ebp_238 | 0x02);
-				if (Mem352[rsi_298 + 0x00:byte] != 0x00)
-				{
-					ebp_238 = eax_350;
-					rbp_240 = DPB(rbp_240, eax_350, 0);
-				}
-				goto l0000000000410F4F;
+				break;
 			}
+l0000000000411038:
+			rbp_240 = (uint64) (ebp_238 | edx_333);
+			Mem352[r15_51 + 0x00:word64] = r14_211 + (int64) ecx_310;
+			ebp_238 = (word32) rbp_240;
+			word32 eax_350 = (word32) (uint64) ((word32) (uint64) ebp_238 | 0x02);
+			if (Mem352[rsi_298 + 0x00:byte] != 0x00)
+			{
+				ebp_238 = eax_350;
+				rbp_240 = DPB(rbp_240, eax_350, 0);
+			}
+			goto l0000000000410F4F;
 		}
 		if (al_901 != 66)
 			goto l0000000000410FCB;
@@ -15009,7 +15701,7 @@ l000000000041177B:
 					edx_403 = 0x01;
 					rbx_1057 = ~0x00;
 				}
-				goto l0000000000411510;
+				break;
 			case 0x0E:
 				rsi_366 = (int64) eax_383;
 				word64 rax_665 = (uint64) (0xFFFFFFFFFFFFFFFF /u rsi_366);
@@ -15032,7 +15724,7 @@ l000000000041177B:
 					edx_403 = (word32) (uint64) (edx_403 | r8d_284);
 					edi_669 = (word32) (uint64) (edi_669 - 0x01);
 				} while (edi_669 == 0x00);
-				goto l0000000000411510;
+				break;
 			case 0x12:
 			case 0x32:
 				rsi_366 = (int64) eax_383;
@@ -15056,7 +15748,7 @@ l000000000041177B:
 					edx_403 = (word32) (uint64) (edx_403 | r8d_284);
 					edi_737 = (word32) (uint64) (edi_737 - 0x01);
 				} while (edi_737 != 0x00);
-				goto l0000000000411510;
+				break;
 			case 0x17:
 				word64 rdi_794 = (int64) eax_383;
 				word64 rax_801 = (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_794);
@@ -15080,7 +15772,7 @@ l000000000041177B:
 					edx_403 = (word32) (uint64) (edx_403 | r8d_284);
 					esi_805 = (word32) rsi_366;
 				} while (esi_805 == 0x00);
-				goto l0000000000411510;
+				break;
 			case 0x18:
 				word64 rdi_862 = (int64) eax_383;
 				word64 rax_869 = (uint64) (0xFFFFFFFFFFFFFFFF /u rdi_862);
@@ -15104,7 +15796,7 @@ l000000000041177B:
 					edx_403 = (word32) (uint64) (edx_403 | r8d_284);
 					esi_873 = (word32) rsi_366;
 				} while (esi_873 == 0x00);
-				goto l0000000000411510;
+				break;
 			case 0x20:
 				word64 r8_930 = 0xFFFFFFFF;
 				*r8Out = r8_930;
@@ -15112,10 +15804,10 @@ l000000000041177B:
 					goto l000000000041175B;
 				rbx_1057 = rbx_1057 << 0x09;
 				edx_403 = 0x00;
-				goto l0000000000411510;
+				break;
 			case 33:
 				edx_403 = 0x00;
-				goto l0000000000411510;
+				break;
 			case 0x35:
 				if (rbx_1057 >= 0x00)
 				{
@@ -15128,20 +15820,21 @@ l000000000041175B:
 					rbx_1057 = ~0x00;
 					edx_403 = 0x01;
 				}
-l0000000000411510:
-				rbp_1009 = (uint64) (ebp_1010 | edx_403);
-				word64 r14_413 = r14_278 + (int64) ecx_378;
-				*r14Out = r14_413;
-				Mem421[r15_255 + 0x00:word64] = r14_413;
-				ebp_1010 = (word32) rbp_1009;
-				word32 eax_419 = (word32) (uint64) ((word32) (uint64) ebp_1010 | 0x02);
-				if (Mem421[rsi_366 + 0x00:byte] != 0x00)
-				{
-					ebp_1010 = eax_419;
-					rbp_1009 = DPB(rbp_1009, eax_419, 0);
-				}
-				goto l0000000000411422;
+				break;
 			}
+l0000000000411510:
+			rbp_1009 = (uint64) (ebp_1010 | edx_403);
+			word64 r14_413 = r14_278 + (int64) ecx_378;
+			*r14Out = r14_413;
+			Mem421[r15_255 + 0x00:word64] = r14_413;
+			ebp_1010 = (word32) rbp_1009;
+			word32 eax_419 = (word32) (uint64) ((word32) (uint64) ebp_1010 | 0x02);
+			if (Mem421[rsi_366 + 0x00:byte] != 0x00)
+			{
+				ebp_1010 = eax_419;
+				rbp_1009 = DPB(rbp_1009, eax_419, 0);
+			}
+			goto l0000000000411422;
 		}
 		if (al_973 != 66)
 			goto l00000000004114A3;

--- a/subjects/regressions/reko-90/PP.c
+++ b/subjects/regressions/reko-90/PP.c
@@ -176,120 +176,116 @@ void main(word16 bp, selector ds)
 	Mem75[ss:bp_277 - 0x02 + 0x00:word16] = dx_280;
 	Mem76[ss:bp_277 - 0x04 + 0x00:word16] = ax_72;
 	word16 bx_77 = Mem76[ds_278:0x2A25:word16];
-	if (bx_77 >u 0x08)
-	{
-l0800_0338:
-		Mem89[ss:fp - 0x0A + 0x00:word16] = 0x00;
-		Mem91[ss:fp - 0x0C + 0x00:word16] = 0x00;
-		byte dl_92;
-		word16 di_93;
-		selector ds_94;
-		word16 ax_97 = fn0800_9764(dl_279, ds_278, ptrArg00, wArg02, out dl_92, out di_93, out ds_94) - Mem91[ss:(bp_277 - 0x04) + 0x00:word16];
-		Mem102[ss:bp_277 - 0x02 + 0x00:word16] = dx_280 - Mem91[ss:(bp_277 - 0x02) + 0x00:word16] - (ax_97 <u 0x00);
-		Mem103[ss:bp_277 - 0x04 + 0x00:word16] = ax_97;
-		Mem106[ss:fp - 0x0A + 0x00:word16] = Mem103[ds_94:10737:word16];
-		Mem109[ss:fp - 0x0C + 0x00:word16] = Mem106[ds_94:0x29EF:word16];
-		Mem112[ss:fp - 0x0E + 0x00:word16] = Mem109[ds_94:10741:word16];
-		Mem115[ss:fp - 0x10 + 0x00:word16] = Mem112[ds_94:0x29F3:word16];
-		word16 di_118;
-		word16 ax_119 = fn0800_0B79(bp_277, si_291, di_93, wArg00, wArg02, wArg04, wArg06, out di_118);
-		Mem127[ss:fp - 0x0A + 0x00:word16] = 0x00;
-		Mem129[ss:fp - 0x0C + 0x00:word16] = 0x3C;
-		Mem132[ss:fp - 0x0E + 0x00:word16] = Mem129[ss:bp_277 - 0x02 + 0x00:word16];
-		Mem135[ss:fp - 0x10 + 0x00:word16] = Mem132[ss:bp_277 - 0x04 + 0x00:word16];
-		word16 dx_136;
-		word16 bp_137;
-		word16 si_138;
-		word16 di_139;
-		word16 ax_140 = fn0800_8BCA(bp_277, ax_119, di_118, bp, out dx_136, out bp_137, out si_138, out di_139);
-		Mem142[ss:fp - 0x12 + 0x00:word16] = dx_136;
-		Mem144[ss:fp - 0x14 + 0x00:word16] = ax_140;
-		Mem150[ss:fp - 22 + 0x00:word16] = 0x00;
-		Mem152[ss:fp - 0x18 + 0x00:word16] = 0x3C;
-		Mem155[ss:fp - 0x1A + 0x00:word16] = 0x00;
-		Mem157[ss:fp - 0x1C + 0x00:word16] = 0x0E10;
-		Mem160[ss:fp - 0x1E + 0x00:word16] = Mem157[ss:bp_137 - 0x02 + 0x00:word16];
-		Mem163[ss:fp - 0x20 + 0x00:word16] = Mem160[ss:bp_137 - 0x04 + 0x00:word16];
-		word16 dx_164;
-		word16 bp_165;
-		word16 si_166;
-		word16 di_167;
-		word16 ax_168 = fn0800_8BCA(bp_137, si_138, di_139, bp, out dx_164, out bp_165, out si_166, out di_167);
-		Mem170[ss:fp - 0x22 + 0x00:word16] = dx_164;
-		Mem172[ss:fp - 0x24 + 0x00:word16] = ax_168;
-		word16 dx_173;
-		word16 bp_174;
-		word16 si_175;
-		word16 di_176;
-		word16 ax_177 = fn0800_8BBB(bp_165, si_166, di_167, bp, out dx_173, out bp_174, out si_175, out di_176);
-		Mem179[ss:fp - 0x26 + 0x00:word16] = dx_173;
-		Mem181[ss:fp - 0x28 + 0x00:word16] = ax_177;
-		Mem187[ss:fp - 0x2A + 0x00:word16] = 0x00;
-		Mem189[ss:fp - 44 + 0x00:word16] = 0x0E10;
-		Mem192[ss:fp - 0x2E + 0x00:word16] = 0x00;
-		Mem194[ss:fp - 0x30 + 0x00:word16] = 0x5180;
-		Mem197[ss:fp - 0x32 + 0x00:word16] = Mem194[ss:bp_174 - 0x02 + 0x00:word16];
-		Mem200[ss:fp - 0x34 + 0x00:word16] = Mem197[ss:bp_174 - 0x04 + 0x00:word16];
-		word16 dx_201;
-		word16 bp_202;
-		word16 si_203;
-		word16 di_204;
-		word16 ax_205 = fn0800_8BCA(bp_174, si_175, di_176, bp, out dx_201, out bp_202, out si_203, out di_204);
-		Mem207[ss:fp - 0x36 + 0x00:word16] = dx_201;
-		Mem209[ss:fp - 0x38 + 0x00:word16] = ax_205;
-		word16 dx_210;
-		word16 bp_211;
-		word16 si_212;
-		word16 di_213;
-		word16 ax_214 = fn0800_8BBB(bp_202, si_203, di_204, bp, out dx_210, out bp_211, out si_212, out di_213);
-		Mem216[ss:fp - 0x3A + 0x00:word16] = dx_210;
-		Mem218[ss:fp - 0x3C + 0x00:word16] = ax_214;
-		Mem227[ss:fp - 0x3E + 0x00:word16] = (uint16) ((uint32) (uint16) si_212 % 100);
-		Mem236[ss:fp - 0x40 + 0x00:word16] = (uint16) ((uint32) (uint16) si_212 /u 100);
-		Mem239[ss:fp - 66 + 0x00:word16] = Mem236[ds_94:10737:word16];
-		Mem242[ss:fp - 0x44 + 0x00:word16] = Mem239[ds_94:0x29EF:word16];
-		Mem245[ss:fp - 0x46 + 0x00:word16] = Mem242[ds_94:10741:word16];
-		Mem248[ss:fp - 0x48 + 0x00:word16] = Mem245[ds_94:0x29F3:word16];
-		Mem250[ss:fp - 0x4A + 0x00:word16] = ds_94;
-		Mem253[ss:fp - 0x4C + 0x00:word16] = 1500;
-		Mem256[ss:fp - 0x4E + 0x00:word16] = 0x08;
-		Mem259[ss:fp - 0x50 + 0x00:word16] = Mem256[ds_94:10771:word16];
-		Mem261[ss:fp - 0x52 + 0x00:word16] = ds_94;
-		Mem264[ss:fp - 0x54 + 0x00:word16] = 2027;
-		word16 di_265;
-		fn0800_B2EF(ds_94, wArg00, wArg02, out di_265);
-		return;
-	}
-	else
+	if (bx_77 <=u 0x08)
 	{
 		switch (bx_77 << 0x01)
 		{
 		case 0x00:
 			dl_279 = fn0800_0DE8(bp_277, si_291, ds_278, out bp_277, out ds_278);
 			dx_280 = DPB(dx, dl_279, 0);
-			goto l0800_0338;
+			break;
 		case 0x01:
 		case 0x02:
 			dl_279 = fn0800_112D(bp_277, si_291, ds_278, out bp_277, out ds_278);
 			dx_280 = DPB(dx, dl_279, 0);
-			goto l0800_0338;
+			break;
 		case 0x03:
 		case 0x04:
 			dl_279 = fn0800_12E2(bp_277, ds_278, out ds_278);
 			dx_280 = DPB(dx, dl_279, 0);
-			goto l0800_0338;
+			break;
 		case 0x05:
 			dl_279 = fn0800_18D9(bp_277, ds_278, out si_291, out ds_278);
 			dx_280 = DPB(dx, dl_279, 0);
-			goto l0800_0338;
+			break;
 		case 0x06:
 		case 0x07:
 		case 0x08:
 			dl_279 = fn0800_19EE(bp_277, ds_278, out ds_278);
 			dx_280 = DPB(dx, dl_279, 0);
-			goto l0800_0338;
+			break;
 		}
 	}
+	Mem89[ss:fp - 0x0A + 0x00:word16] = 0x00;
+	Mem91[ss:fp - 0x0C + 0x00:word16] = 0x00;
+	byte dl_92;
+	word16 di_93;
+	selector ds_94;
+	word16 ax_97 = fn0800_9764(dl_279, ds_278, ptrArg00, wArg02, out dl_92, out di_93, out ds_94) - Mem91[ss:(bp_277 - 0x04) + 0x00:word16];
+	Mem102[ss:bp_277 - 0x02 + 0x00:word16] = dx_280 - Mem91[ss:(bp_277 - 0x02) + 0x00:word16] - (ax_97 <u 0x00);
+	Mem103[ss:bp_277 - 0x04 + 0x00:word16] = ax_97;
+	Mem106[ss:fp - 0x0A + 0x00:word16] = Mem103[ds_94:10737:word16];
+	Mem109[ss:fp - 0x0C + 0x00:word16] = Mem106[ds_94:0x29EF:word16];
+	Mem112[ss:fp - 0x0E + 0x00:word16] = Mem109[ds_94:10741:word16];
+	Mem115[ss:fp - 0x10 + 0x00:word16] = Mem112[ds_94:0x29F3:word16];
+	word16 di_118;
+	word16 ax_119 = fn0800_0B79(bp_277, si_291, di_93, wArg00, wArg02, wArg04, wArg06, out di_118);
+	Mem127[ss:fp - 0x0A + 0x00:word16] = 0x00;
+	Mem129[ss:fp - 0x0C + 0x00:word16] = 0x3C;
+	Mem132[ss:fp - 0x0E + 0x00:word16] = Mem129[ss:bp_277 - 0x02 + 0x00:word16];
+	Mem135[ss:fp - 0x10 + 0x00:word16] = Mem132[ss:bp_277 - 0x04 + 0x00:word16];
+	word16 dx_136;
+	word16 bp_137;
+	word16 si_138;
+	word16 di_139;
+	word16 ax_140 = fn0800_8BCA(bp_277, ax_119, di_118, bp, out dx_136, out bp_137, out si_138, out di_139);
+	Mem142[ss:fp - 0x12 + 0x00:word16] = dx_136;
+	Mem144[ss:fp - 0x14 + 0x00:word16] = ax_140;
+	Mem150[ss:fp - 22 + 0x00:word16] = 0x00;
+	Mem152[ss:fp - 0x18 + 0x00:word16] = 0x3C;
+	Mem155[ss:fp - 0x1A + 0x00:word16] = 0x00;
+	Mem157[ss:fp - 0x1C + 0x00:word16] = 0x0E10;
+	Mem160[ss:fp - 0x1E + 0x00:word16] = Mem157[ss:bp_137 - 0x02 + 0x00:word16];
+	Mem163[ss:fp - 0x20 + 0x00:word16] = Mem160[ss:bp_137 - 0x04 + 0x00:word16];
+	word16 dx_164;
+	word16 bp_165;
+	word16 si_166;
+	word16 di_167;
+	word16 ax_168 = fn0800_8BCA(bp_137, si_138, di_139, bp, out dx_164, out bp_165, out si_166, out di_167);
+	Mem170[ss:fp - 0x22 + 0x00:word16] = dx_164;
+	Mem172[ss:fp - 0x24 + 0x00:word16] = ax_168;
+	word16 dx_173;
+	word16 bp_174;
+	word16 si_175;
+	word16 di_176;
+	word16 ax_177 = fn0800_8BBB(bp_165, si_166, di_167, bp, out dx_173, out bp_174, out si_175, out di_176);
+	Mem179[ss:fp - 0x26 + 0x00:word16] = dx_173;
+	Mem181[ss:fp - 0x28 + 0x00:word16] = ax_177;
+	Mem187[ss:fp - 0x2A + 0x00:word16] = 0x00;
+	Mem189[ss:fp - 44 + 0x00:word16] = 0x0E10;
+	Mem192[ss:fp - 0x2E + 0x00:word16] = 0x00;
+	Mem194[ss:fp - 0x30 + 0x00:word16] = 0x5180;
+	Mem197[ss:fp - 0x32 + 0x00:word16] = Mem194[ss:bp_174 - 0x02 + 0x00:word16];
+	Mem200[ss:fp - 0x34 + 0x00:word16] = Mem197[ss:bp_174 - 0x04 + 0x00:word16];
+	word16 dx_201;
+	word16 bp_202;
+	word16 si_203;
+	word16 di_204;
+	word16 ax_205 = fn0800_8BCA(bp_174, si_175, di_176, bp, out dx_201, out bp_202, out si_203, out di_204);
+	Mem207[ss:fp - 0x36 + 0x00:word16] = dx_201;
+	Mem209[ss:fp - 0x38 + 0x00:word16] = ax_205;
+	word16 dx_210;
+	word16 bp_211;
+	word16 si_212;
+	word16 di_213;
+	word16 ax_214 = fn0800_8BBB(bp_202, si_203, di_204, bp, out dx_210, out bp_211, out si_212, out di_213);
+	Mem216[ss:fp - 0x3A + 0x00:word16] = dx_210;
+	Mem218[ss:fp - 0x3C + 0x00:word16] = ax_214;
+	Mem227[ss:fp - 0x3E + 0x00:word16] = (uint16) ((uint32) (uint16) si_212 % 100);
+	Mem236[ss:fp - 0x40 + 0x00:word16] = (uint16) ((uint32) (uint16) si_212 /u 100);
+	Mem239[ss:fp - 66 + 0x00:word16] = Mem236[ds_94:10737:word16];
+	Mem242[ss:fp - 0x44 + 0x00:word16] = Mem239[ds_94:0x29EF:word16];
+	Mem245[ss:fp - 0x46 + 0x00:word16] = Mem242[ds_94:10741:word16];
+	Mem248[ss:fp - 0x48 + 0x00:word16] = Mem245[ds_94:0x29F3:word16];
+	Mem250[ss:fp - 0x4A + 0x00:word16] = ds_94;
+	Mem253[ss:fp - 0x4C + 0x00:word16] = 1500;
+	Mem256[ss:fp - 0x4E + 0x00:word16] = 0x08;
+	Mem259[ss:fp - 0x50 + 0x00:word16] = Mem256[ds_94:10771:word16];
+	Mem261[ss:fp - 0x52 + 0x00:word16] = ds_94;
+	Mem264[ss:fp - 0x54 + 0x00:word16] = 2027;
+	word16 di_265;
+	fn0800_B2EF(ds_94, wArg00, wArg02, out di_265);
+	return;
 }
 
 // 0800:0402: Register word16 fn0800_0402(Register word16 si, Register selector ds, Register out ptr16 dsOut)

--- a/subjects/regressions/reko-90/PP.c
+++ b/subjects/regressions/reko-90/PP.c
@@ -176,116 +176,120 @@ void main(word16 bp, selector ds)
 	Mem75[ss:bp_277 - 0x02 + 0x00:word16] = dx_280;
 	Mem76[ss:bp_277 - 0x04 + 0x00:word16] = ax_72;
 	word16 bx_77 = Mem76[ds_278:0x2A25:word16];
-	if (bx_77 <=u 0x08)
+	if (bx_77 >u 0x08)
+	{
+l0800_0338:
+		Mem89[ss:fp - 0x0A + 0x00:word16] = 0x00;
+		Mem91[ss:fp - 0x0C + 0x00:word16] = 0x00;
+		byte dl_92;
+		word16 di_93;
+		selector ds_94;
+		word16 ax_97 = fn0800_9764(dl_279, ds_278, ptrArg00, wArg02, out dl_92, out di_93, out ds_94) - Mem91[ss:(bp_277 - 0x04) + 0x00:word16];
+		Mem102[ss:bp_277 - 0x02 + 0x00:word16] = dx_280 - Mem91[ss:(bp_277 - 0x02) + 0x00:word16] - (ax_97 <u 0x00);
+		Mem103[ss:bp_277 - 0x04 + 0x00:word16] = ax_97;
+		Mem106[ss:fp - 0x0A + 0x00:word16] = Mem103[ds_94:10737:word16];
+		Mem109[ss:fp - 0x0C + 0x00:word16] = Mem106[ds_94:0x29EF:word16];
+		Mem112[ss:fp - 0x0E + 0x00:word16] = Mem109[ds_94:10741:word16];
+		Mem115[ss:fp - 0x10 + 0x00:word16] = Mem112[ds_94:0x29F3:word16];
+		word16 di_118;
+		word16 ax_119 = fn0800_0B79(bp_277, si_291, di_93, wArg00, wArg02, wArg04, wArg06, out di_118);
+		Mem127[ss:fp - 0x0A + 0x00:word16] = 0x00;
+		Mem129[ss:fp - 0x0C + 0x00:word16] = 0x3C;
+		Mem132[ss:fp - 0x0E + 0x00:word16] = Mem129[ss:bp_277 - 0x02 + 0x00:word16];
+		Mem135[ss:fp - 0x10 + 0x00:word16] = Mem132[ss:bp_277 - 0x04 + 0x00:word16];
+		word16 dx_136;
+		word16 bp_137;
+		word16 si_138;
+		word16 di_139;
+		word16 ax_140 = fn0800_8BCA(bp_277, ax_119, di_118, bp, out dx_136, out bp_137, out si_138, out di_139);
+		Mem142[ss:fp - 0x12 + 0x00:word16] = dx_136;
+		Mem144[ss:fp - 0x14 + 0x00:word16] = ax_140;
+		Mem150[ss:fp - 22 + 0x00:word16] = 0x00;
+		Mem152[ss:fp - 0x18 + 0x00:word16] = 0x3C;
+		Mem155[ss:fp - 0x1A + 0x00:word16] = 0x00;
+		Mem157[ss:fp - 0x1C + 0x00:word16] = 0x0E10;
+		Mem160[ss:fp - 0x1E + 0x00:word16] = Mem157[ss:bp_137 - 0x02 + 0x00:word16];
+		Mem163[ss:fp - 0x20 + 0x00:word16] = Mem160[ss:bp_137 - 0x04 + 0x00:word16];
+		word16 dx_164;
+		word16 bp_165;
+		word16 si_166;
+		word16 di_167;
+		word16 ax_168 = fn0800_8BCA(bp_137, si_138, di_139, bp, out dx_164, out bp_165, out si_166, out di_167);
+		Mem170[ss:fp - 0x22 + 0x00:word16] = dx_164;
+		Mem172[ss:fp - 0x24 + 0x00:word16] = ax_168;
+		word16 dx_173;
+		word16 bp_174;
+		word16 si_175;
+		word16 di_176;
+		word16 ax_177 = fn0800_8BBB(bp_165, si_166, di_167, bp, out dx_173, out bp_174, out si_175, out di_176);
+		Mem179[ss:fp - 0x26 + 0x00:word16] = dx_173;
+		Mem181[ss:fp - 0x28 + 0x00:word16] = ax_177;
+		Mem187[ss:fp - 0x2A + 0x00:word16] = 0x00;
+		Mem189[ss:fp - 44 + 0x00:word16] = 0x0E10;
+		Mem192[ss:fp - 0x2E + 0x00:word16] = 0x00;
+		Mem194[ss:fp - 0x30 + 0x00:word16] = 0x5180;
+		Mem197[ss:fp - 0x32 + 0x00:word16] = Mem194[ss:bp_174 - 0x02 + 0x00:word16];
+		Mem200[ss:fp - 0x34 + 0x00:word16] = Mem197[ss:bp_174 - 0x04 + 0x00:word16];
+		word16 dx_201;
+		word16 bp_202;
+		word16 si_203;
+		word16 di_204;
+		word16 ax_205 = fn0800_8BCA(bp_174, si_175, di_176, bp, out dx_201, out bp_202, out si_203, out di_204);
+		Mem207[ss:fp - 0x36 + 0x00:word16] = dx_201;
+		Mem209[ss:fp - 0x38 + 0x00:word16] = ax_205;
+		word16 dx_210;
+		word16 bp_211;
+		word16 si_212;
+		word16 di_213;
+		word16 ax_214 = fn0800_8BBB(bp_202, si_203, di_204, bp, out dx_210, out bp_211, out si_212, out di_213);
+		Mem216[ss:fp - 0x3A + 0x00:word16] = dx_210;
+		Mem218[ss:fp - 0x3C + 0x00:word16] = ax_214;
+		Mem227[ss:fp - 0x3E + 0x00:word16] = (uint16) ((uint32) (uint16) si_212 % 100);
+		Mem236[ss:fp - 0x40 + 0x00:word16] = (uint16) ((uint32) (uint16) si_212 /u 100);
+		Mem239[ss:fp - 66 + 0x00:word16] = Mem236[ds_94:10737:word16];
+		Mem242[ss:fp - 0x44 + 0x00:word16] = Mem239[ds_94:0x29EF:word16];
+		Mem245[ss:fp - 0x46 + 0x00:word16] = Mem242[ds_94:10741:word16];
+		Mem248[ss:fp - 0x48 + 0x00:word16] = Mem245[ds_94:0x29F3:word16];
+		Mem250[ss:fp - 0x4A + 0x00:word16] = ds_94;
+		Mem253[ss:fp - 0x4C + 0x00:word16] = 1500;
+		Mem256[ss:fp - 0x4E + 0x00:word16] = 0x08;
+		Mem259[ss:fp - 0x50 + 0x00:word16] = Mem256[ds_94:10771:word16];
+		Mem261[ss:fp - 0x52 + 0x00:word16] = ds_94;
+		Mem264[ss:fp - 0x54 + 0x00:word16] = 2027;
+		word16 di_265;
+		fn0800_B2EF(ds_94, wArg00, wArg02, out di_265);
+		return;
+	}
+	else
 	{
 		switch (bx_77 << 0x01)
 		{
 		case 0x00:
 			dl_279 = fn0800_0DE8(bp_277, si_291, ds_278, out bp_277, out ds_278);
 			dx_280 = DPB(dx, dl_279, 0);
-			break;
+			goto l0800_0338;
 		case 0x01:
 		case 0x02:
 			dl_279 = fn0800_112D(bp_277, si_291, ds_278, out bp_277, out ds_278);
 			dx_280 = DPB(dx, dl_279, 0);
-			break;
+			goto l0800_0338;
 		case 0x03:
 		case 0x04:
 			dl_279 = fn0800_12E2(bp_277, ds_278, out ds_278);
 			dx_280 = DPB(dx, dl_279, 0);
-			break;
+			goto l0800_0338;
 		case 0x05:
 			dl_279 = fn0800_18D9(bp_277, ds_278, out si_291, out ds_278);
 			dx_280 = DPB(dx, dl_279, 0);
-			break;
+			goto l0800_0338;
 		case 0x06:
 		case 0x07:
 		case 0x08:
 			dl_279 = fn0800_19EE(bp_277, ds_278, out ds_278);
 			dx_280 = DPB(dx, dl_279, 0);
-			break;
+			goto l0800_0338;
 		}
 	}
-	Mem89[ss:fp - 0x0A + 0x00:word16] = 0x00;
-	Mem91[ss:fp - 0x0C + 0x00:word16] = 0x00;
-	byte dl_92;
-	word16 di_93;
-	selector ds_94;
-	word16 ax_97 = fn0800_9764(dl_279, ds_278, ptrArg00, wArg02, out dl_92, out di_93, out ds_94) - Mem91[ss:(bp_277 - 0x04) + 0x00:word16];
-	Mem102[ss:bp_277 - 0x02 + 0x00:word16] = dx_280 - Mem91[ss:(bp_277 - 0x02) + 0x00:word16] - (ax_97 <u 0x00);
-	Mem103[ss:bp_277 - 0x04 + 0x00:word16] = ax_97;
-	Mem106[ss:fp - 0x0A + 0x00:word16] = Mem103[ds_94:10737:word16];
-	Mem109[ss:fp - 0x0C + 0x00:word16] = Mem106[ds_94:0x29EF:word16];
-	Mem112[ss:fp - 0x0E + 0x00:word16] = Mem109[ds_94:10741:word16];
-	Mem115[ss:fp - 0x10 + 0x00:word16] = Mem112[ds_94:0x29F3:word16];
-	word16 di_118;
-	word16 ax_119 = fn0800_0B79(bp_277, si_291, di_93, wArg00, wArg02, wArg04, wArg06, out di_118);
-	Mem127[ss:fp - 0x0A + 0x00:word16] = 0x00;
-	Mem129[ss:fp - 0x0C + 0x00:word16] = 0x3C;
-	Mem132[ss:fp - 0x0E + 0x00:word16] = Mem129[ss:bp_277 - 0x02 + 0x00:word16];
-	Mem135[ss:fp - 0x10 + 0x00:word16] = Mem132[ss:bp_277 - 0x04 + 0x00:word16];
-	word16 dx_136;
-	word16 bp_137;
-	word16 si_138;
-	word16 di_139;
-	word16 ax_140 = fn0800_8BCA(bp_277, ax_119, di_118, bp, out dx_136, out bp_137, out si_138, out di_139);
-	Mem142[ss:fp - 0x12 + 0x00:word16] = dx_136;
-	Mem144[ss:fp - 0x14 + 0x00:word16] = ax_140;
-	Mem150[ss:fp - 22 + 0x00:word16] = 0x00;
-	Mem152[ss:fp - 0x18 + 0x00:word16] = 0x3C;
-	Mem155[ss:fp - 0x1A + 0x00:word16] = 0x00;
-	Mem157[ss:fp - 0x1C + 0x00:word16] = 0x0E10;
-	Mem160[ss:fp - 0x1E + 0x00:word16] = Mem157[ss:bp_137 - 0x02 + 0x00:word16];
-	Mem163[ss:fp - 0x20 + 0x00:word16] = Mem160[ss:bp_137 - 0x04 + 0x00:word16];
-	word16 dx_164;
-	word16 bp_165;
-	word16 si_166;
-	word16 di_167;
-	word16 ax_168 = fn0800_8BCA(bp_137, si_138, di_139, bp, out dx_164, out bp_165, out si_166, out di_167);
-	Mem170[ss:fp - 0x22 + 0x00:word16] = dx_164;
-	Mem172[ss:fp - 0x24 + 0x00:word16] = ax_168;
-	word16 dx_173;
-	word16 bp_174;
-	word16 si_175;
-	word16 di_176;
-	word16 ax_177 = fn0800_8BBB(bp_165, si_166, di_167, bp, out dx_173, out bp_174, out si_175, out di_176);
-	Mem179[ss:fp - 0x26 + 0x00:word16] = dx_173;
-	Mem181[ss:fp - 0x28 + 0x00:word16] = ax_177;
-	Mem187[ss:fp - 0x2A + 0x00:word16] = 0x00;
-	Mem189[ss:fp - 44 + 0x00:word16] = 0x0E10;
-	Mem192[ss:fp - 0x2E + 0x00:word16] = 0x00;
-	Mem194[ss:fp - 0x30 + 0x00:word16] = 0x5180;
-	Mem197[ss:fp - 0x32 + 0x00:word16] = Mem194[ss:bp_174 - 0x02 + 0x00:word16];
-	Mem200[ss:fp - 0x34 + 0x00:word16] = Mem197[ss:bp_174 - 0x04 + 0x00:word16];
-	word16 dx_201;
-	word16 bp_202;
-	word16 si_203;
-	word16 di_204;
-	word16 ax_205 = fn0800_8BCA(bp_174, si_175, di_176, bp, out dx_201, out bp_202, out si_203, out di_204);
-	Mem207[ss:fp - 0x36 + 0x00:word16] = dx_201;
-	Mem209[ss:fp - 0x38 + 0x00:word16] = ax_205;
-	word16 dx_210;
-	word16 bp_211;
-	word16 si_212;
-	word16 di_213;
-	word16 ax_214 = fn0800_8BBB(bp_202, si_203, di_204, bp, out dx_210, out bp_211, out si_212, out di_213);
-	Mem216[ss:fp - 0x3A + 0x00:word16] = dx_210;
-	Mem218[ss:fp - 0x3C + 0x00:word16] = ax_214;
-	Mem227[ss:fp - 0x3E + 0x00:word16] = (uint16) ((uint32) (uint16) si_212 % 100);
-	Mem236[ss:fp - 0x40 + 0x00:word16] = (uint16) ((uint32) (uint16) si_212 /u 100);
-	Mem239[ss:fp - 66 + 0x00:word16] = Mem236[ds_94:10737:word16];
-	Mem242[ss:fp - 0x44 + 0x00:word16] = Mem239[ds_94:0x29EF:word16];
-	Mem245[ss:fp - 0x46 + 0x00:word16] = Mem242[ds_94:10741:word16];
-	Mem248[ss:fp - 0x48 + 0x00:word16] = Mem245[ds_94:0x29F3:word16];
-	Mem250[ss:fp - 0x4A + 0x00:word16] = ds_94;
-	Mem253[ss:fp - 0x4C + 0x00:word16] = 1500;
-	Mem256[ss:fp - 0x4E + 0x00:word16] = 0x08;
-	Mem259[ss:fp - 0x50 + 0x00:word16] = Mem256[ds_94:10771:word16];
-	Mem261[ss:fp - 0x52 + 0x00:word16] = ds_94;
-	Mem264[ss:fp - 0x54 + 0x00:word16] = 2027;
-	word16 di_265;
-	fn0800_B2EF(ds_94, wArg00, wArg02, out di_265);
-	return;
 }
 
 // 0800:0402: Register word16 fn0800_0402(Register word16 si, Register selector ds, Register out ptr16 dsOut)
@@ -12365,623 +12369,596 @@ void fn0800_90F2(word16 ax, word16 bx, word16 bp, selector ds)
 // 0800:9107: void fn0800_9107(Register word16 ax, Register word16 dx, Register word16 bx, Register word16 bp, Register word16 di, Register selector ds)
 void fn0800_9107(word16 ax, word16 dx, word16 bx, word16 bp, word16 di, selector ds)
 {
-fn0800_9107_entry:
-	goto l0800_9107
-l0800_8FC8:
-	word16 si_109 = Mem0[ss:bp + 0x0C:word16]
-l0800_8FCB:
-	byte al_134 = Mem0[ds:si_109 + 0x00:byte]
-	word16 si_135 = si_109 + 0x01
-	branch al_134 == 0x00 l0800_9042
-l0800_8FD4:
-	branch al_134 == 0x25 l0800_9045
-l0800_8FD8:
-	Mem179[ss:bp - 0x06 + 0x00:word16] = Mem0[ss:bp - 0x06 + 0x00:word16] + 0x01
-	word16 sp_182 = sp_1019 - 0x02
-	Mem183[ss:sp_182 + 0x00:word16] = Mem179[ss:bp + 0x0A:word16]
-	Mem186[ss:sp_182 - 0x02 + 0x00:word16] = Mem183[ss:bp + 0x08:word16]
-	word16 sp_187
-	byte SZO_190
-	byte C_191
-	byte Z_192
-	word16 ax_193
-	selector es_194
-	word16 di_195
-	word16 dx_196
-	byte al_199
-	byte SCZO_200
-	word16 cx_202
-	byte SO_203
-	byte S_204
-	byte bl_206
-	byte bh_207
-	byte CZ_208
-	byte D_209
-	byte ah_210
-	byte dl_211
-	byte cl_212
-	byte ch_213
-	call SEQ(cs, Mem186[ss:bp + 0x04:word16]) (retsize: 2; depth: 2)
-		uses: ah_113,al_173,ax_176,bh_116,bl_117,bp_131,bx_118,C_141,ch_110,cl_111,cs_121,cx_128,CZ_115,D_114,di_177,dl_112,ds_123,dx_125,es_133,S_119,SCZO_170,si_135,SO_120,sp_185,ss_127,SZO_180,Z_171
-		defs: ah_210,al_199,ax_193,bh_207,bl_206,bp_189,bx_205,C_191,ch_213,cl_212,cs_201,cx_202,CZ_208,D_209,di_195,dl_211,ds_198,dx_196,es_194,S_204,SCZO_200,si_197,SO_203,sp_187,ss_188,SZO_190,Z_192
-	sp_1019 = sp_187 + 0x04
-	byte al_220 = (byte) ax_193
-	branch ax_193 < 0x00 l0800_9016
-l0800_8FEC:
-	word16 ax_254 = (int16) al_220
-	di = di_195
-	branch di_195 < 0x00 || Mem186[ds:di_195 + 9596:byte] != 0x01 l0800_902B
-	goto l0800_8FF8
-l0800_8FF1:
-l0800_8FF8:
-	byte bl_337 = (byte) ax_254
-	word16 bx_340 = DPB(ax_254, bl_337, 0)
-	branch bl_337 < 0x00 || Mem186[ds:bx_340 + 9596:byte] != 0x01 l0800_9019
-	goto l0800_9004
-l0800_8FFD:
-l0800_9004:
-	Mem387[ss:bp - 0x06 + 0x00:word16] = Mem186[ss:bp - 0x06 + 0x00:word16] + 0x01
-	word16 sp_390 = sp_1019 - 0x02
-	Mem391[ss:sp_390 + 0x00:word16] = Mem387[ss:bp + 0x0A:word16]
-	Mem394[ss:sp_390 - 0x02 + 0x00:word16] = Mem391[ss:bp + 0x08:word16]
-	word16 sp_395
-	byte SZO_398
-	byte C_399
-	byte Z_400
-	word16 ax_401
-	selector es_402
-	word16 di_403
-	word16 dx_404
-	word16 si_405
-	byte al_407
-	byte SCZO_408
-	word16 cx_410
-	byte SO_411
-	byte S_412
-	word16 bx_413
-	byte bl_414
-	byte bh_415
-	byte CZ_416
-	byte D_417
-	byte ah_418
-	byte dl_419
-	byte cl_420
-	byte ch_421
-	call SEQ(cs, Mem394[ss:bp + 0x04:word16]) (retsize: 2; depth: 2)
-		uses: ah_335,al_334,ax_332,bh_338,bl_339,bp_329,bx_340,C_343,ch_311,cl_312,cs_318,cx_327,CZ_315,D_314,di_323,dl_313,ds_320,dx_322,es_324,S_342,SCZO_384,si_321,SO_317,sp_393,ss_326,SZO_388,Z_385
-		defs: ah_418,al_407,ax_401,bh_415,bl_414,bp_397,bx_413,C_399,ch_421,cl_420,cs_409,cx_410,CZ_416,D_417,di_403,dl_419,ds_406,dx_404,es_402,S_412,SCZO_408,si_405,SO_411,sp_395,ss_396,SZO_398,Z_400
-	sp_1019 = sp_395 + 0x04
-	ax_254 = ax_401
-	branch ax_401 > 0x00 l0800_8FF8
-l0800_9016:
-	word16 bp_252
-	fn0800_93A6(bp, out bp_252)
-	return
-l0800_9016_thunk_fn0800_93A6:
-l0800_9019:
-	word16 sp_345 = sp_1019 - 0x02
-	Mem346[ss:sp_345 + 0x00:word16] = Mem186[ss:bp + 0x0A:word16]
-	Mem349[ss:sp_345 - 0x02 + 0x00:word16] = Mem346[ss:bp + 0x08:word16]
-	Mem351[ss:sp_345 - 0x04 + 0x00:word16] = bx_340
-	word16 sp_352
-	byte SZO_355
-	byte C_356
-	byte Z_357
-	word16 ax_358
-	selector es_359
-	word16 dx_361
-	byte al_364
-	byte SCZO_365
-	word16 cx_367
-	byte SO_368
-	byte S_369
-	byte bl_371
-	byte bh_372
-	byte CZ_373
-	byte D_374
-	byte ah_375
-	byte dl_376
-	byte cl_377
-	byte ch_378
-	call SEQ(cs, Mem351[ss:bp + 0x06:word16]) (retsize: 2; depth: 2)
-		uses: ah_335,al_334,ax_332,bh_338,bl_339,bp_329,bx_340,C_343,ch_311,cl_312,cs_318,cx_327,CZ_315,D_314,di_323,dl_313,ds_320,dx_322,es_324,S_342,SCZO_319,si_321,SO_317,sp_350,ss_326,SZO_341,Z_325
-		defs: ah_375,al_364,ax_358,bh_372,bl_371,bp_354,bx_370,C_356,ch_378,cl_377,cs_366,cx_367,CZ_373,D_374,di_360,dl_376,ds_363,dx_361,es_359,S_369,SCZO_365,si_362,SO_368,sp_352,ss_353,SZO_355,Z_357
-	Mem382[ss:bp - 0x06 + 0x00:word16] = Mem351[ss:bp - 0x06 + 0x00:word16] - 0x01
-	sp_1019 = sp_352 + 0x06
-	goto l0800_8FCB
-l0800_902B:
-	branch ax_254 == di_195 l0800_8FCB
-l0800_902F:
-	Mem266[ss:sp_187 + 0x02:word16] = Mem186[ss:bp + 0x0A:word16]
-	Mem269[ss:sp_187 + 0x00:word16] = Mem266[ss:bp + 0x08:word16]
-	Mem271[ss:sp_187 - 0x02 + 0x00:word16] = ax_254
-	word16 sp_272
-	selector ss_273
-	word16 bp_274
-	byte SZO_275
-	byte C_276
-	byte Z_277
-	word16 ax_278
-	selector es_279
-	word16 di_280
-	word16 dx_281
-	word16 si_282
-	selector ds_283
-	byte al_284
-	byte SCZO_285
-	selector cs_286
-	word16 cx_287
-	byte SO_288
-	byte S_289
-	word16 bx_290
-	byte bl_291
-	byte bh_292
-	byte CZ_293
-	byte D_294
-	byte ah_295
-	byte dl_296
-	byte cl_297
-	byte ch_298
-	call SEQ(cs, Mem271[ss:bp + 0x06:word16]) (retsize: 2; depth: 2)
-		uses: ah_257,al_256,ax_254,bh_207,bl_206,bp_189,bx_205,C_261,ch_213,cl_212,cs_201,cx_216,CZ_208,D_209,di_258,dl_211,ds_198,dx_196,es_194,S_260,SCZO_262,si_197,SO_222,sp_270,ss_188,SZO_259,Z_263
-		defs: ah_295,al_284,ax_278,bh_292,bl_291,bp_274,bx_290,C_276,ch_298,cl_297,cs_286,cx_287,CZ_293,D_294,di_280,dl_296,ds_283,dx_281,es_279,S_289,SCZO_285,si_282,SO_288,sp_272,ss_273,SZO_275,Z_277
-	Mem302[ss_273:bp_274 - 0x06 + 0x00:word16] = Mem271[ss_273:bp_274 - 0x06 + 0x00:word16] - 0x01
-	word16 bp_307
-	fn0800_93BE(bp_274, psegArg00, wArg02, wArg04, out bp_307)
-	return
-l0800_903F_thunk_fn0800_93BE:
-l0800_9042:
-	word16 bp_1219
-	fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_1219)
-	return
-l0800_9042_thunk_fn0800_93BE:
-l0800_9045:
-	Mem431[ss:bp - 0x0A + 0x00:word16] = ~0x00
-	selector es_432 = Mem431[ss:bp + 0x0E:selector]
-	Mem433[ss:bp - 0x01 + 0x00:byte] = 0x20
-	si_440 = si_135
-l0800_9051:
-	word16 si_440
-	si_440 = si_440 + 0x01
-	word16 ax_446 = (int16) Mem433[ds:si_440 + 0x00:byte]
-	Mem447[ss:bp + 0x0C:word16] = si_440
-	di = ax_446
-	branch ax_446 < 0x00 l0800_9075
-l0800_905C:
-	word16 bx_460 = DPB(bx, 0x00, 8)
-	branch bx_460 <=u 0x15 l0800_906A
-l0800_9067:
-	word16 bp_463
-	fn0800_93A6(bp, out bp_463)
-	return
-l0800_9067_thunk_fn0800_93A6:
-l0800_906A:
-	word16 si_1200
-	bx = bx_460 << 0x01
-	switch (bx_460 << 0x01) { l0800_93BE l0800_93BE l0800_93BE l0800_9071 l0800_9078 l0800_907E l0800_926F l0800_90C2 l0800_90C2 l0800_90CC l0800_91A1 l0800_9092 l0800_909E l0800_9098 l0800_90BD l0800_920B l0800_92B1 l0800_90B0 l0800_90C7 l0800_9127 l0800_90A4 l0800_90AA }
-l0800_906C_thunk_fn0800_93BE:
-	word16 bp_469
-	fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_469)
-	return
-l0800_906C_thunk_fn0800_93BE:
-	word16 bp_471
-	fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_471)
-	return
-l0800_906C_thunk_fn0800_93BE:
-	word16 bp_473
-	fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_473)
-	return
-l0800_9071:
-	goto l0800_8FD8
-l0800_9075:
-	word16 bp_1217
-	fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_1217)
-	return
-l0800_9075_thunk_fn0800_93BE:
-l0800_9078:
-	Mem481[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x01
-	goto l0800_9051
-l0800_907E:
-	word16 v44_485 = Mem447[ss:bp - 0x0A + 0x00:word16]
-	Mem486[ss:bp - 0x0A + 0x00:word16] = ax_446 - 0x30
-	di = v44_485
-	branch v44_485 < 0x00 l0800_9051
-l0800_9088:
-	Mem495[ss:bp - 0x0A + 0x00:word16] = Mem486[ss:bp - 0x0A + 0x00:word16] + 0x0A
-	goto l0800_9051
-l0800_9092:
-	Mem761[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x08
-	goto l0800_9051
-l0800_9098:
-	Mem769[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x04
-	goto l0800_9051
-l0800_909E:
-	Mem765[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x02
-	goto l0800_9051
-l0800_90A4:
-	Mem1210[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] & 223
-	goto l0800_9051
-l0800_90AA:
-	Mem1214[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x20
-	goto l0800_9051
-l0800_90B0:
-	ax = Mem447[ss:bp - 0x06 + 0x00:word16]
-	dx = 0x00
-	branch (Mem447[ss:bp - 0x01 + 0x00:byte] & 0x01) == 0x00 l0800_9110
-	goto l0800_9051
-l0800_90BD:
-	si_1200 = 0x08
-	goto l0800_90CE
-l0800_90C2:
-	si_1200 = 0x0A
-	goto l0800_90CE
-l0800_90C7:
-	si_1200 = 0x10
-	goto l0800_90CE
-l0800_90CC:
-	si_1200 = 0x00
-l0800_90CE:
-	branch (ax_446 & 0x20) != 0x00 || ax_446 == 88 l0800_90DD
-	goto l0800_90D9
-l0800_90D4:
-l0800_90D9:
-	Mem669[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x04
-l0800_90DD:
-	word16 sp_616 = sp_1019 - 0x02
-	Mem617[ss:sp_616 + 0x00:word16] = ss
-	Mem620[ss:sp_616 - 0x02 + 0x00:word16] = bp - 0x08
-	Mem622[ss:sp_616 - 0x04 + 0x00:word16] = ss
-	Mem625[ss:sp_616 - 0x06 + 0x00:word16] = bp - 0x06
-	word16 ax_626 = Mem625[ss:bp - 0x0A + 0x00:word16]
-	Mem631[ss:sp_616 - 0x08 + 0x00:word16] = ax_626 & 0x7FFF
-	Mem633[ss:sp_616 - 0x0A + 0x00:word16] = si_1200
-	Mem636[ss:sp_616 - 0x0C + 0x00:word16] = Mem633[ss:bp + 0x0A:word16]
-	Mem639[ss:sp_616 - 0x0E + 0x00:word16] = Mem636[ss:bp + 0x08:word16]
-	Mem642[ss:sp_616 - 0x10 + 0x00:word16] = Mem639[ss:bp + 0x06:word16]
-	Mem645[ss:sp_616 - 0x12 + 0x00:word16] = Mem642[ss:bp + 0x04:word16]
-	ax = fn0800_94B0(ax_626 & 0x7FFF, bx_460 << 0x01, ds, wArg04, wArg06, wArg08, wArg0A, ptrArg0C, ptrArg10, out dx, out bx, out di)
-	branch Mem645[ss:bp - 0x08 + 0x00:word16] <= 0x00 l0800_911F
-	goto l0800_9107
-l0800_9105_thunk_fn0800_911F:
-	fn0800_911F(bp)
-	return
 l0800_9107:
-	word16 sp_1019 = v3
-	branch (Mem0[ss:bp - 0x01 + 0x00:byte] & 0x01) != 0x00 l0800_911C
-l0800_910D:
-	Mem1257[ss:bp - 0x04 + 0x00:word16] = Mem0[ss:bp - 0x04 + 0x00:word16] + 0x01
+	word16 sp_1019 = v3;
+	if ((Mem0[ss:bp - 0x01 + 0x00:byte] & 0x01) == 0x00)
+	{
+		Mem1257[ss:bp - 0x04 + 0x00:word16] = Mem0[ss:bp - 0x04 + 0x00:word16] + 0x01;
 l0800_9110:
-	selector es_1244
-	word16 di_1245 = fn0800_8FAB(bp, ds, out es_1244)
-	Mem1246[es_1244:di_1245 + 0x00:word16] = ax
-	di = di_1245 + 0x02
-	branch (Mem1246[ss:bp - 0x01 + 0x00:byte] & 0x04) == 0x00 l0800_911C
-l0800_911A:
-	Mem1254[es_1244:di_1245 + 0x02:word16] = dx
-	di = di_1245 + 0x04
-l0800_911C:
-	goto l0800_8FC8
-l0800_9127:
-	word16 bp_1201
-	word16 ax_1202 = fn0800_912A(di, bp, ds, out bp_1201)
-	word16 bp_1207
-	fn0800_912A(ax_1202, bp_1201, ds, out bp_1207)
-	return
-l0800_9127_thunk_fn0800_912A:
-l0800_919E:
-	word16 bp_758
-	fn0800_93A6(bp, out bp_758)
-	return
-l0800_919E_thunk_fn0800_93A6:
-l0800_91A1:
-	word16 sp_676 = sp_1019 - 0x02
-	Mem677[ss:sp_676 + 0x00:word16] = ss
-	Mem680[ss:sp_676 - 0x02 + 0x00:word16] = bp - 0x08
-	Mem682[ss:sp_676 - 0x04 + 0x00:word16] = ss
-	Mem685[ss:sp_676 - 0x06 + 0x00:word16] = bp - 0x06
-	Mem691[ss:sp_676 - 0x08 + 0x00:word16] = Mem685[ss:bp - 0x0A + 0x00:word16] & 0x7FFF
-	Mem694[ss:sp_676 - 0x0A + 0x00:word16] = Mem691[ss:bp + 0x0A:word16]
-	Mem697[ss:sp_676 - 0x0C + 0x00:word16] = Mem694[ss:bp + 0x08:word16]
-	Mem700[ss:sp_676 - 0x0E + 0x00:word16] = Mem697[ss:bp + 0x06:word16]
-	Mem703[ss:sp_676 - 0x10 + 0x00:word16] = Mem700[ss:bp + 0x04:word16]
-	fn0800_A2D0()
-	sp_1019 = sp_676 + 0x02
-	branch Mem703[ss:bp - 0x08 + 0x00:word16] <= 0x00 l0800_9203
-l0800_91CA:
-	branch ((int16) Mem703[ss:bp - 0x01 + 0x00:byte] & 0x01) != 0x00 l0800_91FD
-l0800_91D3:
-	word16 ax_730
-	selector es_717
-	di = fn0800_8FAB(bp, ds, out es_717)
-	Mem720[ss:bp - 0x04 + 0x00:word16] = Mem703[ss:bp - 0x04 + 0x00:word16] + 0x01
-	branch (Mem720[ss:bp - 0x01 + 0x00:byte] & 0x04) == 0x00 l0800_91E4
-l0800_91DF:
-	ax_730 = 0x04
-	goto l0800_91F1
-l0800_91E4:
-	branch (Mem720[ss:bp - 0x01 + 0x00:byte] & 0x08) == 0x00 l0800_91EF
-l0800_91EA:
-	ax_730 = 0x08
-	goto l0800_91F1
-l0800_91EF:
-	ax_730 = 0x00
-l0800_91F1:
-	Mem732[ss:sp_676 + 0x00:word16] = ax_730
-	Mem734[ss:sp_676 - 0x02 + 0x00:word16] = es_717
-	Mem736[ss:sp_676 - 0x04 + 0x00:word16] = di
-	fn0800_A2D4()
-	sp_1019 = sp_676 + 0x02
-	goto l0800_8FC8
-l0800_91FD:
-	fn0800_A2D8()
-	goto l0800_8FC8
-l0800_9203:
-	fn0800_A2D8()
-	branch Mem703[ss:bp - 0x08 + 0x00:word16] < 0x00 l0800_919E
-l0800_9208:
-	word16 bp_756
-	fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_756)
-	return
-l0800_9208_thunk_fn0800_93BE:
-l0800_920B:
-	word16 bp_773
-	word16 ax_774 = fn0800_920E(di, bp, ds, out bp_773)
-	word16 bp_779
-	fn0800_920E(ax_774, bp_773, ds, out bp_779)
-	return
-l0800_920B_thunk_fn0800_920E:
-l0800_926F:
-	branch (Mem447[ss:bp - 0x01 + 0x00:byte] & 0x01) != 0x00 l0800_9278
-l0800_9275:
-	di = fn0800_8FAB(bp, ds, out es_432)
-l0800_9278:
-	word16 si_502 = Mem447[ss:bp - 0x0A + 0x00:word16]
-	branch si_502 == 0x00 l0800_92A2
-	goto l0800_9284
-l0800_9282:
+		selector es_1244;
+		word16 di_1245 = fn0800_8FAB(bp, ds, out es_1244);
+		Mem1246[es_1244:di_1245 + 0x00:word16] = ax;
+		di = di_1245 + 0x02;
+		if ((Mem1246[ss:bp - 0x01 + 0x00:byte] & 0x04) != 0x00)
+		{
+			Mem1254[es_1244:di_1245 + 0x02:word16] = dx;
+			di = di_1245 + 0x04;
+		}
+	}
+l0800_8FC8:
+	word16 si_109 = Mem0[ss:bp + 0x0C:word16];
+l0800_8FCB:
+	byte al_134 = Mem0[ds:si_109 + 0x00:byte];
+	word16 si_135 = si_109 + 0x01;
+	if (al_134 == 0x00)
+	{
+		word16 bp_1219;
+		fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_1219);
+		return;
+	}
+	else if (al_134 == 0x25)
+	{
+		Mem431[ss:bp - 0x0A + 0x00:word16] = ~0x00;
+		selector es_432 = Mem431[ss:bp + 0x0E:selector];
+		Mem433[ss:bp - 0x01 + 0x00:byte] = 0x20;
+		si_440 = si_135;
+l0800_9051:
+		word16 si_440;
+		si_440 = si_440 + 0x01;
+		word16 ax_446 = (int16) Mem433[ds:si_440 + 0x00:byte];
+		Mem447[ss:bp + 0x0C:word16] = si_440;
+		di = ax_446;
+		if (ax_446 < 0x00)
+		{
+			word16 bp_1217;
+			fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_1217);
+			return;
+		}
+		else
+		{
+			word16 bx_460 = DPB(bx, 0x00, 8);
+			if (bx_460 >u 0x15)
+			{
+				word16 bp_463;
+				fn0800_93A6(bp, out bp_463);
+				return;
+			}
+			word16 si_1200;
+			bx = bx_460 << 0x01;
+			switch (bx_460 << 0x01)
+			{
+			case 0x00:
+				word16 bp_469;
+				fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_469);
+				return;
+			case 0x01:
+				word16 bp_471;
+				fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_471);
+				return;
+			case 0x02:
+				word16 bp_473;
+				fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_473);
+				return;
+			case 0x03:
+				goto l0800_8FD8;
+			case 0x04:
+				Mem481[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x01;
+				goto l0800_9051;
+			case 0x05:
+				word16 v44_485 = Mem447[ss:bp - 0x0A + 0x00:word16];
+				Mem486[ss:bp - 0x0A + 0x00:word16] = ax_446 - 0x30;
+				di = v44_485;
+				if (v44_485 >= 0x00)
+					Mem495[ss:bp - 0x0A + 0x00:word16] = Mem486[ss:bp - 0x0A + 0x00:word16] + 0x0A;
+				continue;
+			case 0x06:
+				if ((Mem447[ss:bp - 0x01 + 0x00:byte] & 0x01) == 0x00)
+					di = fn0800_8FAB(bp, ds, out es_432);
+				word16 si_502 = Mem447[ss:bp - 0x0A + 0x00:word16];
+				if (si_502 != 0x00)
+				{
 l0800_9284:
-	Mem549[ss:bp - 0x06 + 0x00:word16] = Mem447[ss:bp - 0x06 + 0x00:word16] + 0x01
-	word16 sp_551 = sp_1019 - 0x02
-	Mem552[ss:sp_551 + 0x00:word16] = es_432
-	Mem555[ss:sp_551 - 0x02 + 0x00:word16] = Mem552[ss:bp + 0x0A:word16]
-	Mem558[ss:sp_551 - 0x04 + 0x00:word16] = Mem555[ss:bp + 0x08:word16]
-	word16 sp_559
-	byte SZO_562
-	byte C_563
-	byte Z_564
-	word16 ax_565
-	selector es_566
-	word16 dx_568
-	word16 si_569
-	byte al_571
-	byte SCZO_572
-	word16 cx_574
-	byte SO_575
-	byte S_576
-	byte bl_578
-	byte bh_579
-	byte CZ_580
-	byte D_581
-	byte ah_582
-	byte dl_583
-	byte cl_584
-	byte ch_585
-	call SEQ(cs, Mem558[ss:bp + 0x04:word16]) (retsize: 2; depth: 2)
-		uses: ah_452,al_451,ax_449,bh_467,bl_466,bp_547,bx_465,C_508,ch_110,cl_111,cs_121,cx_128,CZ_510,D_114,di_500,dl_434,ds_123,dx_441,es_544,S_507,SCZO_509,si_511,SO_506,sp_557,ss_545,SZO_550,Z_505
-		defs: ah_582,al_571,ax_565,bh_579,bl_578,bp_561,bx_577,C_563,ch_585,cl_584,cs_573,cx_574,CZ_580,D_581,di_567,dl_583,ds_570,dx_568,es_566,S_576,SCZO_572,si_569,SO_575,sp_559,ss_560,SZO_562,Z_564
-	es_432 = Mem558[ss:sp_559 + 0x04:selector]
-	sp_1019 = sp_559 + 0x06
-	byte al_594 = (byte) ax_565
-	branch ax_565 < 0x00 l0800_92AE
-l0800_9298:
-	branch (Mem558[ss:bp - 0x01 + 0x00:byte] & 0x01) != 0x00 l0800_929F
-l0800_929E:
-	Mem605[es_432:di + 0x00:byte] = al_594
-	di = di + 0x01
-l0800_929F:
-	branch si_569 > 0x01 l0800_9284
-l0800_92A2:
-	branch (Mem447[ss:bp - 0x01 + 0x00:byte] & 0x01) != 0x00 l0800_92AB
-l0800_92A8:
-	Mem542[ss:bp - 0x04 + 0x00:word16] = Mem447[ss:bp - 0x04 + 0x00:word16] + 0x01
-l0800_92AB:
-	goto l0800_8FC8
-l0800_92AE:
-	word16 bp_607
-	fn0800_93A6(bp, out bp_607)
-	return
-l0800_92AE_thunk_fn0800_93A6:
-l0800_92B1:
-	word16 sp_781 = sp_1019 - 0x02
-	Mem782[ss:sp_781 + 0x00:word16] = es_432
-	Mem790[ss:sp_781 - 0x02 + 0x00:word16] = ss
-	selector es_791 = Mem790[ss:sp_781 - 0x02 + 0x00:selector]
-	word16 di_793 = bp - 0x2A
-	word16 cx_794 = 0x10
-l0800_92BD:
-	branch cx_794 == 0x00 l0800_92BF
-l0800_92BD_1:
-	Mem801[es_791:di_793 + 0x00:word16] = 0x00
-	di_793 = di_793 + 0x02
-	cx_794 = cx_794 - 0x01
-	goto l0800_92BD
-l0800_92BF:
-	byte al_1187 = Mem790[ds:si_440 + 0x00:byte]
-	selector es_1016 = Mem790[ss:sp_781 + 0x00:selector]
-	Mem813[ss:bp - 0x01 + 0x00:byte] = Mem790[ss:bp - 0x01 + 0x00:byte] & ~0x10
-	sp_1019 = sp_781 + 0x02
-	word16 ax_1188 = (word16) al_1187
-	word16 si_1190 = si_440 + 0x01
-	branch al_1187 != 0x5E l0800_92D0
-l0800_92CA:
-	Mem1184[ss:bp - 0x01 + 0x00:byte] = Mem813[ss:bp - 0x01 + 0x00:byte] | 0x10
-	al_1187 = Mem1184[ds:si_440 + 0x01:byte]
-	ax_1188 = DPB(ax_1188, al_1187, 0) (alias)
-	si_1190 = si_440 + 0x02
-l0800_92D0:
-	word16 ax_824 = DPB(ax_1188, 0x00, 8)
+					Mem549[ss:bp - 0x06 + 0x00:word16] = Mem447[ss:bp - 0x06 + 0x00:word16] + 0x01;
+					word16 sp_551 = sp_1019 - 0x02;
+					Mem552[ss:sp_551 + 0x00:word16] = es_432;
+					Mem555[ss:sp_551 - 0x02 + 0x00:word16] = Mem552[ss:bp + 0x0A:word16];
+					Mem558[ss:sp_551 - 0x04 + 0x00:word16] = Mem555[ss:bp + 0x08:word16];
+					word16 sp_559;
+					byte SZO_562;
+					byte C_563;
+					byte Z_564;
+					word16 ax_565;
+					selector es_566;
+					word16 dx_568;
+					word16 si_569;
+					byte al_571;
+					byte SCZO_572;
+					word16 cx_574;
+					byte SO_575;
+					byte S_576;
+					byte bl_578;
+					byte bh_579;
+					byte CZ_580;
+					byte D_581;
+					byte ah_582;
+					byte dl_583;
+					byte cl_584;
+					byte ch_585;
+					SEQ(cs, Mem558[ss:bp + 0x04:word16])();
+					es_432 = Mem558[ss:sp_559 + 0x04:selector];
+					sp_1019 = sp_559 + 0x06;
+					byte al_594 = (byte) ax_565;
+					if (ax_565 < 0x00)
+					{
+						word16 bp_607;
+						fn0800_93A6(bp, out bp_607);
+						return;
+					}
+					if ((Mem558[ss:bp - 0x01 + 0x00:byte] & 0x01) == 0x00)
+					{
+						Mem605[es_432:di + 0x00:byte] = al_594;
+						di = di + 0x01;
+					}
+					if (si_569 > 0x01)
+						goto l0800_9284;
+				}
+				if ((Mem447[ss:bp - 0x01 + 0x00:byte] & 0x01) == 0x00)
+					Mem542[ss:bp - 0x04 + 0x00:word16] = Mem447[ss:bp - 0x04 + 0x00:word16] + 0x01;
+				goto l0800_8FC8;
+			case 0x07:
+			case 0x08:
+				si_1200 = 0x0A;
+				goto l0800_90CE;
+			case 0x09:
+				si_1200 = 0x00;
+				goto l0800_90CE;
+			case 0x0A:
+				word16 sp_676 = sp_1019 - 0x02;
+				Mem677[ss:sp_676 + 0x00:word16] = ss;
+				Mem680[ss:sp_676 - 0x02 + 0x00:word16] = bp - 0x08;
+				Mem682[ss:sp_676 - 0x04 + 0x00:word16] = ss;
+				Mem685[ss:sp_676 - 0x06 + 0x00:word16] = bp - 0x06;
+				Mem691[ss:sp_676 - 0x08 + 0x00:word16] = Mem685[ss:bp - 0x0A + 0x00:word16] & 0x7FFF;
+				Mem694[ss:sp_676 - 0x0A + 0x00:word16] = Mem691[ss:bp + 0x0A:word16];
+				Mem697[ss:sp_676 - 0x0C + 0x00:word16] = Mem694[ss:bp + 0x08:word16];
+				Mem700[ss:sp_676 - 0x0E + 0x00:word16] = Mem697[ss:bp + 0x06:word16];
+				Mem703[ss:sp_676 - 0x10 + 0x00:word16] = Mem700[ss:bp + 0x04:word16];
+				fn0800_A2D0();
+				sp_1019 = sp_676 + 0x02;
+				if (Mem703[ss:bp - 0x08 + 0x00:word16] > 0x00)
+				{
+					if (((int16) Mem703[ss:bp - 0x01 + 0x00:byte] & 0x01) == 0x00)
+					{
+						word16 ax_730;
+						selector es_717;
+						di = fn0800_8FAB(bp, ds, out es_717);
+						Mem720[ss:bp - 0x04 + 0x00:word16] = Mem703[ss:bp - 0x04 + 0x00:word16] + 0x01;
+						if ((Mem720[ss:bp - 0x01 + 0x00:byte] & 0x04) != 0x00)
+							ax_730 = 0x04;
+						else if ((Mem720[ss:bp - 0x01 + 0x00:byte] & 0x08) != 0x00)
+							ax_730 = 0x08;
+						else
+							ax_730 = 0x00;
+						Mem732[ss:sp_676 + 0x00:word16] = ax_730;
+						Mem734[ss:sp_676 - 0x02 + 0x00:word16] = es_717;
+						Mem736[ss:sp_676 - 0x04 + 0x00:word16] = di;
+						fn0800_A2D4();
+						sp_1019 = sp_676 + 0x02;
+					}
+					else
+						fn0800_A2D8();
+					goto l0800_8FC8;
+				}
+				fn0800_A2D8();
+				if (Mem703[ss:bp - 0x08 + 0x00:word16] < 0x00)
+				{
+					word16 bp_758;
+					fn0800_93A6(bp, out bp_758);
+					return;
+				}
+				else
+				{
+					word16 bp_756;
+					fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_756);
+					return;
+				}
+			case 11:
+				Mem761[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x08;
+				continue;
+			case 0x0C:
+				Mem765[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x02;
+				continue;
+			case 0x0D:
+				Mem769[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x04;
+				continue;
+			case 0x0E:
+				si_1200 = 0x08;
+				goto l0800_90CE;
+			case 0x0F:
+				word16 bp_773;
+				word16 ax_774 = fn0800_920E(di, bp, ds, out bp_773);
+				word16 bp_779;
+				fn0800_920E(ax_774, bp_773, ds, out bp_779);
+				return;
+			case 0x10:
+				word16 sp_781 = sp_1019 - 0x02;
+				Mem782[ss:sp_781 + 0x00:word16] = es_432;
+				Mem790[ss:sp_781 - 0x02 + 0x00:word16] = ss;
+				selector es_791 = Mem790[ss:sp_781 - 0x02 + 0x00:selector];
+				word16 di_793 = bp - 0x2A;
+				word16 cx_794 = 0x10;
+				while (cx_794 != 0x00)
+				{
+					Mem801[es_791:di_793 + 0x00:word16] = 0x00;
+					di_793 = di_793 + 0x02;
+					cx_794 = cx_794 - 0x01;
+				}
+				byte al_1187 = Mem790[ds:si_440 + 0x00:byte];
+				selector es_1016 = Mem790[ss:sp_781 + 0x00:selector];
+				Mem813[ss:bp - 0x01 + 0x00:byte] = Mem790[ss:bp - 0x01 + 0x00:byte] & ~0x10;
+				sp_1019 = sp_781 + 0x02;
+				word16 ax_1188 = (word16) al_1187;
+				word16 si_1190 = si_440 + 0x01;
+				if (al_1187 == 0x5E)
+				{
+					Mem1184[ss:bp - 0x01 + 0x00:byte] = Mem813[ss:bp - 0x01 + 0x00:byte] | 0x10;
+					al_1187 = Mem1184[ds:si_440 + 0x01:byte];
+					ax_1188 = DPB(ax_1188, al_1187, 0);
+					si_1190 = si_440 + 0x02;
+				}
+				word16 ax_824 = DPB(ax_1188, 0x00, 8);
 l0800_92D2:
-	di = ax_824 >>u 0x03
-	byte ch_842 = 0x01 << (al_1187 & 0x07)
-	Mem845[ss:bp - 0x2A + di:byte] = Mem813[ss:bp - 0x2A + di:byte] | ch_842
-	byte dl_834 = al_1187
+				di = ax_824 >>u 0x03;
+				byte ch_842 = 0x01 << (al_1187 & 0x07);
+				Mem845[ss:bp - 0x2A + di:byte] = Mem813[ss:bp - 0x2A + di:byte] | ch_842;
+				byte dl_834 = al_1187;
 l0800_92E4:
-	al_1187 = Mem845[ds:si_1190 + 0x00:byte]
-	ax_824 = DPB(ax_824, al_1187, 0) (alias)
-	si_1190 = si_1190 + 0x01
-	branch al_1187 == 0x00 l0800_9313
-l0800_92EA:
-	branch al_1187 == 0x5D l0800_9316
-l0800_92EE:
-	branch al_1187 != 0x2D || (dl_834 >u Mem845[es_1016:si_1190 + 0x00:byte] || Mem845[es_1016:si_1190 + 0x00:byte] == 0x5D) l0800_92D2
-	goto l0800_92FD
-l0800_92F2:
-l0800_92F7:
-l0800_92FD:
-	byte al_875 = Mem845[ds:si_1190 + 0x00:byte] - dl_834
-	si_1190 = si_1190 + 0x01
-	ax_824 = DPB(ax_824, al_875, 0) (alias)
-	branch al_875 == 0x00 l0800_92E4
-l0800_9303:
-	dl_834 = dl_834 + al_875
-l0800_9305:
-	ch_842 = __rol(ch_842, 0x01)
-	di = di + ((ch_842 & 0x80) != 0x00)
-	Mem896[ss:bp - 0x2A + di:byte] = Mem845[ss:bp - 0x2A + di:byte] | ch_842
-	al_875 = al_875 - 0x01
-	ax_824 = DPB(ax_824, al_875, 0) (alias)
-	branch al_875 != 0x00 l0800_9305
-	goto l0800_92E4
-l0800_9313:
-	word16 bp_1181
-	fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_1181)
-	return
-l0800_9313_thunk_fn0800_93BE:
-l0800_9316:
-	Mem904[ss:bp + 0x0C:word16] = si_1190
-	Mem906[ss:bp - 0x0A + 0x00:word16] = Mem904[ss:bp - 0x0A + 0x00:word16] & 0x7FFF
-	word16 si_1096 = Mem906[ss:bp - 0x0A + 0x00:word16]
-	branch (Mem906[ss:bp - 0x01 + 0x00:byte] & 0x01) != 0x00 l0800_932A
-l0800_9327:
-	di = fn0800_8FAB(bp, ds, out es_1016)
+				al_1187 = Mem845[ds:si_1190 + 0x00:byte];
+				ax_824 = DPB(ax_824, al_1187, 0);
+				si_1190 = si_1190 + 0x01;
+				if (al_1187 == 0x00)
+				{
+					word16 bp_1181;
+					fn0800_93BE(bp, psegArg00, wArg02, wArg04, out bp_1181);
+					return;
+				}
+				if (al_1187 != 0x5D)
+				{
+					if (al_1187 != 0x2D || (dl_834 >u Mem845[es_1016:si_1190 + 0x00:byte] || Mem845[es_1016:si_1190 + 0x00:byte] == 0x5D))
+						goto l0800_92D2;
+					byte al_875 = Mem845[ds:si_1190 + 0x00:byte] - dl_834;
+					si_1190 = si_1190 + 0x01;
+					ax_824 = DPB(ax_824, al_875, 0);
+					if (al_875 != 0x00)
+					{
+						dl_834 = dl_834 + al_875;
+						do
+						{
+							ch_842 = __rol(ch_842, 0x01);
+							di = di + ((ch_842 & 0x80) != 0x00);
+							Mem896[ss:bp - 0x2A + di:byte] = Mem845[ss:bp - 0x2A + di:byte] | ch_842;
+							al_875 = al_875 - 0x01;
+							ax_824 = DPB(ax_824, al_875, 0);
+						} while (al_875 != 0x00);
+					}
+					goto l0800_92E4;
+				}
+				Mem904[ss:bp + 0x0C:word16] = si_1190;
+				Mem906[ss:bp - 0x0A + 0x00:word16] = Mem904[ss:bp - 0x0A + 0x00:word16] & 0x7FFF;
+				word16 si_1096 = Mem906[ss:bp - 0x0A + 0x00:word16];
+				if ((Mem906[ss:bp - 0x01 + 0x00:byte] & 0x01) == 0x00)
+					di = fn0800_8FAB(bp, ds, out es_1016);
 l0800_932A:
-	word16 si_938 = si_1096 - 0x01
-	branch si_938 < 0x00 l0800_9385
-l0800_932D:
-	Mem1031[ss:bp - 0x06 + 0x00:word16] = Mem906[ss:bp - 0x06 + 0x00:word16] + 0x01
-	word16 sp_1033 = sp_1019 - 0x02
-	Mem1034[ss:sp_1033 + 0x00:word16] = es_1016
-	Mem1037[ss:sp_1033 - 0x02 + 0x00:word16] = Mem1034[ss:bp + 0x0A:word16]
-	Mem1040[ss:sp_1033 - 0x04 + 0x00:word16] = Mem1037[ss:bp + 0x08:word16]
-	word16 sp_1041
-	byte SZO_1044
-	byte C_1045
-	byte Z_1046
-	word16 ax_1047
-	selector es_1048
-	word16 dx_1050
-	word16 si_1051
-	byte al_1053
-	byte SCZO_1054
-	word16 cx_1056
-	byte SO_1057
-	byte S_1058
-	word16 bx_1059
-	byte bl_1060
-	byte bh_1061
-	byte CZ_1062
-	byte D_1063
-	byte ah_1064
-	byte dl_1065
-	byte cl_1066
-	byte ch_1067
-	call SEQ(cs, Mem1040[ss:bp + 0x04:word16]) (retsize: 2; depth: 2)
-		uses: ah_915,al_934,ax_937,bh_918,bl_919,bp_936,bx_920,C_935,ch_912,cl_913,cs_922,cx_931,CZ_917,D_916,di_927,dl_914,ds_924,dx_926,es_928,S_921,SCZO_923,si_938,SO_940,sp_1039,ss_930,SZO_1032,Z_929
-		defs: ah_1064,al_1053,ax_1047,bh_1061,bl_1060,bp_1043,bx_1059,C_1045,ch_1067,cl_1066,cs_1055,cx_1056,CZ_1062,D_1063,di_1049,dl_1065,ds_1052,dx_1050,es_1048,S_1058,SCZO_1054,si_1051,SO_1057,sp_1041,ss_1042,SZO_1044,Z_1046
-	es_1016 = Mem1040[ss:sp_1041 + 0x04:selector]
-	sp_1019 = sp_1041 + 0x06
-	branch ax_1047 < 0x00 l0800_9394
-l0800_9341:
-	byte ch_1090 = 0x01 << ((byte) ax_1047 & 0x07)
-	si_1096 = si_1051
-	byte al_1100 = (byte) ax_1047
-	bx = ax_1047 >>u 0x03
-	branch (Mem1040[ss:bp - 0x2A + (ax_1047 >>u 0x03):byte] & ch_1090) == 0x00 l0800_935E
-l0800_9356:
-	branch (Mem1040[ss:bp - 0x01 + 0x00:byte] & 0x10) == 0x00 l0800_9364
-	goto l0800_936D
-l0800_935E:
-	branch (Mem1040[ss:bp - 0x01 + 0x00:byte] & 0x10) == 0x00 l0800_936D
-l0800_9364:
-	branch (Mem1040[ss:bp - 0x01 + 0x00:byte] & 0x01) != 0x00 l0800_932A
-l0800_936A:
-	Mem1153[es_1016:di + 0x00:byte] = al_1100
-	di = di + 0x01
-	goto l0800_932A
-l0800_936D:
-	Mem1106[ss:sp_1041 + 0x04:word16] = es_1016
-	Mem1109[ss:sp_1041 + 0x02:word16] = Mem1106[ss:bp + 0x0A:word16]
-	Mem1112[ss:sp_1041 + 0x00:word16] = Mem1109[ss:bp + 0x08:word16]
-	Mem1114[ss:sp_1041 - 0x02 + 0x00:word16] = ax_1047
-	word16 sp_1115
-	byte SZO_1118
-	byte C_1119
-	byte Z_1120
-	word16 ax_1121
-	selector es_1122
-	word16 dx_1124
-	word16 si_1125
-	byte al_1127
-	byte SCZO_1128
-	word16 cx_1130
-	byte SO_1131
-	byte S_1132
-	byte bl_1134
-	byte bh_1135
-	byte CZ_1136
-	byte D_1137
-	byte ah_1138
-	byte dl_1139
-	byte cl_1140
-	byte ch_1141
-	call SEQ(cs, Mem1114[ss:bp + 0x06:word16]) (retsize: 2; depth: 2)
-		uses: ah_1101,al_1100,ax_1098,bh_1104,bl_1103,bp_1043,bx_1102,C_1093,ch_1090,cl_1089,cs_1055,cx_1088,CZ_1062,D_1063,di_1049,dl_1065,ds_1052,dx_1050,es_1072,S_1058,SCZO_1054,si_1096,SO_1079,sp_1113,ss_1042,SZO_1091,Z_1092
-		defs: ah_1138,al_1127,ax_1121,bh_1135,bl_1134,bp_1117,bx_1133,C_1119,ch_1141,cl_1140,cs_1129,cx_1130,CZ_1136,D_1137,di_1123,dl_1139,ds_1126,dx_1124,es_1122,S_1132,SCZO_1128,si_1125,SO_1131,sp_1115,ss_1116,SZO_1118,Z_1120
-	es_1016 = Mem1114[ss:sp_1115 + 0x06:selector]
-	Mem1146[ss:bp - 0x06 + 0x00:word16] = Mem1114[ss:bp - 0x06 + 0x00:word16] - 0x01
-	sp_1019 = sp_1115 + 0x08
-	branch si_1125 + 0x01 >= Mem1146[ss:(bp - 0x0A) + 0x00:word16] l0800_938E
-l0800_9385:
-	branch (Mem906[ss:bp - 0x01 + 0x00:byte] & 0x01) != 0x00 l0800_9391
-l0800_938B:
-	Mem1028[ss:bp - 0x04 + 0x00:word16] = Mem906[ss:bp - 0x04 + 0x00:word16] + 0x01
+				word16 si_938 = si_1096 - 0x01;
+				if (si_938 < 0x00)
+				{
+					if ((Mem906[ss:bp - 0x01 + 0x00:byte] & 0x01) == 0x00)
+					{
+						Mem1028[ss:bp - 0x04 + 0x00:word16] = Mem906[ss:bp - 0x04 + 0x00:word16] + 0x01;
 l0800_938E:
-	Mem997[es_1016:di + 0x00:byte] = 0x00
-	di = di + 0x01
-l0800_9391:
-	goto l0800_8FC8
-l0800_9394:
-	branch si_1051 + 0x01 >= Mem1040[ss:(bp - 0x0A) + 0x00:word16] l0800_9398_thunk_fn0800_93A6
-	goto l0800_939A
-l0800_9398_thunk_fn0800_93A6:
-	word16 bp_1177
-	fn0800_93A6(bp, out bp_1177)
-	return
-l0800_939A:
-	branch (Mem1040[ss:bp - 0x01 + 0x00:byte] & 0x01) != 0x00 l0800_939E_thunk_fn0800_93A6
-	goto l0800_93A0
-l0800_939E_thunk_fn0800_93A6:
-	word16 bp_1175
-	fn0800_93A6(bp, out bp_1175)
-	return
-l0800_93A0:
-	Mem1168[es_1016:di + 0x00:byte] = 0x00
-	Mem1171[ss:bp - 0x04 + 0x00:word16] = Mem1168[ss:bp - 0x04 + 0x00:word16] + 0x01
-	word16 bp_1173
-	fn0800_93A6(bp, out bp_1173)
-	return
-l0800_93A3_thunk_fn0800_93A6:
-fn0800_9107_exit:
+						Mem997[es_1016:di + 0x00:byte] = 0x00;
+						di = di + 0x01;
+					}
+					goto l0800_8FC8;
+				}
+				Mem1031[ss:bp - 0x06 + 0x00:word16] = Mem906[ss:bp - 0x06 + 0x00:word16] + 0x01;
+				word16 sp_1033 = sp_1019 - 0x02;
+				Mem1034[ss:sp_1033 + 0x00:word16] = es_1016;
+				Mem1037[ss:sp_1033 - 0x02 + 0x00:word16] = Mem1034[ss:bp + 0x0A:word16];
+				Mem1040[ss:sp_1033 - 0x04 + 0x00:word16] = Mem1037[ss:bp + 0x08:word16];
+				word16 sp_1041;
+				byte SZO_1044;
+				byte C_1045;
+				byte Z_1046;
+				word16 ax_1047;
+				selector es_1048;
+				word16 dx_1050;
+				word16 si_1051;
+				byte al_1053;
+				byte SCZO_1054;
+				word16 cx_1056;
+				byte SO_1057;
+				byte S_1058;
+				word16 bx_1059;
+				byte bl_1060;
+				byte bh_1061;
+				byte CZ_1062;
+				byte D_1063;
+				byte ah_1064;
+				byte dl_1065;
+				byte cl_1066;
+				byte ch_1067;
+				SEQ(cs, Mem1040[ss:bp + 0x04:word16])();
+				es_1016 = Mem1040[ss:sp_1041 + 0x04:selector];
+				sp_1019 = sp_1041 + 0x06;
+				if (ax_1047 < 0x00)
+				{
+					if (si_1051 + 0x01 >= Mem1040[ss:(bp - 0x0A) + 0x00:word16])
+					{
+						word16 bp_1177;
+						fn0800_93A6(bp, out bp_1177);
+						return;
+					}
+					if ((Mem1040[ss:bp - 0x01 + 0x00:byte] & 0x01) != 0x00)
+					{
+						word16 bp_1175;
+						fn0800_93A6(bp, out bp_1175);
+						return;
+					}
+					else
+					{
+						Mem1168[es_1016:di + 0x00:byte] = 0x00;
+						Mem1171[ss:bp - 0x04 + 0x00:word16] = Mem1168[ss:bp - 0x04 + 0x00:word16] + 0x01;
+						word16 bp_1173;
+						fn0800_93A6(bp, out bp_1173);
+						return;
+					}
+				}
+				byte ch_1090 = 0x01 << ((byte) ax_1047 & 0x07);
+				si_1096 = si_1051;
+				byte al_1100 = (byte) ax_1047;
+				bx = ax_1047 >>u 0x03;
+				if ((Mem1040[ss:bp - 0x2A + (ax_1047 >>u 0x03):byte] & ch_1090) == 0x00)
+				{
+					if ((Mem1040[ss:bp - 0x01 + 0x00:byte] & 0x10) != 0x00)
+						goto l0800_9364;
+					goto l0800_936D;
+				}
+				if ((Mem1040[ss:bp - 0x01 + 0x00:byte] & 0x10) == 0x00)
+				{
+l0800_9364:
+					if ((Mem1040[ss:bp - 0x01 + 0x00:byte] & 0x01) == 0x00)
+					{
+						Mem1153[es_1016:di + 0x00:byte] = al_1100;
+						di = di + 0x01;
+					}
+					goto l0800_932A;
+				}
+				else
+				{
+l0800_936D:
+					Mem1106[ss:sp_1041 + 0x04:word16] = es_1016;
+					Mem1109[ss:sp_1041 + 0x02:word16] = Mem1106[ss:bp + 0x0A:word16];
+					Mem1112[ss:sp_1041 + 0x00:word16] = Mem1109[ss:bp + 0x08:word16];
+					Mem1114[ss:sp_1041 - 0x02 + 0x00:word16] = ax_1047;
+					word16 sp_1115;
+					byte SZO_1118;
+					byte C_1119;
+					byte Z_1120;
+					word16 ax_1121;
+					selector es_1122;
+					word16 dx_1124;
+					word16 si_1125;
+					byte al_1127;
+					byte SCZO_1128;
+					word16 cx_1130;
+					byte SO_1131;
+					byte S_1132;
+					byte bl_1134;
+					byte bh_1135;
+					byte CZ_1136;
+					byte D_1137;
+					byte ah_1138;
+					byte dl_1139;
+					byte cl_1140;
+					byte ch_1141;
+					SEQ(cs, Mem1114[ss:bp + 0x06:word16])();
+					es_1016 = Mem1114[ss:sp_1115 + 0x06:selector];
+					Mem1146[ss:bp - 0x06 + 0x00:word16] = Mem1114[ss:bp - 0x06 + 0x00:word16] - 0x01;
+					sp_1019 = sp_1115 + 0x08;
+					if (si_1125 + 0x01 < Mem1146[ss:(bp - 0x0A) + 0x00:word16])
+						break;
+					goto l0800_938E;
+				}
+			case 0x11:
+				ax = Mem447[ss:bp - 0x06 + 0x00:word16];
+				dx = 0x00;
+				if ((Mem447[ss:bp - 0x01 + 0x00:byte] & 0x01) != 0x00)
+					continue;
+				goto l0800_9110;
+			case 0x12:
+				si_1200 = 0x10;
+l0800_90CE:
+				if ((ax_446 & 0x20) == 0x00 && ax_446 != 88)
+					Mem669[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x04;
+				word16 sp_616 = sp_1019 - 0x02;
+				Mem617[ss:sp_616 + 0x00:word16] = ss;
+				Mem620[ss:sp_616 - 0x02 + 0x00:word16] = bp - 0x08;
+				Mem622[ss:sp_616 - 0x04 + 0x00:word16] = ss;
+				Mem625[ss:sp_616 - 0x06 + 0x00:word16] = bp - 0x06;
+				word16 ax_626 = Mem625[ss:bp - 0x0A + 0x00:word16];
+				Mem631[ss:sp_616 - 0x08 + 0x00:word16] = ax_626 & 0x7FFF;
+				Mem633[ss:sp_616 - 0x0A + 0x00:word16] = si_1200;
+				Mem636[ss:sp_616 - 0x0C + 0x00:word16] = Mem633[ss:bp + 0x0A:word16];
+				Mem639[ss:sp_616 - 0x0E + 0x00:word16] = Mem636[ss:bp + 0x08:word16];
+				Mem642[ss:sp_616 - 0x10 + 0x00:word16] = Mem639[ss:bp + 0x06:word16];
+				Mem645[ss:sp_616 - 0x12 + 0x00:word16] = Mem642[ss:bp + 0x04:word16];
+				ax = fn0800_94B0(ax_626 & 0x7FFF, bx_460 << 0x01, ds, wArg04, wArg06, wArg08, wArg0A, ptrArg0C, ptrArg10, out dx, out bx, out di);
+				if (Mem645[ss:bp - 0x08 + 0x00:word16] > 0x00)
+					goto l0800_9107;
+				fn0800_911F(bp);
+				return;
+			case 0x13:
+				word16 bp_1201;
+				word16 ax_1202 = fn0800_912A(di, bp, ds, out bp_1201);
+				word16 bp_1207;
+				fn0800_912A(ax_1202, bp_1201, ds, out bp_1207);
+				return;
+			case 0x14:
+				Mem1210[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] & 223;
+				continue;
+			case 0x15:
+				Mem1214[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x20;
+				continue;
+			}
+		}
+	}
+	else
+	{
+l0800_8FD8:
+		Mem179[ss:bp - 0x06 + 0x00:word16] = Mem0[ss:bp - 0x06 + 0x00:word16] + 0x01;
+		word16 sp_182 = sp_1019 - 0x02;
+		Mem183[ss:sp_182 + 0x00:word16] = Mem179[ss:bp + 0x0A:word16];
+		Mem186[ss:sp_182 - 0x02 + 0x00:word16] = Mem183[ss:bp + 0x08:word16];
+		word16 sp_187;
+		byte SZO_190;
+		byte C_191;
+		byte Z_192;
+		word16 ax_193;
+		selector es_194;
+		word16 di_195;
+		word16 dx_196;
+		byte al_199;
+		byte SCZO_200;
+		word16 cx_202;
+		byte SO_203;
+		byte S_204;
+		byte bl_206;
+		byte bh_207;
+		byte CZ_208;
+		byte D_209;
+		byte ah_210;
+		byte dl_211;
+		byte cl_212;
+		byte ch_213;
+		SEQ(cs, Mem186[ss:bp + 0x04:word16])();
+		sp_1019 = sp_187 + 0x04;
+		byte al_220 = (byte) ax_193;
+		if (ax_193 >= 0x00)
+		{
+			word16 ax_254 = (int16) al_220;
+			di = di_195;
+			if (di_195 < 0x00 || Mem186[ds:di_195 + 9596:byte] != 0x01)
+			{
+				if (ax_254 == di_195)
+					goto l0800_8FCB;
+				Mem266[ss:sp_187 + 0x02:word16] = Mem186[ss:bp + 0x0A:word16];
+				Mem269[ss:sp_187 + 0x00:word16] = Mem266[ss:bp + 0x08:word16];
+				Mem271[ss:sp_187 - 0x02 + 0x00:word16] = ax_254;
+				word16 sp_272;
+				selector ss_273;
+				word16 bp_274;
+				byte SZO_275;
+				byte C_276;
+				byte Z_277;
+				word16 ax_278;
+				selector es_279;
+				word16 di_280;
+				word16 dx_281;
+				word16 si_282;
+				selector ds_283;
+				byte al_284;
+				byte SCZO_285;
+				selector cs_286;
+				word16 cx_287;
+				byte SO_288;
+				byte S_289;
+				word16 bx_290;
+				byte bl_291;
+				byte bh_292;
+				byte CZ_293;
+				byte D_294;
+				byte ah_295;
+				byte dl_296;
+				byte cl_297;
+				byte ch_298;
+				SEQ(cs, Mem271[ss:bp + 0x06:word16])();
+				Mem302[ss_273:bp_274 - 0x06 + 0x00:word16] = Mem271[ss_273:bp_274 - 0x06 + 0x00:word16] - 0x01;
+				word16 bp_307;
+				fn0800_93BE(bp_274, psegArg00, wArg02, wArg04, out bp_307);
+				return;
+			}
+			do
+			{
+				byte bl_337 = (byte) ax_254;
+				word16 bx_340 = DPB(ax_254, bl_337, 0);
+				if (bl_337 < 0x00 || Mem186[ds:bx_340 + 9596:byte] != 0x01)
+				{
+					word16 sp_345 = sp_1019 - 0x02;
+					Mem346[ss:sp_345 + 0x00:word16] = Mem186[ss:bp + 0x0A:word16];
+					Mem349[ss:sp_345 - 0x02 + 0x00:word16] = Mem346[ss:bp + 0x08:word16];
+					Mem351[ss:sp_345 - 0x04 + 0x00:word16] = bx_340;
+					word16 sp_352;
+					byte SZO_355;
+					byte C_356;
+					byte Z_357;
+					word16 ax_358;
+					selector es_359;
+					word16 dx_361;
+					byte al_364;
+					byte SCZO_365;
+					word16 cx_367;
+					byte SO_368;
+					byte S_369;
+					byte bl_371;
+					byte bh_372;
+					byte CZ_373;
+					byte D_374;
+					byte ah_375;
+					byte dl_376;
+					byte cl_377;
+					byte ch_378;
+					SEQ(cs, Mem351[ss:bp + 0x06:word16])();
+					Mem382[ss:bp - 0x06 + 0x00:word16] = Mem351[ss:bp - 0x06 + 0x00:word16] - 0x01;
+					sp_1019 = sp_352 + 0x06;
+					goto l0800_8FCB;
+				}
+				Mem387[ss:bp - 0x06 + 0x00:word16] = Mem186[ss:bp - 0x06 + 0x00:word16] + 0x01;
+				word16 sp_390 = sp_1019 - 0x02;
+				Mem391[ss:sp_390 + 0x00:word16] = Mem387[ss:bp + 0x0A:word16];
+				Mem394[ss:sp_390 - 0x02 + 0x00:word16] = Mem391[ss:bp + 0x08:word16];
+				word16 sp_395;
+				byte SZO_398;
+				byte C_399;
+				byte Z_400;
+				word16 ax_401;
+				selector es_402;
+				word16 di_403;
+				word16 dx_404;
+				word16 si_405;
+				byte al_407;
+				byte SCZO_408;
+				word16 cx_410;
+				byte SO_411;
+				byte S_412;
+				word16 bx_413;
+				byte bl_414;
+				byte bh_415;
+				byte CZ_416;
+				byte D_417;
+				byte ah_418;
+				byte dl_419;
+				byte cl_420;
+				byte ch_421;
+				SEQ(cs, Mem394[ss:bp + 0x04:word16])();
+				sp_1019 = sp_395 + 0x04;
+				ax_254 = ax_401;
+			} while (ax_401 > 0x00);
+		}
+		word16 bp_252;
+		fn0800_93A6(bp, out bp_252);
+		return;
+	}
 }
 
 // 0800:911F: void fn0800_911F(Register word16 bp)


### PR DESCRIPTION
I have created structure analysis unit test with irregular case exits. `Reko` structure analysis failed on it.
It emits
```
    switch (r1)
    {
    case 0x00:
        if (!done())
            goto l1;
        break;
    case 0x01:
case_1:
        r1 = 0x01;
        break;
    }
    return r1;
```
The correct answer is
```
    switch (r1)
    {
    case 0x00:
        if (!done())
        {
            r1 = 0x02;
            goto case_1;
        }
        break;
    case 0x01:
case_1:
        r1 = 0x01;
        break;
    }
    return r1;
```


Schwartz algorithm has not solution for this case
I'm going to implement definition of case body using the same method as for lexical nodes of loops