### PR TITLE
Backpropagate stack pointer from procedure return [analysis-development]

### DIFF
--- a/src/Decompiler/Analysis/DataFlowAnalysis.cs
+++ b/src/Decompiler/Analysis/DataFlowAnalysis.cs
@@ -358,6 +358,10 @@ namespace Reko.Analysis
                 sst.AddUsesToExitBlock();
                 sst.RemoveDeadSsaIdentifiers();
 
+                // Backpropagate stack pointer from procedure return.
+                var spBackpropagator = new StackPointerBackpropagator(ssa);
+                spBackpropagator.BackpropagateStackPointer();
+
                 // Propagate those newly created stack-based identifiers.
                 vp.Transform();
                 return sst;

--- a/src/Decompiler/Analysis/StackPointerBackpropagator.cs
+++ b/src/Decompiler/Analysis/StackPointerBackpropagator.cs
@@ -1,0 +1,175 @@
+#region License
+/* 
+ * Copyright (C) 1999-2018 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using Reko.Core;
+using Reko.Core.Code;
+using Reko.Core.Expressions;
+using Reko.Core.Operators;
+using System.Linq;
+
+namespace Reko.Analysis
+{
+    /// <summary>
+    /// Backpropagate stack pointer from procedure return.
+    /// Assume that stack pointer at the end of procedure has the same
+    /// value as at the start
+    /// </summary>
+    /// <example>
+    /// If we have
+    /// <code>
+    ///     call eax; We do not know calling convention of this indirect call
+    ///             ; So we do not know value of stack pointer after it
+    /// cleanup:
+    ///     pop esi
+    ///     pop ebp
+    ///     ret
+    /// </code>
+    /// then we could assume than stack pointer at "cleanup" label is
+    /// "fp - 8"
+    /// </example>
+    // $REVIEW: It is highly unlikely that there is a procedure that
+    // leaves the stack pointer at different values depending on what
+    // path you took through it. Should we encounter such procedures in
+    // a binary we might consider turning this analysis off with a user
+    // switch.
+    public class StackPointerBackpropagator
+    {
+        private readonly SsaState ssa;
+        private readonly ExpressionEmitter m;
+
+        public StackPointerBackpropagator(SsaState ssa)
+        {
+            this.ssa = ssa;
+            this.m = new ExpressionEmitter();
+        }
+
+        /// <summary>
+        /// First find use of stack pointer at procedure exit block.
+        /// Check if its definition is like 'sp_at_exit = sp_previous + offset'
+        /// and 'sp_previous' is trashed (usually after indirect calls). We
+        /// assume that stack pointer at the end ('sp_at_exit') is 'fp'. So
+        /// 'sp_previous' is 'fp - offset'. So we replace definition of
+        /// 'sp_previous' with 'fp - offset'
+        /// </summary>
+        public void BackpropagateStackPointer()
+        {
+            var spAtExit = FindStackUseAtExit(ssa.Procedure);
+            if (spAtExit == null)
+                return;
+            var (spPrevious, offset) = MatchStackOffsetPattern(spAtExit);
+            if (spPrevious == null)
+                return;
+            if (!IsTrashed(spPrevious))
+                return;
+            ReplaceStackDefinition(spPrevious, offset);
+        }
+
+        private bool IsTrashed(Identifier sp)
+        {
+            var definition = ssa.Identifiers[sp].DefStatement;
+            switch (definition.Instruction)
+            {
+            case CallInstruction _:
+            case PhiAssignment _:
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        private (Identifier, int) MatchStackOffsetPattern(Identifier sp)
+        {
+            (Identifier, int) noMatch = (null, 0);
+            var def = ssa.Identifiers[sp].DefStatement;
+            if (!(def.Instruction is Assignment ass))
+                return noMatch;
+            if (!(ass.Src is BinaryExpression bin))
+                return noMatch;
+            if ((bin.Operator != Operator.IAdd &&
+                bin.Operator != Operator.ISub))
+                return noMatch;
+            if (!(bin.Left is Identifier id))
+                return noMatch;
+            if (id.Storage != sp.Storage)
+                return noMatch;
+            if (!(bin.Right is Constant c))
+                return noMatch;
+            var offset = c.ToInt32();
+            if (bin.Operator == Operator.ISub)
+                offset = -offset;
+            return (id, offset);
+        }
+
+        /// <summary>
+        /// Replace definition of '<paramref name="sp"/>' with
+        /// 'fp - <paramref name="stackOffset"/>'
+        /// </summary>
+        /// <param name="sp"></param>
+        /// <param name="stackOffset"></param>
+        private void ReplaceStackDefinition(Identifier sp, int stackOffset)
+        {
+            var spDef = ssa.Identifiers[sp].DefStatement;
+            // insert new stack definition
+            InsertStackDefinition(sp, stackOffset, spDef);
+            // remove old stack definition
+            RemoveDefinition(sp, spDef);
+        }
+
+        private void InsertStackDefinition(
+            Identifier stack,
+            int stackOffset,
+            Statement stmAfter)
+        {
+            var fp = ssa.Procedure.Frame.FramePointer;
+            var pos = stmAfter.Block.Statements.IndexOf(stmAfter);
+            var src = m.AddSubSignedInt(fp, -stackOffset);
+            var newStm = stmAfter.Block.Statements.Insert(
+                pos + 1,
+                stmAfter.LinearAddress,
+                new Assignment(stack, src));
+            ssa.Identifiers[stack].DefStatement = newStm;
+            ssa.AddUses(newStm);
+        }
+
+        private void RemoveDefinition(Identifier id, Statement defStatement)
+        {
+            switch (defStatement.Instruction)
+            {
+            case CallInstruction ci:
+                ci.Definitions.RemoveWhere(cb => cb.Expression == id);
+                break;
+            case PhiAssignment phi:
+                ssa.DeleteStatement(defStatement);
+                break;
+            }
+        }
+
+        private Identifier FindStackUseAtExit(Procedure proc)
+        {
+            return proc.ExitBlock.Statements
+                .Select(s => s.Instruction)
+                .OfType<UseInstruction>()
+                .Select(u => u.Expression)
+                .OfType<Identifier>()
+                .Where(id => id.Storage == proc.Architecture.StackRegister)
+                .SingleOrDefault();
+        }
+    }
+}

--- a/src/Decompiler/Analysis/StackPointerBackpropagator.cs
+++ b/src/Decompiler/Analysis/StackPointerBackpropagator.cs
@@ -84,7 +84,7 @@ namespace Reko.Analysis
         private bool IsTrashed(Identifier sp)
         {
             var definition = ssa.Identifiers[sp].DefStatement;
-            switch (definition.Instruction)
+            switch (definition?.Instruction)
             {
             case CallInstruction _:
             case PhiAssignment _:

--- a/src/Decompiler/Decompiler.csproj
+++ b/src/Decompiler/Decompiler.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Analysis\SsaDefinitionsCollector.cs" />
     <Compile Include="Analysis\SequenceIdentifierGenerator.cs" />
     <Compile Include="Analysis\SsaMutator.cs" />
+    <Compile Include="Analysis\StackPointerBackpropagator.cs" />
     <Compile Include="Analysis\TrashedRegisterFinder3.cs" />
     <Compile Include="Analysis\UnalignedMemoryAccessFuser.cs" />
     <Compile Include="Analysis\UnusedOutValuesRemover.cs" />

--- a/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
+++ b/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
@@ -1,0 +1,204 @@
+#region License
+/* 
+ * Copyright (C) 1999-2018 John Källén.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using NUnit.Framework;
+using Reko.Analysis;
+using Reko.Core;
+using Reko.UnitTests.Mocks;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace Reko.UnitTests.Analysis
+{
+    [TestFixture]
+    public class StackPointerBackpropagatorTests
+    {
+        private Program program;
+
+        [SetUp]
+        public void Setup()
+        {
+            var arch = new FakeArchitecture();
+            var platform = new FakePlatform(null, arch);
+            this.program = new Program
+            {
+                Architecture = arch,
+                Platform  = platform,
+            };
+        }
+
+        private void AssertStringsEqual(string sExp, SsaState ssa)
+        {
+            var sw = new StringWriter();
+            ssa.Procedure.Write(false, sw);
+            var sActual = sw.ToString();
+            if (sExp != sActual)
+            {
+                Debug.Print("{0}", sActual);
+                Assert.AreEqual(sExp, sActual);
+            }
+        }
+
+        private SsaState RunTest(ProcedureBuilder m)
+        {
+            var proc = m.Procedure;
+            var scc = new HashSet<Procedure> { proc };
+            var sst = new SsaTransform(program, m.Procedure, scc, null, null);
+            sst.Transform();
+            sst.AddUsesToExitBlock();
+            var ssa = sst.SsaState;
+            var spbp = new StackPointerBackpropagator(ssa);
+            spbp.BackpropagateStackPointer();
+            return ssa;
+        }
+
+        [Test]
+        public void Spbp_LinearProcedure()
+        {
+            var m = new ProcedureBuilder(program.Architecture);
+
+            var fp = m.Frame.FramePointer;
+            var sp = m.Frame.EnsureRegister(m.Architecture.StackRegister);
+            var r1 = m.Reg32("r1");
+            var r2 = m.Reg32("r2");
+            m.Assign(sp, fp);
+            m.Assign(sp, m.ISub(sp, m.Int32(4)));
+            m.MStore(sp, r1);
+            m.Call(r2, 4);      // Indirect call = hell node
+            m.Assign(r1, m.Mem32(sp));
+            m.Assign(sp, m.IAdd(sp, m.Int32(4)));
+            m.Return();
+
+            SsaState ssa = RunTest(m);
+
+            var sExp =
+            #region Expected
+@"// ProcedureBuilder
+// Return size: 0
+define ProcedureBuilder
+ProcedureBuilder_entry:
+	def fp
+	def r1
+	def r2
+	// succ:  l1
+l1:
+	r63_2 = fp
+	r63_3 = r63_2 - 4
+	Mem5[r63_3:word32] = r1
+	call r2 (retsize: 4;)
+		uses: r1:r1,r2:r2,r63:r63_3
+		defs: r1:r1_8,r2:r2_9
+	r63_7 = fp - 4
+	r1_10 = Mem5[r63_7:word32]
+	r63_11 = r63_7 + 4
+	return
+	// succ:  ProcedureBuilder_exit
+ProcedureBuilder_exit:
+	use r1_10
+	use r2_9
+	use r63_11
+";
+            #endregion
+            AssertStringsEqual(sExp, ssa);
+        }
+
+        [Test(Description = "This mirrors real world code which has more than one epilog")]
+        [Ignore("It would be nice if this passed.")]
+        public void Spbp_TwoExits()
+        {
+            var m = new ProcedureBuilder(program.Architecture);
+
+            var fp = m.Frame.FramePointer;
+            var sp = m.Frame.EnsureRegister(m.Architecture.StackRegister);
+            var r1 = m.Reg32("r1");
+            var r2 = m.Reg32("r2");
+            var r3 = m.Reg32("r3");
+            m.Assign(sp, fp);
+            m.Assign(sp, m.ISub(sp, m.Int32(4)));
+            m.MStore(sp, r1);
+            m.BranchIf(m.Eq0(r3), "m_eq0");
+
+            m.Label("m_ne0");
+            m.Call(m.Mem32(m.IAdd(r2, 4)), 4);      // Indirect call = hell node
+            m.Assign(r1, m.Mem32(sp));
+            m.Assign(sp, m.IAdd(sp, m.Int32(4)));
+            m.Return();
+
+            m.Label("m_eq0");
+            m.Call(m.Mem32(m.IAdd(r2, 8)), 4);      // Indirect call = hell node
+            m.Assign(r1, m.Mem32(sp));
+            m.Assign(sp, m.IAdd(sp, m.Int32(4)));
+            m.Return();
+
+            SsaState ssa = RunTest(m);
+
+            var sExp =
+            #region Expected
+@"// ProcedureBuilder
+// Return size: 0
+define ProcedureBuilder
+ProcedureBuilder_entry:
+	def fp
+	def r1
+	def r3
+	def r2
+	// succ:  l1
+l1:
+	r63_2 = fp
+	r63_3 = r63_2 - 4
+	Mem5[r63_3:word32] = r1
+	branch r3 == 0x00000000 m_eq0
+	goto m_ne0
+	// succ:  m_ne0 m_eq0
+m_eq0:
+	call Mem5[r2 + 0x00000008:word32] (retsize: 4;)
+		uses: r1:r1,r2:r2,r3:r3,r63:r63_3
+		defs: r1:r1_9,r2:r2_10,r3:r3_11,r63:r63_8
+	r63_14 = fp - 4
+	r1_12 = Mem5[r63_8:word32]
+	r63_13 = r63_8 + 4
+	return
+	// succ:  ProcedureBuilder_exit
+m_ne0:
+	call Mem5[r2 + 0x00000004:word32] (retsize: 4;)
+		uses: r1:r1,r2:r2,r3:r3,r63:r63_3
+		defs: r1:r1_15,r2:r2_16,r3:r3_17
+	r63_14 = fp - 4
+	r1_18 = Mem5[r63_14:word32]
+	r63_19 = r63_14 + 4
+	return
+	// succ:  ProcedureBuilder_exit
+ProcedureBuilder_exit:
+	r63_23 = PHI(r63_19, r63_13)
+	r3_22 = PHI(r3_17, r3_11)
+	r2_21 = PHI(r2_16, r2_10)
+	r1_20 = PHI(r1_18, r1_12)
+	use r1_20
+	use r2_21
+	use r3_22
+	use r63_23
+";
+            #endregion
+            AssertStringsEqual(sExp, ssa);
+        }
+
+    }
+}

--- a/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
+++ b/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
@@ -64,6 +64,7 @@ namespace Reko.UnitTests.Analysis
         {
             var spbp = new StackPointerBackpropagator(ssa);
             spbp.BackpropagateStackPointer();
+            ssa.Validate(s => Assert.Fail(s));
             return ssa;
         }
 

--- a/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
+++ b/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
@@ -188,14 +188,14 @@ Spbp_LinearProcedure_exit:
             m.Assign(r63_6, m.IAdd(r63_5, m.Int32(4)));
             m.Return();
 
-            m.Phi(r1_5, r1_2, r1_4);
-            m.Phi(r2_3, r2_1, r2_3);
-            m.Phi(r3_3, r3_1, r2_3);
-            m.Phi(r63_6, r63_3, r63_5);
+            m.AddPhiToExitBlock(r1_5, r1_2, r1_4);
+            m.AddPhiToExitBlock(r2_3, r2_1, r2_3);
+            m.AddPhiToExitBlock(r3_3, r3_1, r2_3);
+            m.AddPhiToExitBlock(r63_7, r63_4, r63_6);
             m.AddUseToExitBlock(r1_5);
             m.AddUseToExitBlock(r2_3);
             m.AddUseToExitBlock(r3_3);
-            m.AddUseToExitBlock(r63_6);
+            m.AddUseToExitBlock(r63_7);
 
             SsaState ssa = RunTest(m.Ssa);
 
@@ -218,32 +218,32 @@ l1:
 	goto m_ne0
 	// succ:  m_ne0 m_eq0
 m_eq0:
-	call Mem22[r2 + 0x00000008:word32] (retsize: 4;)
-		uses: r1:r1,r2:r2,r3:r3,r63:r63_3
-		defs: r1:r1_9,r2:r2_10,r3:r3_11,r63:r63_8
-	r63_14 = fp - 4
-	r1_12 = Mem5[r63_8:word32]
-	r63_13 = r63_8 + 4
+	call Mem25[r2 + 0x00000008:word32] (retsize: 4;)
+		uses: r1:r1,r2:r2,r3:r3,r63:r63_2
+		defs: r1:r1_3,r2:r2_2,r3:r3_2
+	r63_5 = fp - 4
+	r1_4 = Mem26[r63_5:word32]
+	r63_6 = r63_5 + 4
 	return
-	// succ:  ProcedureBuilder_exit
+	// succ:  Spbp_TwoExits_exit
 m_ne0:
-	call Mem5[r2 + 0x00000004:word32] (retsize: 4;)
-		uses: r1:r1,r2:r2,r3:r3,r63:r63_3
-		defs: r1:r1_15,r2:r2_16,r3:r3_17
-	r63_14 = fp - 4
-	r1_18 = Mem5[r63_14:word32]
-	r63_19 = r63_14 + 4
+	call Mem23[r2 + 0x00000004:word32] (retsize: 4;)
+		uses: r1:r1,r2:r2,r3:r3,r63:r63_2
+		defs: r1:r1_1,r2:r2_1,r3:r3_1
+	r63_3 = fp - 4
+	r1_2 = Mem24[r63_3:word32]
+	r63_4 = r63_3 + 4
 	return
 	// succ:  Spbp_TwoExits_exit
 Spbp_TwoExits_exit:
-	r63_23 = PHI(r63_19, r63_13)
-	r3_22 = PHI(r3_17, r3_11)
-	r2_21 = PHI(r2_16, r2_10)
-	r1_20 = PHI(r1_18, r1_12)
-	use r1_20
-	use r2_21
-	use r3_22
-	use r63_23
+	r1_5 = PHI(r1_2, r1_4)
+	r2_3 = PHI(r2_1, r2_3)
+	r3_3 = PHI(r3_1, r2_3)
+	r63_7 = PHI(r63_4, r63_6)
+	use r1_5
+	use r2_3
+	use r3_3
+	use r63_7
 ";
             #endregion
             AssertStringsEqual(sExp, ssa);

--- a/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
+++ b/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
@@ -135,7 +135,6 @@ Spbp_LinearProcedure_exit:
         }
 
         [Test(Description = "This mirrors real world code which has more than one epilog")]
-        [Ignore("It would be nice if this passed. I'm leaving the code as is, but it will need to be fixed up")]
         public void Spbp_TwoExits()
         {
             var m = new SsaProcedureBuilder(nameof(Spbp_TwoExits));

--- a/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
+++ b/src/UnitTests/Analysis/StackPointerBackpropagatorTests.cs
@@ -135,60 +135,91 @@ Spbp_LinearProcedure_exit:
         }
 
         [Test(Description = "This mirrors real world code which has more than one epilog")]
-        [Ignore("It would be nice if this passed.")]
+        [Ignore("It would be nice if this passed. I'm leaving the code as is, but it will need to be fixed up")]
         public void Spbp_TwoExits()
         {
             var m = new SsaProcedureBuilder(nameof(Spbp_TwoExits));
 
-            var fp = m.Frame.FramePointer;
-            var sp = m.Frame.EnsureRegister(m.Architecture.StackRegister);
+            var fp = m.Ssa.Identifiers.Add(m.Frame.FramePointer, null, null, false).Identifier;
+            var r63_1 = m.Reg("r63_1", m.Architecture.StackRegister);
+            var r63_2 = m.Reg("r63_2", m.Architecture.StackRegister);
+            var r63_3 = m.Reg("r63_3", m.Architecture.StackRegister);
+            var r63_4 = m.Reg("r63_4", m.Architecture.StackRegister);
+            var r63_5 = m.Reg("r63_5", m.Architecture.StackRegister);
+            var r63_6 = m.Reg("r63_6", m.Architecture.StackRegister);
+            var r63_7 = m.Reg("r63_7", m.Architecture.StackRegister);
             var r1 = m.Reg32("r1");
             var r2 = m.Reg32("r2");
             var r3 = m.Reg32("r3");
-            m.Assign(sp, fp);
-            m.Assign(sp, m.ISub(sp, m.Int32(4)));
-            m.MStore(sp, r1);
+            var r1_1 = m.Reg("r1_1", (RegisterStorage) r1.Storage);
+            var r1_2 = m.Reg("r1_2", (RegisterStorage) r1.Storage);
+            var r1_3 = m.Reg("r1_3", (RegisterStorage) r1.Storage);
+            var r1_4 = m.Reg("r1_4", (RegisterStorage) r1.Storage);
+            var r1_5 = m.Reg("r1_5", (RegisterStorage) r1.Storage);
+            var r2_1 = m.Reg("r2_1", (RegisterStorage) r2.Storage);
+            var r2_2 = m.Reg("r2_2", (RegisterStorage) r2.Storage);
+            var r2_3 = m.Reg("r2_3", (RegisterStorage) r2.Storage);
+            var r3_1 = m.Reg("r3_1", (RegisterStorage) r3.Storage);
+            var r3_2 = m.Reg("r3_2", (RegisterStorage) r3.Storage);
+            var r3_3 = m.Reg("r3_3", (RegisterStorage) r3.Storage);
+
+            m.AddDefToEntryBlock(fp);
+            m.AddDefToEntryBlock(r1);
+            m.AddDefToEntryBlock(r2);
+            m.AddDefToEntryBlock(r3);
+
+            m.Assign(r63_1, fp);
+            m.Assign(r63_2, m.ISub(r63_1, m.Int32(4)));
+            m.MStore(r63_2, r1);
             m.BranchIf(m.Eq0(r3), "m_eq0");
 
             m.Label("m_ne0");
-            m.Call(m.Mem32(m.IAdd(r2, 4)), 4);      // Indirect call = hell node
-            m.Assign(r1, m.Mem32(sp));
-            m.Assign(sp, m.IAdd(sp, m.Int32(4)));
+            m.Call(m.Mem32(m.IAdd(r2, 4)), 4,      // Indirect call = hell node
+                new[] { r1, r2, r3, r63_2 },
+                new[] { r1_1, r2_1, r3_1, r63_3 });
+            m.Assign(r1_2, m.Mem32(r63_3));
+            m.Assign(r63_4, m.IAdd(r63_3, m.Int32(4)));
             m.Return();
 
             m.Label("m_eq0");
-            m.Call(m.Mem32(m.IAdd(r2, 8)), 4);      // Indirect call = hell node
-            m.Assign(r1, m.Mem32(sp));
-            m.Assign(sp, m.IAdd(sp, m.Int32(4)));
+            m.Call(m.Mem32(m.IAdd(r2, 8)), 4,      // Indirect call = hell node
+                new[] { r1, r2, r3, r63_2 },
+                new[] { r1_3, r2_2, r3_2, r63_5 });
+            m.Assign(r1_4, m.Mem32(r63_5));
+            m.Assign(r63_6, m.IAdd(r63_5, m.Int32(4)));
             m.Return();
 
-            m.AddUseToExitBlock(r1);
-            m.AddUseToExitBlock(r2);
-            m.AddUseToExitBlock(r3);
-            m.AddUseToExitBlock(sp);
+            m.Phi(r1_5, r1_2, r1_4);
+            m.Phi(r2_3, r2_1, r2_3);
+            m.Phi(r3_3, r3_1, r2_3);
+            m.Phi(r63_6, r63_3, r63_5);
+            m.AddUseToExitBlock(r1_5);
+            m.AddUseToExitBlock(r2_3);
+            m.AddUseToExitBlock(r3_3);
+            m.AddUseToExitBlock(r63_6);
 
             SsaState ssa = RunTest(m.Ssa);
 
             var sExp =
             #region Expected
-@"// ProcedureBuilder
+@"// Spbp_TwoExits
 // Return size: 0
-define ProcedureBuilder
-ProcedureBuilder_entry:
+define Spbp_TwoExits
+Spbp_TwoExits_entry:
 	def fp
 	def r1
-	def r3
 	def r2
+	def r3
 	// succ:  l1
 l1:
-	r63_2 = fp
-	r63_3 = r63_2 - 4
-	Mem5[r63_3:word32] = r1
+	r63_1 = fp
+	r63_2 = r63_1 - 4
+	Mem22[r63_2:word32] = r1
 	branch r3 == 0x00000000 m_eq0
 	goto m_ne0
 	// succ:  m_ne0 m_eq0
 m_eq0:
-	call Mem5[r2 + 0x00000008:word32] (retsize: 4;)
+	call Mem22[r2 + 0x00000008:word32] (retsize: 4;)
 		uses: r1:r1,r2:r2,r3:r3,r63:r63_3
 		defs: r1:r1_9,r2:r2_10,r3:r3_11,r63:r63_8
 	r63_14 = fp - 4
@@ -204,8 +235,8 @@ m_ne0:
 	r1_18 = Mem5[r63_14:word32]
 	r63_19 = r63_14 + 4
 	return
-	// succ:  ProcedureBuilder_exit
-ProcedureBuilder_exit:
+	// succ:  Spbp_TwoExits_exit
+Spbp_TwoExits_exit:
 	r63_23 = PHI(r63_19, r63_13)
 	r3_22 = PHI(r3_17, r3_11)
 	r2_21 = PHI(r2_16, r2_10)

--- a/src/UnitTests/Mocks/ProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/ProcedureBuilder.cs
@@ -223,7 +223,12 @@ namespace Reko.UnitTests.Mocks
             return Block.Statements.Last;
         }
 
-        public void AddUseToExitBlock(Identifier id)
+        public virtual void AddDefToEntryBlock(Identifier id)
+        {
+            Procedure.EntryBlock.Statements.Add(0, new DefInstruction(id));
+        }
+
+        public virtual void AddUseToExitBlock(Identifier id)
         {
             Procedure.ExitBlock.Statements.Add(0, new UseInstruction(id));
         }

--- a/src/UnitTests/Mocks/ProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/ProcedureBuilder.cs
@@ -223,16 +223,6 @@ namespace Reko.UnitTests.Mocks
             return Block.Statements.Last;
         }
 
-        public virtual void AddDefToEntryBlock(Identifier id)
-        {
-            Procedure.EntryBlock.Statements.Add(0, new DefInstruction(id));
-        }
-
-        public virtual void AddUseToExitBlock(Identifier id)
-        {
-            Procedure.ExitBlock.Statements.Add(0, new UseInstruction(id));
-        }
-
         public Identifier Flags(string s)
         {
             return Frame.EnsureFlagGroup(Architecture.GetFlagGroup(s));

--- a/src/UnitTests/Mocks/SsaProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/SsaProcedureBuilder.cs
@@ -145,8 +145,26 @@ namespace Reko.UnitTests.Mocks
                     Ssa.Identifiers[id].DefExpression = call.Callee;
                 }
                 break;
+            case DefInstruction def:
+                Ssa.Identifiers[def.Identifier].DefStatement = stm;
+                Ssa.Identifiers[def.Identifier].DefExpression = null;
+                break;
             }
             Ssa.AddUses(stm);
+        }
+
+        public void AddDefToEntryBlock(Identifier id)
+        {
+            var def = new DefInstruction(id);
+            var stm = Procedure.EntryBlock.Statements.Add(0, def);
+            ProcessInstruction(def, stm);
+        }
+
+        public void AddUseToExitBlock(Identifier id)
+        {
+            var use = new UseInstruction(id);
+            var stm = Procedure.ExitBlock.Statements.Add(0, use);
+            ProcessInstruction(use, stm);
         }
 
         public void AddPhiToExitBlock(Identifier idDst, params Expression[] exprs)

--- a/src/UnitTests/Mocks/SsaProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/SsaProcedureBuilder.cs
@@ -75,6 +75,14 @@ namespace Reko.UnitTests.Mocks
             return sid.Identifier;
         }
 
+        public Identifier Temp(string name, TemporaryStorage stg)
+        {
+            var id = new Identifier(stg.Name, stg.DataType, stg);
+            var sid = new SsaIdentifier(id, id, null, null, false);
+            Ssa.Identifiers.Add(id, sid);
+            return sid.Identifier;
+        }
+
         public new Identifier Reg32(string name)
         {
             return Reg(name, PrimitiveType.Word32);
@@ -121,6 +129,14 @@ namespace Reko.UnitTests.Mocks
                     {
                         store.Dst = new MemoryAccess(memId, ea, dt);
                     }
+                }
+                break;
+            case CallInstruction call:
+                foreach (var def in call.Definitions)
+                {
+                    var id = (Identifier) def.Expression;
+                    Ssa.Identifiers[id].DefStatement = stm;
+                    Ssa.Identifiers[id].DefExpression = call.Callee;
                 }
                 break;
             }

--- a/src/UnitTests/Mocks/SsaProcedureBuilder.cs
+++ b/src/UnitTests/Mocks/SsaProcedureBuilder.cs
@@ -102,6 +102,12 @@ namespace Reko.UnitTests.Mocks
         public override Statement Emit(Instruction instr)
         {
             var stm = base.Emit(instr);
+            ProcessInstruction(instr, stm);
+            return stm;
+        }
+
+        private void ProcessInstruction(Instruction instr, Statement stm)
+        {
             switch (instr)
             {
             case Assignment ass:
@@ -141,7 +147,14 @@ namespace Reko.UnitTests.Mocks
                 break;
             }
             Ssa.AddUses(stm);
-            return stm;
+        }
+
+        public void AddPhiToExitBlock(Identifier idDst, params Expression[] exprs)
+        {
+            var phiFunc = new PhiFunction(idDst.DataType, exprs);
+            var phi = new PhiAssignment(idDst, phiFunc);
+            var stm = Procedure.ExitBlock.Statements.Add(0, phi);
+            ProcessInstruction(phi, stm);
         }
 
         private MemoryIdentifier AddMemIdToSsa(MemoryIdentifier idOld)

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -139,6 +139,7 @@
   <ItemGroup>
     <Compile Include="Analysis\ProcedureFlowTests.cs" />
     <Compile Include="Analysis\SsaMutatorTests.cs" />
+    <Compile Include="Analysis\StackPointerBackpropagatorTests.cs" />
     <Compile Include="Arch\Alpha\AlphaDisassemblerTests.cs" />
     <Compile Include="Arch\Alpha\AlphaRewriterTests.cs" />
     <Compile Include="Arch\Arm\A64RewriterTests.cs" />


### PR DESCRIPTION
Do changes similar to #633. SSA transform is done at earlier stage in
analysis-development.
So evaluation of each statement at return block is not required. 
We just find use of stack pointer at procedure exit block.
Then check if its definition is like `sp_at_exit = sp_previous + offset`
and `sp_previous` is trashed. 
We assume that stack pointer at the end (`sp_at_exit`) is `fp` and
replace definition of `sp_previous` with `fp - offset`