### PR TITLE
Replace FPU definitions after trivial phi removing

### DIFF
--- a/src/Decompiler/Analysis/SsaTransform.cs
+++ b/src/Decompiler/Analysis/SsaTransform.cs
@@ -1372,6 +1372,13 @@ namespace Reko.Analysis
                             de.Value.SsaId = idNew;
                         }
                     }
+                    foreach (var de in bs.currentFpuDef.ToList())
+                    {
+                        if (de.Value == sidOld)
+                        {
+                            bs.currentFpuDef[de.Key] = idNew;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Create unit test to reproduce FPU definitions corruption after trivial phi removing
- Replace FPU definitions after trivial phi removing