### PR TITLE
Fix RemoveDeadArgumentsFromCalls: avoid cast exceptions

### DIFF
--- a/src/Decompiler/Analysis/DataFlowAnalysis.cs
+++ b/src/Decompiler/Analysis/DataFlowAnalysis.cs
@@ -236,7 +236,8 @@ namespace Reko.Analysis
 
                 // We have a call statement that calls `proc`. Make sure 
                 // that only arguments present in the procedure flow are present.
-                var call = (CallInstruction)stm.Instruction;
+                if (!(stm.Instruction is CallInstruction call))
+                    continue;
                 var filteredUses = ProcedureFlow.IntersectCallBindingsWithUses(call.Uses, flow.BitsUsed)
                     .ToArray();
                 ssa.RemoveUses(stm);


### PR DESCRIPTION
Avoid cast exceptions: caller could be other than `CallInstructions`