### PR TITLE
Do not use MemoryStorage for global variables

### DIFF
--- a/src/Core/Expressions/Identifier.cs
+++ b/src/Core/Expressions/Identifier.cs
@@ -51,7 +51,10 @@ namespace Reko.Core.Expressions
 
         public static Identifier Global(string name, DataType dt)
         {
-            return new Identifier(name, dt, MemoryStorage.Instance);
+            //$HACK: Is there solution which is better than using temporary
+            // storage?
+            var globalStorage = new TemporaryStorage(name, 8000, dt);
+            return new Identifier(name, dt, globalStorage);
         }
 
         public string Name { get; private set; }

--- a/src/Core/Expressions/Identifier.cs
+++ b/src/Core/Expressions/Identifier.cs
@@ -51,9 +51,7 @@ namespace Reko.Core.Expressions
 
         public static Identifier Global(string name, DataType dt)
         {
-            //$HACK: Is there solution which is better than using temporary
-            // storage?
-            var globalStorage = new TemporaryStorage(name, 8000, dt);
+            var globalStorage = new GlobalStorage(name, dt);
             return new Identifier(name, dt, globalStorage);
         }
 

--- a/src/Core/Expressions/Identifier.cs
+++ b/src/Core/Expressions/Identifier.cs
@@ -49,6 +49,11 @@ namespace Reko.Core.Expressions
             return new Identifier(name, dt, tmp);
         }
 
+        public static Identifier Global(string name, DataType dt)
+        {
+            return new Identifier(name, dt, MemoryStorage.Instance);
+        }
+
         public string Name { get; private set; }
 
         public override IEnumerable<Expression> Children

--- a/src/Core/ImportResolver.cs
+++ b/src/Core/ImportResolver.cs
@@ -159,7 +159,7 @@ namespace Reko.Core
                 var dt = (t.Item2 == null) ?
                     new UnknownType() :
                     t.Item2.Accept(dSer);
-                return new Identifier(t.Item1, dt, MemoryStorage.Instance);
+                return Identifier.Global(t.Item1, dt);
             }
             else
                 return null;
@@ -189,7 +189,7 @@ namespace Reko.Core
                 DataType dt;
                 if (program.EnvironmentMetadata.Globals.TryGetValue(name, out dt))
                 {
-                    return new Identifier(name, dt, MemoryStorage.Instance);
+                    return Identifier.Global(name, dt);
                 }
             }
             return platform.ResolveImportByName(moduleName, name);
@@ -232,7 +232,7 @@ namespace Reko.Core
             }
             else
             {
-                var id = new Identifier(sym.Name, sym.DataType, MemoryStorage.Instance);
+                var id = Identifier.Global(sym.Name, sym.DataType);
                 return new UnaryExpression(Operator.AddrOf, program.Platform.PointerType, id);
             }
     }

--- a/src/Core/Program.cs
+++ b/src/Core/Program.cs
@@ -193,7 +193,7 @@ namespace Reko.Core
             if (Platform == null)
                 throw new InvalidOperationException("The program's Platform property must be set before accessing the Globals property.");
             var ptrGlobals = TypeFactory.CreatePointer(GlobalFields, Platform.PointerType.BitSize);
-            globals = new Identifier("globals", ptrGlobals, MemoryStorage.Instance);
+            globals = Identifier.Global("globals", ptrGlobals);
         }
 
         /// <summary>

--- a/src/Core/Storage.cs
+++ b/src/Core/Storage.cs
@@ -121,6 +121,7 @@ namespace Reko.Core
         Register = 0,   // Few architectures have 4096 registers (fingers xD)
         Memory = 4096,
         FpuStack = 4098,
+        Global = 8191,
         Temporary = 8192,
         Stack = 16834,  
     }
@@ -908,11 +909,17 @@ namespace Reko.Core
     /// </remarks>
 	public class TemporaryStorage : Storage
 	{
-		public TemporaryStorage(string name, int number, DataType dt) : base("Temporary")
+        protected TemporaryStorage(string name, StorageDomain domain, DataType dt)
+            : base("Temporary")
         {
-            Domain = StorageDomain.Temporary + number;
+            Domain = domain;
             Name = name;
             DataType = dt;
+        }
+
+        public TemporaryStorage(string name, int number, DataType dt)
+            : this(name, StorageDomain.Temporary + number, dt)
+        {
         }
 
         public DataType DataType { get; private set; }
@@ -950,6 +957,14 @@ namespace Reko.Core
         public override void Write(TextWriter writer)
         {
             writer.Write(Name);
+        }
+    }
+
+    public class GlobalStorage : TemporaryStorage
+    {
+        public GlobalStorage(string name, DataType dt)
+            : base(name, StorageDomain.Global, dt)
+        {
         }
     }
 }

--- a/src/Environments/C64/C64BasicRewriter.cs
+++ b/src/Environments/C64/C64BasicRewriter.cs
@@ -248,7 +248,7 @@ namespace Reko.Environments.C64
                 }
             }
             sb.AppendFormat("_{0}", suffix);
-            id = new Identifier(sb.ToString(), dt, MemoryStorage.Instance);
+            id = Identifier.Global(sb.ToString(), dt);
             return true;
         }
 

--- a/src/Environments/MacOS/MacOSClassic.cs
+++ b/src/Environments/MacOS/MacOSClassic.cs
@@ -130,7 +130,7 @@ namespace Reko.Environments.MacOS
 
             var a5world_t = new StructureType("A5World_t", 0, true);
             var ptr = new Pointer(a5world_t, PointerType.BitSize);
-            this.ptrA5World = new Identifier("a5world", ptr, MemoryStorage.Instance);
+            this.ptrA5World = Identifier.Global("a5world", ptr);
             return this.ptrA5World;
         }
 

--- a/src/ImageLoaders/Llvm/ProgramBuilder.cs
+++ b/src/ImageLoaders/Llvm/ProgramBuilder.cs
@@ -159,7 +159,7 @@ namespace Reko.ImageLoaders.LLVM
         public Identifier RegisterGlobal(GlobalDefinition global)
         {
             var dt = TranslateType(global.Type);
-            var id = new Identifier(global.Name, dt, MemoryStorage.Instance);
+            var id = Identifier.Global(global.Name, dt);
             this.Globals.Add(global.Name, id);
             return id;
         }
@@ -167,7 +167,7 @@ namespace Reko.ImageLoaders.LLVM
         public void RegisterDeclaration(Declaration decl)
         {
             var dt = TranslateType(decl.Type);
-            var id = new Identifier(decl.Name, dt, MemoryStorage.Instance);
+            var id = Identifier.Global(decl.Name, dt);
             this.Globals.Add(id.Name, id);
         }
         

--- a/src/UnitTests/Analysis/SsaTransformTests.cs
+++ b/src/UnitTests/Analysis/SsaTransformTests.cs
@@ -3385,5 +3385,36 @@ proc_exit:
             AssertProcedureCode(expected);
 
         }
+
+        [Test]
+        public void SsaGlobals()
+        {
+            var proc = Given_Procedure("proc", m =>
+            {
+                var global = Identifier.Global("gbl", PrimitiveType.Word32);
+
+                m.Label("body");
+                m.MStore(m.Word32(0x5678), m.Mem32(m.Word32(0x1234)));
+                m.MStore(m.Word32(0x1234), global);
+                m.Return();
+            });
+
+            When_RunSsaTransform();
+
+            var expected =
+            #region Expected
+@"proc_entry:
+	def Mem0
+	def gbl
+body:
+	Mem2[0x00005678:word32] = Mem0[0x00001234:word32]
+	Mem4[0x00001234:word32] = gbl
+	return
+proc_exit:
+";
+            #endregion
+            AssertProcedureCode(expected);
+
+        }
     }
 }

--- a/src/UnitTests/ImageLoaders/Llvm/ProgramBuilderTests.cs
+++ b/src/UnitTests/ImageLoaders/Llvm/ProgramBuilderTests.cs
@@ -63,7 +63,7 @@ namespace Reko.UnitTests.ImageLoaders.Llvm
 
         public void Global(string name, DataType dt)
         {
-            globals.Add(name, new Identifier(name, dt, MemoryStorage.Instance));
+            globals.Add(name, Identifier.Global(name, dt));
         }
 
         private Procedure RunFuncTest(params string[] lines)

--- a/src/UnitTests/Typing/TypeCollectorTests.cs
+++ b/src/UnitTests/Typing/TypeCollectorTests.cs
@@ -155,7 +155,7 @@ namespace Reko.UnitTests.Typing
         {
             RunTest(m =>
             {
-                var foo = new Identifier("foo", new UnknownType(), MemoryStorage.Instance);
+                var foo = Identifier.Global("foo", new UnknownType());
                 var r1 = m.Reg32("r1", 1);
                 m.Assign(r1, m.AddrOf(foo));
                 m.MStore(r1, m.Word16(0x1234));
@@ -176,7 +176,7 @@ namespace Reko.UnitTests.Typing
                         { 4, PrimitiveType.Byte, "byte004"}
                     }
                 });
-                var foo = new Identifier("foo", str, MemoryStorage.Instance);
+                var foo = Identifier.Global("foo", str);
                 var r1 = m.Reg32("r1", 1);
                 m.Assign(r1, m.AddrOf(foo));
                 m.MStore(r1, m.Word16(0x1234));

--- a/src/UnitTests/Typing/TypeTransformTests.cs
+++ b/src/UnitTests/Typing/TypeTransformTests.cs
@@ -481,7 +481,7 @@ namespace Reko.UnitTests.Typing
             var pb = new ProgramBuilder();
             pb.Add("AddressOf", m =>
             {
-                var foo = new Identifier("foo", new UnknownType(), MemoryStorage.Instance);
+                var foo = Identifier.Global("foo", new UnknownType());
                 var r1 = m.Reg32("r1", 1);
                 m.Declare(r1, m.AddrOf(foo));
                 m.MStore(r1, m.Word16(0x1234));
@@ -504,7 +504,7 @@ namespace Reko.UnitTests.Typing
                         { 4, PrimitiveType.Byte, "byte004"}
                     }
                 });
-                var foo = new Identifier("foo", str, MemoryStorage.Instance);
+                var foo = Identifier.Global("foo", str);
                 var r1 = m.Reg32("r1", 1);
                 m.Declare(r1, m.AddrOf(foo));
                 m.MStore(r1, m.Word16(0x1234));

--- a/src/UnitTests/Typing/TypedExpressionRewriterTests.cs
+++ b/src/UnitTests/Typing/TypedExpressionRewriterTests.cs
@@ -1098,7 +1098,7 @@ test_exit:
             var pb = new ProgramBuilder();
             pb.Add("AddressOf", m =>
             {
-                var foo = new Identifier("foo", new UnknownType(), MemoryStorage.Instance);
+                var foo = Identifier.Global("foo", new UnknownType());
                 var r1 = m.Reg32("r1", 1);
                 m.Declare(r1, m.AddrOf(foo));
                 m.MStore(r1, m.Word16(0x1234));
@@ -1121,7 +1121,7 @@ test_exit:
                         { 4, PrimitiveType.Byte, "byte004"}
                     }
                 });
-                var foo = new Identifier("foo", str, MemoryStorage.Instance);
+                var foo = Identifier.Global("foo", str);
                 var r1 = m.Reg32("r1", 1);
                 m.Declare(r1, m.AddrOf(foo));
                 m.MStore(r1, m.Word16(0x1234));

--- a/subjects/PE/x86/ExeDll/Executable.dis
+++ b/subjects/PE/x86/ExeDll/Executable.dis
@@ -9,7 +9,7 @@ fn00401000_entry:
 // DataOut: bl ebp fs
 // DataOut (flags): 
 // SymbolicIn: esp:fp
-// LocalsOut: fp(32) Local -000C(32) Local -0018(32)
+// LocalsOut: exported_critical_section(32) exported_int(32) fp(32) Local -000C(32) Local -0018(32)
 
 l00401000:
 	InitializeCriticalSection(&exported_critical_section)

--- a/subjects/PE/x86/pySample/pySample.dis
+++ b/subjects/PE/x86/pySample/pySample.dis
@@ -174,7 +174,7 @@ py_unused_entry:
 // DataOut:
 // DataOut (flags): 
 // SymbolicIn: esp:fp
-// LocalsOut: fp(32) Stack +0008(32)
+// LocalsOut: _Py_NoneStruct(32) fp(32) Stack +0008(32)
 
 l10001140:
 	word32 eax_15 = PyArg_ParseTuple(args, 0x1000216C)
@@ -182,6 +182,7 @@ l10001140:
 // DataOut: eax
 // DataOut (flags): 
 // SymbolicIn: esp:fp
+// LocalsOut: _Py_NoneStruct(32)
 
 l10001158:
 	word32 eax_24 = &_Py_NoneStruct


### PR DESCRIPTION
- Create SSA transform unit test with global variables
- Do not use `MemoryStorage` for global variables 