### PR TITLE
Enable "Finish decompilation" button before scanning

### DIFF
--- a/src/Gui/Windows/Forms/InitialPageInteractor.cs
+++ b/src/Gui/Windows/Forms/InitialPageInteractor.cs
@@ -67,6 +67,10 @@ namespace Reko.Gui.Windows.Forms
                 case CmdIds.ActionRestartDecompilation:
                     status.Status = 0;
                     return true;
+                case CmdIds.ActionFinishDecompilation:
+                    status.Status = CanAdvance
+                        ? MenuStatus.Visible | MenuStatus.Enabled
+                        : MenuStatus.Visible; return true;
                 case CmdIds.ActionNextPhase:
                     status.Status = CanAdvance 
                         ? MenuStatus.Visible | MenuStatus.Enabled

--- a/src/UnitTests/Gui/Windows/Forms/InitialPageInteractorTests.cs
+++ b/src/UnitTests/Gui/Windows/Forms/InitialPageInteractorTests.cs
@@ -215,20 +215,6 @@ namespace Reko.UnitTests.Gui.Windows.Forms
             mr.VerifyAll();
         }
 
-        //$REFACTOR: copied from LoadedPageInteractor, should
-        // push to base class or utility class.
-        private MenuStatus QueryStatus(int cmdId)
-        {
-            CommandStatus status = new CommandStatus();
-            i.QueryStatus(new CommandID(CmdSets.GuidReko, cmdId), status, null);
-            return status.Status;
-        }
-
-        private ILowLevelViewService AddFakeMemoryViewService()
-        {
-            return memSvc;
-        }
-
         private class TestInitialPageInteractor : InitialPageInteractorImpl
         {
             public IDecompiler decompiler;

--- a/src/UnitTests/Gui/Windows/Forms/InitialPageInteractorTests.cs
+++ b/src/UnitTests/Gui/Windows/Forms/InitialPageInteractorTests.cs
@@ -193,6 +193,28 @@ namespace Reko.UnitTests.Gui.Windows.Forms
             mr.VerifyAll();
         }
 
+        [Test]
+        public void Ipi_FinishDecompilationButton()
+        {
+            program.NeedsScanning = false;
+            dec.Stub(d => d.Load("foo.exe")).Return(false);
+            dec.Stub(d => d.Project).Return(project);
+            browserSvc.Stub(b => b.Load(project));
+            mr.ReplayAll();
+            var status = new CommandStatus();
+            var cmd = new CommandID(
+                CmdSets.GuidReko, CmdIds.ActionFinishDecompilation);
+
+            Assert.IsTrue(i.QueryStatus(cmd, status, null));
+            Assert.AreEqual(MenuStatus.Visible, status.Status);
+
+            i.OpenBinary("foo.exe");
+
+            Assert.IsTrue(i.QueryStatus(cmd, status, null));
+            Assert.AreEqual(MenuStatus.Visible | MenuStatus.Enabled, status.Status);
+            mr.VerifyAll();
+        }
+
         //$REFACTOR: copied from LoadedPageInteractor, should
         // push to base class or utility class.
         private MenuStatus QueryStatus(int cmdId)


### PR DESCRIPTION
- Create unit test for status of `Finish decompilation` button
- Enable `Finish decompilation`button at initial page after loading of binary. It was disabled so user should run `Scan Binary` and then press `Finish decompilation`. Now user could press only `Finish decompilation` and `Reko` will do `Scan`, `Analysis` and `Reconstruct data types`. I think, it's more convenient.