### PR TITLE
ExpressionEmitter: modify IAdd to create right operand as word constant

### DIFF
--- a/src/Core/Expressions/ExpressionEmitter.cs
+++ b/src/Core/Expressions/ExpressionEmitter.cs
@@ -67,7 +67,7 @@ namespace Reko.Core.Expressions
         /// <returns>A binary expression for the sum.</returns>
         public BinaryExpression IAdd(Expression left, int right)
         {
-            return new BinaryExpression(Operator.IAdd, left.DataType, left, Constant.Create(left.DataType, right));
+            return IAdd(left, Word(left.DataType.BitSize, right));
         }
 
         /// <summary>

--- a/src/Core/Expressions/ExpressionEmitter.cs
+++ b/src/Core/Expressions/ExpressionEmitter.cs
@@ -71,6 +71,18 @@ namespace Reko.Core.Expressions
         }
 
         /// <summary>
+        /// Convenience method for addition. The addend is converted to a
+        /// Signed Int Constant.
+        /// </summary>
+        /// <param name="left">Augend</param>
+        /// <param name="right">Addend</param>
+        /// <returns>A binary expression for the sum.</returns>
+        public BinaryExpression IAddS(Expression left, int right)
+        {
+            return IAdd(left, Constant.Int(left.DataType, right));
+        }
+
+        /// <summary>
         /// Creates an offset sum of <paramref name="e"/> and the
         /// signed integer <paramref name="c"/> interpreted as a word.
         /// </summary>

--- a/src/UnitTests/Core/CodeEmitterTests.cs
+++ b/src/UnitTests/Core/CodeEmitterTests.cs
@@ -65,6 +65,19 @@ namespace Reko.UnitTests.Core
         }
 
         [Test]
+        public void AddPointer()
+        {
+            var ptr = new Pointer(new StructureType("tmp", 16), 32);
+            var id = new Identifier("id", ptr, null);
+            var emitter = new CodeEmitterImpl();
+            var add = emitter.IAdd(id, 3);
+            Assert.AreEqual(PrimitiveType.Word32, add.DataType);
+            Assert.AreEqual(PrimitiveType.Word32, add.Right.DataType);
+            Assert.AreEqual("id + 0x00000003", add.ToString());
+        }
+
+
+        [Test]
         public void Cond()
         {
             var emitter = new CodeEmitterImpl();

--- a/src/UnitTests/Fragments/StaggeredArrayFragment.cs
+++ b/src/UnitTests/Fragments/StaggeredArrayFragment.cs
@@ -37,7 +37,7 @@ namespace Reko.UnitTests.Fragments
             Identifier x = Local32("x");
             Identifier i = Local32("i");
             LoadId(x, IAdd(p, SMul(i, 8)));
-            LoadId(x, IAdd(p, IAdd(SMul(i, 8), 4)));
+            LoadId(x, IAdd(p, IAddS(SMul(i, 8), 4)));
         }
     }
 }

--- a/src/UnitTests/Structure/ForLoopRewriterTests.cs
+++ b/src/UnitTests/Structure/ForLoopRewriterTests.cs
@@ -93,7 +93,7 @@ namespace Reko.UnitTests.Structure
                 m.While(m.Le(i, 42), b =>
                 {
                     b.SideEffect(b.Fn(foo, i));
-                    b.Assign(i, b.IAdd(i, 1));
+                    b.Assign(i, b.IAddS(i, 1));
                 });
             });
         }
@@ -122,7 +122,7 @@ namespace Reko.UnitTests.Structure
                 var x = Id("x", PrimitiveType.Int32);
                 var isqrt = Id("isqrt", PrimitiveType.Ptr32);
                 var limit = Id("limit", PrimitiveType.Int32);
-                m.Declare(limit, m.IAdd(m.Fn(isqrt, x), m.Int32(1)));
+                m.Declare(limit, m.IAddS(m.Fn(isqrt, x), 1));
                 m.Assign(i, m.Int32(2));
                 m.While(m.Lt(i, limit), w =>
                 {
@@ -130,7 +130,7 @@ namespace Reko.UnitTests.Structure
                     {
                         wif.Return(m.Int32(0));
                     });
-                    w.Assign(i, w.IAdd(i, w.Int32(1)));
+                    w.Assign(i, w.IAddS(i, 1));
                 });
                 m.Return(m.Int32(1));
             });
@@ -166,11 +166,11 @@ namespace Reko.UnitTests.Structure
                 var x = Id("x", PrimitiveType.Int32);
                 var isqrt = Id("isqrt", PrimitiveType.Ptr32);
                 var limit = Id("limit", PrimitiveType.Int32);
-                m.Declare(limit, m.IAdd(m.Fn(isqrt, x), m.Int32(1)));
+                m.Declare(limit, m.IAddS(m.Fn(isqrt, x), 1));
                 m.Assign(i, m.Int32(2));
                 m.While(m.Lt(i, limit), w =>
                 {
-                    w.Assign(i, w.IAdd(i, w.Int32(1)));
+                    w.Assign(i, w.IAddS(i, 1));
                     w.If(w.Eq0(m.Mod(x, i)), wif =>
                     {
                         wif.Return(m.Int32(0));
@@ -212,7 +212,7 @@ namespace Reko.UnitTests.Structure
                 m.Assign(i, m.Int32(2));
                 m.While(m.Lt(i, limit), w =>
                 {
-                    w.Assign(i, w.IAdd(i, w.Int32(1)));
+                    w.Assign(i, w.IAddS(i, 1));
                     w.Assign(sum, i);       // uses i after it was incremented.
                 });
                 m.Return(m.Int32(1));
@@ -252,7 +252,7 @@ namespace Reko.UnitTests.Structure
                 m.While(m.Lt(i, limit), w =>
                 {
                     w.SideEffect(m.Fn(foo, i));
-                    w.Assign(i, m.IAdd(i, 1));
+                    w.Assign(i, m.IAddS(i, 1));
                 });
                 m.Return(m.Int32(1));
             });
@@ -288,7 +288,7 @@ namespace Reko.UnitTests.Structure
                 m.While(m.Lt(i, limit), w =>
                 {
                     w.SideEffect(m.Fn(foo, i));
-                    w.Assign(i, m.IAdd(i, 1));
+                    w.Assign(i, m.IAddS(i, 1));
                 });
                 m.Return(m.Int32(1));
             });
@@ -319,7 +319,7 @@ namespace Reko.UnitTests.Structure
                 m.SideEffect(m.Fn(foo));
                 m.While(m.Lt(i, n), w =>
                 {
-                    w.Assign(i, w.IAdd(i, 1));
+                    w.Assign(i, w.IAddS(i, 1));
                 });
             });
             /*i = 0;
@@ -358,7 +358,7 @@ namespace Reko.UnitTests.Structure
                 m.Assign(i, m.Int32(0));
                 m.While(m.Lt(i, n), w =>
                 {
-                    w.Assign(i, w.IAdd(i, 1));
+                    w.Assign(i, w.IAddS(i, 1));
                     w.SideEffect(w.Fn(foo));
                 });
             });
@@ -391,7 +391,7 @@ namespace Reko.UnitTests.Structure
                 m.DoWhile(w =>
                     {
                         w.SideEffect(w.Fn(foo));
-                        w.Assign(i, w.IAdd(i, 1));
+                        w.Assign(i, w.IAddS(i, 1));
                     },
                     m.Lt(i, n));
             });
@@ -420,7 +420,7 @@ namespace Reko.UnitTests.Structure
                 m.DoWhile(w =>
                 {
                     w.SideEffect(w.Fn(foo));
-                    w.Assign(i, w.IAdd(i, 1));
+                    w.Assign(i, w.IAddS(i, 1));
                 },
                     m.Ne(i, m.Int32(42)));
             });
@@ -450,7 +450,7 @@ namespace Reko.UnitTests.Structure
                     t.DoWhile(d =>
                     {
                         d.SideEffect(d.Fn(foo, i));
-                        d.Assign(i, d.IAdd(i, 1));
+                        d.Assign(i, d.IAddS(i, 1));
                     },
                     t.Ne(i, n));
                 });
@@ -484,7 +484,7 @@ namespace Reko.UnitTests.Structure
                     t.DoWhile(d =>
                     {
                         d.SideEffect(d.Fn(foo, i));
-                        d.Assign(i, d.IAdd(i, 1));
+                        d.Assign(i, d.IAddS(i, 1));
                     },
                     t.Gt(complex, i));
                 });

--- a/src/UnitTests/Typing/ExpressionNormalizerTests.cs
+++ b/src/UnitTests/Typing/ExpressionNormalizerTests.cs
@@ -57,7 +57,7 @@ namespace Reko.UnitTests.Typing
             Identifier p = m.Local32("p");
             Identifier i = m.Local32("i");
             Expression e = m.Mem(PrimitiveType.Int32,
-                m.IAdd(p, m.IAdd(m.SMul(i, 8), 4)));
+            m.IAdd(p, m.IAddS(m.SMul(i, 8), 4)));
             e = e.Accept(aen);
             Assert.AreEqual("(p + 4)[i * 0x00000008]", e.ToString());
         }


### PR DESCRIPTION
This is the same modification as for `ISub` in #338
Difference between `ISub` and `IAdd` caused incorrect simplification of `FPU`
stack pointer in `analysis-development`. `TOP + 1` expression differs from
`TOP + 0x01` and so `PHI(TOP + 1, TOP + 0x01)` expression could be
simplified




