### PR TITLE
Create hotkey for comment editing

### DIFF
--- a/src/Gui/decompiler-menus.xml
+++ b/src/Gui/decompiler-menus.xml
@@ -204,6 +204,7 @@
 
   <keybinding id="ActionMarkType" cmdSet="Reko" key1="T" alt1="Control" />
   <keybinding id="EditDeclaration" cmdSet="Reko" editor="Reko.Gui.Windows.CombinedCodeViewInteractor"  key1="D" alt1="Control" />
+  <keybinding id="EditComment" cmdSet="Reko" editor="Reko.Gui.Windows.CombinedCodeViewInteractor"  key1="OemSemicolon" />
   <keybinding id="ActionNextSearchHit" cmdSet="Reko" editor="" key1="F8" />
   <keybinding id="ActionPrevSearchHit" cmdSet="Reko" editor="" key1="F8" alt1="Shift" />
   <keybinding id="EditCopy" cmdSet="Reko" editor="" key1="C" alt1="Control" />


### PR DESCRIPTION
Use `Ctrl+T` (T - Text) as hotkey for comment editing. Do you agree, John?