### PR TITLE
Eliminates usage of CreateWordFromBits method 

### DIFF
--- a/src/Arch/Microchip/Common/PICRegisterBitFieldStorage.cs
+++ b/src/Arch/Microchip/Common/PICRegisterBitFieldStorage.cs
@@ -92,7 +92,7 @@ namespace Reko.Arch.MicrochipPIC.Common
         /// <param name="reg">The PIC register containing the bit field.</param>
         /// <param name="sfrfielddef">The bit field definition per PIC XML definition.</param>
         public PICRegisterBitFieldStorage(PICRegisterStorage reg, ISFRBitField sfrfielddef)
-            : base(reg, (uint)(sfrfielddef.BitMask << sfrfielddef.BitPos), sfrfielddef.Name, PrimitiveType.CreateWordFromBits(sfrfielddef.BitWidth))
+            : base(reg, (uint)(sfrfielddef.BitMask << sfrfielddef.BitPos), sfrfielddef.Name, CreateBitFieldType(sfrfielddef.BitWidth))
         {
             SFRField = sfrfielddef;
             BitFieldSortKey = new PICRegisterBitFieldSortKey(sfrfielddef.BitPos, (byte)sfrfielddef.BitWidth);
@@ -124,6 +124,8 @@ namespace Reko.Arch.MicrochipPIC.Common
         /// </summary>
         public PICRegisterStorage ParentReg => FlagRegister as PICRegisterStorage;
 
+        private static PrimitiveType CreateBitFieldType(int bitSize)
+            => (bitSize <= 1 ? PrimitiveType.Bool : PrimitiveType.CreateWord(bitSize));
     }
 
 }

--- a/src/Arch/Microchip/Common/PICRegisterStorage.cs
+++ b/src/Arch/Microchip/Common/PICRegisterStorage.cs
@@ -72,7 +72,7 @@ namespace Reko.Arch.MicrochipPIC.Common
         /// <param name="sfr">The SFR definition.</param>
         /// <param name="number">The Reko index number of this register.</param>
         public PICRegisterStorage(ISFRRegister sfr, int number)
-            : this(sfr.Name, number, 0, PrimitiveType.CreateWordFromBits((uint)sfr.BitWidth), new PICRegisterTraits(sfr))
+            : this(sfr.Name, number, 0, PrimitiveType.CreateWord(sfr.BitWidth), new PICRegisterTraits(sfr))
         {
         }
 
@@ -83,7 +83,7 @@ namespace Reko.Arch.MicrochipPIC.Common
         /// <param name="number">The Reko index number of this register.</param>
         /// <param name="subregs">The sub-registers of the joint.</param>
         public PICRegisterStorage(IJoinedRegister jsfr, int number, IList<PICRegisterStorage> subregs)
-            : base(jsfr.Name, number, 0, PrimitiveType.CreateWordFromBits(jsfr.BitWidth))
+            : base(jsfr.Name, number, 0, PrimitiveType.CreateWord(jsfr.BitWidth))
         {
             Traits = new PICRegisterTraits(jsfr, subregs);
             AttachedRegs = subregs.ToList();
@@ -113,7 +113,7 @@ namespace Reko.Arch.MicrochipPIC.Common
         public bool HasAttachedRegs => ((AttachedRegs?.Count() ?? 0) > 0);
 
         /// <summary>
-        /// Gets the bit-fields composing this register. Sorted by width then position.
+        /// Gets the bit-fields composing this register. Sorted by increasing width then bit position.
         /// </summary>
         public SortedList<PICRegisterBitFieldSortKey, PICRegisterBitFieldStorage> BitFields { get; }
 

--- a/src/Core/Types/PrimitiveType.cs
+++ b/src/Core/Types/PrimitiveType.cs
@@ -163,29 +163,6 @@ namespace Reko.Core.Types
         public static PrimitiveType CreateWord(uint bitSize)
             => CreateWord((int)bitSize);
 
-        //$TODO: Shall remove when Constant.Create will accept any bit-wide PrimitiveType.
-        // As of today only accepts multiple of 1, 2, 4, 8, 16 bytes. See issue #643.
-        public static PrimitiveType CreateWordFromBits(uint bitSize)
-        {
-            if (bitSize == 0)
-                throw new ArgumentOutOfRangeException(nameof(bitSize), $"Value = {bitSize}");
-            if (bitSize == 1)
-                return Bool;
-            if (bitSize <= 8)
-                return Byte;
-            if (bitSize <= 16)
-                return Word16;
-            if (bitSize <= 32)
-                return Word32;
-            if (bitSize <= 64)
-                return Word64;
-            if (bitSize <= 128)
-                return Word128;
-            if (bitSize <= 256)
-                return Word256;
-            throw new ArgumentOutOfRangeException(nameof(bitSize), $"Value = {bitSize}");
-        }
-
         public Domain Domain { get; private set; }
 
 		public override bool Equals(object obj)

--- a/subjects/Microchip/C18/PIC18/PIC18Legacy.c
+++ b/subjects/Microchip/C18/PIC18/PIC18Legacy.c
@@ -76,7 +76,7 @@ l000080:
 	goto l000080;
 }
 
-// 0000D0: void fn0000D0(Register byte LATB, Register byte FSR2L, Register (ptr16 Eq_194) FSR2, Register (ptr16 Eq_195) FSR1)
+// 0000D0: void fn0000D0(Register byte LATB, Register byte FSR2L, Register (ptr Eq_194) FSR2, Register (ptr Eq_195) FSR1)
 void fn0000D0(byte LATB, byte FSR2L, Eq_194 * FSR2, Eq_195 * FSR1)
 {
 	FSR1->b0000 = FSR2L;

--- a/subjects/Microchip/C18/PIC18/PIC18Legacy.c
+++ b/subjects/Microchip/C18/PIC18/PIC18Legacy.c
@@ -12,8 +12,8 @@ void fn00000000()
 	fn00000E(0x00, 0x00);
 }
 
-// 00000E: void fn00000E(Register Eq_17 FSR0, Register word32 TBLPTR)
-void fn00000E(Eq_17 FSR0, word32 TBLPTR)
+// 00000E: void fn00000E(Register Eq_17 FSR0, Register word24 TBLPTR)
+void fn00000E(Eq_17 FSR0, word24 TBLPTR)
 {
 	__tblrd(TBLPTR, 0x01);
 	0x00->b00C5 = TABLAT;
@@ -76,7 +76,7 @@ l000080:
 	goto l000080;
 }
 
-// 0000D0: void fn0000D0(Register byte LATB, Register byte FSR2L, Register (ptr Eq_194) FSR2, Register (ptr Eq_195) FSR1)
+// 0000D0: void fn0000D0(Register byte LATB, Register byte FSR2L, Register (ptr16 Eq_194) FSR2, Register (ptr16 Eq_195) FSR1)
 void fn0000D0(byte LATB, byte FSR2L, Eq_194 * FSR2, Eq_195 * FSR1)
 {
 	FSR1->b0000 = FSR2L;

--- a/subjects/Microchip/C18/PIC18/PIC18Legacy.dis
+++ b/subjects/Microchip/C18/PIC18/PIC18Legacy.dis
@@ -24,14 +24,14 @@ l00000000:
 l00013A:
 	Mem18[0x0001:byte] = Data[0x0001:byte] & 0xBF
 	Stack[0x01] = 0x00014A
-	fn00000E(0x0000, 0x00000000)
+	fn00000E(0x0000, 0x000000)
 // DataOut:
 // DataOut (flags): 
-// SymbolicIn: STKPTR:0x00 STATUS:0x00 PCL:0x00 PCLATH:0x00 WREG:0x00 BSR:0x00 FSR0:0x0000 FSR1:0x0000 FSR2:0x0000 PROD:0x0000 PCLAT:0x00000000 TOS:0x00000000 TBLPTR:0x00000000
+// SymbolicIn: STKPTR:0x00 STATUS:0x00 PCL:0x00 PCLATH:0x00 WREG:0x00 BSR:0x00 FSR0:0x0000 FSR1:0x0000 FSR2:0x0000 PROD:0x0000 PCLAT:0x000000 TOS:0x000000 TBLPTR:0x000000
 
 
 
-void fn00000E(word16 FSR0, word32 TBLPTR)
+void fn00000E(word16 FSR0, word24 TBLPTR)
 // stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  FSR0 TBLPTR
@@ -42,7 +42,7 @@ fn00000E_entry:
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l00000E:
 	__tblrd(TBLPTR, 0x01)
@@ -56,27 +56,27 @@ l00000E:
 // DataOut: FSR0 TBLPTR TBLPTRH TBLPTRL TBLPTRU
 // DataOut (flags): Z
 // SymbolicIn: STKPTR:fp
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000028:
 	branch Z_15 l000030
 // DataOut: FSR0 TBLPTR TBLPTRH TBLPTRL TBLPTRU
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:<invalid> TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l00002A:
 	branch Mem17[0x00:0xC5:byte] == 0x00 l00002E
 // DataOut: FSR0 TBLPTR TBLPTRH TBLPTRL TBLPTRU
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:<invalid> TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l00002E:
 // DataOut:
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:<invalid> TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000AA:
 	return
@@ -93,7 +93,7 @@ l00002C:
 // DataOut: FSR0 TBLPTR TBLPTRH TBLPTRL TBLPTRU
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:<invalid> TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000030:
 	__tblrd(TBLPTR, 0x01)
@@ -121,14 +121,14 @@ l000030:
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): Z
 // SymbolicIn: STKPTR:fp WREG:<invalid> TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000080:
 	branch Z_57 l000086
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:TABLAT TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000082:
 	Mem76[0x00:0xC4:byte] = Mem55[0x00:0xC4:byte]
@@ -136,7 +136,7 @@ l000082:
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:TABLAT TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000094:
 	TBLPTRL_24 = Mem76[0x00C7:byte]
@@ -148,7 +148,7 @@ l000094:
 // DataOut: FSR0 TBLPTR TBLPTRH TBLPTRL TBLPTRU
 // DataOut (flags): Z
 // SymbolicIn: STKPTR:fp WREG:TABLAT TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000086:
 	__tblrd(TBLPTR, 0x01)
@@ -160,14 +160,14 @@ l000086:
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): Z
 // SymbolicIn: STKPTR:fp WREG:TABLAT TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000090:
 	Mem74[0x00:0xC4:byte] = Mem69[0x00:0xC4:byte] - 0x01
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:TABLAT TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 
 
@@ -182,21 +182,21 @@ fn0000D0_entry:
 // DataOut: FSR1 FSR2 FSR2L LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000D0:
 	Mem3[FSR1:byte] = FSR2L
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000D8:
 	branch Mem3[FSR2 + 0xFE:byte] == 0x00 l0000F4
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000F4:
 	Mem29[FSR1 + 0x0001:byte] = Mem3[FSR1 + 0x0001:byte]
@@ -215,7 +215,7 @@ l0000DE:
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000E4:
 	Mem22[0x00:0xCA:byte] = Mem3[0x00:0xCA:byte] & 0xFE
@@ -223,33 +223,33 @@ l0000E4:
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000F0:
 	LATB = LATB & 0x7F
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000EC:
 	LATB = LATB | 0x80
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000E2:
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000F2:
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 
 
@@ -264,14 +264,14 @@ fn000128_entry:
 // DataOut: FSR0 FSR0H FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000128:
 	branch FSR0H <u WREG l00012C
 // DataOut: FSR0 FSR0H FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l00012C:
 	Mem20[FSR0:byte] = 0x00
@@ -279,26 +279,26 @@ l00012C:
 // DataOut: FSR0 FSR0H FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l00012A:
 // DataOut: FSR0 FSR0L
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000130:
 // DataOut: FSR0 FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000132:
 	branch FSR0L <u PRODL l000136
 // DataOut: FSR0 FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:PRODL FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000136:
 	Mem17[FSR0:byte] = 0x00
@@ -306,7 +306,7 @@ l000136:
 // DataOut: FSR0 FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:PRODL FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000134:
 	return

--- a/subjects/Microchip/C18/PIC18/PIC18Legacy.h
+++ b/subjects/Microchip/C18/PIC18/PIC18Legacy.h
@@ -5,15 +5,15 @@
 /*
 // Equivalence classes ////////////
 Eq_1: (struct "Globals" (1 byte b0001) (C7 byte b00C7) (C8 byte b00C8) (C9 byte b00C9))
-	globals_t (in globals : (ptr (struct "Globals")))
-Eq_15: (fn void (Eq_17, word32))
+	globals_t (in globals : (ptr32 (struct "Globals")))
+Eq_15: (fn void (Eq_17, word24))
 	T_15 (in fn00000E : ptr32)
 	T_16 (in signature of fn00000E : void)
-Eq_17: (union "Eq_17" (word16 u0) ((ptr byte) u1))
+Eq_17: (union "Eq_17" (word16 u0) ((ptr32 byte) u1))
 	T_17 (in FSR0 : Eq_17)
 	T_19 (in 0x0000 : word16)
 	T_137 (in FSR0 + 0x0001 : word16)
-Eq_22: (fn void (word32, byte))
+Eq_22: (fn void (word24, byte))
 	T_22 (in __tblrd : ptr32)
 	T_23 (in signature of __tblrd : void)
 	T_32 (in __tblrd : ptr32)
@@ -32,11 +32,11 @@ Eq_22: (fn void (word32, byte))
 	T_123 (in __tblrd : ptr32)
 Eq_29: (segment "Eq_29" (C5 byte b00C5))
 	T_29 (in 0x00 : byte)
-Eq_30: (union "Eq_30" (byte u0) ((memptr (ptr Eq_29) byte) u1))
+Eq_30: (union "Eq_30" (byte u0) ((memptr (ptr8 Eq_29) byte) u1))
 	T_30 (in 0xC5 : byte)
 Eq_35: (segment "Eq_35" (C6 byte b00C6))
 	T_35 (in 0x00 : byte)
-Eq_36: (union "Eq_36" (byte u0) ((memptr (ptr Eq_35) byte) u1))
+Eq_36: (union "Eq_36" (byte u0) ((memptr (ptr8 Eq_35) byte) u1))
 	T_36 (in 0xC6 : byte)
 Eq_44: (union "Eq_44" (byte u0) (Eq_251 u1))
 	T_44 (in Z_15 : Eq_44)
@@ -44,27 +44,27 @@ Eq_44: (union "Eq_44" (byte u0) (Eq_251 u1))
 	T_184 (in cond(0x00->b00C6) : byte)
 Eq_49: (segment "Eq_49" (C0 byte b00C0))
 	T_49 (in 0x00 : byte)
-Eq_50: (union "Eq_50" (byte u0) ((memptr (ptr Eq_49) byte) u1))
+Eq_50: (union "Eq_50" (byte u0) ((memptr (ptr8 Eq_49) byte) u1))
 	T_50 (in 0xC0 : byte)
 Eq_55: (segment "Eq_55" (C1 byte b00C1))
 	T_55 (in 0x00 : byte)
-Eq_56: (union "Eq_56" (byte u0) ((memptr (ptr Eq_55) byte) u1))
+Eq_56: (union "Eq_56" (byte u0) ((memptr (ptr8 Eq_55) byte) u1))
 	T_56 (in 0xC1 : byte)
 Eq_61: (segment "Eq_61" (C2 byte b00C2))
 	T_61 (in 0x00 : byte)
-Eq_62: (union "Eq_62" (byte u0) ((memptr (ptr Eq_61) byte) u1))
+Eq_62: (union "Eq_62" (byte u0) ((memptr (ptr8 Eq_61) byte) u1))
 	T_62 (in 0xC2 : byte)
 Eq_82: (segment "Eq_82" (C3 byte b00C3))
 	T_82 (in 0x00 : byte)
-Eq_83: (union "Eq_83" (byte u0) ((memptr (ptr Eq_82) byte) u1))
+Eq_83: (union "Eq_83" (byte u0) ((memptr (ptr8 Eq_82) byte) u1))
 	T_83 (in 0xC3 : byte)
 Eq_88: (segment "Eq_88" (C4 byte b00C4))
 	T_88 (in 0x00 : byte)
-Eq_89: (union "Eq_89" (byte u0) ((memptr (ptr Eq_88) byte) u1))
+Eq_89: (union "Eq_89" (byte u0) ((memptr (ptr8 Eq_88) byte) u1))
 	T_89 (in 0xC4 : byte)
 Eq_109: (segment "Eq_109" (C3 byte b00C3))
 	T_109 (in 0x00 : byte)
-Eq_110: (union "Eq_110" (byte u0) ((memptr (ptr Eq_109) byte) u1) ((memptr (ptr Eq_112) byte) u2) ((memptr (ptr Eq_115) byte) u3))
+Eq_110: (union "Eq_110" (byte u0) ((memptr (ptr8 Eq_109) byte) u1) ((memptr (ptr8 Eq_112) byte) u2) ((memptr (ptr8 Eq_115) byte) u3))
 	T_110 (in 0xC3 : byte)
 Eq_112: (segment "Eq_112" (C3 byte b00C3))
 	T_112 (in 0x00 : byte)
@@ -76,11 +76,11 @@ Eq_115: (segment "Eq_115" (C3 byte b00C3))
 	T_115 (in 0x00 : byte)
 Eq_118: (segment "Eq_118" (C5 byte b00C5))
 	T_118 (in 0x00 : byte)
-Eq_119: (union "Eq_119" (byte u0) ((memptr (ptr Eq_118) byte) u1))
+Eq_119: (union "Eq_119" (byte u0) ((memptr (ptr8 Eq_118) byte) u1))
 	T_119 (in 0xC5 : byte)
 Eq_129: (segment "Eq_129" (C3 byte b00C3))
 	T_129 (in 0x00 : byte)
-Eq_130: (union "Eq_130" (byte u0) ((memptr (ptr Eq_129) byte) u1) ((memptr (ptr Eq_134) byte) u2) ((memptr (ptr Eq_138) cu8) u3))
+Eq_130: (union "Eq_130" (byte u0) ((memptr (ptr8 Eq_129) byte) u1) ((memptr (ptr8 Eq_134) byte) u2) ((memptr (ptr8 Eq_138) cu8) u3))
 	T_130 (in 0xC3 : byte)
 Eq_134: (segment "Eq_134" (C3 byte b00C3))
 	T_134 (in 0x00 : byte)
@@ -88,7 +88,7 @@ Eq_138: (segment "Eq_138" (C3 cu8 b00C3))
 	T_138 (in 0x00 : byte)
 Eq_144: (segment "Eq_144" (C4 byte b00C4))
 	T_144 (in 0x00 : byte)
-Eq_145: (union "Eq_145" (byte u0) ((memptr (ptr Eq_144) byte) u1) ((memptr (ptr Eq_147) byte) u2) ((memptr (ptr Eq_149) byte) u3))
+Eq_145: (union "Eq_145" (byte u0) ((memptr (ptr8 Eq_144) byte) u1) ((memptr (ptr8 Eq_147) byte) u2) ((memptr (ptr8 Eq_149) byte) u3))
 	T_145 (in 0xC4 : byte)
 Eq_147: (segment "Eq_147" (C4 byte b00C4))
 	T_147 (in 0x00 : byte)
@@ -96,13 +96,13 @@ Eq_149: (segment "Eq_149" (C4 byte b00C4))
 	T_149 (in 0x00 : byte)
 Eq_165: (segment "Eq_165" (C5 byte b00C5))
 	T_165 (in 0x00 : byte)
-Eq_166: (union "Eq_166" (byte u0) ((memptr (ptr Eq_165) byte) u1) ((memptr (ptr Eq_170) byte) u2) ((memptr (ptr Eq_175) byte) u3))
+Eq_166: (union "Eq_166" (byte u0) ((memptr (ptr8 Eq_165) byte) u1) ((memptr (ptr8 Eq_170) byte) u2) ((memptr (ptr8 Eq_175) byte) u3))
 	T_166 (in 0xC5 : byte)
 Eq_170: (segment "Eq_170" (C5 byte b00C5))
 	T_170 (in 0x00 : byte)
 Eq_172: (segment "Eq_172" (C6 byte b00C6))
 	T_172 (in 0x00 : byte)
-Eq_173: (union "Eq_173" (byte u0) ((memptr (ptr Eq_172) byte) u1) ((memptr (ptr Eq_180) byte) u2) ((memptr (ptr Eq_182) byte) u3))
+Eq_173: (union "Eq_173" (byte u0) ((memptr (ptr8 Eq_172) byte) u1) ((memptr (ptr8 Eq_180) byte) u2) ((memptr (ptr8 Eq_182) byte) u3))
 	T_173 (in 0xC6 : byte)
 Eq_175: (segment "Eq_175" (C5 byte b00C5))
 	T_175 (in 0x00 : byte)
@@ -112,33 +112,33 @@ Eq_182: (segment "Eq_182" (C6 byte b00C6))
 	T_182 (in 0x00 : byte)
 Eq_185: (segment "Eq_185" (C4 byte b00C4))
 	T_185 (in 0x00 : byte)
-Eq_186: (union "Eq_186" (byte u0) ((memptr (ptr Eq_185) byte) u1) ((memptr (ptr Eq_190) byte) u2))
+Eq_186: (union "Eq_186" (byte u0) ((memptr (ptr8 Eq_185) byte) u1) ((memptr (ptr8 Eq_190) byte) u2))
 	T_186 (in 0xC4 : byte)
 Eq_190: (segment "Eq_190" (C4 byte b00C4))
 	T_190 (in 0x00 : byte)
 Eq_194: (struct "Eq_194" (FE byte b00FE))
-	T_194 (in FSR2 : (ptr Eq_194))
+	T_194 (in FSR2 : (ptr16 Eq_194))
 Eq_195: (struct "Eq_195" (0 byte b0000) (1 byte b0001))
-	T_195 (in FSR1 : (ptr Eq_195))
+	T_195 (in FSR1 : (ptr16 Eq_195))
 Eq_204: (segment "Eq_204" (CA byte b00CA))
 	T_204 (in 0x00 : byte)
-Eq_205: (union "Eq_205" (byte u0) ((memptr (ptr Eq_204) byte) u1))
+Eq_205: (union "Eq_205" (byte u0) ((memptr (ptr8 Eq_204) byte) u1))
 	T_205 (in 0xCA : byte)
 Eq_211: (segment "Eq_211" (CA byte b00CA))
 	T_211 (in 0x00 : byte)
-Eq_212: (union "Eq_212" (byte u0) ((memptr (ptr Eq_211) byte) u1) ((memptr (ptr Eq_216) byte) u2))
+Eq_212: (union "Eq_212" (byte u0) ((memptr (ptr8 Eq_211) byte) u1) ((memptr (ptr8 Eq_216) byte) u2))
 	T_212 (in 0xCA : byte)
 Eq_216: (segment "Eq_216" (CA byte b00CA))
 	T_216 (in 0x00 : byte)
-Eq_234: (union "Eq_234" (word16 u0) ((ptr byte) u1))
+Eq_234: (union "Eq_234" (word16 u0) ((ptr32 byte) u1))
 	T_234 (in FSR0 : Eq_234)
 	T_241 (in FSR0 + 0x0001 : word16)
 	T_247 (in FSR0 + 0x0001 : word16)
-Eq_240: (union "Eq_240" (word16 u0) ((ptr byte) u1))
+Eq_240: (union "Eq_240" (word16 u0) ((ptr32 byte) u1))
 	T_240 (in 0x0001 : word16)
-Eq_244: (union "Eq_244" (word16 u0) ((ptr byte) u1))
+Eq_244: (union "Eq_244" (word16 u0) ((ptr32 byte) u1))
 	T_244 (in FSR0 + 0x0000 : word16)
-Eq_246: (union "Eq_246" (word16 u0) ((ptr byte) u1))
+Eq_246: (union "Eq_246" (word16 u0) ((ptr32 byte) u1))
 	T_246 (in 0x0001 : word16)
 Eq_250: (struct "Eq_250" 0001 (0 ptr32 ptr0000))
 	T_250
@@ -147,14 +147,14 @@ Eq_251: (union "Eq_251" (bool u0) (byte u1))
 Eq_252: (union "Eq_252" (bool u0) (byte u1))
 	T_252
 // Type Variables ////////////
-globals_t: (in globals : (ptr (struct "Globals")))
+globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
-  DataType: (ptr Eq_1)
-  OrigDataType: (ptr (struct "Globals"))
+  DataType: (ptr32 Eq_1)
+  OrigDataType: (ptr32 (struct "Globals"))
 T_2: (in 0001 : ptr16)
   Class: Eq_2
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_5 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_5 t0000)))
 T_3: (in 0x0000 : word16)
   Class: Eq_3
   DataType: word16
@@ -181,8 +181,8 @@ T_8: (in 0x0000 : word16)
   OrigDataType: word16
 T_9: (in 0x0001 + 0x0000 : word16)
   Class: Eq_9
-  DataType: (ptr byte)
-  OrigDataType: (ptr byte)
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 byte)
 T_10: (in Mem18[0x0001 + 0x0000:byte] : byte)
   Class: Eq_5
   DataType: byte
@@ -193,8 +193,8 @@ T_11: (in 00014A : ptr32)
   OrigDataType: ptr32
 T_12: (in Stack : (arr Eq_250))
   Class: Eq_12
-  DataType: (ptr (arr Eq_250))
-  OrigDataType: (ptr (struct (0 (arr T_250) a0000)))
+  DataType: (ptr32 (arr Eq_250))
+  OrigDataType: (ptr32 (struct (0 (arr T_250) a0000)))
 T_13: (in 0x01 : byte)
   Class: Eq_13
   DataType: byte
@@ -205,43 +205,43 @@ T_14: (in Stack[0x01] : ptr32)
   OrigDataType: ptr32
 T_15: (in fn00000E : ptr32)
   Class: Eq_15
-  DataType: (ptr Eq_15)
-  OrigDataType: (ptr (fn T_21 (T_19, T_20)))
+  DataType: (ptr32 Eq_15)
+  OrigDataType: (ptr32 (fn T_21 (T_19, T_20)))
 T_16: (in signature of fn00000E : void)
   Class: Eq_15
-  DataType: (ptr Eq_15)
+  DataType: (ptr32 Eq_15)
   OrigDataType: 
 T_17: (in FSR0 : Eq_17)
   Class: Eq_17
   DataType: Eq_17
-  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
-T_18: (in TBLPTR : word32)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
+T_18: (in TBLPTR : word24)
   Class: Eq_18
-  DataType: word32
-  OrigDataType: word32
+  DataType: word24
+  OrigDataType: word24
 T_19: (in 0x0000 : word16)
   Class: Eq_17
   DataType: word16
   OrigDataType: word16
-T_20: (in 0x00000000 : word32)
+T_20: (in 0x000000 : word24)
   Class: Eq_18
-  DataType: word32
-  OrigDataType: word32
-T_21: (in fn00000E(0x0000, 0x00000000) : void)
+  DataType: word24
+  OrigDataType: word24
+T_21: (in fn00000E(0x0000, 0x000000) : void)
   Class: Eq_21
   DataType: void
   OrigDataType: void
 T_22: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_27 (T_18, T_26)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_27 (T_18, T_26)))
 T_23: (in signature of __tblrd : void)
   Class: Eq_22
-  DataType: (ptr Eq_22)
+  DataType: (ptr32 Eq_22)
   OrigDataType: 
-T_24: (in  : word32)
+T_24: (in  : word24)
   Class: Eq_18
-  DataType: word32
+  DataType: word24
   OrigDataType: 
 T_25: (in  : byte)
   Class: Eq_25
@@ -261,8 +261,8 @@ T_28: (in TABLAT : byte)
   OrigDataType: byte
 T_29: (in 0x00 : byte)
   Class: Eq_29
-  DataType: (ptr Eq_29)
-  OrigDataType: (ptr (segment (C5 T_31 t00C5)))
+  DataType: (ptr8 Eq_29)
+  OrigDataType: (ptr8 (segment (C5 T_31 t00C5)))
 T_30: (in 0xC5 : byte)
   Class: Eq_30
   DataType: Eq_30
@@ -273,8 +273,8 @@ T_31: (in Mem12[0x00:0xC5:byte] : byte)
   OrigDataType: byte
 T_32: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_34 (T_18, T_33)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_34 (T_18, T_33)))
 T_33: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -285,8 +285,8 @@ T_34: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_35: (in 0x00 : byte)
   Class: Eq_35
-  DataType: (ptr Eq_35)
-  OrigDataType: (ptr (segment (C6 T_37 t00C6)))
+  DataType: (ptr8 Eq_35)
+  OrigDataType: (ptr8 (segment (C6 T_37 t00C6)))
 T_36: (in 0xC6 : byte)
   Class: Eq_36
   DataType: Eq_36
@@ -329,8 +329,8 @@ T_45: (in cond(TABLAT) : byte)
   OrigDataType: byte
 T_46: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_48 (T_18, T_47)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_48 (T_18, T_47)))
 T_47: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -341,8 +341,8 @@ T_48: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_49: (in 0x00 : byte)
   Class: Eq_49
-  DataType: (ptr Eq_49)
-  OrigDataType: (ptr (segment (C0 T_51 t00C0)))
+  DataType: (ptr8 Eq_49)
+  OrigDataType: (ptr8 (segment (C0 T_51 t00C0)))
 T_50: (in 0xC0 : byte)
   Class: Eq_50
   DataType: Eq_50
@@ -353,8 +353,8 @@ T_51: (in Mem35[0x00:0xC0:byte] : byte)
   OrigDataType: byte
 T_52: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_54 (T_18, T_53)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_54 (T_18, T_53)))
 T_53: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -365,8 +365,8 @@ T_54: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_55: (in 0x00 : byte)
   Class: Eq_55
-  DataType: (ptr Eq_55)
-  OrigDataType: (ptr (segment (C1 T_57 t00C1)))
+  DataType: (ptr8 Eq_55)
+  OrigDataType: (ptr8 (segment (C1 T_57 t00C1)))
 T_56: (in 0xC1 : byte)
   Class: Eq_56
   DataType: Eq_56
@@ -377,8 +377,8 @@ T_57: (in Mem37[0x00:0xC1:byte] : byte)
   OrigDataType: byte
 T_58: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_60 (T_18, T_59)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_60 (T_18, T_59)))
 T_59: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -389,8 +389,8 @@ T_60: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_61: (in 0x00 : byte)
   Class: Eq_61
-  DataType: (ptr Eq_61)
-  OrigDataType: (ptr (segment (C2 T_63 t00C2)))
+  DataType: (ptr8 Eq_61)
+  OrigDataType: (ptr8 (segment (C2 T_63 t00C2)))
 T_62: (in 0xC2 : byte)
   Class: Eq_62
   DataType: Eq_62
@@ -401,8 +401,8 @@ T_63: (in Mem39[0x00:0xC2:byte] : byte)
   OrigDataType: byte
 T_64: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_66 (T_18, T_65)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_66 (T_18, T_65)))
 T_65: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -413,8 +413,8 @@ T_66: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_67: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_69 (T_18, T_68)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_69 (T_18, T_68)))
 T_68: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -425,8 +425,8 @@ T_69: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_70: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_72 (T_18, T_71)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_72 (T_18, T_71)))
 T_71: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -437,8 +437,8 @@ T_72: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_73: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_75 (T_18, T_74)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_75 (T_18, T_74)))
 T_74: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -449,8 +449,8 @@ T_75: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_76: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_78 (T_18, T_77)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_78 (T_18, T_77)))
 T_77: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -461,8 +461,8 @@ T_78: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_79: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_81 (T_18, T_80)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_81 (T_18, T_80)))
 T_80: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -473,8 +473,8 @@ T_81: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_82: (in 0x00 : byte)
   Class: Eq_82
-  DataType: (ptr Eq_82)
-  OrigDataType: (ptr (segment (C3 T_84 t00C3)))
+  DataType: (ptr8 Eq_82)
+  OrigDataType: (ptr8 (segment (C3 T_84 t00C3)))
 T_83: (in 0xC3 : byte)
   Class: Eq_83
   DataType: Eq_83
@@ -485,8 +485,8 @@ T_84: (in Mem45[0x00:0xC3:byte] : byte)
   OrigDataType: byte
 T_85: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_87 (T_18, T_86)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_87 (T_18, T_86)))
 T_86: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -497,8 +497,8 @@ T_87: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_88: (in 0x00 : byte)
   Class: Eq_88
-  DataType: (ptr Eq_88)
-  OrigDataType: (ptr (segment (C4 T_90 t00C4)))
+  DataType: (ptr8 Eq_88)
+  OrigDataType: (ptr8 (segment (C4 T_90 t00C4)))
 T_89: (in 0xC4 : byte)
   Class: Eq_89
   DataType: Eq_89
@@ -509,8 +509,8 @@ T_90: (in Mem47[0x00:0xC4:byte] : byte)
   OrigDataType: byte
 T_91: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_93 (T_18, T_92)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_93 (T_18, T_92)))
 T_92: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -521,8 +521,8 @@ T_93: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_94: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_96 (T_18, T_95)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_96 (T_18, T_95)))
 T_95: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -533,8 +533,8 @@ T_96: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_97: (in 00C7 : ptr16)
   Class: Eq_97
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_100 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_100 t0000)))
 T_98: (in 0x0000 : word16)
   Class: Eq_98
   DataType: word16
@@ -549,8 +549,8 @@ T_100: (in Mem48[0x00C7 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_101: (in 00C8 : ptr16)
   Class: Eq_101
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_104 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_104 t0000)))
 T_102: (in 0x0000 : word16)
   Class: Eq_102
   DataType: word16
@@ -565,8 +565,8 @@ T_104: (in Mem49[0x00C8 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_105: (in 00C9 : ptr16)
   Class: Eq_105
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_108 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_108 t0000)))
 T_106: (in 0x0000 : word16)
   Class: Eq_106
   DataType: word16
@@ -581,8 +581,8 @@ T_108: (in Mem50[0x00C9 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_109: (in 0x00 : byte)
   Class: Eq_109
-  DataType: (ptr Eq_109)
-  OrigDataType: (ptr (segment (C3 T_111 t00C3)))
+  DataType: (ptr8 Eq_109)
+  OrigDataType: (ptr8 (segment (C3 T_111 t00C3)))
 T_110: (in 0xC3 : byte)
   Class: Eq_110
   DataType: Eq_110
@@ -593,8 +593,8 @@ T_111: (in Mem50[0x00:0xC3:byte] : byte)
   OrigDataType: byte
 T_112: (in 0x00 : byte)
   Class: Eq_112
-  DataType: (ptr Eq_112)
-  OrigDataType: (ptr (segment (C3 T_113 t00C3)))
+  DataType: (ptr8 Eq_112)
+  OrigDataType: (ptr8 (segment (C3 T_113 t00C3)))
 T_113: (in Mem55[0x00:0xC3:byte] : byte)
   Class: Eq_111
   DataType: byte
@@ -605,8 +605,8 @@ T_114: (in Z_57 : Eq_114)
   OrigDataType: (union (bool u1) (byte u0))
 T_115: (in 0x00 : byte)
   Class: Eq_115
-  DataType: (ptr Eq_115)
-  OrigDataType: (ptr (segment (C3 T_116 t00C3)))
+  DataType: (ptr8 Eq_115)
+  OrigDataType: (ptr8 (segment (C3 T_116 t00C3)))
 T_116: (in Mem55[0x00:0xC3:byte] : byte)
   Class: Eq_116
   DataType: byte
@@ -617,8 +617,8 @@ T_117: (in cond(0x00->b00C3) : byte)
   OrigDataType: byte
 T_118: (in 0x00 : byte)
   Class: Eq_118
-  DataType: (ptr Eq_118)
-  OrigDataType: (ptr (segment (C5 T_120 t00C5)))
+  DataType: (ptr8 Eq_118)
+  OrigDataType: (ptr8 (segment (C5 T_120 t00C5)))
 T_119: (in 0xC5 : byte)
   Class: Eq_119
   DataType: Eq_119
@@ -637,8 +637,8 @@ T_122: (in 0x00->b00C5 == 0x00 : bool)
   OrigDataType: bool
 T_123: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr Eq_22)
-  OrigDataType: (ptr (fn T_125 (T_18, T_124)))
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_125 (T_18, T_124)))
 T_124: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -661,8 +661,8 @@ T_128: (in Mem67[FSR0 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_129: (in 0x00 : byte)
   Class: Eq_129
-  DataType: (ptr Eq_129)
-  OrigDataType: (ptr (segment (C3 T_131 t00C3)))
+  DataType: (ptr8 Eq_129)
+  OrigDataType: (ptr8 (segment (C3 T_131 t00C3)))
 T_130: (in 0xC3 : byte)
   Class: Eq_130
   DataType: Eq_130
@@ -681,24 +681,24 @@ T_133: (in 0x00->b00C3 - 0x01 : byte)
   OrigDataType: byte
 T_134: (in 0x00 : byte)
   Class: Eq_134
-  DataType: (ptr Eq_134)
-  OrigDataType: (ptr (segment (C3 T_135 t00C3)))
+  DataType: (ptr8 Eq_134)
+  OrigDataType: (ptr8 (segment (C3 T_135 t00C3)))
 T_135: (in Mem69[0x00:0xC3:byte] : byte)
   Class: Eq_133
   DataType: byte
   OrigDataType: byte
 T_136: (in 0x0001 : word16)
   Class: Eq_136
-  DataType: (ptr byte)
-  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
+  DataType: (ptr32 byte)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
 T_137: (in FSR0 + 0x0001 : word16)
   Class: Eq_17
   DataType: Eq_17
-  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
+  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
 T_138: (in 0x00 : byte)
   Class: Eq_138
-  DataType: (ptr Eq_138)
-  OrigDataType: (ptr (segment (C3 T_139 t00C3)))
+  DataType: (ptr8 Eq_138)
+  OrigDataType: (ptr8 (segment (C3 T_139 t00C3)))
 T_139: (in Mem69[0x00:0xC3:byte] : byte)
   Class: Eq_139
   DataType: cu8
@@ -721,8 +721,8 @@ T_143: (in 0x00->b00C3 < 0x00 : bool)
   OrigDataType: bool
 T_144: (in 0x00 : byte)
   Class: Eq_144
-  DataType: (ptr Eq_144)
-  OrigDataType: (ptr (segment (C4 T_146 t00C4)))
+  DataType: (ptr8 Eq_144)
+  OrigDataType: (ptr8 (segment (C4 T_146 t00C4)))
 T_145: (in 0xC4 : byte)
   Class: Eq_145
   DataType: Eq_145
@@ -733,16 +733,16 @@ T_146: (in Mem55[0x00:0xC4:byte] : byte)
   OrigDataType: byte
 T_147: (in 0x00 : byte)
   Class: Eq_147
-  DataType: (ptr Eq_147)
-  OrigDataType: (ptr (segment (C4 T_148 t00C4)))
+  DataType: (ptr8 Eq_147)
+  OrigDataType: (ptr8 (segment (C4 T_148 t00C4)))
 T_148: (in Mem76[0x00:0xC4:byte] : byte)
   Class: Eq_146
   DataType: byte
   OrigDataType: byte
 T_149: (in 0x00 : byte)
   Class: Eq_149
-  DataType: (ptr Eq_149)
-  OrigDataType: (ptr (segment (C4 T_150 t00C4)))
+  DataType: (ptr8 Eq_149)
+  OrigDataType: (ptr8 (segment (C4 T_150 t00C4)))
 T_150: (in Mem76[0x00:0xC4:byte] : byte)
   Class: Eq_150
   DataType: byte
@@ -757,8 +757,8 @@ T_152: (in 0x00->b00C4 == 0x00 : bool)
   OrigDataType: bool
 T_153: (in 00C7 : ptr16)
   Class: Eq_153
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_156 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_156 t0000)))
 T_154: (in 0x0000 : word16)
   Class: Eq_154
   DataType: word16
@@ -773,8 +773,8 @@ T_156: (in Mem76[0x00C7 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_157: (in 00C8 : ptr16)
   Class: Eq_157
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_160 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_160 t0000)))
 T_158: (in 0x0000 : word16)
   Class: Eq_158
   DataType: word16
@@ -789,8 +789,8 @@ T_160: (in Mem76[0x00C8 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_161: (in 00C9 : ptr16)
   Class: Eq_161
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_164 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_164 t0000)))
 T_162: (in 0x0000 : word16)
   Class: Eq_162
   DataType: word16
@@ -805,8 +805,8 @@ T_164: (in Mem76[0x00C9 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_165: (in 0x00 : byte)
   Class: Eq_165
-  DataType: (ptr Eq_165)
-  OrigDataType: (ptr (segment (C5 T_167 t00C5)))
+  DataType: (ptr8 Eq_165)
+  OrigDataType: (ptr8 (segment (C5 T_167 t00C5)))
 T_166: (in 0xC5 : byte)
   Class: Eq_166
   DataType: Eq_166
@@ -825,16 +825,16 @@ T_169: (in 0x00->b00C5 - 0x01 : byte)
   OrigDataType: byte
 T_170: (in 0x00 : byte)
   Class: Eq_170
-  DataType: (ptr Eq_170)
-  OrigDataType: (ptr (segment (C5 T_171 t00C5)))
+  DataType: (ptr8 Eq_170)
+  OrigDataType: (ptr8 (segment (C5 T_171 t00C5)))
 T_171: (in Mem83[0x00:0xC5:byte] : byte)
   Class: Eq_169
   DataType: byte
   OrigDataType: byte
 T_172: (in 0x00 : byte)
   Class: Eq_172
-  DataType: (ptr Eq_172)
-  OrigDataType: (ptr (segment (C6 T_174 t00C6)))
+  DataType: (ptr8 Eq_172)
+  OrigDataType: (ptr8 (segment (C6 T_174 t00C6)))
 T_173: (in 0xC6 : byte)
   Class: Eq_173
   DataType: Eq_173
@@ -845,8 +845,8 @@ T_174: (in Mem83[0x00:0xC6:byte] : byte)
   OrigDataType: byte
 T_175: (in 0x00 : byte)
   Class: Eq_175
-  DataType: (ptr Eq_175)
-  OrigDataType: (ptr (segment (C5 T_176 t00C5)))
+  DataType: (ptr8 Eq_175)
+  OrigDataType: (ptr8 (segment (C5 T_176 t00C5)))
 T_176: (in Mem83[0x00:0xC5:byte] : byte)
   Class: Eq_176
   DataType: byte
@@ -865,16 +865,16 @@ T_179: (in 0x00->b00C6 - !cond(0x00->b00C5) : byte)
   OrigDataType: byte
 T_180: (in 0x00 : byte)
   Class: Eq_180
-  DataType: (ptr Eq_180)
-  OrigDataType: (ptr (segment (C6 T_181 t00C6)))
+  DataType: (ptr8 Eq_180)
+  OrigDataType: (ptr8 (segment (C6 T_181 t00C6)))
 T_181: (in Mem87[0x00:0xC6:byte] : byte)
   Class: Eq_179
   DataType: byte
   OrigDataType: byte
 T_182: (in 0x00 : byte)
   Class: Eq_182
-  DataType: (ptr Eq_182)
-  OrigDataType: (ptr (segment (C6 T_183 t00C6)))
+  DataType: (ptr8 Eq_182)
+  OrigDataType: (ptr8 (segment (C6 T_183 t00C6)))
 T_183: (in Mem87[0x00:0xC6:byte] : byte)
   Class: Eq_183
   DataType: byte
@@ -885,8 +885,8 @@ T_184: (in cond(0x00->b00C6) : byte)
   OrigDataType: byte
 T_185: (in 0x00 : byte)
   Class: Eq_185
-  DataType: (ptr Eq_185)
-  OrigDataType: (ptr (segment (C4 T_187 t00C4)))
+  DataType: (ptr8 Eq_185)
+  OrigDataType: (ptr8 (segment (C4 T_187 t00C4)))
 T_186: (in 0xC4 : byte)
   Class: Eq_186
   DataType: Eq_186
@@ -905,8 +905,8 @@ T_189: (in 0x00->b00C4 - 0x01 : byte)
   OrigDataType: byte
 T_190: (in 0x00 : byte)
   Class: Eq_190
-  DataType: (ptr Eq_190)
-  OrigDataType: (ptr (segment (C4 T_191 t00C4)))
+  DataType: (ptr8 Eq_190)
+  OrigDataType: (ptr8 (segment (C4 T_191 t00C4)))
 T_191: (in Mem74[0x00:0xC4:byte] : byte)
   Class: Eq_189
   DataType: byte
@@ -919,14 +919,14 @@ T_193: (in FSR2L : byte)
   Class: Eq_193
   DataType: byte
   OrigDataType: byte
-T_194: (in FSR2 : (ptr Eq_194))
+T_194: (in FSR2 : (ptr16 Eq_194))
   Class: Eq_194
-  DataType: (ptr Eq_194)
-  OrigDataType: (ptr (struct (FE T_224 t00FE)))
-T_195: (in FSR1 : (ptr Eq_195))
+  DataType: (ptr16 Eq_194)
+  OrigDataType: (ptr16 (struct (FE T_224 t00FE)))
+T_195: (in FSR1 : (ptr16 Eq_195))
   Class: Eq_195
-  DataType: (ptr Eq_195)
-  OrigDataType: (ptr (struct (0 T_198 t0000) (1 T_201 t0001)))
+  DataType: (ptr16 Eq_195)
+  OrigDataType: (ptr16 (struct (0 T_198 t0000) (1 T_201 t0001)))
 T_196: (in 0x0000 : word16)
   Class: Eq_196
   DataType: word16
@@ -953,16 +953,16 @@ T_201: (in Mem3[FSR1 + 0x0001:byte] : byte)
   OrigDataType: byte
 T_202: (in FSR1 + 0x0001 : word16)
   Class: Eq_202
-  DataType: (ptr byte)
-  OrigDataType: (ptr byte)
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 byte)
 T_203: (in Mem29[FSR1 + 0x0001:byte] : byte)
   Class: Eq_201
   DataType: byte
   OrigDataType: byte
 T_204: (in 0x00 : byte)
   Class: Eq_204
-  DataType: (ptr Eq_204)
-  OrigDataType: (ptr (segment (CA T_206 t00CA)))
+  DataType: (ptr8 Eq_204)
+  OrigDataType: (ptr8 (segment (CA T_206 t00CA)))
 T_205: (in 0xCA : byte)
   Class: Eq_205
   DataType: Eq_205
@@ -989,8 +989,8 @@ T_210: (in (0x00->b00CA & 0x01) != 0x00 : bool)
   OrigDataType: bool
 T_211: (in 0x00 : byte)
   Class: Eq_211
-  DataType: (ptr Eq_211)
-  OrigDataType: (ptr (segment (CA T_213 t00CA)))
+  DataType: (ptr8 Eq_211)
+  OrigDataType: (ptr8 (segment (CA T_213 t00CA)))
 T_212: (in 0xCA : byte)
   Class: Eq_212
   DataType: Eq_212
@@ -1009,8 +1009,8 @@ T_215: (in 0x00->b00CA & 0xFE : byte)
   OrigDataType: byte
 T_216: (in 0x00 : byte)
   Class: Eq_216
-  DataType: (ptr Eq_216)
-  OrigDataType: (ptr (segment (CA T_217 t00CA)))
+  DataType: (ptr8 Eq_216)
+  OrigDataType: (ptr8 (segment (CA T_217 t00CA)))
 T_217: (in Mem22[0x00:0xCA:byte] : byte)
   Class: Eq_215
   DataType: byte
@@ -1106,11 +1106,11 @@ T_239: (in Mem20[FSR0 + 0x0000:byte] : byte)
 T_240: (in 0x0001 : word16)
   Class: Eq_240
   DataType: word16
-  OrigDataType: (union (word16 u2) ((ptr byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
 T_241: (in FSR0 + 0x0001 : word16)
   Class: Eq_234
   DataType: Eq_234
-  OrigDataType: (union (word16 u2) ((ptr byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
 T_242: (in 0x00 : byte)
   Class: Eq_242
   DataType: byte
@@ -1122,7 +1122,7 @@ T_243: (in 0x0000 : word16)
 T_244: (in FSR0 + 0x0000 : word16)
   Class: Eq_244
   DataType: Eq_244
-  OrigDataType: (union (word16 u2) ((ptr byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
 T_245: (in Mem17[FSR0 + 0x0000:byte] : byte)
   Class: Eq_242
   DataType: Eq_234
@@ -1130,11 +1130,11 @@ T_245: (in Mem17[FSR0 + 0x0000:byte] : byte)
 T_246: (in 0x0001 : word16)
   Class: Eq_246
   DataType: word16
-  OrigDataType: (union (word16 u2) ((ptr byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
 T_247: (in FSR0 + 0x0001 : word16)
   Class: Eq_234
   DataType: Eq_234
-  OrigDataType: (union (word16 u2) ((ptr byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
 T_248: (in PRODL : byte)
   Class: Eq_232
   DataType: cu8
@@ -1163,14 +1163,14 @@ typedef struct Globals {
 	byte b00C9;	// C9
 } Eq_1;
 
-typedef void (Eq_15)(Eq_17, word32);
+typedef void (Eq_15)(Eq_17, word24);
 
 typedef union Eq_17 {
 	word16 u0;
 	byte * u1;
 } Eq_17;
 
-typedef void (Eq_22)(word32, byte);
+typedef void (Eq_22)(word24, byte);
 
 typedef struct Eq_29 {
 	byte b00C5;	// C5

--- a/subjects/Microchip/C18/PIC18/PIC18Legacy.h
+++ b/subjects/Microchip/C18/PIC18/PIC18Legacy.h
@@ -5,11 +5,11 @@
 /*
 // Equivalence classes ////////////
 Eq_1: (struct "Globals" (1 byte b0001) (C7 byte b00C7) (C8 byte b00C8) (C9 byte b00C9))
-	globals_t (in globals : (ptr32 (struct "Globals")))
+	globals_t (in globals : (ptr (struct "Globals")))
 Eq_15: (fn void (Eq_17, word32))
 	T_15 (in fn00000E : ptr32)
 	T_16 (in signature of fn00000E : void)
-Eq_17: (union "Eq_17" (word16 u0) ((ptr32 byte) u1))
+Eq_17: (union "Eq_17" (word16 u0) ((ptr byte) u1))
 	T_17 (in FSR0 : Eq_17)
 	T_19 (in 0x0000 : word16)
 	T_137 (in FSR0 + 0x0001 : word16)
@@ -32,11 +32,11 @@ Eq_22: (fn void (word32, byte))
 	T_123 (in __tblrd : ptr32)
 Eq_29: (segment "Eq_29" (C5 byte b00C5))
 	T_29 (in 0x00 : byte)
-Eq_30: (union "Eq_30" (byte u0) ((memptr (ptr8 Eq_29) byte) u1))
+Eq_30: (union "Eq_30" (byte u0) ((memptr (ptr Eq_29) byte) u1))
 	T_30 (in 0xC5 : byte)
 Eq_35: (segment "Eq_35" (C6 byte b00C6))
 	T_35 (in 0x00 : byte)
-Eq_36: (union "Eq_36" (byte u0) ((memptr (ptr8 Eq_35) byte) u1))
+Eq_36: (union "Eq_36" (byte u0) ((memptr (ptr Eq_35) byte) u1))
 	T_36 (in 0xC6 : byte)
 Eq_44: (union "Eq_44" (byte u0) (Eq_251 u1))
 	T_44 (in Z_15 : Eq_44)
@@ -44,27 +44,27 @@ Eq_44: (union "Eq_44" (byte u0) (Eq_251 u1))
 	T_184 (in cond(0x00->b00C6) : byte)
 Eq_49: (segment "Eq_49" (C0 byte b00C0))
 	T_49 (in 0x00 : byte)
-Eq_50: (union "Eq_50" (byte u0) ((memptr (ptr8 Eq_49) byte) u1))
+Eq_50: (union "Eq_50" (byte u0) ((memptr (ptr Eq_49) byte) u1))
 	T_50 (in 0xC0 : byte)
 Eq_55: (segment "Eq_55" (C1 byte b00C1))
 	T_55 (in 0x00 : byte)
-Eq_56: (union "Eq_56" (byte u0) ((memptr (ptr8 Eq_55) byte) u1))
+Eq_56: (union "Eq_56" (byte u0) ((memptr (ptr Eq_55) byte) u1))
 	T_56 (in 0xC1 : byte)
 Eq_61: (segment "Eq_61" (C2 byte b00C2))
 	T_61 (in 0x00 : byte)
-Eq_62: (union "Eq_62" (byte u0) ((memptr (ptr8 Eq_61) byte) u1))
+Eq_62: (union "Eq_62" (byte u0) ((memptr (ptr Eq_61) byte) u1))
 	T_62 (in 0xC2 : byte)
 Eq_82: (segment "Eq_82" (C3 byte b00C3))
 	T_82 (in 0x00 : byte)
-Eq_83: (union "Eq_83" (byte u0) ((memptr (ptr8 Eq_82) byte) u1))
+Eq_83: (union "Eq_83" (byte u0) ((memptr (ptr Eq_82) byte) u1))
 	T_83 (in 0xC3 : byte)
 Eq_88: (segment "Eq_88" (C4 byte b00C4))
 	T_88 (in 0x00 : byte)
-Eq_89: (union "Eq_89" (byte u0) ((memptr (ptr8 Eq_88) byte) u1))
+Eq_89: (union "Eq_89" (byte u0) ((memptr (ptr Eq_88) byte) u1))
 	T_89 (in 0xC4 : byte)
 Eq_109: (segment "Eq_109" (C3 byte b00C3))
 	T_109 (in 0x00 : byte)
-Eq_110: (union "Eq_110" (byte u0) ((memptr (ptr8 Eq_109) byte) u1) ((memptr (ptr8 Eq_112) byte) u2) ((memptr (ptr8 Eq_115) byte) u3))
+Eq_110: (union "Eq_110" (byte u0) ((memptr (ptr Eq_109) byte) u1) ((memptr (ptr Eq_112) byte) u2) ((memptr (ptr Eq_115) byte) u3))
 	T_110 (in 0xC3 : byte)
 Eq_112: (segment "Eq_112" (C3 byte b00C3))
 	T_112 (in 0x00 : byte)
@@ -76,11 +76,11 @@ Eq_115: (segment "Eq_115" (C3 byte b00C3))
 	T_115 (in 0x00 : byte)
 Eq_118: (segment "Eq_118" (C5 byte b00C5))
 	T_118 (in 0x00 : byte)
-Eq_119: (union "Eq_119" (byte u0) ((memptr (ptr8 Eq_118) byte) u1))
+Eq_119: (union "Eq_119" (byte u0) ((memptr (ptr Eq_118) byte) u1))
 	T_119 (in 0xC5 : byte)
 Eq_129: (segment "Eq_129" (C3 byte b00C3))
 	T_129 (in 0x00 : byte)
-Eq_130: (union "Eq_130" (byte u0) ((memptr (ptr8 Eq_129) byte) u1) ((memptr (ptr8 Eq_134) byte) u2) ((memptr (ptr8 Eq_138) cu8) u3))
+Eq_130: (union "Eq_130" (byte u0) ((memptr (ptr Eq_129) byte) u1) ((memptr (ptr Eq_134) byte) u2) ((memptr (ptr Eq_138) cu8) u3))
 	T_130 (in 0xC3 : byte)
 Eq_134: (segment "Eq_134" (C3 byte b00C3))
 	T_134 (in 0x00 : byte)
@@ -88,7 +88,7 @@ Eq_138: (segment "Eq_138" (C3 cu8 b00C3))
 	T_138 (in 0x00 : byte)
 Eq_144: (segment "Eq_144" (C4 byte b00C4))
 	T_144 (in 0x00 : byte)
-Eq_145: (union "Eq_145" (byte u0) ((memptr (ptr8 Eq_144) byte) u1) ((memptr (ptr8 Eq_147) byte) u2) ((memptr (ptr8 Eq_149) byte) u3))
+Eq_145: (union "Eq_145" (byte u0) ((memptr (ptr Eq_144) byte) u1) ((memptr (ptr Eq_147) byte) u2) ((memptr (ptr Eq_149) byte) u3))
 	T_145 (in 0xC4 : byte)
 Eq_147: (segment "Eq_147" (C4 byte b00C4))
 	T_147 (in 0x00 : byte)
@@ -96,13 +96,13 @@ Eq_149: (segment "Eq_149" (C4 byte b00C4))
 	T_149 (in 0x00 : byte)
 Eq_165: (segment "Eq_165" (C5 byte b00C5))
 	T_165 (in 0x00 : byte)
-Eq_166: (union "Eq_166" (byte u0) ((memptr (ptr8 Eq_165) byte) u1) ((memptr (ptr8 Eq_170) byte) u2) ((memptr (ptr8 Eq_175) byte) u3))
+Eq_166: (union "Eq_166" (byte u0) ((memptr (ptr Eq_165) byte) u1) ((memptr (ptr Eq_170) byte) u2) ((memptr (ptr Eq_175) byte) u3))
 	T_166 (in 0xC5 : byte)
 Eq_170: (segment "Eq_170" (C5 byte b00C5))
 	T_170 (in 0x00 : byte)
 Eq_172: (segment "Eq_172" (C6 byte b00C6))
 	T_172 (in 0x00 : byte)
-Eq_173: (union "Eq_173" (byte u0) ((memptr (ptr8 Eq_172) byte) u1) ((memptr (ptr8 Eq_180) byte) u2) ((memptr (ptr8 Eq_182) byte) u3))
+Eq_173: (union "Eq_173" (byte u0) ((memptr (ptr Eq_172) byte) u1) ((memptr (ptr Eq_180) byte) u2) ((memptr (ptr Eq_182) byte) u3))
 	T_173 (in 0xC6 : byte)
 Eq_175: (segment "Eq_175" (C5 byte b00C5))
 	T_175 (in 0x00 : byte)
@@ -112,33 +112,33 @@ Eq_182: (segment "Eq_182" (C6 byte b00C6))
 	T_182 (in 0x00 : byte)
 Eq_185: (segment "Eq_185" (C4 byte b00C4))
 	T_185 (in 0x00 : byte)
-Eq_186: (union "Eq_186" (byte u0) ((memptr (ptr8 Eq_185) byte) u1) ((memptr (ptr8 Eq_190) byte) u2))
+Eq_186: (union "Eq_186" (byte u0) ((memptr (ptr Eq_185) byte) u1) ((memptr (ptr Eq_190) byte) u2))
 	T_186 (in 0xC4 : byte)
 Eq_190: (segment "Eq_190" (C4 byte b00C4))
 	T_190 (in 0x00 : byte)
 Eq_194: (struct "Eq_194" (FE byte b00FE))
-	T_194 (in FSR2 : (ptr16 Eq_194))
+	T_194 (in FSR2 : (ptr Eq_194))
 Eq_195: (struct "Eq_195" (0 byte b0000) (1 byte b0001))
-	T_195 (in FSR1 : (ptr16 Eq_195))
+	T_195 (in FSR1 : (ptr Eq_195))
 Eq_204: (segment "Eq_204" (CA byte b00CA))
 	T_204 (in 0x00 : byte)
-Eq_205: (union "Eq_205" (byte u0) ((memptr (ptr8 Eq_204) byte) u1))
+Eq_205: (union "Eq_205" (byte u0) ((memptr (ptr Eq_204) byte) u1))
 	T_205 (in 0xCA : byte)
 Eq_211: (segment "Eq_211" (CA byte b00CA))
 	T_211 (in 0x00 : byte)
-Eq_212: (union "Eq_212" (byte u0) ((memptr (ptr8 Eq_211) byte) u1) ((memptr (ptr8 Eq_216) byte) u2))
+Eq_212: (union "Eq_212" (byte u0) ((memptr (ptr Eq_211) byte) u1) ((memptr (ptr Eq_216) byte) u2))
 	T_212 (in 0xCA : byte)
 Eq_216: (segment "Eq_216" (CA byte b00CA))
 	T_216 (in 0x00 : byte)
-Eq_234: (union "Eq_234" (word16 u0) ((ptr32 byte) u1))
+Eq_234: (union "Eq_234" (word16 u0) ((ptr byte) u1))
 	T_234 (in FSR0 : Eq_234)
 	T_241 (in FSR0 + 0x0001 : word16)
 	T_247 (in FSR0 + 0x0001 : word16)
-Eq_240: (union "Eq_240" (word16 u0) ((ptr32 byte) u1))
+Eq_240: (union "Eq_240" (word16 u0) ((ptr byte) u1))
 	T_240 (in 0x0001 : word16)
-Eq_244: (union "Eq_244" (word16 u0) ((ptr32 byte) u1))
+Eq_244: (union "Eq_244" (word16 u0) ((ptr byte) u1))
 	T_244 (in FSR0 + 0x0000 : word16)
-Eq_246: (union "Eq_246" (word16 u0) ((ptr32 byte) u1))
+Eq_246: (union "Eq_246" (word16 u0) ((ptr byte) u1))
 	T_246 (in 0x0001 : word16)
 Eq_250: (struct "Eq_250" 0001 (0 ptr32 ptr0000))
 	T_250
@@ -147,14 +147,14 @@ Eq_251: (union "Eq_251" (bool u0) (byte u1))
 Eq_252: (union "Eq_252" (bool u0) (byte u1))
 	T_252
 // Type Variables ////////////
-globals_t: (in globals : (ptr32 (struct "Globals")))
+globals_t: (in globals : (ptr (struct "Globals")))
   Class: Eq_1
-  DataType: (ptr32 Eq_1)
-  OrigDataType: (ptr32 (struct "Globals"))
+  DataType: (ptr Eq_1)
+  OrigDataType: (ptr (struct "Globals"))
 T_2: (in 0001 : ptr16)
   Class: Eq_2
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_5 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_5 t0000)))
 T_3: (in 0x0000 : word16)
   Class: Eq_3
   DataType: word16
@@ -181,8 +181,8 @@ T_8: (in 0x0000 : word16)
   OrigDataType: word16
 T_9: (in 0x0001 + 0x0000 : word16)
   Class: Eq_9
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 byte)
+  DataType: (ptr byte)
+  OrigDataType: (ptr byte)
 T_10: (in Mem18[0x0001 + 0x0000:byte] : byte)
   Class: Eq_5
   DataType: byte
@@ -193,8 +193,8 @@ T_11: (in 00014A : ptr32)
   OrigDataType: ptr32
 T_12: (in Stack : (arr Eq_250))
   Class: Eq_12
-  DataType: (ptr32 (arr Eq_250))
-  OrigDataType: (ptr32 (struct (0 (arr T_250) a0000)))
+  DataType: (ptr (arr Eq_250))
+  OrigDataType: (ptr (struct (0 (arr T_250) a0000)))
 T_13: (in 0x01 : byte)
   Class: Eq_13
   DataType: byte
@@ -205,16 +205,16 @@ T_14: (in Stack[0x01] : ptr32)
   OrigDataType: ptr32
 T_15: (in fn00000E : ptr32)
   Class: Eq_15
-  DataType: (ptr32 Eq_15)
-  OrigDataType: (ptr32 (fn T_21 (T_19, T_20)))
+  DataType: (ptr Eq_15)
+  OrigDataType: (ptr (fn T_21 (T_19, T_20)))
 T_16: (in signature of fn00000E : void)
   Class: Eq_15
-  DataType: (ptr32 Eq_15)
+  DataType: (ptr Eq_15)
   OrigDataType: 
 T_17: (in FSR0 : Eq_17)
   Class: Eq_17
   DataType: Eq_17
-  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
+  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
 T_18: (in TBLPTR : word32)
   Class: Eq_18
   DataType: word32
@@ -233,11 +233,11 @@ T_21: (in fn00000E(0x0000, 0x00000000) : void)
   OrigDataType: void
 T_22: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_27 (T_18, T_26)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_27 (T_18, T_26)))
 T_23: (in signature of __tblrd : void)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
+  DataType: (ptr Eq_22)
   OrigDataType: 
 T_24: (in  : word32)
   Class: Eq_18
@@ -261,8 +261,8 @@ T_28: (in TABLAT : byte)
   OrigDataType: byte
 T_29: (in 0x00 : byte)
   Class: Eq_29
-  DataType: (ptr8 Eq_29)
-  OrigDataType: (ptr8 (segment (C5 T_31 t00C5)))
+  DataType: (ptr Eq_29)
+  OrigDataType: (ptr (segment (C5 T_31 t00C5)))
 T_30: (in 0xC5 : byte)
   Class: Eq_30
   DataType: Eq_30
@@ -273,8 +273,8 @@ T_31: (in Mem12[0x00:0xC5:byte] : byte)
   OrigDataType: byte
 T_32: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_34 (T_18, T_33)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_34 (T_18, T_33)))
 T_33: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -285,8 +285,8 @@ T_34: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_35: (in 0x00 : byte)
   Class: Eq_35
-  DataType: (ptr8 Eq_35)
-  OrigDataType: (ptr8 (segment (C6 T_37 t00C6)))
+  DataType: (ptr Eq_35)
+  OrigDataType: (ptr (segment (C6 T_37 t00C6)))
 T_36: (in 0xC6 : byte)
   Class: Eq_36
   DataType: Eq_36
@@ -329,8 +329,8 @@ T_45: (in cond(TABLAT) : byte)
   OrigDataType: byte
 T_46: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_48 (T_18, T_47)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_48 (T_18, T_47)))
 T_47: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -341,8 +341,8 @@ T_48: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_49: (in 0x00 : byte)
   Class: Eq_49
-  DataType: (ptr8 Eq_49)
-  OrigDataType: (ptr8 (segment (C0 T_51 t00C0)))
+  DataType: (ptr Eq_49)
+  OrigDataType: (ptr (segment (C0 T_51 t00C0)))
 T_50: (in 0xC0 : byte)
   Class: Eq_50
   DataType: Eq_50
@@ -353,8 +353,8 @@ T_51: (in Mem35[0x00:0xC0:byte] : byte)
   OrigDataType: byte
 T_52: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_54 (T_18, T_53)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_54 (T_18, T_53)))
 T_53: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -365,8 +365,8 @@ T_54: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_55: (in 0x00 : byte)
   Class: Eq_55
-  DataType: (ptr8 Eq_55)
-  OrigDataType: (ptr8 (segment (C1 T_57 t00C1)))
+  DataType: (ptr Eq_55)
+  OrigDataType: (ptr (segment (C1 T_57 t00C1)))
 T_56: (in 0xC1 : byte)
   Class: Eq_56
   DataType: Eq_56
@@ -377,8 +377,8 @@ T_57: (in Mem37[0x00:0xC1:byte] : byte)
   OrigDataType: byte
 T_58: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_60 (T_18, T_59)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_60 (T_18, T_59)))
 T_59: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -389,8 +389,8 @@ T_60: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_61: (in 0x00 : byte)
   Class: Eq_61
-  DataType: (ptr8 Eq_61)
-  OrigDataType: (ptr8 (segment (C2 T_63 t00C2)))
+  DataType: (ptr Eq_61)
+  OrigDataType: (ptr (segment (C2 T_63 t00C2)))
 T_62: (in 0xC2 : byte)
   Class: Eq_62
   DataType: Eq_62
@@ -401,8 +401,8 @@ T_63: (in Mem39[0x00:0xC2:byte] : byte)
   OrigDataType: byte
 T_64: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_66 (T_18, T_65)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_66 (T_18, T_65)))
 T_65: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -413,8 +413,8 @@ T_66: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_67: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_69 (T_18, T_68)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_69 (T_18, T_68)))
 T_68: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -425,8 +425,8 @@ T_69: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_70: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_72 (T_18, T_71)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_72 (T_18, T_71)))
 T_71: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -437,8 +437,8 @@ T_72: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_73: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_75 (T_18, T_74)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_75 (T_18, T_74)))
 T_74: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -449,8 +449,8 @@ T_75: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_76: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_78 (T_18, T_77)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_78 (T_18, T_77)))
 T_77: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -461,8 +461,8 @@ T_78: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_79: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_81 (T_18, T_80)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_81 (T_18, T_80)))
 T_80: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -473,8 +473,8 @@ T_81: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_82: (in 0x00 : byte)
   Class: Eq_82
-  DataType: (ptr8 Eq_82)
-  OrigDataType: (ptr8 (segment (C3 T_84 t00C3)))
+  DataType: (ptr Eq_82)
+  OrigDataType: (ptr (segment (C3 T_84 t00C3)))
 T_83: (in 0xC3 : byte)
   Class: Eq_83
   DataType: Eq_83
@@ -485,8 +485,8 @@ T_84: (in Mem45[0x00:0xC3:byte] : byte)
   OrigDataType: byte
 T_85: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_87 (T_18, T_86)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_87 (T_18, T_86)))
 T_86: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -497,8 +497,8 @@ T_87: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_88: (in 0x00 : byte)
   Class: Eq_88
-  DataType: (ptr8 Eq_88)
-  OrigDataType: (ptr8 (segment (C4 T_90 t00C4)))
+  DataType: (ptr Eq_88)
+  OrigDataType: (ptr (segment (C4 T_90 t00C4)))
 T_89: (in 0xC4 : byte)
   Class: Eq_89
   DataType: Eq_89
@@ -509,8 +509,8 @@ T_90: (in Mem47[0x00:0xC4:byte] : byte)
   OrigDataType: byte
 T_91: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_93 (T_18, T_92)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_93 (T_18, T_92)))
 T_92: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -521,8 +521,8 @@ T_93: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_94: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_96 (T_18, T_95)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_96 (T_18, T_95)))
 T_95: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -533,8 +533,8 @@ T_96: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_97: (in 00C7 : ptr16)
   Class: Eq_97
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_100 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_100 t0000)))
 T_98: (in 0x0000 : word16)
   Class: Eq_98
   DataType: word16
@@ -549,8 +549,8 @@ T_100: (in Mem48[0x00C7 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_101: (in 00C8 : ptr16)
   Class: Eq_101
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_104 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_104 t0000)))
 T_102: (in 0x0000 : word16)
   Class: Eq_102
   DataType: word16
@@ -565,8 +565,8 @@ T_104: (in Mem49[0x00C8 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_105: (in 00C9 : ptr16)
   Class: Eq_105
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_108 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_108 t0000)))
 T_106: (in 0x0000 : word16)
   Class: Eq_106
   DataType: word16
@@ -581,8 +581,8 @@ T_108: (in Mem50[0x00C9 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_109: (in 0x00 : byte)
   Class: Eq_109
-  DataType: (ptr8 Eq_109)
-  OrigDataType: (ptr8 (segment (C3 T_111 t00C3)))
+  DataType: (ptr Eq_109)
+  OrigDataType: (ptr (segment (C3 T_111 t00C3)))
 T_110: (in 0xC3 : byte)
   Class: Eq_110
   DataType: Eq_110
@@ -593,8 +593,8 @@ T_111: (in Mem50[0x00:0xC3:byte] : byte)
   OrigDataType: byte
 T_112: (in 0x00 : byte)
   Class: Eq_112
-  DataType: (ptr8 Eq_112)
-  OrigDataType: (ptr8 (segment (C3 T_113 t00C3)))
+  DataType: (ptr Eq_112)
+  OrigDataType: (ptr (segment (C3 T_113 t00C3)))
 T_113: (in Mem55[0x00:0xC3:byte] : byte)
   Class: Eq_111
   DataType: byte
@@ -605,8 +605,8 @@ T_114: (in Z_57 : Eq_114)
   OrigDataType: (union (bool u1) (byte u0))
 T_115: (in 0x00 : byte)
   Class: Eq_115
-  DataType: (ptr8 Eq_115)
-  OrigDataType: (ptr8 (segment (C3 T_116 t00C3)))
+  DataType: (ptr Eq_115)
+  OrigDataType: (ptr (segment (C3 T_116 t00C3)))
 T_116: (in Mem55[0x00:0xC3:byte] : byte)
   Class: Eq_116
   DataType: byte
@@ -617,8 +617,8 @@ T_117: (in cond(0x00->b00C3) : byte)
   OrigDataType: byte
 T_118: (in 0x00 : byte)
   Class: Eq_118
-  DataType: (ptr8 Eq_118)
-  OrigDataType: (ptr8 (segment (C5 T_120 t00C5)))
+  DataType: (ptr Eq_118)
+  OrigDataType: (ptr (segment (C5 T_120 t00C5)))
 T_119: (in 0xC5 : byte)
   Class: Eq_119
   DataType: Eq_119
@@ -637,8 +637,8 @@ T_122: (in 0x00->b00C5 == 0x00 : bool)
   OrigDataType: bool
 T_123: (in __tblrd : ptr32)
   Class: Eq_22
-  DataType: (ptr32 Eq_22)
-  OrigDataType: (ptr32 (fn T_125 (T_18, T_124)))
+  DataType: (ptr Eq_22)
+  OrigDataType: (ptr (fn T_125 (T_18, T_124)))
 T_124: (in 0x01 : byte)
   Class: Eq_25
   DataType: byte
@@ -661,8 +661,8 @@ T_128: (in Mem67[FSR0 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_129: (in 0x00 : byte)
   Class: Eq_129
-  DataType: (ptr8 Eq_129)
-  OrigDataType: (ptr8 (segment (C3 T_131 t00C3)))
+  DataType: (ptr Eq_129)
+  OrigDataType: (ptr (segment (C3 T_131 t00C3)))
 T_130: (in 0xC3 : byte)
   Class: Eq_130
   DataType: Eq_130
@@ -681,24 +681,24 @@ T_133: (in 0x00->b00C3 - 0x01 : byte)
   OrigDataType: byte
 T_134: (in 0x00 : byte)
   Class: Eq_134
-  DataType: (ptr8 Eq_134)
-  OrigDataType: (ptr8 (segment (C3 T_135 t00C3)))
+  DataType: (ptr Eq_134)
+  OrigDataType: (ptr (segment (C3 T_135 t00C3)))
 T_135: (in Mem69[0x00:0xC3:byte] : byte)
   Class: Eq_133
   DataType: byte
   OrigDataType: byte
 T_136: (in 0x0001 : word16)
   Class: Eq_136
-  DataType: (ptr32 byte)
-  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
+  DataType: (ptr byte)
+  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
 T_137: (in FSR0 + 0x0001 : word16)
   Class: Eq_17
   DataType: Eq_17
-  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
+  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
 T_138: (in 0x00 : byte)
   Class: Eq_138
-  DataType: (ptr8 Eq_138)
-  OrigDataType: (ptr8 (segment (C3 T_139 t00C3)))
+  DataType: (ptr Eq_138)
+  OrigDataType: (ptr (segment (C3 T_139 t00C3)))
 T_139: (in Mem69[0x00:0xC3:byte] : byte)
   Class: Eq_139
   DataType: cu8
@@ -721,8 +721,8 @@ T_143: (in 0x00->b00C3 < 0x00 : bool)
   OrigDataType: bool
 T_144: (in 0x00 : byte)
   Class: Eq_144
-  DataType: (ptr8 Eq_144)
-  OrigDataType: (ptr8 (segment (C4 T_146 t00C4)))
+  DataType: (ptr Eq_144)
+  OrigDataType: (ptr (segment (C4 T_146 t00C4)))
 T_145: (in 0xC4 : byte)
   Class: Eq_145
   DataType: Eq_145
@@ -733,16 +733,16 @@ T_146: (in Mem55[0x00:0xC4:byte] : byte)
   OrigDataType: byte
 T_147: (in 0x00 : byte)
   Class: Eq_147
-  DataType: (ptr8 Eq_147)
-  OrigDataType: (ptr8 (segment (C4 T_148 t00C4)))
+  DataType: (ptr Eq_147)
+  OrigDataType: (ptr (segment (C4 T_148 t00C4)))
 T_148: (in Mem76[0x00:0xC4:byte] : byte)
   Class: Eq_146
   DataType: byte
   OrigDataType: byte
 T_149: (in 0x00 : byte)
   Class: Eq_149
-  DataType: (ptr8 Eq_149)
-  OrigDataType: (ptr8 (segment (C4 T_150 t00C4)))
+  DataType: (ptr Eq_149)
+  OrigDataType: (ptr (segment (C4 T_150 t00C4)))
 T_150: (in Mem76[0x00:0xC4:byte] : byte)
   Class: Eq_150
   DataType: byte
@@ -757,8 +757,8 @@ T_152: (in 0x00->b00C4 == 0x00 : bool)
   OrigDataType: bool
 T_153: (in 00C7 : ptr16)
   Class: Eq_153
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_156 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_156 t0000)))
 T_154: (in 0x0000 : word16)
   Class: Eq_154
   DataType: word16
@@ -773,8 +773,8 @@ T_156: (in Mem76[0x00C7 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_157: (in 00C8 : ptr16)
   Class: Eq_157
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_160 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_160 t0000)))
 T_158: (in 0x0000 : word16)
   Class: Eq_158
   DataType: word16
@@ -789,8 +789,8 @@ T_160: (in Mem76[0x00C8 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_161: (in 00C9 : ptr16)
   Class: Eq_161
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_164 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_164 t0000)))
 T_162: (in 0x0000 : word16)
   Class: Eq_162
   DataType: word16
@@ -805,8 +805,8 @@ T_164: (in Mem76[0x00C9 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_165: (in 0x00 : byte)
   Class: Eq_165
-  DataType: (ptr8 Eq_165)
-  OrigDataType: (ptr8 (segment (C5 T_167 t00C5)))
+  DataType: (ptr Eq_165)
+  OrigDataType: (ptr (segment (C5 T_167 t00C5)))
 T_166: (in 0xC5 : byte)
   Class: Eq_166
   DataType: Eq_166
@@ -825,16 +825,16 @@ T_169: (in 0x00->b00C5 - 0x01 : byte)
   OrigDataType: byte
 T_170: (in 0x00 : byte)
   Class: Eq_170
-  DataType: (ptr8 Eq_170)
-  OrigDataType: (ptr8 (segment (C5 T_171 t00C5)))
+  DataType: (ptr Eq_170)
+  OrigDataType: (ptr (segment (C5 T_171 t00C5)))
 T_171: (in Mem83[0x00:0xC5:byte] : byte)
   Class: Eq_169
   DataType: byte
   OrigDataType: byte
 T_172: (in 0x00 : byte)
   Class: Eq_172
-  DataType: (ptr8 Eq_172)
-  OrigDataType: (ptr8 (segment (C6 T_174 t00C6)))
+  DataType: (ptr Eq_172)
+  OrigDataType: (ptr (segment (C6 T_174 t00C6)))
 T_173: (in 0xC6 : byte)
   Class: Eq_173
   DataType: Eq_173
@@ -845,8 +845,8 @@ T_174: (in Mem83[0x00:0xC6:byte] : byte)
   OrigDataType: byte
 T_175: (in 0x00 : byte)
   Class: Eq_175
-  DataType: (ptr8 Eq_175)
-  OrigDataType: (ptr8 (segment (C5 T_176 t00C5)))
+  DataType: (ptr Eq_175)
+  OrigDataType: (ptr (segment (C5 T_176 t00C5)))
 T_176: (in Mem83[0x00:0xC5:byte] : byte)
   Class: Eq_176
   DataType: byte
@@ -865,16 +865,16 @@ T_179: (in 0x00->b00C6 - !cond(0x00->b00C5) : byte)
   OrigDataType: byte
 T_180: (in 0x00 : byte)
   Class: Eq_180
-  DataType: (ptr8 Eq_180)
-  OrigDataType: (ptr8 (segment (C6 T_181 t00C6)))
+  DataType: (ptr Eq_180)
+  OrigDataType: (ptr (segment (C6 T_181 t00C6)))
 T_181: (in Mem87[0x00:0xC6:byte] : byte)
   Class: Eq_179
   DataType: byte
   OrigDataType: byte
 T_182: (in 0x00 : byte)
   Class: Eq_182
-  DataType: (ptr8 Eq_182)
-  OrigDataType: (ptr8 (segment (C6 T_183 t00C6)))
+  DataType: (ptr Eq_182)
+  OrigDataType: (ptr (segment (C6 T_183 t00C6)))
 T_183: (in Mem87[0x00:0xC6:byte] : byte)
   Class: Eq_183
   DataType: byte
@@ -885,8 +885,8 @@ T_184: (in cond(0x00->b00C6) : byte)
   OrigDataType: byte
 T_185: (in 0x00 : byte)
   Class: Eq_185
-  DataType: (ptr8 Eq_185)
-  OrigDataType: (ptr8 (segment (C4 T_187 t00C4)))
+  DataType: (ptr Eq_185)
+  OrigDataType: (ptr (segment (C4 T_187 t00C4)))
 T_186: (in 0xC4 : byte)
   Class: Eq_186
   DataType: Eq_186
@@ -905,8 +905,8 @@ T_189: (in 0x00->b00C4 - 0x01 : byte)
   OrigDataType: byte
 T_190: (in 0x00 : byte)
   Class: Eq_190
-  DataType: (ptr8 Eq_190)
-  OrigDataType: (ptr8 (segment (C4 T_191 t00C4)))
+  DataType: (ptr Eq_190)
+  OrigDataType: (ptr (segment (C4 T_191 t00C4)))
 T_191: (in Mem74[0x00:0xC4:byte] : byte)
   Class: Eq_189
   DataType: byte
@@ -919,14 +919,14 @@ T_193: (in FSR2L : byte)
   Class: Eq_193
   DataType: byte
   OrigDataType: byte
-T_194: (in FSR2 : (ptr16 Eq_194))
+T_194: (in FSR2 : (ptr Eq_194))
   Class: Eq_194
-  DataType: (ptr16 Eq_194)
-  OrigDataType: (ptr16 (struct (FE T_224 t00FE)))
-T_195: (in FSR1 : (ptr16 Eq_195))
+  DataType: (ptr Eq_194)
+  OrigDataType: (ptr (struct (FE T_224 t00FE)))
+T_195: (in FSR1 : (ptr Eq_195))
   Class: Eq_195
-  DataType: (ptr16 Eq_195)
-  OrigDataType: (ptr16 (struct (0 T_198 t0000) (1 T_201 t0001)))
+  DataType: (ptr Eq_195)
+  OrigDataType: (ptr (struct (0 T_198 t0000) (1 T_201 t0001)))
 T_196: (in 0x0000 : word16)
   Class: Eq_196
   DataType: word16
@@ -953,16 +953,16 @@ T_201: (in Mem3[FSR1 + 0x0001:byte] : byte)
   OrigDataType: byte
 T_202: (in FSR1 + 0x0001 : word16)
   Class: Eq_202
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 byte)
+  DataType: (ptr byte)
+  OrigDataType: (ptr byte)
 T_203: (in Mem29[FSR1 + 0x0001:byte] : byte)
   Class: Eq_201
   DataType: byte
   OrigDataType: byte
 T_204: (in 0x00 : byte)
   Class: Eq_204
-  DataType: (ptr8 Eq_204)
-  OrigDataType: (ptr8 (segment (CA T_206 t00CA)))
+  DataType: (ptr Eq_204)
+  OrigDataType: (ptr (segment (CA T_206 t00CA)))
 T_205: (in 0xCA : byte)
   Class: Eq_205
   DataType: Eq_205
@@ -989,8 +989,8 @@ T_210: (in (0x00->b00CA & 0x01) != 0x00 : bool)
   OrigDataType: bool
 T_211: (in 0x00 : byte)
   Class: Eq_211
-  DataType: (ptr8 Eq_211)
-  OrigDataType: (ptr8 (segment (CA T_213 t00CA)))
+  DataType: (ptr Eq_211)
+  OrigDataType: (ptr (segment (CA T_213 t00CA)))
 T_212: (in 0xCA : byte)
   Class: Eq_212
   DataType: Eq_212
@@ -1009,8 +1009,8 @@ T_215: (in 0x00->b00CA & 0xFE : byte)
   OrigDataType: byte
 T_216: (in 0x00 : byte)
   Class: Eq_216
-  DataType: (ptr8 Eq_216)
-  OrigDataType: (ptr8 (segment (CA T_217 t00CA)))
+  DataType: (ptr Eq_216)
+  OrigDataType: (ptr (segment (CA T_217 t00CA)))
 T_217: (in Mem22[0x00:0xCA:byte] : byte)
   Class: Eq_215
   DataType: byte
@@ -1106,11 +1106,11 @@ T_239: (in Mem20[FSR0 + 0x0000:byte] : byte)
 T_240: (in 0x0001 : word16)
   Class: Eq_240
   DataType: word16
-  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr byte) u1))
 T_241: (in FSR0 + 0x0001 : word16)
   Class: Eq_234
   DataType: Eq_234
-  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr byte) u1))
 T_242: (in 0x00 : byte)
   Class: Eq_242
   DataType: byte
@@ -1122,7 +1122,7 @@ T_243: (in 0x0000 : word16)
 T_244: (in FSR0 + 0x0000 : word16)
   Class: Eq_244
   DataType: Eq_244
-  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr byte) u1))
 T_245: (in Mem17[FSR0 + 0x0000:byte] : byte)
   Class: Eq_242
   DataType: Eq_234
@@ -1130,11 +1130,11 @@ T_245: (in Mem17[FSR0 + 0x0000:byte] : byte)
 T_246: (in 0x0001 : word16)
   Class: Eq_246
   DataType: word16
-  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr byte) u1))
 T_247: (in FSR0 + 0x0001 : word16)
   Class: Eq_234
   DataType: Eq_234
-  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr byte) u1))
 T_248: (in PRODL : byte)
   Class: Eq_232
   DataType: cu8

--- a/subjects/Microchip/C18/PIC18Extd/PIC18EggExtd.c
+++ b/subjects/Microchip/C18/PIC18Extd/PIC18EggExtd.c
@@ -11,8 +11,8 @@ void fn00000000()
 	fn00000E(0x00, 0x00);
 }
 
-// 00000E: void fn00000E(Register Eq_8 FSR0, Register word32 TBLPTR)
-void fn00000E(Eq_8 FSR0, word32 TBLPTR)
+// 00000E: void fn00000E(Register Eq_8 FSR0, Register word24 TBLPTR)
+void fn00000E(Eq_8 FSR0, word24 TBLPTR)
 {
 	__tblrd(TBLPTR, 0x01);
 	0x00->b00C5 = TABLAT;
@@ -75,7 +75,7 @@ l000080:
 	goto l000080;
 }
 
-// 0000D0: void fn0000D0(Register byte LATB, Register byte FSR2L, Register ptr16 FSR2, Register (ptr byte) FSR1)
+// 0000D0: void fn0000D0(Register byte LATB, Register byte FSR2L, Register ptr16 FSR2, Register (ptr16 byte) FSR1)
 void fn0000D0(byte LATB, byte FSR2L, ptr16 FSR2, byte * FSR1)
 {
 	*FSR1 = FSR2L;

--- a/subjects/Microchip/C18/PIC18Extd/PIC18EggExtd.c
+++ b/subjects/Microchip/C18/PIC18Extd/PIC18EggExtd.c
@@ -75,7 +75,7 @@ l000080:
 	goto l000080;
 }
 
-// 0000D0: void fn0000D0(Register byte LATB, Register byte FSR2L, Register ptr16 FSR2, Register (ptr16 byte) FSR1)
+// 0000D0: void fn0000D0(Register byte LATB, Register byte FSR2L, Register ptr16 FSR2, Register (ptr byte) FSR1)
 void fn0000D0(byte LATB, byte FSR2L, ptr16 FSR2, byte * FSR1)
 {
 	*FSR1 = FSR2L;

--- a/subjects/Microchip/C18/PIC18Extd/PIC18EggExtd.dis
+++ b/subjects/Microchip/C18/PIC18Extd/PIC18EggExtd.dis
@@ -23,14 +23,14 @@ l00000000:
 
 l00013A:
 	Stack[0x01] = 0x000148
-	fn00000E(0x0000, 0x00000000)
+	fn00000E(0x0000, 0x000000)
 // DataOut:
 // DataOut (flags): 
-// SymbolicIn: STKPTR:0x00 STATUS:0x00 PCL:0x00 PCLATH:0x00 WREG:0x00 BSR:0x00 FSR0:0x0000 FSR1:0x0000 FSR2:0x0000 PROD:0x0000 PCLAT:0x00000000 TOS:0x00000000 TBLPTR:0x00000000
+// SymbolicIn: STKPTR:0x00 STATUS:0x00 PCL:0x00 PCLATH:0x00 WREG:0x00 BSR:0x00 FSR0:0x0000 FSR1:0x0000 FSR2:0x0000 PROD:0x0000 PCLAT:0x000000 TOS:0x000000 TBLPTR:0x000000
 
 
 
-void fn00000E(word16 FSR0, word32 TBLPTR)
+void fn00000E(word16 FSR0, word24 TBLPTR)
 // stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  FSR0 TBLPTR
@@ -41,7 +41,7 @@ fn00000E_entry:
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l00000E:
 	__tblrd(TBLPTR, 0x01)
@@ -55,27 +55,27 @@ l00000E:
 // DataOut: FSR0 TBLPTR TBLPTRH TBLPTRL TBLPTRU
 // DataOut (flags): Z
 // SymbolicIn: STKPTR:fp
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000028:
 	branch Z_15 l000030
 // DataOut: FSR0 TBLPTR TBLPTRH TBLPTRL TBLPTRU
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:<invalid> TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l00002A:
 	branch Mem17[0x00:0xC5:byte] == 0x00 l00002E
 // DataOut: FSR0 TBLPTR TBLPTRH TBLPTRL TBLPTRU
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:<invalid> TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l00002E:
 // DataOut:
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:<invalid> TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000AA:
 	return
@@ -92,7 +92,7 @@ l00002C:
 // DataOut: FSR0 TBLPTR TBLPTRH TBLPTRL TBLPTRU
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:<invalid> TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000030:
 	__tblrd(TBLPTR, 0x01)
@@ -120,14 +120,14 @@ l000030:
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): Z
 // SymbolicIn: STKPTR:fp WREG:<invalid> TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000080:
 	branch Z_57 l000086
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:TABLAT TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000082:
 	Mem76[0x00:0xC4:byte] = Mem55[0x00:0xC4:byte]
@@ -135,7 +135,7 @@ l000082:
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:TABLAT TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000094:
 	TBLPTRL_24 = Mem76[0x00C7:byte]
@@ -147,7 +147,7 @@ l000094:
 // DataOut: FSR0 TBLPTR TBLPTRH TBLPTRL TBLPTRU
 // DataOut (flags): Z
 // SymbolicIn: STKPTR:fp WREG:TABLAT TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000086:
 	__tblrd(TBLPTR, 0x01)
@@ -159,14 +159,14 @@ l000086:
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): Z
 // SymbolicIn: STKPTR:fp WREG:TABLAT TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000090:
 	Mem74[0x00:0xC4:byte] = Mem69[0x00:0xC4:byte] - 0x01
 // DataOut: FSR0 TBLPTR
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:TABLAT TBLPTRL:<invalid> TBLPTRH:<invalid> TBLPTRU:<invalid> BSR:0x00 FSR0L:TABLAT FSR0H:TABLAT FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 
 
@@ -181,21 +181,21 @@ fn0000D0_entry:
 // DataOut: FSR1 FSR2 FSR2L LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000D0:
 	Mem3[FSR1:byte] = FSR2L
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000DA:
 	branch Mem3[FSR2 - 0x02:byte] == 0x00 l0000F4
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L FSR2:FSR2 - 0x02 WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000F4:
 	return
@@ -213,7 +213,7 @@ l0000DE:
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L FSR2:FSR2 - 0x02 WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000E4:
 	Mem22[0x00:0xCA:byte] = Mem3[0x00:0xCA:byte] & 0xFE
@@ -221,33 +221,33 @@ l0000E4:
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L FSR2:FSR2 - 0x02 WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000F0:
 	LATB = LATB & 0x7F
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L FSR2:FSR2 - 0x02 WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000EC:
 	LATB = LATB | 0x80
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L FSR2:FSR2 - 0x02 WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000E2:
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L FSR2:FSR2 - 0x02 WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l0000F2:
 // DataOut: FSR1 FSR2 LATB
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR1:FSR1 + 0x0001 FSR2L:FSR1L FSR2:FSR2 - 0x02 WREG:<invalid> BSR:0x00 LATB:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 
 
@@ -262,14 +262,14 @@ fn000128_entry:
 // DataOut: FSR0 FSR0H FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000128:
 	branch FSR0H <u WREG l00012C
 // DataOut: FSR0 FSR0H FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l00012C:
 	Mem20[FSR0:byte] = 0x00
@@ -277,26 +277,26 @@ l00012C:
 // DataOut: FSR0 FSR0H FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l00012A:
 // DataOut: FSR0 FSR0L
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000130:
 // DataOut: FSR0 FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000132:
 	branch FSR0L <u PRODL l000136
 // DataOut: FSR0 FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:PRODL FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000136:
 	Mem17[FSR0:byte] = 0x00
@@ -304,7 +304,7 @@ l000136:
 // DataOut: FSR0 FSR0L WREG
 // DataOut (flags): 
 // SymbolicIn: STKPTR:fp WREG:PRODL FSR0:<invalid>
-// LocalsOut: fp(32)
+// LocalsOut: fp(24)
 
 l000134:
 	return

--- a/subjects/Microchip/C18/PIC18Extd/PIC18EggExtd.h
+++ b/subjects/Microchip/C18/PIC18Extd/PIC18EggExtd.h
@@ -5,15 +5,15 @@
 /*
 // Equivalence classes ////////////
 Eq_1: (struct "Globals" (1 byte b0001) (C7 byte b00C7) (C8 byte b00C8) (C9 byte b00C9))
-	globals_t (in globals : (ptr (struct "Globals")))
-Eq_6: (fn void (Eq_8, word32))
+	globals_t (in globals : (ptr32 (struct "Globals")))
+Eq_6: (fn void (Eq_8, word24))
 	T_6 (in fn00000E : ptr32)
 	T_7 (in signature of fn00000E : void)
-Eq_8: (union "Eq_8" (word16 u0) ((ptr byte) u1))
+Eq_8: (union "Eq_8" (word16 u0) ((ptr32 byte) u1))
 	T_8 (in FSR0 : Eq_8)
 	T_10 (in 0x0000 : word16)
 	T_128 (in FSR0 + 0x0001 : word16)
-Eq_13: (fn void (word32, byte))
+Eq_13: (fn void (word24, byte))
 	T_13 (in __tblrd : ptr32)
 	T_14 (in signature of __tblrd : void)
 	T_23 (in __tblrd : ptr32)
@@ -32,11 +32,11 @@ Eq_13: (fn void (word32, byte))
 	T_114 (in __tblrd : ptr32)
 Eq_20: (segment "Eq_20" (C5 byte b00C5))
 	T_20 (in 0x00 : byte)
-Eq_21: (union "Eq_21" (byte u0) ((memptr (ptr Eq_20) byte) u1))
+Eq_21: (union "Eq_21" (byte u0) ((memptr (ptr8 Eq_20) byte) u1))
 	T_21 (in 0xC5 : byte)
 Eq_26: (segment "Eq_26" (C6 byte b00C6))
 	T_26 (in 0x00 : byte)
-Eq_27: (union "Eq_27" (byte u0) ((memptr (ptr Eq_26) byte) u1))
+Eq_27: (union "Eq_27" (byte u0) ((memptr (ptr8 Eq_26) byte) u1))
 	T_27 (in 0xC6 : byte)
 Eq_35: (union "Eq_35" (byte u0) (Eq_239 u1))
 	T_35 (in Z_15 : Eq_35)
@@ -44,27 +44,27 @@ Eq_35: (union "Eq_35" (byte u0) (Eq_239 u1))
 	T_175 (in cond(0x00->b00C6) : byte)
 Eq_40: (segment "Eq_40" (C0 byte b00C0))
 	T_40 (in 0x00 : byte)
-Eq_41: (union "Eq_41" (byte u0) ((memptr (ptr Eq_40) byte) u1))
+Eq_41: (union "Eq_41" (byte u0) ((memptr (ptr8 Eq_40) byte) u1))
 	T_41 (in 0xC0 : byte)
 Eq_46: (segment "Eq_46" (C1 byte b00C1))
 	T_46 (in 0x00 : byte)
-Eq_47: (union "Eq_47" (byte u0) ((memptr (ptr Eq_46) byte) u1))
+Eq_47: (union "Eq_47" (byte u0) ((memptr (ptr8 Eq_46) byte) u1))
 	T_47 (in 0xC1 : byte)
 Eq_52: (segment "Eq_52" (C2 byte b00C2))
 	T_52 (in 0x00 : byte)
-Eq_53: (union "Eq_53" (byte u0) ((memptr (ptr Eq_52) byte) u1))
+Eq_53: (union "Eq_53" (byte u0) ((memptr (ptr8 Eq_52) byte) u1))
 	T_53 (in 0xC2 : byte)
 Eq_73: (segment "Eq_73" (C3 byte b00C3))
 	T_73 (in 0x00 : byte)
-Eq_74: (union "Eq_74" (byte u0) ((memptr (ptr Eq_73) byte) u1))
+Eq_74: (union "Eq_74" (byte u0) ((memptr (ptr8 Eq_73) byte) u1))
 	T_74 (in 0xC3 : byte)
 Eq_79: (segment "Eq_79" (C4 byte b00C4))
 	T_79 (in 0x00 : byte)
-Eq_80: (union "Eq_80" (byte u0) ((memptr (ptr Eq_79) byte) u1))
+Eq_80: (union "Eq_80" (byte u0) ((memptr (ptr8 Eq_79) byte) u1))
 	T_80 (in 0xC4 : byte)
 Eq_100: (segment "Eq_100" (C3 byte b00C3))
 	T_100 (in 0x00 : byte)
-Eq_101: (union "Eq_101" (byte u0) ((memptr (ptr Eq_100) byte) u1) ((memptr (ptr Eq_103) byte) u2) ((memptr (ptr Eq_106) byte) u3))
+Eq_101: (union "Eq_101" (byte u0) ((memptr (ptr8 Eq_100) byte) u1) ((memptr (ptr8 Eq_103) byte) u2) ((memptr (ptr8 Eq_106) byte) u3))
 	T_101 (in 0xC3 : byte)
 Eq_103: (segment "Eq_103" (C3 byte b00C3))
 	T_103 (in 0x00 : byte)
@@ -76,11 +76,11 @@ Eq_106: (segment "Eq_106" (C3 byte b00C3))
 	T_106 (in 0x00 : byte)
 Eq_109: (segment "Eq_109" (C5 byte b00C5))
 	T_109 (in 0x00 : byte)
-Eq_110: (union "Eq_110" (byte u0) ((memptr (ptr Eq_109) byte) u1))
+Eq_110: (union "Eq_110" (byte u0) ((memptr (ptr8 Eq_109) byte) u1))
 	T_110 (in 0xC5 : byte)
 Eq_120: (segment "Eq_120" (C3 byte b00C3))
 	T_120 (in 0x00 : byte)
-Eq_121: (union "Eq_121" (byte u0) ((memptr (ptr Eq_120) byte) u1) ((memptr (ptr Eq_125) byte) u2) ((memptr (ptr Eq_129) cu8) u3))
+Eq_121: (union "Eq_121" (byte u0) ((memptr (ptr8 Eq_120) byte) u1) ((memptr (ptr8 Eq_125) byte) u2) ((memptr (ptr8 Eq_129) cu8) u3))
 	T_121 (in 0xC3 : byte)
 Eq_125: (segment "Eq_125" (C3 byte b00C3))
 	T_125 (in 0x00 : byte)
@@ -88,7 +88,7 @@ Eq_129: (segment "Eq_129" (C3 cu8 b00C3))
 	T_129 (in 0x00 : byte)
 Eq_135: (segment "Eq_135" (C4 byte b00C4))
 	T_135 (in 0x00 : byte)
-Eq_136: (union "Eq_136" (byte u0) ((memptr (ptr Eq_135) byte) u1) ((memptr (ptr Eq_138) byte) u2) ((memptr (ptr Eq_140) byte) u3))
+Eq_136: (union "Eq_136" (byte u0) ((memptr (ptr8 Eq_135) byte) u1) ((memptr (ptr8 Eq_138) byte) u2) ((memptr (ptr8 Eq_140) byte) u3))
 	T_136 (in 0xC4 : byte)
 Eq_138: (segment "Eq_138" (C4 byte b00C4))
 	T_138 (in 0x00 : byte)
@@ -96,13 +96,13 @@ Eq_140: (segment "Eq_140" (C4 byte b00C4))
 	T_140 (in 0x00 : byte)
 Eq_156: (segment "Eq_156" (C5 byte b00C5))
 	T_156 (in 0x00 : byte)
-Eq_157: (union "Eq_157" (byte u0) ((memptr (ptr Eq_156) byte) u1) ((memptr (ptr Eq_161) byte) u2) ((memptr (ptr Eq_166) byte) u3))
+Eq_157: (union "Eq_157" (byte u0) ((memptr (ptr8 Eq_156) byte) u1) ((memptr (ptr8 Eq_161) byte) u2) ((memptr (ptr8 Eq_166) byte) u3))
 	T_157 (in 0xC5 : byte)
 Eq_161: (segment "Eq_161" (C5 byte b00C5))
 	T_161 (in 0x00 : byte)
 Eq_163: (segment "Eq_163" (C6 byte b00C6))
 	T_163 (in 0x00 : byte)
-Eq_164: (union "Eq_164" (byte u0) ((memptr (ptr Eq_163) byte) u1) ((memptr (ptr Eq_171) byte) u2) ((memptr (ptr Eq_173) byte) u3))
+Eq_164: (union "Eq_164" (byte u0) ((memptr (ptr8 Eq_163) byte) u1) ((memptr (ptr8 Eq_171) byte) u2) ((memptr (ptr8 Eq_173) byte) u3))
 	T_164 (in 0xC6 : byte)
 Eq_166: (segment "Eq_166" (C5 byte b00C5))
 	T_166 (in 0x00 : byte)
@@ -112,31 +112,31 @@ Eq_173: (segment "Eq_173" (C6 byte b00C6))
 	T_173 (in 0x00 : byte)
 Eq_176: (segment "Eq_176" (C4 byte b00C4))
 	T_176 (in 0x00 : byte)
-Eq_177: (union "Eq_177" (byte u0) ((memptr (ptr Eq_176) byte) u1) ((memptr (ptr Eq_181) byte) u2))
+Eq_177: (union "Eq_177" (byte u0) ((memptr (ptr8 Eq_176) byte) u1) ((memptr (ptr8 Eq_181) byte) u2))
 	T_177 (in 0xC4 : byte)
 Eq_181: (segment "Eq_181" (C4 byte b00C4))
 	T_181 (in 0x00 : byte)
 Eq_190: (segment "Eq_190" (CA byte b00CA))
 	T_190 (in 0x00 : byte)
-Eq_191: (union "Eq_191" (byte u0) ((memptr (ptr Eq_190) byte) u1))
+Eq_191: (union "Eq_191" (byte u0) ((memptr (ptr8 Eq_190) byte) u1))
 	T_191 (in 0xCA : byte)
 Eq_197: (segment "Eq_197" (CA byte b00CA))
 	T_197 (in 0x00 : byte)
-Eq_198: (union "Eq_198" (byte u0) ((memptr (ptr Eq_197) byte) u1) ((memptr (ptr Eq_202) byte) u2))
+Eq_198: (union "Eq_198" (byte u0) ((memptr (ptr8 Eq_197) byte) u1) ((memptr (ptr8 Eq_202) byte) u2))
 	T_198 (in 0xCA : byte)
 Eq_202: (segment "Eq_202" (CA byte b00CA))
 	T_202 (in 0x00 : byte)
 Eq_208: (union "Eq_208" (ui16 u0) (byte u1))
 	T_208 (in 0x02 : byte)
-Eq_222: (union "Eq_222" (word16 u0) ((ptr byte) u1))
+Eq_222: (union "Eq_222" (word16 u0) ((ptr32 byte) u1))
 	T_222 (in FSR0 : Eq_222)
 	T_229 (in FSR0 + 0x0001 : word16)
 	T_235 (in FSR0 + 0x0001 : word16)
-Eq_228: (union "Eq_228" (word16 u0) ((ptr byte) u1))
+Eq_228: (union "Eq_228" (word16 u0) ((ptr32 byte) u1))
 	T_228 (in 0x0001 : word16)
-Eq_232: (union "Eq_232" (word16 u0) ((ptr byte) u1))
+Eq_232: (union "Eq_232" (word16 u0) ((ptr32 byte) u1))
 	T_232 (in FSR0 + 0x0000 : word16)
-Eq_234: (union "Eq_234" (word16 u0) ((ptr byte) u1))
+Eq_234: (union "Eq_234" (word16 u0) ((ptr32 byte) u1))
 	T_234 (in 0x0001 : word16)
 Eq_238: (struct "Eq_238" 0001 (0 ptr32 ptr0000))
 	T_238
@@ -145,18 +145,18 @@ Eq_239: (union "Eq_239" (bool u0) (byte u1))
 Eq_240: (union "Eq_240" (bool u0) (byte u1))
 	T_240
 // Type Variables ////////////
-globals_t: (in globals : (ptr (struct "Globals")))
+globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
-  DataType: (ptr Eq_1)
-  OrigDataType: (ptr (struct "Globals"))
+  DataType: (ptr32 Eq_1)
+  OrigDataType: (ptr32 (struct "Globals"))
 T_2: (in 000148 : ptr32)
   Class: Eq_2
   DataType: ptr32
   OrigDataType: ptr32
 T_3: (in Stack : (arr Eq_238))
   Class: Eq_3
-  DataType: (ptr (arr Eq_238))
-  OrigDataType: (ptr (struct (0 (arr T_238) a0000)))
+  DataType: (ptr32 (arr Eq_238))
+  OrigDataType: (ptr32 (struct (0 (arr T_238) a0000)))
 T_4: (in 0x01 : byte)
   Class: Eq_4
   DataType: byte
@@ -167,43 +167,43 @@ T_5: (in Stack[0x01] : ptr32)
   OrigDataType: ptr32
 T_6: (in fn00000E : ptr32)
   Class: Eq_6
-  DataType: (ptr Eq_6)
-  OrigDataType: (ptr (fn T_12 (T_10, T_11)))
+  DataType: (ptr32 Eq_6)
+  OrigDataType: (ptr32 (fn T_12 (T_10, T_11)))
 T_7: (in signature of fn00000E : void)
   Class: Eq_6
-  DataType: (ptr Eq_6)
+  DataType: (ptr32 Eq_6)
   OrigDataType: 
 T_8: (in FSR0 : Eq_8)
   Class: Eq_8
   DataType: Eq_8
-  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
-T_9: (in TBLPTR : word32)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
+T_9: (in TBLPTR : word24)
   Class: Eq_9
-  DataType: word32
-  OrigDataType: word32
+  DataType: word24
+  OrigDataType: word24
 T_10: (in 0x0000 : word16)
   Class: Eq_8
   DataType: word16
   OrigDataType: word16
-T_11: (in 0x00000000 : word32)
+T_11: (in 0x000000 : word24)
   Class: Eq_9
-  DataType: word32
-  OrigDataType: word32
-T_12: (in fn00000E(0x0000, 0x00000000) : void)
+  DataType: word24
+  OrigDataType: word24
+T_12: (in fn00000E(0x0000, 0x000000) : void)
   Class: Eq_12
   DataType: void
   OrigDataType: void
 T_13: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_18 (T_9, T_17)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_18 (T_9, T_17)))
 T_14: (in signature of __tblrd : void)
   Class: Eq_13
-  DataType: (ptr Eq_13)
+  DataType: (ptr32 Eq_13)
   OrigDataType: 
-T_15: (in  : word32)
+T_15: (in  : word24)
   Class: Eq_9
-  DataType: word32
+  DataType: word24
   OrigDataType: 
 T_16: (in  : byte)
   Class: Eq_16
@@ -223,8 +223,8 @@ T_19: (in TABLAT : byte)
   OrigDataType: byte
 T_20: (in 0x00 : byte)
   Class: Eq_20
-  DataType: (ptr Eq_20)
-  OrigDataType: (ptr (segment (C5 T_22 t00C5)))
+  DataType: (ptr8 Eq_20)
+  OrigDataType: (ptr8 (segment (C5 T_22 t00C5)))
 T_21: (in 0xC5 : byte)
   Class: Eq_21
   DataType: Eq_21
@@ -235,8 +235,8 @@ T_22: (in Mem12[0x00:0xC5:byte] : byte)
   OrigDataType: byte
 T_23: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_25 (T_9, T_24)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_25 (T_9, T_24)))
 T_24: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -247,8 +247,8 @@ T_25: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_26: (in 0x00 : byte)
   Class: Eq_26
-  DataType: (ptr Eq_26)
-  OrigDataType: (ptr (segment (C6 T_28 t00C6)))
+  DataType: (ptr8 Eq_26)
+  OrigDataType: (ptr8 (segment (C6 T_28 t00C6)))
 T_27: (in 0xC6 : byte)
   Class: Eq_27
   DataType: Eq_27
@@ -291,8 +291,8 @@ T_36: (in cond(TABLAT) : byte)
   OrigDataType: byte
 T_37: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_39 (T_9, T_38)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_39 (T_9, T_38)))
 T_38: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -303,8 +303,8 @@ T_39: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_40: (in 0x00 : byte)
   Class: Eq_40
-  DataType: (ptr Eq_40)
-  OrigDataType: (ptr (segment (C0 T_42 t00C0)))
+  DataType: (ptr8 Eq_40)
+  OrigDataType: (ptr8 (segment (C0 T_42 t00C0)))
 T_41: (in 0xC0 : byte)
   Class: Eq_41
   DataType: Eq_41
@@ -315,8 +315,8 @@ T_42: (in Mem35[0x00:0xC0:byte] : byte)
   OrigDataType: byte
 T_43: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_45 (T_9, T_44)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_45 (T_9, T_44)))
 T_44: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -327,8 +327,8 @@ T_45: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_46: (in 0x00 : byte)
   Class: Eq_46
-  DataType: (ptr Eq_46)
-  OrigDataType: (ptr (segment (C1 T_48 t00C1)))
+  DataType: (ptr8 Eq_46)
+  OrigDataType: (ptr8 (segment (C1 T_48 t00C1)))
 T_47: (in 0xC1 : byte)
   Class: Eq_47
   DataType: Eq_47
@@ -339,8 +339,8 @@ T_48: (in Mem37[0x00:0xC1:byte] : byte)
   OrigDataType: byte
 T_49: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_51 (T_9, T_50)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_51 (T_9, T_50)))
 T_50: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -351,8 +351,8 @@ T_51: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_52: (in 0x00 : byte)
   Class: Eq_52
-  DataType: (ptr Eq_52)
-  OrigDataType: (ptr (segment (C2 T_54 t00C2)))
+  DataType: (ptr8 Eq_52)
+  OrigDataType: (ptr8 (segment (C2 T_54 t00C2)))
 T_53: (in 0xC2 : byte)
   Class: Eq_53
   DataType: Eq_53
@@ -363,8 +363,8 @@ T_54: (in Mem39[0x00:0xC2:byte] : byte)
   OrigDataType: byte
 T_55: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_57 (T_9, T_56)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_57 (T_9, T_56)))
 T_56: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -375,8 +375,8 @@ T_57: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_58: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_60 (T_9, T_59)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_60 (T_9, T_59)))
 T_59: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -387,8 +387,8 @@ T_60: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_61: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_63 (T_9, T_62)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_63 (T_9, T_62)))
 T_62: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -399,8 +399,8 @@ T_63: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_64: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_66 (T_9, T_65)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_66 (T_9, T_65)))
 T_65: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -411,8 +411,8 @@ T_66: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_67: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_69 (T_9, T_68)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_69 (T_9, T_68)))
 T_68: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -423,8 +423,8 @@ T_69: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_70: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_72 (T_9, T_71)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_72 (T_9, T_71)))
 T_71: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -435,8 +435,8 @@ T_72: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_73: (in 0x00 : byte)
   Class: Eq_73
-  DataType: (ptr Eq_73)
-  OrigDataType: (ptr (segment (C3 T_75 t00C3)))
+  DataType: (ptr8 Eq_73)
+  OrigDataType: (ptr8 (segment (C3 T_75 t00C3)))
 T_74: (in 0xC3 : byte)
   Class: Eq_74
   DataType: Eq_74
@@ -447,8 +447,8 @@ T_75: (in Mem45[0x00:0xC3:byte] : byte)
   OrigDataType: byte
 T_76: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_78 (T_9, T_77)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_78 (T_9, T_77)))
 T_77: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -459,8 +459,8 @@ T_78: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_79: (in 0x00 : byte)
   Class: Eq_79
-  DataType: (ptr Eq_79)
-  OrigDataType: (ptr (segment (C4 T_81 t00C4)))
+  DataType: (ptr8 Eq_79)
+  OrigDataType: (ptr8 (segment (C4 T_81 t00C4)))
 T_80: (in 0xC4 : byte)
   Class: Eq_80
   DataType: Eq_80
@@ -471,8 +471,8 @@ T_81: (in Mem47[0x00:0xC4:byte] : byte)
   OrigDataType: byte
 T_82: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_84 (T_9, T_83)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_84 (T_9, T_83)))
 T_83: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -483,8 +483,8 @@ T_84: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_85: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_87 (T_9, T_86)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_87 (T_9, T_86)))
 T_86: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -495,8 +495,8 @@ T_87: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_88: (in 00C7 : ptr16)
   Class: Eq_88
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_91 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_91 t0000)))
 T_89: (in 0x0000 : word16)
   Class: Eq_89
   DataType: word16
@@ -511,8 +511,8 @@ T_91: (in Mem48[0x00C7 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_92: (in 00C8 : ptr16)
   Class: Eq_92
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_95 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_95 t0000)))
 T_93: (in 0x0000 : word16)
   Class: Eq_93
   DataType: word16
@@ -527,8 +527,8 @@ T_95: (in Mem49[0x00C8 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_96: (in 00C9 : ptr16)
   Class: Eq_96
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_99 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_99 t0000)))
 T_97: (in 0x0000 : word16)
   Class: Eq_97
   DataType: word16
@@ -543,8 +543,8 @@ T_99: (in Mem50[0x00C9 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_100: (in 0x00 : byte)
   Class: Eq_100
-  DataType: (ptr Eq_100)
-  OrigDataType: (ptr (segment (C3 T_102 t00C3)))
+  DataType: (ptr8 Eq_100)
+  OrigDataType: (ptr8 (segment (C3 T_102 t00C3)))
 T_101: (in 0xC3 : byte)
   Class: Eq_101
   DataType: Eq_101
@@ -555,8 +555,8 @@ T_102: (in Mem50[0x00:0xC3:byte] : byte)
   OrigDataType: byte
 T_103: (in 0x00 : byte)
   Class: Eq_103
-  DataType: (ptr Eq_103)
-  OrigDataType: (ptr (segment (C3 T_104 t00C3)))
+  DataType: (ptr8 Eq_103)
+  OrigDataType: (ptr8 (segment (C3 T_104 t00C3)))
 T_104: (in Mem55[0x00:0xC3:byte] : byte)
   Class: Eq_102
   DataType: byte
@@ -567,8 +567,8 @@ T_105: (in Z_57 : Eq_105)
   OrigDataType: (union (bool u1) (byte u0))
 T_106: (in 0x00 : byte)
   Class: Eq_106
-  DataType: (ptr Eq_106)
-  OrigDataType: (ptr (segment (C3 T_107 t00C3)))
+  DataType: (ptr8 Eq_106)
+  OrigDataType: (ptr8 (segment (C3 T_107 t00C3)))
 T_107: (in Mem55[0x00:0xC3:byte] : byte)
   Class: Eq_107
   DataType: byte
@@ -579,8 +579,8 @@ T_108: (in cond(0x00->b00C3) : byte)
   OrigDataType: byte
 T_109: (in 0x00 : byte)
   Class: Eq_109
-  DataType: (ptr Eq_109)
-  OrigDataType: (ptr (segment (C5 T_111 t00C5)))
+  DataType: (ptr8 Eq_109)
+  OrigDataType: (ptr8 (segment (C5 T_111 t00C5)))
 T_110: (in 0xC5 : byte)
   Class: Eq_110
   DataType: Eq_110
@@ -599,8 +599,8 @@ T_113: (in 0x00->b00C5 == 0x00 : bool)
   OrigDataType: bool
 T_114: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr Eq_13)
-  OrigDataType: (ptr (fn T_116 (T_9, T_115)))
+  DataType: (ptr32 Eq_13)
+  OrigDataType: (ptr32 (fn T_116 (T_9, T_115)))
 T_115: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -623,8 +623,8 @@ T_119: (in Mem67[FSR0 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_120: (in 0x00 : byte)
   Class: Eq_120
-  DataType: (ptr Eq_120)
-  OrigDataType: (ptr (segment (C3 T_122 t00C3)))
+  DataType: (ptr8 Eq_120)
+  OrigDataType: (ptr8 (segment (C3 T_122 t00C3)))
 T_121: (in 0xC3 : byte)
   Class: Eq_121
   DataType: Eq_121
@@ -643,24 +643,24 @@ T_124: (in 0x00->b00C3 - 0x01 : byte)
   OrigDataType: byte
 T_125: (in 0x00 : byte)
   Class: Eq_125
-  DataType: (ptr Eq_125)
-  OrigDataType: (ptr (segment (C3 T_126 t00C3)))
+  DataType: (ptr8 Eq_125)
+  OrigDataType: (ptr8 (segment (C3 T_126 t00C3)))
 T_126: (in Mem69[0x00:0xC3:byte] : byte)
   Class: Eq_124
   DataType: byte
   OrigDataType: byte
 T_127: (in 0x0001 : word16)
   Class: Eq_127
-  DataType: (ptr byte)
-  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
+  DataType: (ptr32 byte)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
 T_128: (in FSR0 + 0x0001 : word16)
   Class: Eq_8
   DataType: Eq_8
-  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
+  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
 T_129: (in 0x00 : byte)
   Class: Eq_129
-  DataType: (ptr Eq_129)
-  OrigDataType: (ptr (segment (C3 T_130 t00C3)))
+  DataType: (ptr8 Eq_129)
+  OrigDataType: (ptr8 (segment (C3 T_130 t00C3)))
 T_130: (in Mem69[0x00:0xC3:byte] : byte)
   Class: Eq_130
   DataType: cu8
@@ -683,8 +683,8 @@ T_134: (in 0x00->b00C3 < 0x00 : bool)
   OrigDataType: bool
 T_135: (in 0x00 : byte)
   Class: Eq_135
-  DataType: (ptr Eq_135)
-  OrigDataType: (ptr (segment (C4 T_137 t00C4)))
+  DataType: (ptr8 Eq_135)
+  OrigDataType: (ptr8 (segment (C4 T_137 t00C4)))
 T_136: (in 0xC4 : byte)
   Class: Eq_136
   DataType: Eq_136
@@ -695,16 +695,16 @@ T_137: (in Mem55[0x00:0xC4:byte] : byte)
   OrigDataType: byte
 T_138: (in 0x00 : byte)
   Class: Eq_138
-  DataType: (ptr Eq_138)
-  OrigDataType: (ptr (segment (C4 T_139 t00C4)))
+  DataType: (ptr8 Eq_138)
+  OrigDataType: (ptr8 (segment (C4 T_139 t00C4)))
 T_139: (in Mem76[0x00:0xC4:byte] : byte)
   Class: Eq_137
   DataType: byte
   OrigDataType: byte
 T_140: (in 0x00 : byte)
   Class: Eq_140
-  DataType: (ptr Eq_140)
-  OrigDataType: (ptr (segment (C4 T_141 t00C4)))
+  DataType: (ptr8 Eq_140)
+  OrigDataType: (ptr8 (segment (C4 T_141 t00C4)))
 T_141: (in Mem76[0x00:0xC4:byte] : byte)
   Class: Eq_141
   DataType: byte
@@ -719,8 +719,8 @@ T_143: (in 0x00->b00C4 == 0x00 : bool)
   OrigDataType: bool
 T_144: (in 00C7 : ptr16)
   Class: Eq_144
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_147 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_147 t0000)))
 T_145: (in 0x0000 : word16)
   Class: Eq_145
   DataType: word16
@@ -735,8 +735,8 @@ T_147: (in Mem76[0x00C7 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_148: (in 00C8 : ptr16)
   Class: Eq_148
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_151 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_151 t0000)))
 T_149: (in 0x0000 : word16)
   Class: Eq_149
   DataType: word16
@@ -751,8 +751,8 @@ T_151: (in Mem76[0x00C8 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_152: (in 00C9 : ptr16)
   Class: Eq_152
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_155 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_155 t0000)))
 T_153: (in 0x0000 : word16)
   Class: Eq_153
   DataType: word16
@@ -767,8 +767,8 @@ T_155: (in Mem76[0x00C9 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_156: (in 0x00 : byte)
   Class: Eq_156
-  DataType: (ptr Eq_156)
-  OrigDataType: (ptr (segment (C5 T_158 t00C5)))
+  DataType: (ptr8 Eq_156)
+  OrigDataType: (ptr8 (segment (C5 T_158 t00C5)))
 T_157: (in 0xC5 : byte)
   Class: Eq_157
   DataType: Eq_157
@@ -787,16 +787,16 @@ T_160: (in 0x00->b00C5 - 0x01 : byte)
   OrigDataType: byte
 T_161: (in 0x00 : byte)
   Class: Eq_161
-  DataType: (ptr Eq_161)
-  OrigDataType: (ptr (segment (C5 T_162 t00C5)))
+  DataType: (ptr8 Eq_161)
+  OrigDataType: (ptr8 (segment (C5 T_162 t00C5)))
 T_162: (in Mem83[0x00:0xC5:byte] : byte)
   Class: Eq_160
   DataType: byte
   OrigDataType: byte
 T_163: (in 0x00 : byte)
   Class: Eq_163
-  DataType: (ptr Eq_163)
-  OrigDataType: (ptr (segment (C6 T_165 t00C6)))
+  DataType: (ptr8 Eq_163)
+  OrigDataType: (ptr8 (segment (C6 T_165 t00C6)))
 T_164: (in 0xC6 : byte)
   Class: Eq_164
   DataType: Eq_164
@@ -807,8 +807,8 @@ T_165: (in Mem83[0x00:0xC6:byte] : byte)
   OrigDataType: byte
 T_166: (in 0x00 : byte)
   Class: Eq_166
-  DataType: (ptr Eq_166)
-  OrigDataType: (ptr (segment (C5 T_167 t00C5)))
+  DataType: (ptr8 Eq_166)
+  OrigDataType: (ptr8 (segment (C5 T_167 t00C5)))
 T_167: (in Mem83[0x00:0xC5:byte] : byte)
   Class: Eq_167
   DataType: byte
@@ -827,16 +827,16 @@ T_170: (in 0x00->b00C6 - !cond(0x00->b00C5) : byte)
   OrigDataType: byte
 T_171: (in 0x00 : byte)
   Class: Eq_171
-  DataType: (ptr Eq_171)
-  OrigDataType: (ptr (segment (C6 T_172 t00C6)))
+  DataType: (ptr8 Eq_171)
+  OrigDataType: (ptr8 (segment (C6 T_172 t00C6)))
 T_172: (in Mem87[0x00:0xC6:byte] : byte)
   Class: Eq_170
   DataType: byte
   OrigDataType: byte
 T_173: (in 0x00 : byte)
   Class: Eq_173
-  DataType: (ptr Eq_173)
-  OrigDataType: (ptr (segment (C6 T_174 t00C6)))
+  DataType: (ptr8 Eq_173)
+  OrigDataType: (ptr8 (segment (C6 T_174 t00C6)))
 T_174: (in Mem87[0x00:0xC6:byte] : byte)
   Class: Eq_174
   DataType: byte
@@ -847,8 +847,8 @@ T_175: (in cond(0x00->b00C6) : byte)
   OrigDataType: byte
 T_176: (in 0x00 : byte)
   Class: Eq_176
-  DataType: (ptr Eq_176)
-  OrigDataType: (ptr (segment (C4 T_178 t00C4)))
+  DataType: (ptr8 Eq_176)
+  OrigDataType: (ptr8 (segment (C4 T_178 t00C4)))
 T_177: (in 0xC4 : byte)
   Class: Eq_177
   DataType: Eq_177
@@ -867,8 +867,8 @@ T_180: (in 0x00->b00C4 - 0x01 : byte)
   OrigDataType: byte
 T_181: (in 0x00 : byte)
   Class: Eq_181
-  DataType: (ptr Eq_181)
-  OrigDataType: (ptr (segment (C4 T_182 t00C4)))
+  DataType: (ptr8 Eq_181)
+  OrigDataType: (ptr8 (segment (C4 T_182 t00C4)))
 T_182: (in Mem74[0x00:0xC4:byte] : byte)
   Class: Eq_180
   DataType: byte
@@ -885,10 +885,10 @@ T_185: (in FSR2 : ptr16)
   Class: Eq_185
   DataType: ptr16
   OrigDataType: ptr16
-T_186: (in FSR1 : (ptr byte))
+T_186: (in FSR1 : (ptr16 byte))
   Class: Eq_186
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_189 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_189 t0000)))
 T_187: (in 0x0000 : word16)
   Class: Eq_187
   DataType: word16
@@ -903,8 +903,8 @@ T_189: (in Mem3[FSR1 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_190: (in 0x00 : byte)
   Class: Eq_190
-  DataType: (ptr Eq_190)
-  OrigDataType: (ptr (segment (CA T_192 t00CA)))
+  DataType: (ptr8 Eq_190)
+  OrigDataType: (ptr8 (segment (CA T_192 t00CA)))
 T_191: (in 0xCA : byte)
   Class: Eq_191
   DataType: Eq_191
@@ -931,8 +931,8 @@ T_196: (in (0x00->b00CA & 0x01) != 0x00 : bool)
   OrigDataType: bool
 T_197: (in 0x00 : byte)
   Class: Eq_197
-  DataType: (ptr Eq_197)
-  OrigDataType: (ptr (segment (CA T_199 t00CA)))
+  DataType: (ptr8 Eq_197)
+  OrigDataType: (ptr8 (segment (CA T_199 t00CA)))
 T_198: (in 0xCA : byte)
   Class: Eq_198
   DataType: Eq_198
@@ -951,8 +951,8 @@ T_201: (in 0x00->b00CA & 0xFE : byte)
   OrigDataType: byte
 T_202: (in 0x00 : byte)
   Class: Eq_202
-  DataType: (ptr Eq_202)
-  OrigDataType: (ptr (segment (CA T_203 t00CA)))
+  DataType: (ptr8 Eq_202)
+  OrigDataType: (ptr8 (segment (CA T_203 t00CA)))
 T_203: (in Mem22[0x00:0xCA:byte] : byte)
   Class: Eq_201
   DataType: byte
@@ -979,8 +979,8 @@ T_208: (in 0x02 : byte)
   OrigDataType: (union (ui16 u0) (byte u1))
 T_209: (in FSR2 - 0x02 : word16)
   Class: Eq_209
-  DataType: (ptr byte)
-  OrigDataType: (ptr (struct (0 T_212 t0000)))
+  DataType: (ptr16 byte)
+  OrigDataType: (ptr16 (struct (0 T_212 t0000)))
 T_210: (in 0x0000 : word16)
   Class: Eq_210
   DataType: word16
@@ -1056,11 +1056,11 @@ T_227: (in Mem20[FSR0 + 0x0000:byte] : byte)
 T_228: (in 0x0001 : word16)
   Class: Eq_228
   DataType: word16
-  OrigDataType: (union (word16 u2) ((ptr byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
 T_229: (in FSR0 + 0x0001 : word16)
   Class: Eq_222
   DataType: Eq_222
-  OrigDataType: (union (word16 u2) ((ptr byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
 T_230: (in 0x00 : byte)
   Class: Eq_230
   DataType: byte
@@ -1072,7 +1072,7 @@ T_231: (in 0x0000 : word16)
 T_232: (in FSR0 + 0x0000 : word16)
   Class: Eq_232
   DataType: Eq_232
-  OrigDataType: (union (word16 u2) ((ptr byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
 T_233: (in Mem17[FSR0 + 0x0000:byte] : byte)
   Class: Eq_230
   DataType: Eq_222
@@ -1080,11 +1080,11 @@ T_233: (in Mem17[FSR0 + 0x0000:byte] : byte)
 T_234: (in 0x0001 : word16)
   Class: Eq_234
   DataType: word16
-  OrigDataType: (union (word16 u2) ((ptr byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
 T_235: (in FSR0 + 0x0001 : word16)
   Class: Eq_222
   DataType: Eq_222
-  OrigDataType: (union (word16 u2) ((ptr byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
 T_236: (in PRODL : byte)
   Class: Eq_220
   DataType: cu8
@@ -1113,14 +1113,14 @@ typedef struct Globals {
 	byte b00C9;	// C9
 } Eq_1;
 
-typedef void (Eq_6)(Eq_8, word32);
+typedef void (Eq_6)(Eq_8, word24);
 
 typedef union Eq_8 {
 	word16 u0;
 	byte * u1;
 } Eq_8;
 
-typedef void (Eq_13)(word32, byte);
+typedef void (Eq_13)(word24, byte);
 
 typedef struct Eq_20 {
 	byte b00C5;	// C5

--- a/subjects/Microchip/C18/PIC18Extd/PIC18EggExtd.h
+++ b/subjects/Microchip/C18/PIC18Extd/PIC18EggExtd.h
@@ -5,11 +5,11 @@
 /*
 // Equivalence classes ////////////
 Eq_1: (struct "Globals" (1 byte b0001) (C7 byte b00C7) (C8 byte b00C8) (C9 byte b00C9))
-	globals_t (in globals : (ptr32 (struct "Globals")))
+	globals_t (in globals : (ptr (struct "Globals")))
 Eq_6: (fn void (Eq_8, word32))
 	T_6 (in fn00000E : ptr32)
 	T_7 (in signature of fn00000E : void)
-Eq_8: (union "Eq_8" (word16 u0) ((ptr32 byte) u1))
+Eq_8: (union "Eq_8" (word16 u0) ((ptr byte) u1))
 	T_8 (in FSR0 : Eq_8)
 	T_10 (in 0x0000 : word16)
 	T_128 (in FSR0 + 0x0001 : word16)
@@ -32,11 +32,11 @@ Eq_13: (fn void (word32, byte))
 	T_114 (in __tblrd : ptr32)
 Eq_20: (segment "Eq_20" (C5 byte b00C5))
 	T_20 (in 0x00 : byte)
-Eq_21: (union "Eq_21" (byte u0) ((memptr (ptr8 Eq_20) byte) u1))
+Eq_21: (union "Eq_21" (byte u0) ((memptr (ptr Eq_20) byte) u1))
 	T_21 (in 0xC5 : byte)
 Eq_26: (segment "Eq_26" (C6 byte b00C6))
 	T_26 (in 0x00 : byte)
-Eq_27: (union "Eq_27" (byte u0) ((memptr (ptr8 Eq_26) byte) u1))
+Eq_27: (union "Eq_27" (byte u0) ((memptr (ptr Eq_26) byte) u1))
 	T_27 (in 0xC6 : byte)
 Eq_35: (union "Eq_35" (byte u0) (Eq_239 u1))
 	T_35 (in Z_15 : Eq_35)
@@ -44,27 +44,27 @@ Eq_35: (union "Eq_35" (byte u0) (Eq_239 u1))
 	T_175 (in cond(0x00->b00C6) : byte)
 Eq_40: (segment "Eq_40" (C0 byte b00C0))
 	T_40 (in 0x00 : byte)
-Eq_41: (union "Eq_41" (byte u0) ((memptr (ptr8 Eq_40) byte) u1))
+Eq_41: (union "Eq_41" (byte u0) ((memptr (ptr Eq_40) byte) u1))
 	T_41 (in 0xC0 : byte)
 Eq_46: (segment "Eq_46" (C1 byte b00C1))
 	T_46 (in 0x00 : byte)
-Eq_47: (union "Eq_47" (byte u0) ((memptr (ptr8 Eq_46) byte) u1))
+Eq_47: (union "Eq_47" (byte u0) ((memptr (ptr Eq_46) byte) u1))
 	T_47 (in 0xC1 : byte)
 Eq_52: (segment "Eq_52" (C2 byte b00C2))
 	T_52 (in 0x00 : byte)
-Eq_53: (union "Eq_53" (byte u0) ((memptr (ptr8 Eq_52) byte) u1))
+Eq_53: (union "Eq_53" (byte u0) ((memptr (ptr Eq_52) byte) u1))
 	T_53 (in 0xC2 : byte)
 Eq_73: (segment "Eq_73" (C3 byte b00C3))
 	T_73 (in 0x00 : byte)
-Eq_74: (union "Eq_74" (byte u0) ((memptr (ptr8 Eq_73) byte) u1))
+Eq_74: (union "Eq_74" (byte u0) ((memptr (ptr Eq_73) byte) u1))
 	T_74 (in 0xC3 : byte)
 Eq_79: (segment "Eq_79" (C4 byte b00C4))
 	T_79 (in 0x00 : byte)
-Eq_80: (union "Eq_80" (byte u0) ((memptr (ptr8 Eq_79) byte) u1))
+Eq_80: (union "Eq_80" (byte u0) ((memptr (ptr Eq_79) byte) u1))
 	T_80 (in 0xC4 : byte)
 Eq_100: (segment "Eq_100" (C3 byte b00C3))
 	T_100 (in 0x00 : byte)
-Eq_101: (union "Eq_101" (byte u0) ((memptr (ptr8 Eq_100) byte) u1) ((memptr (ptr8 Eq_103) byte) u2) ((memptr (ptr8 Eq_106) byte) u3))
+Eq_101: (union "Eq_101" (byte u0) ((memptr (ptr Eq_100) byte) u1) ((memptr (ptr Eq_103) byte) u2) ((memptr (ptr Eq_106) byte) u3))
 	T_101 (in 0xC3 : byte)
 Eq_103: (segment "Eq_103" (C3 byte b00C3))
 	T_103 (in 0x00 : byte)
@@ -76,11 +76,11 @@ Eq_106: (segment "Eq_106" (C3 byte b00C3))
 	T_106 (in 0x00 : byte)
 Eq_109: (segment "Eq_109" (C5 byte b00C5))
 	T_109 (in 0x00 : byte)
-Eq_110: (union "Eq_110" (byte u0) ((memptr (ptr8 Eq_109) byte) u1))
+Eq_110: (union "Eq_110" (byte u0) ((memptr (ptr Eq_109) byte) u1))
 	T_110 (in 0xC5 : byte)
 Eq_120: (segment "Eq_120" (C3 byte b00C3))
 	T_120 (in 0x00 : byte)
-Eq_121: (union "Eq_121" (byte u0) ((memptr (ptr8 Eq_120) byte) u1) ((memptr (ptr8 Eq_125) byte) u2) ((memptr (ptr8 Eq_129) cu8) u3))
+Eq_121: (union "Eq_121" (byte u0) ((memptr (ptr Eq_120) byte) u1) ((memptr (ptr Eq_125) byte) u2) ((memptr (ptr Eq_129) cu8) u3))
 	T_121 (in 0xC3 : byte)
 Eq_125: (segment "Eq_125" (C3 byte b00C3))
 	T_125 (in 0x00 : byte)
@@ -88,7 +88,7 @@ Eq_129: (segment "Eq_129" (C3 cu8 b00C3))
 	T_129 (in 0x00 : byte)
 Eq_135: (segment "Eq_135" (C4 byte b00C4))
 	T_135 (in 0x00 : byte)
-Eq_136: (union "Eq_136" (byte u0) ((memptr (ptr8 Eq_135) byte) u1) ((memptr (ptr8 Eq_138) byte) u2) ((memptr (ptr8 Eq_140) byte) u3))
+Eq_136: (union "Eq_136" (byte u0) ((memptr (ptr Eq_135) byte) u1) ((memptr (ptr Eq_138) byte) u2) ((memptr (ptr Eq_140) byte) u3))
 	T_136 (in 0xC4 : byte)
 Eq_138: (segment "Eq_138" (C4 byte b00C4))
 	T_138 (in 0x00 : byte)
@@ -96,13 +96,13 @@ Eq_140: (segment "Eq_140" (C4 byte b00C4))
 	T_140 (in 0x00 : byte)
 Eq_156: (segment "Eq_156" (C5 byte b00C5))
 	T_156 (in 0x00 : byte)
-Eq_157: (union "Eq_157" (byte u0) ((memptr (ptr8 Eq_156) byte) u1) ((memptr (ptr8 Eq_161) byte) u2) ((memptr (ptr8 Eq_166) byte) u3))
+Eq_157: (union "Eq_157" (byte u0) ((memptr (ptr Eq_156) byte) u1) ((memptr (ptr Eq_161) byte) u2) ((memptr (ptr Eq_166) byte) u3))
 	T_157 (in 0xC5 : byte)
 Eq_161: (segment "Eq_161" (C5 byte b00C5))
 	T_161 (in 0x00 : byte)
 Eq_163: (segment "Eq_163" (C6 byte b00C6))
 	T_163 (in 0x00 : byte)
-Eq_164: (union "Eq_164" (byte u0) ((memptr (ptr8 Eq_163) byte) u1) ((memptr (ptr8 Eq_171) byte) u2) ((memptr (ptr8 Eq_173) byte) u3))
+Eq_164: (union "Eq_164" (byte u0) ((memptr (ptr Eq_163) byte) u1) ((memptr (ptr Eq_171) byte) u2) ((memptr (ptr Eq_173) byte) u3))
 	T_164 (in 0xC6 : byte)
 Eq_166: (segment "Eq_166" (C5 byte b00C5))
 	T_166 (in 0x00 : byte)
@@ -112,31 +112,31 @@ Eq_173: (segment "Eq_173" (C6 byte b00C6))
 	T_173 (in 0x00 : byte)
 Eq_176: (segment "Eq_176" (C4 byte b00C4))
 	T_176 (in 0x00 : byte)
-Eq_177: (union "Eq_177" (byte u0) ((memptr (ptr8 Eq_176) byte) u1) ((memptr (ptr8 Eq_181) byte) u2))
+Eq_177: (union "Eq_177" (byte u0) ((memptr (ptr Eq_176) byte) u1) ((memptr (ptr Eq_181) byte) u2))
 	T_177 (in 0xC4 : byte)
 Eq_181: (segment "Eq_181" (C4 byte b00C4))
 	T_181 (in 0x00 : byte)
 Eq_190: (segment "Eq_190" (CA byte b00CA))
 	T_190 (in 0x00 : byte)
-Eq_191: (union "Eq_191" (byte u0) ((memptr (ptr8 Eq_190) byte) u1))
+Eq_191: (union "Eq_191" (byte u0) ((memptr (ptr Eq_190) byte) u1))
 	T_191 (in 0xCA : byte)
 Eq_197: (segment "Eq_197" (CA byte b00CA))
 	T_197 (in 0x00 : byte)
-Eq_198: (union "Eq_198" (byte u0) ((memptr (ptr8 Eq_197) byte) u1) ((memptr (ptr8 Eq_202) byte) u2))
+Eq_198: (union "Eq_198" (byte u0) ((memptr (ptr Eq_197) byte) u1) ((memptr (ptr Eq_202) byte) u2))
 	T_198 (in 0xCA : byte)
 Eq_202: (segment "Eq_202" (CA byte b00CA))
 	T_202 (in 0x00 : byte)
 Eq_208: (union "Eq_208" (ui16 u0) (byte u1))
 	T_208 (in 0x02 : byte)
-Eq_222: (union "Eq_222" (word16 u0) ((ptr32 byte) u1))
+Eq_222: (union "Eq_222" (word16 u0) ((ptr byte) u1))
 	T_222 (in FSR0 : Eq_222)
 	T_229 (in FSR0 + 0x0001 : word16)
 	T_235 (in FSR0 + 0x0001 : word16)
-Eq_228: (union "Eq_228" (word16 u0) ((ptr32 byte) u1))
+Eq_228: (union "Eq_228" (word16 u0) ((ptr byte) u1))
 	T_228 (in 0x0001 : word16)
-Eq_232: (union "Eq_232" (word16 u0) ((ptr32 byte) u1))
+Eq_232: (union "Eq_232" (word16 u0) ((ptr byte) u1))
 	T_232 (in FSR0 + 0x0000 : word16)
-Eq_234: (union "Eq_234" (word16 u0) ((ptr32 byte) u1))
+Eq_234: (union "Eq_234" (word16 u0) ((ptr byte) u1))
 	T_234 (in 0x0001 : word16)
 Eq_238: (struct "Eq_238" 0001 (0 ptr32 ptr0000))
 	T_238
@@ -145,18 +145,18 @@ Eq_239: (union "Eq_239" (bool u0) (byte u1))
 Eq_240: (union "Eq_240" (bool u0) (byte u1))
 	T_240
 // Type Variables ////////////
-globals_t: (in globals : (ptr32 (struct "Globals")))
+globals_t: (in globals : (ptr (struct "Globals")))
   Class: Eq_1
-  DataType: (ptr32 Eq_1)
-  OrigDataType: (ptr32 (struct "Globals"))
+  DataType: (ptr Eq_1)
+  OrigDataType: (ptr (struct "Globals"))
 T_2: (in 000148 : ptr32)
   Class: Eq_2
   DataType: ptr32
   OrigDataType: ptr32
 T_3: (in Stack : (arr Eq_238))
   Class: Eq_3
-  DataType: (ptr32 (arr Eq_238))
-  OrigDataType: (ptr32 (struct (0 (arr T_238) a0000)))
+  DataType: (ptr (arr Eq_238))
+  OrigDataType: (ptr (struct (0 (arr T_238) a0000)))
 T_4: (in 0x01 : byte)
   Class: Eq_4
   DataType: byte
@@ -167,16 +167,16 @@ T_5: (in Stack[0x01] : ptr32)
   OrigDataType: ptr32
 T_6: (in fn00000E : ptr32)
   Class: Eq_6
-  DataType: (ptr32 Eq_6)
-  OrigDataType: (ptr32 (fn T_12 (T_10, T_11)))
+  DataType: (ptr Eq_6)
+  OrigDataType: (ptr (fn T_12 (T_10, T_11)))
 T_7: (in signature of fn00000E : void)
   Class: Eq_6
-  DataType: (ptr32 Eq_6)
+  DataType: (ptr Eq_6)
   OrigDataType: 
 T_8: (in FSR0 : Eq_8)
   Class: Eq_8
   DataType: Eq_8
-  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
+  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
 T_9: (in TBLPTR : word32)
   Class: Eq_9
   DataType: word32
@@ -195,11 +195,11 @@ T_12: (in fn00000E(0x0000, 0x00000000) : void)
   OrigDataType: void
 T_13: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_18 (T_9, T_17)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_18 (T_9, T_17)))
 T_14: (in signature of __tblrd : void)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
+  DataType: (ptr Eq_13)
   OrigDataType: 
 T_15: (in  : word32)
   Class: Eq_9
@@ -223,8 +223,8 @@ T_19: (in TABLAT : byte)
   OrigDataType: byte
 T_20: (in 0x00 : byte)
   Class: Eq_20
-  DataType: (ptr8 Eq_20)
-  OrigDataType: (ptr8 (segment (C5 T_22 t00C5)))
+  DataType: (ptr Eq_20)
+  OrigDataType: (ptr (segment (C5 T_22 t00C5)))
 T_21: (in 0xC5 : byte)
   Class: Eq_21
   DataType: Eq_21
@@ -235,8 +235,8 @@ T_22: (in Mem12[0x00:0xC5:byte] : byte)
   OrigDataType: byte
 T_23: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_25 (T_9, T_24)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_25 (T_9, T_24)))
 T_24: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -247,8 +247,8 @@ T_25: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_26: (in 0x00 : byte)
   Class: Eq_26
-  DataType: (ptr8 Eq_26)
-  OrigDataType: (ptr8 (segment (C6 T_28 t00C6)))
+  DataType: (ptr Eq_26)
+  OrigDataType: (ptr (segment (C6 T_28 t00C6)))
 T_27: (in 0xC6 : byte)
   Class: Eq_27
   DataType: Eq_27
@@ -291,8 +291,8 @@ T_36: (in cond(TABLAT) : byte)
   OrigDataType: byte
 T_37: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_39 (T_9, T_38)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_39 (T_9, T_38)))
 T_38: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -303,8 +303,8 @@ T_39: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_40: (in 0x00 : byte)
   Class: Eq_40
-  DataType: (ptr8 Eq_40)
-  OrigDataType: (ptr8 (segment (C0 T_42 t00C0)))
+  DataType: (ptr Eq_40)
+  OrigDataType: (ptr (segment (C0 T_42 t00C0)))
 T_41: (in 0xC0 : byte)
   Class: Eq_41
   DataType: Eq_41
@@ -315,8 +315,8 @@ T_42: (in Mem35[0x00:0xC0:byte] : byte)
   OrigDataType: byte
 T_43: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_45 (T_9, T_44)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_45 (T_9, T_44)))
 T_44: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -327,8 +327,8 @@ T_45: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_46: (in 0x00 : byte)
   Class: Eq_46
-  DataType: (ptr8 Eq_46)
-  OrigDataType: (ptr8 (segment (C1 T_48 t00C1)))
+  DataType: (ptr Eq_46)
+  OrigDataType: (ptr (segment (C1 T_48 t00C1)))
 T_47: (in 0xC1 : byte)
   Class: Eq_47
   DataType: Eq_47
@@ -339,8 +339,8 @@ T_48: (in Mem37[0x00:0xC1:byte] : byte)
   OrigDataType: byte
 T_49: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_51 (T_9, T_50)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_51 (T_9, T_50)))
 T_50: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -351,8 +351,8 @@ T_51: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_52: (in 0x00 : byte)
   Class: Eq_52
-  DataType: (ptr8 Eq_52)
-  OrigDataType: (ptr8 (segment (C2 T_54 t00C2)))
+  DataType: (ptr Eq_52)
+  OrigDataType: (ptr (segment (C2 T_54 t00C2)))
 T_53: (in 0xC2 : byte)
   Class: Eq_53
   DataType: Eq_53
@@ -363,8 +363,8 @@ T_54: (in Mem39[0x00:0xC2:byte] : byte)
   OrigDataType: byte
 T_55: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_57 (T_9, T_56)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_57 (T_9, T_56)))
 T_56: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -375,8 +375,8 @@ T_57: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_58: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_60 (T_9, T_59)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_60 (T_9, T_59)))
 T_59: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -387,8 +387,8 @@ T_60: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_61: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_63 (T_9, T_62)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_63 (T_9, T_62)))
 T_62: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -399,8 +399,8 @@ T_63: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_64: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_66 (T_9, T_65)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_66 (T_9, T_65)))
 T_65: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -411,8 +411,8 @@ T_66: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_67: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_69 (T_9, T_68)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_69 (T_9, T_68)))
 T_68: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -423,8 +423,8 @@ T_69: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_70: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_72 (T_9, T_71)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_72 (T_9, T_71)))
 T_71: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -435,8 +435,8 @@ T_72: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_73: (in 0x00 : byte)
   Class: Eq_73
-  DataType: (ptr8 Eq_73)
-  OrigDataType: (ptr8 (segment (C3 T_75 t00C3)))
+  DataType: (ptr Eq_73)
+  OrigDataType: (ptr (segment (C3 T_75 t00C3)))
 T_74: (in 0xC3 : byte)
   Class: Eq_74
   DataType: Eq_74
@@ -447,8 +447,8 @@ T_75: (in Mem45[0x00:0xC3:byte] : byte)
   OrigDataType: byte
 T_76: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_78 (T_9, T_77)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_78 (T_9, T_77)))
 T_77: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -459,8 +459,8 @@ T_78: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_79: (in 0x00 : byte)
   Class: Eq_79
-  DataType: (ptr8 Eq_79)
-  OrigDataType: (ptr8 (segment (C4 T_81 t00C4)))
+  DataType: (ptr Eq_79)
+  OrigDataType: (ptr (segment (C4 T_81 t00C4)))
 T_80: (in 0xC4 : byte)
   Class: Eq_80
   DataType: Eq_80
@@ -471,8 +471,8 @@ T_81: (in Mem47[0x00:0xC4:byte] : byte)
   OrigDataType: byte
 T_82: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_84 (T_9, T_83)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_84 (T_9, T_83)))
 T_83: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -483,8 +483,8 @@ T_84: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_85: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_87 (T_9, T_86)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_87 (T_9, T_86)))
 T_86: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -495,8 +495,8 @@ T_87: (in __tblrd(TBLPTR, 0x01) : void)
   OrigDataType: void
 T_88: (in 00C7 : ptr16)
   Class: Eq_88
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_91 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_91 t0000)))
 T_89: (in 0x0000 : word16)
   Class: Eq_89
   DataType: word16
@@ -511,8 +511,8 @@ T_91: (in Mem48[0x00C7 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_92: (in 00C8 : ptr16)
   Class: Eq_92
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_95 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_95 t0000)))
 T_93: (in 0x0000 : word16)
   Class: Eq_93
   DataType: word16
@@ -527,8 +527,8 @@ T_95: (in Mem49[0x00C8 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_96: (in 00C9 : ptr16)
   Class: Eq_96
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_99 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_99 t0000)))
 T_97: (in 0x0000 : word16)
   Class: Eq_97
   DataType: word16
@@ -543,8 +543,8 @@ T_99: (in Mem50[0x00C9 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_100: (in 0x00 : byte)
   Class: Eq_100
-  DataType: (ptr8 Eq_100)
-  OrigDataType: (ptr8 (segment (C3 T_102 t00C3)))
+  DataType: (ptr Eq_100)
+  OrigDataType: (ptr (segment (C3 T_102 t00C3)))
 T_101: (in 0xC3 : byte)
   Class: Eq_101
   DataType: Eq_101
@@ -555,8 +555,8 @@ T_102: (in Mem50[0x00:0xC3:byte] : byte)
   OrigDataType: byte
 T_103: (in 0x00 : byte)
   Class: Eq_103
-  DataType: (ptr8 Eq_103)
-  OrigDataType: (ptr8 (segment (C3 T_104 t00C3)))
+  DataType: (ptr Eq_103)
+  OrigDataType: (ptr (segment (C3 T_104 t00C3)))
 T_104: (in Mem55[0x00:0xC3:byte] : byte)
   Class: Eq_102
   DataType: byte
@@ -567,8 +567,8 @@ T_105: (in Z_57 : Eq_105)
   OrigDataType: (union (bool u1) (byte u0))
 T_106: (in 0x00 : byte)
   Class: Eq_106
-  DataType: (ptr8 Eq_106)
-  OrigDataType: (ptr8 (segment (C3 T_107 t00C3)))
+  DataType: (ptr Eq_106)
+  OrigDataType: (ptr (segment (C3 T_107 t00C3)))
 T_107: (in Mem55[0x00:0xC3:byte] : byte)
   Class: Eq_107
   DataType: byte
@@ -579,8 +579,8 @@ T_108: (in cond(0x00->b00C3) : byte)
   OrigDataType: byte
 T_109: (in 0x00 : byte)
   Class: Eq_109
-  DataType: (ptr8 Eq_109)
-  OrigDataType: (ptr8 (segment (C5 T_111 t00C5)))
+  DataType: (ptr Eq_109)
+  OrigDataType: (ptr (segment (C5 T_111 t00C5)))
 T_110: (in 0xC5 : byte)
   Class: Eq_110
   DataType: Eq_110
@@ -599,8 +599,8 @@ T_113: (in 0x00->b00C5 == 0x00 : bool)
   OrigDataType: bool
 T_114: (in __tblrd : ptr32)
   Class: Eq_13
-  DataType: (ptr32 Eq_13)
-  OrigDataType: (ptr32 (fn T_116 (T_9, T_115)))
+  DataType: (ptr Eq_13)
+  OrigDataType: (ptr (fn T_116 (T_9, T_115)))
 T_115: (in 0x01 : byte)
   Class: Eq_16
   DataType: byte
@@ -623,8 +623,8 @@ T_119: (in Mem67[FSR0 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_120: (in 0x00 : byte)
   Class: Eq_120
-  DataType: (ptr8 Eq_120)
-  OrigDataType: (ptr8 (segment (C3 T_122 t00C3)))
+  DataType: (ptr Eq_120)
+  OrigDataType: (ptr (segment (C3 T_122 t00C3)))
 T_121: (in 0xC3 : byte)
   Class: Eq_121
   DataType: Eq_121
@@ -643,24 +643,24 @@ T_124: (in 0x00->b00C3 - 0x01 : byte)
   OrigDataType: byte
 T_125: (in 0x00 : byte)
   Class: Eq_125
-  DataType: (ptr8 Eq_125)
-  OrigDataType: (ptr8 (segment (C3 T_126 t00C3)))
+  DataType: (ptr Eq_125)
+  OrigDataType: (ptr (segment (C3 T_126 t00C3)))
 T_126: (in Mem69[0x00:0xC3:byte] : byte)
   Class: Eq_124
   DataType: byte
   OrigDataType: byte
 T_127: (in 0x0001 : word16)
   Class: Eq_127
-  DataType: (ptr32 byte)
-  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
+  DataType: (ptr byte)
+  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
 T_128: (in FSR0 + 0x0001 : word16)
   Class: Eq_8
   DataType: Eq_8
-  OrigDataType: (union ((ptr32 (struct 0001 (0 byte b0000))) u0) ((ptr32 byte) u1))
+  OrigDataType: (union ((ptr (struct 0001 (0 byte b0000))) u0) ((ptr byte) u1))
 T_129: (in 0x00 : byte)
   Class: Eq_129
-  DataType: (ptr8 Eq_129)
-  OrigDataType: (ptr8 (segment (C3 T_130 t00C3)))
+  DataType: (ptr Eq_129)
+  OrigDataType: (ptr (segment (C3 T_130 t00C3)))
 T_130: (in Mem69[0x00:0xC3:byte] : byte)
   Class: Eq_130
   DataType: cu8
@@ -683,8 +683,8 @@ T_134: (in 0x00->b00C3 < 0x00 : bool)
   OrigDataType: bool
 T_135: (in 0x00 : byte)
   Class: Eq_135
-  DataType: (ptr8 Eq_135)
-  OrigDataType: (ptr8 (segment (C4 T_137 t00C4)))
+  DataType: (ptr Eq_135)
+  OrigDataType: (ptr (segment (C4 T_137 t00C4)))
 T_136: (in 0xC4 : byte)
   Class: Eq_136
   DataType: Eq_136
@@ -695,16 +695,16 @@ T_137: (in Mem55[0x00:0xC4:byte] : byte)
   OrigDataType: byte
 T_138: (in 0x00 : byte)
   Class: Eq_138
-  DataType: (ptr8 Eq_138)
-  OrigDataType: (ptr8 (segment (C4 T_139 t00C4)))
+  DataType: (ptr Eq_138)
+  OrigDataType: (ptr (segment (C4 T_139 t00C4)))
 T_139: (in Mem76[0x00:0xC4:byte] : byte)
   Class: Eq_137
   DataType: byte
   OrigDataType: byte
 T_140: (in 0x00 : byte)
   Class: Eq_140
-  DataType: (ptr8 Eq_140)
-  OrigDataType: (ptr8 (segment (C4 T_141 t00C4)))
+  DataType: (ptr Eq_140)
+  OrigDataType: (ptr (segment (C4 T_141 t00C4)))
 T_141: (in Mem76[0x00:0xC4:byte] : byte)
   Class: Eq_141
   DataType: byte
@@ -719,8 +719,8 @@ T_143: (in 0x00->b00C4 == 0x00 : bool)
   OrigDataType: bool
 T_144: (in 00C7 : ptr16)
   Class: Eq_144
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_147 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_147 t0000)))
 T_145: (in 0x0000 : word16)
   Class: Eq_145
   DataType: word16
@@ -735,8 +735,8 @@ T_147: (in Mem76[0x00C7 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_148: (in 00C8 : ptr16)
   Class: Eq_148
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_151 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_151 t0000)))
 T_149: (in 0x0000 : word16)
   Class: Eq_149
   DataType: word16
@@ -751,8 +751,8 @@ T_151: (in Mem76[0x00C8 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_152: (in 00C9 : ptr16)
   Class: Eq_152
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_155 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_155 t0000)))
 T_153: (in 0x0000 : word16)
   Class: Eq_153
   DataType: word16
@@ -767,8 +767,8 @@ T_155: (in Mem76[0x00C9 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_156: (in 0x00 : byte)
   Class: Eq_156
-  DataType: (ptr8 Eq_156)
-  OrigDataType: (ptr8 (segment (C5 T_158 t00C5)))
+  DataType: (ptr Eq_156)
+  OrigDataType: (ptr (segment (C5 T_158 t00C5)))
 T_157: (in 0xC5 : byte)
   Class: Eq_157
   DataType: Eq_157
@@ -787,16 +787,16 @@ T_160: (in 0x00->b00C5 - 0x01 : byte)
   OrigDataType: byte
 T_161: (in 0x00 : byte)
   Class: Eq_161
-  DataType: (ptr8 Eq_161)
-  OrigDataType: (ptr8 (segment (C5 T_162 t00C5)))
+  DataType: (ptr Eq_161)
+  OrigDataType: (ptr (segment (C5 T_162 t00C5)))
 T_162: (in Mem83[0x00:0xC5:byte] : byte)
   Class: Eq_160
   DataType: byte
   OrigDataType: byte
 T_163: (in 0x00 : byte)
   Class: Eq_163
-  DataType: (ptr8 Eq_163)
-  OrigDataType: (ptr8 (segment (C6 T_165 t00C6)))
+  DataType: (ptr Eq_163)
+  OrigDataType: (ptr (segment (C6 T_165 t00C6)))
 T_164: (in 0xC6 : byte)
   Class: Eq_164
   DataType: Eq_164
@@ -807,8 +807,8 @@ T_165: (in Mem83[0x00:0xC6:byte] : byte)
   OrigDataType: byte
 T_166: (in 0x00 : byte)
   Class: Eq_166
-  DataType: (ptr8 Eq_166)
-  OrigDataType: (ptr8 (segment (C5 T_167 t00C5)))
+  DataType: (ptr Eq_166)
+  OrigDataType: (ptr (segment (C5 T_167 t00C5)))
 T_167: (in Mem83[0x00:0xC5:byte] : byte)
   Class: Eq_167
   DataType: byte
@@ -827,16 +827,16 @@ T_170: (in 0x00->b00C6 - !cond(0x00->b00C5) : byte)
   OrigDataType: byte
 T_171: (in 0x00 : byte)
   Class: Eq_171
-  DataType: (ptr8 Eq_171)
-  OrigDataType: (ptr8 (segment (C6 T_172 t00C6)))
+  DataType: (ptr Eq_171)
+  OrigDataType: (ptr (segment (C6 T_172 t00C6)))
 T_172: (in Mem87[0x00:0xC6:byte] : byte)
   Class: Eq_170
   DataType: byte
   OrigDataType: byte
 T_173: (in 0x00 : byte)
   Class: Eq_173
-  DataType: (ptr8 Eq_173)
-  OrigDataType: (ptr8 (segment (C6 T_174 t00C6)))
+  DataType: (ptr Eq_173)
+  OrigDataType: (ptr (segment (C6 T_174 t00C6)))
 T_174: (in Mem87[0x00:0xC6:byte] : byte)
   Class: Eq_174
   DataType: byte
@@ -847,8 +847,8 @@ T_175: (in cond(0x00->b00C6) : byte)
   OrigDataType: byte
 T_176: (in 0x00 : byte)
   Class: Eq_176
-  DataType: (ptr8 Eq_176)
-  OrigDataType: (ptr8 (segment (C4 T_178 t00C4)))
+  DataType: (ptr Eq_176)
+  OrigDataType: (ptr (segment (C4 T_178 t00C4)))
 T_177: (in 0xC4 : byte)
   Class: Eq_177
   DataType: Eq_177
@@ -867,8 +867,8 @@ T_180: (in 0x00->b00C4 - 0x01 : byte)
   OrigDataType: byte
 T_181: (in 0x00 : byte)
   Class: Eq_181
-  DataType: (ptr8 Eq_181)
-  OrigDataType: (ptr8 (segment (C4 T_182 t00C4)))
+  DataType: (ptr Eq_181)
+  OrigDataType: (ptr (segment (C4 T_182 t00C4)))
 T_182: (in Mem74[0x00:0xC4:byte] : byte)
   Class: Eq_180
   DataType: byte
@@ -885,10 +885,10 @@ T_185: (in FSR2 : ptr16)
   Class: Eq_185
   DataType: ptr16
   OrigDataType: ptr16
-T_186: (in FSR1 : (ptr16 byte))
+T_186: (in FSR1 : (ptr byte))
   Class: Eq_186
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_189 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_189 t0000)))
 T_187: (in 0x0000 : word16)
   Class: Eq_187
   DataType: word16
@@ -903,8 +903,8 @@ T_189: (in Mem3[FSR1 + 0x0000:byte] : byte)
   OrigDataType: byte
 T_190: (in 0x00 : byte)
   Class: Eq_190
-  DataType: (ptr8 Eq_190)
-  OrigDataType: (ptr8 (segment (CA T_192 t00CA)))
+  DataType: (ptr Eq_190)
+  OrigDataType: (ptr (segment (CA T_192 t00CA)))
 T_191: (in 0xCA : byte)
   Class: Eq_191
   DataType: Eq_191
@@ -931,8 +931,8 @@ T_196: (in (0x00->b00CA & 0x01) != 0x00 : bool)
   OrigDataType: bool
 T_197: (in 0x00 : byte)
   Class: Eq_197
-  DataType: (ptr8 Eq_197)
-  OrigDataType: (ptr8 (segment (CA T_199 t00CA)))
+  DataType: (ptr Eq_197)
+  OrigDataType: (ptr (segment (CA T_199 t00CA)))
 T_198: (in 0xCA : byte)
   Class: Eq_198
   DataType: Eq_198
@@ -951,8 +951,8 @@ T_201: (in 0x00->b00CA & 0xFE : byte)
   OrigDataType: byte
 T_202: (in 0x00 : byte)
   Class: Eq_202
-  DataType: (ptr8 Eq_202)
-  OrigDataType: (ptr8 (segment (CA T_203 t00CA)))
+  DataType: (ptr Eq_202)
+  OrigDataType: (ptr (segment (CA T_203 t00CA)))
 T_203: (in Mem22[0x00:0xCA:byte] : byte)
   Class: Eq_201
   DataType: byte
@@ -979,8 +979,8 @@ T_208: (in 0x02 : byte)
   OrigDataType: (union (ui16 u0) (byte u1))
 T_209: (in FSR2 - 0x02 : word16)
   Class: Eq_209
-  DataType: (ptr16 byte)
-  OrigDataType: (ptr16 (struct (0 T_212 t0000)))
+  DataType: (ptr byte)
+  OrigDataType: (ptr (struct (0 T_212 t0000)))
 T_210: (in 0x0000 : word16)
   Class: Eq_210
   DataType: word16
@@ -1056,11 +1056,11 @@ T_227: (in Mem20[FSR0 + 0x0000:byte] : byte)
 T_228: (in 0x0001 : word16)
   Class: Eq_228
   DataType: word16
-  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr byte) u1))
 T_229: (in FSR0 + 0x0001 : word16)
   Class: Eq_222
   DataType: Eq_222
-  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr byte) u1))
 T_230: (in 0x00 : byte)
   Class: Eq_230
   DataType: byte
@@ -1072,7 +1072,7 @@ T_231: (in 0x0000 : word16)
 T_232: (in FSR0 + 0x0000 : word16)
   Class: Eq_232
   DataType: Eq_232
-  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr byte) u1))
 T_233: (in Mem17[FSR0 + 0x0000:byte] : byte)
   Class: Eq_230
   DataType: Eq_222
@@ -1080,11 +1080,11 @@ T_233: (in Mem17[FSR0 + 0x0000:byte] : byte)
 T_234: (in 0x0001 : word16)
   Class: Eq_234
   DataType: word16
-  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr byte) u1))
 T_235: (in FSR0 + 0x0001 : word16)
   Class: Eq_222
   DataType: Eq_222
-  OrigDataType: (union (word16 u2) ((ptr32 byte) u1))
+  OrigDataType: (union (word16 u2) ((ptr byte) u1))
 T_236: (in PRODL : byte)
   Class: Eq_220
   DataType: cu8


### PR DESCRIPTION
Eliminates temporary method to get bit-size constants and binary words as needed specifically by PIC processor (registers).