### PR TITLE
Remove incorrect block state definition replacing after trivial phi simplification

### DIFF
--- a/src/Decompiler/Analysis/SsaTransform.cs
+++ b/src/Decompiler/Analysis/SsaTransform.cs
@@ -1391,11 +1391,6 @@ namespace Reko.Analysis
                     }
                 }
                 sid = EnsureLiveIdentifier(sid);
-                var same = sid.Identifier;
-                if (blockstates[phi.DefStatement.Block].currentDef.TryGetValue(same.Storage.Domain, out var alias))
-                {
-                    alias.SsaId = outer.ssa.Identifiers[same];
-                }
                 phi.DefStatement.Block.Statements.Remove(phi.DefStatement);
                 this.outer.sidsToRemove.Add(phi);
                 return true;


### PR DESCRIPTION
- Create unit test to reproduce incorrect block state after trivial phi simplification
There is incorrect block state definition replacing after trivial phi
simplification. It causes adding incorrect use instruction to exit block
- Remove incorrect block state definition replacing after trivial phi simplification