### PR TITLE
Modify CallRewriter to add uses of out parameter store to Ssa State

### DIFF
--- a/src/Decompiler/Analysis/CallRewriter.cs
+++ b/src/Decompiler/Analysis/CallRewriter.cs
@@ -400,10 +400,12 @@ namespace Reko.Analysis
             Block block,
             int insertPos)
         {
+            var entryBlock = ssa.Procedure.EntryBlock;
+            var paramSid = ssa.EnsureSsaIdentifier(parameter, entryBlock);
             var iAddr = block.Statements[insertPos].LinearAddress;
             var stm = block.Statements.Insert(
                 insertPos, iAddr, 
-                new Store(parameter, e));
+                new Store(paramSid.Identifier, e));
             ssa.AddUses(stm);
         }
     }

--- a/src/Decompiler/Analysis/InstructionUseVisitorBase.cs
+++ b/src/Decompiler/Analysis/InstructionUseVisitorBase.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 /* 
  * Copyright (C) 1999-2018 Pavel Tomin.
  *
@@ -54,9 +54,6 @@ namespace Reko.Analysis
         {
             store.Src.Accept(this);
 
-            // Do not count assignments to out identifiers as uses.
-            if (store.Dst is Identifier idOut && idOut.Storage is OutArgumentStorage)
-                return;
             // Do not add memory identifier to uses
             if (store.Dst is MemoryAccess access)
             {

--- a/src/UnitTests/Analysis/CallRewriterTests.cs
+++ b/src/UnitTests/Analysis/CallRewriterTests.cs
@@ -732,6 +732,7 @@ word32 fnOutParam(word32 r1, word32 r2, ptr32 & r2Out)
 fnOutParam_entry:
 	def r1
 	def r2
+	def r2Out
 	// succ:  m0
 m0:
 	branch r1 == 0x00000000 m2
@@ -864,6 +865,7 @@ main_exit:
             var sExp =
             #region Expected
 @"main_entry:
+	def out
 body:
 	out = <invalid>
 	return <invalid>

--- a/src/tests/Analysis/CoaAsciiHex.exp
+++ b/src/tests/Analysis/CoaAsciiHex.exp
@@ -104,6 +104,9 @@ S_48: orig: S
 S_49: orig: S
 S_50: orig: S
 S_51: orig: S
+alOut:Out:al
+    uses: alOut = al
+          alOut = al_30
 Z_60: orig: Z
 Z_61: orig: Z
 Z_62: orig: Z

--- a/src/tests/Analysis/CoaSideEffectCalls.exp
+++ b/src/tests/Analysis/CoaSideEffectCalls.exp
@@ -34,6 +34,8 @@ sp_2: orig: sp
 Top_3: orig: Top
 ax_4: orig: ax
 bx_5: orig: bx
+bxOut:Out:bx
+    uses: bxOut = 0x002B
 // fn0C00_000E
 // Return size: 0
 word16 fn0C00_000E(ptr16 & bxOut)

--- a/src/tests/Analysis/CrwAsciiHex.exp
+++ b/src/tests/Analysis/CrwAsciiHex.exp
@@ -55,6 +55,7 @@ FlagGroup bool fn0C00_000A(Register byte al, Register out ptr16 alOut)
 bool fn0C00_000A(byte al, ptr16 & alOut)
 fn0C00_000A_entry:
 	def al
+	def alOut
 	// succ:  l0C00_000A
 l0C00_000A:
 	branch al <u 0x30 l0C00_0032

--- a/src/tests/Analysis/CrwLeakyLiveness.exp
+++ b/src/tests/Analysis/CrwLeakyLiveness.exp
@@ -63,6 +63,7 @@ fn0C00_000A_entry:
 	def ds
 	def Mem0
 	def ax
+	def axOut
 	// succ:  l0C00_000A
 l0C00_000A:
 	si_6 = Mem0[ds:0x0100:word16]

--- a/src/tests/Analysis/CrwMutual.exp
+++ b/src/tests/Analysis/CrwMutual.exp
@@ -49,6 +49,7 @@ Register word16 fn0C00_0004(Register word16 dx, Register out ptr16 dxOut)
 word16 fn0C00_0004(word16 dx, ptr16 & dxOut)
 fn0C00_0004_entry:
 	def dx
+	def dxOut
 	// succ:  l0C00_0004
 l0C00_0004:
 	branch dx != 0x001E l0C00_000F

--- a/src/tests/Analysis/CrwParameters.exp
+++ b/src/tests/Analysis/CrwParameters.exp
@@ -57,6 +57,7 @@ fn0C00_0025_entry:
 	def ds
 	def si
 	def Mem0
+	def siOut
 	// succ:  l0C00_0025
 l0C00_0025:
 	ax_7 = Mem0[ds:si:word16]
@@ -91,6 +92,7 @@ fn0C00_0027_entry:
 	def si
 	def ds
 	def Mem0
+	def siOut
 	// succ:  l0C00_0027
 l0C00_0027:
 	ax_4 = 0x0000
@@ -129,6 +131,7 @@ fn0C00_002F_entry:
 	def ds
 	def si
 	def Mem0
+	def siOut
 	// succ:  l0C00_002F
 l0C00_002F:
 	ax_7 = Mem0[ds:si:word16]
@@ -158,6 +161,7 @@ word16 fn0C00_0036(word16 si, selector ds, ptr16 & siOut)
 fn0C00_0036_entry:
 	def ds
 	def si
+	def siOut
 	// succ:  l0C00_0036
 l0C00_0036:
 	ax_9 = fn0C00_0025(si + 0x0002, ds, out si_10)


### PR DESCRIPTION
Modify `CallRewriter` to add uses of out parameter store to `Ssa State`. This is the fix for https://github.com/uxmal/reko/blob/56a7d8b304bd13c6dabdc0f30528561af2566804/subjects/regression.log#L57