### PR TITLE
Sega genesis installer fixes

### DIFF
--- a/src/Core/Serialization/MemoryMap_v1.cs
+++ b/src/Core/Serialization/MemoryMap_v1.cs
@@ -57,7 +57,7 @@ namespace Reko.Core.Serialization
                 var ser = SerializedLibrary.CreateSerializer(
                     typeof(MemoryMap_v1),
                     SerializedLibrary.Namespace_v4);
-                using (var stm = fsSvc.CreateFileStream(filePath, FileMode.Open))
+                using (var stm = fsSvc.CreateFileStream(filePath, FileMode.Open, FileAccess.Read))
                 {
                     var mmap = (MemoryMap_v1)ser.Deserialize(stm);
                     return mmap;

--- a/src/WixInstaller/Product.wxs
+++ b/src/WixInstaller/Product.wxs
@@ -117,6 +117,7 @@
         <File Source="$(var.RT11.TargetPath)" />
         <File Source="$(var.RT11.ProjectDir)rt11_services.xml" />
         <File Source="$(var.SegaGenesis.TargetPath)" />
+        <File Source="$(var.SegaGenesis.ProjectDir)SegaGenesis.xml" />
         <File Source="$(var.SysV.TargetPath)" />
         <File Source="$(var.SysV.ProjectDir)lp32.xml" />
         <File Source="$(var.SysV.ProjectDir)libc.so.xml" />


### PR DESCRIPTION
Fixes for the remaining problems in #528 -

1. The `SegaGenesis.xml` file was not included in the installation package. This has been fixed.
2. All memory map files were being opened in read/write mode. This would work when running a non-installer build, but fail with an access denied for an installer build (if the application was installed to `Program Files (x86)`). This has been fixed.

With these two changes, I can open a Sega Genesis binary with no errors.