### PR TITLE
Avoid exception if parameter definition statement already exist

### DIFF
--- a/src/Decompiler/Analysis/SsaTransform.cs
+++ b/src/Decompiler/Analysis/SsaTransform.cs
@@ -1386,7 +1386,7 @@ namespace Reko.Analysis
                 }
             }
 
-            private SsaIdentifier EnsureDef(Identifier id, Block b)
+            private SsaIdentifier EnsureSsaIdentifier(Identifier id, Block b)
             {
                 if (ssaIds.TryGetValue(id, out var sid))
                     return sid;
@@ -1417,7 +1417,7 @@ namespace Reko.Analysis
                     var param = sig.Parameters.FirstOrDefault(p => p.Storage.Covers(id.Storage));
                     if (param != null)
                     {
-                        var sidParam = EnsureDef(param, b);
+                        var sidParam = EnsureSsaIdentifier(param, b);
                         var copy = new Assignment(id, sidParam.Identifier);
                         var stmCopy = b.Statements.Add(0, copy); 
                         var sidCopy = ssaIds.Add(id, stmCopy, null, false);

--- a/src/Decompiler/Analysis/SsaTransform.cs
+++ b/src/Decompiler/Analysis/SsaTransform.cs
@@ -1386,6 +1386,16 @@ namespace Reko.Analysis
                 }
             }
 
+            private SsaIdentifier EnsureDef(Identifier id, Block b)
+            {
+                if (ssaIds.TryGetValue(id, out var sid))
+                    return sid;
+                sid = ssaIds.Add(id, null, null, false);
+                sid.DefStatement = new Statement(0, new DefInstruction(id), b);
+                b.Statements.Add(sid.DefStatement);
+                return sid;
+            }
+
             /// <summary>
             /// Generate a 'def' instruction for identifiers that are used
             /// without any previous definitions inside the current procedure.
@@ -1407,10 +1417,7 @@ namespace Reko.Analysis
                     var param = sig.Parameters.FirstOrDefault(p => p.Storage.Covers(id.Storage));
                     if (param != null)
                     {
-                        var sidParam = ssaIds.Add(param, null, null, false);
-                        sidParam.DefStatement = new Statement(0, new DefInstruction(param), b);
-                        b.Statements.Add(sidParam.DefStatement);
-
+                        var sidParam = EnsureDef(param, b);
                         var copy = new Assignment(id, sidParam.Identifier);
                         var stmCopy = b.Statements.Add(0, copy); 
                         var sidCopy = ssaIds.Add(id, stmCopy, null, false);

--- a/src/Decompiler/Analysis/SsaTransform.cs
+++ b/src/Decompiler/Analysis/SsaTransform.cs
@@ -1418,6 +1418,8 @@ namespace Reko.Analysis
                     if (param != null)
                     {
                         var sidParam = EnsureSsaIdentifier(param, b);
+                        //$TODO: make sure identifier sizes are observed here, use SLICE
+                        //       when extracting smaller bitvectors out of larger values
                         var copy = new Assignment(id, sidParam.Identifier);
                         var stmCopy = b.Statements.Add(0, copy); 
                         var sidCopy = ssaIds.Add(id, stmCopy, null, false);

--- a/src/UnitTests/Analysis/SsaTransformTests.cs
+++ b/src/UnitTests/Analysis/SsaTransformTests.cs
@@ -49,6 +49,7 @@ namespace Reko.UnitTests.Analysis
         private ProgramDataFlow programFlow;
         private bool addUseInstructions;
         private IImportResolver importResolver;
+        private SsaTransform sst;
 
         private Identifier r1;
         private Identifier r2;
@@ -207,12 +208,19 @@ namespace Reko.UnitTests.Analysis
         {
             this.programFlow = new ProgramDataFlow();
             var proc = this.pb.Program.Procedures.Values.First();
-            var sst = new SsaTransform(
+            this.sst = new SsaTransform(
                 this.pb.Program,
                 proc,
                 new HashSet<Procedure>(),
                 importResolver,
                 programFlow);
+            sst.Transform();
+            sst.SsaState.Validate(s => Assert.Fail(s));
+        }
+
+        private void RenameFrameAccesses()
+        {
+            sst.RenameFrameAccesses = true;
             sst.Transform();
             sst.SsaState.Validate(s => Assert.Fail(s));
         }
@@ -3329,6 +3337,53 @@ test_exit:
             RunSsaTransform();
 
             AssertProcedureCode(sExp);
+        }
+
+        [Test]
+        public void SsaReal64Arg()
+        {
+            var proc = Given_Procedure("proc", m =>
+            {
+                var a = m.Reg32("a", 0);
+                var b = m.Reg32("b", 1);
+                var fp = m.Frame.FramePointer;
+
+                m.Label("body");
+                m.Assign(a, m.Mem32(m.IAdd(fp, 4)));
+                m.Assign(b, m.Mem32(m.IAdd(fp, 8)));
+                m.MStore(m.Word32(0x5678), a);
+                m.MStore(m.Word32(0x567C), b);
+                m.Return();
+            });
+            proc.Signature = FunctionType.Action(
+                new Identifier(
+                    "doubleArg",
+                    PrimitiveType.Real64,
+                    new StackArgumentStorage(4, PrimitiveType.Real64))
+            );
+
+            RunSsaTransform();
+            RenameFrameAccesses();
+
+            var expected =
+            #region Expected
+@"proc_entry:
+	def fp
+	def Mem0
+	def doubleArg
+	dwArg04_8 = doubleArg
+	dwArg08_9 = doubleArg
+body:
+	a_3 = dwArg04_8
+	b_4 = dwArg08_9
+	Mem5[0x00005678:word32] = a_3
+	Mem6[0x0000567C:word32] = b_4
+	return
+proc_exit:
+";
+            #endregion
+            AssertProcedureCode(expected);
+
         }
     }
 }

--- a/src/UnitTests/Analysis/SsaTransformTests.cs
+++ b/src/UnitTests/Analysis/SsaTransformTests.cs
@@ -204,7 +204,7 @@ namespace Reko.UnitTests.Analysis
             return pb.Add(name, builder);
         }
 
-        private void RunSsaTransform()
+        private void When_RunSsaTransform()
         {
             this.programFlow = new ProgramDataFlow();
             var proc = this.pb.Program.Procedures.Values.First();
@@ -218,7 +218,7 @@ namespace Reko.UnitTests.Analysis
             sst.SsaState.Validate(s => Assert.Fail(s));
         }
 
-        private void RenameFrameAccesses()
+        private void When_RenameFrameAccesses()
         {
             sst.RenameFrameAccesses = true;
             sst.Transform();
@@ -3181,7 +3181,7 @@ proc1_exit:
                 m.Return();
             });
 
-            RunSsaTransform();
+            When_RunSsaTransform();
 
             var expected =
             #region Expected
@@ -3247,7 +3247,7 @@ proc_exit:
                 m.Return();
             });
 
-            RunSsaTransform();
+            When_RunSsaTransform();
 
             var expected =
             #region Expected
@@ -3291,7 +3291,7 @@ proc_exit:
             proc.Signature = FunctionType.Action(
                 new Identifier("r2", PrimitiveType.Real32, proc.Architecture.GetRegister("r2")));
 
-            RunSsaTransform();
+            When_RunSsaTransform();
 
             var ass = proc.Statements
                 .Select(stm => stm.Instruction as Assignment)
@@ -3334,7 +3334,7 @@ test_exit:
 ";
             #endregion
 
-            RunSsaTransform();
+            When_RunSsaTransform();
 
             AssertProcedureCode(sExp);
         }
@@ -3362,8 +3362,8 @@ test_exit:
                     new StackArgumentStorage(4, PrimitiveType.Real64))
             );
 
-            RunSsaTransform();
-            RenameFrameAccesses();
+            When_RunSsaTransform();
+            When_RenameFrameAccesses();
 
             var expected =
             #region Expected


### PR DESCRIPTION
- Create `SsaTransform` test to reproduce duplicated dictionary keys exception
- Avoid exception if parameter definition statement already exist