### PR TITLE
Fix structure analysis to make it work on unit test with switch with irregular entries and tail cases

### DIFF
--- a/src/Decompiler/Structure/StructureAnalysis.cs
+++ b/src/Decompiler/Structure/StructureAnalysis.cs
@@ -407,8 +407,9 @@ namespace Reko.Structure
         /// <returns></returns>
         private bool ReduceSwitchRegion(Region n)
         {
+            bool irregularEntries = AreIrregularEntries(n);
             var follow = GetSwitchFollow(n);
-            if (follow != null || AllCasesAreTails(n))
+            if (!irregularEntries && (follow != null || AllCasesAreTails(n)))
             {
                 return ReduceIncSwitch(n, follow);
             }
@@ -620,13 +621,21 @@ all other cases, together they constitute a Switch[].
             return virtualized;
         }
 
+        private bool AreIrregularEntries(Region n)
+        {
+            foreach (var s in regionGraph.Successors(n))
+            {
+                if (regionGraph.Predecessors(s).Where(p => (p != n)).Any())
+                    return true;
+            }
+            return false;
+        }
+
         private Region GetSwitchFollow(Region n)
         {
             Region follow = null;
             foreach (var s in regionGraph.Successors(n))
             {
-                if (regionGraph.Predecessors(s).Where(p => (p != n)).Any())
-                    return null;
                 var ss = SingleSuccessor(s);
                 if (s.Type != RegionType.Tail)
                 {

--- a/src/UnitTests/Structure/ProcedureStructurerTests.cs
+++ b/src/UnitTests/Structure/ProcedureStructurerTests.cs
@@ -670,6 +670,39 @@ case_1:
             RunTest(sExp, m.Procedure);
         }
 
+        [Test]
+        public void ProcStr_Switch_IrregularEntries_AllCasesAreTails()
+        {
+            var r1 = m.Reg32("r1", 1);
+
+            m.BranchIf(m.Fn("check"), "case_0");
+            m.Switch(r1, "case_0", "case_1");
+
+            m.Label("case_0");
+            m.Assign(r1, 2);
+            m.Return(m.IMul(r1, 3));
+
+            m.Label("case_1");
+            m.Assign(r1, 1);
+            m.Return(m.IMul(r1, 4));
+
+            var sExp =
+@"    if (check())
+        goto case_0;
+    switch (r1)
+    {
+    case 0x00:
+case_0:
+        r1 = 0x02;
+        return r1 * 0x03;
+    case 0x01:
+        r1 = 0x01;
+        return r1 * 0x04;
+    }
+";
+            RunTest(sExp, m.Procedure);
+        }
+
         [Test(Description="A do-while with a nested if-then-else")]
         public void ProcStr_DoWhile_NestedIfElse()
         {


### PR DESCRIPTION
Create structure analysis unit test with switch with irregular entries and tail cases. It failed