### PR TITLE
UnitTests' test methods attributes almost ready for NUnit 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 [Oo]bj
 [Bb]in
 TestResults
+/.vs
 /src/Samples/TravisRelease
 /src/.vs
 *.csproj.user

--- a/src/UnitTests/Analysis/DataFlowAnalysisTests2.cs
+++ b/src/UnitTests/Analysis/DataFlowAnalysisTests2.cs
@@ -58,7 +58,7 @@ namespace Reko.UnitTests.Analysis
         }
 
         [Test]
-        [Ignore()]
+        [Ignore("")]
         public void Dfa2_Simple()
         {
             var pb = new ProgramBuilder(new FakeArchitecture());
@@ -88,7 +88,7 @@ test_exit:
         }
 
         [Test]
-        [Ignore()]
+        [Ignore("")]
         public void Dfa2_StackArgs()
         {
             var pb = new ProgramBuilder(new FakeArchitecture());
@@ -177,7 +177,7 @@ test_exit:
         }
 
         [Test]
-        [Ignore()]
+        [Ignore("")]
         public void Dfa2_FactorialReg()
         {
             var program = Factorial.BuildSample();

--- a/src/UnitTests/Analysis/RegisterPreservationTests.cs
+++ b/src/UnitTests/Analysis/RegisterPreservationTests.cs
@@ -364,7 +364,7 @@ test:
         }
 
         [Test(Description = "Processes a self-recursive program")]
-        [Ignore()]
+        [Ignore("")]
         public void Regp_Factorial()
         {
             program = Factorial.BuildSample();

--- a/src/UnitTests/Arch/Intel/DeadConditionFlagsFinderTests.cs
+++ b/src/UnitTests/Arch/Intel/DeadConditionFlagsFinderTests.cs
@@ -33,6 +33,9 @@ namespace Reko.UnitTests.Arch.Intel
 	{
 		private DeadConditionFlagsFinder dcff;
 
+        // Once the project has been ported to use NUnit 3.0, remove this comment and uncomment the line containing "[OneTimeSetup]" and remove the line containing "[TestFixtureSetUp]".
+        // 
+        // [OneTimeSetUp]
 		[TestFixtureSetUp]
 		public void Setup()
 		{

--- a/src/UnitTests/Arch/Intel/OperandRewriterRealModeTests.cs
+++ b/src/UnitTests/Arch/Intel/OperandRewriterRealModeTests.cs
@@ -39,10 +39,13 @@ namespace Reko.UnitTests.Arch.Intel
 		private Procedure proc;
         private X86Instruction instr;
 
-		[TestFixtureSetUp]
-		public void Setup()
-		{
-			arch = new X86ArchitectureReal();
+        // Once the project has been ported to use NUnit 3.0, remove this comment and uncomment the line containing "[OneTimeSetup]" and remove the line containing "[TestFixtureSetUp]".
+        // 
+        // [OneTimeSetUp]
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            arch = new X86ArchitectureReal();
             var mem = new MemoryArea(Address.Ptr32(0x10000), new byte[4]);
 			var prog = new Program(
                 new SegmentMap(

--- a/src/UnitTests/Arch/Intel/OperandRewriterTests.cs
+++ b/src/UnitTests/Arch/Intel/OperandRewriterTests.cs
@@ -45,7 +45,10 @@ namespace Reko.UnitTests.Arch.Intel
 		{
 		}
 
-		[TestFixtureSetUp]
+        // Once the project has been ported to use NUnit 3.0, remove this comment and uncomment the line containing "[OneTimeSetup]" and remove the line containing "[TestFixtureSetUp]".
+        // 
+        // [OneTimeSetUp]
+        [TestFixtureSetUp]
 		public void GlobalSetup()
 		{
 			arch = new X86ArchitectureFlat32();

--- a/src/UnitTests/Arch/Intel/X86ArchitectureTests.cs
+++ b/src/UnitTests/Arch/Intel/X86ArchitectureTests.cs
@@ -76,15 +76,14 @@ namespace Reko.UnitTests.Arch.Intel
 			Assert.AreSame(Registers.di, arch.GetRegister("di"));
 		}
 
-		[ExpectedException(typeof (ArgumentException))]
-		[Test]
-		public void IaFailGetRegisterFromString()
-		{
-			arch.GetRegister("invalidregistername");
-		}
+        [Test]
+        public void IaFailGetRegisterFromString()
+        {
+            Assert.Throws<ArgumentException>(() => arch.GetRegister("invalidregistername"));
+        }
 
-		[Test]
-		public void IaGetRegisterFromNumber()
+        [Test]
+        public void IaGetRegisterFromNumber()
 		{
 			Assert.AreEqual("eax", arch.GetRegister(0).Name);
 			Assert.AreEqual("ecx", arch.GetRegister(1).Name);
@@ -182,12 +181,11 @@ namespace Reko.UnitTests.Arch.Intel
 			Assert.AreEqual(PrimitiveType.Byte, sz.DataType);
 		}
 
-		[Test]
-		[ExpectedException(typeof (ArgumentException))]
-		public void IaGetInvalidRegisterFromName()
-		{
-			Assert.IsNull(arch.GetRegister("NonExistingRegisterName"));
-		}
+        [Test]
+        public void IaGetInvalidRegisterFromName()
+        {
+            Assert.Throws<ArgumentException>(() => arch.GetRegister("NonExistingRegisterName"));
+        }
 
         private EndianImageReader CreateImageReader(params byte[] bytes)
         {

--- a/src/UnitTests/Arch/Sparc/SparcRewriterTests.cs
+++ b/src/UnitTests/Arch/Sparc/SparcRewriterTests.cs
@@ -184,7 +184,7 @@ namespace Reko.UnitTests.Arch.Sparc
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void SparcRw_taddcc()
         {
             BuildTest(0x8B006001);
@@ -192,7 +192,7 @@ namespace Reko.UnitTests.Arch.Sparc
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void SparcRw_mulscc()
         {
             host.Stub(h => h.PseudoProcedure(

--- a/src/UnitTests/Arch/Vax/VaxRewriterTests.cs
+++ b/src/UnitTests/Arch/Vax/VaxRewriterTests.cs
@@ -2090,7 +2090,7 @@ namespace Reko.UnitTests.Arch.Vax
                 "1|L--|v4 = atomic_fetch_add(Mem0[r4:word16], (word16) r2)");
         }
 
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_bbsc()
         {
             BuildTest(0xE4);	// bbsc	
@@ -2214,7 +2214,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_cmpc3()
         {
             BuildTest(0x29, 0x20, 51, 0x5B);	// cmpc3	#20,r1,r11
@@ -2233,7 +2233,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_crc()
         {
             BuildTest(0x0B, 0xD1, 0x52, 0x50, 0x1A, 0x0B, 0xD6, 0x51, 0x11);	// crc	+5052(r1),#0000001A,#000B,+1151(r6)
@@ -2246,7 +2246,7 @@ namespace Reko.UnitTests.Arch.Vax
 
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_cmpc5()
         {
             BuildTest(0x2D);	// cmpc5	
@@ -2256,7 +2256,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_cvtpl()
         {
             BuildTest(0x36);	// cvtpl	
@@ -2266,7 +2266,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_cvtps()
         {
             BuildTest(0x08, 0xE2, 0xFE, 0x7F, 0xE8, 0x50, 0x2B, 0xDD, 0x01, 0xDD, 0xEC, 0x13, 0xC6, 0x00, 0x00);	// cvtps	+50E87FFE(r2),#2B,-22FF(fp),+0000C613(ap)
@@ -2276,7 +2276,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_cvtpt()
         {
             BuildTest(0x24, 0x00, 0x00, 0x00, 0x22);	// cvtpt	#0000,#00,#00,#0022
@@ -2286,7 +2286,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_cvtsp()
         {
             BuildTest(0x09, 0x07, 0x00, 0x00, 0x5A);	// cvtsp	#0007,#00,#0000,r10
@@ -2296,7 +2296,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_editpc()
         {
             BuildTest(0x38);	// editpc	
@@ -2306,7 +2306,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_ediv()
         {
             BuildTest(0x7B);	// ediv	
@@ -2316,7 +2316,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_emul()
         {
             BuildTest(0x7A);	// emul	
@@ -2326,7 +2326,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_emodd()
         {
             BuildTest(0x74, 0x04, 0xE4, 0x04, 0xBC, 0x04, 0xE4, 0x04, 0xE4, 0x04, 0xE4, 0x04, 0xE4, 0x04);	// emodd	#0.75,-1BFB43FC(r4),#0.75,-1BFB1BFC(r4),#0.75
@@ -2336,7 +2336,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_emodf()
         {
             BuildTest(0x54);	// emodf	
@@ -2347,7 +2347,7 @@ namespace Reko.UnitTests.Arch.Vax
 
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_extzv()
         {
             BuildTest(0xEF, 0xA5, 0x30, 0xFF, 0xFF, 0x52, 0x9E, 0xEF, 0xB6, 0xE6, 0xFD, 0xFF, 0x55, 0x7C, 0x59);	// extzv	+30(r5),EF9ED62D,-1A(r6),+597C55FF(fp)
@@ -2357,7 +2357,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_index()
         {
             BuildTest(0x0A, 0x01, 0x00, 0xD4, 0x50, 0x04, 0x9A, 0xE6, 0x18, 0x0A, 0x01, 0x00, 0x52);	// index	#00000001,#00000000,+0450(r4),(r10)+,+00010A18(r6),r2
@@ -2367,7 +2367,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_insqhi()
         {
             BuildTest(0x5C);	// insqhi	
@@ -2377,7 +2377,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_insqti()
         {
             BuildTest(0x5D);	// insqti	
@@ -2387,7 +2387,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_insv()
         {
             BuildTest(0xF0);	// insv	
@@ -2397,7 +2397,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_ldpctx()
         {
             BuildTest(0x06);	// ldpctx	
@@ -2408,7 +2408,7 @@ namespace Reko.UnitTests.Arch.Vax
 
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_locc()
         {
             BuildTest(0x3A);	// locc	
@@ -2419,7 +2419,7 @@ namespace Reko.UnitTests.Arch.Vax
 
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_matchc()
         {
             BuildTest(0x39, 0x51, 0x62, 0x53, 0x64);	// matchc	
@@ -2429,7 +2429,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_movc3()
         {
             BuildTest(0x28, 0x02, 0xE4, 0x04, 0x74, 0x02, 0x88, 0x02);	// movc3	#0002,-77FD8BFC(r4),#02
@@ -2439,7 +2439,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_movc5()
         {
             BuildTest(0x2C);	// movc5	
@@ -2449,7 +2449,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_movp()
         {
             BuildTest(0x34);	// movp	
@@ -2459,7 +2459,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_movpsl()
         {
             BuildTest(0xDC);	// movpsl	
@@ -2469,7 +2469,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_movtc()
         {
             BuildTest(0x2E);	// movtc	
@@ -2479,7 +2479,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_movtuc()
         {
             BuildTest(0x2F);	// movtuc	
@@ -2493,7 +2493,7 @@ namespace Reko.UnitTests.Arch.Vax
 
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_mtpr()
         {
             BuildTest(0xDA);	// mtpr	
@@ -2503,7 +2503,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_mfpr()
         {
             BuildTest(0xDB);	// mfpr	
@@ -2514,7 +2514,7 @@ namespace Reko.UnitTests.Arch.Vax
 
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_popr()
         {
             BuildTest(0xBA);	// popr	
@@ -2524,7 +2524,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_prober()
         {
             BuildTest(0x0C, 0x00, 0xC2, 0x04, 0x5E, 0x9E);	// prober	#00,+5E04(r2),(sp)+
@@ -2534,7 +2534,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_probew()
         {
             BuildTest(0x0D, 0x00, 0x00, 0x00);	// probew	#00,#0000,#00
@@ -2544,7 +2544,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_rei()
         {
             BuildTest(0x02);	// rei	
@@ -2554,7 +2554,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_remqhi()
         {
             BuildTest(0x5E);	// remqhi	
@@ -2565,7 +2565,7 @@ namespace Reko.UnitTests.Arch.Vax
 
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_remqti()
         {
             BuildTest(0x5F);	// remqti	
@@ -2575,7 +2575,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_remque()
         {
             BuildTest(0x0F, 0xC2, 0x04, 0x5E, 0x9E);	// remque	+5E04(r2),(sp)+
@@ -2586,7 +2586,7 @@ namespace Reko.UnitTests.Arch.Vax
 
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_spanc()
         {
             BuildTest(0x2B, 0x00, 0x2C, 0x00, 0x2D);	// spanc	#0000,#2C,#00,#2D
@@ -2596,7 +2596,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_skpc()
         {
             BuildTest(0x3B);	// skpc	
@@ -2606,7 +2606,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_svpctx()
         {
             BuildTest(0x07);	// svpctx	
@@ -2616,7 +2616,7 @@ namespace Reko.UnitTests.Arch.Vax
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void VaxRw_xfc()
         {
             BuildTest(0xFC);	// xfc	

--- a/src/UnitTests/Core/FrameTests.cs
+++ b/src/UnitTests/Core/FrameTests.cs
@@ -116,7 +116,7 @@ namespace Reko.UnitTests.Core
 		}
 
 		[Test]
-        [Ignore()]
+        [Ignore("")]
 		public void FrBindStackParameters()
 		{
 			var f = new Frame(PrimitiveType.Word16);

--- a/src/UnitTests/Environments/SysV/GccMangledNameParserTests.cs
+++ b/src/UnitTests/Environments/SysV/GccMangledNameParserTests.cs
@@ -370,7 +370,7 @@ namespace Reko.UnitTests.Environments.SysV
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void Gmnp_Regression4()
         {
             RunTest(
@@ -382,7 +382,7 @@ namespace Reko.UnitTests.Environments.SysV
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void Gmnp_Substitutions()
         {
             RunTest(

--- a/src/UnitTests/Environments/Windows/MsMangledNameParserTests.cs
+++ b/src/UnitTests/Environments/Windows/MsMangledNameParserTests.cs
@@ -247,7 +247,7 @@ namespace Reko.UnitTests.Environments.Windows
         }
 
         [Test]
-        [Ignore]
+        [Ignore("")]
         public void PMNP_regression7()
         {
             RunTest(

--- a/src/UnitTests/ImageLoaders/Llvm/LlvmParserTests.cs
+++ b/src/UnitTests/ImageLoaders/Llvm/LlvmParserTests.cs
@@ -38,6 +38,7 @@ namespace Reko.UnitTests.ImageLoaders.Llvm
         private string sExp;
         private readonly string nl = Environment.NewLine;
 
+        [SetUp]
         public void Setup()
         {
             this.llir = null;

--- a/src/UnitTests/Structure/SimpleStructureTests.cs
+++ b/src/UnitTests/Structure/SimpleStructureTests.cs
@@ -223,7 +223,7 @@ namespace Reko.UnitTests.Structure
         }
 
         [Test]
-        [Ignore()]
+        [Ignore("")]
         public void StrReg00006()
         {
             RunTest32("Fragments/regressions/r00006.asm", "Structure/StrReg00006.txt", Address.Ptr32(0x100048B0));


### PR DESCRIPTION
Modified the syntax (attributes) of some 'UnitTests' source files to ease future migration to NUnit 3 while keeping compatibility with NUnit 2.6.
Added missing '[SetUp]' attribute.