### PR TITLE
 Pass block address instead of procedure entry address to statement 

### DIFF
--- a/src/Core/Procedure.cs
+++ b/src/Core/Procedure.cs
@@ -231,6 +231,13 @@ namespace Reko.Core
             return block;
         }
 
+        public Block AddSyntheticBlock(Address addr, string name)
+        {
+            var block = AddBlock(addr, name);
+            block.IsSynthesized = true;
+            return block;
+        }
+
         public Block AddBlock(string name)
         {
             Block block = new Block(this, name);

--- a/src/Core/Procedure.cs
+++ b/src/Core/Procedure.cs
@@ -1,6 +1,6 @@
 #region License
 /* 
- * Copyright (C) 1999-2018 John Källén.
+ * Copyright (C) 1999-2018 John KÃ¤llÃ©n.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,9 +51,9 @@ namespace Reko.Core
             this.ControlGraph = new BlockGraph(blocks);
 			this.Frame = frame;
 			this.Signature = new FunctionType();
-            this.EntryBlock = AddBlock(Name + "_entry");
-			this.ExitBlock = AddBlock(Name + "_exit");
-		}
+            this.EntryBlock = AddBlock(addrEntry, Name + "_entry");
+            this.ExitBlock = AddBlock(addrEntry, Name + "_exit");
+        }
 
         public IProcessorArchitecture Architecture { get; }
         public List<AbsynStatement> Body { get; set; }

--- a/src/Decompiler/Analysis/GlobalCallRewriter.cs
+++ b/src/Decompiler/Analysis/GlobalCallRewriter.cs
@@ -1,6 +1,6 @@
 #region License
 /* 
- * Copyright (C) 1999-2018 John Källén.
+ * Copyright (C) 1999-2018 John KÃ¤llÃ©n.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -86,8 +86,7 @@ namespace Reko.Analysis
 					continue;
 
                 proc.ExitBlock.Statements.Add(
-                    //$TODO: should be procedure exit address here
-                    proc.EntryAddress.ToLinear(),
+                    proc.ExitBlock.Address.ToLinear(),
                     new UseInstruction(os.OriginalIdentifier, id));
 			}
 		}

--- a/src/Decompiler/Analysis/LiveCopyInserter.cs
+++ b/src/Decompiler/Analysis/LiveCopyInserter.cs
@@ -1,6 +1,6 @@
 #region License
 /* 
- * Copyright (C) 1999-2018 John Källén.
+ * Copyright (C) 1999-2018 John KÃ¤llÃ©n.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -56,7 +56,7 @@ namespace Reko.Analysis
 		public Identifier InsertAssignmentNewId(Identifier idOld, Block b, int i)
 		{
             var stm = new Statement(
-                (b.Address ?? b.Procedure.EntryAddress).ToLinear(),
+                b.Address.ToLinear(),
                 null,
                 b);
             SsaIdentifier sidNew = ssaIds.Add((Identifier)ssaIds[idOld].OriginalIdentifier, stm, idOld, false);
@@ -69,7 +69,7 @@ namespace Reko.Analysis
 		{
             b.Statements.Insert(
                 i,
-                (b.Address ?? b.Procedure.EntryAddress).ToLinear(),
+                b.Address.ToLinear(),
                 new Assignment(idDst, idSrc));
 			return idDst;
 		}

--- a/src/Decompiler/Analysis/SsaTransform.cs
+++ b/src/Decompiler/Analysis/SsaTransform.cs
@@ -1,6 +1,6 @@
 #region License
 /* 
- * Copyright (C) 1999-2018 John Källén.
+ * Copyright (C) 1999-2018 John KÃ¤llÃ©n.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -93,7 +93,7 @@ namespace Reko.Analysis
 		private Statement InsertPhiStatement(Block b, Identifier v)
 		{
 			var stm = new Statement(
-                (b.Address ?? b.Procedure.EntryAddress).ToLinear(),
+                b.Address.ToLinear(),
 				new PhiAssignment(v, b.Pred.Count),
 				b);
 			b.Statements.Insert(0, stm);
@@ -563,8 +563,7 @@ namespace Reko.Analysis
                                  !(id.Storage is StackArgumentStorage))
                     .OrderBy(id => id.Name)     // Sort them for stability; unit test are sensitive to shifting order 
                     .Select(id => new Statement(
-                        //$TODO: should be procedure exit address here
-                        proc.EntryAddress.ToLinear(),
+                        block.Address.ToLinear(),
                         new UseInstruction(id), block))
                     .ToList();
                 block.Statements.AddRange(stms);
@@ -1066,7 +1065,7 @@ namespace Reko.Analysis
         {
             var phiAss = new PhiAssignment(id, 0);
             var stm = new Statement(
-                (b.Address ?? b.Procedure.EntryAddress).ToLinear(),
+                b.Address.ToLinear(),
                 phiAss,
                 b);
             b.Statements.Insert(0, stm);
@@ -1141,7 +1140,7 @@ namespace Reko.Analysis
         {
             var sid = ssa.Identifiers.Add(id, null, null, false);
             sid.DefStatement = new Statement(
-                (b.Address ?? b.Procedure.EntryAddress).ToLinear(),
+                b.Address.ToLinear(),
                 new DefInstruction(id), b);
             b.Statements.Add(sid.DefStatement);
             return sid;

--- a/src/Decompiler/Scanning/BlockWorkitem.cs
+++ b/src/Decompiler/Scanning/BlockWorkitem.cs
@@ -301,19 +301,18 @@ namespace Reko.Scanning
                 }
                 else
                 {
-                    Block blockDsF = null;
-                    blockDsF = proc.AddBlock(branchingBlock.Name + "_ds_f");
-                    blockDsF.IsSynthesized = true;
-                    blockDsF.Address = ricDelayed.Address;
+                    var blockDsF = proc.AddSyntheticBlock(
+                        ricDelayed.Address,
+                        branchingBlock.Name + "_ds_f");
                     blockCur = blockDsF;
                     ProcessRtlCluster(ricDelayed);
                     EnsureEdge(proc, blockDsF, blockElse);
                     EnsureEdge(proc, branchingBlock, blockDsF);
                 }
 
-                Block blockDsT = proc.AddBlock(branchingBlock.Name + "_ds_t");
-                blockDsT.IsSynthesized = true;
-                blockDsT.Address = ricDelayed.Address;
+                var blockDsT = proc.AddSyntheticBlock(
+                    ricDelayed.Address,
+                    branchingBlock.Name + "_ds_t");
                 blockCur = blockDsT;
                 ProcessRtlCluster(ricDelayed);
                 EnsureEdge(proc, blockDsT, blockThen);
@@ -1083,9 +1082,7 @@ namespace Reko.Scanning
         private Block AddIntraStatementBlock(Procedure proc)
         {
             var label = ric.Address.GenerateName("l", string.Format("_{0}", ++extraLabels));
-            var fallthru = proc.AddBlock(ric.Address, label);
-            fallthru.IsSynthesized = true;
-            return fallthru;
+            return proc.AddSyntheticBlock(ric.Address, label);
         }
 
         /// <summary>

--- a/src/Decompiler/Scanning/BlockWorkitem.cs
+++ b/src/Decompiler/Scanning/BlockWorkitem.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 /* 
  * Copyright (C) 1999-2018 John Källén.
  *
@@ -1083,11 +1083,8 @@ namespace Reko.Scanning
         private Block AddIntraStatementBlock(Procedure proc)
         {
             var label = ric.Address.GenerateName("l", string.Format("_{0}", ++extraLabels));
-            var fallthru = new Block(proc, label)
-            {
-                IsSynthesized = true
-            };
-            proc.ControlGraph.Blocks.Add(fallthru);
+            var fallthru = proc.AddBlock(ric.Address, label);
+            fallthru.IsSynthesized = true;
             return fallthru;
         }
 

--- a/src/Decompiler/Scanning/Scanner.cs
+++ b/src/Decompiler/Scanning/Scanner.cs
@@ -421,8 +421,9 @@ namespace Reko.Scanning
                 "{0}_thunk_{1}",
                 Block.GenerateName(addrFrom),
                 procNew.Name);
-            var callRetThunkBlock = procOld.AddBlock(blockName);
-            callRetThunkBlock.IsSynthesized = true;
+            var callRetThunkBlock = procOld.AddSyntheticBlock(
+                addrFrom,
+                blockName);
 
             var linFrom = addrFrom.ToLinear();
             callRetThunkBlock.Statements.Add(


### PR DESCRIPTION
- Set address of entry and exit blocks in `Procedure` constructor 
- Pass block address instead of procedure entry address to statement. Address of each block should be always set
- Set address of intra statement block during scanning 