### PR TITLE
 Make MemoryAccess and SegmentedAccess immutable 

### DIFF
--- a/src/Core/Code/InstructionTransformer.cs
+++ b/src/Core/Code/InstructionTransformer.cs
@@ -218,9 +218,9 @@ namespace Reko.Core.Code
 		
 		public virtual Expression VisitMemoryAccess(MemoryAccess access)
 		{
-			access.EffectiveAddress = access.EffectiveAddress.Accept(this);
-			access.MemoryId = (MemoryIdentifier) access.MemoryId.Accept(this);
-			return access;
+			var ea = access.EffectiveAddress.Accept(this);
+			var memId = (MemoryIdentifier) access.MemoryId.Accept(this);
+			return new MemoryAccess(memId, ea, access.DataType);
 		}
 
 		public virtual Expression VisitMkSequence(MkSequence seq)
@@ -258,10 +258,10 @@ namespace Reko.Core.Code
 
 		public virtual Expression VisitSegmentedAccess(SegmentedAccess access)
 		{
-			access.BasePointer = access.BasePointer.Accept(this);
-			access.EffectiveAddress = access.EffectiveAddress.Accept(this);
-			access.MemoryId = (MemoryIdentifier) access.MemoryId.Accept(this);
-			return access;
+			var basePtr = access.BasePointer.Accept(this);
+			var ea = access.EffectiveAddress.Accept(this);
+			var memId = (MemoryIdentifier) access.MemoryId.Accept(this);
+			return new SegmentedAccess(memId, basePtr, ea, access.DataType);
 		}
 
 		public virtual Expression VisitScopeResolution(ScopeResolution scope)

--- a/src/Core/Expressions/BinaryExpression.cs
+++ b/src/Core/Expressions/BinaryExpression.cs
@@ -46,7 +46,7 @@ namespace Reko.Core.Expressions
         }
 
         public Operator Operator { get; private set; } 
-        public Expression Left { get; set; }
+        public Expression Left { get; private set; }
         public Expression Right { get; set; }
 
         public override T Accept<T, C>(ExpressionVisitor<T, C> v, C context)

--- a/src/Core/Expressions/MemoryAccess.cs
+++ b/src/Core/Expressions/MemoryAccess.cs
@@ -58,8 +58,8 @@ namespace Reko.Core.Expressions
             this.EffectiveAddress = ea;
         }
 
-        public MemoryIdentifier MemoryId { get; set; }
-        public Expression EffectiveAddress { get; set; }
+        public readonly MemoryIdentifier MemoryId;
+        public readonly Expression EffectiveAddress;
 
         public override IEnumerable<Expression> Children
         {
@@ -113,7 +113,7 @@ namespace Reko.Core.Expressions
 			this.BasePointer = basePtr;
 		}
 
-        public Expression BasePointer { get; set; }         // Segment selector
+        public readonly Expression BasePointer;         // Segment selector
 
         public override T Accept<T, C>(ExpressionVisitor<T, C> v, C context)
         {

--- a/src/Decompiler/Typing/ExpressionNormalizer.cs
+++ b/src/Decompiler/Typing/ExpressionNormalizer.cs
@@ -65,40 +65,42 @@ namespace Reko.Typing
 
 		public override Expression VisitMemoryAccess(MemoryAccess access)
 		{
-            access.EffectiveAddress = access.EffectiveAddress.Accept(this);
-            if (aem.Match(access.EffectiveAddress))
+            var ea = access.EffectiveAddress.Accept(this);
+            if (aem.Match(ea))
             {
                 if (aem.ArrayPointer == null)
                 {
                     aem.ArrayPointer = Constant.Create(
                         PrimitiveType.Create(
                             Domain.Pointer,
-                            access.EffectiveAddress.DataType.BitSize),
+                            ea.DataType.BitSize),
                         0);
                 }
                 return aem.Transform(null, access.DataType);
             }
-            if (access.EffectiveAddress is BinaryExpression bin && bin.Operator == Operator.IAdd)
-                return access;
-            if (access.EffectiveAddress is Constant)
-                return access;
-            access.EffectiveAddress = AddZeroToEffectiveAddress(access.EffectiveAddress);
-            return access;
+            if (!(ea is BinaryExpression bin && bin.Operator == Operator.IAdd) &&
+                !(ea is Constant))
+            {
+                ea = AddZeroToEffectiveAddress(ea);
+            }
+            return new MemoryAccess(access.MemoryId, ea, access.DataType);
         }
 
         public override Expression VisitSegmentedAccess(SegmentedAccess access)
         {
-            access.EffectiveAddress = access.EffectiveAddress.Accept(this);
-            if (aem.Match(access.EffectiveAddress))
+            var ea = access.EffectiveAddress.Accept(this);
+            if (aem.Match(ea))
             {
                 return aem.Transform(access.BasePointer, access.DataType);
             }
-            if (access.EffectiveAddress is BinaryExpression bin && bin.Operator == Operator.IAdd)
-                return access;
-            if (access.EffectiveAddress is Constant)
-                return access;
-            access.EffectiveAddress = AddZeroToEffectiveAddress(access.EffectiveAddress);
-                return access;
+            if (!(ea is BinaryExpression bin && bin.Operator == Operator.IAdd) &&
+                !(ea is Constant))
+            {
+                ea = AddZeroToEffectiveAddress(ea);
+            }
+            var memId = access.MemoryId;
+            var basePtr = access.BasePointer;
+            return new SegmentedAccess(memId, basePtr, ea, access.DataType);
         }
 
 		public void Transform(Program prog)

--- a/src/UnitTests/Analysis/ValuePropagationTests.cs
+++ b/src/UnitTests/Analysis/ValuePropagationTests.cs
@@ -507,7 +507,7 @@ namespace Reko.UnitTests.Analysis
             var bx_4 = m.Reg16("bx_4");
             var es_bx_1 = m.Reg32("es_bx_1");
 
-            m.Store(m.SegMem(PrimitiveType.Byte, es, m.IAdd(bx, 4)), m.Byte(3));
+            m.SStore(es, m.IAdd(bx, 4), m.Byte(3));
             m.Assign(es_bx_1, m.SegMem(PrimitiveType.Word32, es, bx));
             m.Assign(es_2, m.Slice(PrimitiveType.Word16, es_bx_1, 16));
             m.Assign(bx_3, m.Cast(PrimitiveType.Word16, es_bx_1));
@@ -934,7 +934,7 @@ ProcedureBuilder_exit:
             var bx_4 = m.Reg16("bx_4");
             var es_bx_1 = m.Reg32("es_bx_1");
 
-            m.Store(m.SegMem(PrimitiveType.Byte, es, m.IAdd(bx, 4)), m.Byte(3));
+            m.SStore(es, m.IAdd(bx, 4), m.Byte(3));
             m.Assign(es_bx_1, m.SegMem(PrimitiveType.Word32, es, bx));
             m.Assign(es_2, m.Slice(PrimitiveType.Word16, es_bx_1, 16));
             m.Assign(bx_3, m.Cast(PrimitiveType.Word16, es_bx_1));

--- a/src/UnitTests/Mocks/SsaProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/SsaProcedureBuilder.cs
@@ -103,6 +103,7 @@ namespace Reko.UnitTests.Mocks
             case Store store:
                 if (store.Dst is MemoryAccess access)
                 {
+                    AddMemIdToSsa(access);
                     Ssa.Identifiers[access.MemoryId].DefStatement = stm;
                     Ssa.Identifiers[access.MemoryId].DefExpression = null;
                 }

--- a/src/UnitTests/Mocks/SsaProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/SsaProcedureBuilder.cs
@@ -126,6 +126,8 @@ namespace Reko.UnitTests.Mocks
 
         private MemoryIdentifier AddMemIdToSsa(MemoryIdentifier idOld)
         {
+            if (Ssa.Identifiers.Contains(idOld))
+                return idOld;
             var idNew = new MemoryIdentifier(Ssa.Identifiers.Count, idOld.DataType);
             var sid = new SsaIdentifier(idNew, idOld, null, null, false);
             Ssa.Identifiers.Add(idNew, sid);


### PR DESCRIPTION
Backwalker causes several pointers  to same expressions like `Mem[ebp + 8]`. `SsaTransform` in `analysis-development` failed because of unexpected instruction change when other instruction is changing. Making `MemoryAccess` immutable could prevent such errors