### PR TITLE
Fix statuses of buttons after "Finish decompilation" action 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,8 +33,8 @@ after_build:
         mv $filePath $newPath;
 
 test_script:
-  - cmd: nunit-console-x86.exe ./src/tools/c2xml/bin/%CONFIGURATION%/c2xml.exe -exclude=UserInterface,FailedTests /framework:net-4.5
-  - cmd: nunit-console-x86.exe ./src/UnitTests/bin/%CONFIGURATION%/Reko.UnitTests.dll -exclude=UserInterface,FailedTests /framework:net-4.5
+  - cmd: nunit-console-x86.exe ./src/tools/c2xml/bin/%CONFIGURATION%/c2xml.exe -exclude=FailedTests /framework:net-4.5
+  - cmd: nunit-console-x86.exe ./src/UnitTests/bin/%CONFIGURATION%/Reko.UnitTests.dll -exclude=FailedTests /framework:net-4.5
   - cmd: python ./subjects/regressionTests.py --check-output --configuration=%CONFIGURATION%
 
 artifacts:

--- a/src/Gui/Forms/MainFormInteractor.cs
+++ b/src/Gui/Forms/MainFormInteractor.cs
@@ -94,8 +94,8 @@ namespace Reko.Gui.Forms
         {
             pageInitial =  svcFactory.CreateInitialPageInteractor();
             pageScanned = svcFactory.CreateScannedPageInteractor();
-            pageAnalyzed = new AnalyzedPageInteractorImpl(sc);
-            pageFinal = new FinalPageInteractor(sc);
+            pageAnalyzed = svcFactory.CreateAnalyzedPageInteractor();
+            pageFinal = svcFactory.CreateFinalPageInteractor();
         }
 
         public virtual IDecompiler CreateDecompiler(ILoader ldr)

--- a/src/Gui/Forms/MainFormInteractor.cs
+++ b/src/Gui/Forms/MainFormInteractor.cs
@@ -513,6 +513,7 @@ namespace Reko.Gui.Forms
                     }
                 });
                 prev.EnterPage();
+                CurrentPhase = prev;
             }
             catch (Exception ex)
             {

--- a/src/Gui/IServiceFactory.cs
+++ b/src/Gui/IServiceFactory.cs
@@ -46,6 +46,8 @@ namespace Reko.Gui
         IFileSystemService CreateFileSystemService();
         InitialPageInteractor CreateInitialPageInteractor();
         IScannedPageInteractor CreateScannedPageInteractor();
+        IAnalyzedPageInteractor CreateAnalyzedPageInteractor();
+        IFinalPageInteractor CreateFinalPageInteractor();
         ILowLevelViewService CreateMemoryViewService();
         IProjectBrowserService CreateProjectBrowserService(ITreeView treeView);
         ISearchResultService CreateSearchResultService(ListView listView);
@@ -122,6 +124,16 @@ namespace Reko.Gui
         public IScannedPageInteractor CreateScannedPageInteractor()
         {
             return new ScannedPageInteractor(services);
+        }
+
+        public IAnalyzedPageInteractor CreateAnalyzedPageInteractor()
+        {
+            return new AnalyzedPageInteractorImpl(services);
+        }
+
+        public IFinalPageInteractor CreateFinalPageInteractor()
+        {
+            return new FinalPageInteractor(services);
         }
 
         public ITypeLibraryLoaderService CreateTypeLibraryLoaderService()

--- a/src/UnitTests/Gui/Windows/Forms/FakePhasePageInteractors.cs
+++ b/src/UnitTests/Gui/Windows/Forms/FakePhasePageInteractors.cs
@@ -134,4 +134,18 @@ namespace Reko.UnitTests.Gui.Windows.Forms
         {
         }
     }
+
+    public class FakeAnalyzedPageInteractor : FakePhasePageInteractor, IAnalyzedPageInteractor
+    {
+        public FakeAnalyzedPageInteractor()
+        {
+        }
+    }
+
+    public class FakeFinalPageInteractor : FakePhasePageInteractor, IFinalPageInteractor
+    {
+        public FakeFinalPageInteractor()
+        {
+        }
+    }
 }

--- a/src/UnitTests/Gui/Windows/Forms/MainFormInteractorTests.cs
+++ b/src/UnitTests/Gui/Windows/Forms/MainFormInteractorTests.cs
@@ -561,6 +561,8 @@ namespace Reko.UnitTests.Gui.Windows.Forms
             svcFactory.Stub(s => s.CreateDecompilerEventListener()).Return(new FakeDecompilerEventListener());
             svcFactory.Stub(s => s.CreateInitialPageInteractor()).Return(new FakeInitialPageInteractor());
             svcFactory.Stub(s => s.CreateScannedPageInteractor()).Return(new FakeScannedPageInteractor());
+            svcFactory.Stub(s => s.CreateAnalyzedPageInteractor()).Return(new FakeAnalyzedPageInteractor());
+            svcFactory.Stub(s => s.CreateFinalPageInteractor()).Return(new FakeFinalPageInteractor());
             svcFactory.Stub(s => s.CreateTypeLibraryLoaderService()).Return(typeLibSvc);
             svcFactory.Stub(s => s.CreateProjectBrowserService(Arg<ITreeView>.Is.NotNull)).Return(brSvc);
             svcFactory.Stub(s => s.CreateUiPreferencesService()).Return(uiPrefs);

--- a/src/UnitTests/Gui/Windows/Forms/MainFormInteractorTests.cs
+++ b/src/UnitTests/Gui/Windows/Forms/MainFormInteractorTests.cs
@@ -196,6 +196,27 @@ namespace Reko.UnitTests.Gui.Windows.Forms
             mr.VerifyAll();
 		}
 
+        [Test]
+        public void Mfi_FinishDecompilation()
+        {
+            Given_MainFormInteractor();
+            Given_LoadPreferences();
+            Given_DecompilerInstance();
+            Given_XmlWriter();
+            Given_SavePrompt(true);
+            dcSvc.Stub(d => d.Decompiler = null);
+            fsSvc.Stub(f => f.MakeRelativePath("foo.dcproject", "foo.exe")).Return("foo.exe");
+            mr.ReplayAll();
+
+            When_CreateMainFormInteractor();
+            interactor.OpenBinary(null);
+            Assert.AreSame(interactor.InitialPageInteractor, interactor.CurrentPhase);
+            interactor.FinishDecompilation();
+            Assert.AreSame(interactor.FinalPageInteractor, interactor.CurrentPhase);
+
+            mr.VerifyAll();
+        }
+
         private void Given_Loader()
         {
             var bytes = new byte[1000];


### PR DESCRIPTION
- Use factory to create analyzed and final page interactors. It makes unit tests creation easier
- Create unit test to reproduce bug with statuses of buttons after `Finish decompilation` action
- Set correct current phase after `Finish decompilation` action. This is the fix for statuses of buttons after `Finish decompilation` action. `Next phase` and `Finish decompilation` should be disabled when `Finish decompilation` action is done. But it was enabled