### PR TITLE
Avoid InvalidOperationException during enumeration of overlapping stack definition intervals

### DIFF
--- a/src/Decompiler/Analysis/SsaTransform.cs
+++ b/src/Decompiler/Analysis/SsaTransform.cs
@@ -1783,7 +1783,9 @@ namespace Reko.Analysis
 
             public override Identifier WriteVariable(SsaBlockState bs, SsaIdentifier sid, bool performProbe)
             {
-                var ints = bs.currentStackDef.GetIntervalsOverlappingWith(offsetInterval);
+                var ints = bs.currentStackDef
+                    .GetIntervalsOverlappingWith(offsetInterval)
+                    .ToArray();
                 foreach (var i in ints)
                 {
                     if (this.offsetInterval.Covers(i.Key))


### PR DESCRIPTION
 - Create `SsaTransorm` unit test to reproduce `InvalidOperationException` during enumeration of overlapping stack definition intervals
- Convert enumerable to array to avoid `InvalidOperationException`