### PR TITLE
Create new instances of MemoryAccess rather than modifying existing ones [analysis-development]

### DIFF
--- a/src/Decompiler/Analysis/SsaTransform.cs
+++ b/src/Decompiler/Analysis/SsaTransform.cs
@@ -639,12 +639,18 @@ namespace Reko.Analysis
                 }
                 else
                 {
+                    Expression basePtr = null;
                     if (acc is SegmentedAccess sa)
-                        sa.BasePointer = sa.BasePointer.Accept(this);
-                    acc.EffectiveAddress = acc.EffectiveAddress.Accept(this);
+                    {
+                        basePtr = sa.BasePointer.Accept(this);
+                    }
+                    var ea = acc.EffectiveAddress.Accept(this);
+                    var memId = acc.MemoryId;
                     if (!this.RenameFrameAccesses)
-                        UpdateMemoryIdentifier(acc, true);
-                    return acc;
+                        memId = UpdateMemoryIdentifier(memId, true);
+                    if (basePtr != null)
+                        return new SegmentedAccess(memId, basePtr, ea, acc.DataType);
+                    return new MemoryAccess(memId, ea, acc.DataType);
                 }
             }
             else
@@ -808,15 +814,13 @@ namespace Reko.Analysis
 
             if (c != null)
             {
-                access.EffectiveAddress = c;
                 var e = importResolver.ResolveToImportedProcedureConstant(stmCur, c);
                 if (e != null)
                     return e;
                 ea = c;
             }
-            UpdateMemoryIdentifier(access, false);
-            access.EffectiveAddress = ea;
-            return access;
+            var memId = UpdateMemoryIdentifier(access.MemoryId, false);
+            return new MemoryAccess(memId, ea, access.DataType);
         }
 
         public override Expression VisitSegmentedAccess(SegmentedAccess access)
@@ -832,24 +836,24 @@ namespace Reko.Analysis
             }
             else
             {
-                access.BasePointer = access.BasePointer.Accept(this);
-                access.EffectiveAddress = access.EffectiveAddress.Accept(this);
-                access.MemoryId = (MemoryIdentifier)NewUse(access.MemoryId, stmCur, false);
-                return access;
+                var basePtr = access.BasePointer.Accept(this);
+                var ea = access.EffectiveAddress.Accept(this);
+                var memId = (MemoryIdentifier)NewUse(access.MemoryId, stmCur, false);
+                return new SegmentedAccess(memId, basePtr, ea, access.DataType);
             }
         }
 
-        private void UpdateMemoryIdentifier(MemoryAccess access, bool storing)
+        private MemoryIdentifier UpdateMemoryIdentifier(MemoryIdentifier memId, bool storing)
         {
             if (storing)
             {
-                var sid = ssa.Identifiers.Add(access.MemoryId, this.stmCur, null, false);
-                var ss = new RegisterTransformer(access.MemoryId, stmCur, this);
-                access.MemoryId = (MemoryIdentifier)ss.WriteVariable(blockstates[block], sid, false);
+                var sid = ssa.Identifiers.Add(memId, this.stmCur, null, false);
+                var ss = new RegisterTransformer(memId, stmCur, this);
+                return (MemoryIdentifier)ss.WriteVariable(blockstates[block], sid, false);
             }
             else
             {
-                access.MemoryId = (MemoryIdentifier)access.MemoryId.Accept(this);
+                return (MemoryIdentifier)memId.Accept(this);
             }
         }
 

--- a/src/UnitTests/Analysis/UnalignedMemoryAccessFuserTests.cs
+++ b/src/UnitTests/Analysis/UnalignedMemoryAccessFuserTests.cs
@@ -324,7 +324,7 @@ r8:r8
     def:  def r8
     uses: Mem5[r4 + 0x00000028:word32] = r8
 Mem4: orig: Mem0
-Mem5: orig: Mem4
+Mem5: orig: Mem0
     def:  Mem5[r4 + 0x00000028:word32] = r8
 // ProcedureBuilder
 // Return size: 0
@@ -390,30 +390,30 @@ Mem4: orig: Mem0
 r13:r13
     def:  def r13
     uses: Mem15[r8 + 0x00000014:word32] = r13
-Mem6: orig: Mem4
-Mem7: orig: Mem6
-Mem8: orig: Mem7
-Mem9: orig: Mem8
+Mem6: orig: Mem0
+Mem7: orig: Mem0
+Mem8: orig: Mem0
+Mem9: orig: Mem0
 r9:r9
     def:  def r9
     uses: Mem19[r8 + 0x0000002C:word32] = r9
-Mem11: orig: Mem9
-Mem12: orig: Mem11
+Mem11: orig: Mem0
+Mem12: orig: Mem0
 r4_13: orig: r4
     def:  r4_13 = r8 + 0x00000010
-Mem14: orig: Mem12
+Mem14: orig: Mem0
     def:  Mem14[r8 + 0x00000010:word32] = r14
-Mem15: orig: Mem14
+Mem15: orig: Mem0
     def:  Mem15[r8 + 0x00000014:word32] = r13
-Mem16: orig: Mem15
+Mem16: orig: Mem0
     def:  Mem16[r8 + 0x00000018:word32] = 0x00000000
-Mem17: orig: Mem16
+Mem17: orig: Mem0
     def:  Mem17[r8 + 0x0000001C:word32] = 0x00000000
-Mem18: orig: Mem17
+Mem18: orig: Mem0
     def:  Mem18[r8 + 0x00000028:word32] = 0x00000000
-Mem19: orig: Mem18
+Mem19: orig: Mem0
     def:  Mem19[r8 + 0x0000002C:word32] = r9
-Mem20: orig: Mem19
+Mem20: orig: Mem0
     def:  Mem20[r8 + 0x00000030:word32] = 0x00000000
 // ProcedureBuilder
 // Return size: 0
@@ -462,10 +462,10 @@ ProcedureBuilder_exit:
 Mem0:Mem
     def:  def Mem0
 Mem3: orig: Mem0
-Mem4: orig: Mem3
-Mem5: orig: Mem4
+Mem4: orig: Mem0
+Mem5: orig: Mem0
     def:  Mem5[r8 + 0x00000010:word32] = 0x12345678
-Mem6: orig: Mem5
+Mem6: orig: Mem0
     def:  Mem6[r8 + 0x00000014:word32] = 0x9ABCDEF0
 // ProcedureBuilder
 // Return size: 0
@@ -505,7 +505,7 @@ r8:r8
     def:  def r8
     uses: Mem5[r4:word32] = r8
 Mem4: orig: Mem0
-Mem5: orig: Mem4
+Mem5: orig: Mem0
     def:  Mem5[r4:word32] = r8
 // ProcedureBuilder
 // Return size: 0

--- a/src/UnitTests/Analysis/ValuePropagationTests.cs
+++ b/src/UnitTests/Analysis/ValuePropagationTests.cs
@@ -74,35 +74,6 @@ namespace Reko.UnitTests.Analysis
             return sid.Identifier;
         }
 
-        private Identifier Reg16(string name)
-        {
-            var mr = new RegisterStorage(name, m.Ssa.Identifiers.Count, 0, PrimitiveType.Word16);
-            Identifier id = new Identifier(mr.Name, mr.DataType, mr);
-            SsaIdentifier sid = new SsaIdentifier(id, id, null, null, false);
-            m.Ssa.Identifiers.Add(id, sid);
-            return sid.Identifier;
-        }
-
-        private Identifier Reg8(string name)
-        {
-            var mr = new RegisterStorage(name, m.Ssa.Identifiers.Count, 0, PrimitiveType.Byte);
-            Identifier id = new Identifier(mr.Name, mr.DataType, mr);
-            SsaIdentifier sid = new SsaIdentifier(id, id, null, null, false);
-            m.Ssa.Identifiers.Add(id, sid);
-            return sid.Identifier;
-        }
-
-        private SegmentedAccess SegMem(DataType dt, Expression basePtr, Expression ptr)
-        {
-            var segMem = m.SegMem(dt, basePtr, ptr);
-            var idOld = segMem.MemoryId;
-            var idNew = new MemoryIdentifier(m.Ssa.Identifiers.Count, idOld.DataType);
-            segMem.MemoryId = idNew;
-            var sid = new SsaIdentifier(idNew, idOld, null, null, false);
-            m.Ssa.Identifiers.Add(idNew, sid);
-            return segMem;
-        }
-
         private ExternalProcedure CreateExternalProcedure(string name, Identifier ret, params Identifier[] parameters)
         {
             var ep = new ExternalProcedure(name, new FunctionType(ret, parameters));


### PR DESCRIPTION
- Create new instances of `MemoryAccess` rather than modifying existing ones
- Remove unused methods from `ValuePropagationTests `