### PR TITLE
Pass storage as separate argument of UsedRegisterFinder.Classify

### DIFF
--- a/src/Decompiler/Analysis/DataFlowAnalysis.cs
+++ b/src/Decompiler/Analysis/DataFlowAnalysis.cs
@@ -122,7 +122,11 @@ namespace Reko.Analysis
 
             // Discover ssaId's that are live out at each call site.
             // Delete all others.
-            var uvr = new UnusedOutValuesRemover(program, ssts, this.flow, eventListener);
+            var uvr = new UnusedOutValuesRemover(
+                program,
+                ssts.Select(sst => sst.SsaState),
+                this.flow,
+                eventListener);
             uvr.Transform();
 
             // At this point, the exit blocks contain only live out registers.

--- a/src/Decompiler/Analysis/UnusedOutValuesRemover.cs
+++ b/src/Decompiler/Analysis/UnusedOutValuesRemover.cs
@@ -39,7 +39,7 @@ namespace Reko.Analysis
     {
         public static TraceSwitch trace = new TraceSwitch(typeof(UnusedOutValuesRemover).Name, "Trace removal of unused out values");
 
-        private List<SsaTransform> ssts;
+        private IEnumerable<SsaState> ssaStates;
         private WorkList<SsaState> wl;
         private Program program;
         private Dictionary<Procedure, SsaState> procToSsa;
@@ -48,16 +48,15 @@ namespace Reko.Analysis
 
         public UnusedOutValuesRemover(
             Program program,
-            List<SsaTransform> ssts,
+            IEnumerable<SsaState> ssaStates,
             ProgramDataFlow dataFlow,
             DecompilerEventListener eventListener)
-        { 
+        {
             this.dataFlow = dataFlow;
             this.program = program;
-            this.ssts = ssts;
+            this.ssaStates = ssaStates;
             this.eventListener = eventListener;
-            this.procToSsa = ssts
-                .Select(t => t.SsaState)
+            this.procToSsa = ssaStates
                 .ToDictionary(s => s.Procedure);
         }
 
@@ -71,7 +70,7 @@ namespace Reko.Analysis
                 if (eventListener.IsCanceled())
                     return;
                 change = false;
-                this.wl = new WorkList<SsaState>(ssts.Select(t => t.SsaState));
+                this.wl = new WorkList<SsaState>(ssaStates);
                 while (wl.GetWorkItem(out SsaState ssa))
                 {
                     if (this.eventListener.IsCanceled())
@@ -92,7 +91,7 @@ namespace Reko.Analysis
 
         private void CollectLiveOutStorages()
         {
-            var wl = new WorkList<SsaState>(ssts.Select(s => s.SsaState));
+            var wl = new WorkList<SsaState>(ssaStates);
             while (wl.GetWorkItem(out SsaState ssa))
             {
                 var liveOut = CollectLiveOutStorages(ssa.Procedure);

--- a/src/Decompiler/Analysis/UnusedOutValuesRemover.cs
+++ b/src/Decompiler/Analysis/UnusedOutValuesRemover.cs
@@ -272,7 +272,7 @@ namespace Reko.Analysis
                         var sid = ssaCaller.Identifiers[id];
                         if (sid.Uses.Count > 0)
                         {
-                            var br = urf.Classify(ssaCaller, sid, true);
+                            var br = urf.Classify(ssaCaller, sid, def.Storage, true);
                             DebugEx.PrintIf(trace.TraceVerbose, "  {0}: {1}", sid.Identifier.Name, br);
                             if (liveOutStorages.TryGetValue(def.Storage, out BitRange brOld))
                             {

--- a/src/Decompiler/Analysis/UsedRegisterFinder.cs
+++ b/src/Decompiler/Analysis/UsedRegisterFinder.cs
@@ -93,7 +93,7 @@ namespace Reko.Analysis
                      //$REVIEW: flag groups could theoretically be live in
                      // although it's uncommon.
                 {
-                    var n = Classify(ssa, sid, ignoreUse);
+                    var n = Classify(ssa, sid, sid.Identifier.Storage, ignoreUse);
                     if (!n.IsEmpty)
                     {
                         procFlow.BitsUsed[sid.Identifier.Storage] = n;
@@ -106,15 +106,16 @@ namespace Reko.Analysis
         public BitRange Classify(
             SsaState ssa, 
             SsaIdentifier sid,
+            Storage storage,
             bool ignoreUseInstructions)
         {
             this.procFlow = flow[ssa.Procedure];
             this.ssa = ssa;
             this.useLiveness = ignoreUseInstructions;
-            if (sid.Identifier.Storage is RegisterStorage ||
-                 sid.Identifier.Storage is StackArgumentStorage ||
-                 sid.Identifier.Storage is FpuStackStorage ||
-                 sid.Identifier.Storage is FlagGroupStorage)
+            if (storage is RegisterStorage ||
+                storage is StackArgumentStorage ||
+                storage is FpuStackStorage ||
+                storage is FlagGroupStorage)
             {
                 var n = Classify(sid);
                 return n;

--- a/src/UnitTests/Analysis/CallRewriterTests.cs
+++ b/src/UnitTests/Analysis/CallRewriterTests.cs
@@ -33,6 +33,7 @@ using Reko.Arch.X86;
 using Reko.Core.Code;
 using System.Diagnostics;
 using Rhino.Mocks;
+using System.Linq;
 
 namespace Reko.UnitTests.Analysis
 {
@@ -98,7 +99,11 @@ namespace Reko.UnitTests.Analysis
 
             // Discover ssaId's that are live out at each call site.
             // Delete all others.
-            var uvr = new UnusedOutValuesRemover(program, ssts, dfa.ProgramDataFlow, eventListener);
+            var uvr = new UnusedOutValuesRemover(
+                program,
+                ssts.Select(sst => sst.SsaState),
+                dfa.ProgramDataFlow,
+                eventListener);
             uvr.Transform();
 
             foreach (var p in program.Procedures.Values)

--- a/src/UnitTests/Analysis/RegisterLivenessTests.cs
+++ b/src/UnitTests/Analysis/RegisterLivenessTests.cs
@@ -29,6 +29,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Reko.Core.Serialization;
+using System.Linq;
 
 namespace Reko.UnitTests.Analysis
 {
@@ -62,7 +63,11 @@ namespace Reko.UnitTests.Analysis
 
             // Discover ssaId's that are live out at each call site.
             // Delete all others.
-            var uvr = new UnusedOutValuesRemover(program, ssts, dfa.ProgramDataFlow, eventListener);
+            var uvr = new UnusedOutValuesRemover(
+                program,
+                ssts.Select(sst => sst.SsaState),
+                dfa.ProgramDataFlow,
+                eventListener);
             uvr.Transform();
             DumpProcedureFlows(program, dfa, writer);
 		}

--- a/src/UnitTests/Analysis/UnusedOutValuesRemoverTests.cs
+++ b/src/UnitTests/Analysis/UnusedOutValuesRemoverTests.cs
@@ -59,7 +59,11 @@ namespace Reko.UnitTests.Analysis
             var dfa = new DataFlowAnalysis(program, import, eventListener);
             var ssts = dfa.RewriteProceduresToSsa();
 
-            var uvr = new UnusedOutValuesRemover(program, ssts, dfa.ProgramDataFlow, eventListener);
+            var uvr = new UnusedOutValuesRemover(
+                program,
+                ssts.Select(sst => sst.SsaState),
+                dfa.ProgramDataFlow,
+                eventListener);
             uvr.Transform();
 
             var sb = new StringWriter();

--- a/src/UnitTests/Mocks/ProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/ProcedureBuilder.cs
@@ -174,6 +174,19 @@ namespace Reko.UnitTests.Mocks
             return Emit(ci);
         }
 
+        public Statement Call(
+            string procedureName,
+            int retSizeOnStack,
+            IEnumerable<(Storage stg, Expression e)> uses,
+            IEnumerable<(Storage stg, Identifier e)> definitions)
+        {
+            var ci = new CallInstruction(Constant.Invalid, new CallSite(retSizeOnStack, 0));
+            ci.Uses.UnionWith(uses.Select(u => new CallBinding(u.stg, u.e)));
+            ci.Definitions.UnionWith(definitions.Select(d => new CallBinding(d.stg, d.e)));
+            unresolvedProcedures.Add(new ProcedureConstantUpdater(procedureName, ci));
+            return Emit(ci);
+        }
+
 
         public void Compare(string flags, Expression a, Expression b)
         {


### PR DESCRIPTION
- Pass `SsaState` rather than `SsaTransform` to `UnusedOutValuesRemover`
It makes unit testing easier.
- Add `UnusedOutValuesRemover` test with call which definition storage differs from identifier storage
- Pass storage as separate argument of `UsedRegisterFinder.Classify`