### PR TITLE
Remove obsolete FPU methods

### DIFF
--- a/src/Arch/X86/X86Rewriter.Fpu.cs
+++ b/src/Arch/X86/X86Rewriter.Fpu.cs
@@ -521,7 +521,7 @@ namespace Reko.Arch.X86
             var fp = this.FpuRegister(0);
             var tmp = binder.CreateTemporary(fp.DataType);
             m.Assign(tmp, fp);
-            state.GrowFpuStack(instrCur.Address);
+            GrowFpuStack(1);
             m.Assign(this.FpuRegister(1), host.PseudoProcedure("__exponent", fp.DataType, tmp));
             m.Assign(this.FpuRegister(0), host.PseudoProcedure("__significand", fp.DataType, tmp));
         }

--- a/src/Arch/X86/X86Rewriter.Fpu.cs
+++ b/src/Arch/X86/X86Rewriter.Fpu.cs
@@ -32,8 +32,6 @@ namespace Reko.Arch.X86
 {
     public partial class X86Rewriter
     {
-        private int maxFpuStackWrite;
-
         public void EmitCommonFpuInstruction(
             Func<Expression,Expression,Expression> op,
             bool fReversed,
@@ -106,7 +104,6 @@ namespace Reko.Arch.X86
             GrowFpuStack(1);
             m.Assign(FpuRegister(0),
                 host.PseudoProcedure("__fbld", PrimitiveType.Real64, SrcOp(instrCur.op1)));
-            WriteFpuStack(0);
         }
 
         private void RewriteFbstp()
@@ -121,7 +118,6 @@ namespace Reko.Arch.X86
             m.Assign(
                 orw.FpuRegister(0, state),
                 m.Neg(orw.FpuRegister(0, state)));		//$BUGBUG: should be Real, since we don't know the actual size.
-            WriteFpuStack(0);
         }
 
         private void RewriteFclex()
@@ -171,7 +167,6 @@ namespace Reko.Arch.X86
             m.Assign(
                 orw.FpuRegister(0, state),
                 host.PseudoProcedure(name, PrimitiveType.Real64, orw.FpuRegister(0, state)));
-            WriteFpuStack(0);
         }
 
         private void RewriteFicom(bool pop)
@@ -194,7 +189,6 @@ namespace Reko.Arch.X86
             m.Assign(
                 orw.FpuRegister(0, state),
                 m.Cast(PrimitiveType.Real64, SrcOp(instrCur.op1, iType)));
-            WriteFpuStack(0);
         }
 
         private void RewriteFincstp()
@@ -233,7 +227,6 @@ namespace Reko.Arch.X86
                     src);
             }
             m.Assign(dst, src);
-            WriteFpuStack(0);
         }
 
         private void RewriteFldConst(double constant)
@@ -245,7 +238,6 @@ namespace Reko.Arch.X86
         {
             GrowFpuStack(1);
             m.Assign(FpuRegister(0), c);
-            WriteFpuStack(0);
         }
 
         private void RewriteFldcw()
@@ -278,7 +270,6 @@ namespace Reko.Arch.X86
             Expression op2 = FpuRegister(0);
             ShrinkFpuStack(1);
             m.Assign(FpuRegister(0), host.PseudoProcedure("atan", PrimitiveType.Real64, op1, op2));
-            WriteFpuStack(0);
         }
 
         private void RewriteFprem()
@@ -288,7 +279,6 @@ namespace Reko.Arch.X86
             ShrinkFpuStack(1);
             m.Assign(FpuRegister(0),
                 m.Mod(op2, op1));
-            WriteFpuStack(0);
         }
 
         private void RewriteFprem1()
@@ -296,7 +286,6 @@ namespace Reko.Arch.X86
             Expression op1 = SrcOp(instrCur.op1);
             Expression op2 = SrcOp(instrCur.op2);
             m.Assign(op1, host.PseudoProcedure("__fprem1", op1.DataType, op1, op2));
-            WriteFpuStack(0);
         }
 
         private void RewriteFptan()
@@ -315,8 +304,6 @@ namespace Reko.Arch.X86
             GrowFpuStack(1);
             m.Assign(FpuRegister(1), host.PseudoProcedure("cos", PrimitiveType.Real64, itmp));
             m.Assign(FpuRegister(0), host.PseudoProcedure("sin", PrimitiveType.Real64, itmp));
-            WriteFpuStack(0);
-            WriteFpuStack(1);
         }
 
         private void RewriteFst(bool pop)
@@ -536,7 +523,6 @@ namespace Reko.Arch.X86
                       host.PseudoProcedure("lg2", PrimitiveType.Real64, op2)));
 
             ShrinkFpuStack(1);
-            WriteFpuStack(0);
         }
 
         private void RewriteFyl2xp1()
@@ -555,7 +541,6 @@ namespace Reko.Arch.X86
                 orw.AluRegister(Registers.FPUF),
                 m.Cond(op2));
             ShrinkFpuStack(1);
-            WriteFpuStack(0);
         }
 
         private void RewriteWait()
@@ -591,13 +576,6 @@ namespace Reko.Arch.X86
         {
             var top = binder.EnsureRegister(Registers.Top);
             m.Assign(top, m.IAdd(top, amount));
-        }
-
-        private void WriteFpuStack(int offset)
-        {
-            int o = offset - state.FpuStackItems;
-            if (o > maxFpuStackWrite)
-                maxFpuStackWrite = o;
         }
     }
 }

--- a/src/Arch/X86/X86State.cs
+++ b/src/Arch/X86/X86State.cs
@@ -56,13 +56,11 @@ namespace Reko.Arch.X86
 		public X86State(X86State st) : base(st)
 		{
             arch = st.arch;
-            FpuStackItems = st.FpuStackItems;
             regs = (ulong[])st.regs.Clone();
 			valid = (ulong []) st.valid.Clone();
 		}
 
         public override IProcessorArchitecture Architecture { get { return arch; } }
-        public int FpuStackItems { get; set; }
 
 		public Address AddressFromSegOffset(RegisterStorage seg, uint offset)
 		{
@@ -128,7 +126,6 @@ namespace Reko.Arch.X86
 
         public override void OnProcedureEntered()
         {
-            FpuStackItems = 0;
             // We're making an assumption that the direction flag is always clear
             // when a procedure is entered. This is true of the vast majority of
             // x86 code out there, and the assumption is certainly made by most
@@ -140,34 +137,15 @@ namespace Reko.Arch.X86
 
         public override void OnProcedureLeft(FunctionType sig)
         {
-            sig.FpuStackDelta = FpuStackItems;
         }
 
         public override CallSite OnBeforeCall(Identifier sp, int returnAddressSize)
         {
-            return new CallSite(returnAddressSize, FpuStackItems);  
+            return new CallSite(returnAddressSize, 0);
         }
 
         public override void OnAfterCall(FunctionType sig)
         {
-            if (sig == null)
-                return;
-
-            ShrinkFpuStack(-sig.FpuStackDelta);
-        }
-
-		public void GrowFpuStack(Address addrInstr)
-		{
-			++FpuStackItems;
-			if (FpuStackItems > 7)
-			{
-				Debug.WriteLine(string.Format("Possible FPU stack overflow at address {0}", addrInstr));	//$BUGBUG: should be an exception
-			}
-		}
-
-        public void ShrinkFpuStack(int cItems)
-        {
-            FpuStackItems -= cItems;
         }
 
         public Constant GetFlagGroup(uint mask)

--- a/src/UnitTests/Arch/Intel/X86RewriterTests.cs
+++ b/src/UnitTests/Arch/Intel/X86RewriterTests.cs
@@ -3205,10 +3205,11 @@ namespace Reko.UnitTests.Arch.Intel
         {
             Run32bitTest(0xD9, 0xF4);	// fxtract
             AssertCode(
-                "0|L--|10000000(2): 3 instructions",
+                "0|L--|10000000(2): 4 instructions",
                 "1|L--|v3 = ST[Top:real64]",
-                "2|L--|ST[Top + 1:real64] = __exponent(v3)",
-                "3|L--|ST[Top:real64] = __significand(v3)");
+                "2|L--|Top = Top - 0x01",
+                "3|L--|ST[Top + 1:real64] = __exponent(v3)",
+                "4|L--|ST[Top:real64] = __significand(v3)");
         }
 
         [Test]


### PR DESCRIPTION
- Represent FPU accesses explicitly when `FXTRACT` rewriting instead of using obsolete method `GrowFpuStack`
- Remove obsolete FPU methods