### PR TITLE
Check ssa definitions

### DIFF
--- a/src/Decompiler/Analysis/SsaDefinitionsCollector.cs
+++ b/src/Decompiler/Analysis/SsaDefinitionsCollector.cs
@@ -1,0 +1,95 @@
+﻿#region License
+/* 
+ * Copyright (C) 1999-2018 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using Reko.Core;
+using Reko.Core.Code;
+using Reko.Core.Expressions;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Reko.Analysis
+{
+    public class SsaDefinitionsCollector : InstructionVisitorBase
+    {
+        private List<Identifier> definitions;
+
+        public SsaDefinitionsCollector()
+        {
+            this.definitions = new List<Identifier>();
+        }
+
+        public ICollection<Identifier> CollectDefinitions(Statement stm)
+        {
+            definitions.Clear();
+            stm.Instruction.Accept(this);
+            return definitions;
+        }
+
+        #region InstructionVisitor Members
+
+        public override void VisitAssignment(Assignment a)
+        {
+            base.VisitAssignment(a);
+            definitions.Add(a.Dst);
+        }
+
+        public override void VisitCallInstruction(CallInstruction ci)
+        {
+            base.VisitCallInstruction(ci);
+            definitions.AddRange(ci.Definitions
+                .Select(d => d.Identifier));
+        }
+
+        public override void VisitDefInstruction(DefInstruction def)
+        {
+            base.VisitDefInstruction(def);
+            definitions.Add(def.Identifier);
+        }
+
+        public override void VisitPhiAssignment(PhiAssignment phi)
+        {
+            base.VisitPhiAssignment(phi);
+            definitions.Add(phi.Dst);
+        }
+
+        public override void VisitStore(Store store)
+        {
+            base.VisitStore(store);
+            if (store.Dst is MemoryAccess access)
+            {
+                definitions.Add(access.MemoryId);
+            }
+        }
+
+        #endregion
+
+        #region IExpressionVisitor Members
+
+        public override void VisitOutArgument(OutArgument outArg)
+        {
+            if (outArg.Expression is Identifier outId)
+            {
+                definitions.Add(outId);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Decompiler/Analysis/SsaIdentifierCollection.cs
+++ b/src/Decompiler/Analysis/SsaIdentifierCollection.cs
@@ -66,6 +66,11 @@ namespace Reko.Analysis
             get { return sids.Count; }
         }
 
+        public bool Contains(Identifier id)
+        {
+            return sids.ContainsKey(id);
+        }
+
         public IEnumerator<SsaIdentifier> GetEnumerator()
         {
             return sids.Values.GetEnumerator();

--- a/src/Decompiler/Analysis/SsaState.cs
+++ b/src/Decompiler/Analysis/SsaState.cs
@@ -111,6 +111,12 @@ namespace Reko.Analysis
 			}
 		}
 
+        public void Check(Action<string> error)
+        {
+            CheckUses(error);
+            CheckDefinitions(error);
+        }
+
         [Conditional("DEBUG")]
         public void CheckUses()
         {

--- a/src/Decompiler/Decompiler.csproj
+++ b/src/Decompiler/Decompiler.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Analysis\ProcedureFlow2.cs" />
     <Compile Include="Analysis\ProcedureGraph.cs" />
     <Compile Include="Analysis\RegisterPreservation.cs" />
+    <Compile Include="Analysis\SsaDefinitionsCollector.cs" />
     <Compile Include="Analysis\SsaMutator.cs" />
     <Compile Include="Analysis\TrashedRegisterFinder2.cs" />
     <Compile Include="Analysis\UnalignedMemoryAccessFuser.cs" />

--- a/src/UnitTests/Analysis/CoalescerTests.cs
+++ b/src/UnitTests/Analysis/CoalescerTests.cs
@@ -46,7 +46,7 @@ namespace Reko.UnitTests.Analysis
         {
             var co = new Coalescer(m.Ssa.Procedure, m.Ssa);
             co.Transform();
-            m.Ssa.CheckUses(s => Assert.Fail(s));
+            m.Ssa.Check(s => Assert.Fail(s));
         }
 
         private void AssertProcedureCode(string expected)
@@ -82,7 +82,7 @@ namespace Reko.UnitTests.Analysis
 				proc.Write(false, fut);
 				fut.WriteLine();
 
-                ssa.CheckUses(s => Assert.Fail(s));
+                ssa.Check(s => Assert.Fail(s));
             }
         }
 

--- a/src/UnitTests/Analysis/IndirectCallRewriterTests.cs
+++ b/src/UnitTests/Analysis/IndirectCallRewriterTests.cs
@@ -246,7 +246,7 @@ namespace Reko.UnitTests.Analysis
                 m.Ssa,
                 eventListener);
             icrw.Rewrite();
-            m.Ssa.CheckUses(s => Assert.Fail(s));
+            m.Ssa.Check(s => Assert.Fail(s));
         }
 
         private void AssertProcedureCode(string expected)

--- a/src/UnitTests/Analysis/SsaTests.cs
+++ b/src/UnitTests/Analysis/SsaTests.cs
@@ -175,7 +175,7 @@ namespace Reko.UnitTests.Analysis
                 ssa.Write(fut.TextWriter);
                 proc.Write(false, fut.TextWriter);
                 fut.AssertFilesEqual();
-                ssa.CheckUses(s => Assert.Fail(s));
+                ssa.Check(s => Assert.Fail(s));
             }
         }
 
@@ -217,7 +217,7 @@ namespace Reko.UnitTests.Analysis
 				ssa.Write(writer);
 				proc.Write(false, true, writer);
 				writer.WriteLine();
-                ssa.CheckUses(s => Assert.Fail(s));
+                ssa.Check(s => Assert.Fail(s));
 			}
 		}
 

--- a/src/UnitTests/Analysis/SsaTransformTests.cs
+++ b/src/UnitTests/Analysis/SsaTransformTests.cs
@@ -113,7 +113,7 @@ namespace Reko.UnitTests.Analysis
             if (sActual != sExp)
                 Debug.Print(sActual);
             Assert.AreEqual(sExp, sActual);
-            ssa.SsaState.CheckUses(s => Assert.Fail(s));
+            ssa.SsaState.Check(s => Assert.Fail(s));
         }
 
         private void RunTest2(string sExp, Action<ProcedureBuilder> builder)


### PR DESCRIPTION
- Add check `ssa` definitions method to `SsaState`
- Add check `SsaState` method which checks both uses and definitions 
- Use `Check` rather than `CheckUses` (except `ValuePropagatorTests`) 