### PR TITLE
Modify CFG Cleaner to do not eliminate critical instructions

### DIFF
--- a/src/Core/Code/CriticalInstruction.cs
+++ b/src/Core/Code/CriticalInstruction.cs
@@ -18,11 +18,10 @@
  */
 #endregion
 
-using Reko.Core.Code;
 using Reko.Core.Expressions;
 using System;
 
-namespace Reko.Analysis
+namespace Reko.Core.Code
 {
 	/// <summary>
 	/// Determines whether an instruction is critical or not. Non-critical

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -258,6 +258,7 @@
     <Compile Include="CLanguage\SymbolTable.cs" />
     <Compile Include="CLanguage\TypeSizer.cs" />
     <Compile Include="Code\CodeComment.cs" />
+    <Compile Include="Code\CriticalInstruction.cs" />
     <Compile Include="Code\GotoInstruction.cs" />
     <Compile Include="Code\SwitchInstruction.cs" />
     <Compile Include="Configuration\ArchitectureElement.cs" />

--- a/src/Decompiler/Decompiler.csproj
+++ b/src/Decompiler/Decompiler.csproj
@@ -117,9 +117,6 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Analysis\ConstDivisionImplementedByMultiplication.cs" />
-    <Compile Include="Analysis\CriticalInstruction.cs">
-      <SubType>Code</SubType>
-    </Compile>
     <Compile Include="Analysis\DataFlow.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/UnitTests/Core/CriticalInstructionTests.cs
+++ b/src/UnitTests/Core/CriticalInstructionTests.cs
@@ -18,7 +18,6 @@
  */
 #endregion
 
-using Reko.Analysis;
 using Reko.Core.Code;
 using Reko.Core.Expressions;
 using Reko.Core.Operators;
@@ -27,7 +26,7 @@ using Reko.Core;
 using NUnit.Framework;
 using System;
 
-namespace Reko.UnitTests.Analysis
+namespace Reko.UnitTests.Core
 {
 	[TestFixture]
 	public class CriticalInstructionTests

--- a/src/UnitTests/Structure/StructureAnalysisTests.cs
+++ b/src/UnitTests/Structure/StructureAnalysisTests.cs
@@ -79,6 +79,23 @@ namespace Reko.UnitTests.Structure
         }
 
         [Test]
+        public void StrAnls_DoNoCleanProcedureCall()
+        {
+            m.Label("head");
+            m.BranchIf(m.Fn("someCheck"), "failed");
+            m.Goto("exit");
+            m.Label("failed");
+            m.Label("exit");
+            m.Return();
+
+            var sExp =
+@"    someCheck();
+    return;
+";
+            RunTest(sExp, m.Procedure);
+        }
+
+        [Test]
         public void StrAnls_IfThen()
         {
             var r1 = m.Reg32("r1", 1);

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Arch\i8051\i8051DisassemblerTests.cs" />
     <Compile Include="Arch\i8051\i8051RewriterTests.cs" />
     <Compile Include="Arch\Intel\FastcallConventionTests.cs" />
+    <Compile Include="Core\CriticalInstructionTests.cs" />
     <Compile Include="Core\Pascal\PascalLexerTests.cs" />
     <Compile Include="Core\Pascal\PascalParserTests.cs" />
     <Compile Include="Core\Serialization\Json\JsonProjectSerializerTests.cs" />
@@ -218,7 +219,6 @@
     <Compile Include="Analysis\CallRewriterTests.cs" />
     <Compile Include="Analysis\CoalescerTests.cs" />
     <Compile Include="Analysis\ConditionCodeEliminatorTests.cs" />
-    <Compile Include="Analysis\CriticalInstructionTests.cs" />
     <Compile Include="Analysis\DataFlowAnalysisTests.cs" />
     <Compile Include="Analysis\DataFlowAnalysisTests2.cs" />
     <Compile Include="Analysis\DeadCodeTests.cs" />

--- a/subjects/Elf/MIPS/redir/redir.c
+++ b/subjects/Elf/MIPS/redir/redir.c
@@ -274,6 +274,7 @@ void main(word32 r5, word32 dwArg00, word32 dwArg04)
 	word32 r3_163;
 	word32 r7_164;
 	__xpg_basename();
+	*globals->ptr10000A28 >= 0x00;
 	<anonymous> * r25_205 = globals->ptr100009EC;
 	word32 sp_206;
 	word32 r28_207;

--- a/subjects/Elf/RiscV/ipcalc/ipcalc.c
+++ b/subjects/Elf/RiscV/ipcalc/ipcalc.c
@@ -491,9 +491,10 @@ l0000000000015458:
 			Eq_292 a0_862 = fn00000000000166F4(ra, gp, &fp->dwFFFFFE5C, s10_45, 0x01, out a1_861);
 			if (a0_862 < 0x00)
 			{
-				if ((word64) gp->dwFFFFF814 == 0x00)
-					goto l0000000000015B8C;
-				goto l00000000000153D8;
+				if ((word64) gp->dwFFFFF814 != 0x00)
+					goto l00000000000153D8;
+				(word64) fp->dwFFFFFE5C != 0x00;
+				goto l0000000000015B8C;
 			}
 			fp->tFFFFFE48 = a0_862;
 			word64 s1_867 = (word64) fp->dwFFFFFE5C;
@@ -618,6 +619,7 @@ l00000000000155E4:
 					goto l00000000000155FC;
 				if ((word64) gp->dwFFFFF814 == 0x00)
 				{
+					(word64) *((word64) sp_132 + 0x001C) != 0x00;
 l0000000000015B8C:
 					__fprintf_chk();
 				}

--- a/subjects/PE/MIPS/swlswr/test.c
+++ b/subjects/PE/MIPS/swlswr/test.c
@@ -232,5 +232,6 @@ code * fn0001152C(code * r2, word32 dwArg00)
 // 000116FC: void fn000116FC(Register (ptr code) r2, Stack word32 dwArg00)
 void fn000116FC(code * r2, word32 dwArg00)
 {
+	fn0001152C(r2, dwLoc20) == 0x00;
 }
 

--- a/subjects/TLCS/90/TLCS-90.c
+++ b/subjects/TLCS/90/TLCS-90.c
@@ -2165,6 +2165,7 @@ void fn291C(byte a, ptr16 hl)
 {
 	Eq_16 a_13 = 0x00 - (__ror(*(hl - 0x01), 0x01) < 0x00);
 	byte a_20 = 0x00 - (__ror(a, 0x01) < 0x00);
+	__rcl(a_13, 0x01, cond(__rcl(a_13 ^ a_20, 0x01, false))) >= 0x00;
 	fn1C54();
 }
 


### PR DESCRIPTION
- Create unit test to reproduce removing procedure call by CFG Cleaner
- Move `CriticalInstruction` to Reko.Core.Code
- Modify CFG Cleaner to do not eliminate critical instructions