### PR TITLE
CallApplicationBuilder: return fallback for stack argumens not found in the map

### DIFF
--- a/src/Decompiler/Analysis/CallRewriter.cs
+++ b/src/Decompiler/Analysis/CallRewriter.cs
@@ -314,7 +314,7 @@ namespace Reko.Analysis
         public int RewriteCalls(SsaState ssaCaller)
         {
             int unConverted = 0;
-            foreach (Statement stm in ssaCaller.Procedure.Statements)
+            foreach (Statement stm in ssaCaller.Procedure.Statements.ToList())
             {
                 if (stm.Instruction is CallInstruction ci)
                 {


### PR DESCRIPTION
Argument can be not found in the map due to bugs at previous stages.
Create `stack{offset} = <Invalid>` statement in this case.
Return `stack{offset}` as fallback
This is better than exception throwing