### PR TITLE
Improvements around Borland SymbolLoader

### DIFF
--- a/src/ImageLoaders/MzExe/Borland/SymbolLoader.cs
+++ b/src/ImageLoaders/MzExe/Borland/SymbolLoader.cs
@@ -593,9 +593,11 @@ private const byte TID_LOCALHANDLE = 0x3F;    //  Windows local handle
                     {
                         var b2 = rdr.ReadByte();
                         var w = rdr.ReadLeUInt16();
-                        var lang = ClassifyFuncProgrammingLanguage(b2 & 0x7F);
+                        var lang = ClassifyFuncProgrammingLanguage(b2 & 0x7);
+                        var nested = (b2 & 0x40) != 0 ? " nested" : "";
                         var varargs = (b2 & 0x80) != 0 ? " varargs" : "";
-                        DebugEx.PrintIf(trace.TraceVerbose, $"    function/procedure: returns {w:X4} ({lang}{varargs})");
+                        var additional = (b2 & 0x38) != 0 ? $" additional bits: {(b2 & 0x38):X2}" : "";
+                        DebugEx.PrintIf(trace.TraceVerbose, $"    function/procedure: returns {w:X4} ({lang}{varargs}{nested}{additional})");
                         bt = new Callable { };
                         break;
                     }
@@ -701,7 +703,7 @@ private const byte TID_LOCALHANDLE = 0x3F;    //  Windows local handle
             case 0x05: return "__far __pascal";
             case 0x07: return "__interrupt";
             }
-            throw new ArgumentOutOfRangeException("n");
+            throw new ArgumentOutOfRangeException(nameof(n), n, $"Unsupported function type {n:X2}");
         }
 
         private string[] CreateNameIndex(long name_pool_offset)

--- a/src/ImageLoaders/MzExe/MsdosImageLoader.cs
+++ b/src/ImageLoaders/MzExe/MsdosImageLoader.cs
@@ -135,7 +135,14 @@ namespace Reko.ImageLoaders.MzExe
                 ep.NoDecompile = true;
             }
 
-            LoadDebugSymbols(results.Symbols, addrLoad);
+			try
+			{
+				LoadDebugSymbols(results.Symbols, addrLoad);
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine("Failed to load Borland debug symbols: {0}", e.Message);
+			}
             return results;
 		}
 


### PR DESCRIPTION
* Failure in loading Borland debug symbols should not fail 'open file' action
* Improve function type parsing - actually cause of exception