### PR TITLE
IdentifierReplacer: add correct uses for new expression which replaces old id

### DIFF
--- a/src/Decompiler/Analysis/Coalescer.cs
+++ b/src/Decompiler/Analysis/Coalescer.cs
@@ -1,6 +1,6 @@
-#region License
+ï»¿#region License
 /* 
- * Copyright (C) 1999-2018 John Källén.
+ * Copyright (C) 1999-2018 John KÃ¤llÃ©n.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -133,7 +133,6 @@ namespace Reko.Analysis
 		public bool CoalesceStatements(SsaIdentifier sid, Expression defExpr, Statement def, Statement use)
 		{
             PreCoalesceDump(sid, def, use);
-			def.Instruction.Accept(new UsedIdentifierAdjuster(def, ssa.Identifiers, use));
             use.Instruction.Accept(new IdentifierReplacer(ssa.Identifiers, use, sid.Identifier, defExpr, false));
 
 			if (defsByStatement.TryGetValue(def, out var sids))
@@ -255,49 +254,5 @@ namespace Reko.Analysis
 			}
 			return MoveAssignment(initialPosition, block.Statements.Count, block);
 		}
-    }
-
-    /// <summary>
-    /// Replace uses of identifiers in the defined statement to reflect that it
-    /// has been moved into the using statement.
-    /// </summary>
-    public class UsedIdentifierAdjuster : InstructionVisitorBase
-    {
-        private Statement def;
-        private Statement use;
-        private SsaIdentifierCollection ssaIds;
-
-        public UsedIdentifierAdjuster(Statement def, SsaIdentifierCollection ssaIds, Statement use)
-        {
-            this.def = def;
-            this.use = use;
-            this.ssaIds = ssaIds;
-        }
-
-        public void Transform()
-        {
-            def.Instruction.Accept(this);
-        }
-
-        public override void VisitAssignment(Assignment a)
-        {
-            a.Src.Accept(this);
-        }
-
-        public override void VisitIdentifier(Identifier id)
-        {
-            SsaIdentifier sid = ssaIds[id];
-            for (int i = 0; i < sid.Uses.Count; ++i)
-            {
-                if (sid.Uses[i] == def)
-                    sid.Uses[i] = use;
-            }
-        }
-
-        public override void VisitStore(Store store)
-        {
-            store.Dst.Accept(this);
-            store.Src.Accept(this);
-        }
     }
 }

--- a/src/Decompiler/Analysis/IdentifierReplacer.cs
+++ b/src/Decompiler/Analysis/IdentifierReplacer.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 /* 
  * Copyright (C) 1999-2018 John Källén.
  *
@@ -37,7 +37,6 @@ namespace Reko.Analysis
         private Statement use;
         private Identifier idOld;
         private Expression exprNew;
-        private Identifier idNew;
         private bool replaceDefinitions;
 
         public IdentifierReplacer(SsaIdentifierCollection ssaIds, Statement use, Identifier idOld, Expression exprNew, bool replaceDefinitions)
@@ -46,7 +45,6 @@ namespace Reko.Analysis
             this.use = use;
             this.idOld = idOld;
             this.exprNew = exprNew;
-            this.idNew = exprNew as Identifier;
             this.replaceDefinitions = replaceDefinitions;
         }
 
@@ -80,9 +78,10 @@ namespace Reko.Analysis
             if (idOld == id)
             {
                 ssaIds[id].Uses.Remove(use);
-                if (idNew != null)
+                var usedIds = ExpressionIdentifierUseFinder.Find(ssaIds, exprNew);
+                foreach(var usedId in usedIds)
                 {
-                    ssaIds[idNew].Uses.Add(use);
+                    ssaIds[usedId].Uses.Add(use);
                 }
                 return exprNew;
             }

--- a/src/UnitTests/Analysis/CoalescerTests.cs
+++ b/src/UnitTests/Analysis/CoalescerTests.cs
@@ -243,5 +243,23 @@ b = Mem3[Mem2[0x00123400:word32]:word32]
 ";
             AssertProcedureCode(sExp);
         }
+
+        [Test]
+        public void CoaIdentifier()
+        {
+            var a = m.Reg32("a");
+            var b = m.Reg32("b");
+            var c = m.Reg32("c");
+            m.Assign(a, b);
+            m.Assign(c, m.IAddS(a, 1));
+
+            RunCoalescer();
+
+            var sExp =
+@"
+c = b + 1
+";
+            AssertProcedureCode(sExp);
+        }
     }
 }

--- a/src/tests/Analysis/CoaConditionals.exp
+++ b/src/tests/Analysis/CoaConditionals.exp
@@ -3,16 +3,11 @@ sp_2: orig: sp
 Top_3: orig: Top
 ds:ds
     def:  def ds
-    uses: branch Mem0[ds:0x0102:word16] == Mem0[ds:0x0100:word16] l0C00_000F
-          Mem9[ds:0x0F00:byte] = 0x01
-          v7_13 = Mem11[ds:0x0106:word16] - Mem11[ds:0x0104:word16]
+    uses: Mem9[ds:0x0F00:byte] = 0x01
           v7_13 = Mem11[ds:0x0106:word16] - Mem11[ds:0x0104:word16]
           Mem14[ds:0x0106:word16] = v7_13
           Mem17[ds:0x0F01:byte] = 0x01
-          branch (Mem19[ds:0x0106:word16] & Mem19[ds:0x0108:word16]) == 0x0000 l0C00_002D
-          branch (Mem19[ds:0x0106:word16] & Mem19[ds:0x0108:word16]) == 0x0000 l0C00_002D
           Mem25[ds:0x0F02:byte] = 0x01
-          branch Mem27[ds:0x010A:word16] >=u Mem27[ds:0x010C:word16] l0C00_003D
           Mem32[ds:0x0F03:byte] = 0x01
           Mem49[ds:0x0F04:byte] = 0x01
           Mem55[ds:0x0F05:byte] = 0x01
@@ -20,11 +15,16 @@ ds:ds
           branch Mem0[ds:0x0102:word16] == Mem0[ds:0x0100:word16] l0C00_000F
           branch Mem27[ds:0x010A:word16] >=u Mem27[ds:0x010C:word16] l0C00_003D
           branch (Mem51[ds:0x010E:word16] & 0x01FF) == 0x0000 l0C00_0056
+          branch Mem0[ds:0x0102:word16] == Mem0[ds:0x0100:word16] l0C00_000F
+          v7_13 = Mem11[ds:0x0106:word16] - Mem11[ds:0x0104:word16]
+          branch (Mem19[ds:0x0106:word16] & Mem19[ds:0x0108:word16]) == 0x0000 l0C00_002D
+          branch (Mem19[ds:0x0106:word16] & Mem19[ds:0x0108:word16]) == 0x0000 l0C00_002D
+          branch Mem27[ds:0x010A:word16] >=u Mem27[ds:0x010C:word16] l0C00_003D
 Mem0:Mem
     def:  def Mem0
     uses: branch Mem0[ds:0x0102:word16] == Mem0[ds:0x0100:word16] l0C00_000F
-          branch Mem0[ds:0x0102:word16] == Mem0[ds:0x0100:word16] l0C00_000F
           Mem11 = PHI(Mem0, Mem9)
+          branch Mem0[ds:0x0102:word16] == Mem0[ds:0x0100:word16] l0C00_000F
 ax_6: orig: ax
 SCZO_7: orig: SCZO
 Z_8: orig: Z
@@ -50,9 +50,9 @@ Mem17: orig: Mem0
     uses: Mem19 = PHI(Mem14, Mem17)
 Mem19: orig: Mem0
     def:  Mem19 = PHI(Mem14, Mem17)
-    uses: branch (Mem19[ds:0x0106:word16] & Mem19[ds:0x0108:word16]) == 0x0000 l0C00_002D
+    uses: Mem27 = PHI(Mem19, Mem25)
           branch (Mem19[ds:0x0106:word16] & Mem19[ds:0x0108:word16]) == 0x0000 l0C00_002D
-          Mem27 = PHI(Mem19, Mem25)
+          branch (Mem19[ds:0x0106:word16] & Mem19[ds:0x0108:word16]) == 0x0000 l0C00_002D
 ax_20: orig: ax
 ax_21: orig: ax
 SZO_22: orig: SZO
@@ -96,9 +96,9 @@ Mem55: orig: Mem0
 C_84: orig: C
 bp:bp
     def:  def bp
-    uses: branch !OVERFLOW((bp - 0x0010) * 0x0002) l0C00_0068
-          Mem68[ss:bp - 0x000A:byte] = 0x01
+    uses: Mem68[ss:bp - 0x000A:byte] = 0x01
           branch bp < 0x0010 l0C00_005F
+          branch !OVERFLOW((bp - 0x0010) * 0x0002) l0C00_0068
 bp_63: orig: bp
 SCZO_64: orig: SCZO
 SO_65: orig: SO

--- a/src/tests/Analysis/CoaDataConstraint.exp
+++ b/src/tests/Analysis/CoaDataConstraint.exp
@@ -7,13 +7,13 @@ ds:ds
           Mem8[ds:0x0200:word16] = 0x0000
           Mem9[ds:0x0300:word16] = ax_7
           Mem11[ds:0x0202:word16] = Mem9[ds:si + 0x0202:word16]
-          Mem11[ds:0x0202:word16] = Mem9[ds:si + 0x0202:word16]
-          Mem14[ds:0x0204:word16] = Mem11[ds:0x0204:word16] + Mem11[ds:si + 0x0204:word16]
-          Mem14[ds:0x0204:word16] = Mem11[ds:0x0204:word16] + Mem11[ds:si + 0x0204:word16]
           Mem14[ds:0x0204:word16] = Mem11[ds:0x0204:word16] + Mem11[ds:si + 0x0204:word16]
           ax_16 = Mem14[ds:0x0200:word16]
           fn0C00_002A(ds)
           Mem17[ds:0x0200:word16] = ax_16
+          Mem11[ds:0x0202:word16] = Mem9[ds:si + 0x0202:word16]
+          Mem14[ds:0x0204:word16] = Mem11[ds:0x0204:word16] + Mem11[ds:si + 0x0204:word16]
+          Mem14[ds:0x0204:word16] = Mem11[ds:0x0204:word16] + Mem11[ds:si + 0x0204:word16]
 si:si
     def:  def si
     uses: ax_7 = Mem0[ds:si + 0x0200:word16]

--- a/src/tests/Analysis/CoaFactorialReg.exp
+++ b/src/tests/Analysis/CoaFactorialReg.exp
@@ -36,8 +36,8 @@ ss:ss
 Mem7: orig: Mem0
 cx:cx
     def:  def cx
-    uses: ax_23 = (word16) (cx *s fn0C00_000B(cx - 0x0001)) (alias)
-          branch cx <= 0x0001 l0C00_001C
+    uses: branch cx <= 0x0001 l0C00_001C
+          ax_23 = (word16) (cx *s fn0C00_000B(cx - 0x0001)) (alias)
           ax_23 = (word16) (cx *s fn0C00_000B(cx - 0x0001)) (alias)
 SCZO_9: orig: SCZO
 SZO_10: orig: SZO

--- a/src/tests/Analysis/CoaSliceReturn.exp
+++ b/src/tests/Analysis/CoaSliceReturn.exp
@@ -5,8 +5,8 @@ si_4: orig: si
 ds:ds
     def:  def ds
     uses: Mem7[ds:0x0202:word16] = fn0C00_0015(0x0200, ds)
-          Mem7[ds:0x0202:word16] = fn0C00_0015(0x0200, ds)
           Mem11[ds:0x0302:byte] = (byte) fn0C00_0015(0x0300, ds)
+          Mem7[ds:0x0202:word16] = fn0C00_0015(0x0200, ds)
           Mem11[ds:0x0302:byte] = (byte) fn0C00_0015(0x0300, ds)
 ax_6: orig: ax
 Mem7: orig: Mem0

--- a/src/tests/Analysis/CoaSmallLoop.exp
+++ b/src/tests/Analysis/CoaSmallLoop.exp
@@ -25,8 +25,8 @@ ax_11: orig: ax
 cx_12: orig: cx
     def:  cx_12 = PHI(cx_10, cx_16)
     uses: ax_14 = ax_11 + cx_12 + cx_12
-          ax_14 = ax_11 + cx_12 + cx_12
           cx_16 = cx_12 - 0x0001
+          ax_14 = ax_11 + cx_12 + cx_12
 ax_13: orig: ax
 ax_14: orig: ax
     def:  ax_14 = ax_11 + cx_12 + cx_12

--- a/src/tests/Analysis/CoaWhileGoto.exp
+++ b/src/tests/Analysis/CoaWhileGoto.exp
@@ -29,8 +29,8 @@ SCZO_11: orig: SCZO
 Z_12: orig: Z
 Mem14: orig: Mem0
     def:  Mem14[ds:di:word16] = ax_9
-    uses: Mem22[ds:0x0302:word16] = Mem14[ds:0x0302:word16] + 0x0001
-          Mem8 = PHI(Mem0, Mem14, Mem22)
+    uses: Mem8 = PHI(Mem0, Mem14, Mem22)
+          Mem22[ds:0x0302:word16] = Mem14[ds:0x0302:word16] + 0x0001
 ax_15: orig: ax
 SZO_16: orig: SZO
 C_17: orig: C
@@ -62,8 +62,8 @@ ds:ds
     uses: ax_9 = Mem8[ds:si_7:word16]
           Mem14[ds:di:word16] = ax_9
           Mem22[ds:0x0302:word16] = Mem14[ds:0x0302:word16] + 0x0001
-          Mem22[ds:0x0302:word16] = Mem14[ds:0x0302:word16] + 0x0001
           Mem31[ds:0x0300:word16] = ax_29
+          Mem22[ds:0x0302:word16] = Mem14[ds:0x0302:word16] + 0x0001
 Mem0:Mem
     def:  def Mem0
     uses: Mem8 = PHI(Mem0, Mem14, Mem22)

--- a/src/tests/Analysis/SltManyIncrements.exp
+++ b/src/tests/Analysis/SltManyIncrements.exp
@@ -7,19 +7,19 @@ r0_3: orig: r0
 Mem4: orig: Mem0
     def:  Mem4 = PHI(Mem0, Mem15, Mem9)
     uses: r1_5 = Mem4[r0_3:byte]
-          Mem9[0x33333330:word32] = Mem4[r0_6:byte]
           Mem12[0x33333330:word32] = Mem4[r0_6:byte]
+          Mem9[0x33333330:word32] = Mem4[r0_6:byte]
 r1_5: orig: r1
     def:  r1_5 = Mem4[r0_3:byte]
     uses: branch r1_5 != 1 not1
           branch r1_5 != 2 done
 r0_6: orig: r0
     def:  r0_6 = r0_3 + 0x00000001
-    uses: Mem9[0x33333330:word32] = Mem4[r0_6:byte]
-          r0_8 = r0_6 + 0x00000001
+    uses: r0_8 = r0_6 + 0x00000001
+          r0_14 = r0_6 + 0x00000002
           Mem12[0x33333330:word32] = Mem4[r0_6:byte]
           Mem15[0x33333331:word32] = Mem12[r0_6 + 0x00000001:byte]
-          r0_14 = r0_6 + 0x00000002
+          Mem9[0x33333330:word32] = Mem4[r0_6:byte]
 r1_7: orig: r1
 r0_8: orig: r0
     def:  r0_8 = r0_6 + 0x00000001

--- a/src/tests/Analysis/SltSimple.exp
+++ b/src/tests/Analysis/SltSimple.exp
@@ -1,7 +1,7 @@
 a:Local -0004
     def:  def a
-    uses: Mem4[0x10000000:word32] = a + b
-          Mem5[0x10000004:word32] = a
+    uses: Mem5[0x10000004:word32] = a
+          Mem4[0x10000000:word32] = a + b
 b:Local -0008
     def:  def b
     uses: Mem4[0x10000000:word32] = a + b

--- a/src/tests/Analysis/SltWhileGoto.exp
+++ b/src/tests/Analysis/SltWhileGoto.exp
@@ -28,8 +28,8 @@ SCZO_11: orig: SCZO
 Z_12: orig: Z
 Mem14: orig: Mem0
     def:  Mem14[ds:di:word16] = ax_9
-    uses: Mem22[ds:0x0302:word16] = Mem14[ds:0x0302:word16] + 0x0001
-          Mem8 = PHI(Mem0, Mem14, Mem22)
+    uses: Mem8 = PHI(Mem0, Mem14, Mem22)
+          Mem22[ds:0x0302:word16] = Mem14[ds:0x0302:word16] + 0x0001
 ax_15: orig: ax
 SZO_16: orig: SZO
 C_17: orig: C
@@ -59,8 +59,8 @@ ds:ds
     uses: ax_9 = Mem8[ds:si_7:word16]
           Mem14[ds:di:word16] = ax_9
           Mem22[ds:0x0302:word16] = Mem14[ds:0x0302:word16] + 0x0001
-          Mem22[ds:0x0302:word16] = Mem14[ds:0x0302:word16] + 0x0001
           Mem31[ds:0x0300:word16] = ax_29
+          Mem22[ds:0x0302:word16] = Mem14[ds:0x0302:word16] + 0x0001
 Mem0:Mem
     def:  def Mem0
     uses: Mem8 = PHI(Mem0, Mem14, Mem22)

--- a/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.c
+++ b/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.c
@@ -4157,6 +4157,7 @@ Eq_3067 pexecute(Eq_3067 o0, pid_t * o1, word32 o2, word32 o3, word32 * o4, word
 	while (true)
 	{
 		Eq_8111 Z_104;
+		Eq_8112 g0_83;
 		if (dwLoc28_400 > 0x03)
 			break;
 		g0_83 = l1 - ~0x00;

--- a/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.dis
+++ b/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.dis
@@ -12423,6 +12423,7 @@ l00016A98:
 
 l00016AC8:
 	byte Z_104
+	word32 g0_83
 	branch dwLoc28_400 > 0x00000003 l00016AC8_ds_t
 // DataOut:
 // DataOut (flags):

--- a/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.h
+++ b/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.h
@@ -1834,9 +1834,9 @@ Eq_3067: pid_t
 	T_3118 (in l1 : Eq_3067)
 	T_8071 (in i0_329 : Eq_3067)
 	T_8110 (in 0xFFFFFFFF : word32)
-	T_8119 (in o0_85 : Eq_3067)
-	T_8122 (in vfork() : pid_t)
-	T_8125 (in 0x00000000 : word32)
+	T_8120 (in o0_85 : Eq_3067)
+	T_8123 (in vfork() : pid_t)
+	T_8126 (in 0x00000000 : word32)
 	T_8147 (in 0x00000000 : word32)
 	T_8230 (in wait(o1) : pid_t)
 	T_8273 (in o0_45 : Eq_3067)
@@ -2900,14 +2900,14 @@ Eq_8111: (union "Eq_8111" (bool u0) (byte u1))
 	T_8111 (in Z_104 : Eq_8111)
 	T_8131 (in SLICE(cond(g0_83), bool, 2) : bool)
 	T_8145 (in SLICE(cond(o0_85 - 0xFFFFFFFF), bool, 2) : bool)
-Eq_8120: (fn Eq_3067 ())
-	T_8120 (in vfork : ptr32)
-	T_8121 (in signature of vfork : void)
-Eq_8127: pid_t
-	T_8127 (in 0xFFFFFFFF : word32)
+Eq_8112: pid_t
+	T_8112 (in g0_83 : Eq_8112)
+	T_8129 (in l1 - 0xFFFFFFFF : word32)
+Eq_8121: (fn Eq_3067 ())
+	T_8121 (in vfork : ptr32)
+	T_8122 (in signature of vfork : void)
 Eq_8128: pid_t
-	T_8128 (in l1 - 0xFFFFFFFF : word32)
-	T_8129 (in g0_83 : word32)
+	T_8128 (in 0xFFFFFFFF : word32)
 Eq_8132: (fn uint32 (uint32))
 	T_8132 (in sleep : ptr32)
 	T_8133 (in signature of sleep : void)
@@ -35478,77 +35478,77 @@ T_8111: (in Z_104 : Eq_8111)
   Class: Eq_8111
   DataType: Eq_8111
   OrigDataType: (union (bool u0) (byte u1))
-T_8112: (in dwLoc28_400 : int32)
+T_8112: (in g0_83 : Eq_8112)
   Class: Eq_8112
+  DataType: Eq_8112
+  OrigDataType: pid_t
+T_8113: (in dwLoc28_400 : int32)
+  Class: Eq_8113
   DataType: int32
   OrigDataType: int32
-T_8113: (in 0x00000003 : word32)
-  Class: Eq_8112
+T_8114: (in 0x00000003 : word32)
+  Class: Eq_8113
   DataType: int32
   OrigDataType: int32
-T_8114: (in dwLoc28_400 > 0x00000003 : bool)
-  Class: Eq_8114
+T_8115: (in dwLoc28_400 > 0x00000003 : bool)
+  Class: Eq_8115
   DataType: bool
   OrigDataType: bool
-T_8115: (in dwLoc2C_399 : uint32)
-  Class: Eq_8115
+T_8116: (in dwLoc2C_399 : uint32)
+  Class: Eq_8116
   DataType: uint32
   OrigDataType: uint32
-T_8116: (in 0x00000001 : word32)
-  Class: Eq_8115
+T_8117: (in 0x00000001 : word32)
+  Class: Eq_8116
   DataType: uint32
   OrigDataType: word32
-T_8117: (in 0x00000000 : word32)
-  Class: Eq_8112
+T_8118: (in 0x00000000 : word32)
+  Class: Eq_8113
   DataType: int32
   OrigDataType: word32
-T_8118: (in 0x0002B000 : word32)
+T_8119: (in 0x0002B000 : word32)
   Class: Eq_3125
   DataType: ptr32
   OrigDataType: word32
-T_8119: (in o0_85 : Eq_3067)
+T_8120: (in o0_85 : Eq_3067)
   Class: Eq_3067
   DataType: Eq_3067
   OrigDataType: (union (pid_t u1))
-T_8120: (in vfork : ptr32)
-  Class: Eq_8120
-  DataType: (ptr32 Eq_8120)
-  OrigDataType: (ptr32 (fn T_8122 ()))
-T_8121: (in signature of vfork : void)
-  Class: Eq_8120
-  DataType: (ptr32 Eq_8120)
+T_8121: (in vfork : ptr32)
+  Class: Eq_8121
+  DataType: (ptr32 Eq_8121)
+  OrigDataType: (ptr32 (fn T_8123 ()))
+T_8122: (in signature of vfork : void)
+  Class: Eq_8121
+  DataType: (ptr32 Eq_8121)
   OrigDataType: 
-T_8122: (in vfork() : pid_t)
+T_8123: (in vfork() : pid_t)
   Class: Eq_3067
   DataType: Eq_3067
   OrigDataType: pid_t
-T_8123: (in 0xFFFFFFFC : word32)
-  Class: Eq_8123
+T_8124: (in 0xFFFFFFFC : word32)
+  Class: Eq_8124
   DataType: int32
   OrigDataType: int32
-T_8124: (in sp_126 + 0xFFFFFFFC : word32)
+T_8125: (in sp_126 + 0xFFFFFFFC : word32)
   Class: Eq_8057
   DataType: ptr32
   OrigDataType: ptr32
-T_8125: (in 0x00000000 : word32)
+T_8126: (in 0x00000000 : word32)
   Class: Eq_3067
   DataType: Eq_3067
   OrigDataType: int32
-T_8126: (in o0_85 < 0x00000000 : bool)
-  Class: Eq_8126
+T_8127: (in o0_85 < 0x00000000 : bool)
+  Class: Eq_8127
   DataType: bool
   OrigDataType: bool
-T_8127: (in 0xFFFFFFFF : word32)
-  Class: Eq_8127
-  DataType: Eq_8127
+T_8128: (in 0xFFFFFFFF : word32)
+  Class: Eq_8128
+  DataType: Eq_8128
   OrigDataType: (union (pid_t u1))
-T_8128: (in l1 - 0xFFFFFFFF : word32)
-  Class: Eq_8128
-  DataType: Eq_8128
-  OrigDataType: pid_t
-T_8129: (in g0_83 : word32)
-  Class: Eq_8128
-  DataType: Eq_8128
+T_8129: (in l1 - 0xFFFFFFFF : word32)
+  Class: Eq_8112
+  DataType: Eq_8112
   OrigDataType: pid_t
 T_8130: (in cond(g0_83) : byte)
   Class: Eq_8130
@@ -35561,13 +35561,13 @@ T_8131: (in SLICE(cond(g0_83), bool, 2) : bool)
 T_8132: (in sleep : ptr32)
   Class: Eq_8132
   DataType: (ptr32 Eq_8132)
-  OrigDataType: (ptr32 (fn T_8135 (T_8115)))
+  OrigDataType: (ptr32 (fn T_8135 (T_8116)))
 T_8133: (in signature of sleep : void)
   Class: Eq_8132
   DataType: (ptr32 Eq_8132)
   OrigDataType: 
 T_8134: (in seconds : uint32)
-  Class: Eq_8115
+  Class: Eq_8116
   DataType: uint32
   OrigDataType: 
 T_8135: (in sleep(dwLoc2C_399) : uint32)
@@ -35587,7 +35587,7 @@ T_8138: (in 0x00000001 : word32)
   DataType: word32
   OrigDataType: word32
 T_8139: (in dwLoc2C_399 << 0x00000001 : word32)
-  Class: Eq_8115
+  Class: Eq_8116
   DataType: uint32
   OrigDataType: ui32
 T_8140: (in 0x00000001 : word32)
@@ -35595,7 +35595,7 @@ T_8140: (in 0x00000001 : word32)
   DataType: word32
   OrigDataType: word32
 T_8141: (in dwLoc28_400 + 0x00000001 : word32)
-  Class: Eq_8112
+  Class: Eq_8113
   DataType: int32
   OrigDataType: int32
 T_8142: (in 0xFFFFFFFF : word32)
@@ -39916,9 +39916,9 @@ typedef union Eq_8111 {
 	byte u1;
 } Eq_8111;
 
-typedef pid_t (Eq_8120)();
+typedef pid_t Eq_8112;
 
-typedef pid_t Eq_8127;
+typedef pid_t (Eq_8121)();
 
 typedef pid_t Eq_8128;
 


### PR DESCRIPTION
- Create unit test to reproduce inconsistent SSA state after `Coalescer` running
Coalescing
```
a = b
c = a + 1
```
to
```
c = b + 1
```
causes duplicated uses of `b`
- `IdentifierReplacer`: add correct uses for new expression which replaces old id.
Use `ExpressionIdentifierUseFinder` to get all ids for expression
So `UsedIdentifierAdjuster` is not required for `Coalescer`,
`IdentifierReplacer `always adjusts uses now