### PR TITLE
Improve last resort refinement of switches

### DIFF
--- a/subjects/Elf-x86-64/ls.c
+++ b/subjects/Elf-x86-64/ls.c
@@ -14403,7 +14403,7 @@ l0000000000410FD5:
 					goto l0000000000411283;
 				rbx_214 = rbx_214 << 0x0A;
 				edx_337 = 0x00;
-				goto l0000000000411038;
+				break;
 			case 0x01:
 			case 0x02:
 			case 0x04:
@@ -14468,7 +14468,7 @@ l0000000000411028:
 					edx_337 = (word32) (uint64) (edx_337 | r8d_420);
 					esi_397 = (word32) rsi_300;
 				} while (esi_397 == 0x00);
-				goto l0000000000411038;
+				break;
 			case 0x05:
 			case 0x25:
 				rsi_300 = (int64) eax_317;
@@ -14491,7 +14491,7 @@ l0000000000411028:
 					edx_337 = (word32) (uint64) (edx_337 | r8d_480);
 					edi_457 = (word32) (uint64) (edi_457 - 0x01);
 				} while (edi_457 != 0x00);
-				goto l0000000000411038;
+				break;
 			case 0x09:
 			case 0x29:
 				rdi_506 = (int64) eax_317;
@@ -14500,7 +14500,7 @@ l0000000000411028:
 					goto l0000000000411193;
 				rbx_214 = ~0x00;
 				edx_337 = 0x01;
-				goto l0000000000411038;
+				break;
 			case 11:
 			case 0x2B:
 				rdi_506 = (int64) eax_317;
@@ -14637,7 +14637,6 @@ l0000000000411283:
 				}
 				break;
 			}
-l0000000000411038:
 			rbp_242 = (uint64) (ebp_240 | edx_337);
 			Mem354[r15_44 + 0x00:word64] = r14_212 + (int64) ecx_312;
 			ebp_240 = (word32) rbp_242;
@@ -14897,7 +14896,7 @@ l00000000004114AD:
 					goto l000000000041175B;
 				rbx_273 = rbx_273 << 0x0A;
 				edx_398 = 0x00;
-				goto l0000000000411510;
+				break;
 			case 0x01:
 			case 0x02:
 			case 0x04:
@@ -14966,7 +14965,7 @@ l0000000000411500:
 					edx_398 = (word32) (uint64) (edx_398 | r8d_479);
 					esi_456 = (word32) rsi_359;
 				} while (esi_456 == 0x00);
-				goto l0000000000411510;
+				break;
 			case 0x05:
 			case 0x25:
 				rsi_359 = (int64) eax_376;
@@ -14993,7 +14992,7 @@ l0000000000411500:
 					edx_398 = (word32) (uint64) (edx_398 | r8d_539);
 					edi_516 = (word32) (uint64) (edi_516 - 0x01);
 				} while (edi_516 != 0x00);
-				goto l0000000000411510;
+				break;
 			case 0x09:
 			case 0x29:
 				rdi_565 = (int64) eax_376;
@@ -15002,7 +15001,7 @@ l0000000000411500:
 					goto l000000000041166B;
 				rbx_273 = ~0x00;
 				edx_398 = 0x01;
-				goto l0000000000411510;
+				break;
 			case 11:
 			case 0x2B:
 				rdi_565 = (int64) eax_376;
@@ -15155,7 +15154,6 @@ l000000000041175B:
 				}
 				break;
 			}
-l0000000000411510:
 			rbp_301 = (uint64) (ebp_302 | edx_398);
 			Mem413[r15_238 + 0x00:word64] = r14_271 + (int64) ecx_371;
 			ebp_302 = (word32) rbp_301;

--- a/subjects/MZ-x86/BENCHFN.c
+++ b/subjects/MZ-x86/BENCHFN.c
@@ -2003,7 +2003,6 @@ l0800_1726:
 		si_409 = si_107;
 		while (true)
 		{
-l0800_1794:
 			Eq_304 si_409;
 			si_409 = (word32) si_409 + 0x01;
 			int16 ax_414 = (int16) (ds->*si_409);
@@ -2030,13 +2029,13 @@ l0800_17E6:
 				goto l0800_172F;
 			case 0x04:
 				bLoc2B_1212 = bLoc2B_1212 | 0x01;
-				goto l0800_1794;
+				break;
 			case 0x05:
 				wLoc24_396 = ax_414 - 0x30;
 				int16 wLoc24_1221 = wLoc24_396;
 				if (wLoc24_1221 >= 0x00)
 					wLoc24_396 = ax_414 - 0x26;
-				goto l0800_1794;
+				break;
 			case 0x06:
 				if ((bLoc2B_1212 & 0x01) == 0x00)
 					fn0800_1708(bp_1001, ds, out es);
@@ -2137,13 +2136,13 @@ l0800_19DD:
 				}
 			case 11:
 				bLoc2B_1212 = bLoc2B_1212 | 0x08;
-				goto l0800_1794;
+				break;
 			case 0x0C:
 				bLoc2B_1212 = bLoc2B_1212 | 0x02;
-				goto l0800_1794;
+				break;
 			case 0x0D:
 				bLoc2B_1212 = bLoc2B_1212 | 0x04;
-				goto l0800_1794;
+				break;
 			case 0x0E:
 				si_1203.u0 = 0x08;
 				goto l0800_1844;

--- a/subjects/regressions/reko-90/PP.c
+++ b/subjects/regressions/reko-90/PP.c
@@ -12411,14 +12411,14 @@ l0800_9051:
 					goto l0800_8FD8;
 				case 0x04:
 					Mem481[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x01;
-					goto l0800_9051;
+					break;
 				case 0x05:
 					word16 v44_485 = Mem447[ss:bp - 0x0A + 0x00:word16];
 					Mem486[ss:bp - 0x0A + 0x00:word16] = ax_446 - 0x30;
 					di = v44_485;
 					if (v44_485 >= 0x00)
 						Mem495[ss:bp - 0x0A + 0x00:word16] = Mem486[ss:bp - 0x0A + 0x00:word16] + 0x0A;
-					goto l0800_9051;
+					break;
 				case 0x06:
 					if ((Mem447[ss:bp - 0x01 + 0x00:byte] & 0x01) == 0x00)
 						di = fn0800_8FAB(bp, ds, out es_432);
@@ -12532,13 +12532,13 @@ l0800_9284:
 					}
 				case 11:
 					Mem761[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x08;
-					goto l0800_9051;
+					break;
 				case 0x0C:
 					Mem765[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x02;
-					goto l0800_9051;
+					break;
 				case 0x0D:
 					Mem769[ss:bp - 0x01 + 0x00:byte] = Mem447[ss:bp - 0x01 + 0x00:byte] | 0x04;
-					goto l0800_9051;
+					break;
 				case 0x0E:
 					si_1200 = 0x08;
 					goto l0800_90CE;
@@ -13820,14 +13820,14 @@ l0800_9949:
 						}
 					case 0x06:
 						wLoc04_1055 = wLoc04_1055 | 0x10;
-						goto l0800_9931;
+						break;
 					case 0x07:
 						wLoc04_1055 = wLoc04_1055 | 0x0100;
 						goto l0800_99D1;
 					case 0x08:
 l0800_99D1:
 						wLoc04_1055 = wLoc04_1055 & ~0x10;
-						goto l0800_9931;
+						break;
 					case 0x09:
 						if (ch_249 >u 0x00)
 							goto l0800_9987;
@@ -14178,7 +14178,6 @@ l0800_9C82:
 						wLoc04_1055 = wLoc04_1055 | 0x20;
 						break;
 					}
-l0800_9931:
 					ch_249 = 0x05;
 l0800_98DB:
 					ax = DPB(ax_275, Mem0[ds:si_133 + 0x00:byte], 0);


### PR DESCRIPTION
- Create structure analysis unit test to reproduce error in the last resort refinement of switch
- Improve last resort refinement of switches. Schwartz algorithm suggests to first remove edges whose source does not dominate its target, nor whose target dominates its source.
Current implementation in reko removes edge from first node in the list.
It causes unnecessary gotos.