### PR TITLE
CallApplicationBuilder: return fallback for register arguments not found in the map

### DIFF
--- a/src/Decompiler/Analysis/CallApplicationBuilder.cs
+++ b/src/Decompiler/Analysis/CallApplicationBuilder.cs
@@ -41,6 +41,7 @@ namespace Reko.Analysis
         private readonly Dictionary<StorageDomain, CallBinding> defs;
         private readonly Dictionary<StorageDomain, CallBinding> uses;
         private Dictionary<StorageDomain, CallBinding> map;
+        private bool bindUses;
 
         public CallApplicationBuilder(SsaState ssaCaller, Statement stmCall, CallInstruction call, Expression callee) : base(call.CallSite, callee)
         {
@@ -59,18 +60,30 @@ namespace Reko.Analysis
 
         public override Expression Bind(Identifier id)
         {
-            return With(uses, id.Storage);
+            return WithUses(id.Storage);
         }
 
         public override OutArgument BindOutArg(Identifier id)
         {
-            var exp = With(defs, id.Storage);
+            var exp = WithDefinitions(id.Storage);
             return new OutArgument(arch.FramePointerType, exp);
         }
 
         public override Expression BindReturnValue(Identifier id)
         {
-            return With(defs, id.Storage);
+            return WithDefinitions(id.Storage);
+        }
+
+        private Expression WithUses(Storage stg)
+        {
+            this.bindUses = true;
+            return With(uses, stg);
+        }
+
+        private Expression WithDefinitions(Storage stg)
+        {
+            this.bindUses = false;
+            return With(defs, stg);
         }
 
         private Expression With(Dictionary<StorageDomain, CallBinding> map, Storage stg)
@@ -119,9 +132,11 @@ namespace Reko.Analysis
 
         public Expression VisitRegisterStorage(RegisterStorage reg)
         {
-            return map.TryGetValue(reg.Domain, out CallBinding cb)
-                ? cb.Expression
-                : null;
+            if (map.TryGetValue(reg.Domain, out CallBinding cb))
+                return cb.Expression;
+            if (bindUses)
+                return EnsureRegister(reg);
+            return null;
         }
 
         public Expression VisitSequenceStorage(SequenceStorage seq)
@@ -197,6 +212,25 @@ Please report this issue at https://github.com/uxmal/reko";
             var iPos = block.Statements.IndexOf(stmBefore);
             var linAddr = stmBefore.LinearAddress;
             return block.Statements.Insert(iPos, linAddr, instr);
+        }
+
+        private Identifier EnsureRegister(RegisterStorage reg)
+        {
+            var id = ssaCaller.Procedure.Frame.EnsureRegister(reg);
+            var sid = EnsureSsaIdentifier(id);
+            sid.Uses.Add(stmCall);
+            return sid.Identifier;
+        }
+
+        private SsaIdentifier EnsureSsaIdentifier(Identifier id)
+        {
+            if (ssaCaller.Identifiers.TryGetValue(id, out var sid))
+                return sid;
+            sid = ssaCaller.Identifiers.Add(id, null, null, false);
+            var def = new DefInstruction(sid.Identifier);
+            var block = ssaCaller.Procedure.EntryBlock;
+            sid.DefStatement = block.Statements.Add(0, def);
+            return sid;
         }
     }
 }

--- a/src/Decompiler/Analysis/CallApplicationBuilder.cs
+++ b/src/Decompiler/Analysis/CallApplicationBuilder.cs
@@ -217,20 +217,10 @@ Please report this issue at https://github.com/uxmal/reko";
         private Identifier EnsureRegister(RegisterStorage reg)
         {
             var id = ssaCaller.Procedure.Frame.EnsureRegister(reg);
-            var sid = EnsureSsaIdentifier(id);
+            var entryBlock = ssaCaller.Procedure.EntryBlock;
+            var sid = ssaCaller.EnsureSsaIdentifier(id, entryBlock);
             sid.Uses.Add(stmCall);
             return sid.Identifier;
-        }
-
-        private SsaIdentifier EnsureSsaIdentifier(Identifier id)
-        {
-            if (ssaCaller.Identifiers.TryGetValue(id, out var sid))
-                return sid;
-            sid = ssaCaller.Identifiers.Add(id, null, null, false);
-            var def = new DefInstruction(sid.Identifier);
-            var block = ssaCaller.Procedure.EntryBlock;
-            sid.DefStatement = block.Statements.Add(0, def);
-            return sid;
         }
     }
 }

--- a/src/Decompiler/Analysis/SsaState.cs
+++ b/src/Decompiler/Analysis/SsaState.cs
@@ -78,6 +78,25 @@ namespace Reko.Analysis
 			Procedure.ExitBlock.Statements.Clear();
 		}
 
+        /// <summary>
+        /// If there is no defined SSA identifier for <paramref name="id"/>
+        /// identifier, then create DefInstruction in the <paramref name="b"/>
+        /// block. Return existing SSA identifier otherwise
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="b"></param>
+        /// <returns>
+        /// New or existing SSA identifier for <paramref name="id"/>
+        /// </returns>
+        public SsaIdentifier EnsureSsaIdentifier(Identifier id, Block b)
+        {
+            if (Identifiers.TryGetValue(id, out var sid))
+                return sid;
+            sid = Identifiers.Add(id, null, null, false);
+            sid.DefStatement = b.Statements.Add(0, new DefInstruction(id));
+            return sid;
+        }
+
         [Conditional("DEBUG")]
 		public void Dump(bool trace)
 		{

--- a/src/Decompiler/Analysis/SsaTransform.cs
+++ b/src/Decompiler/Analysis/SsaTransform.cs
@@ -1413,16 +1413,6 @@ namespace Reko.Analysis
                 }
             }
 
-            private SsaIdentifier EnsureSsaIdentifier(Identifier id, Block b)
-            {
-                if (ssaIds.TryGetValue(id, out var sid))
-                    return sid;
-                sid = ssaIds.Add(id, null, null, false);
-                sid.DefStatement = new Statement(0, new DefInstruction(id), b);
-                b.Statements.Add(sid.DefStatement);
-                return sid;
-            }
-
             /// <summary>
             /// Generate a 'def' instruction for identifiers that are used
             /// without any previous definitions inside the current procedure.
@@ -1444,7 +1434,7 @@ namespace Reko.Analysis
                     var param = sig.Parameters.FirstOrDefault(p => p.Storage.Covers(id.Storage));
                     if (param != null)
                     {
-                        var sidParam = EnsureSsaIdentifier(param, b);
+                        var sidParam = outer.ssa.EnsureSsaIdentifier(param, b);
                         //$TODO: make sure identifier sizes are observed here, use SLICE
                         //       when extracting smaller bitvectors out of larger values
                         var copy = new Assignment(id, sidParam.Identifier);
@@ -1457,10 +1447,7 @@ namespace Reko.Analysis
                         return sidCopy;
                     }
                 }
-                var sid = ssaIds.Add(id, null, null, false);
-                sid.DefStatement = new Statement(0, new DefInstruction(id), b);
-                b.Statements.Add(sid.DefStatement);
-                return sid;
+                return outer.ssa.EnsureSsaIdentifier(id, b);
             }
 
             private void ReplaceBy(SsaIdentifier sidOld, SsaIdentifier idNew)

--- a/src/UnitTests/Analysis/CallRewriterTests.cs
+++ b/src/UnitTests/Analysis/CallRewriterTests.cs
@@ -787,5 +787,44 @@ main_exit:
             #endregion
             AssertProcedureCode(sExp, ssa);
         }
+
+        [Test]
+        public void CrwRegisterArgumentNotFound()
+        {
+            var ret = new RegisterStorage("ret", 1, 0, PrimitiveType.Word32);
+            var arg = new RegisterStorage("arg", 2, 0, PrimitiveType.Word32);
+            var ssa = Given_Procedure("main", m =>
+            {
+                m.Label("body");
+                m.Call("fn", 4, new Identifier[] { }, new Identifier[] { });
+                m.Return();
+            });
+            Given_Procedure("fn", m => { });
+            Given_Signature(
+                "fn",
+                FunctionType.Func(
+                    new Identifier(
+                        "ret",
+                        PrimitiveType.Word32,
+                        ret),
+                    new Identifier(
+                        "arg",
+                        PrimitiveType.Word32,
+                        arg)));
+
+            When_RewriteCalls(ssa);
+
+            var sExp =
+            #region Expected
+@"main_entry:
+	def arg
+body:
+	fn(arg)
+	return
+main_exit:
+";
+            #endregion
+            AssertProcedureCode(sExp, ssa);
+        }
     }
 }


### PR DESCRIPTION
- Create unit test for `CallRewriter` to verify not found register argument 