### PR TITLE
Improve unit test for SsaMutators

### DIFF
--- a/src/UnitTests/Analysis/SsaMutatorTests.cs
+++ b/src/UnitTests/Analysis/SsaMutatorTests.cs
@@ -22,6 +22,7 @@ using NUnit.Framework;
 using Reko.Analysis;
 using Reko.Core;
 using Reko.Core.Code;
+using Reko.Core.Expressions;
 using Reko.UnitTests.Mocks;
 using Rhino.Mocks;
 using System;
@@ -37,111 +38,52 @@ namespace Reko.UnitTests.Analysis
     [TestFixture]
     public class SsaMutatorTests
     {
-        private MockRepository mr;
-        private FakeArchitecture arch;
-        private ProgramDataFlow flow;
-        private HashSet<RegisterStorage> implicitRegs;
-        private IImportResolver imp;
+        private SsaProcedureBuilder m;
 
         [SetUp]
         public void Setup()
         {
-            mr = new MockRepository();
-            this.flow = new ProgramDataFlow();
-            this.implicitRegs = new HashSet<RegisterStorage>();
-            this.imp = mr.Stub<IImportResolver>();
-            this.arch = new FakeArchitecture();
-            imp.Replay();
+            m = new SsaProcedureBuilder();
         }
 
-        private SsaTransform BuildSsa(Action<ProcedureBuilder>builder)
+        public void RunSsaMutator(Action<SsaMutator> action)
         {
-            var m = new ProcedureBuilder(arch);
-            builder(m);
-            var gr = m.Procedure.CreateBlockDominatorGraph();
-            var sst = new SsaTransform(flow, m.Procedure, imp, gr, implicitRegs);
-            return sst;
+            var ssam = new SsaMutator(m.Ssa);
+            action(ssam);
+            m.Ssa.Validate(s => Assert.Fail(s));
         }
 
-        private void AssertEqual(string sExpected, SsaState ssa)
+        private void AssertProcedureCode(string expected)
         {
-            var sw = new StringWriter();
-            ssa.Write(sw);
-            ssa.Procedure.Write(false, sw);
-            var sActual = sw.ToString();
-            if (sExpected != sActual)
-            {
-                Debug.WriteLine(sActual);
-                Assert.AreEqual(sExpected, sActual);
-            }
+            ProcedureCodeVerifier.AssertCode(m.Ssa.Procedure, expected);
         }
 
         [Test]
         public void SsamCallBypass()
         {
-            var sst = BuildSsa(m =>
-            {
-                var a7 = m.Frame.EnsureRegister(m.Architecture.StackRegister);
-                var a1 = m.Reg32("a1", 0x09);
-                var a3 = m.Reg32("a3", 0x0B);
-                m.Assign(a7, m.Frame.FramePointer);
-                m.Assign(a1, m.Mem32(m.IAdd(a3, 8)));
-                m.Call(a1, 4);
-                m.Return();
-            });
-            var ssam = new SsaMutator(sst.SsaState);
-            var block = sst.SsaState.Procedure.EntryBlock.Succ[0];
-            var stmCall = block.Statements[2];
-            var call = (CallInstruction)stmCall.Instruction;
+            var sp = m.Architecture.StackRegister;
+            var sp_1 = m.Reg("sp_1", sp);
+            var sp_5 = m.Reg("sp_5", sp);
+            var a = m.Reg32("a");
+            var fp = m.Reg32("fp");
+            m.Assign(sp_1, fp);
+            var uses = new Identifier[] { a, sp_1 };
+            var defines = new Identifier[] { sp_5 };
+            var stmCall = m.Call(a, 4, uses, defines);
 
-            ssam.AdjustRegisterAfterCall(stmCall, call, arch.StackRegister, 0);
-            var sExp =
-            #region Expected
-@"fp:fp
-    def:  def fp
-    uses: r63_1 = fp
-r63_1: orig: r63
-    def:  r63_1 = fp
-    uses: call a1_4 (retsize: 4;)	uses: a1_4,a3,r63_1	defs: a1_6,a3_7
-          r63_5 = r63_1
-a3:a3
-    def:  def a3
-    uses: a1_4 = Mem0[a3 + 0x00000008:word32]
-          call a1_4 (retsize: 4;)	uses: a1_4,a3,r63_1	defs: a1_6,a3_7
-Mem0:Global memory
-    def:  def Mem0
-    uses: a1_4 = Mem0[a3 + 0x00000008:word32]
-a1_4: orig: a1
-    def:  a1_4 = Mem0[a3 + 0x00000008:word32]
-    uses: call a1_4 (retsize: 4;)	uses: a1_4,a3,r63_1	defs: a1_6,a3_7
-          call a1_4 (retsize: 4;)	uses: a1_4,a3,r63_1	defs: a1_6,a3_7
-r63_5: orig: r63
-    def:  r63_5 = r63_1
-a1_6: orig: a1
-    def:  call a1_4 (retsize: 4;)	uses: a1_4,a3,r63_1	defs: a1_6,a3_7
-a3_7: orig: a3
-    def:  call a1_4 (retsize: 4;)	uses: a1_4,a3,r63_1	defs: a1_6,a3_7
-// ProcedureBuilder
-// Return size: 0
-void ProcedureBuilder()
-ProcedureBuilder_entry:
-	def fp
-	def a3
-	def Mem0
-	// succ:  l1
-l1:
-	r63_1 = fp
-	a1_4 = Mem0[a3 + 0x00000008:word32]
-	call a1_4 (retsize: 4;)
-		uses: a1_4,a3,r63_1
-		defs: a1_6,a3_7
-	r63_5 = r63_1
-	return
-	// succ:  ProcedureBuilder_exit
-ProcedureBuilder_exit:
+            RunSsaMutator(ssam =>
+            {
+                var call = (CallInstruction)stmCall.Instruction;
+                ssam.AdjustRegisterAfterCall(stmCall, call, sp, 0);
+            });
+
+            var sExp = @"
+sp_1 = fp
+call a (retsize: 4;)
+	uses: a,sp_1
+sp_5 = sp_1
 ";
-            #endregion
-            AssertEqual(sExp, sst.SsaState);
+            AssertProcedureCode(sExp);
         }
     }
 }

--- a/src/UnitTests/Mocks/SsaProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/SsaProcedureBuilder.cs
@@ -43,13 +43,22 @@ namespace Reko.UnitTests.Mocks
             this.Ssa = new SsaState(Procedure, null);
         }
 
-        private Identifier Reg(string name, PrimitiveType pt)
+        public RegisterStorage RegisterStorage(string name, PrimitiveType pt)
         {
-            var r = new RegisterStorage(name, Ssa.Identifiers.Count, 0, pt);
-            var id = new Identifier(r.Name, r.DataType, r);
+            return new RegisterStorage(name, Ssa.Identifiers.Count, 0, pt);
+        }
+
+        public Identifier Reg(string name, RegisterStorage r)
+        {
+            var id = new Identifier(name, r.DataType, r);
             var sid = new SsaIdentifier(id, id, null, null, false);
             Ssa.Identifiers.Add(id, sid);
             return sid.Identifier;
+        }
+
+        private Identifier Reg(string name, PrimitiveType pt)
+        {
+            return Reg(name, RegisterStorage(name, pt));
         }
 
         public override Identifier Local32(string name, int offset)


### PR DESCRIPTION
Improve unit test for `SsaMutators`: use `SsaProcedureBuilder` to avoid `SsaTransform` call