### PR TITLE
 IntersectCallBindingsWithUses: do not add not found bindings to uses list

### DIFF
--- a/src/Decompiler/Analysis/ProcedureFlow.cs
+++ b/src/Decompiler/Analysis/ProcedureFlow.cs
@@ -178,15 +178,18 @@ namespace Reko.Analysis
             // If it can be improved, do so.
             foreach (var use in uses)
             {
+                CallBinding callBinding = null;
                 switch (use.Key)
                 {
                 case RegisterStorage reg:
-                    yield return IntersectRegisterBinding(reg, callBindings);
+                    callBinding = IntersectRegisterBinding(reg, callBindings);
                     break;
                 case StackArgumentStorage stArg:
-                    yield return IntersectStackRegisterBinding(stArg, callBindings);
+                    callBinding = IntersectStackRegisterBinding(stArg, callBindings);
                     break;
                 }
+                if (callBinding != null)
+                    yield return callBinding;
             }
         }
 
@@ -201,7 +204,7 @@ namespace Reko.Analysis
                         return binding;
                 }
             }
-            return new CallBinding(stArg, new StringConstant(new UnknownType(), "???unsatisfied???"));
+            return null;
         }
 
         private static CallBinding IntersectRegisterBinding(RegisterStorage regCallee, IEnumerable<CallBinding> callBindings)
@@ -223,7 +226,7 @@ namespace Reko.Analysis
                     }
                 }
             }
-            return new CallBinding(regCallee, new StringConstant(new UnknownType(), "???unsatisfied???"));
+            return null;
         }
     }
 }

--- a/src/UnitTests/Analysis/ProcedureFlowTests.cs
+++ b/src/UnitTests/Analysis/ProcedureFlowTests.cs
@@ -99,5 +99,30 @@ namespace Reko.UnitTests.Analysis
             Assert.AreEqual(1, bindings.Length);
             Assert.AreEqual("Stack +0004:local", bindings[0].ToString());
         }
+
+        [Test]
+        public void Pflow_IntersectBinding_NotFoundUses()
+        {
+            var reg = new RegisterStorage("r1", 1, 0, PrimitiveType.Word32);
+            var stCallee = new StackArgumentStorage(4, PrimitiveType.Word32);
+            var id = new Identifier("r1", reg.DataType, reg);
+            var cbs = new CallBinding[] { } ;
+            var uses = new Dictionary<Storage, BitRange>
+            {
+                {
+                    reg,
+                    new BitRange(0, 31)
+                },
+                {
+                    stCallee,
+                    new BitRange(0, 31)
+                },
+            };
+
+            var bindings = ProcedureFlow.IntersectCallBindingsWithUses(cbs, uses)
+                .ToArray();
+
+            Assert.AreEqual(0, bindings.Length);
+        }
     }
 } 


### PR DESCRIPTION
Do not return string constants as fallback. Just do not add
not found bindings to uses list at all. `CallApplicationBuilder` fallback
created in 31b7ba7 and e0dc20a can do this work properly