### PR TITLE
Move UserSignatureBuilder call after creation of SSA

### DIFF
--- a/src/Decompiler/Analysis/DataFlowAnalysis.cs
+++ b/src/Decompiler/Analysis/DataFlowAnalysis.cs
@@ -115,14 +115,16 @@ namespace Reko.Analysis
         {
             eventListener.ShowProgress("Rewriting procedures.", 0, program.Procedures.Count);
 
-            var usb = new UserSignatureBuilder(program);
-            usb.BuildSignatures(eventListener);
-                
             IntraBlockDeadRegisters.Apply(program, eventListener);
 
             AdjacentBranchCollector.Transform(program, eventListener);
 
             var ssts = RewriteProceduresToSsa();
+
+            // Recreate user-defined signatures. It should prevent type
+            // inference between user-defined parameters and other expressions
+            var usb = new UserSignatureBuilder(program);
+            usb.BuildSignatures(eventListener);
 
             // Discover ssaId's that are live out at each call site.
             // Delete all others.

--- a/src/UnitTests/Analysis/DataFlowAnalysisTests.cs
+++ b/src/UnitTests/Analysis/DataFlowAnalysisTests.cs
@@ -79,6 +79,11 @@ namespace Reko.UnitTests.Analysis
                         CSignature = this.CSignature
                     });
             }
+            if (this.CSignature != null)
+            {
+                var usb = new UserSignatureBuilder(program);
+                usb.BuildSignatures(new FakeDecompilerEventListener());
+            }
         }
 
         protected void Given_CSignature(string CSignature)

--- a/src/UnitTests/Analysis/DataFlowAnalysisTests2.cs
+++ b/src/UnitTests/Analysis/DataFlowAnalysisTests2.cs
@@ -259,6 +259,8 @@ test_exit:
 
             var importResolver = new Mock<IImportResolver>().Object;
             program.Platform = platform.Object;
+            var usb = new UserSignatureBuilder(program);
+            usb.BuildSignatures(new FakeDecompilerEventListener());
             var dfa = new DataFlowAnalysis(program, importResolver, new FakeDecompilerEventListener());
             dfa.AnalyzeProgram();
             var sExp = @"// test

--- a/subjects/PE/x86/IncorrectUserSignature/IncorrectUserSignature.h
+++ b/subjects/PE/x86/IncorrectUserSignature/IncorrectUserSignature.h
@@ -8,18 +8,20 @@ Eq_1: (struct "Globals")
 	globals_t (in globals : (ptr32 (struct "Globals")))
 Eq_2: cdecl_class
 	T_2 (in c : (ptr32 Eq_2))
-Eq_6: cdecl_class_vtbl
-	T_6 (in c + 0x00000000 : word32)
+Eq_5: cdecl_class
+	T_5 (in c : (ptr32 cdecl_class))
 Eq_7: cdecl_class_vtbl
-	T_7 (in Mem19[c + 0x00000000:word32] : word32)
-Eq_9: (fn void ((ptr32 cdecl_class), int32, int32))
-	T_9 (in Mem19[c + 0x00000000:word32] + 0x00000008 : word32)
+	T_7 (in c + 0x00000000 : word32)
+Eq_8: cdecl_class_vtbl
+	T_8 (in Mem19[c + 0x00000000:word32] : word32)
 Eq_10: (fn void ((ptr32 cdecl_class), int32, int32))
-	T_10 (in Mem19[Mem19[c + 0x00000000:word32] + 0x00000008:word32] : word32)
-Eq_16: (struct "Eq_16" (4 (ptr32 Eq_19) ptr0004))
-	T_16 (in Mem37[c + 0x00000000:word32] : word32)
-Eq_19: (fn void ((ptr32 Eq_2), word32))
-	T_19 (in Mem37[Mem37[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+	T_10 (in Mem19[c + 0x00000000:word32] + 0x00000008 : word32)
+Eq_11: (fn void ((ptr32 cdecl_class), int32, int32))
+	T_11 (in Mem19[Mem19[c + 0x00000000:word32] + 0x00000008:word32] : word32)
+Eq_19: (struct "Eq_19" (4 (ptr32 Eq_22) ptr0004))
+	T_19 (in Mem37[c + 0x00000000:word32] : word32)
+Eq_22: (fn void ((ptr32 Eq_5), word32))
+	T_22 (in Mem37[Mem37[c + 0x00000000:word32] + 0x00000004:word32] : word32)
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -37,68 +39,80 @@ T_4: (in b : int32)
   Class: Eq_4
   DataType: int32
   OrigDataType: int32
-T_5: (in 0x00000000 : word32)
+T_5: (in c : (ptr32 cdecl_class))
   Class: Eq_5
-  DataType: word32
-  OrigDataType: word32
-T_6: (in c + 0x00000000 : word32)
+  DataType: (ptr32 Eq_5)
+  OrigDataType: (ptr32 cdecl_class)
+T_6: (in 0x00000000 : word32)
   Class: Eq_6
-  DataType: (ptr32 (ptr32 Eq_6))
-  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
-T_7: (in Mem19[c + 0x00000000:word32] : word32)
-  Class: Eq_7
-  DataType: (ptr32 Eq_7)
-  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
-T_8: (in 0x00000008 : word32)
-  Class: Eq_8
   DataType: word32
   OrigDataType: word32
-T_9: (in Mem19[c + 0x00000000:word32] + 0x00000008 : word32)
+T_7: (in c + 0x00000000 : word32)
+  Class: Eq_7
+  DataType: (ptr32 (ptr32 Eq_7))
+  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
+T_8: (in Mem19[c + 0x00000000:word32] : word32)
+  Class: Eq_8
+  DataType: (ptr32 Eq_8)
+  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
+T_9: (in 0x00000008 : word32)
   Class: Eq_9
-  DataType: (ptr32 (ptr32 Eq_9))
-  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 cdecl_class), int32, int32))))
-T_10: (in Mem19[Mem19[c + 0x00000000:word32] + 0x00000008:word32] : word32)
+  DataType: word32
+  OrigDataType: word32
+T_10: (in Mem19[c + 0x00000000:word32] + 0x00000008 : word32)
   Class: Eq_10
-  DataType: (ptr32 Eq_10)
-  OrigDataType: (ptr32 (fn T_11 ((ptr32 cdecl_class), int32, int32)))
-T_11: (in c->vtbl->sum(c, a, b) : void)
+  DataType: (ptr32 (ptr32 Eq_10))
+  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 cdecl_class), int32, int32))))
+T_11: (in Mem19[Mem19[c + 0x00000000:word32] + 0x00000008:word32] : word32)
   Class: Eq_11
+  DataType: (ptr32 Eq_11)
+  OrigDataType: (ptr32 (fn T_14 ((ptr32 cdecl_class), int32, int32)))
+T_12: (in a : int32)
+  Class: Eq_12
+  DataType: int32
+  OrigDataType: int32
+T_13: (in b : int32)
+  Class: Eq_13
+  DataType: int32
+  OrigDataType: int32
+T_14: (in c->vtbl->sum(c, a, b) : void)
+  Class: Eq_14
   DataType: void
   OrigDataType: void
-T_12: (in eax_25 : word32)
-  Class: Eq_12
+T_15: (in eax_25 : word32)
+  Class: Eq_15
   DataType: word32
   OrigDataType: word32
-T_13: (in <invalid> : void)
-  Class: Eq_12
+T_16: (in <invalid> : void)
+  Class: Eq_15
   DataType: word32
   OrigDataType: void
-T_14: (in 0x00000000 : word32)
-  Class: Eq_14
-  DataType: word32
-  OrigDataType: word32
-T_15: (in c + 0x00000000 : word32)
-  Class: Eq_15
-  DataType: ptr32
-  OrigDataType: ptr32
-T_16: (in Mem37[c + 0x00000000:word32] : word32)
-  Class: Eq_16
-  DataType: (ptr32 Eq_16)
-  OrigDataType: (ptr32 (struct (4 T_19 t0004)))
-T_17: (in 0x00000004 : word32)
+T_17: (in 0x00000000 : word32)
   Class: Eq_17
   DataType: word32
   OrigDataType: word32
-T_18: (in Mem37[c + 0x00000000:word32] + 0x00000004 : word32)
+T_18: (in c + 0x00000000 : word32)
   Class: Eq_18
-  DataType: word32
-  OrigDataType: word32
-T_19: (in Mem37[Mem37[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_19: (in Mem37[c + 0x00000000:word32] : word32)
   Class: Eq_19
   DataType: (ptr32 Eq_19)
-  OrigDataType: (ptr32 (fn T_20 (T_2, T_12)))
-T_20: (in c->vtbl->method04(c, eax_25) : void)
+  OrigDataType: (ptr32 (struct (4 T_22 t0004)))
+T_20: (in 0x00000004 : word32)
   Class: Eq_20
+  DataType: word32
+  OrigDataType: word32
+T_21: (in Mem37[c + 0x00000000:word32] + 0x00000004 : word32)
+  Class: Eq_21
+  DataType: word32
+  OrigDataType: word32
+T_22: (in Mem37[Mem37[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+  Class: Eq_22
+  DataType: (ptr32 Eq_22)
+  OrigDataType: (ptr32 (fn T_23 (T_5, T_15)))
+T_23: (in c->vtbl->method04(c, eax_25) : void)
+  Class: Eq_23
   DataType: void
   OrigDataType: void
 */
@@ -107,17 +121,19 @@ typedef struct Globals {
 
 typedef cdecl_class Eq_2;
 
-typedef cdecl_class_vtbl Eq_6;
+typedef cdecl_class Eq_5;
 
 typedef cdecl_class_vtbl Eq_7;
 
-typedef void (Eq_9)(cdecl_class * ptrArg04, int32 dwArg08, int32 dwArg0C);
+typedef cdecl_class_vtbl Eq_8;
 
-typedef void (Eq_10)(cdecl_class *, int32, int32);
+typedef void (Eq_10)(cdecl_class * ptrArg04, int32 dwArg08, int32 dwArg0C);
 
-typedef struct Eq_16 {
+typedef void (Eq_11)(cdecl_class *, int32, int32);
+
+typedef struct Eq_19 {
 	void (* ptr0004)(cdecl_class *, word32);	// 4
-} Eq_16;
+} Eq_19;
 
-typedef void (Eq_19)(cdecl_class *, word32);
+typedef void (Eq_22)(cdecl_class *, word32);
 

--- a/subjects/PE/x86/VCExeSample/VCExeSample.c
+++ b/subjects/PE/x86/VCExeSample/VCExeSample.c
@@ -46,7 +46,7 @@ void test5()
 // 00401120: void test6(Stack Eq_n c, Stack int32 a, Stack int32 b)
 void test6(Eq_n c, int32 a, int32 b)
 {
-	c.u0->vtbl->method04(c, c.u0->vtbl->sum(c, a, b));
+	c->vtbl->method04(c, c->vtbl->sum(c, a, b));
 }
 
 // 00401160: void test7(Stack real64 rArg04)

--- a/subjects/PE/x86/VCExeSample/VCExeSample.h
+++ b/subjects/PE/x86/VCExeSample/VCExeSample.h
@@ -9,172 +9,178 @@ Eq_1: (struct "Globals" (4020C0 (str char) str4020C0) (4020C8 (str char) str4020
 Eq_5: (fn void ((ptr32 char), int32, (ptr32 char), real32))
 	T_5 (in test1 : ptr32)
 	T_6 (in signature of test1 : void)
-	T_29 (in test1 : ptr32)
-	T_38 (in test1 : ptr32)
-Eq_18: (fn int32 ((ptr32 char), (ptr32 char), int32, (ptr32 char), real64))
-	T_18 (in printf : ptr32)
-	T_19 (in signature of printf : void)
-Eq_45: cdecl_class
-	T_45 (in c : (ptr32 Eq_45))
-Eq_47: cdecl_class_vtbl
-	T_47 (in c + 0x00000000 : word32)
-Eq_48: cdecl_class_vtbl
-	T_48 (in Mem12[c + 0x00000000:word32] : word32)
-Eq_50: (fn void ((ptr32 cdecl_class), int32))
-	T_50 (in Mem12[c + 0x00000000:word32] + 0x00000004 : word32)
-Eq_51: (fn void ((ptr32 cdecl_class), int32))
-	T_51 (in Mem12[Mem12[c + 0x00000000:word32] + 0x00000004:word32] : word32)
-Eq_54: cdecl_class_ptr
-	T_54 (in 00403018 : ptr32)
-Eq_55: (union "Eq_55" ((ptr32 cdecl_class) u0) (cdecl_class_ptr u1))
-	T_55 (in Mem10[0x00403018:word32] : word32)
-	T_63 (in Mem6[0x00403018:word32] : word32)
-	T_66 (in Mem18[0x00403018:word32] : word32)
-	T_74 (in Mem15[0x00403018:word32] : word32)
-	T_79 (in c : Eq_55)
-	T_141 (in Mem59[0x00403018:word32] : word32)
-Eq_57: cdecl_class_vtbl
-	T_57 (in Mem10[0x00403018:word32] + 0x00000000 : word32)
-Eq_58: cdecl_class_vtbl
-	T_58 (in Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] : word32)
-Eq_60: (fn void ((ptr32 cdecl_class)))
-	T_60 (in Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] + 0x00000000 : word32)
-Eq_61: (fn void ((ptr32 cdecl_class)))
-	T_61 (in Mem10[Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
-Eq_62: cdecl_class_ptr
-	T_62 (in 00403018 : ptr32)
-Eq_65: cdecl_class_ptr
-	T_65 (in 00403018 : ptr32)
-Eq_68: cdecl_class_vtbl
-	T_68 (in Mem18[0x00403018:word32] + 0x00000000 : word32)
-Eq_69: cdecl_class_vtbl
-	T_69 (in Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] : word32)
-Eq_71: (fn void ((ptr32 cdecl_class), int32))
-	T_71 (in Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] + 0x00000004 : word32)
-Eq_72: (union "Eq_72" ((fn void ((ptr32 cdecl_class), int32)) u0) ((fn void (Eq_55, word32, real32)) u1))
-	T_72 (in Mem18[Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
-Eq_73: cdecl_class_ptr
-	T_73 (in 00403018 : ptr32)
-Eq_83: cdecl_class_vtbl
-	T_83 (in c + 0x00000000 : word32)
-Eq_84: cdecl_class_vtbl
-	T_84 (in Mem37[c + 0x00000000:word32] : word32)
-Eq_86: (fn void ((ptr32 cdecl_class), int32))
-	T_86 (in Mem37[c + 0x00000000:word32] + 0x00000004 : word32)
-Eq_87: (fn void ((ptr32 cdecl_class), int32))
-	T_87 (in Mem37[Mem37[c + 0x00000000:word32] + 0x00000004:word32] : word32)
-Eq_89: cdecl_class_vtbl
-	T_89 (in c + 0x00000000 : word32)
-Eq_90: cdecl_class_vtbl
-	T_90 (in Mem19[c + 0x00000000:word32] : word32)
-Eq_92: (fn int32 ((ptr32 cdecl_class), int32, int32))
-	T_92 (in Mem19[c + 0x00000000:word32] + 0x00000008 : word32)
-Eq_93: (fn int32 ((ptr32 cdecl_class), int32, int32))
-	T_93 (in Mem19[Mem19[c + 0x00000000:word32] + 0x00000008:word32] : word32)
-Eq_99: thiscall_class
-	T_99 (in 00403024 : ptr32)
-Eq_100: thiscall_class
-	T_100 (in Mem40[0x00403024:word32] : word32)
-	T_108 (in Mem40[0x00403024:word32] : word32)
-	T_112 (in Mem17[0x00403024:word32] : word32)
-	T_120 (in Mem17[0x00403024:word32] : word32)
-	T_124 (in Mem15[0x00403024:word32] : word32)
-	T_132 (in Mem15[0x00403024:word32] : word32)
-	T_149 (in Mem43[0x00403024:word32] : word32)
-	T_157 (in Mem43[0x00403024:word32] : word32)
-	T_163 (in Mem25[0x00403024:word32] : word32)
-	T_171 (in Mem25[0x00403024:word32] : word32)
-	T_177 (in Mem49[0x00403024:word32] : word32)
-	T_185 (in Mem49[0x00403024:word32] : word32)
-Eq_102: thiscall_class_vtbl
-	T_102 (in Mem40[0x00403024:word32] + 0x00000000 : word32)
-Eq_103: thiscall_class_vtbl
-	T_103 (in Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] : word32)
-Eq_105: (fn real64 ((ptr32 thiscall_class), int32, real64))
-	T_105 (in Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
-Eq_106: (fn real64 ((ptr32 thiscall_class), int32, real64))
-	T_106 (in Mem40[Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
-Eq_107: thiscall_class
-	T_107 (in 00403024 : ptr32)
-Eq_111: thiscall_class
-	T_111 (in 00403024 : ptr32)
-Eq_114: thiscall_class_vtbl
-	T_114 (in Mem17[0x00403024:word32] + 0x00000000 : word32)
-Eq_115: thiscall_class_vtbl
-	T_115 (in Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] : word32)
-Eq_117: (fn void ((ptr32 thiscall_class), real64))
-	T_117 (in Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
-Eq_118: (fn void ((ptr32 thiscall_class), real64))
-	T_118 (in Mem17[Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
-Eq_119: thiscall_class
-	T_119 (in 00403024 : ptr32)
-Eq_123: thiscall_class
-	T_123 (in 00403024 : ptr32)
-Eq_126: thiscall_class_vtbl
-	T_126 (in Mem15[0x00403024:word32] + 0x00000000 : word32)
-Eq_127: thiscall_class_vtbl
-	T_127 (in Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] : word32)
-Eq_129: (fn real64 ((ptr32 thiscall_class), int32, real64))
-	T_129 (in Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
-Eq_130: (fn real64 ((ptr32 thiscall_class), int32, real64))
-	T_130 (in Mem15[Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
-Eq_131: thiscall_class
-	T_131 (in 00403024 : ptr32)
-Eq_138: (fn void (Eq_55, int32, int32))
-	T_138 (in test6 : ptr32)
-	T_139 (in signature of test6 : void)
-Eq_140: cdecl_class_ptr
-	T_140 (in 00403018 : ptr32)
-Eq_148: thiscall_class
-	T_148 (in 00403024 : ptr32)
-Eq_151: thiscall_class_vtbl
-	T_151 (in Mem43[0x00403024:word32] + 0x00000000 : word32)
-Eq_152: thiscall_class_vtbl
-	T_152 (in Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] : word32)
-Eq_154: (fn void ((ptr32 thiscall_class), real64))
-	T_154 (in Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
-Eq_155: (fn void ((ptr32 thiscall_class), real64))
-	T_155 (in Mem43[Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
-Eq_156: thiscall_class
-	T_156 (in 00403024 : ptr32)
-Eq_162: thiscall_class
-	T_162 (in 00403024 : ptr32)
-Eq_165: thiscall_class_vtbl
-	T_165 (in Mem25[0x00403024:word32] + 0x00000000 : word32)
-Eq_166: thiscall_class_vtbl
-	T_166 (in Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] : word32)
-Eq_168: (fn real64 ((ptr32 thiscall_class), int32, real64))
-	T_168 (in Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
-Eq_169: (fn real64 ((ptr32 thiscall_class), int32, real64))
-	T_169 (in Mem25[Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
-Eq_170: thiscall_class
-	T_170 (in 00403024 : ptr32)
-Eq_176: thiscall_class
-	T_176 (in 00403024 : ptr32)
-Eq_179: thiscall_class_vtbl
-	T_179 (in Mem49[0x00403024:word32] + 0x00000000 : word32)
-Eq_180: thiscall_class_vtbl
-	T_180 (in Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] : word32)
-Eq_182: (fn void ((ptr32 thiscall_class), real64))
-	T_182 (in Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
-Eq_183: (fn void ((ptr32 thiscall_class), real64))
-	T_183 (in Mem49[Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
-Eq_184: thiscall_class
-	T_184 (in 00403024 : ptr32)
-Eq_221: (fn void (real64))
-	T_221 (in nested_if_blocks_test8 : ptr32)
-	T_222 (in signature of nested_if_blocks_test8 : void)
-Eq_224: (fn void (real32))
-	T_224 (in loop_test9 : ptr32)
-	T_225 (in signature of loop_test9 : void)
-Eq_232: nested_structs_type
-	T_232 (in dwArg04 : (ptr32 Eq_232))
-	T_249 (in str : (ptr32 Eq_232))
-Eq_250: (fn void ((ptr32 Eq_232)))
-	T_250 (in nested_structs_test12 : ptr32)
-	T_251 (in signature of nested_structs_test12 : void)
-Eq_253: (struct "nested_struct" (0 int32 b) (4 int32 c))
-	T_253
+	T_35 (in test1 : ptr32)
+	T_44 (in test1 : ptr32)
+Eq_20: (fn int32 ((ptr32 char), (ptr32 char), int32, (ptr32 char), real64))
+	T_20 (in printf : ptr32)
+	T_21 (in signature of printf : void)
+Eq_51: cdecl_class
+	T_51 (in c : (ptr32 Eq_51))
+Eq_52: cdecl_class
+	T_52 (in c : (ptr32 cdecl_class))
+Eq_54: cdecl_class_vtbl
+	T_54 (in c + 0x00000000 : word32)
+Eq_55: cdecl_class_vtbl
+	T_55 (in Mem12[c + 0x00000000:word32] : word32)
+Eq_57: (fn void ((ptr32 cdecl_class), int32))
+	T_57 (in Mem12[c + 0x00000000:word32] + 0x00000004 : word32)
+Eq_58: (fn void ((ptr32 cdecl_class), int32))
+	T_58 (in Mem12[Mem12[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+Eq_61: cdecl_class_ptr
+	T_61 (in 00403018 : ptr32)
+Eq_62: (union "Eq_62" ((ptr32 cdecl_class) u0) (cdecl_class_ptr u1))
+	T_62 (in Mem10[0x00403018:word32] : word32)
+	T_70 (in Mem6[0x00403018:word32] : word32)
+	T_73 (in Mem18[0x00403018:word32] : word32)
+	T_81 (in Mem15[0x00403018:word32] : word32)
+	T_86 (in c : Eq_62)
+	T_151 (in Mem59[0x00403018:word32] : word32)
+Eq_64: cdecl_class_vtbl
+	T_64 (in Mem10[0x00403018:word32] + 0x00000000 : word32)
+Eq_65: cdecl_class_vtbl
+	T_65 (in Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] : word32)
+Eq_67: (fn void ((ptr32 cdecl_class)))
+	T_67 (in Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] + 0x00000000 : word32)
+Eq_68: (fn void ((ptr32 cdecl_class)))
+	T_68 (in Mem10[Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
+Eq_69: cdecl_class_ptr
+	T_69 (in 00403018 : ptr32)
+Eq_72: cdecl_class_ptr
+	T_72 (in 00403018 : ptr32)
+Eq_75: cdecl_class_vtbl
+	T_75 (in Mem18[0x00403018:word32] + 0x00000000 : word32)
+Eq_76: cdecl_class_vtbl
+	T_76 (in Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] : word32)
+Eq_78: (fn void ((ptr32 cdecl_class), int32))
+	T_78 (in Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] + 0x00000004 : word32)
+Eq_79: (union "Eq_79" ((fn void ((ptr32 cdecl_class), int32)) u0) ((fn void (Eq_62, word32, real32)) u1))
+	T_79 (in Mem18[Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
+Eq_80: cdecl_class_ptr
+	T_80 (in 00403018 : ptr32)
+Eq_89: cdecl_class
+	T_89 (in c : (ptr32 cdecl_class))
+Eq_91: cdecl_class_vtbl
+	T_91 (in c + 0x00000000 : word32)
+Eq_92: cdecl_class_vtbl
+	T_92 (in Mem37[c + 0x00000000:word32] : word32)
+Eq_94: (fn void ((ptr32 cdecl_class), int32))
+	T_94 (in Mem37[c + 0x00000000:word32] + 0x00000004 : word32)
+Eq_95: (fn void ((ptr32 cdecl_class), int32))
+	T_95 (in Mem37[Mem37[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+Eq_97: cdecl_class_vtbl
+	T_97 (in c + 0x00000000 : word32)
+Eq_98: cdecl_class_vtbl
+	T_98 (in Mem19[c + 0x00000000:word32] : word32)
+Eq_100: (fn int32 ((ptr32 cdecl_class), int32, int32))
+	T_100 (in Mem19[c + 0x00000000:word32] + 0x00000008 : word32)
+Eq_101: (fn int32 ((ptr32 cdecl_class), int32, int32))
+	T_101 (in Mem19[Mem19[c + 0x00000000:word32] + 0x00000008:word32] : word32)
+Eq_109: thiscall_class
+	T_109 (in 00403024 : ptr32)
+Eq_110: thiscall_class
+	T_110 (in Mem40[0x00403024:word32] : word32)
+	T_118 (in Mem40[0x00403024:word32] : word32)
+	T_122 (in Mem17[0x00403024:word32] : word32)
+	T_130 (in Mem17[0x00403024:word32] : word32)
+	T_134 (in Mem15[0x00403024:word32] : word32)
+	T_142 (in Mem15[0x00403024:word32] : word32)
+	T_159 (in Mem43[0x00403024:word32] : word32)
+	T_167 (in Mem43[0x00403024:word32] : word32)
+	T_173 (in Mem25[0x00403024:word32] : word32)
+	T_181 (in Mem25[0x00403024:word32] : word32)
+	T_187 (in Mem49[0x00403024:word32] : word32)
+	T_195 (in Mem49[0x00403024:word32] : word32)
+Eq_112: thiscall_class_vtbl
+	T_112 (in Mem40[0x00403024:word32] + 0x00000000 : word32)
+Eq_113: thiscall_class_vtbl
+	T_113 (in Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] : word32)
+Eq_115: (fn real64 ((ptr32 thiscall_class), int32, real64))
+	T_115 (in Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
+Eq_116: (fn real64 ((ptr32 thiscall_class), int32, real64))
+	T_116 (in Mem40[Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
+Eq_117: thiscall_class
+	T_117 (in 00403024 : ptr32)
+Eq_121: thiscall_class
+	T_121 (in 00403024 : ptr32)
+Eq_124: thiscall_class_vtbl
+	T_124 (in Mem17[0x00403024:word32] + 0x00000000 : word32)
+Eq_125: thiscall_class_vtbl
+	T_125 (in Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] : word32)
+Eq_127: (fn void ((ptr32 thiscall_class), real64))
+	T_127 (in Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
+Eq_128: (fn void ((ptr32 thiscall_class), real64))
+	T_128 (in Mem17[Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
+Eq_129: thiscall_class
+	T_129 (in 00403024 : ptr32)
+Eq_133: thiscall_class
+	T_133 (in 00403024 : ptr32)
+Eq_136: thiscall_class_vtbl
+	T_136 (in Mem15[0x00403024:word32] + 0x00000000 : word32)
+Eq_137: thiscall_class_vtbl
+	T_137 (in Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] : word32)
+Eq_139: (fn real64 ((ptr32 thiscall_class), int32, real64))
+	T_139 (in Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
+Eq_140: (fn real64 ((ptr32 thiscall_class), int32, real64))
+	T_140 (in Mem15[Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
+Eq_141: thiscall_class
+	T_141 (in 00403024 : ptr32)
+Eq_148: (fn void (Eq_62, int32, int32))
+	T_148 (in test6 : ptr32)
+	T_149 (in signature of test6 : void)
+Eq_150: cdecl_class_ptr
+	T_150 (in 00403018 : ptr32)
+Eq_158: thiscall_class
+	T_158 (in 00403024 : ptr32)
+Eq_161: thiscall_class_vtbl
+	T_161 (in Mem43[0x00403024:word32] + 0x00000000 : word32)
+Eq_162: thiscall_class_vtbl
+	T_162 (in Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] : word32)
+Eq_164: (fn void ((ptr32 thiscall_class), real64))
+	T_164 (in Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
+Eq_165: (fn void ((ptr32 thiscall_class), real64))
+	T_165 (in Mem43[Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
+Eq_166: thiscall_class
+	T_166 (in 00403024 : ptr32)
+Eq_172: thiscall_class
+	T_172 (in 00403024 : ptr32)
+Eq_175: thiscall_class_vtbl
+	T_175 (in Mem25[0x00403024:word32] + 0x00000000 : word32)
+Eq_176: thiscall_class_vtbl
+	T_176 (in Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] : word32)
+Eq_178: (fn real64 ((ptr32 thiscall_class), int32, real64))
+	T_178 (in Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
+Eq_179: (fn real64 ((ptr32 thiscall_class), int32, real64))
+	T_179 (in Mem25[Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
+Eq_180: thiscall_class
+	T_180 (in 00403024 : ptr32)
+Eq_186: thiscall_class
+	T_186 (in 00403024 : ptr32)
+Eq_189: thiscall_class_vtbl
+	T_189 (in Mem49[0x00403024:word32] + 0x00000000 : word32)
+Eq_190: thiscall_class_vtbl
+	T_190 (in Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] : word32)
+Eq_192: (fn void ((ptr32 thiscall_class), real64))
+	T_192 (in Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
+Eq_193: (fn void ((ptr32 thiscall_class), real64))
+	T_193 (in Mem49[Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
+Eq_194: thiscall_class
+	T_194 (in 00403024 : ptr32)
+Eq_231: (fn void (real64))
+	T_231 (in nested_if_blocks_test8 : ptr32)
+	T_232 (in signature of nested_if_blocks_test8 : void)
+Eq_234: (fn void (real32))
+	T_234 (in loop_test9 : ptr32)
+	T_235 (in signature of loop_test9 : void)
+Eq_242: nested_structs_type
+	T_242 (in dwArg04 : (ptr32 Eq_242))
+	T_262 (in str : (ptr32 nested_structs_type))
+Eq_259: nested_structs_type
+	T_259 (in str : (ptr32 Eq_259))
+Eq_260: (fn void ((ptr32 Eq_242)))
+	T_260 (in nested_structs_test12 : ptr32)
+	T_261 (in signature of nested_structs_test12 : void)
+Eq_264: (struct "nested_struct" (0 int32 b) (4 int32 c))
+	T_264
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -191,11 +197,11 @@ T_3: (in argc : int32)
 T_4: (in argv : (ptr32 (ptr32 char)))
   Class: Eq_4
   DataType: (ptr32 (ptr32 char))
-  OrigDataType: (ptr32 (struct (0 (ptr32 char) ptr0000)))
+  OrigDataType: (ptr32 (ptr32 char))
 T_5: (in test1 : ptr32)
   Class: Eq_5
   DataType: (ptr32 Eq_5)
-  OrigDataType: (ptr32 (fn T_16 (T_13, T_3, T_14, T_15)))
+  OrigDataType: (ptr32 (fn T_18 (T_14, T_15, T_16, T_17)))
 T_6: (in signature of test1 : void)
   Class: Eq_5
   DataType: (ptr32 Eq_5)
@@ -205,7 +211,7 @@ T_7: (in arg1 : (ptr32 char))
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
 T_8: (in arg2 : int32)
-  Class: Eq_3
+  Class: Eq_8
   DataType: int32
   OrigDataType: int32
 T_9: (in arg3 : (ptr32 char))
@@ -216,977 +222,1021 @@ T_10: (in arg4 : real32)
   Class: Eq_10
   DataType: real32
   OrigDataType: real32
-T_11: (in 0x00000000 : word32)
+T_11: (in argv : (ptr32 (ptr32 char)))
   Class: Eq_11
+  DataType: (ptr32 (ptr32 char))
+  OrigDataType: (ptr32 (struct (0 (ptr32 char) ptr0000)))
+T_12: (in 0x00000000 : word32)
+  Class: Eq_12
   DataType: word32
   OrigDataType: word32
-T_12: (in argv + 0x00000000 : word32)
-  Class: Eq_12
+T_13: (in argv + 0x00000000 : word32)
+  Class: Eq_13
   DataType: ptr32
   OrigDataType: ptr32
-T_13: (in Mem19[argv + 0x00000000:word32] : word32)
+T_14: (in Mem19[argv + 0x00000000:word32] : word32)
   Class: Eq_7
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_14: (in 0x004020C0 : word32)
+T_15: (in argc : int32)
+  Class: Eq_8
+  DataType: int32
+  OrigDataType: int32
+T_16: (in 0x004020C0 : word32)
   Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_15: (in 1.0F : real32)
+T_17: (in 1.0F : real32)
   Class: Eq_10
   DataType: real32
   OrigDataType: real32
-T_16: (in test1(*argv, argc, "test123", 1.0F) : void)
-  Class: Eq_16
+T_18: (in test1(*argv, argc, "test123", 1.0F) : void)
+  Class: Eq_18
   DataType: void
   OrigDataType: void
-T_17: (in 0x00000000 : word32)
+T_19: (in 0x00000000 : word32)
   Class: Eq_2
   DataType: int32
   OrigDataType: word32
-T_18: (in printf : ptr32)
-  Class: Eq_18
-  DataType: (ptr32 Eq_18)
-  OrigDataType: (ptr32 (fn T_27 (T_25, T_7, T_8, T_9, T_26)))
-T_19: (in signature of printf : void)
-  Class: Eq_18
-  DataType: (ptr32 Eq_18)
-  OrigDataType: 
-T_20: (in ptrArg04 : (ptr32 char))
+T_20: (in printf : ptr32)
   Class: Eq_20
-  DataType: (ptr32 char)
+  DataType: (ptr32 Eq_20)
+  OrigDataType: (ptr32 (fn T_33 (T_27, T_28, T_29, T_30, T_32)))
+T_21: (in signature of printf : void)
+  Class: Eq_20
+  DataType: (ptr32 Eq_20)
   OrigDataType: 
-T_21: (in  : (ptr32 char))
-  Class: Eq_7
+T_22: (in ptrArg04 : (ptr32 char))
+  Class: Eq_22
   DataType: (ptr32 char)
-  OrigDataType: 
-T_22: (in  : int32)
-  Class: Eq_3
-  DataType: int32
   OrigDataType: 
 T_23: (in  : (ptr32 char))
-  Class: Eq_9
+  Class: Eq_23
   DataType: (ptr32 char)
   OrigDataType: 
-T_24: (in  : real64)
+T_24: (in  : int32)
   Class: Eq_24
+  DataType: int32
+  OrigDataType: 
+T_25: (in  : (ptr32 char))
+  Class: Eq_25
+  DataType: (ptr32 char)
+  OrigDataType: 
+T_26: (in  : real64)
+  Class: Eq_26
   DataType: real64
   OrigDataType: 
-T_25: (in 0x004020C8 : word32)
-  Class: Eq_20
+T_27: (in 0x004020C8 : word32)
+  Class: Eq_22
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_26: (in (real64) arg4 : real64)
+T_28: (in arg1 : (ptr32 char))
+  Class: Eq_23
+  DataType: (ptr32 char)
+  OrigDataType: (ptr32 char)
+T_29: (in arg2 : int32)
   Class: Eq_24
+  DataType: int32
+  OrigDataType: int32
+T_30: (in arg3 : (ptr32 char))
+  Class: Eq_25
+  DataType: (ptr32 char)
+  OrigDataType: (ptr32 char)
+T_31: (in arg4 : real32)
+  Class: Eq_31
+  DataType: real32
+  OrigDataType: real32
+T_32: (in (real64) arg4 : real64)
+  Class: Eq_26
   DataType: real64
   OrigDataType: real64
-T_27: (in printf("%s %d %s %f", arg1, arg2, arg3, (real64) arg4) : int32)
-  Class: Eq_27
+T_33: (in printf("%s %d %s %f", arg1, arg2, arg3, (real64) arg4) : int32)
+  Class: Eq_33
   DataType: int32
   OrigDataType: int32
-T_28: (in dwArg04 : word32)
-  Class: Eq_28
+T_34: (in dwArg04 : word32)
+  Class: Eq_34
   DataType: word32
   OrigDataType: word32
-T_29: (in test1 : ptr32)
+T_35: (in test1 : ptr32)
   Class: Eq_5
   DataType: (ptr32 Eq_5)
-  OrigDataType: (ptr32 (fn T_35 (T_30, T_31, T_32, T_34)))
-T_30: (in 0x004020D8 : word32)
+  OrigDataType: (ptr32 (fn T_41 (T_36, T_37, T_38, T_40)))
+T_36: (in 0x004020D8 : word32)
   Class: Eq_7
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_31: (in 0x00000002 : word32)
-  Class: Eq_3
+T_37: (in 0x00000002 : word32)
+  Class: Eq_8
   DataType: int32
   OrigDataType: int32
-T_32: (in 0x004020D4 : word32)
+T_38: (in 0x004020D4 : word32)
   Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_33: (in 004020E8 : ptr32)
-  Class: Eq_33
+T_39: (in 004020E8 : ptr32)
+  Class: Eq_39
   DataType: (ptr32 real32)
-  OrigDataType: (ptr32 (struct (0 T_34 t0000)))
-T_34: (in Mem10[0x004020E8:real32] : real32)
+  OrigDataType: (ptr32 (struct (0 T_40 t0000)))
+T_40: (in Mem10[0x004020E8:real32] : real32)
   Class: Eq_10
   DataType: real32
   OrigDataType: real32
-T_35: (in test1("1", 0x00000002, "3", globals->r4020E8) : void)
-  Class: Eq_16
+T_41: (in test1("1", 0x00000002, "3", globals->r4020E8) : void)
+  Class: Eq_18
   DataType: void
   OrigDataType: void
-T_36: (in 0x00000000 : word32)
-  Class: Eq_28
+T_42: (in 0x00000000 : word32)
+  Class: Eq_34
   DataType: word32
   OrigDataType: word32
-T_37: (in dwArg04 != 0x00000000 : bool)
-  Class: Eq_37
+T_43: (in dwArg04 != 0x00000000 : bool)
+  Class: Eq_43
   DataType: bool
   OrigDataType: bool
-T_38: (in test1 : ptr32)
+T_44: (in test1 : ptr32)
   Class: Eq_5
   DataType: (ptr32 Eq_5)
-  OrigDataType: (ptr32 (fn T_44 (T_39, T_40, T_41, T_43)))
-T_39: (in 0x004020E0 : word32)
+  OrigDataType: (ptr32 (fn T_50 (T_45, T_46, T_47, T_49)))
+T_45: (in 0x004020E0 : word32)
   Class: Eq_7
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_40: (in 0x00000006 : word32)
-  Class: Eq_3
+T_46: (in 0x00000006 : word32)
+  Class: Eq_8
   DataType: int32
   OrigDataType: int32
-T_41: (in 0x004020DC : word32)
+T_47: (in 0x004020DC : word32)
   Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_42: (in 004020E4 : ptr32)
-  Class: Eq_42
+T_48: (in 004020E4 : ptr32)
+  Class: Eq_48
   DataType: (ptr32 real32)
-  OrigDataType: (ptr32 (struct (0 T_43 t0000)))
-T_43: (in Mem25[0x004020E4:real32] : real32)
+  OrigDataType: (ptr32 (struct (0 T_49 t0000)))
+T_49: (in Mem25[0x004020E4:real32] : real32)
   Class: Eq_10
   DataType: real32
   OrigDataType: real32
-T_44: (in test1("5", 0x00000006, "7", globals->r4020E4) : void)
-  Class: Eq_16
+T_50: (in test1("5", 0x00000006, "7", globals->r4020E4) : void)
+  Class: Eq_18
   DataType: void
   OrigDataType: void
-T_45: (in c : (ptr32 Eq_45))
-  Class: Eq_45
-  DataType: (ptr32 Eq_45)
-  OrigDataType: (ptr32 (union (cdecl_class u1)))
-T_46: (in 0x00000000 : word32)
-  Class: Eq_46
-  DataType: word32
-  OrigDataType: word32
-T_47: (in c + 0x00000000 : word32)
-  Class: Eq_47
-  DataType: (ptr32 (ptr32 Eq_47))
-  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
-T_48: (in Mem12[c + 0x00000000:word32] : word32)
-  Class: Eq_48
-  DataType: (ptr32 Eq_48)
-  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
-T_49: (in 0x00000004 : word32)
-  Class: Eq_49
-  DataType: word32
-  OrigDataType: word32
-T_50: (in Mem12[c + 0x00000000:word32] + 0x00000004 : word32)
-  Class: Eq_50
-  DataType: (ptr32 (ptr32 Eq_50))
-  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 cdecl_class), int32))))
-T_51: (in Mem12[Mem12[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+T_51: (in c : (ptr32 Eq_51))
   Class: Eq_51
   DataType: (ptr32 Eq_51)
-  OrigDataType: (ptr32 (fn T_53 ((ptr32 cdecl_class), int32)))
-T_52: (in 0x000003E8 : word32)
+  OrigDataType: (ptr32 cdecl_class)
+T_52: (in c : (ptr32 cdecl_class))
   Class: Eq_52
-  DataType: int32
-  OrigDataType: int32
-T_53: (in c->vtbl->method04(c, 0x000003E8) : void)
+  DataType: (ptr32 Eq_52)
+  OrigDataType: (ptr32 (union (cdecl_class u1)))
+T_53: (in 0x00000000 : word32)
   Class: Eq_53
-  DataType: void
-  OrigDataType: void
-T_54: (in 00403018 : ptr32)
+  DataType: word32
+  OrigDataType: word32
+T_54: (in c + 0x00000000 : word32)
   Class: Eq_54
-  DataType: (ptr32 Eq_54)
-  OrigDataType: (ptr32 (struct (0 cdecl_class_ptr t0000)))
-T_55: (in Mem10[0x00403018:word32] : word32)
+  DataType: (ptr32 (ptr32 Eq_54))
+  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
+T_55: (in Mem12[c + 0x00000000:word32] : word32)
   Class: Eq_55
-  DataType: Eq_55
-  OrigDataType: (union (cdecl_class_ptr u1))
-T_56: (in 0x00000000 : word32)
+  DataType: (ptr32 Eq_55)
+  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
+T_56: (in 0x00000004 : word32)
   Class: Eq_56
   DataType: word32
   OrigDataType: word32
-T_57: (in Mem10[0x00403018:word32] + 0x00000000 : word32)
+T_57: (in Mem12[c + 0x00000000:word32] + 0x00000004 : word32)
   Class: Eq_57
   DataType: (ptr32 (ptr32 Eq_57))
-  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
-T_58: (in Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] : word32)
+  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 cdecl_class), int32))))
+T_58: (in Mem12[Mem12[c + 0x00000000:word32] + 0x00000004:word32] : word32)
   Class: Eq_58
   DataType: (ptr32 Eq_58)
-  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
-T_59: (in 0x00000000 : word32)
+  OrigDataType: (ptr32 (fn T_60 ((ptr32 cdecl_class), int32)))
+T_59: (in 0x000003E8 : word32)
   Class: Eq_59
-  DataType: word32
-  OrigDataType: word32
-T_60: (in Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] + 0x00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_60: (in c->vtbl->method04(c, 0x000003E8) : void)
   Class: Eq_60
-  DataType: (ptr32 (ptr32 Eq_60))
-  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 cdecl_class)))))
-T_61: (in Mem10[Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
+  DataType: void
+  OrigDataType: void
+T_61: (in 00403018 : ptr32)
   Class: Eq_61
   DataType: (ptr32 Eq_61)
-  OrigDataType: (ptr32 (fn T_64 ((ptr32 cdecl_class))))
-T_62: (in 00403018 : ptr32)
-  Class: Eq_62
-  DataType: (ptr32 Eq_62)
   OrigDataType: (ptr32 (struct (0 cdecl_class_ptr t0000)))
-T_63: (in Mem6[0x00403018:word32] : word32)
-  Class: Eq_55
-  DataType: Eq_55
-  OrigDataType: (union ((ptr32 cdecl_class) u1) (cdecl_class_ptr u0))
-T_64: (in globals->gbl_c->vtbl->method00(globals->gbl_c) : void)
+T_62: (in Mem10[0x00403018:word32] : word32)
+  Class: Eq_62
+  DataType: Eq_62
+  OrigDataType: (union (cdecl_class_ptr u1))
+T_63: (in 0x00000000 : word32)
+  Class: Eq_63
+  DataType: word32
+  OrigDataType: word32
+T_64: (in Mem10[0x00403018:word32] + 0x00000000 : word32)
   Class: Eq_64
-  DataType: void
-  OrigDataType: void
-T_65: (in 00403018 : ptr32)
+  DataType: (ptr32 (ptr32 Eq_64))
+  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
+T_65: (in Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] : word32)
   Class: Eq_65
   DataType: (ptr32 Eq_65)
-  OrigDataType: (ptr32 (struct (0 cdecl_class_ptr t0000)))
-T_66: (in Mem18[0x00403018:word32] : word32)
-  Class: Eq_55
-  DataType: Eq_55
-  OrigDataType: (union (cdecl_class_ptr u1))
-T_67: (in 0x00000000 : word32)
-  Class: Eq_67
+  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
+T_66: (in 0x00000000 : word32)
+  Class: Eq_66
   DataType: word32
   OrigDataType: word32
-T_68: (in Mem18[0x00403018:word32] + 0x00000000 : word32)
+T_67: (in Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] + 0x00000000 : word32)
+  Class: Eq_67
+  DataType: (ptr32 (ptr32 Eq_67))
+  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 cdecl_class)))))
+T_68: (in Mem10[Mem10[Mem10[0x00403018:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
   Class: Eq_68
-  DataType: (ptr32 (ptr32 Eq_68))
-  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
-T_69: (in Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] : word32)
+  DataType: (ptr32 Eq_68)
+  OrigDataType: (ptr32 (fn T_71 ((ptr32 cdecl_class))))
+T_69: (in 00403018 : ptr32)
   Class: Eq_69
   DataType: (ptr32 Eq_69)
-  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
-T_70: (in 0x00000004 : word32)
-  Class: Eq_70
-  DataType: word32
-  OrigDataType: word32
-T_71: (in Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] + 0x00000004 : word32)
-  Class: Eq_71
-  DataType: (ptr32 (ptr32 Eq_71))
-  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 cdecl_class), int32))))
-T_72: (in Mem18[Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
-  Class: Eq_72
-  DataType: (ptr32 Eq_72)
-  OrigDataType: (ptr32 (union ((fn void ((ptr32 cdecl_class), int32)) u0) ((fn void (Eq_55, word32, real32)) u1)))
-T_73: (in 00403018 : ptr32)
-  Class: Eq_73
-  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 cdecl_class_ptr t0000)))
-T_74: (in Mem15[0x00403018:word32] : word32)
-  Class: Eq_55
-  DataType: Eq_55
-  OrigDataType: cdecl_class_ptr
-T_75: (in 0x000003E7 : word32)
-  Class: Eq_75
-  DataType: word32
-  OrigDataType: word32
-T_76: (in 004020EC : ptr32)
-  Class: Eq_76
-  DataType: (ptr32 real32)
-  OrigDataType: (ptr32 (struct (0 T_77 t0000)))
-T_77: (in Mem9[0x004020EC:real32] : real32)
-  Class: Eq_77
-  DataType: real32
-  OrigDataType: real32
-T_78: (in globals->gbl_c->vtbl->method04(globals->gbl_c, 0x000003E7, globals->r4020EC) : void)
-  Class: Eq_78
+T_70: (in Mem6[0x00403018:word32] : word32)
+  Class: Eq_62
+  DataType: Eq_62
+  OrigDataType: (union ((ptr32 cdecl_class) u1) (cdecl_class_ptr u0))
+T_71: (in globals->gbl_c->vtbl->method00(globals->gbl_c) : void)
+  Class: Eq_71
   DataType: void
   OrigDataType: void
-T_79: (in c : Eq_55)
-  Class: Eq_55
-  DataType: Eq_55
-  OrigDataType: (ptr32 cdecl_class)
-T_80: (in a : int32)
+T_72: (in 00403018 : ptr32)
+  Class: Eq_72
+  DataType: (ptr32 Eq_72)
+  OrigDataType: (ptr32 (struct (0 cdecl_class_ptr t0000)))
+T_73: (in Mem18[0x00403018:word32] : word32)
+  Class: Eq_62
+  DataType: Eq_62
+  OrigDataType: (union (cdecl_class_ptr u1))
+T_74: (in 0x00000000 : word32)
+  Class: Eq_74
+  DataType: word32
+  OrigDataType: word32
+T_75: (in Mem18[0x00403018:word32] + 0x00000000 : word32)
+  Class: Eq_75
+  DataType: (ptr32 (ptr32 Eq_75))
+  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
+T_76: (in Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] : word32)
+  Class: Eq_76
+  DataType: (ptr32 Eq_76)
+  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
+T_77: (in 0x00000004 : word32)
+  Class: Eq_77
+  DataType: word32
+  OrigDataType: word32
+T_78: (in Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] + 0x00000004 : word32)
+  Class: Eq_78
+  DataType: (ptr32 (ptr32 Eq_78))
+  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 cdecl_class), int32))))
+T_79: (in Mem18[Mem18[Mem18[0x00403018:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
+  Class: Eq_79
+  DataType: (ptr32 Eq_79)
+  OrigDataType: (ptr32 (union ((fn void ((ptr32 cdecl_class), int32)) u0) ((fn void (Eq_62, word32, real32)) u1)))
+T_80: (in 00403018 : ptr32)
   Class: Eq_80
-  DataType: int32
-  OrigDataType: int32
-T_81: (in b : int32)
-  Class: Eq_81
-  DataType: int32
-  OrigDataType: int32
-T_82: (in 0x00000000 : word32)
+  DataType: (ptr32 Eq_80)
+  OrigDataType: (ptr32 (struct (0 cdecl_class_ptr t0000)))
+T_81: (in Mem15[0x00403018:word32] : word32)
+  Class: Eq_62
+  DataType: Eq_62
+  OrigDataType: cdecl_class_ptr
+T_82: (in 0x000003E7 : word32)
   Class: Eq_82
   DataType: word32
   OrigDataType: word32
-T_83: (in c + 0x00000000 : word32)
+T_83: (in 004020EC : ptr32)
   Class: Eq_83
-  DataType: (ptr32 (ptr32 Eq_83))
-  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
-T_84: (in Mem37[c + 0x00000000:word32] : word32)
+  DataType: (ptr32 real32)
+  OrigDataType: (ptr32 (struct (0 T_84 t0000)))
+T_84: (in Mem9[0x004020EC:real32] : real32)
   Class: Eq_84
-  DataType: (ptr32 Eq_84)
-  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
-T_85: (in 0x00000004 : word32)
+  DataType: real32
+  OrigDataType: real32
+T_85: (in globals->gbl_c->vtbl->method04(globals->gbl_c, 0x000003E7, globals->r4020EC) : void)
   Class: Eq_85
-  DataType: word32
-  OrigDataType: word32
-T_86: (in Mem37[c + 0x00000000:word32] + 0x00000004 : word32)
-  Class: Eq_86
-  DataType: (ptr32 (ptr32 Eq_86))
-  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 cdecl_class), int32))))
-T_87: (in Mem37[Mem37[c + 0x00000000:word32] + 0x00000004:word32] : word32)
-  Class: Eq_87
-  DataType: (ptr32 Eq_87)
-  OrigDataType: (ptr32 (fn T_95 ((ptr32 cdecl_class), int32)))
-T_88: (in 0x00000000 : word32)
-  Class: Eq_88
-  DataType: word32
-  OrigDataType: word32
-T_89: (in c + 0x00000000 : word32)
-  Class: Eq_89
-  DataType: (ptr32 (ptr32 Eq_89))
-  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
-T_90: (in Mem19[c + 0x00000000:word32] : word32)
-  Class: Eq_90
-  DataType: (ptr32 Eq_90)
-  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
-T_91: (in 0x00000008 : word32)
-  Class: Eq_91
-  DataType: word32
-  OrigDataType: word32
-T_92: (in Mem19[c + 0x00000000:word32] + 0x00000008 : word32)
-  Class: Eq_92
-  DataType: (ptr32 (ptr32 Eq_92))
-  OrigDataType: (ptr32 (ptr32 (fn int32 ((ptr32 cdecl_class), int32, int32))))
-T_93: (in Mem19[Mem19[c + 0x00000000:word32] + 0x00000008:word32] : word32)
-  Class: Eq_93
-  DataType: (ptr32 Eq_93)
-  OrigDataType: (ptr32 (fn int32 ((ptr32 cdecl_class), int32, int32)))
-T_94: (in c.u0->vtbl->sum(c, a, b) : int32)
-  Class: Eq_94
-  DataType: int32
-  OrigDataType: int32
-T_95: (in c.u0->vtbl->method04(c, c.u0->vtbl->sum(c, a, b)) : void)
-  Class: Eq_95
   DataType: void
   OrigDataType: void
-T_96: (in rArg04 : real64)
-  Class: Eq_96
-  DataType: real64
-  OrigDataType: real64
-T_97: (in 1.0 : real64)
-  Class: Eq_96
-  DataType: real64
-  OrigDataType: real64
-T_98: (in rArg04 <= 1.0 : bool)
-  Class: Eq_98
-  DataType: bool
-  OrigDataType: bool
-T_99: (in 00403024 : ptr32)
-  Class: Eq_99
-  DataType: (ptr32 (ptr32 Eq_99))
-  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_100: (in Mem40[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
-  OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_101: (in 0x00000000 : word32)
-  Class: Eq_101
-  DataType: word32
-  OrigDataType: word32
-T_102: (in Mem40[0x00403024:word32] + 0x00000000 : word32)
-  Class: Eq_102
-  DataType: (ptr32 (ptr32 Eq_102))
-  OrigDataType: (ptr32 (ptr32 thiscall_class_vtbl))
-T_103: (in Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] : word32)
-  Class: Eq_103
-  DataType: (ptr32 Eq_103)
-  OrigDataType: (ptr32 (union (thiscall_class_vtbl u1)))
-T_104: (in 0x00000004 : word32)
-  Class: Eq_104
-  DataType: word32
-  OrigDataType: word32
-T_105: (in Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
-  Class: Eq_105
-  DataType: (ptr32 (ptr32 Eq_105))
-  OrigDataType: (ptr32 (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64))))
-T_106: (in Mem40[Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
-  Class: Eq_106
-  DataType: (ptr32 Eq_106)
-  OrigDataType: (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64)))
-T_107: (in 00403024 : ptr32)
-  Class: Eq_107
-  DataType: (ptr32 (ptr32 Eq_107))
-  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_108: (in Mem40[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
-  OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_109: (in 0x0000000D : word32)
-  Class: Eq_109
+T_86: (in c : Eq_62)
+  Class: Eq_62
+  DataType: Eq_62
+  OrigDataType: (ptr32 cdecl_class)
+T_87: (in a : int32)
+  Class: Eq_87
   DataType: int32
   OrigDataType: int32
-T_110: (in globals->gbl_thiscall->vtbl->modify_double(globals->gbl_thiscall, 0x0000000D, rArg04) : real64)
-  Class: Eq_110
+T_88: (in b : int32)
+  Class: Eq_88
+  DataType: int32
+  OrigDataType: int32
+T_89: (in c : (ptr32 cdecl_class))
+  Class: Eq_89
+  DataType: (ptr32 Eq_89)
+  OrigDataType: (ptr32 cdecl_class)
+T_90: (in 0x00000000 : word32)
+  Class: Eq_90
+  DataType: word32
+  OrigDataType: word32
+T_91: (in c + 0x00000000 : word32)
+  Class: Eq_91
+  DataType: (ptr32 (ptr32 Eq_91))
+  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
+T_92: (in Mem37[c + 0x00000000:word32] : word32)
+  Class: Eq_92
+  DataType: (ptr32 Eq_92)
+  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
+T_93: (in 0x00000004 : word32)
+  Class: Eq_93
+  DataType: word32
+  OrigDataType: word32
+T_94: (in Mem37[c + 0x00000000:word32] + 0x00000004 : word32)
+  Class: Eq_94
+  DataType: (ptr32 (ptr32 Eq_94))
+  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 cdecl_class), int32))))
+T_95: (in Mem37[Mem37[c + 0x00000000:word32] + 0x00000004:word32] : word32)
+  Class: Eq_95
+  DataType: (ptr32 Eq_95)
+  OrigDataType: (ptr32 (fn T_105 ((ptr32 cdecl_class), int32)))
+T_96: (in 0x00000000 : word32)
+  Class: Eq_96
+  DataType: word32
+  OrigDataType: word32
+T_97: (in c + 0x00000000 : word32)
+  Class: Eq_97
+  DataType: (ptr32 (ptr32 Eq_97))
+  OrigDataType: (ptr32 (ptr32 cdecl_class_vtbl))
+T_98: (in Mem19[c + 0x00000000:word32] : word32)
+  Class: Eq_98
+  DataType: (ptr32 Eq_98)
+  OrigDataType: (ptr32 (union (cdecl_class_vtbl u1)))
+T_99: (in 0x00000008 : word32)
+  Class: Eq_99
+  DataType: word32
+  OrigDataType: word32
+T_100: (in Mem19[c + 0x00000000:word32] + 0x00000008 : word32)
+  Class: Eq_100
+  DataType: (ptr32 (ptr32 Eq_100))
+  OrigDataType: (ptr32 (ptr32 (fn int32 ((ptr32 cdecl_class), int32, int32))))
+T_101: (in Mem19[Mem19[c + 0x00000000:word32] + 0x00000008:word32] : word32)
+  Class: Eq_101
+  DataType: (ptr32 Eq_101)
+  OrigDataType: (ptr32 (fn int32 ((ptr32 cdecl_class), int32, int32)))
+T_102: (in a : int32)
+  Class: Eq_102
+  DataType: int32
+  OrigDataType: int32
+T_103: (in b : int32)
+  Class: Eq_103
+  DataType: int32
+  OrigDataType: int32
+T_104: (in c->vtbl->sum(c, a, b) : int32)
+  Class: Eq_104
+  DataType: int32
+  OrigDataType: int32
+T_105: (in c->vtbl->method04(c, c->vtbl->sum(c, a, b)) : void)
+  Class: Eq_105
+  DataType: void
+  OrigDataType: void
+T_106: (in rArg04 : real64)
+  Class: Eq_106
   DataType: real64
   OrigDataType: real64
-T_111: (in 00403024 : ptr32)
-  Class: Eq_111
-  DataType: (ptr32 (ptr32 Eq_111))
+T_107: (in 1.0 : real64)
+  Class: Eq_106
+  DataType: real64
+  OrigDataType: real64
+T_108: (in rArg04 <= 1.0 : bool)
+  Class: Eq_108
+  DataType: bool
+  OrigDataType: bool
+T_109: (in 00403024 : ptr32)
+  Class: Eq_109
+  DataType: (ptr32 (ptr32 Eq_109))
   OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_112: (in Mem17[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+T_110: (in Mem40[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
   OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_113: (in 0x00000000 : word32)
-  Class: Eq_113
+T_111: (in 0x00000000 : word32)
+  Class: Eq_111
   DataType: word32
   OrigDataType: word32
-T_114: (in Mem17[0x00403024:word32] + 0x00000000 : word32)
-  Class: Eq_114
-  DataType: (ptr32 (ptr32 Eq_114))
+T_112: (in Mem40[0x00403024:word32] + 0x00000000 : word32)
+  Class: Eq_112
+  DataType: (ptr32 (ptr32 Eq_112))
   OrigDataType: (ptr32 (ptr32 thiscall_class_vtbl))
-T_115: (in Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] : word32)
-  Class: Eq_115
-  DataType: (ptr32 Eq_115)
+T_113: (in Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] : word32)
+  Class: Eq_113
+  DataType: (ptr32 Eq_113)
   OrigDataType: (ptr32 (union (thiscall_class_vtbl u1)))
-T_116: (in 0x00000000 : word32)
-  Class: Eq_116
+T_114: (in 0x00000004 : word32)
+  Class: Eq_114
   DataType: word32
   OrigDataType: word32
-T_117: (in Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
+T_115: (in Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
+  Class: Eq_115
+  DataType: (ptr32 (ptr32 Eq_115))
+  OrigDataType: (ptr32 (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64))))
+T_116: (in Mem40[Mem40[Mem40[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
+  Class: Eq_116
+  DataType: (ptr32 Eq_116)
+  OrigDataType: (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64)))
+T_117: (in 00403024 : ptr32)
   Class: Eq_117
   DataType: (ptr32 (ptr32 Eq_117))
-  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 thiscall_class), real64))))
-T_118: (in Mem17[Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
-  Class: Eq_118
-  DataType: (ptr32 Eq_118)
-  OrigDataType: (ptr32 (fn T_121 ((ptr32 thiscall_class), real64)))
-T_119: (in 00403024 : ptr32)
-  Class: Eq_119
-  DataType: (ptr32 (ptr32 Eq_119))
   OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_120: (in Mem17[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+T_118: (in Mem40[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
   OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_121: (in globals->gbl_thiscall->vtbl->set_double(globals->gbl_thiscall, rArg04) : void)
-  Class: Eq_121
-  DataType: void
-  OrigDataType: void
-T_122: (in rArg04 : real64)
-  Class: Eq_122
+T_119: (in 0x0000000D : word32)
+  Class: Eq_119
+  DataType: int32
+  OrigDataType: int32
+T_120: (in globals->gbl_thiscall->vtbl->modify_double(globals->gbl_thiscall, 0x0000000D, rArg04) : real64)
+  Class: Eq_120
   DataType: real64
   OrigDataType: real64
-T_123: (in 00403024 : ptr32)
-  Class: Eq_123
-  DataType: (ptr32 (ptr32 Eq_123))
+T_121: (in 00403024 : ptr32)
+  Class: Eq_121
+  DataType: (ptr32 (ptr32 Eq_121))
   OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_124: (in Mem15[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+T_122: (in Mem17[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
   OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_125: (in 0x00000000 : word32)
-  Class: Eq_125
+T_123: (in 0x00000000 : word32)
+  Class: Eq_123
   DataType: word32
   OrigDataType: word32
-T_126: (in Mem15[0x00403024:word32] + 0x00000000 : word32)
-  Class: Eq_126
-  DataType: (ptr32 (ptr32 Eq_126))
+T_124: (in Mem17[0x00403024:word32] + 0x00000000 : word32)
+  Class: Eq_124
+  DataType: (ptr32 (ptr32 Eq_124))
   OrigDataType: (ptr32 (ptr32 thiscall_class_vtbl))
-T_127: (in Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] : word32)
-  Class: Eq_127
-  DataType: (ptr32 Eq_127)
+T_125: (in Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] : word32)
+  Class: Eq_125
+  DataType: (ptr32 Eq_125)
   OrigDataType: (ptr32 (union (thiscall_class_vtbl u1)))
-T_128: (in 0x00000004 : word32)
-  Class: Eq_128
+T_126: (in 0x00000000 : word32)
+  Class: Eq_126
   DataType: word32
   OrigDataType: word32
-T_129: (in Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
+T_127: (in Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
+  Class: Eq_127
+  DataType: (ptr32 (ptr32 Eq_127))
+  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 thiscall_class), real64))))
+T_128: (in Mem17[Mem17[Mem17[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
+  Class: Eq_128
+  DataType: (ptr32 Eq_128)
+  OrigDataType: (ptr32 (fn T_131 ((ptr32 thiscall_class), real64)))
+T_129: (in 00403024 : ptr32)
   Class: Eq_129
   DataType: (ptr32 (ptr32 Eq_129))
-  OrigDataType: (ptr32 (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64))))
-T_130: (in Mem15[Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
-  Class: Eq_130
-  DataType: (ptr32 Eq_130)
-  OrigDataType: (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64)))
-T_131: (in 00403024 : ptr32)
-  Class: Eq_131
-  DataType: (ptr32 (ptr32 Eq_131))
   OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_132: (in Mem15[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+T_130: (in Mem17[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
   OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_133: (in 0xFFFFFFFF : word32)
-  Class: Eq_133
-  DataType: int32
-  OrigDataType: int32
-T_134: (in globals->gbl_thiscall->vtbl->modify_double(globals->gbl_thiscall, 0xFFFFFFFF, rArg04) : real64)
-  Class: Eq_134
-  DataType: real64
-  OrigDataType: real64
-T_135: (in 004020F8 : ptr32)
-  Class: Eq_135
-  DataType: (ptr32 real64)
-  OrigDataType: (ptr32 (struct (0 T_136 t0000)))
-T_136: (in Mem15[0x004020F8:real64] : real64)
-  Class: Eq_122
-  DataType: real64
-  OrigDataType: real64
-T_137: (in globals->r4020F8 == rArg04 : bool)
-  Class: Eq_137
-  DataType: bool
-  OrigDataType: bool
-T_138: (in test6 : ptr32)
-  Class: Eq_138
-  DataType: (ptr32 Eq_138)
-  OrigDataType: (ptr32 (fn T_144 (T_141, T_142, T_143)))
-T_139: (in signature of test6 : void)
-  Class: Eq_138
-  DataType: (ptr32 Eq_138)
-  OrigDataType: 
-T_140: (in 00403018 : ptr32)
-  Class: Eq_140
-  DataType: (ptr32 Eq_140)
-  OrigDataType: (ptr32 (struct (0 cdecl_class_ptr t0000)))
-T_141: (in Mem59[0x00403018:word32] : word32)
-  Class: Eq_55
-  DataType: Eq_55
-  OrigDataType: (union ((ptr32 cdecl_class) u1) (cdecl_class_ptr u0))
-T_142: (in 0x00000006 : word32)
-  Class: Eq_80
-  DataType: int32
-  OrigDataType: int32
-T_143: (in 0x00000007 : word32)
-  Class: Eq_81
-  DataType: int32
-  OrigDataType: int32
-T_144: (in test6(globals->gbl_c, 0x00000006, 0x00000007) : void)
-  Class: Eq_144
+T_131: (in globals->gbl_thiscall->vtbl->set_double(globals->gbl_thiscall, rArg04) : void)
+  Class: Eq_131
   DataType: void
   OrigDataType: void
-T_145: (in 004020F0 : ptr32)
+T_132: (in rArg04 : real64)
+  Class: Eq_132
+  DataType: real64
+  OrigDataType: real64
+T_133: (in 00403024 : ptr32)
+  Class: Eq_133
+  DataType: (ptr32 (ptr32 Eq_133))
+  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
+T_134: (in Mem15[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
+  OrigDataType: (ptr32 (union (thiscall_class u1)))
+T_135: (in 0x00000000 : word32)
+  Class: Eq_135
+  DataType: word32
+  OrigDataType: word32
+T_136: (in Mem15[0x00403024:word32] + 0x00000000 : word32)
+  Class: Eq_136
+  DataType: (ptr32 (ptr32 Eq_136))
+  OrigDataType: (ptr32 (ptr32 thiscall_class_vtbl))
+T_137: (in Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] : word32)
+  Class: Eq_137
+  DataType: (ptr32 Eq_137)
+  OrigDataType: (ptr32 (union (thiscall_class_vtbl u1)))
+T_138: (in 0x00000004 : word32)
+  Class: Eq_138
+  DataType: word32
+  OrigDataType: word32
+T_139: (in Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
+  Class: Eq_139
+  DataType: (ptr32 (ptr32 Eq_139))
+  OrigDataType: (ptr32 (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64))))
+T_140: (in Mem15[Mem15[Mem15[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
+  Class: Eq_140
+  DataType: (ptr32 Eq_140)
+  OrigDataType: (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64)))
+T_141: (in 00403024 : ptr32)
+  Class: Eq_141
+  DataType: (ptr32 (ptr32 Eq_141))
+  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
+T_142: (in Mem15[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
+  OrigDataType: (ptr32 (union (thiscall_class u1)))
+T_143: (in 0xFFFFFFFF : word32)
+  Class: Eq_143
+  DataType: int32
+  OrigDataType: int32
+T_144: (in globals->gbl_thiscall->vtbl->modify_double(globals->gbl_thiscall, 0xFFFFFFFF, rArg04) : real64)
+  Class: Eq_144
+  DataType: real64
+  OrigDataType: real64
+T_145: (in 004020F8 : ptr32)
   Class: Eq_145
   DataType: (ptr32 real64)
   OrigDataType: (ptr32 (struct (0 T_146 t0000)))
-T_146: (in Mem15[0x004020F0:real64] : real64)
-  Class: Eq_122
+T_146: (in Mem15[0x004020F8:real64] : real64)
+  Class: Eq_132
   DataType: real64
   OrigDataType: real64
-T_147: (in globals->r4020F0 <= rArg04 : bool)
+T_147: (in globals->r4020F8 == rArg04 : bool)
   Class: Eq_147
   DataType: bool
   OrigDataType: bool
-T_148: (in 00403024 : ptr32)
+T_148: (in test6 : ptr32)
   Class: Eq_148
-  DataType: (ptr32 (ptr32 Eq_148))
-  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_149: (in Mem43[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
-  OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_150: (in 0x00000000 : word32)
+  DataType: (ptr32 Eq_148)
+  OrigDataType: (ptr32 (fn T_154 (T_151, T_152, T_153)))
+T_149: (in signature of test6 : void)
+  Class: Eq_148
+  DataType: (ptr32 Eq_148)
+  OrigDataType: 
+T_150: (in 00403018 : ptr32)
   Class: Eq_150
-  DataType: word32
-  OrigDataType: word32
-T_151: (in Mem43[0x00403024:word32] + 0x00000000 : word32)
-  Class: Eq_151
-  DataType: (ptr32 (ptr32 Eq_151))
-  OrigDataType: (ptr32 (ptr32 thiscall_class_vtbl))
-T_152: (in Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] : word32)
-  Class: Eq_152
-  DataType: (ptr32 Eq_152)
-  OrigDataType: (ptr32 (union (thiscall_class_vtbl u1)))
-T_153: (in 0x00000000 : word32)
-  Class: Eq_153
-  DataType: word32
-  OrigDataType: word32
-T_154: (in Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
-  Class: Eq_154
-  DataType: (ptr32 (ptr32 Eq_154))
-  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 thiscall_class), real64))))
-T_155: (in Mem43[Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
-  Class: Eq_155
-  DataType: (ptr32 Eq_155)
-  OrigDataType: (ptr32 (fn T_158 ((ptr32 thiscall_class), real64)))
-T_156: (in 00403024 : ptr32)
-  Class: Eq_156
-  DataType: (ptr32 (ptr32 Eq_156))
-  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_157: (in Mem43[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
-  OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_158: (in globals->gbl_thiscall->vtbl->set_double(globals->gbl_thiscall, rArg04) : void)
-  Class: Eq_158
-  DataType: void
-  OrigDataType: void
-T_159: (in rArg04 : real32)
-  Class: Eq_159
-  DataType: real32
-  OrigDataType: real32
-T_160: (in dwLoc08_67 : int32)
-  Class: Eq_160
+  DataType: (ptr32 Eq_150)
+  OrigDataType: (ptr32 (struct (0 cdecl_class_ptr t0000)))
+T_151: (in Mem59[0x00403018:word32] : word32)
+  Class: Eq_62
+  DataType: Eq_62
+  OrigDataType: (union ((ptr32 cdecl_class) u1) (cdecl_class_ptr u0))
+T_152: (in 0x00000006 : word32)
+  Class: Eq_87
   DataType: int32
   OrigDataType: int32
-T_161: (in 0x00000000 : word32)
-  Class: Eq_160
+T_153: (in 0x00000007 : word32)
+  Class: Eq_88
   DataType: int32
-  OrigDataType: word32
-T_162: (in 00403024 : ptr32)
-  Class: Eq_162
-  DataType: (ptr32 (ptr32 Eq_162))
-  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_163: (in Mem25[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
-  OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_164: (in 0x00000000 : word32)
-  Class: Eq_164
-  DataType: word32
-  OrigDataType: word32
-T_165: (in Mem25[0x00403024:word32] + 0x00000000 : word32)
-  Class: Eq_165
-  DataType: (ptr32 (ptr32 Eq_165))
-  OrigDataType: (ptr32 (ptr32 thiscall_class_vtbl))
-T_166: (in Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] : word32)
-  Class: Eq_166
-  DataType: (ptr32 Eq_166)
-  OrigDataType: (ptr32 (union (thiscall_class_vtbl u1)))
-T_167: (in 0x00000004 : word32)
-  Class: Eq_167
-  DataType: word32
-  OrigDataType: word32
-T_168: (in Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
-  Class: Eq_168
-  DataType: (ptr32 (ptr32 Eq_168))
-  OrigDataType: (ptr32 (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64))))
-T_169: (in Mem25[Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
-  Class: Eq_169
-  DataType: (ptr32 Eq_169)
-  OrigDataType: (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64)))
-T_170: (in 00403024 : ptr32)
-  Class: Eq_170
-  DataType: (ptr32 (ptr32 Eq_170))
-  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_171: (in Mem25[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
-  OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_172: (in (real64) rArg04 : real64)
-  Class: Eq_172
-  DataType: real64
-  OrigDataType: real64
-T_173: (in globals->gbl_thiscall->vtbl->modify_double(globals->gbl_thiscall, dwLoc08_67, (real64) rArg04) : real64)
-  Class: Eq_173
-  DataType: real64
-  OrigDataType: real64
-T_174: (in (real64) dwLoc08_67 : real64)
-  Class: Eq_173
-  DataType: real64
-  OrigDataType: real64
-T_175: (in globals->gbl_thiscall->vtbl->modify_double(globals->gbl_thiscall, dwLoc08_67, (real64) rArg04) <= (real64) dwLoc08_67 : bool)
-  Class: Eq_175
-  DataType: bool
-  OrigDataType: bool
-T_176: (in 00403024 : ptr32)
-  Class: Eq_176
-  DataType: (ptr32 (ptr32 Eq_176))
-  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_177: (in Mem49[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
-  OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_178: (in 0x00000000 : word32)
-  Class: Eq_178
-  DataType: word32
-  OrigDataType: word32
-T_179: (in Mem49[0x00403024:word32] + 0x00000000 : word32)
-  Class: Eq_179
-  DataType: (ptr32 (ptr32 Eq_179))
-  OrigDataType: (ptr32 (ptr32 thiscall_class_vtbl))
-T_180: (in Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] : word32)
-  Class: Eq_180
-  DataType: (ptr32 Eq_180)
-  OrigDataType: (ptr32 (union (thiscall_class_vtbl u1)))
-T_181: (in 0x00000000 : word32)
-  Class: Eq_181
-  DataType: word32
-  OrigDataType: word32
-T_182: (in Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
-  Class: Eq_182
-  DataType: (ptr32 (ptr32 Eq_182))
-  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 thiscall_class), real64))))
-T_183: (in Mem49[Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: (ptr32 (fn T_187 ((ptr32 thiscall_class), real64)))
-T_184: (in 00403024 : ptr32)
-  Class: Eq_184
-  DataType: (ptr32 (ptr32 Eq_184))
-  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
-T_185: (in Mem49[0x00403024:word32] : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
-  OrigDataType: (ptr32 (union (thiscall_class u1)))
-T_186: (in (real64) rArg04 : real64)
-  Class: Eq_186
-  DataType: real64
-  OrigDataType: real64
-T_187: (in globals->gbl_thiscall->vtbl->set_double(globals->gbl_thiscall, (real64) rArg04) : void)
-  Class: Eq_187
+  OrigDataType: int32
+T_154: (in test6(globals->gbl_c, 0x00000006, 0x00000007) : void)
+  Class: Eq_154
   DataType: void
   OrigDataType: void
-T_188: (in 0x00000001 : word32)
+T_155: (in 004020F0 : ptr32)
+  Class: Eq_155
+  DataType: (ptr32 real64)
+  OrigDataType: (ptr32 (struct (0 T_156 t0000)))
+T_156: (in Mem15[0x004020F0:real64] : real64)
+  Class: Eq_132
+  DataType: real64
+  OrigDataType: real64
+T_157: (in globals->r4020F0 <= rArg04 : bool)
+  Class: Eq_157
+  DataType: bool
+  OrigDataType: bool
+T_158: (in 00403024 : ptr32)
+  Class: Eq_158
+  DataType: (ptr32 (ptr32 Eq_158))
+  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
+T_159: (in Mem43[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
+  OrigDataType: (ptr32 (union (thiscall_class u1)))
+T_160: (in 0x00000000 : word32)
+  Class: Eq_160
+  DataType: word32
+  OrigDataType: word32
+T_161: (in Mem43[0x00403024:word32] + 0x00000000 : word32)
+  Class: Eq_161
+  DataType: (ptr32 (ptr32 Eq_161))
+  OrigDataType: (ptr32 (ptr32 thiscall_class_vtbl))
+T_162: (in Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] : word32)
+  Class: Eq_162
+  DataType: (ptr32 Eq_162)
+  OrigDataType: (ptr32 (union (thiscall_class_vtbl u1)))
+T_163: (in 0x00000000 : word32)
+  Class: Eq_163
+  DataType: word32
+  OrigDataType: word32
+T_164: (in Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
+  Class: Eq_164
+  DataType: (ptr32 (ptr32 Eq_164))
+  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 thiscall_class), real64))))
+T_165: (in Mem43[Mem43[Mem43[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
+  Class: Eq_165
+  DataType: (ptr32 Eq_165)
+  OrigDataType: (ptr32 (fn T_168 ((ptr32 thiscall_class), real64)))
+T_166: (in 00403024 : ptr32)
+  Class: Eq_166
+  DataType: (ptr32 (ptr32 Eq_166))
+  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
+T_167: (in Mem43[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
+  OrigDataType: (ptr32 (union (thiscall_class u1)))
+T_168: (in globals->gbl_thiscall->vtbl->set_double(globals->gbl_thiscall, rArg04) : void)
+  Class: Eq_168
+  DataType: void
+  OrigDataType: void
+T_169: (in rArg04 : real32)
+  Class: Eq_169
+  DataType: real32
+  OrigDataType: real32
+T_170: (in dwLoc08_67 : int32)
+  Class: Eq_170
+  DataType: int32
+  OrigDataType: int32
+T_171: (in 0x00000000 : word32)
+  Class: Eq_170
+  DataType: int32
+  OrigDataType: word32
+T_172: (in 00403024 : ptr32)
+  Class: Eq_172
+  DataType: (ptr32 (ptr32 Eq_172))
+  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
+T_173: (in Mem25[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
+  OrigDataType: (ptr32 (union (thiscall_class u1)))
+T_174: (in 0x00000000 : word32)
+  Class: Eq_174
+  DataType: word32
+  OrigDataType: word32
+T_175: (in Mem25[0x00403024:word32] + 0x00000000 : word32)
+  Class: Eq_175
+  DataType: (ptr32 (ptr32 Eq_175))
+  OrigDataType: (ptr32 (ptr32 thiscall_class_vtbl))
+T_176: (in Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] : word32)
+  Class: Eq_176
+  DataType: (ptr32 Eq_176)
+  OrigDataType: (ptr32 (union (thiscall_class_vtbl u1)))
+T_177: (in 0x00000004 : word32)
+  Class: Eq_177
+  DataType: word32
+  OrigDataType: word32
+T_178: (in Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] + 0x00000004 : word32)
+  Class: Eq_178
+  DataType: (ptr32 (ptr32 Eq_178))
+  OrigDataType: (ptr32 (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64))))
+T_179: (in Mem25[Mem25[Mem25[0x00403024:word32] + 0x00000000:word32] + 0x00000004:word32] : word32)
+  Class: Eq_179
+  DataType: (ptr32 Eq_179)
+  OrigDataType: (ptr32 (fn real64 ((ptr32 thiscall_class), int32, real64)))
+T_180: (in 00403024 : ptr32)
+  Class: Eq_180
+  DataType: (ptr32 (ptr32 Eq_180))
+  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
+T_181: (in Mem25[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
+  OrigDataType: (ptr32 (union (thiscall_class u1)))
+T_182: (in (real64) rArg04 : real64)
+  Class: Eq_182
+  DataType: real64
+  OrigDataType: real64
+T_183: (in globals->gbl_thiscall->vtbl->modify_double(globals->gbl_thiscall, dwLoc08_67, (real64) rArg04) : real64)
+  Class: Eq_183
+  DataType: real64
+  OrigDataType: real64
+T_184: (in (real64) dwLoc08_67 : real64)
+  Class: Eq_183
+  DataType: real64
+  OrigDataType: real64
+T_185: (in globals->gbl_thiscall->vtbl->modify_double(globals->gbl_thiscall, dwLoc08_67, (real64) rArg04) <= (real64) dwLoc08_67 : bool)
+  Class: Eq_185
+  DataType: bool
+  OrigDataType: bool
+T_186: (in 00403024 : ptr32)
+  Class: Eq_186
+  DataType: (ptr32 (ptr32 Eq_186))
+  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
+T_187: (in Mem49[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
+  OrigDataType: (ptr32 (union (thiscall_class u1)))
+T_188: (in 0x00000000 : word32)
   Class: Eq_188
   DataType: word32
   OrigDataType: word32
-T_189: (in dwLoc08_67 + 0x00000001 : word32)
-  Class: Eq_160
-  DataType: int32
-  OrigDataType: int32
-T_190: (in dwArg04 : word32)
+T_189: (in Mem49[0x00403024:word32] + 0x00000000 : word32)
+  Class: Eq_189
+  DataType: (ptr32 (ptr32 Eq_189))
+  OrigDataType: (ptr32 (ptr32 thiscall_class_vtbl))
+T_190: (in Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] : word32)
   Class: Eq_190
+  DataType: (ptr32 Eq_190)
+  OrigDataType: (ptr32 (union (thiscall_class_vtbl u1)))
+T_191: (in 0x00000000 : word32)
+  Class: Eq_191
   DataType: word32
   OrigDataType: word32
-T_191: (in eax_18 : uint32)
-  Class: Eq_191
-  DataType: uint32
-  OrigDataType: uint32
-T_192: (in 0x0000000A : word32)
-  Class: Eq_191
-  DataType: uint32
-  OrigDataType: word32
-T_193: (in ecx_20 : uint32)
+T_192: (in Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] + 0x00000000 : word32)
+  Class: Eq_192
+  DataType: (ptr32 (ptr32 Eq_192))
+  OrigDataType: (ptr32 (ptr32 (fn void ((ptr32 thiscall_class), real64))))
+T_193: (in Mem49[Mem49[Mem49[0x00403024:word32] + 0x00000000:word32] + 0x00000000:word32] : word32)
   Class: Eq_193
-  DataType: uint32
-  OrigDataType: uint32
-T_194: (in 0x00000003 : word32)
-  Class: Eq_193
-  DataType: uint32
-  OrigDataType: word32
-T_195: (in 0x00000000 : word32)
-  Class: Eq_190
-  DataType: word32
-  OrigDataType: word32
-T_196: (in dwArg04 == 0x00000000 : bool)
+  DataType: (ptr32 Eq_193)
+  OrigDataType: (ptr32 (fn T_197 ((ptr32 thiscall_class), real64)))
+T_194: (in 00403024 : ptr32)
+  Class: Eq_194
+  DataType: (ptr32 (ptr32 Eq_194))
+  OrigDataType: (ptr32 (struct (0 (ptr32 thiscall_class) ptr0000)))
+T_195: (in Mem49[0x00403024:word32] : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
+  OrigDataType: (ptr32 (union (thiscall_class u1)))
+T_196: (in (real64) rArg04 : real64)
   Class: Eq_196
-  DataType: bool
-  OrigDataType: bool
-T_197: (in 0040301C : ptr32)
-  Class: Eq_197
-  DataType: (ptr32 uint32)
-  OrigDataType: (ptr32 (struct (0 T_198 t0000)))
-T_198: (in Mem22[0x0040301C:word32] : word32)
-  Class: Eq_193
-  DataType: uint32
-  OrigDataType: word32
-T_199: (in 00403020 : ptr32)
-  Class: Eq_199
-  DataType: (ptr32 uint32)
-  OrigDataType: (ptr32 (struct (0 T_200 t0000)))
-T_200: (in Mem24[0x00403020:word32] : word32)
-  Class: Eq_191
-  DataType: uint32
-  OrigDataType: word32
-T_201: (in 0x00000003 : uint32)
-  Class: Eq_191
-  DataType: uint32
-  OrigDataType: uint32
-T_202: (in 0x00000001 : uint32)
-  Class: Eq_193
-  DataType: uint32
-  OrigDataType: uint32
-T_203: (in rArg04 : real64)
-  Class: Eq_122
   DataType: real64
   OrigDataType: real64
-T_204: (in dwLoc08_100 : int32)
-  Class: Eq_204
+T_197: (in globals->gbl_thiscall->vtbl->set_double(globals->gbl_thiscall, (real64) rArg04) : void)
+  Class: Eq_197
+  DataType: void
+  OrigDataType: void
+T_198: (in 0x00000001 : word32)
+  Class: Eq_198
+  DataType: word32
+  OrigDataType: word32
+T_199: (in dwLoc08_67 + 0x00000001 : word32)
+  Class: Eq_170
   DataType: int32
   OrigDataType: int32
-T_205: (in 0x00000005 : word32)
-  Class: Eq_204
-  DataType: int32
+T_200: (in dwArg04 : word32)
+  Class: Eq_200
+  DataType: word32
   OrigDataType: word32
-T_206: (in eax_19 : ui32)
+T_201: (in eax_18 : uint32)
+  Class: Eq_201
+  DataType: uint32
+  OrigDataType: uint32
+T_202: (in 0x0000000A : word32)
+  Class: Eq_201
+  DataType: uint32
+  OrigDataType: word32
+T_203: (in ecx_20 : uint32)
+  Class: Eq_203
+  DataType: uint32
+  OrigDataType: uint32
+T_204: (in 0x00000003 : word32)
+  Class: Eq_203
+  DataType: uint32
+  OrigDataType: word32
+T_205: (in 0x00000000 : word32)
+  Class: Eq_200
+  DataType: word32
+  OrigDataType: word32
+T_206: (in dwArg04 == 0x00000000 : bool)
   Class: Eq_206
-  DataType: ui32
-  OrigDataType: ui32
-T_207: (in 0x80000001 : word32)
+  DataType: bool
+  OrigDataType: bool
+T_207: (in 0040301C : ptr32)
   Class: Eq_207
-  DataType: ui32
-  OrigDataType: ui32
-T_208: (in dwLoc08_100 & 0x80000001 : word32)
-  Class: Eq_206
-  DataType: ui32
-  OrigDataType: ui32
-T_209: (in dwLoc08_100 & 0x80000001 : word32)
-  Class: Eq_209
-  DataType: int32
-  OrigDataType: int32
-T_210: (in 0x00000000 : word32)
-  Class: Eq_209
-  DataType: int32
-  OrigDataType: int32
-T_211: (in (dwLoc08_100 & 0x80000001) >= 0x00000000 : bool)
-  Class: Eq_211
-  DataType: bool
-  OrigDataType: bool
-T_212: (in 0x00000000 : word32)
-  Class: Eq_206
-  DataType: ui32
+  DataType: (ptr32 uint32)
+  OrigDataType: (ptr32 (struct (0 T_208 t0000)))
+T_208: (in Mem22[0x0040301C:word32] : word32)
+  Class: Eq_203
+  DataType: uint32
   OrigDataType: word32
-T_213: (in eax_19 != 0x00000000 : bool)
-  Class: Eq_213
-  DataType: bool
-  OrigDataType: bool
-T_214: (in dwLoc08_100 & 0x80000001 : word32)
+T_209: (in 00403020 : ptr32)
+  Class: Eq_209
+  DataType: (ptr32 uint32)
+  OrigDataType: (ptr32 (struct (0 T_210 t0000)))
+T_210: (in Mem24[0x00403020:word32] : word32)
+  Class: Eq_201
+  DataType: uint32
+  OrigDataType: word32
+T_211: (in 0x00000003 : uint32)
+  Class: Eq_201
+  DataType: uint32
+  OrigDataType: uint32
+T_212: (in 0x00000001 : uint32)
+  Class: Eq_203
+  DataType: uint32
+  OrigDataType: uint32
+T_213: (in rArg04 : real64)
+  Class: Eq_132
+  DataType: real64
+  OrigDataType: real64
+T_214: (in dwLoc08_100 : int32)
   Class: Eq_214
-  DataType: ui32
-  OrigDataType: ui32
-T_215: (in 0x00000001 : word32)
-  Class: Eq_215
-  DataType: ui32
-  OrigDataType: ui32
-T_216: (in (dwLoc08_100 & 0x80000001) - 0x00000001 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_215: (in 0x00000005 : word32)
+  Class: Eq_214
+  DataType: int32
+  OrigDataType: word32
+T_216: (in eax_19 : ui32)
   Class: Eq_216
   DataType: ui32
   OrigDataType: ui32
-T_217: (in 0xFFFFFFFE : word32)
+T_217: (in 0x80000001 : word32)
   Class: Eq_217
   DataType: ui32
   OrigDataType: ui32
-T_218: (in (dwLoc08_100 & 0x80000001) - 0x00000001 | 0xFFFFFFFE : word32)
-  Class: Eq_218
+T_218: (in dwLoc08_100 & 0x80000001 : word32)
+  Class: Eq_216
   DataType: ui32
   OrigDataType: ui32
-T_219: (in 0x00000001 : word32)
+T_219: (in dwLoc08_100 & 0x80000001 : word32)
   Class: Eq_219
-  DataType: word32
+  DataType: int32
+  OrigDataType: int32
+T_220: (in 0x00000000 : word32)
+  Class: Eq_219
+  DataType: int32
+  OrigDataType: int32
+T_221: (in (dwLoc08_100 & 0x80000001) >= 0x00000000 : bool)
+  Class: Eq_221
+  DataType: bool
+  OrigDataType: bool
+T_222: (in 0x00000000 : word32)
+  Class: Eq_216
+  DataType: ui32
   OrigDataType: word32
-T_220: (in ((dwLoc08_100 & 0x80000001) - 0x00000001 | 0xFFFFFFFE) + 0x00000001 : word32)
-  Class: Eq_206
+T_223: (in eax_19 != 0x00000000 : bool)
+  Class: Eq_223
+  DataType: bool
+  OrigDataType: bool
+T_224: (in dwLoc08_100 & 0x80000001 : word32)
+  Class: Eq_224
   DataType: ui32
   OrigDataType: ui32
-T_221: (in nested_if_blocks_test8 : ptr32)
-  Class: Eq_221
-  DataType: (ptr32 Eq_221)
-  OrigDataType: (ptr32 (fn T_223 (T_203)))
-T_222: (in signature of nested_if_blocks_test8 : void)
-  Class: Eq_221
-  DataType: (ptr32 Eq_221)
-  OrigDataType: 
-T_223: (in nested_if_blocks_test8(rArg04) : void)
-  Class: Eq_223
-  DataType: void
-  OrigDataType: void
-T_224: (in loop_test9 : ptr32)
-  Class: Eq_224
-  DataType: (ptr32 Eq_224)
-  OrigDataType: (ptr32 (fn T_227 (T_226)))
-T_225: (in signature of loop_test9 : void)
-  Class: Eq_224
-  DataType: (ptr32 Eq_224)
-  OrigDataType: 
-T_226: (in (real32) rArg04 : real32)
-  Class: Eq_159
-  DataType: real32
-  OrigDataType: real32
-T_227: (in loop_test9((real32) rArg04) : void)
+T_225: (in 0x00000001 : word32)
+  Class: Eq_225
+  DataType: ui32
+  OrigDataType: ui32
+T_226: (in (dwLoc08_100 & 0x80000001) - 0x00000001 : word32)
+  Class: Eq_226
+  DataType: ui32
+  OrigDataType: ui32
+T_227: (in 0xFFFFFFFE : word32)
   Class: Eq_227
-  DataType: void
-  OrigDataType: void
-T_228: (in 0x00000001 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_228: (in (dwLoc08_100 & 0x80000001) - 0x00000001 | 0xFFFFFFFE : word32)
   Class: Eq_228
   DataType: ui32
   OrigDataType: ui32
-T_229: (in dwLoc08_100 - 0x00000001 : word32)
-  Class: Eq_204
-  DataType: int32
+T_229: (in 0x00000001 : word32)
+  Class: Eq_229
+  DataType: word32
+  OrigDataType: word32
+T_230: (in ((dwLoc08_100 & 0x80000001) - 0x00000001 | 0xFFFFFFFE) + 0x00000001 : word32)
+  Class: Eq_216
+  DataType: ui32
   OrigDataType: ui32
-T_230: (in 0x00000000 : word32)
-  Class: Eq_204
-  DataType: int32
-  OrigDataType: int32
-T_231: (in dwLoc08_100 <= 0x00000000 : bool)
+T_231: (in nested_if_blocks_test8 : ptr32)
   Class: Eq_231
-  DataType: bool
-  OrigDataType: bool
-T_232: (in dwArg04 : (ptr32 Eq_232))
-  Class: Eq_232
-  DataType: (ptr32 Eq_232)
-  OrigDataType: (ptr32 (struct (0 T_236 t0000) (4 T_240 t0004) (8 T_244 t0008) (C T_248 t000C)))
-T_233: (in 0x00000001 : word32)
-  Class: Eq_233
-  DataType: word32
-  OrigDataType: word32
-T_234: (in 0x00000000 : word32)
-  Class: Eq_234
-  DataType: word32
-  OrigDataType: word32
-T_235: (in dwArg04 + 0x00000000 : word32)
-  Class: Eq_235
-  DataType: word32
-  OrigDataType: word32
-T_236: (in Mem9[dwArg04 + 0x00000000:word32] : word32)
-  Class: Eq_233
-  DataType: word32
-  OrigDataType: word32
-T_237: (in 0x00000002 : word32)
-  Class: Eq_237
-  DataType: word32
-  OrigDataType: word32
-T_238: (in 0x00000004 : word32)
-  Class: Eq_238
-  DataType: word32
-  OrigDataType: word32
-T_239: (in dwArg04 + 0x00000004 : word32)
-  Class: Eq_239
-  DataType: ptr32
-  OrigDataType: ptr32
-T_240: (in Mem11[dwArg04 + 0x00000004:word32] : word32)
-  Class: Eq_237
-  DataType: word32
-  OrigDataType: word32
-T_241: (in 0x00000003 : word32)
-  Class: Eq_241
-  DataType: word32
-  OrigDataType: word32
-T_242: (in 0x00000008 : word32)
-  Class: Eq_242
-  DataType: word32
-  OrigDataType: word32
-T_243: (in dwArg04 + 0x00000008 : word32)
-  Class: Eq_243
-  DataType: ptr32
-  OrigDataType: ptr32
-T_244: (in Mem13[dwArg04 + 0x00000008:word32] : word32)
-  Class: Eq_241
-  DataType: word32
-  OrigDataType: word32
-T_245: (in 0x00000004 : word32)
-  Class: Eq_245
-  DataType: word32
-  OrigDataType: word32
-T_246: (in 0x0000000C : word32)
-  Class: Eq_246
-  DataType: word32
-  OrigDataType: word32
-T_247: (in dwArg04 + 0x0000000C : word32)
-  Class: Eq_247
-  DataType: ptr32
-  OrigDataType: ptr32
-T_248: (in Mem15[dwArg04 + 0x0000000C:word32] : word32)
-  Class: Eq_245
-  DataType: word32
-  OrigDataType: word32
-T_249: (in str : (ptr32 Eq_232))
-  Class: Eq_232
-  DataType: (ptr32 Eq_232)
-  OrigDataType: (ptr32 nested_structs_type)
-T_250: (in nested_structs_test12 : ptr32)
-  Class: Eq_250
-  DataType: (ptr32 Eq_250)
-  OrigDataType: (ptr32 (fn T_252 (T_249)))
-T_251: (in signature of nested_structs_test12 : void)
-  Class: Eq_250
-  DataType: (ptr32 Eq_250)
+  DataType: (ptr32 Eq_231)
+  OrigDataType: (ptr32 (fn T_233 (T_213)))
+T_232: (in signature of nested_if_blocks_test8 : void)
+  Class: Eq_231
+  DataType: (ptr32 Eq_231)
   OrigDataType: 
-T_252: (in nested_structs_test12(str) : void)
-  Class: Eq_252
+T_233: (in nested_if_blocks_test8(rArg04) : void)
+  Class: Eq_233
   DataType: void
   OrigDataType: void
-T_253:
+T_234: (in loop_test9 : ptr32)
+  Class: Eq_234
+  DataType: (ptr32 Eq_234)
+  OrigDataType: (ptr32 (fn T_237 (T_236)))
+T_235: (in signature of loop_test9 : void)
+  Class: Eq_234
+  DataType: (ptr32 Eq_234)
+  OrigDataType: 
+T_236: (in (real32) rArg04 : real32)
+  Class: Eq_169
+  DataType: real32
+  OrigDataType: real32
+T_237: (in loop_test9((real32) rArg04) : void)
+  Class: Eq_237
+  DataType: void
+  OrigDataType: void
+T_238: (in 0x00000001 : word32)
+  Class: Eq_238
+  DataType: ui32
+  OrigDataType: ui32
+T_239: (in dwLoc08_100 - 0x00000001 : word32)
+  Class: Eq_214
+  DataType: int32
+  OrigDataType: ui32
+T_240: (in 0x00000000 : word32)
+  Class: Eq_214
+  DataType: int32
+  OrigDataType: int32
+T_241: (in dwLoc08_100 <= 0x00000000 : bool)
+  Class: Eq_241
+  DataType: bool
+  OrigDataType: bool
+T_242: (in dwArg04 : (ptr32 Eq_242))
+  Class: Eq_242
+  DataType: (ptr32 Eq_242)
+  OrigDataType: (ptr32 (struct (0 T_246 t0000) (4 T_250 t0004) (8 T_254 t0008) (C T_258 t000C)))
+T_243: (in 0x00000001 : word32)
+  Class: Eq_243
+  DataType: word32
+  OrigDataType: word32
+T_244: (in 0x00000000 : word32)
+  Class: Eq_244
+  DataType: word32
+  OrigDataType: word32
+T_245: (in dwArg04 + 0x00000000 : word32)
+  Class: Eq_245
+  DataType: word32
+  OrigDataType: word32
+T_246: (in Mem9[dwArg04 + 0x00000000:word32] : word32)
+  Class: Eq_243
+  DataType: word32
+  OrigDataType: word32
+T_247: (in 0x00000002 : word32)
+  Class: Eq_247
+  DataType: word32
+  OrigDataType: word32
+T_248: (in 0x00000004 : word32)
+  Class: Eq_248
+  DataType: word32
+  OrigDataType: word32
+T_249: (in dwArg04 + 0x00000004 : word32)
+  Class: Eq_249
+  DataType: ptr32
+  OrigDataType: ptr32
+T_250: (in Mem11[dwArg04 + 0x00000004:word32] : word32)
+  Class: Eq_247
+  DataType: word32
+  OrigDataType: word32
+T_251: (in 0x00000003 : word32)
+  Class: Eq_251
+  DataType: word32
+  OrigDataType: word32
+T_252: (in 0x00000008 : word32)
+  Class: Eq_252
+  DataType: word32
+  OrigDataType: word32
+T_253: (in dwArg04 + 0x00000008 : word32)
   Class: Eq_253
-  DataType: Eq_253
+  DataType: ptr32
+  OrigDataType: ptr32
+T_254: (in Mem13[dwArg04 + 0x00000008:word32] : word32)
+  Class: Eq_251
+  DataType: word32
+  OrigDataType: word32
+T_255: (in 0x00000004 : word32)
+  Class: Eq_255
+  DataType: word32
+  OrigDataType: word32
+T_256: (in 0x0000000C : word32)
+  Class: Eq_256
+  DataType: word32
+  OrigDataType: word32
+T_257: (in dwArg04 + 0x0000000C : word32)
+  Class: Eq_257
+  DataType: ptr32
+  OrigDataType: ptr32
+T_258: (in Mem15[dwArg04 + 0x0000000C:word32] : word32)
+  Class: Eq_255
+  DataType: word32
+  OrigDataType: word32
+T_259: (in str : (ptr32 Eq_259))
+  Class: Eq_259
+  DataType: (ptr32 Eq_259)
+  OrigDataType: (ptr32 nested_structs_type)
+T_260: (in nested_structs_test12 : ptr32)
+  Class: Eq_260
+  DataType: (ptr32 Eq_260)
+  OrigDataType: (ptr32 (fn T_263 (T_262)))
+T_261: (in signature of nested_structs_test12 : void)
+  Class: Eq_260
+  DataType: (ptr32 Eq_260)
+  OrigDataType: 
+T_262: (in str : (ptr32 nested_structs_type))
+  Class: Eq_242
+  DataType: (ptr32 Eq_242)
+  OrigDataType: (ptr32 nested_structs_type)
+T_263: (in nested_structs_test12(str) : void)
+  Class: Eq_263
+  DataType: void
+  OrigDataType: void
+T_264:
+  Class: Eq_264
+  DataType: Eq_264
   OrigDataType: 
 */
 typedef struct Globals {
@@ -1209,154 +1259,160 @@ typedef struct Globals {
 
 typedef void (Eq_5)(char *, int32, char *, real32);
 
-typedef int32 (Eq_18)(char *, char *, int32, char *, real64);
+typedef int32 (Eq_20)(char *, char *, int32, char *, real64);
 
-typedef cdecl_class Eq_45;
+typedef cdecl_class Eq_51;
 
-typedef cdecl_class_vtbl Eq_47;
+typedef cdecl_class Eq_52;
 
-typedef cdecl_class_vtbl Eq_48;
+typedef cdecl_class_vtbl Eq_54;
 
-typedef void (Eq_50)(cdecl_class * ptrArg04, int32 dwArg08);
+typedef cdecl_class_vtbl Eq_55;
 
-typedef void (Eq_51)(cdecl_class *, int32);
+typedef void (Eq_57)(cdecl_class * ptrArg04, int32 dwArg08);
 
-typedef cdecl_class_ptr Eq_54;
+typedef void (Eq_58)(cdecl_class *, int32);
 
-typedef union Eq_55 {
+typedef cdecl_class_ptr Eq_61;
+
+typedef union Eq_62 {
 	cdecl_class * u0;
 	cdecl_class_ptr u1;
-} Eq_55;
+} Eq_62;
 
-typedef cdecl_class_vtbl Eq_57;
+typedef cdecl_class_vtbl Eq_64;
 
-typedef cdecl_class_vtbl Eq_58;
+typedef cdecl_class_vtbl Eq_65;
 
-typedef void (Eq_60)(cdecl_class * ptrArg04);
+typedef void (Eq_67)(cdecl_class * ptrArg04);
 
-typedef void (Eq_61)(cdecl_class *);
+typedef void (Eq_68)(cdecl_class *);
 
-typedef cdecl_class_ptr Eq_62;
+typedef cdecl_class_ptr Eq_69;
 
-typedef cdecl_class_ptr Eq_65;
+typedef cdecl_class_ptr Eq_72;
 
-typedef cdecl_class_vtbl Eq_68;
+typedef cdecl_class_vtbl Eq_75;
 
-typedef cdecl_class_vtbl Eq_69;
+typedef cdecl_class_vtbl Eq_76;
 
-typedef void (Eq_71)(cdecl_class * ptrArg04, int32 dwArg08);
+typedef void (Eq_78)(cdecl_class * ptrArg04, int32 dwArg08);
 
-typedef union Eq_72 {
+typedef union Eq_79 {
 	void u0(cdecl_class * ptrArg04, int32 dwArg08);
-	void u1(Eq_55, word32, real32);
-} Eq_72;
+	void u1(Eq_62, word32, real32);
+} Eq_79;
 
-typedef cdecl_class_ptr Eq_73;
+typedef cdecl_class_ptr Eq_80;
 
-typedef cdecl_class_vtbl Eq_83;
+typedef cdecl_class Eq_89;
 
-typedef cdecl_class_vtbl Eq_84;
+typedef cdecl_class_vtbl Eq_91;
 
-typedef void (Eq_86)(cdecl_class * ptrArg04, int32 dwArg08);
+typedef cdecl_class_vtbl Eq_92;
 
-typedef void (Eq_87)(cdecl_class *, int32);
+typedef void (Eq_94)(cdecl_class * ptrArg04, int32 dwArg08);
 
-typedef cdecl_class_vtbl Eq_89;
+typedef void (Eq_95)(cdecl_class *, int32);
 
-typedef cdecl_class_vtbl Eq_90;
+typedef cdecl_class_vtbl Eq_97;
 
-typedef int32 (Eq_92)(cdecl_class * ptrArg04, int32 dwArg08, int32 dwArg0C);
+typedef cdecl_class_vtbl Eq_98;
 
-typedef int32 (Eq_93)(cdecl_class *, int32, int32);
+typedef int32 (Eq_100)(cdecl_class * ptrArg04, int32 dwArg08, int32 dwArg0C);
 
-typedef thiscall_class Eq_99;
+typedef int32 (Eq_101)(cdecl_class *, int32, int32);
 
-typedef thiscall_class Eq_100;
+typedef thiscall_class Eq_109;
 
-typedef thiscall_class_vtbl Eq_102;
+typedef thiscall_class Eq_110;
 
-typedef thiscall_class_vtbl Eq_103;
+typedef thiscall_class_vtbl Eq_112;
 
-typedef real64 (Eq_105)(thiscall_class * this, int32 dwArg04, real64 rArg08);
+typedef thiscall_class_vtbl Eq_113;
 
-typedef real64 (Eq_106)(thiscall_class *, int32, real64);
+typedef real64 (Eq_115)(thiscall_class * this, int32 dwArg04, real64 rArg08);
 
-typedef thiscall_class Eq_107;
+typedef real64 (Eq_116)(thiscall_class *, int32, real64);
 
-typedef thiscall_class Eq_111;
+typedef thiscall_class Eq_117;
 
-typedef thiscall_class_vtbl Eq_114;
+typedef thiscall_class Eq_121;
 
-typedef thiscall_class_vtbl Eq_115;
+typedef thiscall_class_vtbl Eq_124;
 
-typedef void (Eq_117)(thiscall_class * this, real64 rArg04);
+typedef thiscall_class_vtbl Eq_125;
 
-typedef void (Eq_118)(thiscall_class *, real64);
+typedef void (Eq_127)(thiscall_class * this, real64 rArg04);
 
-typedef thiscall_class Eq_119;
+typedef void (Eq_128)(thiscall_class *, real64);
 
-typedef thiscall_class Eq_123;
+typedef thiscall_class Eq_129;
 
-typedef thiscall_class_vtbl Eq_126;
+typedef thiscall_class Eq_133;
 
-typedef thiscall_class_vtbl Eq_127;
+typedef thiscall_class_vtbl Eq_136;
 
-typedef real64 (Eq_129)(thiscall_class * this, int32 dwArg04, real64 rArg08);
+typedef thiscall_class_vtbl Eq_137;
 
-typedef real64 (Eq_130)(thiscall_class *, int32, real64);
+typedef real64 (Eq_139)(thiscall_class * this, int32 dwArg04, real64 rArg08);
 
-typedef thiscall_class Eq_131;
+typedef real64 (Eq_140)(thiscall_class *, int32, real64);
 
-typedef void (Eq_138)(Eq_55, int32, int32);
+typedef thiscall_class Eq_141;
 
-typedef cdecl_class_ptr Eq_140;
+typedef void (Eq_148)(Eq_62, int32, int32);
 
-typedef thiscall_class Eq_148;
+typedef cdecl_class_ptr Eq_150;
 
-typedef thiscall_class_vtbl Eq_151;
+typedef thiscall_class Eq_158;
 
-typedef thiscall_class_vtbl Eq_152;
+typedef thiscall_class_vtbl Eq_161;
 
-typedef void (Eq_154)(thiscall_class * this, real64 rArg04);
+typedef thiscall_class_vtbl Eq_162;
 
-typedef void (Eq_155)(thiscall_class *, real64);
+typedef void (Eq_164)(thiscall_class * this, real64 rArg04);
 
-typedef thiscall_class Eq_156;
+typedef void (Eq_165)(thiscall_class *, real64);
 
-typedef thiscall_class Eq_162;
+typedef thiscall_class Eq_166;
 
-typedef thiscall_class_vtbl Eq_165;
+typedef thiscall_class Eq_172;
 
-typedef thiscall_class_vtbl Eq_166;
+typedef thiscall_class_vtbl Eq_175;
 
-typedef real64 (Eq_168)(thiscall_class * this, int32 dwArg04, real64 rArg08);
+typedef thiscall_class_vtbl Eq_176;
 
-typedef real64 (Eq_169)(thiscall_class *, int32, real64);
+typedef real64 (Eq_178)(thiscall_class * this, int32 dwArg04, real64 rArg08);
 
-typedef thiscall_class Eq_170;
+typedef real64 (Eq_179)(thiscall_class *, int32, real64);
 
-typedef thiscall_class Eq_176;
+typedef thiscall_class Eq_180;
 
-typedef thiscall_class_vtbl Eq_179;
+typedef thiscall_class Eq_186;
 
-typedef thiscall_class_vtbl Eq_180;
+typedef thiscall_class_vtbl Eq_189;
 
-typedef void (Eq_182)(thiscall_class * this, real64 rArg04);
+typedef thiscall_class_vtbl Eq_190;
 
-typedef void (Eq_183)(thiscall_class *, real64);
+typedef void (Eq_192)(thiscall_class * this, real64 rArg04);
 
-typedef thiscall_class Eq_184;
+typedef void (Eq_193)(thiscall_class *, real64);
 
-typedef void (Eq_221)(real64);
+typedef thiscall_class Eq_194;
 
-typedef void (Eq_224)(real32);
+typedef void (Eq_231)(real64);
 
-typedef nested_structs_type Eq_232;
+typedef void (Eq_234)(real32);
 
-typedef void (Eq_250)(nested_structs_type *);
+typedef nested_structs_type Eq_242;
+
+typedef nested_structs_type Eq_259;
+
+typedef void (Eq_260)(nested_structs_type *);
 
 typedef struct nested_struct {
 	int32 b;	// 0
 	int32 c;	// 4
-} Eq_253;
+} Eq_264;
 

--- a/subjects/PE/x86/pySample/pySample.h
+++ b/subjects/PE/x86/pySample/pySample.h
@@ -4,7 +4,7 @@
 
 /*
 // Equivalence classes ////////////
-Eq_1: (struct "Globals" (FFFFFFFF word32 dwFFFFFFFF) (10002098 Eq_306 t10002098) (1000209C Eq_307 t1000209C) (100020A0 Eq_247 t100020A0) (100020A8 word32 dw100020A8) (100020CC word32 dw100020CC) (100020E0 (str char) str100020E0) (100020F4 (str char) str100020F4) (100020FC (str char) str100020FC) (10002110 (str char) str10002110) (10002114 (str char) str10002114) (10002128 (str char) str10002128) (1000212C (str char) str1000212C) (10002140 (str char) str10002140) (10002144 (str char) str10002144) (1000214C (str char) str1000214C) (10002150 (str char) str10002150) (10002158 (str char) str10002158) (10002160 (str char) str10002160) (10002168 (str char) str10002168) (1000216C (str char) str1000216C) (10002174 (str char) str10002174) (100021D8 (arr word32 1) a100021D8) (10003000 ui32 dw10003000) (10003004 ui32 dw10003004) (10003008 Eq_136 t10003008) (10003010 (arr PyMethodDef 5) methods) (10003070 int32 dw10003070) (100033A4 (ptr32 word32) ptr100033A4) (100033A8 word32 dw100033A8) (100033AC Eq_191 t100033AC) (100033B0 (ptr32 word32) ptr100033B0) (100033B4 (ptr32 word32) ptr100033B4) (100033B8 (ptr32 code) ptr100033B8))
+Eq_1: (struct "Globals" (FFFFFFFF word32 dwFFFFFFFF) (10002098 Eq_307 t10002098) (1000209C Eq_308 t1000209C) (100020A0 Eq_248 t100020A0) (100020A8 word32 dw100020A8) (100020CC word32 dw100020CC) (100020E0 (str char) str100020E0) (100020F4 (str char) str100020F4) (100020FC (str char) str100020FC) (10002110 (str char) str10002110) (10002114 (str char) str10002114) (10002128 (str char) str10002128) (1000212C (str char) str1000212C) (10002140 (str char) str10002140) (10002144 (str char) str10002144) (1000214C (str char) str1000214C) (10002150 (str char) str10002150) (10002158 (str char) str10002158) (10002160 (str char) str10002160) (10002168 (str char) str10002168) (1000216C (str char) str1000216C) (10002174 (str char) str10002174) (100021D8 (arr word32 1) a100021D8) (10003000 ui32 dw10003000) (10003004 ui32 dw10003004) (10003008 Eq_137 t10003008) (10003010 (arr PyMethodDef 5) methods) (10003070 int32 dw10003070) (100033A4 (ptr32 word32) ptr100033A4) (100033A8 word32 dw100033A8) (100033AC Eq_192 t100033AC) (100033B0 (ptr32 word32) ptr100033B0) (100033B4 (ptr32 word32) ptr100033B4) (100033B8 (ptr32 code) ptr100033B8))
 	globals_t (in globals : (ptr32 (struct "Globals")))
 Eq_2: PyObject
 	T_2 (in eax : (ptr32 Eq_2))
@@ -29,7 +29,7 @@ Eq_3: PyObject
 Eq_4: PyObject
 	T_4 (in ptrArg08 : (ptr32 Eq_4))
 	T_8 (in ptrArg04 : (ptr32 PyObject))
-	T_101 (in args : (ptr32 Eq_4))
+	T_105 (in args : (ptr32 PyObject))
 Eq_6: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 int32), (ptr32 int32)))
 	T_6 (in PyArg_ParseTuple : ptr32)
 	T_7 (in signature of PyArg_ParseTuple : void)
@@ -57,358 +57,360 @@ Eq_90: (fn (ptr32 Eq_2) ((ptr32 char), real64))
 Eq_99: PyObject
 	T_99 (in eax : (ptr32 Eq_99))
 	T_102 (in eax_10 : (ptr32 Eq_99))
-	T_106 (in PyArg_ParseTuple(args, ":unused") : int32)
-	T_107 (in 0x00000000 : word32)
-	T_121 (in &_Py_NoneStruct : word32)
+	T_107 (in PyArg_ParseTuple(args, ":unused") : int32)
+	T_108 (in 0x00000000 : word32)
+	T_122 (in &_Py_NoneStruct : word32)
 Eq_100: PyObject
 	T_100 (in self : (ptr32 Eq_100))
+Eq_101: PyObject
+	T_101 (in args : (ptr32 Eq_101))
 Eq_103: (fn (ptr32 Eq_99) ((ptr32 Eq_4), (ptr32 char)))
 	T_103 (in PyArg_ParseTuple : ptr32)
 	T_104 (in signature of PyArg_ParseTuple : void)
-Eq_109: PyObject
-	T_109 (in eax_16 : (ptr32 Eq_109))
-	T_111 (in &_Py_NoneStruct : word32)
 Eq_110: PyObject
-	T_110 (in _Py_NoneStruct : PyObject)
-	T_120 (in _Py_NoneStruct : PyObject)
-Eq_122: (fn (ptr32 Eq_134) ((ptr32 char), (ptr32 Eq_125), (ptr32 char), (ptr32 Eq_127), int32))
-	T_122 (in Py_InitModule4 : ptr32)
-	T_123 (in signature of Py_InitModule4 : void)
-Eq_125: PyMethodDef
-	T_125 (in ptrArg08 : (ptr32 PyMethodDef))
-	T_130 (in 0x10003010 : word32)
-Eq_127: PyObject
-	T_127 (in ptrArg10 : (ptr32 PyObject))
-	T_132 (in 0x00000000 : word32)
-Eq_134: PyObject
-	T_134 (in Py_InitModule4("pySample", globals->methods, null, null, 0x000003EF) : (ptr32 PyObject))
-Eq_136: (union "Eq_136" (ptr32 u0) (DWORD u1))
-	T_136 (in edx : Eq_136)
-	T_139 (in esi : Eq_136)
-	T_143 (in edxOut : Eq_136)
-	T_145 (in esiOut : Eq_136)
-	T_214 (in dwMilliseconds : DWORD)
-	T_215 (in 0x000003E8 : word32)
-	T_259 (in 0x000003E8 : word32)
-	T_328 (in Mem261[esp_264 + 0x00000000:word32] : word32)
-	T_427 (in edx : Eq_136)
-	T_459 (in Mem29[0x10003008:word32] : word32)
-	T_468 (in esi_113 : Eq_136)
-	T_469 (in 0x00000000 : word32)
-	T_471 (in 0x00000001 : word32)
-	T_518 (in edx_65 : Eq_136)
-	T_524 (in 0x00000002 : word32)
-	T_536 (in Mem114[esp_109 - 4 + 0x00000000:word32] : word32)
-	T_564 (in 0x00000001 : word32)
-	T_582 (in Mem56[esp_103 - 8 + 0x00000000:word32] : word32)
-	T_606 (in Mem86[esp_81 - 4 + 0x00000000:word32] : word32)
-	T_622 (in out edx : ptr32)
-	T_624 (in out esi_113 : ptr32)
-	T_636 (in 0x00000000 : word32)
-	T_686 (in out edx : ptr32)
-	T_688 (in out esi_113 : ptr32)
-	T_725 (in Mem193[esp_187 - 4 + 0x00000000:word32] : word32)
-	T_744 (in out edx_210 : ptr32)
-	T_746 (in out esi_207 : ptr32)
-	T_754 (in 0x00000003 : word32)
-	T_800 (in 0xFFFFFFFF : word32)
-	T_802 (in Mem4[0x10003008:word32] : word32)
-	T_805 (in dwReason : Eq_136)
-	T_807 (in 0x00000001 : word32)
-	T_1317 (in GetCurrentProcessId() : DWORD)
-	T_1321 (in GetCurrentThreadId() : DWORD)
-	T_1325 (in GetTickCount() : DWORD)
-Eq_137: (union "Eq_137" (ui32 u0) (ptr32 u1))
-	T_137 (in ebx : Eq_137)
-	T_144 (in ebxOut : Eq_137)
-	T_331 (in Mem261[esp_264 + 4:word32] : word32)
-	T_442 (in ebx_116 : Eq_137)
-	T_445 (in Mem7[ebp_13 + 0x00000008:word32] : word32)
-	T_541 (in Mem117[esp_109 - 8 + 0x00000000:word32] : word32)
-	T_587 (in Mem60[esp_103 - 12 + 0x00000000:word32] : word32)
-	T_611 (in Mem89[esp_81 - 8 + 0x00000000:word32] : word32)
-	T_623 (in out ebx_116 : ptr32)
-	T_652 (in Mem136[esp_109 - 8 + 0x00000000:word32] : word32)
-	T_677 (in Mem148[esp_109 - 8 + 0x00000000:word32] : word32)
-	T_687 (in out ebx_116 : ptr32)
-	T_712 (in Mem172[esp_109 - 8 + 0x00000000:word32] : word32)
-	T_730 (in Mem197[esp_187 - 8 + 0x00000000:word32] : word32)
-	T_745 (in out ebx_205 : ptr32)
-	T_931 (in Mem57[ebp_13 + 0x00000008:word32] : word32)
-	T_936 (in Mem60[esp_31 - 16 + 0x00000000:word32] : word32)
-	T_1016 (in Mem26[ebp_13 + 0x00000008:word32] : word32)
-	T_1021 (in Mem90[esp_14 - 4 + 0x00000000:word32] : word32)
-	T_1178 (in Mem25[ebp_13 + 0x00000008:word32] : word32)
-Eq_138: (struct "Eq_138" (0 word32 dw0000) (8 Eq_137 t0008))
-	T_138 (in ebp : (ptr32 Eq_138))
-	T_431 (in ebp_13 : (ptr32 Eq_138))
-	T_441 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000010) : word32)
-	T_512 (in ebp : (ptr32 Eq_138))
-	T_824 (in ebp_13 : (ptr32 Eq_138))
-	T_828 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000014) : word32)
-	T_1134 (in ebp_13 : (ptr32 Eq_138))
-	T_1138 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
-Eq_140: LPVOID
-	T_140 (in edi : Eq_140)
-	T_146 (in ediOut : Eq_140)
-	T_325 (in Mem261[esp_120 + 0x00000000:word32] : word32)
-	T_426 (in ecx : Eq_140)
-	T_467 (in edi_110 : Eq_140)
-	T_531 (in Mem111[esp_109 + 0x00000000:word32] : word32)
-	T_577 (in Mem53[esp_103 - 4 + 0x00000000:word32] : word32)
-	T_601 (in Mem83[esp_81 + 0x00000000:word32] : word32)
-	T_625 (in out edi_110 : ptr32)
-	T_642 (in Mem132[esp_109 + 0x00000000:word32] : word32)
-	T_666 (in Mem144[esp_109 + 0x00000000:word32] : word32)
-	T_689 (in out edi_110 : ptr32)
-	T_701 (in Mem168[esp_109 + 0x00000000:word32] : word32)
-	T_720 (in Mem190[esp_187 + 0x00000000:word32] : word32)
-	T_734 (in edi_209 : Eq_140)
-	T_747 (in out edi_209 : ptr32)
-	T_781 (in Mem234[esp_187 + 0x00000000:word32] : word32)
-	T_806 (in lpReserved : Eq_140)
-Eq_150: LONG
-	T_150 (in ebp_147 : Eq_150)
-	T_151 (in 0x00000000 : word32)
-	T_181 (in edi_126 : Eq_150)
-	T_187 (in Mem38[Mem38[fs:0x00000018:word32] + 0x00000004:word32] : word32)
-	T_188 (in eax_138 : Eq_150)
-	T_192 (in Exchange : LONG)
-	T_193 (in Comperand : LONG)
-	T_195 (in 0x00000000 : word32)
-	T_196 (in InterlockedCompareExchange(&globals->t100033AC, edi_126, 0x00000000) : LONG)
-	T_197 (in 0x00000000 : word32)
-	T_202 (in 0x00000001 : word32)
-	T_203 (in 0x00000000 : word32)
-	T_204 (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) : LONG)
-	T_205 (in 0x00000000 : word32)
-	T_257 (in 0x00000001 : word32)
-	T_264 (in 0x00000000 : word32)
-	T_267 (in Mem113[esp_112 + 0x00000000:word32] : word32)
-	T_280 (in Value : LONG)
-	T_287 (in Mem118[esp_112 + 0x00000000:LONG] : LONG)
-	T_288 (in InterlockedExchange(*(esp_112 - 4), *esp_112) : LONG)
-	T_317 (in 0x00000000 : word32)
-	T_372 (in InterlockedExchange(&globals->t100033AC, ebp_147) : LONG)
-Eq_182: (segment "Eq_182" (18 (ptr32 Eq_184) ptr0018))
-	T_182 (in fs : selector)
-Eq_184: (struct "Eq_184" (4 Eq_150 t0004))
-	T_184 (in Mem38[fs:0x00000018:word32] : word32)
-Eq_189: (fn Eq_150 ((ptr32 Eq_191), Eq_150, Eq_150))
-	T_189 (in InterlockedCompareExchange : ptr32)
-	T_190 (in signature of InterlockedCompareExchange : void)
-	T_200 (in InterlockedCompareExchange : ptr32)
-	T_384 (in ebx : (ptr32 Eq_189))
-	T_389 (in InterlockedCompareExchange : ptr32)
-	T_428 (in ebx : (ptr32 Eq_189))
-	T_434 (in ebx : (ptr32 Eq_189))
-	T_811 (in ebx : word32)
-	T_819 (in ebx : (ptr32 Eq_189))
-	T_1037 (in ebx : (ptr32 Eq_189))
-	T_1250 (in Mem17[esp_14 - 4 + 0x00000000:word32] : word32)
-Eq_191: LONG
-	T_191 (in Destination : (ptr32 LONG))
-	T_194 (in 0x100033AC : ptr32)
-	T_201 (in 0x100033AC : ptr32)
-Eq_212: (fn void (Eq_136))
-	T_212 (in Sleep : ptr32)
-	T_213 (in signature of Sleep : void)
-	T_258 (in Sleep : ptr32)
-Eq_225: (fn (ptr32 word32) ((ptr32 word32)))
-	T_225 (in _decode_pointer : ptr32)
-	T_226 (in signature of _decode_pointer : void)
-	T_299 (in _decode_pointer : ptr32)
-	T_838 (in _decode_pointer : ptr32)
-	T_887 (in _decode_pointer : ptr32)
-	T_904 (in _decode_pointer : ptr32)
-Eq_234: (fn void (int32))
-	T_234 (in _amsg_exit : ptr32)
-	T_235 (in signature of _amsg_exit : void)
-	T_254 (in _amsg_exit : ptr32)
-Eq_245: (fn int32 ((ptr32 Eq_247), (ptr32 Eq_248)))
-	T_245 (in _initterm_e : ptr32)
-	T_246 (in signature of _initterm_e : void)
-Eq_247: PVFV
-	T_247 (in fStart : (ptr32 PVFV))
-	T_249 (in 0x100020A0 : word32)
+	T_110 (in eax_16 : (ptr32 Eq_110))
+	T_112 (in &_Py_NoneStruct : word32)
+Eq_111: PyObject
+	T_111 (in _Py_NoneStruct : PyObject)
+	T_121 (in _Py_NoneStruct : PyObject)
+Eq_123: (fn (ptr32 Eq_135) ((ptr32 char), (ptr32 Eq_126), (ptr32 char), (ptr32 Eq_128), int32))
+	T_123 (in Py_InitModule4 : ptr32)
+	T_124 (in signature of Py_InitModule4 : void)
+Eq_126: PyMethodDef
+	T_126 (in ptrArg08 : (ptr32 PyMethodDef))
+	T_131 (in 0x10003010 : word32)
+Eq_128: PyObject
+	T_128 (in ptrArg10 : (ptr32 PyObject))
+	T_133 (in 0x00000000 : word32)
+Eq_135: PyObject
+	T_135 (in Py_InitModule4("pySample", globals->methods, null, null, 0x000003EF) : (ptr32 PyObject))
+Eq_137: (union "Eq_137" (ptr32 u0) (DWORD u1))
+	T_137 (in edx : Eq_137)
+	T_140 (in esi : Eq_137)
+	T_144 (in edxOut : Eq_137)
+	T_146 (in esiOut : Eq_137)
+	T_215 (in dwMilliseconds : DWORD)
+	T_216 (in 0x000003E8 : word32)
+	T_260 (in 0x000003E8 : word32)
+	T_329 (in Mem261[esp_264 + 0x00000000:word32] : word32)
+	T_428 (in edx : Eq_137)
+	T_460 (in Mem29[0x10003008:word32] : word32)
+	T_469 (in esi_113 : Eq_137)
+	T_470 (in 0x00000000 : word32)
+	T_472 (in 0x00000001 : word32)
+	T_519 (in edx_65 : Eq_137)
+	T_525 (in 0x00000002 : word32)
+	T_537 (in Mem114[esp_109 - 4 + 0x00000000:word32] : word32)
+	T_565 (in 0x00000001 : word32)
+	T_583 (in Mem56[esp_103 - 8 + 0x00000000:word32] : word32)
+	T_607 (in Mem86[esp_81 - 4 + 0x00000000:word32] : word32)
+	T_623 (in out edx : ptr32)
+	T_625 (in out esi_113 : ptr32)
+	T_637 (in 0x00000000 : word32)
+	T_687 (in out edx : ptr32)
+	T_689 (in out esi_113 : ptr32)
+	T_726 (in Mem193[esp_187 - 4 + 0x00000000:word32] : word32)
+	T_745 (in out edx_210 : ptr32)
+	T_747 (in out esi_207 : ptr32)
+	T_755 (in 0x00000003 : word32)
+	T_801 (in 0xFFFFFFFF : word32)
+	T_803 (in Mem4[0x10003008:word32] : word32)
+	T_806 (in dwReason : Eq_137)
+	T_808 (in 0x00000001 : word32)
+	T_1318 (in GetCurrentProcessId() : DWORD)
+	T_1322 (in GetCurrentThreadId() : DWORD)
+	T_1326 (in GetTickCount() : DWORD)
+Eq_138: (union "Eq_138" (ui32 u0) (ptr32 u1))
+	T_138 (in ebx : Eq_138)
+	T_145 (in ebxOut : Eq_138)
+	T_332 (in Mem261[esp_264 + 4:word32] : word32)
+	T_443 (in ebx_116 : Eq_138)
+	T_446 (in Mem7[ebp_13 + 0x00000008:word32] : word32)
+	T_542 (in Mem117[esp_109 - 8 + 0x00000000:word32] : word32)
+	T_588 (in Mem60[esp_103 - 12 + 0x00000000:word32] : word32)
+	T_612 (in Mem89[esp_81 - 8 + 0x00000000:word32] : word32)
+	T_624 (in out ebx_116 : ptr32)
+	T_653 (in Mem136[esp_109 - 8 + 0x00000000:word32] : word32)
+	T_678 (in Mem148[esp_109 - 8 + 0x00000000:word32] : word32)
+	T_688 (in out ebx_116 : ptr32)
+	T_713 (in Mem172[esp_109 - 8 + 0x00000000:word32] : word32)
+	T_731 (in Mem197[esp_187 - 8 + 0x00000000:word32] : word32)
+	T_746 (in out ebx_205 : ptr32)
+	T_932 (in Mem57[ebp_13 + 0x00000008:word32] : word32)
+	T_937 (in Mem60[esp_31 - 16 + 0x00000000:word32] : word32)
+	T_1017 (in Mem26[ebp_13 + 0x00000008:word32] : word32)
+	T_1022 (in Mem90[esp_14 - 4 + 0x00000000:word32] : word32)
+	T_1179 (in Mem25[ebp_13 + 0x00000008:word32] : word32)
+Eq_139: (struct "Eq_139" (0 word32 dw0000) (8 Eq_138 t0008))
+	T_139 (in ebp : (ptr32 Eq_139))
+	T_432 (in ebp_13 : (ptr32 Eq_139))
+	T_442 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000010) : word32)
+	T_513 (in ebp : (ptr32 Eq_139))
+	T_825 (in ebp_13 : (ptr32 Eq_139))
+	T_829 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000014) : word32)
+	T_1135 (in ebp_13 : (ptr32 Eq_139))
+	T_1139 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
+Eq_141: LPVOID
+	T_141 (in edi : Eq_141)
+	T_147 (in ediOut : Eq_141)
+	T_326 (in Mem261[esp_120 + 0x00000000:word32] : word32)
+	T_427 (in ecx : Eq_141)
+	T_468 (in edi_110 : Eq_141)
+	T_532 (in Mem111[esp_109 + 0x00000000:word32] : word32)
+	T_578 (in Mem53[esp_103 - 4 + 0x00000000:word32] : word32)
+	T_602 (in Mem83[esp_81 + 0x00000000:word32] : word32)
+	T_626 (in out edi_110 : ptr32)
+	T_643 (in Mem132[esp_109 + 0x00000000:word32] : word32)
+	T_667 (in Mem144[esp_109 + 0x00000000:word32] : word32)
+	T_690 (in out edi_110 : ptr32)
+	T_702 (in Mem168[esp_109 + 0x00000000:word32] : word32)
+	T_721 (in Mem190[esp_187 + 0x00000000:word32] : word32)
+	T_735 (in edi_209 : Eq_141)
+	T_748 (in out edi_209 : ptr32)
+	T_782 (in Mem234[esp_187 + 0x00000000:word32] : word32)
+	T_807 (in lpReserved : Eq_141)
+Eq_151: LONG
+	T_151 (in ebp_147 : Eq_151)
+	T_152 (in 0x00000000 : word32)
+	T_182 (in edi_126 : Eq_151)
+	T_188 (in Mem38[Mem38[fs:0x00000018:word32] + 0x00000004:word32] : word32)
+	T_189 (in eax_138 : Eq_151)
+	T_193 (in Exchange : LONG)
+	T_194 (in Comperand : LONG)
+	T_196 (in 0x00000000 : word32)
+	T_197 (in InterlockedCompareExchange(&globals->t100033AC, edi_126, 0x00000000) : LONG)
+	T_198 (in 0x00000000 : word32)
+	T_203 (in 0x00000001 : word32)
+	T_204 (in 0x00000000 : word32)
+	T_205 (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) : LONG)
+	T_206 (in 0x00000000 : word32)
+	T_258 (in 0x00000001 : word32)
+	T_265 (in 0x00000000 : word32)
+	T_268 (in Mem113[esp_112 + 0x00000000:word32] : word32)
+	T_281 (in Value : LONG)
+	T_288 (in Mem118[esp_112 + 0x00000000:LONG] : LONG)
+	T_289 (in InterlockedExchange(*(esp_112 - 4), *esp_112) : LONG)
+	T_318 (in 0x00000000 : word32)
+	T_373 (in InterlockedExchange(&globals->t100033AC, ebp_147) : LONG)
+Eq_183: (segment "Eq_183" (18 (ptr32 Eq_185) ptr0018))
+	T_183 (in fs : selector)
+Eq_185: (struct "Eq_185" (4 Eq_151 t0004))
+	T_185 (in Mem38[fs:0x00000018:word32] : word32)
+Eq_190: (fn Eq_151 ((ptr32 Eq_192), Eq_151, Eq_151))
+	T_190 (in InterlockedCompareExchange : ptr32)
+	T_191 (in signature of InterlockedCompareExchange : void)
+	T_201 (in InterlockedCompareExchange : ptr32)
+	T_385 (in ebx : (ptr32 Eq_190))
+	T_390 (in InterlockedCompareExchange : ptr32)
+	T_429 (in ebx : (ptr32 Eq_190))
+	T_435 (in ebx : (ptr32 Eq_190))
+	T_812 (in ebx : word32)
+	T_820 (in ebx : (ptr32 Eq_190))
+	T_1038 (in ebx : (ptr32 Eq_190))
+	T_1251 (in Mem17[esp_14 - 4 + 0x00000000:word32] : word32)
+Eq_192: LONG
+	T_192 (in Destination : (ptr32 LONG))
+	T_195 (in 0x100033AC : ptr32)
+	T_202 (in 0x100033AC : ptr32)
+Eq_213: (fn void (Eq_137))
+	T_213 (in Sleep : ptr32)
+	T_214 (in signature of Sleep : void)
+	T_259 (in Sleep : ptr32)
+Eq_226: (fn (ptr32 word32) ((ptr32 word32)))
+	T_226 (in _decode_pointer : ptr32)
+	T_227 (in signature of _decode_pointer : void)
+	T_300 (in _decode_pointer : ptr32)
+	T_839 (in _decode_pointer : ptr32)
+	T_888 (in _decode_pointer : ptr32)
+	T_905 (in _decode_pointer : ptr32)
+Eq_235: (fn void (int32))
+	T_235 (in _amsg_exit : ptr32)
+	T_236 (in signature of _amsg_exit : void)
+	T_255 (in _amsg_exit : ptr32)
+Eq_246: (fn int32 ((ptr32 Eq_248), (ptr32 Eq_249)))
+	T_246 (in _initterm_e : ptr32)
+	T_247 (in signature of _initterm_e : void)
 Eq_248: PVFV
-	T_248 (in fEnd : (ptr32 PVFV))
-	T_250 (in 0x100020A8 : word32)
-Eq_277: (fn Eq_150 ((ptr32 Eq_279), Eq_150))
-	T_277 (in InterlockedExchange : ptr32)
-	T_278 (in signature of InterlockedExchange : void)
-	T_370 (in InterlockedExchange : ptr32)
-Eq_279: LONG
-	T_279 (in Target : (ptr32 LONG))
-	T_284 (in Mem118[esp_112 - 4 + 0x00000000:(ptr32 LONG)] : (ptr32 LONG))
-	T_371 (in 0x100033AC : ptr32)
-Eq_304: (fn void ((ptr32 Eq_306), (ptr32 Eq_307)))
-	T_304 (in _initterm : ptr32)
-	T_305 (in signature of _initterm : void)
-Eq_306: PVFV
-	T_306 (in fStart : (ptr32 PVFV))
-	T_308 (in 0x10002098 : word32)
+	T_248 (in fStart : (ptr32 PVFV))
+	T_250 (in 0x100020A0 : word32)
+Eq_249: PVFV
+	T_249 (in fEnd : (ptr32 PVFV))
+	T_251 (in 0x100020A8 : word32)
+Eq_278: (fn Eq_151 ((ptr32 Eq_280), Eq_151))
+	T_278 (in InterlockedExchange : ptr32)
+	T_279 (in signature of InterlockedExchange : void)
+	T_371 (in InterlockedExchange : ptr32)
+Eq_280: LONG
+	T_280 (in Target : (ptr32 LONG))
+	T_285 (in Mem118[esp_112 - 4 + 0x00000000:(ptr32 LONG)] : (ptr32 LONG))
+	T_372 (in 0x100033AC : ptr32)
+Eq_305: (fn void ((ptr32 Eq_307), (ptr32 Eq_308)))
+	T_305 (in _initterm : ptr32)
+	T_306 (in signature of _initterm : void)
 Eq_307: PVFV
-	T_307 (in fEnd : (ptr32 PVFV))
-	T_309 (in 0x1000209C : word32)
-Eq_320: (struct "Eq_320" (0 Eq_136 t0000) (4 Eq_137 t0004))
-	T_320 (in esp_264 : (ptr32 Eq_320))
-	T_322 (in esp_120 + 4 : word32)
-Eq_344: (fn void ((ptr32 word32)))
-	T_344 (in free : ptr32)
-	T_345 (in signature of free : void)
-Eq_355: (fn (ptr32 word32) ())
-	T_355 (in _encoded_null : ptr32)
-	T_356 (in signature of _encoded_null : void)
-Eq_382: (fn word32 ((ptr32 Eq_189), ptr32, word32, ptr32, ptr32))
-	T_382 (in fn10001742 : ptr32)
-	T_383 (in signature of fn10001742 : void)
-Eq_395: (union "Eq_395" (int8 u0) ((ptr32 Eq_1361) u1))
-	T_395 (in esp_219 : Eq_395)
-	T_396 (in <invalid> : void)
-	T_466 (in esp_103 : Eq_395)
-	T_563 (in esp_109 + 0x00000004 : word32)
-	T_633 (in esp_81 + 0x00000004 : word32)
-	T_691 (in Top_155 : Eq_395)
-	T_693 (in esp_109 + 0x00000004 : word32)
-	T_749 (in Top_208 : Eq_395)
-	T_751 (in esp_187 + 0x00000004 : word32)
-	T_823 (in esp_81 : Eq_395)
-	T_829 (in esp_14 : Eq_395)
-	T_1008 (in esp_76 + 0x0000001C : word32)
-	T_1151 (in esp_14 : Eq_395)
-Eq_432: (fn (ptr32 Eq_138) ((ptr32 Eq_189), ptr32, word32, word32, ui32))
-	T_432 (in fn100017E8 : ptr32)
-	T_433 (in signature of fn100017E8 : void)
-	T_825 (in fn100017E8 : ptr32)
-	T_1135 (in fn100017E8 : ptr32)
-Eq_501: (fn void ())
-	T_501 (in fn10001493 : ptr32)
-	T_502 (in signature of fn10001493 : void)
-Eq_510: (fn ptr32 ((ptr32 Eq_138), word32))
-	T_510 (in fn1000182D : ptr32)
-	T_511 (in signature of fn1000182D : void)
-	T_1030 (in fn1000182D : ptr32)
-	T_1223 (in fn1000182D : ptr32)
-Eq_543: (fn word32 (Eq_545, word32))
-	T_543 (in fn100017C6 : ptr32)
-	T_544 (in signature of fn100017C6 : void)
-	T_653 (in fn100017C6 : ptr32)
-Eq_545: HMODULE
-	T_545 (in dwArg04 : Eq_545)
-	T_550 (in Mem117[esp_109 - 8 + 0x00000000:word32] : word32)
-	T_657 (in Mem136[esp_109 - 8 + 0x00000000:word32] : word32)
-	T_1238 (in hLibModule : HMODULE)
-Eq_613: (fn ui32 (Eq_136, Eq_137, (ptr32 Eq_138), Eq_136, Eq_140, word32, (ptr32 word32), Eq_136, Eq_137, Eq_136, Eq_140))
-	T_613 (in fn100011E9 : ptr32)
-	T_614 (in signature of fn100011E9 : void)
-	T_679 (in fn100011E9 : ptr32)
-	T_737 (in fn100011E9 : ptr32)
-Eq_803: BOOL
-	T_803 (in eax : Eq_803)
-	T_814 (in fn10001388(lpReserved, dwReason, ebx, esi, edi) : word32)
-	T_1239 (in DisableThreadLibraryCalls(dwArg04) : BOOL)
-	T_1332 (in QueryPerformanceCounter(fp - 0x00000014) : BOOL)
-Eq_804: HANDLE
-	T_804 (in hModule : Eq_804)
-Eq_809: (fn Eq_803 (Eq_140, Eq_136, (ptr32 Eq_189), ptr32, word32))
-	T_809 (in fn10001388 : ptr32)
-	T_810 (in signature of fn10001388 : void)
-Eq_815: (fn void ())
-	T_815 (in fn10001864 : ptr32)
-	T_816 (in signature of fn10001864 : void)
-Eq_818: _onexit_t
-	T_818 (in eax : Eq_818)
-	T_822 (in eax_110 : Eq_818)
-	T_937 (in eax_61 : Eq_818)
-	T_940 (in func : _onexit_t)
-	T_946 (in Mem60[esp_31 - 16 + 0x00000000:_onexit_t] : _onexit_t)
-	T_957 (in __dllonexit(*(esp_31 - 16), *(esp_31 - 12), *(esp_31 - 8)) : _onexit_t)
-	T_962 (in Mem62[ebp_13 - 0x00000024 + 0x00000000:word32] : word32)
-	T_1013 (in Mem84[ebp_13 - 0x00000024 + 0x00000000:word32] : word32)
-	T_1024 (in _Func : _onexit_t)
-	T_1028 (in Mem90[esp_14 - 4 + 0x00000000:_onexit_t] : _onexit_t)
-	T_1029 (in _onexit(*(esp_14 - 4)) : _onexit_t)
-Eq_938: (fn Eq_818 (Eq_818, (ptr32 (ptr32 Eq_941)), (ptr32 (ptr32 Eq_942))))
-	T_938 (in __dllonexit : ptr32)
-	T_939 (in signature of __dllonexit : void)
-Eq_941: PVFV
-	T_941 (in pbegin : (ptr32 (ptr32 PVFV)))
-	T_951 (in Mem60[esp_31 - 12 + 0x00000000:(ptr32 (ptr32 PVFV))] : (ptr32 (ptr32 PVFV)))
+	T_307 (in fStart : (ptr32 PVFV))
+	T_309 (in 0x10002098 : word32)
+Eq_308: PVFV
+	T_308 (in fEnd : (ptr32 PVFV))
+	T_310 (in 0x1000209C : word32)
+Eq_321: (struct "Eq_321" (0 Eq_137 t0000) (4 Eq_138 t0004))
+	T_321 (in esp_264 : (ptr32 Eq_321))
+	T_323 (in esp_120 + 4 : word32)
+Eq_345: (fn void ((ptr32 word32)))
+	T_345 (in free : ptr32)
+	T_346 (in signature of free : void)
+Eq_356: (fn (ptr32 word32) ())
+	T_356 (in _encoded_null : ptr32)
+	T_357 (in signature of _encoded_null : void)
+Eq_383: (fn word32 ((ptr32 Eq_190), ptr32, word32, ptr32, ptr32))
+	T_383 (in fn10001742 : ptr32)
+	T_384 (in signature of fn10001742 : void)
+Eq_396: (union "Eq_396" (int8 u0) ((ptr32 Eq_1362) u1))
+	T_396 (in esp_219 : Eq_396)
+	T_397 (in <invalid> : void)
+	T_467 (in esp_103 : Eq_396)
+	T_564 (in esp_109 + 0x00000004 : word32)
+	T_634 (in esp_81 + 0x00000004 : word32)
+	T_692 (in Top_155 : Eq_396)
+	T_694 (in esp_109 + 0x00000004 : word32)
+	T_750 (in Top_208 : Eq_396)
+	T_752 (in esp_187 + 0x00000004 : word32)
+	T_824 (in esp_81 : Eq_396)
+	T_830 (in esp_14 : Eq_396)
+	T_1009 (in esp_76 + 0x0000001C : word32)
+	T_1152 (in esp_14 : Eq_396)
+Eq_433: (fn (ptr32 Eq_139) ((ptr32 Eq_190), ptr32, word32, word32, ui32))
+	T_433 (in fn100017E8 : ptr32)
+	T_434 (in signature of fn100017E8 : void)
+	T_826 (in fn100017E8 : ptr32)
+	T_1136 (in fn100017E8 : ptr32)
+Eq_502: (fn void ())
+	T_502 (in fn10001493 : ptr32)
+	T_503 (in signature of fn10001493 : void)
+Eq_511: (fn ptr32 ((ptr32 Eq_139), word32))
+	T_511 (in fn1000182D : ptr32)
+	T_512 (in signature of fn1000182D : void)
+	T_1031 (in fn1000182D : ptr32)
+	T_1224 (in fn1000182D : ptr32)
+Eq_544: (fn word32 (Eq_546, word32))
+	T_544 (in fn100017C6 : ptr32)
+	T_545 (in signature of fn100017C6 : void)
+	T_654 (in fn100017C6 : ptr32)
+Eq_546: HMODULE
+	T_546 (in dwArg04 : Eq_546)
+	T_551 (in Mem117[esp_109 - 8 + 0x00000000:word32] : word32)
+	T_658 (in Mem136[esp_109 - 8 + 0x00000000:word32] : word32)
+	T_1239 (in hLibModule : HMODULE)
+Eq_614: (fn ui32 (Eq_137, Eq_138, (ptr32 Eq_139), Eq_137, Eq_141, word32, (ptr32 word32), Eq_137, Eq_138, Eq_137, Eq_141))
+	T_614 (in fn100011E9 : ptr32)
+	T_615 (in signature of fn100011E9 : void)
+	T_680 (in fn100011E9 : ptr32)
+	T_738 (in fn100011E9 : ptr32)
+Eq_804: BOOL
+	T_804 (in eax : Eq_804)
+	T_815 (in fn10001388(lpReserved, dwReason, ebx, esi, edi) : word32)
+	T_1240 (in DisableThreadLibraryCalls(dwArg04) : BOOL)
+	T_1333 (in QueryPerformanceCounter(fp - 0x00000014) : BOOL)
+Eq_805: HANDLE
+	T_805 (in hModule : Eq_805)
+Eq_810: (fn Eq_804 (Eq_141, Eq_137, (ptr32 Eq_190), ptr32, word32))
+	T_810 (in fn10001388 : ptr32)
+	T_811 (in signature of fn10001388 : void)
+Eq_816: (fn void ())
+	T_816 (in fn10001864 : ptr32)
+	T_817 (in signature of fn10001864 : void)
+Eq_819: _onexit_t
+	T_819 (in eax : Eq_819)
+	T_823 (in eax_110 : Eq_819)
+	T_938 (in eax_61 : Eq_819)
+	T_941 (in func : _onexit_t)
+	T_947 (in Mem60[esp_31 - 16 + 0x00000000:_onexit_t] : _onexit_t)
+	T_958 (in __dllonexit(*(esp_31 - 16), *(esp_31 - 12), *(esp_31 - 8)) : _onexit_t)
+	T_963 (in Mem62[ebp_13 - 0x00000024 + 0x00000000:word32] : word32)
+	T_1014 (in Mem84[ebp_13 - 0x00000024 + 0x00000000:word32] : word32)
+	T_1025 (in _Func : _onexit_t)
+	T_1029 (in Mem90[esp_14 - 4 + 0x00000000:_onexit_t] : _onexit_t)
+	T_1030 (in _onexit(*(esp_14 - 4)) : _onexit_t)
+Eq_939: (fn Eq_819 (Eq_819, (ptr32 (ptr32 Eq_942)), (ptr32 (ptr32 Eq_943))))
+	T_939 (in __dllonexit : ptr32)
+	T_940 (in signature of __dllonexit : void)
 Eq_942: PVFV
-	T_942 (in pend : (ptr32 (ptr32 PVFV)))
-	T_956 (in Mem60[esp_31 - 8 + 0x00000000:(ptr32 (ptr32 PVFV))] : (ptr32 (ptr32 PVFV)))
-Eq_1003: (fn void (word32))
-	T_1003 (in fn10001665 : ptr32)
-	T_1004 (in signature of fn10001665 : void)
-Eq_1022: (fn Eq_818 (Eq_818))
-	T_1022 (in _onexit : ptr32)
-	T_1023 (in signature of _onexit : void)
-Eq_1040: (fn word32 ((ptr32 Eq_189), ptr32, word32))
-	T_1040 (in fn100015CF : ptr32)
-	T_1041 (in signature of fn100015CF : void)
-Eq_1067: (struct "Eq_1067" (0 word16 w0000) (3C word32 dw003C))
-	T_1067 (in dwArg04 : (ptr32 Eq_1067))
-	T_1165 (in Mem25[esp_14 - 4 + 0x00000000:word32] : word32)
-Eq_1073: (struct "Eq_1073" (0 word32 dw0000) (18 word16 w0018))
-	T_1073 (in eax_9 : (ptr32 Eq_1073))
-	T_1077 (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
-Eq_1090: (struct "Eq_1090" 0028 (8 up32 dw0008) (C word32 dw000C))
-	T_1090 (in eax : (ptr32 Eq_1090))
-	T_1106 (in eax_22 : (ptr32 Eq_1090))
-	T_1113 (in (word32) Mem0[ecx_7 + 0x00000014:word16] + 0x00000018 + ecx_7 : word32)
-	T_1116 (in 0x00000000 : word32)
-	T_1120 (in eax_22 + 0x00000028 : word32)
-Eq_1091: (struct "Eq_1091" (3C word32 dw003C))
-	T_1091 (in dwArg04 : (ptr32 Eq_1091))
-	T_1198 (in Mem43[esp_14 - 8 + 0x00000000:word32] : word32)
-Eq_1094: (struct "Eq_1094" (6 word16 w0006) (14 word16 w0014))
-	T_1094 (in ecx_7 : (ptr32 Eq_1094))
-	T_1098 (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
-Eq_1160: (fn word32 ((ptr32 Eq_1067)))
-	T_1160 (in fn100016D0 : ptr32)
-	T_1161 (in signature of fn100016D0 : void)
-Eq_1179: (union "Eq_1179" (ui32 u0) (ptr32 u1))
-	T_1179 (in 0x10000000 : ptr32)
-Eq_1192: (struct "Eq_1192" (24 uint32 dw0024))
-	T_1192 (in eax_44 : (ptr32 Eq_1192))
-	T_1205 (in fn10001700(*(esp_14 - 8), *(esp_14 - 4), out edx_23) : word32)
-	T_1206 (in 0x00000000 : word32)
-Eq_1193: (fn (ptr32 Eq_1192) ((ptr32 Eq_1091), up32, ptr32))
-	T_1193 (in fn10001700 : ptr32)
-	T_1194 (in signature of fn10001700 : void)
-Eq_1236: (fn Eq_803 (Eq_545))
-	T_1236 (in DisableThreadLibraryCalls : ptr32)
-	T_1237 (in signature of DisableThreadLibraryCalls : void)
-Eq_1278: (segment "Eq_1278" (0 ptr32 ptr0000))
-	T_1278 (in fs : selector)
-Eq_1288: (segment "Eq_1288" (0 word32 dw0000))
-	T_1288 (in fs : selector)
-Eq_1289: (union "Eq_1289" (ptr32 u0) ((memptr (ptr32 Eq_1288) word32) u1))
-	T_1289 (in 0x00000000 : ptr32)
-Eq_1300: (fn void (Eq_1302))
-	T_1300 (in GetSystemTimeAsFileTime : ptr32)
-	T_1301 (in signature of GetSystemTimeAsFileTime : void)
-Eq_1302: LPFILETIME
-	T_1302 (in lpSystemTimeAsFileTime : LPFILETIME)
-	T_1305 (in fp - 0x0000000C : word32)
-Eq_1315: (fn Eq_136 ())
-	T_1315 (in GetCurrentProcessId : ptr32)
-	T_1316 (in signature of GetCurrentProcessId : void)
-Eq_1319: (fn Eq_136 ())
-	T_1319 (in GetCurrentThreadId : ptr32)
-	T_1320 (in signature of GetCurrentThreadId : void)
-Eq_1323: (fn Eq_136 ())
-	T_1323 (in GetTickCount : ptr32)
-	T_1324 (in signature of GetTickCount : void)
-Eq_1327: (fn Eq_803 ((ptr32 Eq_1329)))
-	T_1327 (in QueryPerformanceCounter : ptr32)
-	T_1328 (in signature of QueryPerformanceCounter : void)
-Eq_1329: LARGE_INTEGER
-	T_1329 (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
-	T_1331 (in fp - 0x00000014 : word32)
-Eq_1361: (struct "Eq_1361" (FFFFFFFC word32 dwFFFFFFFC) (0 (ptr32 word32) ptr0000) (18 word32 dw0018) (20 (ptr32 word32) ptr0020))
-	T_1361
+	T_942 (in pbegin : (ptr32 (ptr32 PVFV)))
+	T_952 (in Mem60[esp_31 - 12 + 0x00000000:(ptr32 (ptr32 PVFV))] : (ptr32 (ptr32 PVFV)))
+Eq_943: PVFV
+	T_943 (in pend : (ptr32 (ptr32 PVFV)))
+	T_957 (in Mem60[esp_31 - 8 + 0x00000000:(ptr32 (ptr32 PVFV))] : (ptr32 (ptr32 PVFV)))
+Eq_1004: (fn void (word32))
+	T_1004 (in fn10001665 : ptr32)
+	T_1005 (in signature of fn10001665 : void)
+Eq_1023: (fn Eq_819 (Eq_819))
+	T_1023 (in _onexit : ptr32)
+	T_1024 (in signature of _onexit : void)
+Eq_1041: (fn word32 ((ptr32 Eq_190), ptr32, word32))
+	T_1041 (in fn100015CF : ptr32)
+	T_1042 (in signature of fn100015CF : void)
+Eq_1068: (struct "Eq_1068" (0 word16 w0000) (3C word32 dw003C))
+	T_1068 (in dwArg04 : (ptr32 Eq_1068))
+	T_1166 (in Mem25[esp_14 - 4 + 0x00000000:word32] : word32)
+Eq_1074: (struct "Eq_1074" (0 word32 dw0000) (18 word16 w0018))
+	T_1074 (in eax_9 : (ptr32 Eq_1074))
+	T_1078 (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
+Eq_1091: (struct "Eq_1091" 0028 (8 up32 dw0008) (C word32 dw000C))
+	T_1091 (in eax : (ptr32 Eq_1091))
+	T_1107 (in eax_22 : (ptr32 Eq_1091))
+	T_1114 (in (word32) Mem0[ecx_7 + 0x00000014:word16] + 0x00000018 + ecx_7 : word32)
+	T_1117 (in 0x00000000 : word32)
+	T_1121 (in eax_22 + 0x00000028 : word32)
+Eq_1092: (struct "Eq_1092" (3C word32 dw003C))
+	T_1092 (in dwArg04 : (ptr32 Eq_1092))
+	T_1199 (in Mem43[esp_14 - 8 + 0x00000000:word32] : word32)
+Eq_1095: (struct "Eq_1095" (6 word16 w0006) (14 word16 w0014))
+	T_1095 (in ecx_7 : (ptr32 Eq_1095))
+	T_1099 (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
+Eq_1161: (fn word32 ((ptr32 Eq_1068)))
+	T_1161 (in fn100016D0 : ptr32)
+	T_1162 (in signature of fn100016D0 : void)
+Eq_1180: (union "Eq_1180" (ui32 u0) (ptr32 u1))
+	T_1180 (in 0x10000000 : ptr32)
+Eq_1193: (struct "Eq_1193" (24 uint32 dw0024))
+	T_1193 (in eax_44 : (ptr32 Eq_1193))
+	T_1206 (in fn10001700(*(esp_14 - 8), *(esp_14 - 4), out edx_23) : word32)
+	T_1207 (in 0x00000000 : word32)
+Eq_1194: (fn (ptr32 Eq_1193) ((ptr32 Eq_1092), up32, ptr32))
+	T_1194 (in fn10001700 : ptr32)
+	T_1195 (in signature of fn10001700 : void)
+Eq_1237: (fn Eq_804 (Eq_546))
+	T_1237 (in DisableThreadLibraryCalls : ptr32)
+	T_1238 (in signature of DisableThreadLibraryCalls : void)
+Eq_1279: (segment "Eq_1279" (0 ptr32 ptr0000))
+	T_1279 (in fs : selector)
+Eq_1289: (segment "Eq_1289" (0 word32 dw0000))
+	T_1289 (in fs : selector)
+Eq_1290: (union "Eq_1290" (ptr32 u0) ((memptr (ptr32 Eq_1289) word32) u1))
+	T_1290 (in 0x00000000 : ptr32)
+Eq_1301: (fn void (Eq_1303))
+	T_1301 (in GetSystemTimeAsFileTime : ptr32)
+	T_1302 (in signature of GetSystemTimeAsFileTime : void)
+Eq_1303: LPFILETIME
+	T_1303 (in lpSystemTimeAsFileTime : LPFILETIME)
+	T_1306 (in fp - 0x0000000C : word32)
+Eq_1316: (fn Eq_137 ())
+	T_1316 (in GetCurrentProcessId : ptr32)
+	T_1317 (in signature of GetCurrentProcessId : void)
+Eq_1320: (fn Eq_137 ())
+	T_1320 (in GetCurrentThreadId : ptr32)
+	T_1321 (in signature of GetCurrentThreadId : void)
+Eq_1324: (fn Eq_137 ())
+	T_1324 (in GetTickCount : ptr32)
+	T_1325 (in signature of GetTickCount : void)
+Eq_1328: (fn Eq_804 ((ptr32 Eq_1330)))
+	T_1328 (in QueryPerformanceCounter : ptr32)
+	T_1329 (in signature of QueryPerformanceCounter : void)
+Eq_1330: LARGE_INTEGER
+	T_1330 (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
+	T_1332 (in fp - 0x00000014 : word32)
+Eq_1362: (struct "Eq_1362" (FFFFFFFC word32 dwFFFFFFFC) (0 (ptr32 word32) ptr0000) (18 word32 dw0018) (20 (ptr32 word32) ptr0020))
+	T_1362
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -810,10 +812,10 @@ T_100: (in self : (ptr32 Eq_100))
   Class: Eq_100
   DataType: (ptr32 Eq_100)
   OrigDataType: (ptr32 PyObject)
-T_101: (in args : (ptr32 Eq_4))
-  Class: Eq_4
-  DataType: (ptr32 Eq_4)
-  OrigDataType: (ptr32 (union (PyObject u1)))
+T_101: (in args : (ptr32 Eq_101))
+  Class: Eq_101
+  DataType: (ptr32 Eq_101)
+  OrigDataType: (ptr32 PyObject)
 T_102: (in eax_10 : (ptr32 Eq_99))
   Class: Eq_99
   DataType: (ptr32 Eq_99)
@@ -821,5045 +823,5049 @@ T_102: (in eax_10 : (ptr32 Eq_99))
 T_103: (in PyArg_ParseTuple : ptr32)
   Class: Eq_103
   DataType: (ptr32 Eq_103)
-  OrigDataType: (ptr32 (fn T_106 (T_101, T_105)))
+  OrigDataType: (ptr32 (fn T_107 (T_105, T_106)))
 T_104: (in signature of PyArg_ParseTuple : void)
   Class: Eq_103
   DataType: (ptr32 Eq_103)
   OrigDataType: 
-T_105: (in 0x1000216C : word32)
+T_105: (in args : (ptr32 PyObject))
+  Class: Eq_4
+  DataType: (ptr32 Eq_4)
+  OrigDataType: (ptr32 (union (PyObject u1)))
+T_106: (in 0x1000216C : word32)
   Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_106: (in PyArg_ParseTuple(args, ":unused") : int32)
+T_107: (in PyArg_ParseTuple(args, ":unused") : int32)
   Class: Eq_99
   DataType: (ptr32 Eq_99)
   OrigDataType: int32
-T_107: (in 0x00000000 : word32)
+T_108: (in 0x00000000 : word32)
   Class: Eq_99
   DataType: (ptr32 Eq_99)
   OrigDataType: word32
-T_108: (in eax_10 != null : bool)
-  Class: Eq_108
+T_109: (in eax_10 != null : bool)
+  Class: Eq_109
   DataType: bool
   OrigDataType: bool
-T_109: (in eax_16 : (ptr32 Eq_109))
-  Class: Eq_109
-  DataType: (ptr32 Eq_109)
-  OrigDataType: (ptr32 PyObject)
-T_110: (in _Py_NoneStruct : PyObject)
+T_110: (in eax_16 : (ptr32 Eq_110))
   Class: Eq_110
-  DataType: Eq_110
-  OrigDataType: PyObject
-T_111: (in &_Py_NoneStruct : word32)
-  Class: Eq_109
-  DataType: (ptr32 Eq_109)
+  DataType: (ptr32 Eq_110)
   OrigDataType: (ptr32 PyObject)
-T_112: (in 0x00000000 : word32)
-  Class: Eq_112
-  DataType: word32
-  OrigDataType: word32
-T_113: (in eax_16 + 0x00000000 : word32)
+T_111: (in _Py_NoneStruct : PyObject)
+  Class: Eq_111
+  DataType: Eq_111
+  OrigDataType: PyObject
+T_112: (in &_Py_NoneStruct : word32)
+  Class: Eq_110
+  DataType: (ptr32 Eq_110)
+  OrigDataType: (ptr32 PyObject)
+T_113: (in 0x00000000 : word32)
   Class: Eq_113
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_114: (in Mem9[eax_16 + 0x00000000:word32] : word32)
+  DataType: word32
+  OrigDataType: word32
+T_114: (in eax_16 + 0x00000000 : word32)
   Class: Eq_114
-  DataType: int32
-  OrigDataType: int32
-T_115: (in 0x00000001 : word32)
-  Class: Eq_115
-  DataType: word32
-  OrigDataType: word32
-T_116: (in eax_16->ob_refcnt + 0x00000001 : word32)
-  Class: Eq_116
-  DataType: int32
-  OrigDataType: int32
-T_117: (in 0x00000000 : word32)
-  Class: Eq_117
-  DataType: word32
-  OrigDataType: word32
-T_118: (in eax_16 + 0x00000000 : word32)
-  Class: Eq_118
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
-T_119: (in Mem18[eax_16 + 0x00000000:word32] : word32)
-  Class: Eq_116
+T_115: (in Mem9[eax_16 + 0x00000000:word32] : word32)
+  Class: Eq_115
   DataType: int32
   OrigDataType: int32
-T_120: (in _Py_NoneStruct : PyObject)
-  Class: Eq_110
-  DataType: Eq_110
+T_116: (in 0x00000001 : word32)
+  Class: Eq_116
+  DataType: word32
+  OrigDataType: word32
+T_117: (in eax_16->ob_refcnt + 0x00000001 : word32)
+  Class: Eq_117
+  DataType: int32
+  OrigDataType: int32
+T_118: (in 0x00000000 : word32)
+  Class: Eq_118
+  DataType: word32
+  OrigDataType: word32
+T_119: (in eax_16 + 0x00000000 : word32)
+  Class: Eq_119
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_120: (in Mem18[eax_16 + 0x00000000:word32] : word32)
+  Class: Eq_117
+  DataType: int32
+  OrigDataType: int32
+T_121: (in _Py_NoneStruct : PyObject)
+  Class: Eq_111
+  DataType: Eq_111
   OrigDataType: PyObject
-T_121: (in &_Py_NoneStruct : word32)
+T_122: (in &_Py_NoneStruct : word32)
   Class: Eq_99
   DataType: (ptr32 Eq_99)
   OrigDataType: (ptr32 PyObject)
-T_122: (in Py_InitModule4 : ptr32)
-  Class: Eq_122
-  DataType: (ptr32 Eq_122)
-  OrigDataType: (ptr32 (fn T_134 (T_129, T_130, T_131, T_132, T_133)))
-T_123: (in signature of Py_InitModule4 : void)
-  Class: Eq_122
-  DataType: (ptr32 Eq_122)
+T_123: (in Py_InitModule4 : ptr32)
+  Class: Eq_123
+  DataType: (ptr32 Eq_123)
+  OrigDataType: (ptr32 (fn T_135 (T_130, T_131, T_132, T_133, T_134)))
+T_124: (in signature of Py_InitModule4 : void)
+  Class: Eq_123
+  DataType: (ptr32 Eq_123)
   OrigDataType: 
-T_124: (in ptrArg04 : (ptr32 char))
-  Class: Eq_124
-  DataType: (ptr32 char)
-  OrigDataType: 
-T_125: (in ptrArg08 : (ptr32 PyMethodDef))
+T_125: (in ptrArg04 : (ptr32 char))
   Class: Eq_125
-  DataType: (ptr32 Eq_125)
-  OrigDataType: 
-T_126: (in ptrArg0C : (ptr32 char))
-  Class: Eq_126
   DataType: (ptr32 char)
   OrigDataType: 
-T_127: (in ptrArg10 : (ptr32 PyObject))
-  Class: Eq_127
-  DataType: (ptr32 Eq_127)
+T_126: (in ptrArg08 : (ptr32 PyMethodDef))
+  Class: Eq_126
+  DataType: (ptr32 Eq_126)
   OrigDataType: 
-T_128: (in dwArg14 : int32)
+T_127: (in ptrArg0C : (ptr32 char))
+  Class: Eq_127
+  DataType: (ptr32 char)
+  OrigDataType: 
+T_128: (in ptrArg10 : (ptr32 PyObject))
   Class: Eq_128
+  DataType: (ptr32 Eq_128)
+  OrigDataType: 
+T_129: (in dwArg14 : int32)
+  Class: Eq_129
   DataType: int32
   OrigDataType: 
-T_129: (in 0x10002174 : word32)
-  Class: Eq_124
-  DataType: (ptr32 char)
-  OrigDataType: (ptr32 char)
-T_130: (in 0x10003010 : word32)
+T_130: (in 0x10002174 : word32)
   Class: Eq_125
-  DataType: (ptr32 Eq_125)
-  OrigDataType: (ptr32 PyMethodDef)
-T_131: (in 0x00000000 : word32)
-  Class: Eq_126
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
+T_131: (in 0x10003010 : word32)
+  Class: Eq_126
+  DataType: (ptr32 Eq_126)
+  OrigDataType: (ptr32 PyMethodDef)
 T_132: (in 0x00000000 : word32)
   Class: Eq_127
-  DataType: (ptr32 Eq_127)
-  OrigDataType: (ptr32 PyObject)
-T_133: (in 0x000003EF : word32)
+  DataType: (ptr32 char)
+  OrigDataType: (ptr32 char)
+T_133: (in 0x00000000 : word32)
   Class: Eq_128
+  DataType: (ptr32 Eq_128)
+  OrigDataType: (ptr32 PyObject)
+T_134: (in 0x000003EF : word32)
+  Class: Eq_129
   DataType: int32
   OrigDataType: int32
-T_134: (in Py_InitModule4("pySample", globals->methods, null, null, 0x000003EF) : (ptr32 PyObject))
-  Class: Eq_134
-  DataType: (ptr32 Eq_134)
-  OrigDataType: (ptr32 PyObject)
-T_135: (in eax : word32)
+T_135: (in Py_InitModule4("pySample", globals->methods, null, null, 0x000003EF) : (ptr32 PyObject))
   Class: Eq_135
+  DataType: (ptr32 Eq_135)
+  OrigDataType: (ptr32 PyObject)
+T_136: (in eax : word32)
+  Class: Eq_136
   DataType: word32
   OrigDataType: word32
-T_136: (in edx : Eq_136)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: word32
-T_137: (in ebx : Eq_137)
+T_137: (in edx : Eq_137)
   Class: Eq_137
   DataType: Eq_137
   OrigDataType: word32
-T_138: (in ebp : (ptr32 Eq_138))
+T_138: (in ebx : Eq_138)
   Class: Eq_138
-  DataType: (ptr32 Eq_138)
+  DataType: Eq_138
   OrigDataType: word32
-T_139: (in esi : Eq_136)
-  Class: Eq_136
-  DataType: Eq_136
+T_139: (in ebp : (ptr32 Eq_139))
+  Class: Eq_139
+  DataType: (ptr32 Eq_139)
   OrigDataType: word32
-T_140: (in edi : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
+T_140: (in esi : Eq_137)
+  Class: Eq_137
+  DataType: Eq_137
   OrigDataType: word32
-T_141: (in dwArg08 : word32)
+T_141: (in edi : Eq_141)
   Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: word32
+T_142: (in dwArg08 : word32)
+  Class: Eq_142
   DataType: word32
   OrigDataType: word32
-T_142: (in ecxOut : (ptr32 word32))
-  Class: Eq_142
+T_143: (in ecxOut : (ptr32 word32))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: ptr32
-T_143: (in edxOut : Eq_136)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: ptr32
-T_144: (in ebxOut : Eq_137)
+T_144: (in edxOut : Eq_137)
   Class: Eq_137
   DataType: Eq_137
   OrigDataType: ptr32
-T_145: (in esiOut : Eq_136)
-  Class: Eq_136
-  DataType: Eq_136
+T_145: (in ebxOut : Eq_138)
+  Class: Eq_138
+  DataType: Eq_138
   OrigDataType: ptr32
-T_146: (in ediOut : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
+T_146: (in esiOut : Eq_137)
+  Class: Eq_137
+  DataType: Eq_137
   OrigDataType: ptr32
-T_147: (in Top_101 : int8)
-  Class: Eq_147
-  DataType: int8
-  OrigDataType: int8
-T_148: (in 0 : int8)
-  Class: Eq_147
-  DataType: int8
-  OrigDataType: int8
-T_149: (in eax_14 : word32)
-  Class: Eq_135
-  DataType: word32
-  OrigDataType: word32
-T_150: (in ebp_147 : Eq_150)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: LONG
-T_151: (in 0x00000000 : word32)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: word32
-T_152: (in 0x00000000 : word32)
+T_147: (in ediOut : Eq_141)
   Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: ptr32
+T_148: (in Top_101 : int8)
+  Class: Eq_148
+  DataType: int8
+  OrigDataType: int8
+T_149: (in 0 : int8)
+  Class: Eq_148
+  DataType: int8
+  OrigDataType: int8
+T_150: (in eax_14 : word32)
+  Class: Eq_136
   DataType: word32
   OrigDataType: word32
-T_153: (in dwArg08 != 0x00000000 : bool)
-  Class: Eq_153
+T_151: (in ebp_147 : Eq_151)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: LONG
+T_152: (in 0x00000000 : word32)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: word32
+T_153: (in 0x00000000 : word32)
+  Class: Eq_142
+  DataType: word32
+  OrigDataType: word32
+T_154: (in dwArg08 != 0x00000000 : bool)
+  Class: Eq_154
   DataType: bool
   OrigDataType: bool
-T_154: (in adjust_fdiv : ptr32)
-  Class: Eq_154
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_158 t0000)))
-T_155: (in signature of adjust_fdiv : void)
+T_155: (in adjust_fdiv : ptr32)
   Class: Eq_155
-  DataType: Eq_155
-  OrigDataType: 
-T_156: (in 0x00000000 : word32)
+  DataType: (ptr32 (ptr32 word32))
+  OrigDataType: (ptr32 (struct (0 T_159 t0000)))
+T_156: (in signature of adjust_fdiv : void)
   Class: Eq_156
+  DataType: Eq_156
+  OrigDataType: 
+T_157: (in 0x00000000 : word32)
+  Class: Eq_157
   DataType: word32
   OrigDataType: word32
-T_157: (in adjust_fdiv + 0x00000000 : word32)
-  Class: Eq_157
+T_158: (in adjust_fdiv + 0x00000000 : word32)
+  Class: Eq_158
   DataType: ptr32
   OrigDataType: ptr32
-T_158: (in Mem23[adjust_fdiv + 0x00000000:word32] : word32)
-  Class: Eq_142
+T_159: (in Mem23[adjust_fdiv + 0x00000000:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_159: (in ecx : word32)
-  Class: Eq_142
+T_160: (in ecx : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_160: (in 100033A4 : ptr32)
-  Class: Eq_160
+T_161: (in 100033A4 : ptr32)
+  Class: Eq_161
   DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_161 t0000)))
-T_161: (in Mem38[0x100033A4:word32] : word32)
-  Class: Eq_142
+  OrigDataType: (ptr32 (struct (0 T_162 t0000)))
+T_162: (in Mem38[0x100033A4:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_162: (in esp_120 : (ptr32 Eq_140))
-  Class: Eq_162
-  DataType: (ptr32 Eq_140)
-  OrigDataType: (ptr32 (struct (0 T_325 t0000)))
-T_163: (in fp : ptr32)
+T_163: (in esp_120 : (ptr32 Eq_141))
   Class: Eq_163
+  DataType: (ptr32 Eq_141)
+  OrigDataType: (ptr32 (struct (0 T_326 t0000)))
+T_164: (in fp : ptr32)
+  Class: Eq_164
   DataType: ptr32
   OrigDataType: ptr32
-T_164: (in 16 : int32)
-  Class: Eq_164
+T_165: (in 16 : int32)
+  Class: Eq_165
   DataType: int32
   OrigDataType: int32
-T_165: (in fp - 16 : word32)
-  Class: Eq_162
-  DataType: (ptr32 Eq_140)
+T_166: (in fp - 16 : word32)
+  Class: Eq_163
+  DataType: (ptr32 Eq_141)
   OrigDataType: ptr32
-T_166: (in 0x00000001 : word32)
-  Class: Eq_141
+T_167: (in 0x00000001 : word32)
+  Class: Eq_142
   DataType: word32
   OrigDataType: word32
-T_167: (in dwArg08 != 0x00000001 : bool)
-  Class: Eq_167
-  DataType: bool
-  OrigDataType: bool
-T_168: (in 10003070 : ptr32)
+T_168: (in dwArg08 != 0x00000001 : bool)
   Class: Eq_168
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_169 t0000)))
-T_169: (in Mem8[0x10003070:word32] : word32)
-  Class: Eq_169
-  DataType: int32
-  OrigDataType: int32
-T_170: (in 0x00000000 : word32)
-  Class: Eq_169
-  DataType: int32
-  OrigDataType: int32
-T_171: (in globals->dw10003070 <= 0x00000000 : bool)
-  Class: Eq_171
   DataType: bool
   OrigDataType: bool
-T_172: (in 0x00000000 : word32)
-  Class: Eq_135
-  DataType: word32
-  OrigDataType: word32
-T_173: (in 10003070 : ptr32)
-  Class: Eq_173
+T_169: (in 10003070 : ptr32)
+  Class: Eq_169
   DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_174 t0000)))
-T_174: (in Mem8[0x10003070:word32] : word32)
-  Class: Eq_169
+  OrigDataType: (ptr32 (struct (0 T_170 t0000)))
+T_170: (in Mem8[0x10003070:word32] : word32)
+  Class: Eq_170
   DataType: int32
-  OrigDataType: word32
-T_175: (in 0x00000001 : word32)
-  Class: Eq_175
-  DataType: word32
-  OrigDataType: word32
-T_176: (in globals->dw10003070 - 0x00000001 : word32)
-  Class: Eq_169
+  OrigDataType: int32
+T_171: (in 0x00000000 : word32)
+  Class: Eq_170
   DataType: int32
-  OrigDataType: word32
-T_177: (in 10003070 : ptr32)
-  Class: Eq_177
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_178 t0000)))
-T_178: (in Mem18[0x10003070:word32] : word32)
-  Class: Eq_169
-  DataType: int32
-  OrigDataType: word32
-T_179: (in 0x00000000 : word32)
-  Class: Eq_141
-  DataType: word32
-  OrigDataType: word32
-T_180: (in dwArg08 != 0x00000000 : bool)
-  Class: Eq_180
+  OrigDataType: int32
+T_172: (in globals->dw10003070 <= 0x00000000 : bool)
+  Class: Eq_172
   DataType: bool
   OrigDataType: bool
-T_181: (in edi_126 : Eq_150)
-  Class: Eq_150
-  DataType: Eq_150
+T_173: (in 0x00000000 : word32)
+  Class: Eq_136
+  DataType: word32
+  OrigDataType: word32
+T_174: (in 10003070 : ptr32)
+  Class: Eq_174
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_175 t0000)))
+T_175: (in Mem8[0x10003070:word32] : word32)
+  Class: Eq_170
+  DataType: int32
+  OrigDataType: word32
+T_176: (in 0x00000001 : word32)
+  Class: Eq_176
+  DataType: word32
+  OrigDataType: word32
+T_177: (in globals->dw10003070 - 0x00000001 : word32)
+  Class: Eq_170
+  DataType: int32
+  OrigDataType: word32
+T_178: (in 10003070 : ptr32)
+  Class: Eq_178
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_179 t0000)))
+T_179: (in Mem18[0x10003070:word32] : word32)
+  Class: Eq_170
+  DataType: int32
+  OrigDataType: word32
+T_180: (in 0x00000000 : word32)
+  Class: Eq_142
+  DataType: word32
+  OrigDataType: word32
+T_181: (in dwArg08 != 0x00000000 : bool)
+  Class: Eq_181
+  DataType: bool
+  OrigDataType: bool
+T_182: (in edi_126 : Eq_151)
+  Class: Eq_151
+  DataType: Eq_151
   OrigDataType: LONG
-T_182: (in fs : selector)
-  Class: Eq_182
-  DataType: (ptr32 Eq_182)
-  OrigDataType: (ptr32 (segment (18 T_184 t0018)))
-T_183: (in 0x00000018 : word32)
+T_183: (in fs : selector)
   Class: Eq_183
-  DataType: (memptr (ptr32 Eq_182) (ptr32 Eq_184))
-  OrigDataType: (memptr T_182 (struct (0 T_184 t0000)))
-T_184: (in Mem38[fs:0x00000018:word32] : word32)
+  DataType: (ptr32 Eq_183)
+  OrigDataType: (ptr32 (segment (18 T_185 t0018)))
+T_184: (in 0x00000018 : word32)
   Class: Eq_184
-  DataType: (ptr32 Eq_184)
-  OrigDataType: (ptr32 (struct (4 T_187 t0004)))
-T_185: (in 0x00000004 : word32)
+  DataType: (memptr (ptr32 Eq_183) (ptr32 Eq_185))
+  OrigDataType: (memptr T_183 (struct (0 T_185 t0000)))
+T_185: (in Mem38[fs:0x00000018:word32] : word32)
   Class: Eq_185
-  DataType: word32
-  OrigDataType: word32
-T_186: (in Mem38[fs:0x00000018:word32] + 0x00000004 : word32)
+  DataType: (ptr32 Eq_185)
+  OrigDataType: (ptr32 (struct (4 T_188 t0004)))
+T_186: (in 0x00000004 : word32)
   Class: Eq_186
   DataType: word32
   OrigDataType: word32
-T_187: (in Mem38[Mem38[fs:0x00000018:word32] + 0x00000004:word32] : word32)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: word32
-T_188: (in eax_138 : Eq_150)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: LONG
-T_189: (in InterlockedCompareExchange : ptr32)
-  Class: Eq_189
-  DataType: (ptr32 Eq_189)
-  OrigDataType: (ptr32 (fn T_196 (T_194, T_181, T_195)))
-T_190: (in signature of InterlockedCompareExchange : void)
-  Class: Eq_189
-  DataType: (ptr32 Eq_189)
-  OrigDataType: 
-T_191: (in Destination : (ptr32 LONG))
-  Class: Eq_191
-  DataType: (ptr32 Eq_191)
-  OrigDataType: 
-T_192: (in Exchange : LONG)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: 
-T_193: (in Comperand : LONG)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: 
-T_194: (in 0x100033AC : ptr32)
-  Class: Eq_191
-  DataType: (ptr32 Eq_191)
-  OrigDataType: (ptr32 LONG)
-T_195: (in 0x00000000 : word32)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: LONG
-T_196: (in InterlockedCompareExchange(&globals->t100033AC, edi_126, 0x00000000) : LONG)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: LONG
-T_197: (in 0x00000000 : word32)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: word32
-T_198: (in eax_138 != 0x00000000 : bool)
-  Class: Eq_198
-  DataType: bool
-  OrigDataType: bool
-T_199: (in 0x00000001 : word32)
-  Class: Eq_135
+T_187: (in Mem38[fs:0x00000018:word32] + 0x00000004 : word32)
+  Class: Eq_187
   DataType: word32
   OrigDataType: word32
-T_200: (in InterlockedCompareExchange : ptr32)
-  Class: Eq_189
-  DataType: (ptr32 Eq_189)
-  OrigDataType: (ptr32 (fn T_204 (T_201, T_202, T_203)))
-T_201: (in 0x100033AC : ptr32)
-  Class: Eq_191
-  DataType: (ptr32 Eq_191)
-  OrigDataType: (ptr32 LONG)
-T_202: (in 0x00000001 : word32)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: LONG
-T_203: (in 0x00000000 : word32)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: LONG
-T_204: (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) : LONG)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: LONG
-T_205: (in 0x00000000 : word32)
-  Class: Eq_150
-  DataType: Eq_150
+T_188: (in Mem38[Mem38[fs:0x00000018:word32] + 0x00000004:word32] : word32)
+  Class: Eq_151
+  DataType: Eq_151
   OrigDataType: word32
-T_206: (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) != 0x00000000 : bool)
-  Class: Eq_206
+T_189: (in eax_138 : Eq_151)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: LONG
+T_190: (in InterlockedCompareExchange : ptr32)
+  Class: Eq_190
+  DataType: (ptr32 Eq_190)
+  OrigDataType: (ptr32 (fn T_197 (T_195, T_182, T_196)))
+T_191: (in signature of InterlockedCompareExchange : void)
+  Class: Eq_190
+  DataType: (ptr32 Eq_190)
+  OrigDataType: 
+T_192: (in Destination : (ptr32 LONG))
+  Class: Eq_192
+  DataType: (ptr32 Eq_192)
+  OrigDataType: 
+T_193: (in Exchange : LONG)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: 
+T_194: (in Comperand : LONG)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: 
+T_195: (in 0x100033AC : ptr32)
+  Class: Eq_192
+  DataType: (ptr32 Eq_192)
+  OrigDataType: (ptr32 LONG)
+T_196: (in 0x00000000 : word32)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: LONG
+T_197: (in InterlockedCompareExchange(&globals->t100033AC, edi_126, 0x00000000) : LONG)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: LONG
+T_198: (in 0x00000000 : word32)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: word32
+T_199: (in eax_138 != 0x00000000 : bool)
+  Class: Eq_199
   DataType: bool
   OrigDataType: bool
-T_207: (in eax_138 == edi_126 : bool)
+T_200: (in 0x00000001 : word32)
+  Class: Eq_136
+  DataType: word32
+  OrigDataType: word32
+T_201: (in InterlockedCompareExchange : ptr32)
+  Class: Eq_190
+  DataType: (ptr32 Eq_190)
+  OrigDataType: (ptr32 (fn T_205 (T_202, T_203, T_204)))
+T_202: (in 0x100033AC : ptr32)
+  Class: Eq_192
+  DataType: (ptr32 Eq_192)
+  OrigDataType: (ptr32 LONG)
+T_203: (in 0x00000001 : word32)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: LONG
+T_204: (in 0x00000000 : word32)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: LONG
+T_205: (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) : LONG)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: LONG
+T_206: (in 0x00000000 : word32)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: word32
+T_207: (in InterlockedCompareExchange(&globals->t100033AC, 0x00000001, 0x00000000) != 0x00000000 : bool)
   Class: Eq_207
   DataType: bool
   OrigDataType: bool
-T_208: (in 100033A8 : ptr32)
+T_208: (in eax_138 == edi_126 : bool)
   Class: Eq_208
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_209 t0000)))
-T_209: (in Mem137[0x100033A8:word32] : word32)
-  Class: Eq_209
-  DataType: word32
-  OrigDataType: word32
-T_210: (in 0x00000000 : word32)
-  Class: Eq_209
-  DataType: word32
-  OrigDataType: word32
-T_211: (in globals->dw100033A8 == 0x00000000 : bool)
-  Class: Eq_211
   DataType: bool
   OrigDataType: bool
-T_212: (in Sleep : ptr32)
+T_209: (in 100033A8 : ptr32)
+  Class: Eq_209
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_210 t0000)))
+T_210: (in Mem137[0x100033A8:word32] : word32)
+  Class: Eq_210
+  DataType: word32
+  OrigDataType: word32
+T_211: (in 0x00000000 : word32)
+  Class: Eq_210
+  DataType: word32
+  OrigDataType: word32
+T_212: (in globals->dw100033A8 == 0x00000000 : bool)
   Class: Eq_212
-  DataType: (ptr32 Eq_212)
-  OrigDataType: (ptr32 (fn T_216 (T_215)))
-T_213: (in signature of Sleep : void)
-  Class: Eq_212
-  DataType: (ptr32 Eq_212)
+  DataType: bool
+  OrigDataType: bool
+T_213: (in Sleep : ptr32)
+  Class: Eq_213
+  DataType: (ptr32 Eq_213)
+  OrigDataType: (ptr32 (fn T_217 (T_216)))
+T_214: (in signature of Sleep : void)
+  Class: Eq_213
+  DataType: (ptr32 Eq_213)
   OrigDataType: 
-T_214: (in dwMilliseconds : DWORD)
-  Class: Eq_136
-  DataType: Eq_136
+T_215: (in dwMilliseconds : DWORD)
+  Class: Eq_137
+  DataType: Eq_137
   OrigDataType: 
-T_215: (in 0x000003E8 : word32)
-  Class: Eq_136
+T_216: (in 0x000003E8 : word32)
+  Class: Eq_137
   DataType: ptr32
   OrigDataType: DWORD
-T_216: (in Sleep(0x000003E8) : void)
-  Class: Eq_216
-  DataType: void
-  OrigDataType: void
-T_217: (in 100033A8 : ptr32)
+T_217: (in Sleep(0x000003E8) : void)
   Class: Eq_217
+  DataType: void
+  OrigDataType: void
+T_218: (in 100033A8 : ptr32)
+  Class: Eq_218
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_218 t0000)))
-T_218: (in Mem53[0x100033A8:word32] : word32)
-  Class: Eq_209
+  OrigDataType: (ptr32 (struct (0 T_219 t0000)))
+T_219: (in Mem53[0x100033A8:word32] : word32)
+  Class: Eq_210
   DataType: word32
   OrigDataType: word32
-T_219: (in 0x00000002 : word32)
-  Class: Eq_209
+T_220: (in 0x00000002 : word32)
+  Class: Eq_210
   DataType: word32
   OrigDataType: word32
-T_220: (in globals->dw100033A8 == 0x00000002 : bool)
-  Class: Eq_220
+T_221: (in globals->dw100033A8 == 0x00000002 : bool)
+  Class: Eq_221
   DataType: bool
   OrigDataType: bool
-T_221: (in v15_65 : (ptr32 word32))
-  Class: Eq_142
+T_222: (in v15_65 : (ptr32 word32))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_222: (in 100033B4 : ptr32)
-  Class: Eq_222
+T_223: (in 100033B4 : ptr32)
+  Class: Eq_223
   DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_223 t0000)))
-T_223: (in Mem53[0x100033B4:word32] : word32)
-  Class: Eq_142
+  OrigDataType: (ptr32 (struct (0 T_224 t0000)))
+T_224: (in Mem53[0x100033B4:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_224: (in eax_69 : (ptr32 word32))
-  Class: Eq_142
+T_225: (in eax_69 : (ptr32 word32))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_225: (in _decode_pointer : ptr32)
-  Class: Eq_225
-  DataType: (ptr32 Eq_225)
-  OrigDataType: (ptr32 (fn T_228 (T_221)))
-T_226: (in signature of _decode_pointer : void)
-  Class: Eq_225
-  DataType: (ptr32 Eq_225)
+T_226: (in _decode_pointer : ptr32)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
+  OrigDataType: (ptr32 (fn T_229 (T_222)))
+T_227: (in signature of _decode_pointer : void)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
   OrigDataType: 
-T_227: (in ptrArg04 : (ptr32 void))
-  Class: Eq_142
+T_228: (in ptrArg04 : (ptr32 void))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: 
-T_228: (in _decode_pointer(v15_65) : (ptr32 void))
-  Class: Eq_142
+T_229: (in _decode_pointer(v15_65) : (ptr32 void))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_229: (in esp_107 : ptr32)
-  Class: Eq_229
-  DataType: ptr32
-  OrigDataType: ptr32
-T_230: (in 16 : int32)
+T_230: (in esp_107 : ptr32)
   Class: Eq_230
-  DataType: int32
-  OrigDataType: int32
-T_231: (in fp - 16 : word32)
-  Class: Eq_229
   DataType: ptr32
   OrigDataType: ptr32
-T_232: (in 0x00000000 : word32)
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: word32
-T_233: (in eax_69 == null : bool)
-  Class: Eq_233
-  DataType: bool
-  OrigDataType: bool
-T_234: (in _amsg_exit : ptr32)
-  Class: Eq_234
-  DataType: (ptr32 Eq_234)
-  OrigDataType: (ptr32 (fn T_238 (T_237)))
-T_235: (in signature of _amsg_exit : void)
-  Class: Eq_234
-  DataType: (ptr32 Eq_234)
-  OrigDataType: 
-T_236: (in n : int32)
-  Class: Eq_236
-  DataType: int32
-  OrigDataType: 
-T_237: (in 0x0000001F : word32)
-  Class: Eq_236
+T_231: (in 16 : int32)
+  Class: Eq_231
   DataType: int32
   OrigDataType: int32
-T_238: (in _amsg_exit(0x0000001F) : void)
-  Class: Eq_238
-  DataType: void
-  OrigDataType: void
-T_239: (in 0x00000001 : word32)
-  Class: Eq_209
-  DataType: word32
-  OrigDataType: word32
-T_240: (in 100033A8 : ptr32)
-  Class: Eq_240
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_241 t0000)))
-T_241: (in Mem168[0x100033A8:word32] : word32)
-  Class: Eq_209
-  DataType: word32
-  OrigDataType: word32
-T_242: (in 0x100020A8 : word32)
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: word32
-T_243: (in 16 : int32)
-  Class: Eq_243
-  DataType: int32
-  OrigDataType: int32
-T_244: (in fp - 16 : word32)
-  Class: Eq_162
-  DataType: (ptr32 Eq_140)
+T_232: (in fp - 16 : word32)
+  Class: Eq_230
+  DataType: ptr32
   OrigDataType: ptr32
-T_245: (in _initterm_e : ptr32)
-  Class: Eq_245
-  DataType: (ptr32 Eq_245)
-  OrigDataType: (ptr32 (fn T_251 (T_249, T_250)))
-T_246: (in signature of _initterm_e : void)
-  Class: Eq_245
-  DataType: (ptr32 Eq_245)
-  OrigDataType: 
-T_247: (in fStart : (ptr32 PVFV))
-  Class: Eq_247
-  DataType: (ptr32 Eq_247)
-  OrigDataType: 
-T_248: (in fEnd : (ptr32 PVFV))
-  Class: Eq_248
-  DataType: (ptr32 Eq_248)
-  OrigDataType: 
-T_249: (in 0x100020A0 : word32)
-  Class: Eq_247
-  DataType: (ptr32 Eq_247)
-  OrigDataType: (ptr32 PVFV)
-T_250: (in 0x100020A8 : word32)
-  Class: Eq_248
-  DataType: (ptr32 Eq_248)
-  OrigDataType: (ptr32 PVFV)
-T_251: (in _initterm_e(&globals->t100020A0, &globals->dw100020A8) : int32)
-  Class: Eq_251
-  DataType: int32
-  OrigDataType: int32
-T_252: (in 0x00000000 : word32)
-  Class: Eq_251
-  DataType: int32
+T_233: (in 0x00000000 : word32)
+  Class: Eq_143
+  DataType: (ptr32 word32)
   OrigDataType: word32
-T_253: (in _initterm_e(&globals->t100020A0, &globals->dw100020A8) == 0x00000000 : bool)
-  Class: Eq_253
+T_234: (in eax_69 == null : bool)
+  Class: Eq_234
   DataType: bool
   OrigDataType: bool
-T_254: (in _amsg_exit : ptr32)
-  Class: Eq_234
-  DataType: (ptr32 Eq_234)
-  OrigDataType: (ptr32 (fn T_256 (T_255)))
-T_255: (in 0x0000001F : word32)
-  Class: Eq_236
+T_235: (in _amsg_exit : ptr32)
+  Class: Eq_235
+  DataType: (ptr32 Eq_235)
+  OrigDataType: (ptr32 (fn T_239 (T_238)))
+T_236: (in signature of _amsg_exit : void)
+  Class: Eq_235
+  DataType: (ptr32 Eq_235)
+  OrigDataType: 
+T_237: (in n : int32)
+  Class: Eq_237
+  DataType: int32
+  OrigDataType: 
+T_238: (in 0x0000001F : word32)
+  Class: Eq_237
   DataType: int32
   OrigDataType: int32
-T_256: (in _amsg_exit(0x0000001F) : void)
-  Class: Eq_238
+T_239: (in _amsg_exit(0x0000001F) : void)
+  Class: Eq_239
   DataType: void
   OrigDataType: void
-T_257: (in 0x00000001 : word32)
-  Class: Eq_150
-  DataType: Eq_150
+T_240: (in 0x00000001 : word32)
+  Class: Eq_210
+  DataType: word32
   OrigDataType: word32
-T_258: (in Sleep : ptr32)
-  Class: Eq_212
-  DataType: (ptr32 Eq_212)
-  OrigDataType: (ptr32 (fn T_260 (T_259)))
-T_259: (in 0x000003E8 : word32)
-  Class: Eq_136
+T_241: (in 100033A8 : ptr32)
+  Class: Eq_241
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_242 t0000)))
+T_242: (in Mem168[0x100033A8:word32] : word32)
+  Class: Eq_210
+  DataType: word32
+  OrigDataType: word32
+T_243: (in 0x100020A8 : word32)
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: word32
+T_244: (in 16 : int32)
+  Class: Eq_244
+  DataType: int32
+  OrigDataType: int32
+T_245: (in fp - 16 : word32)
+  Class: Eq_163
+  DataType: (ptr32 Eq_141)
+  OrigDataType: ptr32
+T_246: (in _initterm_e : ptr32)
+  Class: Eq_246
+  DataType: (ptr32 Eq_246)
+  OrigDataType: (ptr32 (fn T_252 (T_250, T_251)))
+T_247: (in signature of _initterm_e : void)
+  Class: Eq_246
+  DataType: (ptr32 Eq_246)
+  OrigDataType: 
+T_248: (in fStart : (ptr32 PVFV))
+  Class: Eq_248
+  DataType: (ptr32 Eq_248)
+  OrigDataType: 
+T_249: (in fEnd : (ptr32 PVFV))
+  Class: Eq_249
+  DataType: (ptr32 Eq_249)
+  OrigDataType: 
+T_250: (in 0x100020A0 : word32)
+  Class: Eq_248
+  DataType: (ptr32 Eq_248)
+  OrigDataType: (ptr32 PVFV)
+T_251: (in 0x100020A8 : word32)
+  Class: Eq_249
+  DataType: (ptr32 Eq_249)
+  OrigDataType: (ptr32 PVFV)
+T_252: (in _initterm_e(&globals->t100020A0, &globals->dw100020A8) : int32)
+  Class: Eq_252
+  DataType: int32
+  OrigDataType: int32
+T_253: (in 0x00000000 : word32)
+  Class: Eq_252
+  DataType: int32
+  OrigDataType: word32
+T_254: (in _initterm_e(&globals->t100020A0, &globals->dw100020A8) == 0x00000000 : bool)
+  Class: Eq_254
+  DataType: bool
+  OrigDataType: bool
+T_255: (in _amsg_exit : ptr32)
+  Class: Eq_235
+  DataType: (ptr32 Eq_235)
+  OrigDataType: (ptr32 (fn T_257 (T_256)))
+T_256: (in 0x0000001F : word32)
+  Class: Eq_237
+  DataType: int32
+  OrigDataType: int32
+T_257: (in _amsg_exit(0x0000001F) : void)
+  Class: Eq_239
+  DataType: void
+  OrigDataType: void
+T_258: (in 0x00000001 : word32)
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: word32
+T_259: (in Sleep : ptr32)
+  Class: Eq_213
+  DataType: (ptr32 Eq_213)
+  OrigDataType: (ptr32 (fn T_261 (T_260)))
+T_260: (in 0x000003E8 : word32)
+  Class: Eq_137
   DataType: ptr32
   OrigDataType: DWORD
-T_260: (in Sleep(0x000003E8) : void)
-  Class: Eq_216
+T_261: (in Sleep(0x000003E8) : void)
+  Class: Eq_217
   DataType: void
   OrigDataType: void
-T_261: (in esp_112 : (ptr32 Eq_150))
-  Class: Eq_261
-  DataType: (ptr32 Eq_150)
-  OrigDataType: (ptr32 (struct (0 T_150 t0000)))
-T_262: (in 4 : int32)
+T_262: (in esp_112 : (ptr32 Eq_151))
   Class: Eq_262
+  DataType: (ptr32 Eq_151)
+  OrigDataType: (ptr32 (struct (0 T_151 t0000)))
+T_263: (in 4 : int32)
+  Class: Eq_263
   DataType: int32
   OrigDataType: int32
-T_263: (in esp_107 - 4 : word32)
-  Class: Eq_261
-  DataType: (ptr32 Eq_150)
+T_264: (in esp_107 - 4 : word32)
+  Class: Eq_262
+  DataType: (ptr32 Eq_151)
   OrigDataType: ptr32
-T_264: (in 0x00000000 : word32)
-  Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: word32
 T_265: (in 0x00000000 : word32)
-  Class: Eq_265
+  Class: Eq_151
+  DataType: Eq_151
+  OrigDataType: word32
+T_266: (in 0x00000000 : word32)
+  Class: Eq_266
   DataType: word32
   OrigDataType: word32
-T_266: (in esp_112 + 0x00000000 : word32)
-  Class: Eq_266
+T_267: (in esp_112 + 0x00000000 : word32)
+  Class: Eq_267
   DataType: ptr32
   OrigDataType: ptr32
-T_267: (in Mem113[esp_112 + 0x00000000:word32] : word32)
-  Class: Eq_150
-  DataType: Eq_150
+T_268: (in Mem113[esp_112 + 0x00000000:word32] : word32)
+  Class: Eq_151
+  DataType: Eq_151
   OrigDataType: word32
-T_268: (in 0x100033AC : ptr32)
-  Class: Eq_268
+T_269: (in 0x100033AC : ptr32)
+  Class: Eq_269
   DataType: ptr32
   OrigDataType: ptr32
-T_269: (in 4 : int32)
-  Class: Eq_269
+T_270: (in 4 : int32)
+  Class: Eq_270
   DataType: int32
   OrigDataType: int32
-T_270: (in esp_112 - 4 : word32)
-  Class: Eq_270
-  DataType: (ptr32 ptr32)
-  OrigDataType: (ptr32 (struct (0 T_273 t0000)))
-T_271: (in 0x00000000 : word32)
+T_271: (in esp_112 - 4 : word32)
   Class: Eq_271
-  DataType: word32
-  OrigDataType: word32
-T_272: (in esp_112 - 4 + 0x00000000 : word32)
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_274 t0000)))
+T_272: (in 0x00000000 : word32)
   Class: Eq_272
-  DataType: ptr32
-  OrigDataType: ptr32
-T_273: (in Mem116[esp_112 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_268
-  DataType: ptr32
-  OrigDataType: word32
-T_274: (in 0x00000000 : word32)
-  Class: Eq_209
   DataType: word32
   OrigDataType: word32
-T_275: (in 100033A8 : ptr32)
-  Class: Eq_275
+T_273: (in esp_112 - 4 + 0x00000000 : word32)
+  Class: Eq_273
+  DataType: ptr32
+  OrigDataType: ptr32
+T_274: (in Mem116[esp_112 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_269
+  DataType: ptr32
+  OrigDataType: word32
+T_275: (in 0x00000000 : word32)
+  Class: Eq_210
+  DataType: word32
+  OrigDataType: word32
+T_276: (in 100033A8 : ptr32)
+  Class: Eq_276
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_276 t0000)))
-T_276: (in Mem118[0x100033A8:word32] : word32)
-  Class: Eq_209
+  OrigDataType: (ptr32 (struct (0 T_277 t0000)))
+T_277: (in Mem118[0x100033A8:word32] : word32)
+  Class: Eq_210
   DataType: word32
   OrigDataType: word32
-T_277: (in InterlockedExchange : ptr32)
-  Class: Eq_277
-  DataType: (ptr32 Eq_277)
-  OrigDataType: (ptr32 (fn T_288 (T_284, T_287)))
-T_278: (in signature of InterlockedExchange : void)
-  Class: Eq_277
-  DataType: (ptr32 Eq_277)
+T_278: (in InterlockedExchange : ptr32)
+  Class: Eq_278
+  DataType: (ptr32 Eq_278)
+  OrigDataType: (ptr32 (fn T_289 (T_285, T_288)))
+T_279: (in signature of InterlockedExchange : void)
+  Class: Eq_278
+  DataType: (ptr32 Eq_278)
   OrigDataType: 
-T_279: (in Target : (ptr32 LONG))
-  Class: Eq_279
-  DataType: (ptr32 Eq_279)
+T_280: (in Target : (ptr32 LONG))
+  Class: Eq_280
+  DataType: (ptr32 Eq_280)
   OrigDataType: 
-T_280: (in Value : LONG)
-  Class: Eq_150
-  DataType: Eq_150
+T_281: (in Value : LONG)
+  Class: Eq_151
+  DataType: Eq_151
   OrigDataType: 
-T_281: (in esp_112 - 4 : word32)
-  Class: Eq_281
-  DataType: (ptr32 (ptr32 Eq_279))
-  OrigDataType: (ptr32 (struct (0 T_284 t0000)))
-T_282: (in 0x00000000 : word32)
+T_282: (in esp_112 - 4 : word32)
   Class: Eq_282
+  DataType: (ptr32 (ptr32 Eq_280))
+  OrigDataType: (ptr32 (struct (0 T_285 t0000)))
+T_283: (in 0x00000000 : word32)
+  Class: Eq_283
   DataType: word32
   OrigDataType: word32
-T_283: (in esp_112 - 4 + 0x00000000 : word32)
-  Class: Eq_283
+T_284: (in esp_112 - 4 + 0x00000000 : word32)
+  Class: Eq_284
   DataType: ptr32
   OrigDataType: ptr32
-T_284: (in Mem118[esp_112 - 4 + 0x00000000:(ptr32 LONG)] : (ptr32 LONG))
-  Class: Eq_279
-  DataType: (ptr32 Eq_279)
+T_285: (in Mem118[esp_112 - 4 + 0x00000000:(ptr32 LONG)] : (ptr32 LONG))
+  Class: Eq_280
+  DataType: (ptr32 Eq_280)
   OrigDataType: (ptr32 LONG)
-T_285: (in 0x00000000 : word32)
-  Class: Eq_285
+T_286: (in 0x00000000 : word32)
+  Class: Eq_286
   DataType: word32
   OrigDataType: word32
-T_286: (in esp_112 + 0x00000000 : word32)
-  Class: Eq_286
+T_287: (in esp_112 + 0x00000000 : word32)
+  Class: Eq_287
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_287: (in Mem118[esp_112 + 0x00000000:LONG] : LONG)
-  Class: Eq_150
-  DataType: Eq_150
+T_288: (in Mem118[esp_112 + 0x00000000:LONG] : LONG)
+  Class: Eq_151
+  DataType: Eq_151
   OrigDataType: LONG
-T_288: (in InterlockedExchange(*(esp_112 - 4), *esp_112) : LONG)
-  Class: Eq_150
-  DataType: Eq_150
+T_289: (in InterlockedExchange(*(esp_112 - 4), *esp_112) : LONG)
+  Class: Eq_151
+  DataType: Eq_151
   OrigDataType: LONG
-T_289: (in 0x00000004 : word32)
-  Class: Eq_289
+T_290: (in 0x00000004 : word32)
+  Class: Eq_290
   DataType: int32
   OrigDataType: int32
-T_290: (in esp_112 + 0x00000004 : word32)
-  Class: Eq_162
-  DataType: (ptr32 Eq_140)
+T_291: (in esp_112 + 0x00000004 : word32)
+  Class: Eq_163
+  DataType: (ptr32 Eq_141)
   OrigDataType: ptr32
-T_291: (in v16_76 : (ptr32 word32))
-  Class: Eq_142
+T_292: (in v16_76 : (ptr32 word32))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_292: (in 100033B0 : ptr32)
-  Class: Eq_292
+T_293: (in 100033B0 : ptr32)
+  Class: Eq_293
   DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_293 t0000)))
-T_293: (in Mem67[0x100033B0:word32] : word32)
-  Class: Eq_142
+  OrigDataType: (ptr32 (struct (0 T_294 t0000)))
+T_294: (in Mem67[0x100033B0:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_294: (in ecx_80 : (ptr32 word32))
-  Class: Eq_142
+T_295: (in ecx_80 : (ptr32 word32))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_295: (in esp_81 : ptr32)
-  Class: Eq_295
+T_296: (in esp_81 : ptr32)
+  Class: Eq_296
   DataType: ptr32
   OrigDataType: ptr32
-T_296: (in 16 : int32)
-  Class: Eq_296
+T_297: (in 16 : int32)
+  Class: Eq_297
   DataType: int32
   OrigDataType: int32
-T_297: (in fp - 16 : word32)
-  Class: Eq_295
+T_298: (in fp - 16 : word32)
+  Class: Eq_296
   DataType: ptr32
   OrigDataType: ptr32
-T_298: (in edi_82 : (ptr32 word32))
-  Class: Eq_142
+T_299: (in edi_82 : (ptr32 word32))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
-T_299: (in _decode_pointer : ptr32)
-  Class: Eq_225
-  DataType: (ptr32 Eq_225)
-  OrigDataType: (ptr32 (fn T_300 (T_291)))
-T_300: (in _decode_pointer(v16_76) : (ptr32 void))
-  Class: Eq_142
+T_300: (in _decode_pointer : ptr32)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
+  OrigDataType: (ptr32 (fn T_301 (T_292)))
+T_301: (in _decode_pointer(v16_76) : (ptr32 void))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_301: (in 0x00000004 : word32)
-  Class: Eq_301
+T_302: (in 0x00000004 : word32)
+  Class: Eq_302
   DataType: ui32
   OrigDataType: ui32
-T_302: (in edi_82 - 0x00000004 : word32)
-  Class: Eq_142
+T_303: (in edi_82 - 0x00000004 : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: ptr32
-T_303: (in edi_82 >= eax_69 : bool)
-  Class: Eq_303
+T_304: (in edi_82 >= eax_69 : bool)
+  Class: Eq_304
   DataType: bool
   OrigDataType: bool
-T_304: (in _initterm : ptr32)
-  Class: Eq_304
-  DataType: (ptr32 Eq_304)
-  OrigDataType: (ptr32 (fn T_310 (T_308, T_309)))
-T_305: (in signature of _initterm : void)
-  Class: Eq_304
-  DataType: (ptr32 Eq_304)
+T_305: (in _initterm : ptr32)
+  Class: Eq_305
+  DataType: (ptr32 Eq_305)
+  OrigDataType: (ptr32 (fn T_311 (T_309, T_310)))
+T_306: (in signature of _initterm : void)
+  Class: Eq_305
+  DataType: (ptr32 Eq_305)
   OrigDataType: 
-T_306: (in fStart : (ptr32 PVFV))
-  Class: Eq_306
-  DataType: (ptr32 Eq_306)
-  OrigDataType: 
-T_307: (in fEnd : (ptr32 PVFV))
+T_307: (in fStart : (ptr32 PVFV))
   Class: Eq_307
   DataType: (ptr32 Eq_307)
   OrigDataType: 
-T_308: (in 0x10002098 : word32)
-  Class: Eq_306
-  DataType: (ptr32 Eq_306)
-  OrigDataType: (ptr32 PVFV)
-T_309: (in 0x1000209C : word32)
+T_308: (in fEnd : (ptr32 PVFV))
+  Class: Eq_308
+  DataType: (ptr32 Eq_308)
+  OrigDataType: 
+T_309: (in 0x10002098 : word32)
   Class: Eq_307
   DataType: (ptr32 Eq_307)
   OrigDataType: (ptr32 PVFV)
-T_310: (in _initterm(&globals->t10002098, &globals->t1000209C) : void)
-  Class: Eq_310
+T_310: (in 0x1000209C : word32)
+  Class: Eq_308
+  DataType: (ptr32 Eq_308)
+  OrigDataType: (ptr32 PVFV)
+T_311: (in _initterm(&globals->t10002098, &globals->t1000209C) : void)
+  Class: Eq_311
   DataType: void
   OrigDataType: void
-T_311: (in 0x00000002 : word32)
-  Class: Eq_209
+T_312: (in 0x00000002 : word32)
+  Class: Eq_210
   DataType: word32
   OrigDataType: word32
-T_312: (in 100033A8 : ptr32)
-  Class: Eq_312
+T_313: (in 100033A8 : ptr32)
+  Class: Eq_313
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_313 t0000)))
-T_313: (in Mem183[0x100033A8:word32] : word32)
-  Class: Eq_209
+  OrigDataType: (ptr32 (struct (0 T_314 t0000)))
+T_314: (in Mem183[0x100033A8:word32] : word32)
+  Class: Eq_210
   DataType: word32
   OrigDataType: word32
-T_314: (in dwLoc18_309 : ptr32)
-  Class: Eq_314
+T_315: (in dwLoc18_309 : ptr32)
+  Class: Eq_315
   DataType: ptr32
   OrigDataType: ptr32
-T_315: (in 0x10002098 : word32)
-  Class: Eq_314
+T_316: (in 0x10002098 : word32)
+  Class: Eq_315
   DataType: ptr32
   OrigDataType: word32
-T_316: (in 0x1000209C : word32)
-  Class: Eq_142
+T_317: (in 0x1000209C : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_317: (in 0x00000000 : word32)
-  Class: Eq_150
-  DataType: Eq_150
+T_318: (in 0x00000000 : word32)
+  Class: Eq_151
+  DataType: Eq_151
   OrigDataType: word32
-T_318: (in ebp_147 != 0x00000000 : bool)
-  Class: Eq_318
+T_319: (in ebp_147 != 0x00000000 : bool)
+  Class: Eq_319
   DataType: bool
   OrigDataType: bool
-T_319: (in 0x00000000 : word32)
-  Class: Eq_135
-  DataType: word32
-  OrigDataType: word32
-T_320: (in esp_264 : (ptr32 Eq_320))
-  Class: Eq_320
-  DataType: (ptr32 Eq_320)
-  OrigDataType: (ptr32 (struct (0 T_328 t0000) (4 T_331 t0004)))
-T_321: (in 4 : int32)
-  Class: Eq_321
-  DataType: int32
-  OrigDataType: int32
-T_322: (in esp_120 + 4 : word32)
-  Class: Eq_320
-  DataType: (ptr32 Eq_320)
-  OrigDataType: ptr32
-T_323: (in 0x00000000 : word32)
-  Class: Eq_323
-  DataType: word32
-  OrigDataType: word32
-T_324: (in esp_120 + 0x00000000 : word32)
-  Class: Eq_324
-  DataType: ptr32
-  OrigDataType: ptr32
-T_325: (in Mem261[esp_120 + 0x00000000:word32] : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_326: (in 0x00000000 : word32)
-  Class: Eq_326
-  DataType: word32
-  OrigDataType: word32
-T_327: (in esp_264 + 0x00000000 : word32)
-  Class: Eq_327
-  DataType: ptr32
-  OrigDataType: ptr32
-T_328: (in Mem261[esp_264 + 0x00000000:word32] : word32)
+T_320: (in 0x00000000 : word32)
   Class: Eq_136
-  DataType: Eq_136
+  DataType: word32
   OrigDataType: word32
-T_329: (in 4 : int32)
-  Class: Eq_329
+T_321: (in esp_264 : (ptr32 Eq_321))
+  Class: Eq_321
+  DataType: (ptr32 Eq_321)
+  OrigDataType: (ptr32 (struct (0 T_329 t0000) (4 T_332 t0004)))
+T_322: (in 4 : int32)
+  Class: Eq_322
   DataType: int32
   OrigDataType: int32
-T_330: (in esp_264 + 4 : word32)
-  Class: Eq_330
+T_323: (in esp_120 + 4 : word32)
+  Class: Eq_321
+  DataType: (ptr32 Eq_321)
+  OrigDataType: ptr32
+T_324: (in 0x00000000 : word32)
+  Class: Eq_324
+  DataType: word32
+  OrigDataType: word32
+T_325: (in esp_120 + 0x00000000 : word32)
+  Class: Eq_325
   DataType: ptr32
   OrigDataType: ptr32
-T_331: (in Mem261[esp_264 + 4:word32] : word32)
+T_326: (in Mem261[esp_120 + 0x00000000:word32] : word32)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: word32
+T_327: (in 0x00000000 : word32)
+  Class: Eq_327
+  DataType: word32
+  OrigDataType: word32
+T_328: (in esp_264 + 0x00000000 : word32)
+  Class: Eq_328
+  DataType: ptr32
+  OrigDataType: ptr32
+T_329: (in Mem261[esp_264 + 0x00000000:word32] : word32)
   Class: Eq_137
   DataType: Eq_137
   OrigDataType: word32
-T_332: (in eax_89 : (ptr32 code))
-  Class: Eq_332
+T_330: (in 4 : int32)
+  Class: Eq_330
+  DataType: int32
+  OrigDataType: int32
+T_331: (in esp_264 + 4 : word32)
+  Class: Eq_331
+  DataType: ptr32
+  OrigDataType: ptr32
+T_332: (in Mem261[esp_264 + 4:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: word32
+T_333: (in eax_89 : (ptr32 code))
+  Class: Eq_333
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_333: (in 0x00000000 : word32)
-  Class: Eq_333
+T_334: (in 0x00000000 : word32)
+  Class: Eq_334
   DataType: word32
   OrigDataType: word32
-T_334: (in edi_82 + 0x00000000 : word32)
-  Class: Eq_334
+T_335: (in edi_82 + 0x00000000 : word32)
+  Class: Eq_335
   DataType: ptr32
   OrigDataType: ptr32
-T_335: (in Mem78[edi_82 + 0x00000000:word32] : word32)
-  Class: Eq_332
+T_336: (in Mem78[edi_82 + 0x00000000:word32] : word32)
+  Class: Eq_333
   DataType: (ptr32 code)
   OrigDataType: word32
-T_336: (in 0x00000000 : word32)
-  Class: Eq_332
+T_337: (in 0x00000000 : word32)
+  Class: Eq_333
   DataType: (ptr32 code)
   OrigDataType: word32
-T_337: (in eax_89 == null : bool)
-  Class: Eq_337
+T_338: (in eax_89 == null : bool)
+  Class: Eq_338
   DataType: bool
   OrigDataType: bool
-T_338: (in esp_104 : (ptr32 (ptr32 word32)))
-  Class: Eq_338
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_142 t0000)))
-T_339: (in 4 : int32)
+T_339: (in esp_104 : (ptr32 (ptr32 word32)))
   Class: Eq_339
+  DataType: (ptr32 (ptr32 word32))
+  OrigDataType: (ptr32 (struct (0 T_143 t0000)))
+T_340: (in 4 : int32)
+  Class: Eq_340
   DataType: int32
   OrigDataType: int32
-T_340: (in esp_81 - 4 : word32)
-  Class: Eq_338
+T_341: (in esp_81 - 4 : word32)
+  Class: Eq_339
   DataType: (ptr32 (ptr32 word32))
   OrigDataType: ptr32
-T_341: (in 0x00000000 : word32)
-  Class: Eq_341
+T_342: (in 0x00000000 : word32)
+  Class: Eq_342
   DataType: word32
   OrigDataType: word32
-T_342: (in esp_104 + 0x00000000 : word32)
-  Class: Eq_342
+T_343: (in esp_104 + 0x00000000 : word32)
+  Class: Eq_343
   DataType: ptr32
   OrigDataType: ptr32
-T_343: (in Mem105[esp_104 + 0x00000000:word32] : word32)
-  Class: Eq_142
+T_344: (in Mem105[esp_104 + 0x00000000:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_344: (in free : ptr32)
-  Class: Eq_344
-  DataType: (ptr32 Eq_344)
-  OrigDataType: (ptr32 (fn T_350 (T_349)))
-T_345: (in signature of free : void)
-  Class: Eq_344
-  DataType: (ptr32 Eq_344)
+T_345: (in free : ptr32)
+  Class: Eq_345
+  DataType: (ptr32 Eq_345)
+  OrigDataType: (ptr32 (fn T_351 (T_350)))
+T_346: (in signature of free : void)
+  Class: Eq_345
+  DataType: (ptr32 Eq_345)
   OrigDataType: 
-T_346: (in ptrArg04 : (ptr32 void))
-  Class: Eq_142
+T_347: (in ptrArg04 : (ptr32 void))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: 
-T_347: (in 0x00000000 : word32)
-  Class: Eq_347
+T_348: (in 0x00000000 : word32)
+  Class: Eq_348
   DataType: word32
   OrigDataType: word32
-T_348: (in esp_104 + 0x00000000 : word32)
-  Class: Eq_348
+T_349: (in esp_104 + 0x00000000 : word32)
+  Class: Eq_349
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_349: (in Mem105[esp_104 + 0x00000000:(ptr32 void)] : (ptr32 void))
-  Class: Eq_142
+T_350: (in Mem105[esp_104 + 0x00000000:(ptr32 void)] : (ptr32 void))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_350: (in free(*esp_104) : void)
-  Class: Eq_350
+T_351: (in free(*esp_104) : void)
+  Class: Eq_351
   DataType: void
   OrigDataType: void
-T_351: (in 0x00000000 : word32)
-  Class: Eq_351
+T_352: (in 0x00000000 : word32)
+  Class: Eq_352
   DataType: word32
   OrigDataType: word32
-T_352: (in esp_104 + 0x00000000 : word32)
-  Class: Eq_352
+T_353: (in esp_104 + 0x00000000 : word32)
+  Class: Eq_353
   DataType: (ptr32 (ptr32 void))
   OrigDataType: (ptr32 (ptr32 void))
-T_353: (in Mem105[esp_104 + 0x00000000:word32] : word32)
-  Class: Eq_142
+T_354: (in Mem105[esp_104 + 0x00000000:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_354: (in eax_108 : (ptr32 word32))
-  Class: Eq_142
+T_355: (in eax_108 : (ptr32 word32))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_355: (in _encoded_null : ptr32)
-  Class: Eq_355
-  DataType: (ptr32 Eq_355)
-  OrigDataType: (ptr32 (fn T_357 ()))
-T_356: (in signature of _encoded_null : void)
-  Class: Eq_355
-  DataType: (ptr32 Eq_355)
+T_356: (in _encoded_null : ptr32)
+  Class: Eq_356
+  DataType: (ptr32 Eq_356)
+  OrigDataType: (ptr32 (fn T_358 ()))
+T_357: (in signature of _encoded_null : void)
+  Class: Eq_356
+  DataType: (ptr32 Eq_356)
   OrigDataType: 
-T_357: (in _encoded_null() : (ptr32 void))
-  Class: Eq_142
+T_358: (in _encoded_null() : (ptr32 void))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_358: (in 100033B0 : ptr32)
-  Class: Eq_358
+T_359: (in 100033B0 : ptr32)
+  Class: Eq_359
   DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_359 t0000)))
-T_359: (in Mem109[0x100033B0:word32] : word32)
-  Class: Eq_142
+  OrigDataType: (ptr32 (struct (0 T_360 t0000)))
+T_360: (in Mem109[0x100033B0:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_360: (in 100033B4 : ptr32)
-  Class: Eq_360
+T_361: (in 100033B4 : ptr32)
+  Class: Eq_361
   DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_361 t0000)))
-T_361: (in Mem110[0x100033B4:word32] : word32)
-  Class: Eq_142
+  OrigDataType: (ptr32 (struct (0 T_362 t0000)))
+T_362: (in Mem110[0x100033B4:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_362: (in 4 : int32)
-  Class: Eq_362
+T_363: (in 4 : int32)
+  Class: Eq_363
   DataType: int32
   OrigDataType: int32
-T_363: (in esp_104 + 4 : word32)
-  Class: Eq_229
+T_364: (in esp_104 + 4 : word32)
+  Class: Eq_230
   DataType: ptr32
   OrigDataType: ptr32
-T_364: (in 16 : int32)
-  Class: Eq_364
+T_365: (in 16 : int32)
+  Class: Eq_365
   DataType: int32
   OrigDataType: int32
-T_365: (in fp - 16 : word32)
-  Class: Eq_162
-  DataType: (ptr32 Eq_140)
+T_366: (in fp - 16 : word32)
+  Class: Eq_163
+  DataType: (ptr32 Eq_141)
   OrigDataType: ptr32
-T_366: (in 100033B8 : ptr32)
-  Class: Eq_366
+T_367: (in 100033B8 : ptr32)
+  Class: Eq_367
   DataType: (ptr32 (ptr32 code))
-  OrigDataType: (ptr32 (struct (0 T_367 t0000)))
-T_367: (in Mem198[0x100033B8:word32] : word32)
-  Class: Eq_367
+  OrigDataType: (ptr32 (struct (0 T_368 t0000)))
+T_368: (in Mem198[0x100033B8:word32] : word32)
+  Class: Eq_368
   DataType: (ptr32 code)
   OrigDataType: word32
-T_368: (in 0x00000000 : word32)
-  Class: Eq_367
+T_369: (in 0x00000000 : word32)
+  Class: Eq_368
   DataType: (ptr32 code)
   OrigDataType: word32
-T_369: (in globals->ptr100033B8 == null : bool)
-  Class: Eq_369
+T_370: (in globals->ptr100033B8 == null : bool)
+  Class: Eq_370
   DataType: bool
   OrigDataType: bool
-T_370: (in InterlockedExchange : ptr32)
-  Class: Eq_277
-  DataType: (ptr32 Eq_277)
-  OrigDataType: (ptr32 (fn T_372 (T_371, T_150)))
-T_371: (in 0x100033AC : ptr32)
-  Class: Eq_279
-  DataType: (ptr32 Eq_279)
+T_371: (in InterlockedExchange : ptr32)
+  Class: Eq_278
+  DataType: (ptr32 Eq_278)
+  OrigDataType: (ptr32 (fn T_373 (T_372, T_151)))
+T_372: (in 0x100033AC : ptr32)
+  Class: Eq_280
+  DataType: (ptr32 Eq_280)
   OrigDataType: (ptr32 LONG)
-T_372: (in InterlockedExchange(&globals->t100033AC, ebp_147) : LONG)
-  Class: Eq_150
-  DataType: Eq_150
+T_373: (in InterlockedExchange(&globals->t100033AC, ebp_147) : LONG)
+  Class: Eq_151
+  DataType: Eq_151
   OrigDataType: LONG
-T_373: (in 0x100033AC : ptr32)
-  Class: Eq_314
+T_374: (in 0x100033AC : ptr32)
+  Class: Eq_315
   DataType: ptr32
   OrigDataType: ptr32
-T_374: (in 10003070 : ptr32)
-  Class: Eq_374
+T_375: (in 10003070 : ptr32)
+  Class: Eq_375
   DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_375 t0000)))
-T_375: (in Mem247[0x10003070:word32] : word32)
-  Class: Eq_169
+  OrigDataType: (ptr32 (struct (0 T_376 t0000)))
+T_376: (in Mem247[0x10003070:word32] : word32)
+  Class: Eq_170
   DataType: int32
   OrigDataType: word32
-T_376: (in 0x00000001 : word32)
-  Class: Eq_376
+T_377: (in 0x00000001 : word32)
+  Class: Eq_377
   DataType: word32
   OrigDataType: word32
-T_377: (in globals->dw10003070 + 0x00000001 : word32)
-  Class: Eq_169
+T_378: (in globals->dw10003070 + 0x00000001 : word32)
+  Class: Eq_170
   DataType: int32
   OrigDataType: word32
-T_378: (in 10003070 : ptr32)
-  Class: Eq_378
+T_379: (in 10003070 : ptr32)
+  Class: Eq_379
   DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_379 t0000)))
-T_379: (in Mem249[0x10003070:word32] : word32)
-  Class: Eq_169
+  OrigDataType: (ptr32 (struct (0 T_380 t0000)))
+T_380: (in Mem249[0x10003070:word32] : word32)
+  Class: Eq_170
   DataType: int32
   OrigDataType: word32
-T_380: (in edi_216 : word32)
-  Class: Eq_380
-  DataType: word32
-  OrigDataType: word32
-T_381: (in eax_212 : word32)
+T_381: (in edi_216 : word32)
   Class: Eq_381
   DataType: word32
   OrigDataType: word32
-T_382: (in fn10001742 : ptr32)
+T_382: (in eax_212 : word32)
   Class: Eq_382
-  DataType: (ptr32 Eq_382)
-  OrigDataType: (ptr32 (fn T_394 (T_389, T_390, T_391, T_392, T_393)))
-T_383: (in signature of fn10001742 : void)
-  Class: Eq_382
-  DataType: (ptr32 Eq_382)
+  DataType: word32
+  OrigDataType: word32
+T_383: (in fn10001742 : ptr32)
+  Class: Eq_383
+  DataType: (ptr32 Eq_383)
+  OrigDataType: (ptr32 (fn T_395 (T_390, T_391, T_392, T_393, T_394)))
+T_384: (in signature of fn10001742 : void)
+  Class: Eq_383
+  DataType: (ptr32 Eq_383)
   OrigDataType: 
-T_384: (in ebx : (ptr32 Eq_189))
-  Class: Eq_189
-  DataType: (ptr32 Eq_189)
+T_385: (in ebx : (ptr32 Eq_190))
+  Class: Eq_190
+  DataType: (ptr32 Eq_190)
   OrigDataType: word32
-T_385: (in esi : ptr32)
-  Class: Eq_385
+T_386: (in esi : ptr32)
+  Class: Eq_386
   DataType: ptr32
   OrigDataType: word32
-T_386: (in edi : word32)
-  Class: Eq_386
+T_387: (in edi : word32)
+  Class: Eq_387
   DataType: word32
   OrigDataType: word32
-T_387: (in edxOut : ptr32)
-  Class: Eq_387
-  DataType: ptr32
-  OrigDataType: ptr32
-T_388: (in ediOut : ptr32)
+T_388: (in edxOut : ptr32)
   Class: Eq_388
   DataType: ptr32
   OrigDataType: ptr32
-T_389: (in InterlockedCompareExchange : ptr32)
-  Class: Eq_189
-  DataType: (ptr32 Eq_189)
-  OrigDataType: ptr32
-T_390: (in 0x100033AC : ptr32)
-  Class: Eq_385
+T_389: (in ediOut : ptr32)
+  Class: Eq_389
   DataType: ptr32
   OrigDataType: ptr32
-T_391: (in 0x00000002 : word32)
+T_390: (in InterlockedCompareExchange : ptr32)
+  Class: Eq_190
+  DataType: (ptr32 Eq_190)
+  OrigDataType: ptr32
+T_391: (in 0x100033AC : ptr32)
   Class: Eq_386
+  DataType: ptr32
+  OrigDataType: ptr32
+T_392: (in 0x00000002 : word32)
+  Class: Eq_387
   DataType: word32
   OrigDataType: word32
-T_392: (in out edx : ptr32)
-  Class: Eq_387
-  DataType: ptr32
-  OrigDataType: ptr32
-T_393: (in out edi_216 : ptr32)
+T_393: (in out edx : ptr32)
   Class: Eq_388
   DataType: ptr32
   OrigDataType: ptr32
-T_394: (in fn10001742(InterlockedCompareExchange, 0x100033AC, 0x00000002, out edx, out edi_216) : word32)
-  Class: Eq_381
+T_394: (in out edi_216 : ptr32)
+  Class: Eq_389
+  DataType: ptr32
+  OrigDataType: ptr32
+T_395: (in fn10001742(InterlockedCompareExchange, 0x100033AC, 0x00000002, out edx, out edi_216) : word32)
+  Class: Eq_382
   DataType: word32
   OrigDataType: word32
-T_395: (in esp_219 : Eq_395)
-  Class: Eq_395
-  DataType: Eq_395
-  OrigDataType: (ptr32 (struct (0 T_142 t0000) (18 T_417 t0018) (20 T_406 t0020)))
-T_396: (in <invalid> : void)
-  Class: Eq_395
+T_396: (in esp_219 : Eq_396)
+  Class: Eq_396
+  DataType: Eq_396
+  OrigDataType: (ptr32 (struct (0 T_143 t0000) (18 T_418 t0018) (20 T_407 t0020)))
+T_397: (in <invalid> : void)
+  Class: Eq_396
   DataType: int8
   OrigDataType: void
-T_397: (in 0x00000000 : word32)
-  Class: Eq_397
-  DataType: word32
-  OrigDataType: word32
-T_398: (in esp_219 + 0x00000000 : word32)
+T_398: (in 0x00000000 : word32)
   Class: Eq_398
   DataType: word32
   OrigDataType: word32
-T_399: (in Mem203[esp_219 + 0x00000000:word32] : word32)
-  Class: Eq_142
+T_399: (in esp_219 + 0x00000000 : word32)
+  Class: Eq_399
+  DataType: word32
+  OrigDataType: word32
+T_400: (in Mem203[esp_219 + 0x00000000:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_400: (in 4 : int32)
-  Class: Eq_400
+T_401: (in 4 : int32)
+  Class: Eq_401
   DataType: int32
   OrigDataType: int32
-T_401: (in esp_219 + 4 : word32)
-  Class: Eq_162
-  DataType: (ptr32 Eq_140)
+T_402: (in esp_219 + 4 : word32)
+  Class: Eq_163
+  DataType: (ptr32 Eq_141)
   OrigDataType: ptr32
-T_402: (in 0x00000000 : word32)
+T_403: (in 0x00000000 : word32)
+  Class: Eq_382
+  DataType: word32
+  OrigDataType: word32
+T_404: (in eax_212 == 0x00000000 : bool)
+  Class: Eq_404
+  DataType: bool
+  OrigDataType: bool
+T_405: (in 0x00000020 : word32)
+  Class: Eq_405
+  DataType: word32
+  OrigDataType: word32
+T_406: (in esp_219 + 0x00000020 : word32)
+  Class: Eq_406
+  DataType: ptr32
+  OrigDataType: ptr32
+T_407: (in Mem203[esp_219 + 0x00000020:word32] : word32)
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: word32
+T_408: (in 0x00000000 : word32)
+  Class: Eq_408
+  DataType: word32
+  OrigDataType: word32
+T_409: (in esp_219 + 0x00000000 : word32)
+  Class: Eq_409
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_410: (in Mem231[esp_219 + 0x00000000:word32] : word32)
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: word32
+T_411: (in 4 : int32)
+  Class: Eq_411
+  DataType: int32
+  OrigDataType: int32
+T_412: (in esp_219 - 4 : word32)
+  Class: Eq_412
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_415 t0000)))
+T_413: (in 0x00000000 : word32)
+  Class: Eq_413
+  DataType: word32
+  OrigDataType: word32
+T_414: (in esp_219 - 4 + 0x00000000 : word32)
+  Class: Eq_414
+  DataType: ptr32
+  OrigDataType: ptr32
+T_415: (in Mem233[esp_219 - 4 + 0x00000000:word32] : word32)
   Class: Eq_381
   DataType: word32
   OrigDataType: word32
-T_403: (in eax_212 == 0x00000000 : bool)
-  Class: Eq_403
-  DataType: bool
-  OrigDataType: bool
-T_404: (in 0x00000020 : word32)
-  Class: Eq_404
-  DataType: word32
-  OrigDataType: word32
-T_405: (in esp_219 + 0x00000020 : word32)
-  Class: Eq_405
-  DataType: ptr32
-  OrigDataType: ptr32
-T_406: (in Mem203[esp_219 + 0x00000020:word32] : word32)
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: word32
-T_407: (in 0x00000000 : word32)
-  Class: Eq_407
-  DataType: word32
-  OrigDataType: word32
-T_408: (in esp_219 + 0x00000000 : word32)
-  Class: Eq_408
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_409: (in Mem231[esp_219 + 0x00000000:word32] : word32)
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: word32
-T_410: (in 4 : int32)
-  Class: Eq_410
-  DataType: int32
-  OrigDataType: int32
-T_411: (in esp_219 - 4 : word32)
-  Class: Eq_411
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_414 t0000)))
-T_412: (in 0x00000000 : word32)
-  Class: Eq_412
-  DataType: word32
-  OrigDataType: word32
-T_413: (in esp_219 - 4 + 0x00000000 : word32)
-  Class: Eq_413
-  DataType: ptr32
-  OrigDataType: ptr32
-T_414: (in Mem233[esp_219 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_380
-  DataType: word32
-  OrigDataType: word32
-T_415: (in 0x00000018 : word32)
-  Class: Eq_415
-  DataType: word32
-  OrigDataType: word32
-T_416: (in esp_219 + 0x00000018 : word32)
+T_416: (in 0x00000018 : word32)
   Class: Eq_416
-  DataType: ptr32
-  OrigDataType: ptr32
-T_417: (in Mem233[esp_219 + 0x00000018:word32] : word32)
-  Class: Eq_417
   DataType: word32
   OrigDataType: word32
-T_418: (in 8 : int32)
+T_417: (in esp_219 + 0x00000018 : word32)
+  Class: Eq_417
+  DataType: ptr32
+  OrigDataType: ptr32
+T_418: (in Mem233[esp_219 + 0x00000018:word32] : word32)
   Class: Eq_418
+  DataType: word32
+  OrigDataType: word32
+T_419: (in 8 : int32)
+  Class: Eq_419
   DataType: int32
   OrigDataType: int32
-T_419: (in esp_219 - 8 : word32)
-  Class: Eq_419
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_422 t0000)))
-T_420: (in 0x00000000 : word32)
+T_420: (in esp_219 - 8 : word32)
   Class: Eq_420
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_423 t0000)))
+T_421: (in 0x00000000 : word32)
+  Class: Eq_421
   DataType: word32
   OrigDataType: word32
-T_421: (in esp_219 - 8 + 0x00000000 : word32)
-  Class: Eq_421
+T_422: (in esp_219 - 8 + 0x00000000 : word32)
+  Class: Eq_422
   DataType: ptr32
   OrigDataType: ptr32
-T_422: (in Mem236[esp_219 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_417
+T_423: (in Mem236[esp_219 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_418
   DataType: word32
   OrigDataType: word32
-T_423: (in 100033B8 : ptr32)
-  Class: Eq_423
+T_424: (in 100033B8 : ptr32)
+  Class: Eq_424
   DataType: (ptr32 (ptr32 code))
-  OrigDataType: (ptr32 (struct (0 T_424 t0000)))
-T_424: (in Mem236[0x100033B8:word32] : word32)
-  Class: Eq_367
+  OrigDataType: (ptr32 (struct (0 T_425 t0000)))
+T_425: (in Mem236[0x100033B8:word32] : word32)
+  Class: Eq_368
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_425: (in eax : word32)
-  Class: Eq_425
+T_426: (in eax : word32)
+  Class: Eq_426
   DataType: word32
   OrigDataType: word32
-T_426: (in ecx : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
+T_427: (in ecx : Eq_141)
+  Class: Eq_141
+  DataType: Eq_141
   OrigDataType: word32
-T_427: (in edx : Eq_136)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: word32
-T_428: (in ebx : (ptr32 Eq_189))
-  Class: Eq_189
-  DataType: (ptr32 Eq_189)
-  OrigDataType: word32
-T_429: (in esi : ptr32)
-  Class: Eq_385
-  DataType: ptr32
-  OrigDataType: word32
-T_430: (in edi : word32)
-  Class: Eq_386
-  DataType: word32
-  OrigDataType: word32
-T_431: (in ebp_13 : (ptr32 Eq_138))
-  Class: Eq_138
-  DataType: (ptr32 Eq_138)
-  OrigDataType: (ptr32 (struct (8 T_445 t0008)))
-T_432: (in fn100017E8 : ptr32)
-  Class: Eq_432
-  DataType: (ptr32 Eq_432)
-  OrigDataType: (ptr32 (fn T_441 (T_428, T_429, T_430, T_439, T_440)))
-T_433: (in signature of fn100017E8 : void)
-  Class: Eq_432
-  DataType: (ptr32 Eq_432)
-  OrigDataType: 
-T_434: (in ebx : (ptr32 Eq_189))
-  Class: Eq_189
-  DataType: (ptr32 Eq_189)
-  OrigDataType: word32
-T_435: (in esi : ptr32)
-  Class: Eq_385
-  DataType: ptr32
-  OrigDataType: word32
-T_436: (in edi : word32)
-  Class: Eq_386
-  DataType: word32
-  OrigDataType: word32
-T_437: (in dwArg00 : word32)
-  Class: Eq_437
-  DataType: word32
-  OrigDataType: word32
-T_438: (in dwArg08 : ui32)
-  Class: Eq_438
-  DataType: ui32
-  OrigDataType: ui32
-T_439: (in dwLoc0C : word32)
-  Class: Eq_437
-  DataType: word32
-  OrigDataType: word32
-T_440: (in 0x00000010 : word32)
-  Class: Eq_438
-  DataType: ui32
-  OrigDataType: word32
-T_441: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000010) : word32)
-  Class: Eq_138
-  DataType: (ptr32 Eq_138)
-  OrigDataType: word32
-T_442: (in ebx_116 : Eq_137)
+T_428: (in edx : Eq_137)
   Class: Eq_137
   DataType: Eq_137
   OrigDataType: word32
-T_443: (in 0x00000008 : word32)
-  Class: Eq_443
+T_429: (in ebx : (ptr32 Eq_190))
+  Class: Eq_190
+  DataType: (ptr32 Eq_190)
+  OrigDataType: word32
+T_430: (in esi : ptr32)
+  Class: Eq_386
+  DataType: ptr32
+  OrigDataType: word32
+T_431: (in edi : word32)
+  Class: Eq_387
   DataType: word32
   OrigDataType: word32
-T_444: (in ebp_13 + 0x00000008 : word32)
+T_432: (in ebp_13 : (ptr32 Eq_139))
+  Class: Eq_139
+  DataType: (ptr32 Eq_139)
+  OrigDataType: (ptr32 (struct (8 T_446 t0008)))
+T_433: (in fn100017E8 : ptr32)
+  Class: Eq_433
+  DataType: (ptr32 Eq_433)
+  OrigDataType: (ptr32 (fn T_442 (T_429, T_430, T_431, T_440, T_441)))
+T_434: (in signature of fn100017E8 : void)
+  Class: Eq_433
+  DataType: (ptr32 Eq_433)
+  OrigDataType: 
+T_435: (in ebx : (ptr32 Eq_190))
+  Class: Eq_190
+  DataType: (ptr32 Eq_190)
+  OrigDataType: word32
+T_436: (in esi : ptr32)
+  Class: Eq_386
+  DataType: ptr32
+  OrigDataType: word32
+T_437: (in edi : word32)
+  Class: Eq_387
+  DataType: word32
+  OrigDataType: word32
+T_438: (in dwArg00 : word32)
+  Class: Eq_438
+  DataType: word32
+  OrigDataType: word32
+T_439: (in dwArg08 : ui32)
+  Class: Eq_439
+  DataType: ui32
+  OrigDataType: ui32
+T_440: (in dwLoc0C : word32)
+  Class: Eq_438
+  DataType: word32
+  OrigDataType: word32
+T_441: (in 0x00000010 : word32)
+  Class: Eq_439
+  DataType: ui32
+  OrigDataType: word32
+T_442: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000010) : word32)
+  Class: Eq_139
+  DataType: (ptr32 Eq_139)
+  OrigDataType: word32
+T_443: (in ebx_116 : Eq_138)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: word32
+T_444: (in 0x00000008 : word32)
   Class: Eq_444
   DataType: word32
   OrigDataType: word32
-T_445: (in Mem7[ebp_13 + 0x00000008:word32] : word32)
+T_445: (in ebp_13 + 0x00000008 : word32)
+  Class: Eq_445
+  DataType: word32
+  OrigDataType: word32
+T_446: (in Mem7[ebp_13 + 0x00000008:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: word32
+T_447: (in 0x00000001 : word32)
+  Class: Eq_447
+  DataType: word32
+  OrigDataType: word32
+T_448: (in 0x0000001C : word32)
+  Class: Eq_448
+  DataType: ui32
+  OrigDataType: ui32
+T_449: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_449
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_452 t0000)))
+T_450: (in 0x00000000 : word32)
+  Class: Eq_450
+  DataType: word32
+  OrigDataType: word32
+T_451: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_451
+  DataType: ptr32
+  OrigDataType: ptr32
+T_452: (in Mem26[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_447
+  DataType: word32
+  OrigDataType: word32
+T_453: (in 0x00000000 : word32)
+  Class: Eq_453
+  DataType: word32
+  OrigDataType: word32
+T_454: (in 0x00000004 : word32)
+  Class: Eq_454
+  DataType: ui32
+  OrigDataType: ui32
+T_455: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_455
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_458 t0000)))
+T_456: (in 0x00000000 : word32)
+  Class: Eq_456
+  DataType: word32
+  OrigDataType: word32
+T_457: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_457
+  DataType: ptr32
+  OrigDataType: ptr32
+T_458: (in Mem28[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_453
+  DataType: word32
+  OrigDataType: word32
+T_459: (in 10003008 : ptr32)
+  Class: Eq_459
+  DataType: (ptr32 Eq_137)
+  OrigDataType: (ptr32 (struct (0 T_460 t0000)))
+T_460: (in Mem29[0x10003008:word32] : word32)
   Class: Eq_137
   DataType: Eq_137
   OrigDataType: word32
-T_446: (in 0x00000001 : word32)
-  Class: Eq_446
-  DataType: word32
-  OrigDataType: word32
-T_447: (in 0x0000001C : word32)
-  Class: Eq_447
-  DataType: ui32
-  OrigDataType: ui32
-T_448: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_448
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_451 t0000)))
-T_449: (in 0x00000000 : word32)
-  Class: Eq_449
-  DataType: word32
-  OrigDataType: word32
-T_450: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_450
-  DataType: ptr32
-  OrigDataType: ptr32
-T_451: (in Mem26[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_446
-  DataType: word32
-  OrigDataType: word32
-T_452: (in 0x00000000 : word32)
-  Class: Eq_452
-  DataType: word32
-  OrigDataType: word32
-T_453: (in 0x00000004 : word32)
-  Class: Eq_453
-  DataType: ui32
-  OrigDataType: ui32
-T_454: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_454
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_457 t0000)))
-T_455: (in 0x00000000 : word32)
-  Class: Eq_455
-  DataType: word32
-  OrigDataType: word32
-T_456: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_456
-  DataType: ptr32
-  OrigDataType: ptr32
-T_457: (in Mem28[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_452
-  DataType: word32
-  OrigDataType: word32
-T_458: (in 10003008 : ptr32)
-  Class: Eq_458
-  DataType: (ptr32 Eq_136)
-  OrigDataType: (ptr32 (struct (0 T_459 t0000)))
-T_459: (in Mem29[0x10003008:word32] : word32)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: word32
-T_460: (in 0x00000001 : word32)
-  Class: Eq_460
-  DataType: word32
-  OrigDataType: word32
-T_461: (in 0x00000004 : word32)
+T_461: (in 0x00000001 : word32)
   Class: Eq_461
-  DataType: ui32
-  OrigDataType: ui32
-T_462: (in ebp_13 - 0x00000004 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_462: (in 0x00000004 : word32)
   Class: Eq_462
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_465 t0000)))
-T_463: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_463: (in ebp_13 - 0x00000004 : word32)
   Class: Eq_463
-  DataType: word32
-  OrigDataType: word32
-T_464: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_464
-  DataType: ptr32
-  OrigDataType: ptr32
-T_465: (in Mem30[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_460
-  DataType: word32
-  OrigDataType: word32
-T_466: (in esp_103 : Eq_395)
-  Class: Eq_395
-  DataType: Eq_395
-  OrigDataType: (ptr32 char)
-T_467: (in edi_110 : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_468: (in esi_113 : Eq_136)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: word32
-T_469: (in 0x00000000 : word32)
-  Class: Eq_136
-  DataType: ptr32
-  OrigDataType: word32
-T_470: (in edx != 0x00000000 : bool)
-  Class: Eq_470
-  DataType: bool
-  OrigDataType: bool
-T_471: (in 0x00000001 : word32)
-  Class: Eq_136
-  DataType: ptr32
-  OrigDataType: word32
-T_472: (in edx == 0x00000001 : bool)
-  Class: Eq_472
-  DataType: bool
-  OrigDataType: bool
-T_473: (in 10003070 : ptr32)
-  Class: Eq_473
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_474 t0000)))
-T_474: (in Mem30[0x10003070:word32] : word32)
-  Class: Eq_169
-  DataType: int32
-  OrigDataType: word32
-T_475: (in 0x00000000 : word32)
-  Class: Eq_169
-  DataType: int32
-  OrigDataType: word32
-T_476: (in globals->dw10003070 != 0x00000000 : bool)
-  Class: Eq_476
-  DataType: bool
-  OrigDataType: bool
-T_477: (in 0x00000000 : word32)
-  Class: Eq_477
-  DataType: word32
-  OrigDataType: word32
-T_478: (in 0x0000001C : word32)
-  Class: Eq_478
-  DataType: ui32
-  OrigDataType: ui32
-T_479: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_479
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_482 t0000)))
-T_480: (in 0x00000000 : word32)
-  Class: Eq_480
+  OrigDataType: (ptr32 (struct (0 T_466 t0000)))
+T_464: (in 0x00000000 : word32)
+  Class: Eq_464
   DataType: word32
   OrigDataType: word32
-T_481: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_481
+T_465: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_465
   DataType: ptr32
   OrigDataType: ptr32
-T_482: (in Mem252[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+T_466: (in Mem30[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_461
+  DataType: word32
+  OrigDataType: word32
+T_467: (in esp_103 : Eq_396)
+  Class: Eq_396
+  DataType: Eq_396
+  OrigDataType: (ptr32 char)
+T_468: (in edi_110 : Eq_141)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: word32
+T_469: (in esi_113 : Eq_137)
+  Class: Eq_137
+  DataType: Eq_137
+  OrigDataType: word32
+T_470: (in 0x00000000 : word32)
+  Class: Eq_137
+  DataType: ptr32
+  OrigDataType: word32
+T_471: (in edx != 0x00000000 : bool)
+  Class: Eq_471
+  DataType: bool
+  OrigDataType: bool
+T_472: (in 0x00000001 : word32)
+  Class: Eq_137
+  DataType: ptr32
+  OrigDataType: word32
+T_473: (in edx == 0x00000001 : bool)
+  Class: Eq_473
+  DataType: bool
+  OrigDataType: bool
+T_474: (in 10003070 : ptr32)
+  Class: Eq_474
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_475 t0000)))
+T_475: (in Mem30[0x10003070:word32] : word32)
+  Class: Eq_170
+  DataType: int32
+  OrigDataType: word32
+T_476: (in 0x00000000 : word32)
+  Class: Eq_170
+  DataType: int32
+  OrigDataType: word32
+T_477: (in globals->dw10003070 != 0x00000000 : bool)
   Class: Eq_477
+  DataType: bool
+  OrigDataType: bool
+T_478: (in 0x00000000 : word32)
+  Class: Eq_478
   DataType: word32
   OrigDataType: word32
-T_483: (in 0x00000004 : word32)
-  Class: Eq_483
+T_479: (in 0x0000001C : word32)
+  Class: Eq_479
   DataType: ui32
   OrigDataType: ui32
-T_484: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_484
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_487 t0000)))
-T_485: (in 0x00000000 : word32)
-  Class: Eq_485
+T_480: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_480
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_483 t0000)))
+T_481: (in 0x00000000 : word32)
+  Class: Eq_481
   DataType: word32
   OrigDataType: word32
-T_486: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_486
+T_482: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_482
   DataType: ptr32
   OrigDataType: ptr32
-T_487: (in Mem254[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_487
+T_483: (in Mem252[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_478
+  DataType: word32
+  OrigDataType: word32
+T_484: (in 0x00000004 : word32)
+  Class: Eq_484
   DataType: ui32
   OrigDataType: ui32
-T_488: (in 0x00000000 : word32)
+T_485: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_485
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_488 t0000)))
+T_486: (in 0x00000000 : word32)
+  Class: Eq_486
+  DataType: word32
+  OrigDataType: word32
+T_487: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_487
+  DataType: ptr32
+  OrigDataType: ptr32
+T_488: (in Mem254[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
   Class: Eq_488
   DataType: ui32
   OrigDataType: ui32
-T_489: (in *(ebp_13 - 0x00000004) & 0x00000000 : word32)
+T_489: (in 0x00000000 : word32)
   Class: Eq_489
   DataType: ui32
   OrigDataType: ui32
-T_490: (in 0x00000004 : word32)
+T_490: (in *(ebp_13 - 0x00000004) & 0x00000000 : word32)
   Class: Eq_490
   DataType: ui32
   OrigDataType: ui32
-T_491: (in ebp_13 - 0x00000004 : word32)
+T_491: (in 0x00000004 : word32)
   Class: Eq_491
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_494 t0000)))
-T_492: (in 0x00000000 : word32)
-  Class: Eq_492
-  DataType: word32
-  OrigDataType: word32
-T_493: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_493
-  DataType: ptr32
-  OrigDataType: ptr32
-T_494: (in Mem257[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_489
-  DataType: ui32
-  OrigDataType: word32
-T_495: (in 0xFFFFFFFE : word32)
-  Class: Eq_495
-  DataType: word32
-  OrigDataType: word32
-T_496: (in 0x00000004 : word32)
-  Class: Eq_496
   DataType: ui32
   OrigDataType: ui32
-T_497: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_497
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_500 t0000)))
-T_498: (in 0x00000000 : word32)
-  Class: Eq_498
+T_492: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_492
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_495 t0000)))
+T_493: (in 0x00000000 : word32)
+  Class: Eq_493
   DataType: word32
   OrigDataType: word32
-T_499: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_499
+T_494: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_494
   DataType: ptr32
   OrigDataType: ptr32
-T_500: (in Mem260[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_495
+T_495: (in Mem257[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_490
+  DataType: ui32
+  OrigDataType: word32
+T_496: (in 0xFFFFFFFE : word32)
+  Class: Eq_496
   DataType: word32
   OrigDataType: word32
-T_501: (in fn10001493 : ptr32)
-  Class: Eq_501
-  DataType: (ptr32 Eq_501)
-  OrigDataType: (ptr32 (fn T_503 ()))
-T_502: (in signature of fn10001493 : void)
-  Class: Eq_501
-  DataType: (ptr32 Eq_501)
+T_497: (in 0x00000004 : word32)
+  Class: Eq_497
+  DataType: ui32
+  OrigDataType: ui32
+T_498: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_498
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_501 t0000)))
+T_499: (in 0x00000000 : word32)
+  Class: Eq_499
+  DataType: word32
+  OrigDataType: word32
+T_500: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_500
+  DataType: ptr32
+  OrigDataType: ptr32
+T_501: (in Mem260[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_496
+  DataType: word32
+  OrigDataType: word32
+T_502: (in fn10001493 : ptr32)
+  Class: Eq_502
+  DataType: (ptr32 Eq_502)
+  OrigDataType: (ptr32 (fn T_504 ()))
+T_503: (in signature of fn10001493 : void)
+  Class: Eq_502
+  DataType: (ptr32 Eq_502)
   OrigDataType: 
-T_503: (in fn10001493() : void)
-  Class: Eq_503
+T_504: (in fn10001493() : void)
+  Class: Eq_504
   DataType: void
   OrigDataType: void
-T_504: (in eax_261 : word32)
-  Class: Eq_425
+T_505: (in eax_261 : word32)
+  Class: Eq_426
   DataType: word32
   OrigDataType: word32
-T_505: (in 0x0000001C : word32)
-  Class: Eq_505
-  DataType: ui32
-  OrigDataType: ui32
-T_506: (in ebp_13 - 0x0000001C : word32)
+T_506: (in 0x0000001C : word32)
   Class: Eq_506
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_509 t0000)))
-T_507: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_507: (in ebp_13 - 0x0000001C : word32)
   Class: Eq_507
-  DataType: word32
-  OrigDataType: word32
-T_508: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_510 t0000)))
+T_508: (in 0x00000000 : word32)
   Class: Eq_508
+  DataType: word32
+  OrigDataType: word32
+T_509: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_509
   DataType: ptr32
   OrigDataType: ptr32
-T_509: (in Mem260[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_425
+T_510: (in Mem260[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_426
   DataType: word32
   OrigDataType: word32
-T_510: (in fn1000182D : ptr32)
-  Class: Eq_510
-  DataType: (ptr32 Eq_510)
-  OrigDataType: (ptr32 (fn T_517 (T_431, T_516)))
-T_511: (in signature of fn1000182D : void)
-  Class: Eq_510
-  DataType: (ptr32 Eq_510)
+T_511: (in fn1000182D : ptr32)
+  Class: Eq_511
+  DataType: (ptr32 Eq_511)
+  OrigDataType: (ptr32 (fn T_518 (T_432, T_517)))
+T_512: (in signature of fn1000182D : void)
+  Class: Eq_511
+  DataType: (ptr32 Eq_511)
   OrigDataType: 
-T_512: (in ebp : (ptr32 Eq_138))
-  Class: Eq_138
-  DataType: (ptr32 Eq_138)
-  OrigDataType: (ptr32 (struct (0 T_1293 t0000)))
-T_513: (in dwArg00 : word32)
-  Class: Eq_513
-  DataType: word32
-  OrigDataType: word32
-T_514: (in -4 : int32)
+T_513: (in ebp : (ptr32 Eq_139))
+  Class: Eq_139
+  DataType: (ptr32 Eq_139)
+  OrigDataType: (ptr32 (struct (0 T_1294 t0000)))
+T_514: (in dwArg00 : word32)
   Class: Eq_514
-  DataType: int32
-  OrigDataType: int32
-T_515: (in esp_103 + -4 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_515: (in -4 : int32)
   Class: Eq_515
+  DataType: int32
+  OrigDataType: int32
+T_516: (in esp_103 + -4 : word32)
+  Class: Eq_516
   DataType: word32
   OrigDataType: word32
-T_516: (in Mem260[esp_103 + -4:word32] : word32)
-  Class: Eq_513
+T_517: (in Mem260[esp_103 + -4:word32] : word32)
+  Class: Eq_514
   DataType: word32
   OrigDataType: word32
-T_517: (in fn1000182D(ebp_13, *((word32) esp_103 - 4)) : word32)
-  Class: Eq_388
+T_518: (in fn1000182D(ebp_13, *((word32) esp_103 - 4)) : word32)
+  Class: Eq_389
   DataType: ptr32
   OrigDataType: word32
-T_518: (in edx_65 : Eq_136)
-  Class: Eq_136
-  DataType: Eq_136
+T_519: (in edx_65 : Eq_137)
+  Class: Eq_137
+  DataType: Eq_137
   OrigDataType: word32
-T_519: (in eax_43 : word32)
-  Class: Eq_519
-  DataType: word32
-  OrigDataType: word32
-T_520: (in 100020CC : ptr32)
+T_520: (in eax_43 : word32)
   Class: Eq_520
+  DataType: word32
+  OrigDataType: word32
+T_521: (in 100020CC : ptr32)
+  Class: Eq_521
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_521 t0000)))
-T_521: (in Mem30[0x100020CC:word32] : word32)
-  Class: Eq_519
+  OrigDataType: (ptr32 (struct (0 T_522 t0000)))
+T_522: (in Mem30[0x100020CC:word32] : word32)
+  Class: Eq_520
   DataType: word32
   OrigDataType: word32
-T_522: (in 0x00000000 : word32)
-  Class: Eq_519
+T_523: (in 0x00000000 : word32)
+  Class: Eq_520
   DataType: word32
   OrigDataType: word32
-T_523: (in eax_43 == 0x00000000 : bool)
-  Class: Eq_523
+T_524: (in eax_43 == 0x00000000 : bool)
+  Class: Eq_524
   DataType: bool
   OrigDataType: bool
-T_524: (in 0x00000002 : word32)
-  Class: Eq_136
+T_525: (in 0x00000002 : word32)
+  Class: Eq_137
   DataType: ptr32
   OrigDataType: word32
-T_525: (in edx != 0x00000002 : bool)
-  Class: Eq_525
+T_526: (in edx != 0x00000002 : bool)
+  Class: Eq_526
   DataType: bool
   OrigDataType: bool
-T_526: (in esp_109 : (ptr32 Eq_140))
-  Class: Eq_526
-  DataType: (ptr32 Eq_140)
-  OrigDataType: (ptr32 (struct (0 T_140 t0000)))
-T_527: (in 4 : int32)
+T_527: (in esp_109 : (ptr32 Eq_141))
   Class: Eq_527
+  DataType: (ptr32 Eq_141)
+  OrigDataType: (ptr32 (struct (0 T_141 t0000)))
+T_528: (in 4 : int32)
+  Class: Eq_528
   DataType: int32
   OrigDataType: int32
-T_528: (in esp_103 - 4 : word32)
-  Class: Eq_526
-  DataType: (ptr32 Eq_140)
+T_529: (in esp_103 - 4 : word32)
+  Class: Eq_527
+  DataType: (ptr32 Eq_141)
   OrigDataType: ptr32
-T_529: (in 0x00000000 : word32)
-  Class: Eq_529
-  DataType: word32
-  OrigDataType: word32
-T_530: (in esp_109 + 0x00000000 : word32)
+T_530: (in 0x00000000 : word32)
   Class: Eq_530
+  DataType: word32
+  OrigDataType: word32
+T_531: (in esp_109 + 0x00000000 : word32)
+  Class: Eq_531
   DataType: ptr32
   OrigDataType: ptr32
-T_531: (in Mem111[esp_109 + 0x00000000:word32] : word32)
-  Class: Eq_140
-  DataType: Eq_140
+T_532: (in Mem111[esp_109 + 0x00000000:word32] : word32)
+  Class: Eq_141
+  DataType: Eq_141
   OrigDataType: word32
-T_532: (in 4 : int32)
-  Class: Eq_532
-  DataType: int32
-  OrigDataType: int32
-T_533: (in esp_109 - 4 : word32)
+T_533: (in 4 : int32)
   Class: Eq_533
-  DataType: (ptr32 Eq_136)
-  OrigDataType: (ptr32 (struct (0 T_536 t0000)))
-T_534: (in 0x00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_534: (in esp_109 - 4 : word32)
   Class: Eq_534
-  DataType: word32
-  OrigDataType: word32
-T_535: (in esp_109 - 4 + 0x00000000 : word32)
+  DataType: (ptr32 Eq_137)
+  OrigDataType: (ptr32 (struct (0 T_537 t0000)))
+T_535: (in 0x00000000 : word32)
   Class: Eq_535
+  DataType: word32
+  OrigDataType: word32
+T_536: (in esp_109 - 4 + 0x00000000 : word32)
+  Class: Eq_536
   DataType: ptr32
   OrigDataType: ptr32
-T_536: (in Mem114[esp_109 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_136
-  DataType: Eq_136
+T_537: (in Mem114[esp_109 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_137
+  DataType: Eq_137
   OrigDataType: word32
-T_537: (in 8 : int32)
-  Class: Eq_537
-  DataType: int32
-  OrigDataType: int32
-T_538: (in esp_109 - 8 : word32)
+T_538: (in 8 : int32)
   Class: Eq_538
-  DataType: (ptr32 Eq_137)
-  OrigDataType: (ptr32 (struct (0 T_541 t0000)))
-T_539: (in 0x00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_539: (in esp_109 - 8 : word32)
   Class: Eq_539
-  DataType: word32
-  OrigDataType: word32
-T_540: (in esp_109 - 8 + 0x00000000 : word32)
+  DataType: (ptr32 Eq_138)
+  OrigDataType: (ptr32 (struct (0 T_542 t0000)))
+T_540: (in 0x00000000 : word32)
   Class: Eq_540
-  DataType: ptr32
-  OrigDataType: ptr32
-T_541: (in Mem117[esp_109 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_137
-  DataType: Eq_137
-  OrigDataType: word32
-T_542: (in eax_118 : word32)
-  Class: Eq_542
   DataType: word32
   OrigDataType: word32
-T_543: (in fn100017C6 : ptr32)
+T_541: (in esp_109 - 8 + 0x00000000 : word32)
+  Class: Eq_541
+  DataType: ptr32
+  OrigDataType: ptr32
+T_542: (in Mem117[esp_109 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: word32
+T_543: (in eax_118 : word32)
   Class: Eq_543
-  DataType: (ptr32 Eq_543)
-  OrigDataType: (ptr32 (fn T_556 (T_550, T_555)))
-T_544: (in signature of fn100017C6 : void)
-  Class: Eq_543
-  DataType: (ptr32 Eq_543)
+  DataType: word32
+  OrigDataType: word32
+T_544: (in fn100017C6 : ptr32)
+  Class: Eq_544
+  DataType: (ptr32 Eq_544)
+  OrigDataType: (ptr32 (fn T_557 (T_551, T_556)))
+T_545: (in signature of fn100017C6 : void)
+  Class: Eq_544
+  DataType: (ptr32 Eq_544)
   OrigDataType: 
-T_545: (in dwArg04 : Eq_545)
-  Class: Eq_545
-  DataType: Eq_545
+T_546: (in dwArg04 : Eq_546)
+  Class: Eq_546
+  DataType: Eq_546
   OrigDataType: HMODULE
-T_546: (in dwArg08 : word32)
-  Class: Eq_546
-  DataType: word32
-  OrigDataType: word32
-T_547: (in esp_109 - 8 : word32)
+T_547: (in dwArg08 : word32)
   Class: Eq_547
-  DataType: (ptr32 Eq_545)
-  OrigDataType: (ptr32 (struct (0 T_550 t0000)))
-T_548: (in 0x00000000 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_548: (in esp_109 - 8 : word32)
   Class: Eq_548
-  DataType: word32
-  OrigDataType: word32
-T_549: (in esp_109 - 8 + 0x00000000 : word32)
+  DataType: (ptr32 Eq_546)
+  OrigDataType: (ptr32 (struct (0 T_551 t0000)))
+T_549: (in 0x00000000 : word32)
   Class: Eq_549
+  DataType: word32
+  OrigDataType: word32
+T_550: (in esp_109 - 8 + 0x00000000 : word32)
+  Class: Eq_550
   DataType: ptr32
   OrigDataType: ptr32
-T_550: (in Mem117[esp_109 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_545
-  DataType: Eq_545
+T_551: (in Mem117[esp_109 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_546
+  DataType: Eq_546
   OrigDataType: word32
-T_551: (in 4 : int32)
-  Class: Eq_551
-  DataType: int32
-  OrigDataType: int32
-T_552: (in esp_109 - 4 : word32)
+T_552: (in 4 : int32)
   Class: Eq_552
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_555 t0000)))
-T_553: (in 0x00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_553: (in esp_109 - 4 : word32)
   Class: Eq_553
-  DataType: word32
-  OrigDataType: word32
-T_554: (in esp_109 - 4 + 0x00000000 : word32)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_556 t0000)))
+T_554: (in 0x00000000 : word32)
   Class: Eq_554
+  DataType: word32
+  OrigDataType: word32
+T_555: (in esp_109 - 4 + 0x00000000 : word32)
+  Class: Eq_555
   DataType: ptr32
   OrigDataType: ptr32
-T_555: (in Mem117[esp_109 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_546
+T_556: (in Mem117[esp_109 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_547
   DataType: word32
   OrigDataType: word32
-T_556: (in fn100017C6(*(esp_109 - 8), *(esp_109 - 4)) : word32)
-  Class: Eq_542
-  DataType: word32
-  OrigDataType: word32
-T_557: (in 0x0000001C : word32)
-  Class: Eq_557
-  DataType: ui32
-  OrigDataType: ui32
-T_558: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_558
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_561 t0000)))
-T_559: (in 0x00000000 : word32)
-  Class: Eq_559
-  DataType: word32
-  OrigDataType: word32
-T_560: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_560
-  DataType: ptr32
-  OrigDataType: ptr32
-T_561: (in Mem125[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_542
-  DataType: word32
-  OrigDataType: word32
-T_562: (in 0x00000004 : word32)
-  Class: Eq_562
-  DataType: int32
-  OrigDataType: int32
-T_563: (in esp_109 + 0x00000004 : word32)
-  Class: Eq_395
-  DataType: Eq_395
-  OrigDataType: ptr32
-T_564: (in 0x00000001 : word32)
-  Class: Eq_136
-  DataType: ptr32
-  OrigDataType: word32
-T_565: (in esi_113 != 0x00000001 : bool)
-  Class: Eq_565
-  DataType: bool
-  OrigDataType: bool
-T_566: (in 0x0000001C : word32)
-  Class: Eq_566
-  DataType: ui32
-  OrigDataType: ui32
-T_567: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_567
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_570 t0000)))
-T_568: (in 0x00000000 : word32)
-  Class: Eq_568
-  DataType: word32
-  OrigDataType: word32
-T_569: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_569
-  DataType: ptr32
-  OrigDataType: ptr32
-T_570: (in Mem77[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_570
-  DataType: word32
-  OrigDataType: word32
-T_571: (in 0x00000000 : word32)
-  Class: Eq_570
-  DataType: word32
-  OrigDataType: word32
-T_572: (in *(ebp_13 - 0x0000001C) == 0x00000000 : bool)
-  Class: Eq_572
-  DataType: bool
-  OrigDataType: bool
-T_573: (in 4 : int32)
-  Class: Eq_573
-  DataType: int32
-  OrigDataType: int32
-T_574: (in esp_103 - 4 : word32)
-  Class: Eq_574
-  DataType: (ptr32 Eq_140)
-  OrigDataType: (ptr32 (struct (0 T_577 t0000)))
-T_575: (in 0x00000000 : word32)
-  Class: Eq_575
-  DataType: word32
-  OrigDataType: word32
-T_576: (in esp_103 - 4 + 0x00000000 : word32)
-  Class: Eq_576
-  DataType: ptr32
-  OrigDataType: ptr32
-T_577: (in Mem53[esp_103 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_578: (in 8 : int32)
-  Class: Eq_578
-  DataType: int32
-  OrigDataType: int32
-T_579: (in esp_103 - 8 : word32)
-  Class: Eq_579
-  DataType: (ptr32 Eq_136)
-  OrigDataType: (ptr32 (struct (0 T_582 t0000)))
-T_580: (in 0x00000000 : word32)
-  Class: Eq_580
-  DataType: word32
-  OrigDataType: word32
-T_581: (in esp_103 - 8 + 0x00000000 : word32)
-  Class: Eq_581
-  DataType: ptr32
-  OrigDataType: ptr32
-T_582: (in Mem56[esp_103 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: word32
-T_583: (in 12 : int32)
-  Class: Eq_583
-  DataType: int32
-  OrigDataType: int32
-T_584: (in esp_103 - 12 : word32)
-  Class: Eq_584
-  DataType: (ptr32 Eq_137)
-  OrigDataType: (ptr32 (struct (0 T_587 t0000)))
-T_585: (in 0x00000000 : word32)
-  Class: Eq_585
-  DataType: word32
-  OrigDataType: word32
-T_586: (in esp_103 - 12 + 0x00000000 : word32)
-  Class: Eq_586
-  DataType: ptr32
-  OrigDataType: ptr32
-T_587: (in Mem60[esp_103 - 12 + 0x00000000:word32] : word32)
-  Class: Eq_137
-  DataType: Eq_137
-  OrigDataType: word32
-T_588: (in eax_68 : word32)
-  Class: Eq_588
-  DataType: word32
-  OrigDataType: word32
-T_589: (in fn00000000 : ptr32)
-  Class: Eq_589
-  DataType: (ptr32 code)
-  OrigDataType: (ptr32 code)
-T_590: (in signature of fn00000000 : void)
-  Class: Eq_590
-  DataType: Eq_590
-  OrigDataType: 
-T_591: (in 0x0000001C : word32)
-  Class: Eq_591
-  DataType: ui32
-  OrigDataType: ui32
-T_592: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_592
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_595 t0000)))
-T_593: (in 0x00000000 : word32)
-  Class: Eq_593
-  DataType: word32
-  OrigDataType: word32
-T_594: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_594
-  DataType: ptr32
-  OrigDataType: ptr32
-T_595: (in Mem75[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_588
-  DataType: word32
-  OrigDataType: word32
-T_596: (in esp_81 : (ptr32 Eq_140))
-  Class: Eq_596
-  DataType: (ptr32 Eq_140)
-  OrigDataType: (ptr32 (struct (0 T_601 t0000)))
-T_597: (in 4 : int32)
-  Class: Eq_597
-  DataType: int32
-  OrigDataType: int32
-T_598: (in esp_103 - 4 : word32)
-  Class: Eq_596
-  DataType: (ptr32 Eq_140)
-  OrigDataType: ptr32
-T_599: (in 0x00000000 : word32)
-  Class: Eq_599
-  DataType: word32
-  OrigDataType: word32
-T_600: (in esp_81 + 0x00000000 : word32)
-  Class: Eq_600
-  DataType: ptr32
-  OrigDataType: ptr32
-T_601: (in Mem83[esp_81 + 0x00000000:word32] : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_602: (in 4 : int32)
-  Class: Eq_602
-  DataType: int32
-  OrigDataType: int32
-T_603: (in esp_81 - 4 : word32)
-  Class: Eq_603
-  DataType: (ptr32 Eq_136)
-  OrigDataType: (ptr32 (struct (0 T_606 t0000)))
-T_604: (in 0x00000000 : word32)
-  Class: Eq_604
-  DataType: word32
-  OrigDataType: word32
-T_605: (in esp_81 - 4 + 0x00000000 : word32)
-  Class: Eq_605
-  DataType: ptr32
-  OrigDataType: ptr32
-T_606: (in Mem86[esp_81 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: word32
-T_607: (in 8 : int32)
-  Class: Eq_607
-  DataType: int32
-  OrigDataType: int32
-T_608: (in esp_81 - 8 : word32)
-  Class: Eq_608
-  DataType: (ptr32 Eq_137)
-  OrigDataType: (ptr32 (struct (0 T_611 t0000)))
-T_609: (in 0x00000000 : word32)
-  Class: Eq_609
-  DataType: word32
-  OrigDataType: word32
-T_610: (in esp_81 - 8 + 0x00000000 : word32)
-  Class: Eq_610
-  DataType: ptr32
-  OrigDataType: ptr32
-T_611: (in Mem89[esp_81 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_137
-  DataType: Eq_137
-  OrigDataType: word32
-T_612: (in eax_92 : ui32)
-  Class: Eq_612
-  DataType: ui32
-  OrigDataType: word32
-T_613: (in fn100011E9 : ptr32)
-  Class: Eq_613
-  DataType: (ptr32 Eq_613)
-  OrigDataType: (ptr32 (fn T_626 (T_518, T_442, T_431, T_427, T_426, T_619, T_621, T_622, T_623, T_624, T_625)))
-T_614: (in signature of fn100011E9 : void)
-  Class: Eq_613
-  DataType: (ptr32 Eq_613)
-  OrigDataType: 
-T_615: (in 4 : int32)
-  Class: Eq_615
-  DataType: int32
-  OrigDataType: int32
-T_616: (in esp_81 - 4 : word32)
-  Class: Eq_616
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_619 t0000)))
-T_617: (in 0x00000000 : word32)
-  Class: Eq_617
-  DataType: word32
-  OrigDataType: word32
-T_618: (in esp_81 - 4 + 0x00000000 : word32)
-  Class: Eq_618
-  DataType: ptr32
-  OrigDataType: ptr32
-T_619: (in Mem89[esp_81 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_141
-  DataType: word32
-  OrigDataType: word32
-T_620: (in ecx_302 : word32)
-  Class: Eq_620
-  DataType: word32
-  OrigDataType: word32
-T_621: (in out ecx_302 : ptr32)
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: ptr32
-T_622: (in out edx : ptr32)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: ptr32
-T_623: (in out ebx_116 : ptr32)
-  Class: Eq_137
-  DataType: Eq_137
-  OrigDataType: ptr32
-T_624: (in out esi_113 : ptr32)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: ptr32
-T_625: (in out edi_110 : ptr32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: ptr32
-T_626: (in fn100011E9(edx_65, ebx_116, ebp_13, edx, ecx, *(esp_81 - 4), out ecx_302, out edx, out ebx_116, out esi_113, out edi_110) : word32)
-  Class: Eq_612
-  DataType: ui32
-  OrigDataType: word32
-T_627: (in 0x0000001C : word32)
-  Class: Eq_627
-  DataType: ui32
-  OrigDataType: ui32
-T_628: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_628
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_631 t0000)))
-T_629: (in 0x00000000 : word32)
-  Class: Eq_629
-  DataType: word32
-  OrigDataType: word32
-T_630: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_630
-  DataType: ptr32
-  OrigDataType: ptr32
-T_631: (in Mem104[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_612
-  DataType: ui32
-  OrigDataType: word32
-T_632: (in 0x00000004 : word32)
-  Class: Eq_632
-  DataType: int32
-  OrigDataType: int32
-T_633: (in esp_81 + 0x00000004 : word32)
-  Class: Eq_395
-  DataType: Eq_395
-  OrigDataType: ptr32
-T_634: (in 0x00000000 : word32)
-  Class: Eq_612
-  DataType: ui32
-  OrigDataType: word32
-T_635: (in eax_92 == 0x00000000 : bool)
-  Class: Eq_635
-  DataType: bool
-  OrigDataType: bool
-T_636: (in 0x00000000 : word32)
-  Class: Eq_136
-  DataType: ptr32
-  OrigDataType: word32
-T_637: (in esi_113 == 0x00000000 : bool)
-  Class: Eq_637
-  DataType: bool
-  OrigDataType: bool
-T_638: (in 0x00000000 : word32)
-  Class: Eq_542
-  DataType: word32
-  OrigDataType: word32
-T_639: (in eax_118 != 0x00000000 : bool)
-  Class: Eq_639
-  DataType: bool
-  OrigDataType: bool
-T_640: (in 0x00000000 : word32)
-  Class: Eq_640
-  DataType: word32
-  OrigDataType: word32
-T_641: (in esp_109 + 0x00000000 : word32)
-  Class: Eq_641
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_642: (in Mem132[esp_109 + 0x00000000:word32] : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_643: (in 4 : int32)
-  Class: Eq_643
-  DataType: int32
-  OrigDataType: int32
-T_644: (in esp_109 - 4 : word32)
-  Class: Eq_644
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_647 t0000)))
-T_645: (in 0x00000000 : word32)
-  Class: Eq_645
-  DataType: word32
-  OrigDataType: word32
-T_646: (in esp_109 - 4 + 0x00000000 : word32)
-  Class: Eq_646
-  DataType: ptr32
-  OrigDataType: ptr32
-T_647: (in Mem134[esp_109 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_542
-  DataType: word32
-  OrigDataType: word32
-T_648: (in 8 : int32)
-  Class: Eq_648
-  DataType: int32
-  OrigDataType: int32
-T_649: (in esp_109 - 8 : word32)
-  Class: Eq_649
-  DataType: (ptr32 Eq_137)
-  OrigDataType: (ptr32 (struct (0 T_652 t0000)))
-T_650: (in 0x00000000 : word32)
-  Class: Eq_650
-  DataType: word32
-  OrigDataType: word32
-T_651: (in esp_109 - 8 + 0x00000000 : word32)
-  Class: Eq_651
-  DataType: ptr32
-  OrigDataType: ptr32
-T_652: (in Mem136[esp_109 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_137
-  DataType: Eq_137
-  OrigDataType: word32
-T_653: (in fn100017C6 : ptr32)
+T_557: (in fn100017C6(*(esp_109 - 8), *(esp_109 - 4)) : word32)
   Class: Eq_543
-  DataType: (ptr32 Eq_543)
-  OrigDataType: (ptr32 (fn T_663 (T_657, T_662)))
-T_654: (in esp_109 - 8 : word32)
-  Class: Eq_654
-  DataType: (ptr32 Eq_545)
-  OrigDataType: (ptr32 (struct (0 T_657 t0000)))
-T_655: (in 0x00000000 : word32)
-  Class: Eq_655
   DataType: word32
   OrigDataType: word32
-T_656: (in esp_109 - 8 + 0x00000000 : word32)
-  Class: Eq_656
-  DataType: ptr32
-  OrigDataType: ptr32
-T_657: (in Mem136[esp_109 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_545
-  DataType: Eq_545
-  OrigDataType: word32
-T_658: (in 4 : int32)
-  Class: Eq_658
-  DataType: int32
-  OrigDataType: int32
-T_659: (in esp_109 - 4 : word32)
-  Class: Eq_659
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_662 t0000)))
-T_660: (in 0x00000000 : word32)
-  Class: Eq_660
-  DataType: word32
-  OrigDataType: word32
-T_661: (in esp_109 - 4 + 0x00000000 : word32)
-  Class: Eq_661
-  DataType: ptr32
-  OrigDataType: ptr32
-T_662: (in Mem136[esp_109 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_546
-  DataType: word32
-  OrigDataType: word32
-T_663: (in fn100017C6(*(esp_109 - 8), *(esp_109 - 4)) : word32)
-  Class: Eq_542
-  DataType: word32
-  OrigDataType: word32
-T_664: (in 0x00000000 : word32)
-  Class: Eq_664
-  DataType: word32
-  OrigDataType: word32
-T_665: (in esp_109 + 0x00000000 : word32)
-  Class: Eq_665
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_666: (in Mem144[esp_109 + 0x00000000:word32] : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_667: (in 0x00000000 : word32)
-  Class: Eq_667
-  DataType: word32
-  OrigDataType: word32
-T_668: (in 4 : int32)
-  Class: Eq_668
-  DataType: int32
-  OrigDataType: int32
-T_669: (in esp_109 - 4 : word32)
-  Class: Eq_669
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_672 t0000)))
-T_670: (in 0x00000000 : word32)
-  Class: Eq_670
-  DataType: word32
-  OrigDataType: word32
-T_671: (in esp_109 - 4 + 0x00000000 : word32)
-  Class: Eq_671
-  DataType: ptr32
-  OrigDataType: ptr32
-T_672: (in Mem146[esp_109 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_667
-  DataType: word32
-  OrigDataType: word32
-T_673: (in 8 : int32)
-  Class: Eq_673
-  DataType: int32
-  OrigDataType: int32
-T_674: (in esp_109 - 8 : word32)
-  Class: Eq_674
-  DataType: (ptr32 Eq_137)
-  OrigDataType: (ptr32 (struct (0 T_677 t0000)))
-T_675: (in 0x00000000 : word32)
-  Class: Eq_675
-  DataType: word32
-  OrigDataType: word32
-T_676: (in esp_109 - 8 + 0x00000000 : word32)
-  Class: Eq_676
-  DataType: ptr32
-  OrigDataType: ptr32
-T_677: (in Mem148[esp_109 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_137
-  DataType: Eq_137
-  OrigDataType: word32
-T_678: (in ecx_153 : word32)
-  Class: Eq_678
-  DataType: word32
-  OrigDataType: word32
-T_679: (in fn100011E9 : ptr32)
-  Class: Eq_613
-  DataType: (ptr32 Eq_613)
-  OrigDataType: (ptr32 (fn T_690 (T_427, T_442, T_431, T_468, T_467, T_684, T_685, T_686, T_687, T_688, T_689)))
-T_680: (in 4 : int32)
-  Class: Eq_680
-  DataType: int32
-  OrigDataType: int32
-T_681: (in esp_109 - 4 : word32)
-  Class: Eq_681
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_684 t0000)))
-T_682: (in 0x00000000 : word32)
-  Class: Eq_682
-  DataType: word32
-  OrigDataType: word32
-T_683: (in esp_109 - 4 + 0x00000000 : word32)
-  Class: Eq_683
-  DataType: ptr32
-  OrigDataType: ptr32
-T_684: (in Mem148[esp_109 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_141
-  DataType: word32
-  OrigDataType: word32
-T_685: (in out ecx_153 : ptr32)
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: ptr32
-T_686: (in out edx : ptr32)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: ptr32
-T_687: (in out ebx_116 : ptr32)
-  Class: Eq_137
-  DataType: Eq_137
-  OrigDataType: ptr32
-T_688: (in out esi_113 : ptr32)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: ptr32
-T_689: (in out edi_110 : ptr32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: ptr32
-T_690: (in fn100011E9(edx, ebx_116, ebp_13, esi_113, edi_110, *(esp_109 - 4), out ecx_153, out edx, out ebx_116, out esi_113, out edi_110) : word32)
-  Class: Eq_612
+T_558: (in 0x0000001C : word32)
+  Class: Eq_558
   DataType: ui32
+  OrigDataType: ui32
+T_559: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_559
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_562 t0000)))
+T_560: (in 0x00000000 : word32)
+  Class: Eq_560
+  DataType: word32
   OrigDataType: word32
-T_691: (in Top_155 : Eq_395)
-  Class: Eq_395
-  DataType: Eq_395
-  OrigDataType: int8
-T_692: (in 0x00000004 : word32)
-  Class: Eq_692
+T_561: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_561
+  DataType: ptr32
+  OrigDataType: ptr32
+T_562: (in Mem125[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_543
+  DataType: word32
+  OrigDataType: word32
+T_563: (in 0x00000004 : word32)
+  Class: Eq_563
   DataType: int32
   OrigDataType: int32
-T_693: (in esp_109 + 0x00000004 : word32)
-  Class: Eq_395
-  DataType: Eq_395
+T_564: (in esp_109 + 0x00000004 : word32)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: ptr32
-T_694: (in eax_163 : word32)
-  Class: Eq_519
-  DataType: word32
+T_565: (in 0x00000001 : word32)
+  Class: Eq_137
+  DataType: ptr32
   OrigDataType: word32
-T_695: (in 100020CC : ptr32)
-  Class: Eq_695
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_696 t0000)))
-T_696: (in Mem148[0x100020CC:word32] : word32)
-  Class: Eq_519
-  DataType: word32
-  OrigDataType: word32
-T_697: (in 0x00000000 : word32)
-  Class: Eq_519
-  DataType: word32
-  OrigDataType: word32
-T_698: (in eax_163 == 0x00000000 : bool)
-  Class: Eq_698
+T_566: (in esi_113 != 0x00000001 : bool)
+  Class: Eq_566
   DataType: bool
   OrigDataType: bool
-T_699: (in 0x00000000 : word32)
-  Class: Eq_699
-  DataType: word32
-  OrigDataType: word32
-T_700: (in esp_109 + 0x00000000 : word32)
-  Class: Eq_700
+T_567: (in 0x0000001C : word32)
+  Class: Eq_567
+  DataType: ui32
+  OrigDataType: ui32
+T_568: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_568
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_701: (in Mem168[esp_109 + 0x00000000:word32] : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_702: (in 0x00000000 : word32)
-  Class: Eq_702
+  OrigDataType: (ptr32 (struct (0 T_571 t0000)))
+T_569: (in 0x00000000 : word32)
+  Class: Eq_569
   DataType: word32
   OrigDataType: word32
-T_703: (in 4 : int32)
-  Class: Eq_703
-  DataType: int32
-  OrigDataType: int32
-T_704: (in esp_109 - 4 : word32)
-  Class: Eq_704
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_707 t0000)))
-T_705: (in 0x00000000 : word32)
-  Class: Eq_705
-  DataType: word32
-  OrigDataType: word32
-T_706: (in esp_109 - 4 + 0x00000000 : word32)
-  Class: Eq_706
+T_570: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_570
   DataType: ptr32
   OrigDataType: ptr32
-T_707: (in Mem170[esp_109 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_702
+T_571: (in Mem77[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_571
   DataType: word32
   OrigDataType: word32
-T_708: (in 8 : int32)
-  Class: Eq_708
+T_572: (in 0x00000000 : word32)
+  Class: Eq_571
+  DataType: word32
+  OrigDataType: word32
+T_573: (in *(ebp_13 - 0x0000001C) == 0x00000000 : bool)
+  Class: Eq_573
+  DataType: bool
+  OrigDataType: bool
+T_574: (in 4 : int32)
+  Class: Eq_574
   DataType: int32
   OrigDataType: int32
-T_709: (in esp_109 - 8 : word32)
-  Class: Eq_709
+T_575: (in esp_103 - 4 : word32)
+  Class: Eq_575
+  DataType: (ptr32 Eq_141)
+  OrigDataType: (ptr32 (struct (0 T_578 t0000)))
+T_576: (in 0x00000000 : word32)
+  Class: Eq_576
+  DataType: word32
+  OrigDataType: word32
+T_577: (in esp_103 - 4 + 0x00000000 : word32)
+  Class: Eq_577
+  DataType: ptr32
+  OrigDataType: ptr32
+T_578: (in Mem53[esp_103 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: word32
+T_579: (in 8 : int32)
+  Class: Eq_579
+  DataType: int32
+  OrigDataType: int32
+T_580: (in esp_103 - 8 : word32)
+  Class: Eq_580
   DataType: (ptr32 Eq_137)
-  OrigDataType: (ptr32 (struct (0 T_712 t0000)))
-T_710: (in 0x00000000 : word32)
-  Class: Eq_710
+  OrigDataType: (ptr32 (struct (0 T_583 t0000)))
+T_581: (in 0x00000000 : word32)
+  Class: Eq_581
   DataType: word32
   OrigDataType: word32
-T_711: (in esp_109 - 8 + 0x00000000 : word32)
-  Class: Eq_711
+T_582: (in esp_103 - 8 + 0x00000000 : word32)
+  Class: Eq_582
   DataType: ptr32
   OrigDataType: ptr32
-T_712: (in Mem172[esp_109 - 8 + 0x00000000:word32] : word32)
+T_583: (in Mem56[esp_103 - 8 + 0x00000000:word32] : word32)
   Class: Eq_137
   DataType: Eq_137
   OrigDataType: word32
-T_713: (in fn00000000 : ptr32)
-  Class: Eq_713
+T_584: (in 12 : int32)
+  Class: Eq_584
+  DataType: int32
+  OrigDataType: int32
+T_585: (in esp_103 - 12 : word32)
+  Class: Eq_585
+  DataType: (ptr32 Eq_138)
+  OrigDataType: (ptr32 (struct (0 T_588 t0000)))
+T_586: (in 0x00000000 : word32)
+  Class: Eq_586
+  DataType: word32
+  OrigDataType: word32
+T_587: (in esp_103 - 12 + 0x00000000 : word32)
+  Class: Eq_587
+  DataType: ptr32
+  OrigDataType: ptr32
+T_588: (in Mem60[esp_103 - 12 + 0x00000000:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: word32
+T_589: (in eax_68 : word32)
+  Class: Eq_589
+  DataType: word32
+  OrigDataType: word32
+T_590: (in fn00000000 : ptr32)
+  Class: Eq_590
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_714: (in signature of fn00000000 : void)
-  Class: Eq_714
-  DataType: Eq_714
+T_591: (in signature of fn00000000 : void)
+  Class: Eq_591
+  DataType: Eq_591
   OrigDataType: 
-T_715: (in esp_187 : (ptr32 Eq_140))
-  Class: Eq_715
-  DataType: (ptr32 Eq_140)
-  OrigDataType: (ptr32 (struct (0 T_140 t0000)))
-T_716: (in 4 : int32)
-  Class: Eq_716
-  DataType: int32
-  OrigDataType: int32
-T_717: (in esp_103 - 4 : word32)
-  Class: Eq_715
-  DataType: (ptr32 Eq_140)
-  OrigDataType: ptr32
-T_718: (in 0x00000000 : word32)
-  Class: Eq_718
+T_592: (in 0x0000001C : word32)
+  Class: Eq_592
+  DataType: ui32
+  OrigDataType: ui32
+T_593: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_593
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_596 t0000)))
+T_594: (in 0x00000000 : word32)
+  Class: Eq_594
   DataType: word32
   OrigDataType: word32
-T_719: (in esp_187 + 0x00000000 : word32)
-  Class: Eq_719
+T_595: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_595
   DataType: ptr32
   OrigDataType: ptr32
-T_720: (in Mem190[esp_187 + 0x00000000:word32] : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_721: (in 4 : int32)
-  Class: Eq_721
-  DataType: int32
-  OrigDataType: int32
-T_722: (in esp_187 - 4 : word32)
-  Class: Eq_722
-  DataType: (ptr32 Eq_136)
-  OrigDataType: (ptr32 (struct (0 T_725 t0000)))
-T_723: (in 0x00000000 : word32)
-  Class: Eq_723
+T_596: (in Mem75[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_589
   DataType: word32
   OrigDataType: word32
-T_724: (in esp_187 - 4 + 0x00000000 : word32)
-  Class: Eq_724
-  DataType: ptr32
-  OrigDataType: ptr32
-T_725: (in Mem193[esp_187 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: word32
-T_726: (in 8 : int32)
-  Class: Eq_726
+T_597: (in esp_81 : (ptr32 Eq_141))
+  Class: Eq_597
+  DataType: (ptr32 Eq_141)
+  OrigDataType: (ptr32 (struct (0 T_602 t0000)))
+T_598: (in 4 : int32)
+  Class: Eq_598
   DataType: int32
   OrigDataType: int32
-T_727: (in esp_187 - 8 : word32)
-  Class: Eq_727
+T_599: (in esp_103 - 4 : word32)
+  Class: Eq_597
+  DataType: (ptr32 Eq_141)
+  OrigDataType: ptr32
+T_600: (in 0x00000000 : word32)
+  Class: Eq_600
+  DataType: word32
+  OrigDataType: word32
+T_601: (in esp_81 + 0x00000000 : word32)
+  Class: Eq_601
+  DataType: ptr32
+  OrigDataType: ptr32
+T_602: (in Mem83[esp_81 + 0x00000000:word32] : word32)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: word32
+T_603: (in 4 : int32)
+  Class: Eq_603
+  DataType: int32
+  OrigDataType: int32
+T_604: (in esp_81 - 4 : word32)
+  Class: Eq_604
   DataType: (ptr32 Eq_137)
-  OrigDataType: (ptr32 (struct (0 T_730 t0000)))
-T_728: (in 0x00000000 : word32)
-  Class: Eq_728
+  OrigDataType: (ptr32 (struct (0 T_607 t0000)))
+T_605: (in 0x00000000 : word32)
+  Class: Eq_605
   DataType: word32
   OrigDataType: word32
-T_729: (in esp_187 - 8 + 0x00000000 : word32)
-  Class: Eq_729
+T_606: (in esp_81 - 4 + 0x00000000 : word32)
+  Class: Eq_606
   DataType: ptr32
   OrigDataType: ptr32
-T_730: (in Mem197[esp_187 - 8 + 0x00000000:word32] : word32)
+T_607: (in Mem86[esp_81 - 4 + 0x00000000:word32] : word32)
   Class: Eq_137
   DataType: Eq_137
   OrigDataType: word32
-T_731: (in ebx_205 : word32)
-  Class: Eq_731
+T_608: (in 8 : int32)
+  Class: Eq_608
+  DataType: int32
+  OrigDataType: int32
+T_609: (in esp_81 - 8 : word32)
+  Class: Eq_609
+  DataType: (ptr32 Eq_138)
+  OrigDataType: (ptr32 (struct (0 T_612 t0000)))
+T_610: (in 0x00000000 : word32)
+  Class: Eq_610
   DataType: word32
   OrigDataType: word32
-T_732: (in ecx_206 : word32)
+T_611: (in esp_81 - 8 + 0x00000000 : word32)
+  Class: Eq_611
+  DataType: ptr32
+  OrigDataType: ptr32
+T_612: (in Mem89[esp_81 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: word32
+T_613: (in eax_92 : ui32)
+  Class: Eq_613
+  DataType: ui32
+  OrigDataType: word32
+T_614: (in fn100011E9 : ptr32)
+  Class: Eq_614
+  DataType: (ptr32 Eq_614)
+  OrigDataType: (ptr32 (fn T_627 (T_519, T_443, T_432, T_428, T_427, T_620, T_622, T_623, T_624, T_625, T_626)))
+T_615: (in signature of fn100011E9 : void)
+  Class: Eq_614
+  DataType: (ptr32 Eq_614)
+  OrigDataType: 
+T_616: (in 4 : int32)
+  Class: Eq_616
+  DataType: int32
+  OrigDataType: int32
+T_617: (in esp_81 - 4 : word32)
+  Class: Eq_617
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_620 t0000)))
+T_618: (in 0x00000000 : word32)
+  Class: Eq_618
+  DataType: word32
+  OrigDataType: word32
+T_619: (in esp_81 - 4 + 0x00000000 : word32)
+  Class: Eq_619
+  DataType: ptr32
+  OrigDataType: ptr32
+T_620: (in Mem89[esp_81 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_142
+  DataType: word32
+  OrigDataType: word32
+T_621: (in ecx_302 : word32)
+  Class: Eq_621
+  DataType: word32
+  OrigDataType: word32
+T_622: (in out ecx_302 : ptr32)
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: ptr32
+T_623: (in out edx : ptr32)
+  Class: Eq_137
+  DataType: Eq_137
+  OrigDataType: ptr32
+T_624: (in out ebx_116 : ptr32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: ptr32
+T_625: (in out esi_113 : ptr32)
+  Class: Eq_137
+  DataType: Eq_137
+  OrigDataType: ptr32
+T_626: (in out edi_110 : ptr32)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: ptr32
+T_627: (in fn100011E9(edx_65, ebx_116, ebp_13, edx, ecx, *(esp_81 - 4), out ecx_302, out edx, out ebx_116, out esi_113, out edi_110) : word32)
+  Class: Eq_613
+  DataType: ui32
+  OrigDataType: word32
+T_628: (in 0x0000001C : word32)
+  Class: Eq_628
+  DataType: ui32
+  OrigDataType: ui32
+T_629: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_629
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_632 t0000)))
+T_630: (in 0x00000000 : word32)
+  Class: Eq_630
+  DataType: word32
+  OrigDataType: word32
+T_631: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_631
+  DataType: ptr32
+  OrigDataType: ptr32
+T_632: (in Mem104[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_613
+  DataType: ui32
+  OrigDataType: word32
+T_633: (in 0x00000004 : word32)
+  Class: Eq_633
+  DataType: int32
+  OrigDataType: int32
+T_634: (in esp_81 + 0x00000004 : word32)
+  Class: Eq_396
+  DataType: Eq_396
+  OrigDataType: ptr32
+T_635: (in 0x00000000 : word32)
+  Class: Eq_613
+  DataType: ui32
+  OrigDataType: word32
+T_636: (in eax_92 == 0x00000000 : bool)
+  Class: Eq_636
+  DataType: bool
+  OrigDataType: bool
+T_637: (in 0x00000000 : word32)
+  Class: Eq_137
+  DataType: ptr32
+  OrigDataType: word32
+T_638: (in esi_113 == 0x00000000 : bool)
+  Class: Eq_638
+  DataType: bool
+  OrigDataType: bool
+T_639: (in 0x00000000 : word32)
+  Class: Eq_543
+  DataType: word32
+  OrigDataType: word32
+T_640: (in eax_118 != 0x00000000 : bool)
+  Class: Eq_640
+  DataType: bool
+  OrigDataType: bool
+T_641: (in 0x00000000 : word32)
+  Class: Eq_641
+  DataType: word32
+  OrigDataType: word32
+T_642: (in esp_109 + 0x00000000 : word32)
+  Class: Eq_642
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_643: (in Mem132[esp_109 + 0x00000000:word32] : word32)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: word32
+T_644: (in 4 : int32)
+  Class: Eq_644
+  DataType: int32
+  OrigDataType: int32
+T_645: (in esp_109 - 4 : word32)
+  Class: Eq_645
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_648 t0000)))
+T_646: (in 0x00000000 : word32)
+  Class: Eq_646
+  DataType: word32
+  OrigDataType: word32
+T_647: (in esp_109 - 4 + 0x00000000 : word32)
+  Class: Eq_647
+  DataType: ptr32
+  OrigDataType: ptr32
+T_648: (in Mem134[esp_109 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_543
+  DataType: word32
+  OrigDataType: word32
+T_649: (in 8 : int32)
+  Class: Eq_649
+  DataType: int32
+  OrigDataType: int32
+T_650: (in esp_109 - 8 : word32)
+  Class: Eq_650
+  DataType: (ptr32 Eq_138)
+  OrigDataType: (ptr32 (struct (0 T_653 t0000)))
+T_651: (in 0x00000000 : word32)
+  Class: Eq_651
+  DataType: word32
+  OrigDataType: word32
+T_652: (in esp_109 - 8 + 0x00000000 : word32)
+  Class: Eq_652
+  DataType: ptr32
+  OrigDataType: ptr32
+T_653: (in Mem136[esp_109 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: word32
+T_654: (in fn100017C6 : ptr32)
+  Class: Eq_544
+  DataType: (ptr32 Eq_544)
+  OrigDataType: (ptr32 (fn T_664 (T_658, T_663)))
+T_655: (in esp_109 - 8 : word32)
+  Class: Eq_655
+  DataType: (ptr32 Eq_546)
+  OrigDataType: (ptr32 (struct (0 T_658 t0000)))
+T_656: (in 0x00000000 : word32)
+  Class: Eq_656
+  DataType: word32
+  OrigDataType: word32
+T_657: (in esp_109 - 8 + 0x00000000 : word32)
+  Class: Eq_657
+  DataType: ptr32
+  OrigDataType: ptr32
+T_658: (in Mem136[esp_109 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_546
+  DataType: Eq_546
+  OrigDataType: word32
+T_659: (in 4 : int32)
+  Class: Eq_659
+  DataType: int32
+  OrigDataType: int32
+T_660: (in esp_109 - 4 : word32)
+  Class: Eq_660
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_663 t0000)))
+T_661: (in 0x00000000 : word32)
+  Class: Eq_661
+  DataType: word32
+  OrigDataType: word32
+T_662: (in esp_109 - 4 + 0x00000000 : word32)
+  Class: Eq_662
+  DataType: ptr32
+  OrigDataType: ptr32
+T_663: (in Mem136[esp_109 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_547
+  DataType: word32
+  OrigDataType: word32
+T_664: (in fn100017C6(*(esp_109 - 8), *(esp_109 - 4)) : word32)
+  Class: Eq_543
+  DataType: word32
+  OrigDataType: word32
+T_665: (in 0x00000000 : word32)
+  Class: Eq_665
+  DataType: word32
+  OrigDataType: word32
+T_666: (in esp_109 + 0x00000000 : word32)
+  Class: Eq_666
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_667: (in Mem144[esp_109 + 0x00000000:word32] : word32)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: word32
+T_668: (in 0x00000000 : word32)
+  Class: Eq_668
+  DataType: word32
+  OrigDataType: word32
+T_669: (in 4 : int32)
+  Class: Eq_669
+  DataType: int32
+  OrigDataType: int32
+T_670: (in esp_109 - 4 : word32)
+  Class: Eq_670
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_673 t0000)))
+T_671: (in 0x00000000 : word32)
+  Class: Eq_671
+  DataType: word32
+  OrigDataType: word32
+T_672: (in esp_109 - 4 + 0x00000000 : word32)
+  Class: Eq_672
+  DataType: ptr32
+  OrigDataType: ptr32
+T_673: (in Mem146[esp_109 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_668
+  DataType: word32
+  OrigDataType: word32
+T_674: (in 8 : int32)
+  Class: Eq_674
+  DataType: int32
+  OrigDataType: int32
+T_675: (in esp_109 - 8 : word32)
+  Class: Eq_675
+  DataType: (ptr32 Eq_138)
+  OrigDataType: (ptr32 (struct (0 T_678 t0000)))
+T_676: (in 0x00000000 : word32)
+  Class: Eq_676
+  DataType: word32
+  OrigDataType: word32
+T_677: (in esp_109 - 8 + 0x00000000 : word32)
+  Class: Eq_677
+  DataType: ptr32
+  OrigDataType: ptr32
+T_678: (in Mem148[esp_109 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: word32
+T_679: (in ecx_153 : word32)
+  Class: Eq_679
+  DataType: word32
+  OrigDataType: word32
+T_680: (in fn100011E9 : ptr32)
+  Class: Eq_614
+  DataType: (ptr32 Eq_614)
+  OrigDataType: (ptr32 (fn T_691 (T_428, T_443, T_432, T_469, T_468, T_685, T_686, T_687, T_688, T_689, T_690)))
+T_681: (in 4 : int32)
+  Class: Eq_681
+  DataType: int32
+  OrigDataType: int32
+T_682: (in esp_109 - 4 : word32)
+  Class: Eq_682
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_685 t0000)))
+T_683: (in 0x00000000 : word32)
+  Class: Eq_683
+  DataType: word32
+  OrigDataType: word32
+T_684: (in esp_109 - 4 + 0x00000000 : word32)
+  Class: Eq_684
+  DataType: ptr32
+  OrigDataType: ptr32
+T_685: (in Mem148[esp_109 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_142
+  DataType: word32
+  OrigDataType: word32
+T_686: (in out ecx_153 : ptr32)
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: ptr32
+T_687: (in out edx : ptr32)
+  Class: Eq_137
+  DataType: Eq_137
+  OrigDataType: ptr32
+T_688: (in out ebx_116 : ptr32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: ptr32
+T_689: (in out esi_113 : ptr32)
+  Class: Eq_137
+  DataType: Eq_137
+  OrigDataType: ptr32
+T_690: (in out edi_110 : ptr32)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: ptr32
+T_691: (in fn100011E9(edx, ebx_116, ebp_13, esi_113, edi_110, *(esp_109 - 4), out ecx_153, out edx, out ebx_116, out esi_113, out edi_110) : word32)
+  Class: Eq_613
+  DataType: ui32
+  OrigDataType: word32
+T_692: (in Top_155 : Eq_396)
+  Class: Eq_396
+  DataType: Eq_396
+  OrigDataType: int8
+T_693: (in 0x00000004 : word32)
+  Class: Eq_693
+  DataType: int32
+  OrigDataType: int32
+T_694: (in esp_109 + 0x00000004 : word32)
+  Class: Eq_396
+  DataType: Eq_396
+  OrigDataType: ptr32
+T_695: (in eax_163 : word32)
+  Class: Eq_520
+  DataType: word32
+  OrigDataType: word32
+T_696: (in 100020CC : ptr32)
+  Class: Eq_696
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_697 t0000)))
+T_697: (in Mem148[0x100020CC:word32] : word32)
+  Class: Eq_520
+  DataType: word32
+  OrigDataType: word32
+T_698: (in 0x00000000 : word32)
+  Class: Eq_520
+  DataType: word32
+  OrigDataType: word32
+T_699: (in eax_163 == 0x00000000 : bool)
+  Class: Eq_699
+  DataType: bool
+  OrigDataType: bool
+T_700: (in 0x00000000 : word32)
+  Class: Eq_700
+  DataType: word32
+  OrigDataType: word32
+T_701: (in esp_109 + 0x00000000 : word32)
+  Class: Eq_701
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_702: (in Mem168[esp_109 + 0x00000000:word32] : word32)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: word32
+T_703: (in 0x00000000 : word32)
+  Class: Eq_703
+  DataType: word32
+  OrigDataType: word32
+T_704: (in 4 : int32)
+  Class: Eq_704
+  DataType: int32
+  OrigDataType: int32
+T_705: (in esp_109 - 4 : word32)
+  Class: Eq_705
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_708 t0000)))
+T_706: (in 0x00000000 : word32)
+  Class: Eq_706
+  DataType: word32
+  OrigDataType: word32
+T_707: (in esp_109 - 4 + 0x00000000 : word32)
+  Class: Eq_707
+  DataType: ptr32
+  OrigDataType: ptr32
+T_708: (in Mem170[esp_109 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_703
+  DataType: word32
+  OrigDataType: word32
+T_709: (in 8 : int32)
+  Class: Eq_709
+  DataType: int32
+  OrigDataType: int32
+T_710: (in esp_109 - 8 : word32)
+  Class: Eq_710
+  DataType: (ptr32 Eq_138)
+  OrigDataType: (ptr32 (struct (0 T_713 t0000)))
+T_711: (in 0x00000000 : word32)
+  Class: Eq_711
+  DataType: word32
+  OrigDataType: word32
+T_712: (in esp_109 - 8 + 0x00000000 : word32)
+  Class: Eq_712
+  DataType: ptr32
+  OrigDataType: ptr32
+T_713: (in Mem172[esp_109 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: word32
+T_714: (in fn00000000 : ptr32)
+  Class: Eq_714
+  DataType: (ptr32 code)
+  OrigDataType: (ptr32 code)
+T_715: (in signature of fn00000000 : void)
+  Class: Eq_715
+  DataType: Eq_715
+  OrigDataType: 
+T_716: (in esp_187 : (ptr32 Eq_141))
+  Class: Eq_716
+  DataType: (ptr32 Eq_141)
+  OrigDataType: (ptr32 (struct (0 T_141 t0000)))
+T_717: (in 4 : int32)
+  Class: Eq_717
+  DataType: int32
+  OrigDataType: int32
+T_718: (in esp_103 - 4 : word32)
+  Class: Eq_716
+  DataType: (ptr32 Eq_141)
+  OrigDataType: ptr32
+T_719: (in 0x00000000 : word32)
+  Class: Eq_719
+  DataType: word32
+  OrigDataType: word32
+T_720: (in esp_187 + 0x00000000 : word32)
+  Class: Eq_720
+  DataType: ptr32
+  OrigDataType: ptr32
+T_721: (in Mem190[esp_187 + 0x00000000:word32] : word32)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: word32
+T_722: (in 4 : int32)
+  Class: Eq_722
+  DataType: int32
+  OrigDataType: int32
+T_723: (in esp_187 - 4 : word32)
+  Class: Eq_723
+  DataType: (ptr32 Eq_137)
+  OrigDataType: (ptr32 (struct (0 T_726 t0000)))
+T_724: (in 0x00000000 : word32)
+  Class: Eq_724
+  DataType: word32
+  OrigDataType: word32
+T_725: (in esp_187 - 4 + 0x00000000 : word32)
+  Class: Eq_725
+  DataType: ptr32
+  OrigDataType: ptr32
+T_726: (in Mem193[esp_187 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_137
+  DataType: Eq_137
+  OrigDataType: word32
+T_727: (in 8 : int32)
+  Class: Eq_727
+  DataType: int32
+  OrigDataType: int32
+T_728: (in esp_187 - 8 : word32)
+  Class: Eq_728
+  DataType: (ptr32 Eq_138)
+  OrigDataType: (ptr32 (struct (0 T_731 t0000)))
+T_729: (in 0x00000000 : word32)
+  Class: Eq_729
+  DataType: word32
+  OrigDataType: word32
+T_730: (in esp_187 - 8 + 0x00000000 : word32)
+  Class: Eq_730
+  DataType: ptr32
+  OrigDataType: ptr32
+T_731: (in Mem197[esp_187 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: word32
+T_732: (in ebx_205 : word32)
   Class: Eq_732
   DataType: word32
   OrigDataType: word32
-T_733: (in esi_207 : word32)
+T_733: (in ecx_206 : word32)
   Class: Eq_733
   DataType: word32
   OrigDataType: word32
-T_734: (in edi_209 : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_735: (in edx_210 : word32)
-  Class: Eq_735
+T_734: (in esi_207 : word32)
+  Class: Eq_734
   DataType: word32
   OrigDataType: word32
-T_736: (in eax_204 : ui32)
-  Class: Eq_612
+T_735: (in edi_209 : Eq_141)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: word32
+T_736: (in edx_210 : word32)
+  Class: Eq_736
+  DataType: word32
+  OrigDataType: word32
+T_737: (in eax_204 : ui32)
+  Class: Eq_613
   DataType: ui32
   OrigDataType: ui32
-T_737: (in fn100011E9 : ptr32)
-  Class: Eq_613
-  DataType: (ptr32 Eq_613)
-  OrigDataType: (ptr32 (fn T_748 (T_427, T_442, T_431, T_468, T_467, T_742, T_743, T_744, T_745, T_746, T_747)))
-T_738: (in 4 : int32)
-  Class: Eq_738
+T_738: (in fn100011E9 : ptr32)
+  Class: Eq_614
+  DataType: (ptr32 Eq_614)
+  OrigDataType: (ptr32 (fn T_749 (T_428, T_443, T_432, T_469, T_468, T_743, T_744, T_745, T_746, T_747, T_748)))
+T_739: (in 4 : int32)
+  Class: Eq_739
   DataType: int32
   OrigDataType: int32
-T_739: (in esp_187 - 4 : word32)
-  Class: Eq_739
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_742 t0000)))
-T_740: (in 0x00000000 : word32)
+T_740: (in esp_187 - 4 : word32)
   Class: Eq_740
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_743 t0000)))
+T_741: (in 0x00000000 : word32)
+  Class: Eq_741
   DataType: word32
   OrigDataType: word32
-T_741: (in esp_187 - 4 + 0x00000000 : word32)
-  Class: Eq_741
+T_742: (in esp_187 - 4 + 0x00000000 : word32)
+  Class: Eq_742
   DataType: ptr32
   OrigDataType: ptr32
-T_742: (in Mem197[esp_187 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_141
+T_743: (in Mem197[esp_187 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_142
   DataType: word32
   OrigDataType: word32
-T_743: (in out ecx_206 : ptr32)
-  Class: Eq_142
+T_744: (in out ecx_206 : ptr32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: ptr32
-T_744: (in out edx_210 : ptr32)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: ptr32
-T_745: (in out ebx_205 : ptr32)
+T_745: (in out edx_210 : ptr32)
   Class: Eq_137
   DataType: Eq_137
   OrigDataType: ptr32
-T_746: (in out esi_207 : ptr32)
-  Class: Eq_136
-  DataType: Eq_136
+T_746: (in out ebx_205 : ptr32)
+  Class: Eq_138
+  DataType: Eq_138
   OrigDataType: ptr32
-T_747: (in out edi_209 : ptr32)
-  Class: Eq_140
-  DataType: Eq_140
+T_747: (in out esi_207 : ptr32)
+  Class: Eq_137
+  DataType: Eq_137
   OrigDataType: ptr32
-T_748: (in fn100011E9(edx, ebx_116, ebp_13, esi_113, edi_110, *(esp_187 - 4), out ecx_206, out edx_210, out ebx_205, out esi_207, out edi_209) : word32)
-  Class: Eq_612
+T_748: (in out edi_209 : ptr32)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: ptr32
+T_749: (in fn100011E9(edx, ebx_116, ebp_13, esi_113, edi_110, *(esp_187 - 4), out ecx_206, out edx_210, out ebx_205, out esi_207, out edi_209) : word32)
+  Class: Eq_613
   DataType: ui32
   OrigDataType: word32
-T_749: (in Top_208 : Eq_395)
-  Class: Eq_395
-  DataType: Eq_395
+T_750: (in Top_208 : Eq_396)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: int8
-T_750: (in 0x00000004 : word32)
-  Class: Eq_750
+T_751: (in 0x00000004 : word32)
+  Class: Eq_751
   DataType: int32
   OrigDataType: int32
-T_751: (in esp_187 + 0x00000004 : word32)
-  Class: Eq_395
-  DataType: Eq_395
+T_752: (in esp_187 + 0x00000004 : word32)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: ptr32
-T_752: (in 0x00000000 : word32)
-  Class: Eq_612
+T_753: (in 0x00000000 : word32)
+  Class: Eq_613
   DataType: ui32
   OrigDataType: word32
-T_753: (in eax_204 != 0x00000000 : bool)
-  Class: Eq_753
+T_754: (in eax_204 != 0x00000000 : bool)
+  Class: Eq_754
   DataType: bool
   OrigDataType: bool
-T_754: (in 0x00000003 : word32)
-  Class: Eq_136
+T_755: (in 0x00000003 : word32)
+  Class: Eq_137
   DataType: ptr32
   OrigDataType: word32
-T_755: (in esi_113 != 0x00000003 : bool)
-  Class: Eq_755
-  DataType: bool
-  OrigDataType: bool
-T_756: (in 0x0000001C : word32)
+T_756: (in esi_113 != 0x00000003 : bool)
   Class: Eq_756
-  DataType: ui32
-  OrigDataType: ui32
-T_757: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_757
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_760 t0000)))
-T_758: (in 0x00000000 : word32)
-  Class: Eq_758
-  DataType: word32
-  OrigDataType: word32
-T_759: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_759
-  DataType: ptr32
-  OrigDataType: ptr32
-T_760: (in Mem224[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_760
-  DataType: word32
-  OrigDataType: word32
-T_761: (in 0x00000000 : word32)
-  Class: Eq_760
-  DataType: word32
-  OrigDataType: word32
-T_762: (in *(ebp_13 - 0x0000001C) == 0x00000000 : bool)
-  Class: Eq_762
   DataType: bool
   OrigDataType: bool
-T_763: (in 0x0000001C : word32)
-  Class: Eq_763
+T_757: (in 0x0000001C : word32)
+  Class: Eq_757
   DataType: ui32
   OrigDataType: ui32
-T_764: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_764
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_767 t0000)))
-T_765: (in 0x00000000 : word32)
-  Class: Eq_765
+T_758: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_758
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_761 t0000)))
+T_759: (in 0x00000000 : word32)
+  Class: Eq_759
   DataType: word32
   OrigDataType: word32
-T_766: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_766
+T_760: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_760
   DataType: ptr32
   OrigDataType: ptr32
-T_767: (in Mem197[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_767
+T_761: (in Mem224[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_761
+  DataType: word32
+  OrigDataType: word32
+T_762: (in 0x00000000 : word32)
+  Class: Eq_761
+  DataType: word32
+  OrigDataType: word32
+T_763: (in *(ebp_13 - 0x0000001C) == 0x00000000 : bool)
+  Class: Eq_763
+  DataType: bool
+  OrigDataType: bool
+T_764: (in 0x0000001C : word32)
+  Class: Eq_764
   DataType: ui32
   OrigDataType: ui32
-T_768: (in *(ebp_13 - 0x0000001C) & eax_204 : word32)
+T_765: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_765
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_768 t0000)))
+T_766: (in 0x00000000 : word32)
+  Class: Eq_766
+  DataType: word32
+  OrigDataType: word32
+T_767: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_767
+  DataType: ptr32
+  OrigDataType: ptr32
+T_768: (in Mem197[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
   Class: Eq_768
   DataType: ui32
   OrigDataType: ui32
-T_769: (in 0x0000001C : word32)
+T_769: (in *(ebp_13 - 0x0000001C) & eax_204 : word32)
   Class: Eq_769
   DataType: ui32
   OrigDataType: ui32
-T_770: (in ebp_13 - 0x0000001C : word32)
+T_770: (in 0x0000001C : word32)
   Class: Eq_770
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_773 t0000)))
-T_771: (in 0x00000000 : word32)
-  Class: Eq_771
-  DataType: word32
-  OrigDataType: word32
-T_772: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_772
-  DataType: ptr32
-  OrigDataType: ptr32
-T_773: (in Mem220[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_768
-  DataType: ui32
-  OrigDataType: word32
-T_774: (in eax_227 : word32)
-  Class: Eq_519
-  DataType: word32
-  OrigDataType: word32
-T_775: (in 100020CC : ptr32)
-  Class: Eq_775
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_776 t0000)))
-T_776: (in Mem224[0x100020CC:word32] : word32)
-  Class: Eq_519
-  DataType: word32
-  OrigDataType: word32
-T_777: (in 0x00000000 : word32)
-  Class: Eq_519
-  DataType: word32
-  OrigDataType: word32
-T_778: (in eax_227 == 0x00000000 : bool)
-  Class: Eq_778
-  DataType: bool
-  OrigDataType: bool
-T_779: (in 0x00000000 : word32)
-  Class: Eq_779
-  DataType: word32
-  OrigDataType: word32
-T_780: (in esp_187 + 0x00000000 : word32)
-  Class: Eq_780
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_781: (in Mem234[esp_187 + 0x00000000:word32] : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_782: (in 4 : int32)
-  Class: Eq_782
-  DataType: int32
-  OrigDataType: int32
-T_783: (in esp_187 - 4 : word32)
-  Class: Eq_783
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_786 t0000)))
-T_784: (in 0x00000000 : word32)
-  Class: Eq_784
-  DataType: word32
-  OrigDataType: word32
-T_785: (in esp_187 - 4 + 0x00000000 : word32)
-  Class: Eq_785
-  DataType: ptr32
-  OrigDataType: ptr32
-T_786: (in Mem237[esp_187 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_733
-  DataType: word32
-  OrigDataType: word32
-T_787: (in 8 : int32)
-  Class: Eq_787
-  DataType: int32
-  OrigDataType: int32
-T_788: (in esp_187 - 8 : word32)
-  Class: Eq_788
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_791 t0000)))
-T_789: (in 0x00000000 : word32)
-  Class: Eq_789
-  DataType: word32
-  OrigDataType: word32
-T_790: (in esp_187 - 8 + 0x00000000 : word32)
-  Class: Eq_790
-  DataType: ptr32
-  OrigDataType: ptr32
-T_791: (in Mem240[esp_187 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_731
-  DataType: word32
-  OrigDataType: word32
-T_792: (in eax_246 : word32)
-  Class: Eq_792
-  DataType: word32
-  OrigDataType: word32
-T_793: (in fn00000000 : ptr32)
-  Class: Eq_793
-  DataType: (ptr32 code)
-  OrigDataType: (ptr32 code)
-T_794: (in signature of fn00000000 : void)
-  Class: Eq_794
-  DataType: Eq_794
-  OrigDataType: 
-T_795: (in 0x0000001C : word32)
-  Class: Eq_795
   DataType: ui32
   OrigDataType: ui32
-T_796: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_796
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_799 t0000)))
-T_797: (in 0x00000000 : word32)
-  Class: Eq_797
+T_771: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_771
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_774 t0000)))
+T_772: (in 0x00000000 : word32)
+  Class: Eq_772
   DataType: word32
   OrigDataType: word32
-T_798: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_798
+T_773: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_773
   DataType: ptr32
   OrigDataType: ptr32
-T_799: (in Mem251[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_792
-  DataType: word32
-  OrigDataType: word32
-T_800: (in 0xFFFFFFFF : word32)
-  Class: Eq_136
-  DataType: ptr32
-  OrigDataType: word32
-T_801: (in 10003008 : ptr32)
-  Class: Eq_801
-  DataType: (ptr32 Eq_136)
-  OrigDataType: (ptr32 (struct (0 T_802 t0000)))
-T_802: (in Mem4[0x10003008:word32] : word32)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: ptr32
-T_803: (in eax : Eq_803)
-  Class: Eq_803
-  DataType: Eq_803
-  OrigDataType: BOOL
-T_804: (in hModule : Eq_804)
-  Class: Eq_804
-  DataType: Eq_804
-  OrigDataType: HANDLE
-T_805: (in dwReason : Eq_136)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: DWORD
-T_806: (in lpReserved : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: LPVOID
-T_807: (in 0x00000001 : word32)
-  Class: Eq_136
-  DataType: ptr32
-  OrigDataType: word32
-T_808: (in dwReason != 0x00000001 : bool)
-  Class: Eq_808
-  DataType: bool
-  OrigDataType: bool
-T_809: (in fn10001388 : ptr32)
-  Class: Eq_809
-  DataType: (ptr32 Eq_809)
-  OrigDataType: (ptr32 (fn T_814 (T_806, T_805, T_811, T_812, T_813)))
-T_810: (in signature of fn10001388 : void)
-  Class: Eq_809
-  DataType: (ptr32 Eq_809)
-  OrigDataType: 
-T_811: (in ebx : word32)
-  Class: Eq_189
-  DataType: (ptr32 Eq_189)
-  OrigDataType: word32
-T_812: (in esi : word32)
-  Class: Eq_385
-  DataType: ptr32
-  OrigDataType: word32
-T_813: (in edi : word32)
-  Class: Eq_386
-  DataType: word32
-  OrigDataType: word32
-T_814: (in fn10001388(lpReserved, dwReason, ebx, esi, edi) : word32)
-  Class: Eq_803
-  DataType: Eq_803
-  OrigDataType: word32
-T_815: (in fn10001864 : ptr32)
-  Class: Eq_815
-  DataType: (ptr32 Eq_815)
-  OrigDataType: (ptr32 (fn T_817 ()))
-T_816: (in signature of fn10001864 : void)
-  Class: Eq_815
-  DataType: (ptr32 Eq_815)
-  OrigDataType: 
-T_817: (in fn10001864() : void)
-  Class: Eq_817
-  DataType: void
-  OrigDataType: void
-T_818: (in eax : Eq_818)
-  Class: Eq_818
-  DataType: Eq_818
-  OrigDataType: word32
-T_819: (in ebx : (ptr32 Eq_189))
-  Class: Eq_189
-  DataType: (ptr32 Eq_189)
-  OrigDataType: word32
-T_820: (in esi : ptr32)
-  Class: Eq_385
-  DataType: ptr32
-  OrigDataType: word32
-T_821: (in edi : word32)
-  Class: Eq_386
-  DataType: word32
-  OrigDataType: word32
-T_822: (in eax_110 : Eq_818)
-  Class: Eq_818
-  DataType: Eq_818
-  OrigDataType: (union (_onexit_t u1))
-T_823: (in esp_81 : Eq_395)
-  Class: Eq_395
-  DataType: Eq_395
-  OrigDataType: (ptr32 (struct (FFFFFFFC T_1033 tFFFFFFFC)))
-T_824: (in ebp_13 : (ptr32 Eq_138))
-  Class: Eq_138
-  DataType: (ptr32 Eq_138)
-  OrigDataType: (ptr32 (struct (8 T_931 t0008)))
-T_825: (in fn100017E8 : ptr32)
-  Class: Eq_432
-  DataType: (ptr32 Eq_432)
-  OrigDataType: (ptr32 (fn T_828 (T_819, T_820, T_821, T_826, T_827)))
-T_826: (in dwLoc0C : word32)
-  Class: Eq_437
-  DataType: word32
-  OrigDataType: word32
-T_827: (in 0x00000014 : word32)
-  Class: Eq_438
+T_774: (in Mem220[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_769
   DataType: ui32
   OrigDataType: word32
-T_828: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000014) : word32)
-  Class: Eq_138
-  DataType: (ptr32 Eq_138)
-  OrigDataType: word32
-T_829: (in esp_14 : Eq_395)
-  Class: Eq_395
-  DataType: Eq_395
-  OrigDataType: ptr32
-T_830: (in 100033B4 : ptr32)
-  Class: Eq_830
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_831 t0000)))
-T_831: (in Mem7[0x100033B4:word32] : word32)
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: word32
-T_832: (in 4 : int32)
-  Class: Eq_832
-  DataType: int32
-  OrigDataType: int32
-T_833: (in esp_14 - 4 : word32)
-  Class: Eq_833
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_836 t0000)))
-T_834: (in 0x00000000 : word32)
-  Class: Eq_834
+T_775: (in eax_227 : word32)
+  Class: Eq_520
   DataType: word32
   OrigDataType: word32
-T_835: (in esp_14 - 4 + 0x00000000 : word32)
+T_776: (in 100020CC : ptr32)
+  Class: Eq_776
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_777 t0000)))
+T_777: (in Mem224[0x100020CC:word32] : word32)
+  Class: Eq_520
+  DataType: word32
+  OrigDataType: word32
+T_778: (in 0x00000000 : word32)
+  Class: Eq_520
+  DataType: word32
+  OrigDataType: word32
+T_779: (in eax_227 == 0x00000000 : bool)
+  Class: Eq_779
+  DataType: bool
+  OrigDataType: bool
+T_780: (in 0x00000000 : word32)
+  Class: Eq_780
+  DataType: word32
+  OrigDataType: word32
+T_781: (in esp_187 + 0x00000000 : word32)
+  Class: Eq_781
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_782: (in Mem234[esp_187 + 0x00000000:word32] : word32)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: word32
+T_783: (in 4 : int32)
+  Class: Eq_783
+  DataType: int32
+  OrigDataType: int32
+T_784: (in esp_187 - 4 : word32)
+  Class: Eq_784
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_787 t0000)))
+T_785: (in 0x00000000 : word32)
+  Class: Eq_785
+  DataType: word32
+  OrigDataType: word32
+T_786: (in esp_187 - 4 + 0x00000000 : word32)
+  Class: Eq_786
+  DataType: ptr32
+  OrigDataType: ptr32
+T_787: (in Mem237[esp_187 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_734
+  DataType: word32
+  OrigDataType: word32
+T_788: (in 8 : int32)
+  Class: Eq_788
+  DataType: int32
+  OrigDataType: int32
+T_789: (in esp_187 - 8 : word32)
+  Class: Eq_789
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_792 t0000)))
+T_790: (in 0x00000000 : word32)
+  Class: Eq_790
+  DataType: word32
+  OrigDataType: word32
+T_791: (in esp_187 - 8 + 0x00000000 : word32)
+  Class: Eq_791
+  DataType: ptr32
+  OrigDataType: ptr32
+T_792: (in Mem240[esp_187 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_732
+  DataType: word32
+  OrigDataType: word32
+T_793: (in eax_246 : word32)
+  Class: Eq_793
+  DataType: word32
+  OrigDataType: word32
+T_794: (in fn00000000 : ptr32)
+  Class: Eq_794
+  DataType: (ptr32 code)
+  OrigDataType: (ptr32 code)
+T_795: (in signature of fn00000000 : void)
+  Class: Eq_795
+  DataType: Eq_795
+  OrigDataType: 
+T_796: (in 0x0000001C : word32)
+  Class: Eq_796
+  DataType: ui32
+  OrigDataType: ui32
+T_797: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_797
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_800 t0000)))
+T_798: (in 0x00000000 : word32)
+  Class: Eq_798
+  DataType: word32
+  OrigDataType: word32
+T_799: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_799
+  DataType: ptr32
+  OrigDataType: ptr32
+T_800: (in Mem251[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_793
+  DataType: word32
+  OrigDataType: word32
+T_801: (in 0xFFFFFFFF : word32)
+  Class: Eq_137
+  DataType: ptr32
+  OrigDataType: word32
+T_802: (in 10003008 : ptr32)
+  Class: Eq_802
+  DataType: (ptr32 Eq_137)
+  OrigDataType: (ptr32 (struct (0 T_803 t0000)))
+T_803: (in Mem4[0x10003008:word32] : word32)
+  Class: Eq_137
+  DataType: Eq_137
+  OrigDataType: ptr32
+T_804: (in eax : Eq_804)
+  Class: Eq_804
+  DataType: Eq_804
+  OrigDataType: BOOL
+T_805: (in hModule : Eq_805)
+  Class: Eq_805
+  DataType: Eq_805
+  OrigDataType: HANDLE
+T_806: (in dwReason : Eq_137)
+  Class: Eq_137
+  DataType: Eq_137
+  OrigDataType: DWORD
+T_807: (in lpReserved : Eq_141)
+  Class: Eq_141
+  DataType: Eq_141
+  OrigDataType: LPVOID
+T_808: (in 0x00000001 : word32)
+  Class: Eq_137
+  DataType: ptr32
+  OrigDataType: word32
+T_809: (in dwReason != 0x00000001 : bool)
+  Class: Eq_809
+  DataType: bool
+  OrigDataType: bool
+T_810: (in fn10001388 : ptr32)
+  Class: Eq_810
+  DataType: (ptr32 Eq_810)
+  OrigDataType: (ptr32 (fn T_815 (T_807, T_806, T_812, T_813, T_814)))
+T_811: (in signature of fn10001388 : void)
+  Class: Eq_810
+  DataType: (ptr32 Eq_810)
+  OrigDataType: 
+T_812: (in ebx : word32)
+  Class: Eq_190
+  DataType: (ptr32 Eq_190)
+  OrigDataType: word32
+T_813: (in esi : word32)
+  Class: Eq_386
+  DataType: ptr32
+  OrigDataType: word32
+T_814: (in edi : word32)
+  Class: Eq_387
+  DataType: word32
+  OrigDataType: word32
+T_815: (in fn10001388(lpReserved, dwReason, ebx, esi, edi) : word32)
+  Class: Eq_804
+  DataType: Eq_804
+  OrigDataType: word32
+T_816: (in fn10001864 : ptr32)
+  Class: Eq_816
+  DataType: (ptr32 Eq_816)
+  OrigDataType: (ptr32 (fn T_818 ()))
+T_817: (in signature of fn10001864 : void)
+  Class: Eq_816
+  DataType: (ptr32 Eq_816)
+  OrigDataType: 
+T_818: (in fn10001864() : void)
+  Class: Eq_818
+  DataType: void
+  OrigDataType: void
+T_819: (in eax : Eq_819)
+  Class: Eq_819
+  DataType: Eq_819
+  OrigDataType: word32
+T_820: (in ebx : (ptr32 Eq_190))
+  Class: Eq_190
+  DataType: (ptr32 Eq_190)
+  OrigDataType: word32
+T_821: (in esi : ptr32)
+  Class: Eq_386
+  DataType: ptr32
+  OrigDataType: word32
+T_822: (in edi : word32)
+  Class: Eq_387
+  DataType: word32
+  OrigDataType: word32
+T_823: (in eax_110 : Eq_819)
+  Class: Eq_819
+  DataType: Eq_819
+  OrigDataType: (union (_onexit_t u1))
+T_824: (in esp_81 : Eq_396)
+  Class: Eq_396
+  DataType: Eq_396
+  OrigDataType: (ptr32 (struct (FFFFFFFC T_1034 tFFFFFFFC)))
+T_825: (in ebp_13 : (ptr32 Eq_139))
+  Class: Eq_139
+  DataType: (ptr32 Eq_139)
+  OrigDataType: (ptr32 (struct (8 T_932 t0008)))
+T_826: (in fn100017E8 : ptr32)
+  Class: Eq_433
+  DataType: (ptr32 Eq_433)
+  OrigDataType: (ptr32 (fn T_829 (T_820, T_821, T_822, T_827, T_828)))
+T_827: (in dwLoc0C : word32)
+  Class: Eq_438
+  DataType: word32
+  OrigDataType: word32
+T_828: (in 0x00000014 : word32)
+  Class: Eq_439
+  DataType: ui32
+  OrigDataType: word32
+T_829: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000014) : word32)
+  Class: Eq_139
+  DataType: (ptr32 Eq_139)
+  OrigDataType: word32
+T_830: (in esp_14 : Eq_396)
+  Class: Eq_396
+  DataType: Eq_396
+  OrigDataType: ptr32
+T_831: (in 100033B4 : ptr32)
+  Class: Eq_831
+  DataType: (ptr32 (ptr32 word32))
+  OrigDataType: (ptr32 (struct (0 T_832 t0000)))
+T_832: (in Mem7[0x100033B4:word32] : word32)
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: word32
+T_833: (in 4 : int32)
+  Class: Eq_833
+  DataType: int32
+  OrigDataType: int32
+T_834: (in esp_14 - 4 : word32)
+  Class: Eq_834
+  DataType: (ptr32 (ptr32 word32))
+  OrigDataType: (ptr32 (struct (0 T_837 t0000)))
+T_835: (in 0x00000000 : word32)
   Class: Eq_835
   DataType: word32
   OrigDataType: word32
-T_836: (in Mem21[esp_14 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_142
+T_836: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_836
+  DataType: word32
+  OrigDataType: word32
+T_837: (in Mem21[esp_14 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_837: (in eax_23 : (ptr32 word32))
-  Class: Eq_142
+T_838: (in eax_23 : (ptr32 word32))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_838: (in _decode_pointer : ptr32)
-  Class: Eq_225
-  DataType: (ptr32 Eq_225)
-  OrigDataType: (ptr32 (fn T_843 (T_842)))
-T_839: (in esp_14 - 4 : word32)
-  Class: Eq_839
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_842 t0000)))
-T_840: (in 0x00000000 : word32)
+T_839: (in _decode_pointer : ptr32)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
+  OrigDataType: (ptr32 (fn T_844 (T_843)))
+T_840: (in esp_14 - 4 : word32)
   Class: Eq_840
-  DataType: word32
-  OrigDataType: word32
-T_841: (in esp_14 - 4 + 0x00000000 : word32)
+  DataType: (ptr32 (ptr32 word32))
+  OrigDataType: (ptr32 (struct (0 T_843 t0000)))
+T_841: (in 0x00000000 : word32)
   Class: Eq_841
-  DataType: ptr32
-  OrigDataType: ptr32
-T_842: (in Mem21[esp_14 - 4 + 0x00000000:(ptr32 void)] : (ptr32 void))
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 void)
-T_843: (in _decode_pointer(*(esp_14 - 4)) : (ptr32 void))
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 void)
-T_844: (in ecx_24 : word32)
-  Class: Eq_844
   DataType: word32
   OrigDataType: word32
-T_845: (in esp_14 - 4 : word32)
+T_842: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_842
+  DataType: ptr32
+  OrigDataType: ptr32
+T_843: (in Mem21[esp_14 - 4 + 0x00000000:(ptr32 void)] : (ptr32 void))
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 void)
+T_844: (in _decode_pointer(*(esp_14 - 4)) : (ptr32 void))
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 void)
+T_845: (in ecx_24 : word32)
   Class: Eq_845
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_848 t0000)))
-T_846: (in 0x00000000 : word32)
-  Class: Eq_846
   DataType: word32
   OrigDataType: word32
-T_847: (in esp_14 - 4 + 0x00000000 : word32)
+T_846: (in esp_14 - 4 : word32)
+  Class: Eq_846
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_849 t0000)))
+T_847: (in 0x00000000 : word32)
   Class: Eq_847
+  DataType: word32
+  OrigDataType: word32
+T_848: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_848
   DataType: ptr32
   OrigDataType: ptr32
-T_848: (in Mem21[esp_14 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_844
+T_849: (in Mem21[esp_14 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_845
   DataType: word32
   OrigDataType: word32
-T_849: (in 0x0000001C : word32)
-  Class: Eq_849
+T_850: (in 0x0000001C : word32)
+  Class: Eq_850
   DataType: ui32
   OrigDataType: ui32
-T_850: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_850
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_853 t0000)))
-T_851: (in 0x00000000 : word32)
+T_851: (in ebp_13 - 0x0000001C : word32)
   Class: Eq_851
-  DataType: word32
-  OrigDataType: word32
-T_852: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  DataType: (ptr32 (ptr32 word32))
+  OrigDataType: (ptr32 (struct (0 T_854 t0000)))
+T_852: (in 0x00000000 : word32)
   Class: Eq_852
   DataType: word32
   OrigDataType: word32
-T_853: (in Mem26[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_142
+T_853: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_853
+  DataType: word32
+  OrigDataType: word32
+T_854: (in Mem26[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_854: (in 0xFFFFFFFF : word32)
-  Class: Eq_142
+T_855: (in 0xFFFFFFFF : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_855: (in eax_23 != (word32 *) 0xFFFFFFFF : bool)
-  Class: Eq_855
+T_856: (in eax_23 != (word32 *) 0xFFFFFFFF : bool)
+  Class: Eq_856
   DataType: bool
   OrigDataType: bool
-T_856: (in 0x00000008 : word32)
-  Class: Eq_856
+T_857: (in 0x00000008 : word32)
+  Class: Eq_857
   DataType: word32
   OrigDataType: word32
-T_857: (in 4 : int32)
-  Class: Eq_857
+T_858: (in 4 : int32)
+  Class: Eq_858
   DataType: int32
   OrigDataType: int32
-T_858: (in esp_14 - 4 : word32)
-  Class: Eq_858
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_861 t0000)))
-T_859: (in 0x00000000 : word32)
+T_859: (in esp_14 - 4 : word32)
   Class: Eq_859
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_862 t0000)))
+T_860: (in 0x00000000 : word32)
+  Class: Eq_860
   DataType: word32
   OrigDataType: word32
-T_860: (in esp_14 - 4 + 0x00000000 : word32)
-  Class: Eq_860
+T_861: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_861
   DataType: ptr32
   OrigDataType: ptr32
-T_861: (in Mem30[esp_14 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_856
+T_862: (in Mem30[esp_14 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_857
   DataType: word32
   OrigDataType: word32
-T_862: (in esp_31 : (ptr32 (ptr32 word32)))
-  Class: Eq_862
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_142 t0000)))
-T_863: (in Top_34 : int8)
+T_863: (in esp_31 : (ptr32 (ptr32 word32)))
   Class: Eq_863
+  DataType: (ptr32 (ptr32 word32))
+  OrigDataType: (ptr32 (struct (0 T_143 t0000)))
+T_864: (in Top_34 : int8)
+  Class: Eq_864
   DataType: int8
   OrigDataType: int8
-T_864: (in lock : ptr32)
-  Class: Eq_864
+T_865: (in lock : ptr32)
+  Class: Eq_865
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_865: (in signature of lock : void)
-  Class: Eq_865
-  DataType: Eq_865
+T_866: (in signature of lock : void)
+  Class: Eq_866
+  DataType: Eq_866
   OrigDataType: 
-T_866: (in ecx_36 : (ptr32 word32))
-  Class: Eq_142
+T_867: (in ecx_36 : (ptr32 word32))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_867: (in 0x00000000 : word32)
-  Class: Eq_867
-  DataType: word32
-  OrigDataType: word32
-T_868: (in esp_31 + 0x00000000 : word32)
+T_868: (in 0x00000000 : word32)
   Class: Eq_868
   DataType: word32
   OrigDataType: word32
-T_869: (in Mem30[esp_31 + 0x00000000:word32] : word32)
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: word32
-T_870: (in 0x00000004 : word32)
-  Class: Eq_870
-  DataType: ui32
-  OrigDataType: ui32
-T_871: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_871
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_874 t0000)))
-T_872: (in 0x00000000 : word32)
-  Class: Eq_872
+T_869: (in esp_31 + 0x00000000 : word32)
+  Class: Eq_869
   DataType: word32
   OrigDataType: word32
-T_873: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_873
-  DataType: ptr32
-  OrigDataType: ptr32
-T_874: (in Mem30[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_874
+T_870: (in Mem30[esp_31 + 0x00000000:word32] : word32)
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: word32
+T_871: (in 0x00000004 : word32)
+  Class: Eq_871
   DataType: ui32
   OrigDataType: ui32
-T_875: (in 0x00000000 : word32)
+T_872: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_872
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_875 t0000)))
+T_873: (in 0x00000000 : word32)
+  Class: Eq_873
+  DataType: word32
+  OrigDataType: word32
+T_874: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_874
+  DataType: ptr32
+  OrigDataType: ptr32
+T_875: (in Mem30[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
   Class: Eq_875
   DataType: ui32
   OrigDataType: ui32
-T_876: (in *(ebp_13 - 0x00000004) & 0x00000000 : word32)
+T_876: (in 0x00000000 : word32)
   Class: Eq_876
   DataType: ui32
   OrigDataType: ui32
-T_877: (in 0x00000004 : word32)
+T_877: (in *(ebp_13 - 0x00000004) & 0x00000000 : word32)
   Class: Eq_877
   DataType: ui32
   OrigDataType: ui32
-T_878: (in ebp_13 - 0x00000004 : word32)
+T_878: (in 0x00000004 : word32)
   Class: Eq_878
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_881 t0000)))
-T_879: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_879: (in ebp_13 - 0x00000004 : word32)
   Class: Eq_879
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_882 t0000)))
+T_880: (in 0x00000000 : word32)
+  Class: Eq_880
   DataType: word32
   OrigDataType: word32
-T_880: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_880
+T_881: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_881
   DataType: ptr32
   OrigDataType: ptr32
-T_881: (in Mem39[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_876
+T_882: (in Mem39[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_877
   DataType: ui32
   OrigDataType: word32
-T_882: (in 100033B4 : ptr32)
-  Class: Eq_882
+T_883: (in 100033B4 : ptr32)
+  Class: Eq_883
   DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_883 t0000)))
-T_883: (in Mem39[0x100033B4:word32] : word32)
-  Class: Eq_142
+  OrigDataType: (ptr32 (struct (0 T_884 t0000)))
+T_884: (in Mem39[0x100033B4:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_884: (in 0x00000000 : word32)
-  Class: Eq_884
+T_885: (in 0x00000000 : word32)
+  Class: Eq_885
   DataType: word32
   OrigDataType: word32
-T_885: (in esp_31 + 0x00000000 : word32)
-  Class: Eq_885
+T_886: (in esp_31 + 0x00000000 : word32)
+  Class: Eq_886
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_886: (in Mem44[esp_31 + 0x00000000:word32] : word32)
-  Class: Eq_142
+T_887: (in Mem44[esp_31 + 0x00000000:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_887: (in _decode_pointer : ptr32)
-  Class: Eq_225
-  DataType: (ptr32 Eq_225)
-  OrigDataType: (ptr32 (fn T_891 (T_890)))
-T_888: (in 0x00000000 : word32)
-  Class: Eq_888
+T_888: (in _decode_pointer : ptr32)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
+  OrigDataType: (ptr32 (fn T_892 (T_891)))
+T_889: (in 0x00000000 : word32)
+  Class: Eq_889
   DataType: word32
   OrigDataType: word32
-T_889: (in esp_31 + 0x00000000 : word32)
-  Class: Eq_889
+T_890: (in esp_31 + 0x00000000 : word32)
+  Class: Eq_890
   DataType: (ptr32 ptr32)
   OrigDataType: (ptr32 ptr32)
-T_890: (in Mem44[esp_31 + 0x00000000:(ptr32 void)] : (ptr32 void))
-  Class: Eq_142
+T_891: (in Mem44[esp_31 + 0x00000000:(ptr32 void)] : (ptr32 void))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_891: (in _decode_pointer(*esp_31) : (ptr32 void))
-  Class: Eq_142
+T_892: (in _decode_pointer(*esp_31) : (ptr32 void))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_892: (in 0x0000001C : word32)
-  Class: Eq_892
-  DataType: ui32
-  OrigDataType: ui32
-T_893: (in ebp_13 - 0x0000001C : word32)
+T_893: (in 0x0000001C : word32)
   Class: Eq_893
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_896 t0000)))
-T_894: (in 0x00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_894: (in ebp_13 - 0x0000001C : word32)
   Class: Eq_894
-  DataType: word32
-  OrigDataType: word32
-T_895: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  DataType: (ptr32 (ptr32 word32))
+  OrigDataType: (ptr32 (struct (0 T_897 t0000)))
+T_895: (in 0x00000000 : word32)
   Class: Eq_895
+  DataType: word32
+  OrigDataType: word32
+T_896: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
+  Class: Eq_896
   DataType: ptr32
   OrigDataType: ptr32
-T_896: (in Mem46[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_142
+T_897: (in Mem46[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_897: (in 100033B0 : ptr32)
-  Class: Eq_897
+T_898: (in 100033B0 : ptr32)
+  Class: Eq_898
   DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_898 t0000)))
-T_898: (in Mem46[0x100033B0:word32] : word32)
-  Class: Eq_142
+  OrigDataType: (ptr32 (struct (0 T_899 t0000)))
+T_899: (in Mem46[0x100033B0:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_899: (in 4 : int32)
-  Class: Eq_899
-  DataType: int32
-  OrigDataType: int32
-T_900: (in esp_31 - 4 : word32)
+T_900: (in 4 : int32)
   Class: Eq_900
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_903 t0000)))
-T_901: (in 0x00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_901: (in esp_31 - 4 : word32)
   Class: Eq_901
-  DataType: word32
-  OrigDataType: word32
-T_902: (in esp_31 - 4 + 0x00000000 : word32)
+  DataType: (ptr32 (ptr32 word32))
+  OrigDataType: (ptr32 (struct (0 T_904 t0000)))
+T_902: (in 0x00000000 : word32)
   Class: Eq_902
+  DataType: word32
+  OrigDataType: word32
+T_903: (in esp_31 - 4 + 0x00000000 : word32)
+  Class: Eq_903
   DataType: ptr32
   OrigDataType: ptr32
-T_903: (in Mem49[esp_31 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_142
+T_904: (in Mem49[esp_31 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_904: (in _decode_pointer : ptr32)
-  Class: Eq_225
-  DataType: (ptr32 Eq_225)
-  OrigDataType: (ptr32 (fn T_909 (T_908)))
-T_905: (in esp_31 - 4 : word32)
-  Class: Eq_905
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_908 t0000)))
-T_906: (in 0x00000000 : word32)
+T_905: (in _decode_pointer : ptr32)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
+  OrigDataType: (ptr32 (fn T_910 (T_909)))
+T_906: (in esp_31 - 4 : word32)
   Class: Eq_906
-  DataType: word32
-  OrigDataType: word32
-T_907: (in esp_31 - 4 + 0x00000000 : word32)
-  Class: Eq_907
-  DataType: ptr32
-  OrigDataType: ptr32
-T_908: (in Mem49[esp_31 - 4 + 0x00000000:(ptr32 void)] : (ptr32 void))
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 void)
-T_909: (in _decode_pointer(*(esp_31 - 4)) : (ptr32 void))
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 void)
-T_910: (in 0x00000020 : word32)
-  Class: Eq_910
-  DataType: ui32
-  OrigDataType: ui32
-T_911: (in ebp_13 - 0x00000020 : word32)
-  Class: Eq_911
   DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_914 t0000)))
-T_912: (in 0x00000000 : word32)
+  OrigDataType: (ptr32 (struct (0 T_909 t0000)))
+T_907: (in 0x00000000 : word32)
+  Class: Eq_907
+  DataType: word32
+  OrigDataType: word32
+T_908: (in esp_31 - 4 + 0x00000000 : word32)
+  Class: Eq_908
+  DataType: ptr32
+  OrigDataType: ptr32
+T_909: (in Mem49[esp_31 - 4 + 0x00000000:(ptr32 void)] : (ptr32 void))
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 void)
+T_910: (in _decode_pointer(*(esp_31 - 4)) : (ptr32 void))
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 void)
+T_911: (in 0x00000020 : word32)
+  Class: Eq_911
+  DataType: ui32
+  OrigDataType: ui32
+T_912: (in ebp_13 - 0x00000020 : word32)
   Class: Eq_912
-  DataType: word32
-  OrigDataType: word32
-T_913: (in ebp_13 - 0x00000020 + 0x00000000 : word32)
+  DataType: (ptr32 (ptr32 word32))
+  OrigDataType: (ptr32 (struct (0 T_915 t0000)))
+T_913: (in 0x00000000 : word32)
   Class: Eq_913
+  DataType: word32
+  OrigDataType: word32
+T_914: (in ebp_13 - 0x00000020 + 0x00000000 : word32)
+  Class: Eq_914
   DataType: ptr32
   OrigDataType: ptr32
-T_914: (in Mem51[ebp_13 - 0x00000020 + 0x00000000:word32] : word32)
-  Class: Eq_142
+T_915: (in Mem51[ebp_13 - 0x00000020 + 0x00000000:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_915: (in 0x00000020 : word32)
-  Class: Eq_915
+T_916: (in 0x00000020 : word32)
+  Class: Eq_916
   DataType: ui32
   OrigDataType: ui32
-T_916: (in ebp_13 - 0x00000020 : word32)
-  Class: Eq_916
-  DataType: ptr32
-  OrigDataType: ptr32
-T_917: (in 8 : int32)
+T_917: (in ebp_13 - 0x00000020 : word32)
   Class: Eq_917
-  DataType: int32
-  OrigDataType: int32
-T_918: (in esp_31 - 8 : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_918: (in 8 : int32)
   Class: Eq_918
-  DataType: (ptr32 ptr32)
-  OrigDataType: (ptr32 (struct (0 T_921 t0000)))
-T_919: (in 0x00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_919: (in esp_31 - 8 : word32)
   Class: Eq_919
-  DataType: word32
-  OrigDataType: word32
-T_920: (in esp_31 - 8 + 0x00000000 : word32)
-  Class: Eq_920
-  DataType: ptr32
-  OrigDataType: ptr32
-T_921: (in Mem54[esp_31 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_916
-  DataType: ptr32
-  OrigDataType: word32
-T_922: (in 0x0000001C : word32)
-  Class: Eq_922
-  DataType: ui32
-  OrigDataType: ui32
-T_923: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_923
-  DataType: ptr32
-  OrigDataType: ptr32
-T_924: (in 12 : int32)
-  Class: Eq_924
-  DataType: int32
-  OrigDataType: int32
-T_925: (in esp_31 - 12 : word32)
-  Class: Eq_925
   DataType: (ptr32 ptr32)
-  OrigDataType: (ptr32 (struct (0 T_928 t0000)))
-T_926: (in 0x00000000 : word32)
-  Class: Eq_926
+  OrigDataType: (ptr32 (struct (0 T_922 t0000)))
+T_920: (in 0x00000000 : word32)
+  Class: Eq_920
   DataType: word32
   OrigDataType: word32
-T_927: (in esp_31 - 12 + 0x00000000 : word32)
-  Class: Eq_927
+T_921: (in esp_31 - 8 + 0x00000000 : word32)
+  Class: Eq_921
   DataType: ptr32
   OrigDataType: ptr32
-T_928: (in Mem57[esp_31 - 12 + 0x00000000:word32] : word32)
+T_922: (in Mem54[esp_31 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_917
+  DataType: ptr32
+  OrigDataType: word32
+T_923: (in 0x0000001C : word32)
   Class: Eq_923
+  DataType: ui32
+  OrigDataType: ui32
+T_924: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_924
   DataType: ptr32
-  OrigDataType: word32
-T_929: (in 0x00000008 : word32)
-  Class: Eq_929
+  OrigDataType: ptr32
+T_925: (in 12 : int32)
+  Class: Eq_925
+  DataType: int32
+  OrigDataType: int32
+T_926: (in esp_31 - 12 : word32)
+  Class: Eq_926
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_929 t0000)))
+T_927: (in 0x00000000 : word32)
+  Class: Eq_927
   DataType: word32
   OrigDataType: word32
-T_930: (in ebp_13 + 0x00000008 : word32)
+T_928: (in esp_31 - 12 + 0x00000000 : word32)
+  Class: Eq_928
+  DataType: ptr32
+  OrigDataType: ptr32
+T_929: (in Mem57[esp_31 - 12 + 0x00000000:word32] : word32)
+  Class: Eq_924
+  DataType: ptr32
+  OrigDataType: word32
+T_930: (in 0x00000008 : word32)
   Class: Eq_930
+  DataType: word32
+  OrigDataType: word32
+T_931: (in ebp_13 + 0x00000008 : word32)
+  Class: Eq_931
   DataType: ptr32
   OrigDataType: ptr32
-T_931: (in Mem57[ebp_13 + 0x00000008:word32] : word32)
-  Class: Eq_137
-  DataType: Eq_137
+T_932: (in Mem57[ebp_13 + 0x00000008:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
   OrigDataType: word32
-T_932: (in 16 : int32)
-  Class: Eq_932
-  DataType: int32
-  OrigDataType: int32
-T_933: (in esp_31 - 16 : word32)
+T_933: (in 16 : int32)
   Class: Eq_933
-  DataType: (ptr32 Eq_137)
-  OrigDataType: (ptr32 (struct (0 T_936 t0000)))
-T_934: (in 0x00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_934: (in esp_31 - 16 : word32)
   Class: Eq_934
-  DataType: word32
-  OrigDataType: word32
-T_935: (in esp_31 - 16 + 0x00000000 : word32)
+  DataType: (ptr32 Eq_138)
+  OrigDataType: (ptr32 (struct (0 T_937 t0000)))
+T_935: (in 0x00000000 : word32)
   Class: Eq_935
+  DataType: word32
+  OrigDataType: word32
+T_936: (in esp_31 - 16 + 0x00000000 : word32)
+  Class: Eq_936
   DataType: ptr32
   OrigDataType: ptr32
-T_936: (in Mem60[esp_31 - 16 + 0x00000000:word32] : word32)
-  Class: Eq_137
-  DataType: Eq_137
+T_937: (in Mem60[esp_31 - 16 + 0x00000000:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
   OrigDataType: word32
-T_937: (in eax_61 : Eq_818)
-  Class: Eq_818
-  DataType: Eq_818
+T_938: (in eax_61 : Eq_819)
+  Class: Eq_819
+  DataType: Eq_819
   OrigDataType: (union (_onexit_t u1))
-T_938: (in __dllonexit : ptr32)
-  Class: Eq_938
-  DataType: (ptr32 Eq_938)
-  OrigDataType: (ptr32 (fn T_957 (T_946, T_951, T_956)))
-T_939: (in signature of __dllonexit : void)
-  Class: Eq_938
-  DataType: (ptr32 Eq_938)
+T_939: (in __dllonexit : ptr32)
+  Class: Eq_939
+  DataType: (ptr32 Eq_939)
+  OrigDataType: (ptr32 (fn T_958 (T_947, T_952, T_957)))
+T_940: (in signature of __dllonexit : void)
+  Class: Eq_939
+  DataType: (ptr32 Eq_939)
   OrigDataType: 
-T_940: (in func : _onexit_t)
-  Class: Eq_818
-  DataType: Eq_818
+T_941: (in func : _onexit_t)
+  Class: Eq_819
+  DataType: Eq_819
   OrigDataType: 
-T_941: (in pbegin : (ptr32 (ptr32 PVFV)))
-  Class: Eq_941
-  DataType: (ptr32 (ptr32 Eq_941))
-  OrigDataType: 
-T_942: (in pend : (ptr32 (ptr32 PVFV)))
+T_942: (in pbegin : (ptr32 (ptr32 PVFV)))
   Class: Eq_942
   DataType: (ptr32 (ptr32 Eq_942))
   OrigDataType: 
-T_943: (in esp_31 - 16 : word32)
+T_943: (in pend : (ptr32 (ptr32 PVFV)))
   Class: Eq_943
-  DataType: (ptr32 Eq_818)
-  OrigDataType: (ptr32 (struct (0 T_946 t0000)))
-T_944: (in 0x00000000 : word32)
+  DataType: (ptr32 (ptr32 Eq_943))
+  OrigDataType: 
+T_944: (in esp_31 - 16 : word32)
   Class: Eq_944
-  DataType: word32
-  OrigDataType: word32
-T_945: (in esp_31 - 16 + 0x00000000 : word32)
+  DataType: (ptr32 Eq_819)
+  OrigDataType: (ptr32 (struct (0 T_947 t0000)))
+T_945: (in 0x00000000 : word32)
   Class: Eq_945
+  DataType: word32
+  OrigDataType: word32
+T_946: (in esp_31 - 16 + 0x00000000 : word32)
+  Class: Eq_946
   DataType: ptr32
   OrigDataType: ptr32
-T_946: (in Mem60[esp_31 - 16 + 0x00000000:_onexit_t] : _onexit_t)
-  Class: Eq_818
-  DataType: Eq_818
+T_947: (in Mem60[esp_31 - 16 + 0x00000000:_onexit_t] : _onexit_t)
+  Class: Eq_819
+  DataType: Eq_819
   OrigDataType: _onexit_t
-T_947: (in 12 : int32)
-  Class: Eq_947
-  DataType: int32
-  OrigDataType: int32
-T_948: (in esp_31 - 12 : word32)
+T_948: (in 12 : int32)
   Class: Eq_948
-  DataType: (ptr32 (ptr32 (ptr32 Eq_941)))
-  OrigDataType: (ptr32 (struct (0 T_951 t0000)))
-T_949: (in 0x00000000 : word32)
-  Class: Eq_949
-  DataType: word32
-  OrigDataType: word32
-T_950: (in esp_31 - 12 + 0x00000000 : word32)
-  Class: Eq_950
-  DataType: ptr32
-  OrigDataType: ptr32
-T_951: (in Mem60[esp_31 - 12 + 0x00000000:(ptr32 (ptr32 PVFV))] : (ptr32 (ptr32 PVFV)))
-  Class: Eq_941
-  DataType: (ptr32 (ptr32 Eq_941))
-  OrigDataType: (ptr32 (ptr32 PVFV))
-T_952: (in 8 : int32)
-  Class: Eq_952
   DataType: int32
   OrigDataType: int32
-T_953: (in esp_31 - 8 : word32)
-  Class: Eq_953
+T_949: (in esp_31 - 12 : word32)
+  Class: Eq_949
   DataType: (ptr32 (ptr32 (ptr32 Eq_942)))
-  OrigDataType: (ptr32 (struct (0 T_956 t0000)))
-T_954: (in 0x00000000 : word32)
-  Class: Eq_954
+  OrigDataType: (ptr32 (struct (0 T_952 t0000)))
+T_950: (in 0x00000000 : word32)
+  Class: Eq_950
   DataType: word32
   OrigDataType: word32
-T_955: (in esp_31 - 8 + 0x00000000 : word32)
-  Class: Eq_955
+T_951: (in esp_31 - 12 + 0x00000000 : word32)
+  Class: Eq_951
   DataType: ptr32
   OrigDataType: ptr32
-T_956: (in Mem60[esp_31 - 8 + 0x00000000:(ptr32 (ptr32 PVFV))] : (ptr32 (ptr32 PVFV)))
+T_952: (in Mem60[esp_31 - 12 + 0x00000000:(ptr32 (ptr32 PVFV))] : (ptr32 (ptr32 PVFV)))
   Class: Eq_942
   DataType: (ptr32 (ptr32 Eq_942))
   OrigDataType: (ptr32 (ptr32 PVFV))
-T_957: (in __dllonexit(*(esp_31 - 16), *(esp_31 - 12), *(esp_31 - 8)) : _onexit_t)
-  Class: Eq_818
-  DataType: Eq_818
-  OrigDataType: _onexit_t
-T_958: (in 0x00000024 : word32)
-  Class: Eq_958
-  DataType: ui32
-  OrigDataType: ui32
-T_959: (in ebp_13 - 0x00000024 : word32)
-  Class: Eq_959
-  DataType: (ptr32 Eq_818)
-  OrigDataType: (ptr32 (struct (0 T_962 t0000)))
-T_960: (in 0x00000000 : word32)
-  Class: Eq_960
-  DataType: word32
-  OrigDataType: word32
-T_961: (in ebp_13 - 0x00000024 + 0x00000000 : word32)
-  Class: Eq_961
-  DataType: ptr32
-  OrigDataType: ptr32
-T_962: (in Mem62[ebp_13 - 0x00000024 + 0x00000000:word32] : word32)
-  Class: Eq_818
-  DataType: Eq_818
-  OrigDataType: word32
-T_963: (in 0x0000001C : word32)
-  Class: Eq_963
-  DataType: ui32
-  OrigDataType: ui32
-T_964: (in ebp_13 - 0x0000001C : word32)
-  Class: Eq_964
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_967 t0000)))
-T_965: (in 0x00000000 : word32)
-  Class: Eq_965
-  DataType: word32
-  OrigDataType: word32
-T_966: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
-  Class: Eq_966
-  DataType: ptr32
-  OrigDataType: ptr32
-T_967: (in Mem62[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
-  Class: Eq_967
-  DataType: word32
-  OrigDataType: word32
-T_968: (in 20 : int32)
-  Class: Eq_968
+T_953: (in 8 : int32)
+  Class: Eq_953
   DataType: int32
   OrigDataType: int32
-T_969: (in esp_31 - 20 : word32)
-  Class: Eq_969
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_972 t0000)))
-T_970: (in 0x00000000 : word32)
-  Class: Eq_970
+T_954: (in esp_31 - 8 : word32)
+  Class: Eq_954
+  DataType: (ptr32 (ptr32 (ptr32 Eq_943)))
+  OrigDataType: (ptr32 (struct (0 T_957 t0000)))
+T_955: (in 0x00000000 : word32)
+  Class: Eq_955
   DataType: word32
   OrigDataType: word32
-T_971: (in esp_31 - 20 + 0x00000000 : word32)
-  Class: Eq_971
+T_956: (in esp_31 - 8 + 0x00000000 : word32)
+  Class: Eq_956
   DataType: ptr32
   OrigDataType: ptr32
-T_972: (in Mem65[esp_31 - 20 + 0x00000000:word32] : word32)
+T_957: (in Mem60[esp_31 - 8 + 0x00000000:(ptr32 (ptr32 PVFV))] : (ptr32 (ptr32 PVFV)))
+  Class: Eq_943
+  DataType: (ptr32 (ptr32 Eq_943))
+  OrigDataType: (ptr32 (ptr32 PVFV))
+T_958: (in __dllonexit(*(esp_31 - 16), *(esp_31 - 12), *(esp_31 - 8)) : _onexit_t)
+  Class: Eq_819
+  DataType: Eq_819
+  OrigDataType: _onexit_t
+T_959: (in 0x00000024 : word32)
+  Class: Eq_959
+  DataType: ui32
+  OrigDataType: ui32
+T_960: (in ebp_13 - 0x00000024 : word32)
+  Class: Eq_960
+  DataType: (ptr32 Eq_819)
+  OrigDataType: (ptr32 (struct (0 T_963 t0000)))
+T_961: (in 0x00000000 : word32)
+  Class: Eq_961
+  DataType: word32
+  OrigDataType: word32
+T_962: (in ebp_13 - 0x00000024 + 0x00000000 : word32)
+  Class: Eq_962
+  DataType: ptr32
+  OrigDataType: ptr32
+T_963: (in Mem62[ebp_13 - 0x00000024 + 0x00000000:word32] : word32)
+  Class: Eq_819
+  DataType: Eq_819
+  OrigDataType: word32
+T_964: (in 0x0000001C : word32)
+  Class: Eq_964
+  DataType: ui32
+  OrigDataType: ui32
+T_965: (in ebp_13 - 0x0000001C : word32)
+  Class: Eq_965
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_968 t0000)))
+T_966: (in 0x00000000 : word32)
+  Class: Eq_966
+  DataType: word32
+  OrigDataType: word32
+T_967: (in ebp_13 - 0x0000001C + 0x00000000 : word32)
   Class: Eq_967
-  DataType: word32
-  OrigDataType: word32
-T_973: (in esp_67 : ptr32)
-  Class: Eq_973
   DataType: ptr32
   OrigDataType: ptr32
-T_974: (in eax_68 : (ptr32 word32))
-  Class: Eq_142
-  DataType: (ptr32 word32)
-  OrigDataType: word32
-T_975: (in ecx_69 : word32)
-  Class: Eq_975
+T_968: (in Mem62[ebp_13 - 0x0000001C + 0x00000000:word32] : word32)
+  Class: Eq_968
   DataType: word32
   OrigDataType: word32
-T_976: (in Top_70 : int8)
+T_969: (in 20 : int32)
+  Class: Eq_969
+  DataType: int32
+  OrigDataType: int32
+T_970: (in esp_31 - 20 : word32)
+  Class: Eq_970
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_973 t0000)))
+T_971: (in 0x00000000 : word32)
+  Class: Eq_971
+  DataType: word32
+  OrigDataType: word32
+T_972: (in esp_31 - 20 + 0x00000000 : word32)
+  Class: Eq_972
+  DataType: ptr32
+  OrigDataType: ptr32
+T_973: (in Mem65[esp_31 - 20 + 0x00000000:word32] : word32)
+  Class: Eq_968
+  DataType: word32
+  OrigDataType: word32
+T_974: (in esp_67 : ptr32)
+  Class: Eq_974
+  DataType: ptr32
+  OrigDataType: ptr32
+T_975: (in eax_68 : (ptr32 word32))
+  Class: Eq_143
+  DataType: (ptr32 word32)
+  OrigDataType: word32
+T_976: (in ecx_69 : word32)
   Class: Eq_976
+  DataType: word32
+  OrigDataType: word32
+T_977: (in Top_70 : int8)
+  Class: Eq_977
   DataType: int8
   OrigDataType: int8
-T_977: (in encode_pointer : ptr32)
-  Class: Eq_977
+T_978: (in encode_pointer : ptr32)
+  Class: Eq_978
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_978: (in signature of encode_pointer : void)
-  Class: Eq_978
-  DataType: Eq_978
-  OrigDataType: 
-T_979: (in 100033B4 : ptr32)
+T_979: (in signature of encode_pointer : void)
   Class: Eq_979
+  DataType: Eq_979
+  OrigDataType: 
+T_980: (in 100033B4 : ptr32)
+  Class: Eq_980
   DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_980 t0000)))
-T_980: (in Mem72[0x100033B4:word32] : word32)
-  Class: Eq_142
+  OrigDataType: (ptr32 (struct (0 T_981 t0000)))
+T_981: (in Mem72[0x100033B4:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_981: (in 0x00000020 : word32)
-  Class: Eq_981
+T_982: (in 0x00000020 : word32)
+  Class: Eq_982
   DataType: ui32
   OrigDataType: ui32
-T_982: (in ebp_13 - 0x00000020 : word32)
-  Class: Eq_982
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_985 t0000)))
-T_983: (in 0x00000000 : word32)
+T_983: (in ebp_13 - 0x00000020 : word32)
   Class: Eq_983
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_986 t0000)))
+T_984: (in 0x00000000 : word32)
+  Class: Eq_984
   DataType: word32
   OrigDataType: word32
-T_984: (in ebp_13 - 0x00000020 + 0x00000000 : word32)
-  Class: Eq_984
+T_985: (in ebp_13 - 0x00000020 + 0x00000000 : word32)
+  Class: Eq_985
   DataType: ptr32
   OrigDataType: ptr32
-T_985: (in Mem72[ebp_13 - 0x00000020 + 0x00000000:word32] : word32)
-  Class: Eq_985
+T_986: (in Mem72[ebp_13 - 0x00000020 + 0x00000000:word32] : word32)
+  Class: Eq_986
   DataType: word32
   OrigDataType: word32
-T_986: (in 4 : int32)
-  Class: Eq_986
+T_987: (in 4 : int32)
+  Class: Eq_987
   DataType: int32
   OrigDataType: int32
-T_987: (in esp_67 - 4 : word32)
-  Class: Eq_987
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_990 t0000)))
-T_988: (in 0x00000000 : word32)
+T_988: (in esp_67 - 4 : word32)
   Class: Eq_988
-  DataType: word32
-  OrigDataType: word32
-T_989: (in esp_67 - 4 + 0x00000000 : word32)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_991 t0000)))
+T_989: (in 0x00000000 : word32)
   Class: Eq_989
   DataType: word32
   OrigDataType: word32
-T_990: (in Mem75[esp_67 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_985
+T_990: (in esp_67 - 4 + 0x00000000 : word32)
+  Class: Eq_990
   DataType: word32
   OrigDataType: word32
-T_991: (in esp_76 : word32)
-  Class: Eq_991
+T_991: (in Mem75[esp_67 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_986
   DataType: word32
   OrigDataType: word32
-T_992: (in eax_77 : (ptr32 word32))
-  Class: Eq_142
+T_992: (in esp_76 : word32)
+  Class: Eq_992
+  DataType: word32
+  OrigDataType: word32
+T_993: (in eax_77 : (ptr32 word32))
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_993: (in ecx_78 : word32)
-  Class: Eq_993
+T_994: (in ecx_78 : word32)
+  Class: Eq_994
   DataType: word32
   OrigDataType: word32
-T_994: (in encode_pointer : ptr32)
-  Class: Eq_994
+T_995: (in encode_pointer : ptr32)
+  Class: Eq_995
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_995: (in 100033B0 : ptr32)
-  Class: Eq_995
+T_996: (in 100033B0 : ptr32)
+  Class: Eq_996
   DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_996 t0000)))
-T_996: (in Mem83[0x100033B0:word32] : word32)
-  Class: Eq_142
+  OrigDataType: (ptr32 (struct (0 T_997 t0000)))
+T_997: (in Mem83[0x100033B0:word32] : word32)
+  Class: Eq_143
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_997: (in 0xFFFFFFFE : word32)
-  Class: Eq_997
+T_998: (in 0xFFFFFFFE : word32)
+  Class: Eq_998
   DataType: word32
   OrigDataType: word32
-T_998: (in 0x00000004 : word32)
-  Class: Eq_998
+T_999: (in 0x00000004 : word32)
+  Class: Eq_999
   DataType: ui32
   OrigDataType: ui32
-T_999: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_999
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1002 t0000)))
-T_1000: (in 0x00000000 : word32)
+T_1000: (in ebp_13 - 0x00000004 : word32)
   Class: Eq_1000
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_1003 t0000)))
+T_1001: (in 0x00000000 : word32)
+  Class: Eq_1001
   DataType: word32
   OrigDataType: word32
-T_1001: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_1001
+T_1002: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_1002
   DataType: ptr32
   OrigDataType: ptr32
-T_1002: (in Mem84[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_997
+T_1003: (in Mem84[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_998
   DataType: word32
   OrigDataType: word32
-T_1003: (in fn10001665 : ptr32)
-  Class: Eq_1003
-  DataType: (ptr32 Eq_1003)
-  OrigDataType: (ptr32 (fn T_1006 (T_993)))
-T_1004: (in signature of fn10001665 : void)
-  Class: Eq_1003
-  DataType: (ptr32 Eq_1003)
+T_1004: (in fn10001665 : ptr32)
+  Class: Eq_1004
+  DataType: (ptr32 Eq_1004)
+  OrigDataType: (ptr32 (fn T_1007 (T_994)))
+T_1005: (in signature of fn10001665 : void)
+  Class: Eq_1004
+  DataType: (ptr32 Eq_1004)
   OrigDataType: 
-T_1005: (in ecx : word32)
-  Class: Eq_993
+T_1006: (in ecx : word32)
+  Class: Eq_994
   DataType: word32
   OrigDataType: word32
-T_1006: (in fn10001665(ecx_78) : void)
-  Class: Eq_1006
+T_1007: (in fn10001665(ecx_78) : void)
+  Class: Eq_1007
   DataType: void
   OrigDataType: void
-T_1007: (in 0x0000001C : word32)
-  Class: Eq_1007
+T_1008: (in 0x0000001C : word32)
+  Class: Eq_1008
   DataType: word32
   OrigDataType: word32
-T_1008: (in esp_76 + 0x0000001C : word32)
-  Class: Eq_395
-  DataType: Eq_395
+T_1009: (in esp_76 + 0x0000001C : word32)
+  Class: Eq_396
+  DataType: Eq_396
   OrigDataType: word32
-T_1009: (in 0x00000024 : word32)
-  Class: Eq_1009
+T_1010: (in 0x00000024 : word32)
+  Class: Eq_1010
   DataType: ui32
   OrigDataType: ui32
-T_1010: (in ebp_13 - 0x00000024 : word32)
-  Class: Eq_1010
-  DataType: (ptr32 Eq_818)
-  OrigDataType: (ptr32 (struct (0 T_1013 t0000)))
-T_1011: (in 0x00000000 : word32)
+T_1011: (in ebp_13 - 0x00000024 : word32)
   Class: Eq_1011
+  DataType: (ptr32 Eq_819)
+  OrigDataType: (ptr32 (struct (0 T_1014 t0000)))
+T_1012: (in 0x00000000 : word32)
+  Class: Eq_1012
   DataType: word32
   OrigDataType: word32
-T_1012: (in ebp_13 - 0x00000024 + 0x00000000 : word32)
-  Class: Eq_1012
+T_1013: (in ebp_13 - 0x00000024 + 0x00000000 : word32)
+  Class: Eq_1013
   DataType: ptr32
   OrigDataType: ptr32
-T_1013: (in Mem84[ebp_13 - 0x00000024 + 0x00000000:word32] : word32)
-  Class: Eq_818
-  DataType: Eq_818
+T_1014: (in Mem84[ebp_13 - 0x00000024 + 0x00000000:word32] : word32)
+  Class: Eq_819
+  DataType: Eq_819
   OrigDataType: word32
-T_1014: (in 0x00000008 : word32)
-  Class: Eq_1014
+T_1015: (in 0x00000008 : word32)
+  Class: Eq_1015
   DataType: word32
   OrigDataType: word32
-T_1015: (in ebp_13 + 0x00000008 : word32)
-  Class: Eq_1015
+T_1016: (in ebp_13 + 0x00000008 : word32)
+  Class: Eq_1016
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_1016: (in Mem26[ebp_13 + 0x00000008:word32] : word32)
-  Class: Eq_137
-  DataType: Eq_137
+T_1017: (in Mem26[ebp_13 + 0x00000008:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
   OrigDataType: word32
-T_1017: (in 4 : int32)
-  Class: Eq_1017
-  DataType: int32
-  OrigDataType: int32
-T_1018: (in esp_14 - 4 : word32)
+T_1018: (in 4 : int32)
   Class: Eq_1018
-  DataType: (ptr32 Eq_137)
-  OrigDataType: (ptr32 (struct (0 T_1021 t0000)))
-T_1019: (in 0x00000000 : word32)
-  Class: Eq_1019
-  DataType: word32
-  OrigDataType: word32
-T_1020: (in esp_14 - 4 + 0x00000000 : word32)
-  Class: Eq_1020
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1021: (in Mem90[esp_14 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_137
-  DataType: Eq_137
-  OrigDataType: word32
-T_1022: (in _onexit : ptr32)
-  Class: Eq_1022
-  DataType: (ptr32 Eq_1022)
-  OrigDataType: (ptr32 (fn T_1029 (T_1028)))
-T_1023: (in signature of _onexit : void)
-  Class: Eq_1022
-  DataType: (ptr32 Eq_1022)
-  OrigDataType: 
-T_1024: (in _Func : _onexit_t)
-  Class: Eq_818
-  DataType: Eq_818
-  OrigDataType: 
-T_1025: (in esp_14 - 4 : word32)
-  Class: Eq_1025
-  DataType: (ptr32 Eq_818)
-  OrigDataType: (ptr32 (struct (0 T_1028 t0000)))
-T_1026: (in 0x00000000 : word32)
-  Class: Eq_1026
-  DataType: word32
-  OrigDataType: word32
-T_1027: (in esp_14 - 4 + 0x00000000 : word32)
-  Class: Eq_1027
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1028: (in Mem90[esp_14 - 4 + 0x00000000:_onexit_t] : _onexit_t)
-  Class: Eq_818
-  DataType: Eq_818
-  OrigDataType: _onexit_t
-T_1029: (in _onexit(*(esp_14 - 4)) : _onexit_t)
-  Class: Eq_818
-  DataType: Eq_818
-  OrigDataType: _onexit_t
-T_1030: (in fn1000182D : ptr32)
-  Class: Eq_510
-  DataType: (ptr32 Eq_510)
-  OrigDataType: (ptr32 (fn T_1034 (T_824, T_1033)))
-T_1031: (in -4 : int32)
-  Class: Eq_1031
   DataType: int32
   OrigDataType: int32
-T_1032: (in esp_81 + -4 : word32)
-  Class: Eq_1032
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1033: (in Mem97[esp_81 + -4:word32] : word32)
-  Class: Eq_513
+T_1019: (in esp_14 - 4 : word32)
+  Class: Eq_1019
+  DataType: (ptr32 Eq_138)
+  OrigDataType: (ptr32 (struct (0 T_1022 t0000)))
+T_1020: (in 0x00000000 : word32)
+  Class: Eq_1020
   DataType: word32
   OrigDataType: word32
-T_1034: (in fn1000182D(ebp_13, *((word32) esp_81 - 4)) : word32)
-  Class: Eq_388
+T_1021: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_1021
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1022: (in Mem90[esp_14 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: word32
+T_1023: (in _onexit : ptr32)
+  Class: Eq_1023
+  DataType: (ptr32 Eq_1023)
+  OrigDataType: (ptr32 (fn T_1030 (T_1029)))
+T_1024: (in signature of _onexit : void)
+  Class: Eq_1023
+  DataType: (ptr32 Eq_1023)
+  OrigDataType: 
+T_1025: (in _Func : _onexit_t)
+  Class: Eq_819
+  DataType: Eq_819
+  OrigDataType: 
+T_1026: (in esp_14 - 4 : word32)
+  Class: Eq_1026
+  DataType: (ptr32 Eq_819)
+  OrigDataType: (ptr32 (struct (0 T_1029 t0000)))
+T_1027: (in 0x00000000 : word32)
+  Class: Eq_1027
+  DataType: word32
+  OrigDataType: word32
+T_1028: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_1028
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1029: (in Mem90[esp_14 - 4 + 0x00000000:_onexit_t] : _onexit_t)
+  Class: Eq_819
+  DataType: Eq_819
+  OrigDataType: _onexit_t
+T_1030: (in _onexit(*(esp_14 - 4)) : _onexit_t)
+  Class: Eq_819
+  DataType: Eq_819
+  OrigDataType: _onexit_t
+T_1031: (in fn1000182D : ptr32)
+  Class: Eq_511
+  DataType: (ptr32 Eq_511)
+  OrigDataType: (ptr32 (fn T_1035 (T_825, T_1034)))
+T_1032: (in -4 : int32)
+  Class: Eq_1032
+  DataType: int32
+  OrigDataType: int32
+T_1033: (in esp_81 + -4 : word32)
+  Class: Eq_1033
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1034: (in Mem97[esp_81 + -4:word32] : word32)
+  Class: Eq_514
+  DataType: word32
+  OrigDataType: word32
+T_1035: (in fn1000182D(ebp_13, *((word32) esp_81 - 4)) : word32)
+  Class: Eq_389
   DataType: ptr32
   OrigDataType: word32
-T_1035: (in unlock : ptr32)
-  Class: Eq_1035
+T_1036: (in unlock : ptr32)
+  Class: Eq_1036
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_1036: (in signature of unlock : void)
-  Class: Eq_1036
-  DataType: Eq_1036
+T_1037: (in signature of unlock : void)
+  Class: Eq_1037
+  DataType: Eq_1037
   OrigDataType: 
-T_1037: (in ebx : (ptr32 Eq_189))
-  Class: Eq_189
-  DataType: (ptr32 Eq_189)
+T_1038: (in ebx : (ptr32 Eq_190))
+  Class: Eq_190
+  DataType: (ptr32 Eq_190)
   OrigDataType: word32
-T_1038: (in esi : ptr32)
-  Class: Eq_385
+T_1039: (in esi : ptr32)
+  Class: Eq_386
   DataType: ptr32
   OrigDataType: word32
-T_1039: (in edi : word32)
-  Class: Eq_386
+T_1040: (in edi : word32)
+  Class: Eq_387
   DataType: word32
   OrigDataType: word32
-T_1040: (in fn100015CF : ptr32)
-  Class: Eq_1040
-  DataType: (ptr32 Eq_1040)
-  OrigDataType: (ptr32 (fn T_1042 (T_1037, T_1038, T_1039)))
-T_1041: (in signature of fn100015CF : void)
-  Class: Eq_1040
-  DataType: (ptr32 Eq_1040)
+T_1041: (in fn100015CF : ptr32)
+  Class: Eq_1041
+  DataType: (ptr32 Eq_1041)
+  OrigDataType: (ptr32 (fn T_1043 (T_1038, T_1039, T_1040)))
+T_1042: (in signature of fn100015CF : void)
+  Class: Eq_1041
+  DataType: (ptr32 Eq_1041)
   OrigDataType: 
-T_1042: (in fn100015CF(ebx, esi, edi) : word32)
-  Class: Eq_1042
-  DataType: word32
-  OrigDataType: word32
-T_1043: (in esi : word32)
+T_1043: (in fn100015CF(ebx, esi, edi) : word32)
   Class: Eq_1043
   DataType: word32
   OrigDataType: word32
-T_1044: (in edi : word32)
+T_1044: (in esi : word32)
   Class: Eq_1044
   DataType: word32
   OrigDataType: word32
-T_1045: (in Top_25 : int8)
+T_1045: (in edi : word32)
   Class: Eq_1045
+  DataType: word32
+  OrigDataType: word32
+T_1046: (in Top_25 : int8)
+  Class: Eq_1046
   DataType: int8
   OrigDataType: int8
-T_1046: (in 0 : int8)
-  Class: Eq_1045
+T_1047: (in 0 : int8)
+  Class: Eq_1046
   DataType: int8
   OrigDataType: int8
-T_1047: (in esp_21 : ptr32)
-  Class: Eq_1047
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1048: (in fp : ptr32)
+T_1048: (in esp_21 : ptr32)
   Class: Eq_1048
   DataType: ptr32
   OrigDataType: ptr32
-T_1049: (in 8 : int32)
+T_1049: (in fp : ptr32)
   Class: Eq_1049
-  DataType: int32
-  OrigDataType: int32
-T_1050: (in fp - 8 : word32)
-  Class: Eq_1047
   DataType: ptr32
   OrigDataType: ptr32
-T_1051: (in esi_13 : (ptr32 word32))
-  Class: Eq_1051
+T_1050: (in 8 : int32)
+  Class: Eq_1050
+  DataType: int32
+  OrigDataType: int32
+T_1051: (in fp - 8 : word32)
+  Class: Eq_1048
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1052: (in esi_13 : (ptr32 word32))
+  Class: Eq_1052
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
-T_1052: (in 0x100021D8 : ptr32)
-  Class: Eq_1051
+T_1053: (in 0x100021D8 : ptr32)
+  Class: Eq_1052
   DataType: (ptr32 word32)
   OrigDataType: ptr32
-T_1053: (in true : bool)
-  Class: Eq_1053
+T_1054: (in true : bool)
+  Class: Eq_1054
   DataType: bool
   OrigDataType: bool
-T_1054: (in eax_17 : word32)
-  Class: Eq_1054
-  DataType: word32
-  OrigDataType: word32
-T_1055: (in 0x00000000 : word32)
+T_1055: (in eax_17 : word32)
   Class: Eq_1055
   DataType: word32
   OrigDataType: word32
-T_1056: (in esi_13 + 0x00000000 : word32)
+T_1056: (in 0x00000000 : word32)
   Class: Eq_1056
+  DataType: word32
+  OrigDataType: word32
+T_1057: (in esi_13 + 0x00000000 : word32)
+  Class: Eq_1057
   DataType: ptr32
   OrigDataType: ptr32
-T_1057: (in Mem9[esi_13 + 0x00000000:word32] : word32)
-  Class: Eq_1054
+T_1058: (in Mem9[esi_13 + 0x00000000:word32] : word32)
+  Class: Eq_1055
   DataType: word32
   OrigDataType: word32
-T_1058: (in 0x00000000 : word32)
-  Class: Eq_1054
+T_1059: (in 0x00000000 : word32)
+  Class: Eq_1055
   DataType: word32
   OrigDataType: word32
-T_1059: (in eax_17 == 0x00000000 : bool)
-  Class: Eq_1059
+T_1060: (in eax_17 == 0x00000000 : bool)
+  Class: Eq_1060
   DataType: bool
   OrigDataType: bool
-T_1060: (in 0x00000004 : word32)
-  Class: Eq_1060
+T_1061: (in 0x00000004 : word32)
+  Class: Eq_1061
   DataType: int32
   OrigDataType: int32
-T_1061: (in esi_13 + 0x00000004 : word32)
-  Class: Eq_1051
+T_1062: (in esi_13 + 0x00000004 : word32)
+  Class: Eq_1052
   DataType: (ptr32 word32)
   OrigDataType: ptr32
-T_1062: (in 0x100021D8 : ptr32)
-  Class: Eq_1051
+T_1063: (in 0x100021D8 : ptr32)
+  Class: Eq_1052
   DataType: (ptr32 word32)
   OrigDataType: ptr32
-T_1063: (in esi_13 < globals->a100021D8 : bool)
-  Class: Eq_1063
+T_1064: (in esi_13 < globals->a100021D8 : bool)
+  Class: Eq_1064
   DataType: bool
   OrigDataType: bool
-T_1064: (in fn00000000 : ptr32)
-  Class: Eq_1064
+T_1065: (in fn00000000 : ptr32)
+  Class: Eq_1065
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_1065: (in signature of fn00000000 : void)
-  Class: Eq_1065
-  DataType: Eq_1065
-  OrigDataType: 
-T_1066: (in eax : word32)
+T_1066: (in signature of fn00000000 : void)
   Class: Eq_1066
-  DataType: word32
-  OrigDataType: word32
-T_1067: (in dwArg04 : (ptr32 Eq_1067))
+  DataType: Eq_1066
+  OrigDataType: 
+T_1067: (in eax : word32)
   Class: Eq_1067
-  DataType: (ptr32 Eq_1067)
-  OrigDataType: (ptr32 (struct (0 T_1070 t0000) (3C T_1076 t003C)))
-T_1068: (in 0x00000000 : word32)
-  Class: Eq_1068
   DataType: word32
   OrigDataType: word32
-T_1069: (in dwArg04 + 0x00000000 : word32)
+T_1068: (in dwArg04 : (ptr32 Eq_1068))
+  Class: Eq_1068
+  DataType: (ptr32 Eq_1068)
+  OrigDataType: (ptr32 (struct (0 T_1071 t0000) (3C T_1077 t003C)))
+T_1069: (in 0x00000000 : word32)
   Class: Eq_1069
   DataType: word32
   OrigDataType: word32
-T_1070: (in Mem0[dwArg04 + 0x00000000:word16] : word16)
+T_1070: (in dwArg04 + 0x00000000 : word32)
   Class: Eq_1070
+  DataType: word32
+  OrigDataType: word32
+T_1071: (in Mem0[dwArg04 + 0x00000000:word16] : word16)
+  Class: Eq_1071
   DataType: word16
   OrigDataType: word16
-T_1071: (in 0x5A4D : word16)
-  Class: Eq_1070
+T_1072: (in 0x5A4D : word16)
+  Class: Eq_1071
   DataType: word16
   OrigDataType: word16
-T_1072: (in dwArg04->w0000 == 0x5A4D : bool)
-  Class: Eq_1072
+T_1073: (in dwArg04->w0000 == 0x5A4D : bool)
+  Class: Eq_1073
   DataType: bool
   OrigDataType: bool
-T_1073: (in eax_9 : (ptr32 Eq_1073))
-  Class: Eq_1073
-  DataType: (ptr32 Eq_1073)
-  OrigDataType: (ptr32 (struct (0 T_1080 t0000) (18 T_1086 t0018)))
-T_1074: (in 0x0000003C : word32)
+T_1074: (in eax_9 : (ptr32 Eq_1074))
   Class: Eq_1074
+  DataType: (ptr32 Eq_1074)
+  OrigDataType: (ptr32 (struct (0 T_1081 t0000) (18 T_1087 t0018)))
+T_1075: (in 0x0000003C : word32)
+  Class: Eq_1075
   DataType: word32
   OrigDataType: word32
-T_1075: (in dwArg04 + 0x0000003C : word32)
-  Class: Eq_1075
+T_1076: (in dwArg04 + 0x0000003C : word32)
+  Class: Eq_1076
   DataType: ptr32
   OrigDataType: ptr32
-T_1076: (in Mem0[dwArg04 + 0x0000003C:word32] : word32)
-  Class: Eq_1076
+T_1077: (in Mem0[dwArg04 + 0x0000003C:word32] : word32)
+  Class: Eq_1077
   DataType: word32
   OrigDataType: word32
-T_1077: (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
-  Class: Eq_1073
-  DataType: (ptr32 Eq_1073)
+T_1078: (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
+  Class: Eq_1074
+  DataType: (ptr32 Eq_1074)
   OrigDataType: word32
-T_1078: (in 0x00000000 : word32)
-  Class: Eq_1078
-  DataType: word32
-  OrigDataType: word32
-T_1079: (in eax_9 + 0x00000000 : word32)
+T_1079: (in 0x00000000 : word32)
   Class: Eq_1079
   DataType: word32
   OrigDataType: word32
-T_1080: (in Mem0[eax_9 + 0x00000000:word32] : word32)
+T_1080: (in eax_9 + 0x00000000 : word32)
   Class: Eq_1080
   DataType: word32
   OrigDataType: word32
-T_1081: (in 0x00004550 : word32)
-  Class: Eq_1080
+T_1081: (in Mem0[eax_9 + 0x00000000:word32] : word32)
+  Class: Eq_1081
   DataType: word32
   OrigDataType: word32
-T_1082: (in eax_9->dw0000 != 0x00004550 : bool)
-  Class: Eq_1082
+T_1082: (in 0x00004550 : word32)
+  Class: Eq_1081
+  DataType: word32
+  OrigDataType: word32
+T_1083: (in eax_9->dw0000 != 0x00004550 : bool)
+  Class: Eq_1083
   DataType: bool
   OrigDataType: bool
-T_1083: (in 0x00000000 : word32)
-  Class: Eq_1066
+T_1084: (in 0x00000000 : word32)
+  Class: Eq_1067
   DataType: word32
   OrigDataType: word32
-T_1084: (in 0x00000018 : word32)
-  Class: Eq_1084
-  DataType: word32
-  OrigDataType: word32
-T_1085: (in eax_9 + 0x00000018 : word32)
+T_1085: (in 0x00000018 : word32)
   Class: Eq_1085
+  DataType: word32
+  OrigDataType: word32
+T_1086: (in eax_9 + 0x00000018 : word32)
+  Class: Eq_1086
   DataType: ptr32
   OrigDataType: ptr32
-T_1086: (in Mem0[eax_9 + 0x00000018:word16] : word16)
-  Class: Eq_1086
+T_1087: (in Mem0[eax_9 + 0x00000018:word16] : word16)
+  Class: Eq_1087
   DataType: word16
   OrigDataType: word16
-T_1087: (in 0x010B : word16)
-  Class: Eq_1086
+T_1088: (in 0x010B : word16)
+  Class: Eq_1087
   DataType: word16
   OrigDataType: word16
-T_1088: (in eax_9->w0018 == 0x010B : bool)
-  Class: Eq_1088
+T_1089: (in eax_9->w0018 == 0x010B : bool)
+  Class: Eq_1089
   DataType: bool
   OrigDataType: bool
-T_1089: (in (word32) (Mem0[eax_9 + 0x00000018:word16] == 0x010B) : word32)
-  Class: Eq_1066
+T_1090: (in (word32) (Mem0[eax_9 + 0x00000018:word16] == 0x010B) : word32)
+  Class: Eq_1067
   DataType: word32
   OrigDataType: word32
-T_1090: (in eax : (ptr32 Eq_1090))
-  Class: Eq_1090
-  DataType: (ptr32 Eq_1090)
-  OrigDataType: word32
-T_1091: (in dwArg04 : (ptr32 Eq_1091))
+T_1091: (in eax : (ptr32 Eq_1091))
   Class: Eq_1091
   DataType: (ptr32 Eq_1091)
-  OrigDataType: (ptr32 (struct (3C T_1097 t003C)))
-T_1092: (in dwArg08 : up32)
+  OrigDataType: word32
+T_1092: (in dwArg04 : (ptr32 Eq_1092))
   Class: Eq_1092
+  DataType: (ptr32 Eq_1092)
+  OrigDataType: (ptr32 (struct (3C T_1098 t003C)))
+T_1093: (in dwArg08 : up32)
+  Class: Eq_1093
   DataType: up32
   OrigDataType: up32
-T_1093: (in edxOut : ptr32)
-  Class: Eq_1093
+T_1094: (in edxOut : ptr32)
+  Class: Eq_1094
   DataType: ptr32
   OrigDataType: ptr32
-T_1094: (in ecx_7 : (ptr32 Eq_1094))
-  Class: Eq_1094
-  DataType: (ptr32 Eq_1094)
-  OrigDataType: (ptr32 (struct (6 T_1102 t0006) (14 T_1109 t0014)))
-T_1095: (in 0x0000003C : word32)
+T_1095: (in ecx_7 : (ptr32 Eq_1095))
   Class: Eq_1095
-  DataType: word32
-  OrigDataType: word32
-T_1096: (in dwArg04 + 0x0000003C : word32)
+  DataType: (ptr32 Eq_1095)
+  OrigDataType: (ptr32 (struct (6 T_1103 t0006) (14 T_1110 t0014)))
+T_1096: (in 0x0000003C : word32)
   Class: Eq_1096
   DataType: word32
   OrigDataType: word32
-T_1097: (in Mem0[dwArg04 + 0x0000003C:word32] : word32)
+T_1097: (in dwArg04 + 0x0000003C : word32)
   Class: Eq_1097
   DataType: word32
   OrigDataType: word32
-T_1098: (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
-  Class: Eq_1094
-  DataType: (ptr32 Eq_1094)
-  OrigDataType: word32
-T_1099: (in esi_15 : ptr32)
-  Class: Eq_1093
-  DataType: ptr32
-  OrigDataType: up32
-T_1100: (in 0x00000006 : word32)
-  Class: Eq_1100
+T_1098: (in Mem0[dwArg04 + 0x0000003C:word32] : word32)
+  Class: Eq_1098
   DataType: word32
   OrigDataType: word32
-T_1101: (in ecx_7 + 0x00000006 : word32)
+T_1099: (in Mem0[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
+  Class: Eq_1095
+  DataType: (ptr32 Eq_1095)
+  OrigDataType: word32
+T_1100: (in esi_15 : ptr32)
+  Class: Eq_1094
+  DataType: ptr32
+  OrigDataType: up32
+T_1101: (in 0x00000006 : word32)
   Class: Eq_1101
   DataType: word32
   OrigDataType: word32
-T_1102: (in Mem14[ecx_7 + 0x00000006:word16] : word16)
+T_1102: (in ecx_7 + 0x00000006 : word32)
   Class: Eq_1102
+  DataType: word32
+  OrigDataType: word32
+T_1103: (in Mem14[ecx_7 + 0x00000006:word16] : word16)
+  Class: Eq_1103
   DataType: word16
   OrigDataType: word16
-T_1103: (in (word32) Mem14[ecx_7 + 0x00000006:word16] : word32)
-  Class: Eq_1093
+T_1104: (in (word32) Mem14[ecx_7 + 0x00000006:word16] : word32)
+  Class: Eq_1094
   DataType: ptr32
   OrigDataType: word32
-T_1104: (in edx_16 : ptr32)
-  Class: Eq_1093
+T_1105: (in edx_16 : ptr32)
+  Class: Eq_1094
   DataType: ptr32
   OrigDataType: up32
-T_1105: (in 0x00000000 : word32)
-  Class: Eq_1093
+T_1106: (in 0x00000000 : word32)
+  Class: Eq_1094
   DataType: ptr32
   OrigDataType: word32
-T_1106: (in eax_22 : (ptr32 Eq_1090))
-  Class: Eq_1090
-  DataType: (ptr32 Eq_1090)
+T_1107: (in eax_22 : (ptr32 Eq_1091))
+  Class: Eq_1091
+  DataType: (ptr32 Eq_1091)
   OrigDataType: (ptr32 (struct 0028 (8 up32 dw0008) (C word32 dw000C)))
-T_1107: (in 0x00000014 : word32)
-  Class: Eq_1107
+T_1108: (in 0x00000014 : word32)
+  Class: Eq_1108
   DataType: word32
   OrigDataType: word32
-T_1108: (in ecx_7 + 0x00000014 : word32)
-  Class: Eq_1108
+T_1109: (in ecx_7 + 0x00000014 : word32)
+  Class: Eq_1109
   DataType: ptr32
   OrigDataType: ptr32
-T_1109: (in Mem0[ecx_7 + 0x00000014:word16] : word16)
-  Class: Eq_1109
+T_1110: (in Mem0[ecx_7 + 0x00000014:word16] : word16)
+  Class: Eq_1110
   DataType: word16
   OrigDataType: word16
-T_1110: (in (word32) Mem0[ecx_7 + 0x00000014:word16] : word32)
-  Class: Eq_1110
-  DataType: word32
-  OrigDataType: word32
-T_1111: (in 0x00000018 : word32)
+T_1111: (in (word32) Mem0[ecx_7 + 0x00000014:word16] : word32)
   Class: Eq_1111
   DataType: word32
   OrigDataType: word32
-T_1112: (in (word32) ecx_7->w0014 + 0x00000018 : word32)
+T_1112: (in 0x00000018 : word32)
   Class: Eq_1112
   DataType: word32
   OrigDataType: word32
-T_1113: (in (word32) Mem0[ecx_7 + 0x00000014:word16] + 0x00000018 + ecx_7 : word32)
-  Class: Eq_1090
-  DataType: (ptr32 Eq_1090)
-  OrigDataType: word32
-T_1114: (in 0x00000000 : word32)
-  Class: Eq_1093
-  DataType: ptr32
-  OrigDataType: up32
-T_1115: (in esi_15 <= 0x00000000 : bool)
-  Class: Eq_1115
-  DataType: bool
-  OrigDataType: bool
-T_1116: (in 0x00000000 : word32)
-  Class: Eq_1090
-  DataType: (ptr32 Eq_1090)
-  OrigDataType: word32
-T_1117: (in 0x00000001 : word32)
-  Class: Eq_1117
+T_1113: (in (word32) ecx_7->w0014 + 0x00000018 : word32)
+  Class: Eq_1113
   DataType: word32
   OrigDataType: word32
-T_1118: (in edx_16 + 0x00000001 : word32)
-  Class: Eq_1093
-  DataType: ptr32
-  OrigDataType: word32
-T_1119: (in 0x00000028 : word32)
-  Class: Eq_1119
-  DataType: word32
-  OrigDataType: word32
-T_1120: (in eax_22 + 0x00000028 : word32)
-  Class: Eq_1090
-  DataType: (ptr32 Eq_1090)
-  OrigDataType: word32
-T_1121: (in edx_16 < esi_15 : bool)
-  Class: Eq_1121
-  DataType: bool
-  OrigDataType: bool
-T_1122: (in 0x00000008 : word32)
-  Class: Eq_1122
-  DataType: word32
-  OrigDataType: word32
-T_1123: (in eax_22 + 0x00000008 : word32)
-  Class: Eq_1123
-  DataType: word32
-  OrigDataType: word32
-T_1124: (in Mem21[eax_22 + 0x00000008:word32] : word32)
-  Class: Eq_1124
-  DataType: up32
-  OrigDataType: up32
-T_1125: (in ecx_28 : up32)
-  Class: Eq_1092
-  DataType: up32
-  OrigDataType: up32
-T_1126: (in eax_22->dw0008 + ecx_28 : word32)
-  Class: Eq_1092
-  DataType: up32
-  OrigDataType: up32
-T_1127: (in dwArg08 < eax_22->dw0008 + ecx_28 : bool)
-  Class: Eq_1127
-  DataType: bool
-  OrigDataType: bool
-T_1128: (in 0x0000000C : word32)
-  Class: Eq_1128
-  DataType: word32
-  OrigDataType: word32
-T_1129: (in eax_22 + 0x0000000C : word32)
-  Class: Eq_1129
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1130: (in Mem21[eax_22 + 0x0000000C:word32] : word32)
-  Class: Eq_1092
-  DataType: up32
-  OrigDataType: word32
-T_1131: (in dwArg08 < ecx_28 : bool)
-  Class: Eq_1131
-  DataType: bool
-  OrigDataType: bool
-T_1132: (in eax : ui32)
-  Class: Eq_1132
-  DataType: ui32
-  OrigDataType: word32
-T_1133: (in eax_60 : ui32)
-  Class: Eq_1132
-  DataType: ui32
-  OrigDataType: ui32
-T_1134: (in ebp_13 : (ptr32 Eq_138))
-  Class: Eq_138
-  DataType: (ptr32 Eq_138)
-  OrigDataType: (ptr32 (struct (8 T_1178 t0008)))
-T_1135: (in fn100017E8 : ptr32)
-  Class: Eq_432
-  DataType: (ptr32 Eq_432)
-  OrigDataType: (ptr32 (fn T_1138 (T_384, T_385, T_386, T_1136, T_1137)))
-T_1136: (in dwLoc0C : word32)
-  Class: Eq_437
-  DataType: word32
-  OrigDataType: word32
-T_1137: (in 0x00000008 : word32)
-  Class: Eq_438
-  DataType: ui32
-  OrigDataType: word32
-T_1138: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
-  Class: Eq_138
-  DataType: (ptr32 Eq_138)
-  OrigDataType: word32
-T_1139: (in 0x00000004 : word32)
-  Class: Eq_1139
-  DataType: ui32
-  OrigDataType: ui32
-T_1140: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_1140
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1143 t0000)))
-T_1141: (in 0x00000000 : word32)
-  Class: Eq_1141
-  DataType: word32
-  OrigDataType: word32
-T_1142: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_1142
-  DataType: word32
-  OrigDataType: word32
-T_1143: (in Mem7[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_1143
-  DataType: ui32
-  OrigDataType: ui32
-T_1144: (in 0x00000000 : word32)
-  Class: Eq_1144
-  DataType: ui32
-  OrigDataType: ui32
-T_1145: (in *(ebp_13 - 0x00000004) & 0x00000000 : word32)
-  Class: Eq_1145
-  DataType: ui32
-  OrigDataType: ui32
-T_1146: (in 0x00000004 : word32)
-  Class: Eq_1146
-  DataType: ui32
-  OrigDataType: ui32
-T_1147: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_1147
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1150 t0000)))
-T_1148: (in 0x00000000 : word32)
-  Class: Eq_1148
-  DataType: word32
-  OrigDataType: word32
-T_1149: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_1149
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1150: (in Mem20[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_1145
-  DataType: ui32
-  OrigDataType: word32
-T_1151: (in esp_14 : Eq_395)
-  Class: Eq_395
-  DataType: Eq_395
-  OrigDataType: (ptr32 (struct (FFFFFFFC T_1226 tFFFFFFFC)))
-T_1152: (in 0x10000000 : ptr32)
-  Class: Eq_1152
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1153: (in 4 : int32)
-  Class: Eq_1153
-  DataType: int32
-  OrigDataType: int32
-T_1154: (in esp_14 - 4 : word32)
-  Class: Eq_1154
-  DataType: (ptr32 ptr32)
-  OrigDataType: (ptr32 (struct (0 T_1157 t0000)))
-T_1155: (in 0x00000000 : word32)
-  Class: Eq_1155
-  DataType: word32
-  OrigDataType: word32
-T_1156: (in esp_14 - 4 + 0x00000000 : word32)
-  Class: Eq_1156
-  DataType: word32
-  OrigDataType: word32
-T_1157: (in Mem25[esp_14 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_1152
-  DataType: ptr32
-  OrigDataType: word32
-T_1158: (in edx_23 : ptr32)
-  Class: Eq_387
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1159: (in 0x10000000 : ptr32)
-  Class: Eq_387
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1160: (in fn100016D0 : ptr32)
-  Class: Eq_1160
-  DataType: (ptr32 Eq_1160)
-  OrigDataType: (ptr32 (fn T_1166 (T_1165)))
-T_1161: (in signature of fn100016D0 : void)
-  Class: Eq_1160
-  DataType: (ptr32 Eq_1160)
-  OrigDataType: 
-T_1162: (in esp_14 - 4 : word32)
-  Class: Eq_1162
-  DataType: (ptr32 (ptr32 Eq_1067))
-  OrigDataType: (ptr32 (struct (0 T_1165 t0000)))
-T_1163: (in 0x00000000 : word32)
-  Class: Eq_1163
-  DataType: word32
-  OrigDataType: word32
-T_1164: (in esp_14 - 4 + 0x00000000 : word32)
-  Class: Eq_1164
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1165: (in Mem25[esp_14 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_1067
-  DataType: (ptr32 Eq_1067)
-  OrigDataType: word32
-T_1166: (in fn100016D0(*(esp_14 - 4)) : word32)
-  Class: Eq_1166
-  DataType: word32
-  OrigDataType: word32
-T_1167: (in 0x00000000 : word32)
-  Class: Eq_1166
-  DataType: word32
-  OrigDataType: word32
-T_1168: (in fn100016D0(*(esp_14 - 4)) == 0x00000000 : bool)
-  Class: Eq_1168
-  DataType: bool
-  OrigDataType: bool
-T_1169: (in 0xFFFFFFFE : word32)
-  Class: Eq_1169
-  DataType: word32
-  OrigDataType: word32
-T_1170: (in 0x00000004 : word32)
-  Class: Eq_1170
-  DataType: ui32
-  OrigDataType: ui32
-T_1171: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_1171
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1174 t0000)))
-T_1172: (in 0x00000000 : word32)
-  Class: Eq_1172
-  DataType: word32
-  OrigDataType: word32
-T_1173: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_1173
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1174: (in Mem59[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_1169
-  DataType: word32
-  OrigDataType: word32
-T_1175: (in 0x00000000 : word32)
-  Class: Eq_1132
-  DataType: ui32
-  OrigDataType: word32
-T_1176: (in 0x00000008 : word32)
-  Class: Eq_1176
-  DataType: word32
-  OrigDataType: word32
-T_1177: (in ebp_13 + 0x00000008 : word32)
-  Class: Eq_1177
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1178: (in Mem25[ebp_13 + 0x00000008:word32] : word32)
-  Class: Eq_137
-  DataType: Eq_137
-  OrigDataType: ui32
-T_1179: (in 0x10000000 : ptr32)
-  Class: Eq_1179
-  DataType: ui32
-  OrigDataType: (union (ui32 u0) (ptr32 u1))
-T_1180: (in ebp_13->t0008 - 0x10000000 : word32)
-  Class: Eq_1180
-  DataType: ui32
-  OrigDataType: ui32
-T_1181: (in 4 : int32)
-  Class: Eq_1181
-  DataType: int32
-  OrigDataType: int32
-T_1182: (in esp_14 - 4 : word32)
-  Class: Eq_1182
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1185 t0000)))
-T_1183: (in 0x00000000 : word32)
-  Class: Eq_1183
-  DataType: word32
-  OrigDataType: word32
-T_1184: (in esp_14 - 4 + 0x00000000 : word32)
-  Class: Eq_1184
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1185: (in Mem41[esp_14 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_1180
-  DataType: ui32
-  OrigDataType: word32
-T_1186: (in 0x10000000 : ptr32)
-  Class: Eq_1186
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1187: (in 8 : int32)
-  Class: Eq_1187
-  DataType: int32
-  OrigDataType: int32
-T_1188: (in esp_14 - 8 : word32)
-  Class: Eq_1188
-  DataType: (ptr32 ptr32)
-  OrigDataType: (ptr32 (struct (0 T_1191 t0000)))
-T_1189: (in 0x00000000 : word32)
-  Class: Eq_1189
-  DataType: word32
-  OrigDataType: word32
-T_1190: (in esp_14 - 8 + 0x00000000 : word32)
-  Class: Eq_1190
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1191: (in Mem43[esp_14 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_1186
-  DataType: ptr32
-  OrigDataType: word32
-T_1192: (in eax_44 : (ptr32 Eq_1192))
-  Class: Eq_1192
-  DataType: (ptr32 Eq_1192)
-  OrigDataType: (ptr32 (struct (24 T_1210 t0024)))
-T_1193: (in fn10001700 : ptr32)
-  Class: Eq_1193
-  DataType: (ptr32 Eq_1193)
-  OrigDataType: (ptr32 (fn T_1205 (T_1198, T_1203, T_1204)))
-T_1194: (in signature of fn10001700 : void)
-  Class: Eq_1193
-  DataType: (ptr32 Eq_1193)
-  OrigDataType: 
-T_1195: (in esp_14 - 8 : word32)
-  Class: Eq_1195
-  DataType: (ptr32 (ptr32 Eq_1091))
-  OrigDataType: (ptr32 (struct (0 T_1198 t0000)))
-T_1196: (in 0x00000000 : word32)
-  Class: Eq_1196
-  DataType: word32
-  OrigDataType: word32
-T_1197: (in esp_14 - 8 + 0x00000000 : word32)
-  Class: Eq_1197
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1198: (in Mem43[esp_14 - 8 + 0x00000000:word32] : word32)
+T_1114: (in (word32) Mem0[ecx_7 + 0x00000014:word16] + 0x00000018 + ecx_7 : word32)
   Class: Eq_1091
   DataType: (ptr32 Eq_1091)
   OrigDataType: word32
-T_1199: (in 4 : int32)
-  Class: Eq_1199
-  DataType: int32
-  OrigDataType: int32
-T_1200: (in esp_14 - 4 : word32)
-  Class: Eq_1200
-  DataType: (ptr32 up32)
-  OrigDataType: (ptr32 (struct (0 T_1203 t0000)))
-T_1201: (in 0x00000000 : word32)
-  Class: Eq_1201
-  DataType: word32
-  OrigDataType: word32
-T_1202: (in esp_14 - 4 + 0x00000000 : word32)
-  Class: Eq_1202
+T_1115: (in 0x00000000 : word32)
+  Class: Eq_1094
   DataType: ptr32
-  OrigDataType: ptr32
-T_1203: (in Mem43[esp_14 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_1092
-  DataType: up32
-  OrigDataType: word32
-T_1204: (in out edx_23 : ptr32)
-  Class: Eq_1093
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1205: (in fn10001700(*(esp_14 - 8), *(esp_14 - 4), out edx_23) : word32)
-  Class: Eq_1192
-  DataType: (ptr32 Eq_1192)
-  OrigDataType: word32
-T_1206: (in 0x00000000 : word32)
-  Class: Eq_1192
-  DataType: (ptr32 Eq_1192)
-  OrigDataType: word32
-T_1207: (in eax_44 == null : bool)
-  Class: Eq_1207
+  OrigDataType: up32
+T_1116: (in esi_15 <= 0x00000000 : bool)
+  Class: Eq_1116
   DataType: bool
   OrigDataType: bool
-T_1208: (in 0x00000024 : word32)
-  Class: Eq_1208
+T_1117: (in 0x00000000 : word32)
+  Class: Eq_1091
+  DataType: (ptr32 Eq_1091)
+  OrigDataType: word32
+T_1118: (in 0x00000001 : word32)
+  Class: Eq_1118
   DataType: word32
   OrigDataType: word32
-T_1209: (in eax_44 + 0x00000024 : word32)
+T_1119: (in edx_16 + 0x00000001 : word32)
+  Class: Eq_1094
+  DataType: ptr32
+  OrigDataType: word32
+T_1120: (in 0x00000028 : word32)
+  Class: Eq_1120
+  DataType: word32
+  OrigDataType: word32
+T_1121: (in eax_22 + 0x00000028 : word32)
+  Class: Eq_1091
+  DataType: (ptr32 Eq_1091)
+  OrigDataType: word32
+T_1122: (in edx_16 < esi_15 : bool)
+  Class: Eq_1122
+  DataType: bool
+  OrigDataType: bool
+T_1123: (in 0x00000008 : word32)
+  Class: Eq_1123
+  DataType: word32
+  OrigDataType: word32
+T_1124: (in eax_22 + 0x00000008 : word32)
+  Class: Eq_1124
+  DataType: word32
+  OrigDataType: word32
+T_1125: (in Mem21[eax_22 + 0x00000008:word32] : word32)
+  Class: Eq_1125
+  DataType: up32
+  OrigDataType: up32
+T_1126: (in ecx_28 : up32)
+  Class: Eq_1093
+  DataType: up32
+  OrigDataType: up32
+T_1127: (in eax_22->dw0008 + ecx_28 : word32)
+  Class: Eq_1093
+  DataType: up32
+  OrigDataType: up32
+T_1128: (in dwArg08 < eax_22->dw0008 + ecx_28 : bool)
+  Class: Eq_1128
+  DataType: bool
+  OrigDataType: bool
+T_1129: (in 0x0000000C : word32)
+  Class: Eq_1129
+  DataType: word32
+  OrigDataType: word32
+T_1130: (in eax_22 + 0x0000000C : word32)
+  Class: Eq_1130
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1131: (in Mem21[eax_22 + 0x0000000C:word32] : word32)
+  Class: Eq_1093
+  DataType: up32
+  OrigDataType: word32
+T_1132: (in dwArg08 < ecx_28 : bool)
+  Class: Eq_1132
+  DataType: bool
+  OrigDataType: bool
+T_1133: (in eax : ui32)
+  Class: Eq_1133
+  DataType: ui32
+  OrigDataType: word32
+T_1134: (in eax_60 : ui32)
+  Class: Eq_1133
+  DataType: ui32
+  OrigDataType: ui32
+T_1135: (in ebp_13 : (ptr32 Eq_139))
+  Class: Eq_139
+  DataType: (ptr32 Eq_139)
+  OrigDataType: (ptr32 (struct (8 T_1179 t0008)))
+T_1136: (in fn100017E8 : ptr32)
+  Class: Eq_433
+  DataType: (ptr32 Eq_433)
+  OrigDataType: (ptr32 (fn T_1139 (T_385, T_386, T_387, T_1137, T_1138)))
+T_1137: (in dwLoc0C : word32)
+  Class: Eq_438
+  DataType: word32
+  OrigDataType: word32
+T_1138: (in 0x00000008 : word32)
+  Class: Eq_439
+  DataType: ui32
+  OrigDataType: word32
+T_1139: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
+  Class: Eq_139
+  DataType: (ptr32 Eq_139)
+  OrigDataType: word32
+T_1140: (in 0x00000004 : word32)
+  Class: Eq_1140
+  DataType: ui32
+  OrigDataType: ui32
+T_1141: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_1141
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1144 t0000)))
+T_1142: (in 0x00000000 : word32)
+  Class: Eq_1142
+  DataType: word32
+  OrigDataType: word32
+T_1143: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_1143
+  DataType: word32
+  OrigDataType: word32
+T_1144: (in Mem7[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_1144
+  DataType: ui32
+  OrigDataType: ui32
+T_1145: (in 0x00000000 : word32)
+  Class: Eq_1145
+  DataType: ui32
+  OrigDataType: ui32
+T_1146: (in *(ebp_13 - 0x00000004) & 0x00000000 : word32)
+  Class: Eq_1146
+  DataType: ui32
+  OrigDataType: ui32
+T_1147: (in 0x00000004 : word32)
+  Class: Eq_1147
+  DataType: ui32
+  OrigDataType: ui32
+T_1148: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_1148
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1151 t0000)))
+T_1149: (in 0x00000000 : word32)
+  Class: Eq_1149
+  DataType: word32
+  OrigDataType: word32
+T_1150: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_1150
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1151: (in Mem20[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_1146
+  DataType: ui32
+  OrigDataType: word32
+T_1152: (in esp_14 : Eq_396)
+  Class: Eq_396
+  DataType: Eq_396
+  OrigDataType: (ptr32 (struct (FFFFFFFC T_1227 tFFFFFFFC)))
+T_1153: (in 0x10000000 : ptr32)
+  Class: Eq_1153
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1154: (in 4 : int32)
+  Class: Eq_1154
+  DataType: int32
+  OrigDataType: int32
+T_1155: (in esp_14 - 4 : word32)
+  Class: Eq_1155
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_1158 t0000)))
+T_1156: (in 0x00000000 : word32)
+  Class: Eq_1156
+  DataType: word32
+  OrigDataType: word32
+T_1157: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_1157
+  DataType: word32
+  OrigDataType: word32
+T_1158: (in Mem25[esp_14 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_1153
+  DataType: ptr32
+  OrigDataType: word32
+T_1159: (in edx_23 : ptr32)
+  Class: Eq_388
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1160: (in 0x10000000 : ptr32)
+  Class: Eq_388
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1161: (in fn100016D0 : ptr32)
+  Class: Eq_1161
+  DataType: (ptr32 Eq_1161)
+  OrigDataType: (ptr32 (fn T_1167 (T_1166)))
+T_1162: (in signature of fn100016D0 : void)
+  Class: Eq_1161
+  DataType: (ptr32 Eq_1161)
+  OrigDataType: 
+T_1163: (in esp_14 - 4 : word32)
+  Class: Eq_1163
+  DataType: (ptr32 (ptr32 Eq_1068))
+  OrigDataType: (ptr32 (struct (0 T_1166 t0000)))
+T_1164: (in 0x00000000 : word32)
+  Class: Eq_1164
+  DataType: word32
+  OrigDataType: word32
+T_1165: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_1165
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1166: (in Mem25[esp_14 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_1068
+  DataType: (ptr32 Eq_1068)
+  OrigDataType: word32
+T_1167: (in fn100016D0(*(esp_14 - 4)) : word32)
+  Class: Eq_1167
+  DataType: word32
+  OrigDataType: word32
+T_1168: (in 0x00000000 : word32)
+  Class: Eq_1167
+  DataType: word32
+  OrigDataType: word32
+T_1169: (in fn100016D0(*(esp_14 - 4)) == 0x00000000 : bool)
+  Class: Eq_1169
+  DataType: bool
+  OrigDataType: bool
+T_1170: (in 0xFFFFFFFE : word32)
+  Class: Eq_1170
+  DataType: word32
+  OrigDataType: word32
+T_1171: (in 0x00000004 : word32)
+  Class: Eq_1171
+  DataType: ui32
+  OrigDataType: ui32
+T_1172: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_1172
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_1175 t0000)))
+T_1173: (in 0x00000000 : word32)
+  Class: Eq_1173
+  DataType: word32
+  OrigDataType: word32
+T_1174: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_1174
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1175: (in Mem59[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_1170
+  DataType: word32
+  OrigDataType: word32
+T_1176: (in 0x00000000 : word32)
+  Class: Eq_1133
+  DataType: ui32
+  OrigDataType: word32
+T_1177: (in 0x00000008 : word32)
+  Class: Eq_1177
+  DataType: word32
+  OrigDataType: word32
+T_1178: (in ebp_13 + 0x00000008 : word32)
+  Class: Eq_1178
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1179: (in Mem25[ebp_13 + 0x00000008:word32] : word32)
+  Class: Eq_138
+  DataType: Eq_138
+  OrigDataType: ui32
+T_1180: (in 0x10000000 : ptr32)
+  Class: Eq_1180
+  DataType: ui32
+  OrigDataType: (union (ui32 u0) (ptr32 u1))
+T_1181: (in ebp_13->t0008 - 0x10000000 : word32)
+  Class: Eq_1181
+  DataType: ui32
+  OrigDataType: ui32
+T_1182: (in 4 : int32)
+  Class: Eq_1182
+  DataType: int32
+  OrigDataType: int32
+T_1183: (in esp_14 - 4 : word32)
+  Class: Eq_1183
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1186 t0000)))
+T_1184: (in 0x00000000 : word32)
+  Class: Eq_1184
+  DataType: word32
+  OrigDataType: word32
+T_1185: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_1185
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1186: (in Mem41[esp_14 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_1181
+  DataType: ui32
+  OrigDataType: word32
+T_1187: (in 0x10000000 : ptr32)
+  Class: Eq_1187
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1188: (in 8 : int32)
+  Class: Eq_1188
+  DataType: int32
+  OrigDataType: int32
+T_1189: (in esp_14 - 8 : word32)
+  Class: Eq_1189
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_1192 t0000)))
+T_1190: (in 0x00000000 : word32)
+  Class: Eq_1190
+  DataType: word32
+  OrigDataType: word32
+T_1191: (in esp_14 - 8 + 0x00000000 : word32)
+  Class: Eq_1191
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1192: (in Mem43[esp_14 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_1187
+  DataType: ptr32
+  OrigDataType: word32
+T_1193: (in eax_44 : (ptr32 Eq_1193))
+  Class: Eq_1193
+  DataType: (ptr32 Eq_1193)
+  OrigDataType: (ptr32 (struct (24 T_1211 t0024)))
+T_1194: (in fn10001700 : ptr32)
+  Class: Eq_1194
+  DataType: (ptr32 Eq_1194)
+  OrigDataType: (ptr32 (fn T_1206 (T_1199, T_1204, T_1205)))
+T_1195: (in signature of fn10001700 : void)
+  Class: Eq_1194
+  DataType: (ptr32 Eq_1194)
+  OrigDataType: 
+T_1196: (in esp_14 - 8 : word32)
+  Class: Eq_1196
+  DataType: (ptr32 (ptr32 Eq_1092))
+  OrigDataType: (ptr32 (struct (0 T_1199 t0000)))
+T_1197: (in 0x00000000 : word32)
+  Class: Eq_1197
+  DataType: word32
+  OrigDataType: word32
+T_1198: (in esp_14 - 8 + 0x00000000 : word32)
+  Class: Eq_1198
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1199: (in Mem43[esp_14 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_1092
+  DataType: (ptr32 Eq_1092)
+  OrigDataType: word32
+T_1200: (in 4 : int32)
+  Class: Eq_1200
+  DataType: int32
+  OrigDataType: int32
+T_1201: (in esp_14 - 4 : word32)
+  Class: Eq_1201
+  DataType: (ptr32 up32)
+  OrigDataType: (ptr32 (struct (0 T_1204 t0000)))
+T_1202: (in 0x00000000 : word32)
+  Class: Eq_1202
+  DataType: word32
+  OrigDataType: word32
+T_1203: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_1203
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1204: (in Mem43[esp_14 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_1093
+  DataType: up32
+  OrigDataType: word32
+T_1205: (in out edx_23 : ptr32)
+  Class: Eq_1094
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1206: (in fn10001700(*(esp_14 - 8), *(esp_14 - 4), out edx_23) : word32)
+  Class: Eq_1193
+  DataType: (ptr32 Eq_1193)
+  OrigDataType: word32
+T_1207: (in 0x00000000 : word32)
+  Class: Eq_1193
+  DataType: (ptr32 Eq_1193)
+  OrigDataType: word32
+T_1208: (in eax_44 == null : bool)
+  Class: Eq_1208
+  DataType: bool
+  OrigDataType: bool
+T_1209: (in 0x00000024 : word32)
   Class: Eq_1209
   DataType: word32
   OrigDataType: word32
-T_1210: (in Mem43[eax_44 + 0x00000024:word32] : word32)
+T_1210: (in eax_44 + 0x00000024 : word32)
   Class: Eq_1210
-  DataType: uint32
-  OrigDataType: uint32
-T_1211: (in 0x0000001F : word32)
-  Class: Eq_1211
   DataType: word32
   OrigDataType: word32
-T_1212: (in eax_44->dw0024 >> 0x0000001F : word32)
-  Class: Eq_1212
+T_1211: (in Mem43[eax_44 + 0x00000024:word32] : word32)
+  Class: Eq_1211
   DataType: uint32
   OrigDataType: uint32
-T_1213: (in ~(eax_44->dw0024 >> 0x0000001F) : word32)
+T_1212: (in 0x0000001F : word32)
+  Class: Eq_1212
+  DataType: word32
+  OrigDataType: word32
+T_1213: (in eax_44->dw0024 >> 0x0000001F : word32)
   Class: Eq_1213
   DataType: uint32
   OrigDataType: uint32
-T_1214: (in 0x00000001 : word32)
+T_1214: (in ~(eax_44->dw0024 >> 0x0000001F) : word32)
   Class: Eq_1214
+  DataType: uint32
+  OrigDataType: uint32
+T_1215: (in 0x00000001 : word32)
+  Class: Eq_1215
   DataType: ui32
   OrigDataType: ui32
-T_1215: (in ~(eax_44->dw0024 >> 0x0000001F) & 0x00000001 : word32)
-  Class: Eq_1132
+T_1216: (in ~(eax_44->dw0024 >> 0x0000001F) & 0x00000001 : word32)
+  Class: Eq_1133
   DataType: ui32
   OrigDataType: ui32
-T_1216: (in 0xFFFFFFFE : word32)
-  Class: Eq_1216
-  DataType: word32
-  OrigDataType: word32
-T_1217: (in 0x00000004 : word32)
+T_1217: (in 0xFFFFFFFE : word32)
   Class: Eq_1217
-  DataType: ui32
-  OrigDataType: ui32
-T_1218: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_1218
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1221 t0000)))
-T_1219: (in 0x00000000 : word32)
-  Class: Eq_1219
   DataType: word32
   OrigDataType: word32
-T_1220: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+T_1218: (in 0x00000004 : word32)
+  Class: Eq_1218
+  DataType: ui32
+  OrigDataType: ui32
+T_1219: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_1219
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_1222 t0000)))
+T_1220: (in 0x00000000 : word32)
   Class: Eq_1220
+  DataType: word32
+  OrigDataType: word32
+T_1221: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_1221
   DataType: ptr32
   OrigDataType: ptr32
-T_1221: (in Mem69[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_1216
+T_1222: (in Mem69[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_1217
   DataType: word32
   OrigDataType: word32
-T_1222: (in edi_79 : ptr32)
-  Class: Eq_388
+T_1223: (in edi_79 : ptr32)
+  Class: Eq_389
   DataType: ptr32
   OrigDataType: word32
-T_1223: (in fn1000182D : ptr32)
-  Class: Eq_510
-  DataType: (ptr32 Eq_510)
-  OrigDataType: (ptr32 (fn T_1227 (T_1134, T_1226)))
-T_1224: (in -4 : int32)
-  Class: Eq_1224
+T_1224: (in fn1000182D : ptr32)
+  Class: Eq_511
+  DataType: (ptr32 Eq_511)
+  OrigDataType: (ptr32 (fn T_1228 (T_1135, T_1227)))
+T_1225: (in -4 : int32)
+  Class: Eq_1225
   DataType: int32
   OrigDataType: int32
-T_1225: (in esp_14 + -4 : word32)
-  Class: Eq_1225
+T_1226: (in esp_14 + -4 : word32)
+  Class: Eq_1226
   DataType: ptr32
   OrigDataType: ptr32
-T_1226: (in Mem75[esp_14 + -4:word32] : word32)
-  Class: Eq_513
+T_1227: (in Mem75[esp_14 + -4:word32] : word32)
+  Class: Eq_514
   DataType: word32
   OrigDataType: word32
-T_1227: (in fn1000182D(ebp_13, *((word32) esp_14 - 4)) : word32)
-  Class: Eq_388
+T_1228: (in fn1000182D(ebp_13, *((word32) esp_14 - 4)) : word32)
+  Class: Eq_389
   DataType: ptr32
   OrigDataType: word32
-T_1228: (in eax : word32)
-  Class: Eq_1228
+T_1229: (in eax : word32)
+  Class: Eq_1229
   DataType: word32
   OrigDataType: word32
-T_1229: (in 0x00000001 : word32)
-  Class: Eq_546
+T_1230: (in 0x00000001 : word32)
+  Class: Eq_547
   DataType: word32
   OrigDataType: word32
-T_1230: (in dwArg08 != 0x00000001 : bool)
-  Class: Eq_1230
+T_1231: (in dwArg08 != 0x00000001 : bool)
+  Class: Eq_1231
   DataType: bool
   OrigDataType: bool
-T_1231: (in 0x00000001 : word32)
-  Class: Eq_1228
+T_1232: (in 0x00000001 : word32)
+  Class: Eq_1229
   DataType: word32
   OrigDataType: word32
-T_1232: (in 100020CC : ptr32)
-  Class: Eq_1232
+T_1233: (in 100020CC : ptr32)
+  Class: Eq_1233
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1233 t0000)))
-T_1233: (in Mem0[0x100020CC:word32] : word32)
-  Class: Eq_519
+  OrigDataType: (ptr32 (struct (0 T_1234 t0000)))
+T_1234: (in Mem0[0x100020CC:word32] : word32)
+  Class: Eq_520
   DataType: word32
   OrigDataType: word32
-T_1234: (in 0x00000000 : word32)
-  Class: Eq_519
+T_1235: (in 0x00000000 : word32)
+  Class: Eq_520
   DataType: word32
   OrigDataType: word32
-T_1235: (in globals->dw100020CC != 0x00000000 : bool)
-  Class: Eq_1235
+T_1236: (in globals->dw100020CC != 0x00000000 : bool)
+  Class: Eq_1236
   DataType: bool
   OrigDataType: bool
-T_1236: (in DisableThreadLibraryCalls : ptr32)
-  Class: Eq_1236
-  DataType: (ptr32 Eq_1236)
-  OrigDataType: (ptr32 (fn T_1239 (T_545)))
-T_1237: (in signature of DisableThreadLibraryCalls : void)
-  Class: Eq_1236
-  DataType: (ptr32 Eq_1236)
+T_1237: (in DisableThreadLibraryCalls : ptr32)
+  Class: Eq_1237
+  DataType: (ptr32 Eq_1237)
+  OrigDataType: (ptr32 (fn T_1240 (T_546)))
+T_1238: (in signature of DisableThreadLibraryCalls : void)
+  Class: Eq_1237
+  DataType: (ptr32 Eq_1237)
   OrigDataType: 
-T_1238: (in hLibModule : HMODULE)
-  Class: Eq_545
-  DataType: Eq_545
+T_1239: (in hLibModule : HMODULE)
+  Class: Eq_546
+  DataType: Eq_546
   OrigDataType: 
-T_1239: (in DisableThreadLibraryCalls(dwArg04) : BOOL)
-  Class: Eq_803
-  DataType: Eq_803
+T_1240: (in DisableThreadLibraryCalls(dwArg04) : BOOL)
+  Class: Eq_804
+  DataType: Eq_804
   OrigDataType: BOOL
-T_1240: (in ebp : ptr32)
-  Class: Eq_1240
-  DataType: ptr32
-  OrigDataType: word32
-T_1241: (in esp_14 : ptr32)
+T_1241: (in ebp : ptr32)
   Class: Eq_1241
   DataType: ptr32
-  OrigDataType: ptr32
-T_1242: (in fp : ptr32)
+  OrigDataType: word32
+T_1242: (in esp_14 : ptr32)
   Class: Eq_1242
   DataType: ptr32
   OrigDataType: ptr32
-T_1243: (in 8 : int32)
+T_1243: (in fp : ptr32)
   Class: Eq_1243
-  DataType: int32
-  OrigDataType: int32
-T_1244: (in fp - 8 : word32)
-  Class: Eq_1244
   DataType: ptr32
   OrigDataType: ptr32
-T_1245: (in fp - 8 - dwArg08 : word32)
+T_1244: (in 8 : int32)
+  Class: Eq_1244
+  DataType: int32
+  OrigDataType: int32
+T_1245: (in fp - 8 : word32)
+  Class: Eq_1245
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1246: (in fp - 8 - dwArg08 : word32)
+  Class: Eq_1242
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1247: (in 4 : int32)
+  Class: Eq_1247
+  DataType: int32
+  OrigDataType: int32
+T_1248: (in esp_14 - 4 : word32)
+  Class: Eq_1248
+  DataType: (ptr32 (ptr32 Eq_190))
+  OrigDataType: (ptr32 (struct (0 T_1251 t0000)))
+T_1249: (in 0x00000000 : word32)
+  Class: Eq_1249
+  DataType: word32
+  OrigDataType: word32
+T_1250: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_1250
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1251: (in Mem17[esp_14 - 4 + 0x00000000:word32] : word32)
+  Class: Eq_190
+  DataType: (ptr32 Eq_190)
+  OrigDataType: word32
+T_1252: (in 8 : int32)
+  Class: Eq_1252
+  DataType: int32
+  OrigDataType: int32
+T_1253: (in esp_14 - 8 : word32)
+  Class: Eq_1253
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_1256 t0000)))
+T_1254: (in 0x00000000 : word32)
+  Class: Eq_1254
+  DataType: word32
+  OrigDataType: word32
+T_1255: (in esp_14 - 8 + 0x00000000 : word32)
+  Class: Eq_1255
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1256: (in Mem20[esp_14 - 8 + 0x00000000:word32] : word32)
+  Class: Eq_386
+  DataType: ptr32
+  OrigDataType: word32
+T_1257: (in 12 : int32)
+  Class: Eq_1257
+  DataType: int32
+  OrigDataType: int32
+T_1258: (in esp_14 - 12 : word32)
+  Class: Eq_1258
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_1261 t0000)))
+T_1259: (in 0x00000000 : word32)
+  Class: Eq_1259
+  DataType: word32
+  OrigDataType: word32
+T_1260: (in esp_14 - 12 + 0x00000000 : word32)
+  Class: Eq_1260
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1261: (in Mem23[esp_14 - 12 + 0x00000000:word32] : word32)
+  Class: Eq_387
+  DataType: word32
+  OrigDataType: word32
+T_1262: (in 10003000 : ptr32)
+  Class: Eq_1262
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1263 t0000)))
+T_1263: (in Mem23[0x10003000:word32] : word32)
+  Class: Eq_1263
+  DataType: ui32
+  OrigDataType: word32
+T_1264: (in 0x00000008 : word32)
+  Class: Eq_1264
+  DataType: int32
+  OrigDataType: int32
+T_1265: (in fp + 0x00000008 : word32)
+  Class: Eq_1265
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1266: (in globals->dw10003000 ^ fp + 0x00000008 : word32)
+  Class: Eq_1266
+  DataType: ui32
+  OrigDataType: ui32
+T_1267: (in 16 : int32)
+  Class: Eq_1267
+  DataType: int32
+  OrigDataType: int32
+T_1268: (in esp_14 - 16 : word32)
+  Class: Eq_1268
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1271 t0000)))
+T_1269: (in 0x00000000 : word32)
+  Class: Eq_1269
+  DataType: word32
+  OrigDataType: word32
+T_1270: (in esp_14 - 16 + 0x00000000 : word32)
+  Class: Eq_1270
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1271: (in Mem32[esp_14 - 16 + 0x00000000:word32] : word32)
+  Class: Eq_1266
+  DataType: ui32
+  OrigDataType: word32
+T_1272: (in 20 : int32)
+  Class: Eq_1272
+  DataType: int32
+  OrigDataType: int32
+T_1273: (in esp_14 - 20 : word32)
+  Class: Eq_1273
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_1276 t0000)))
+T_1274: (in 0x00000000 : word32)
+  Class: Eq_1274
+  DataType: word32
+  OrigDataType: word32
+T_1275: (in esp_14 - 20 + 0x00000000 : word32)
+  Class: Eq_1275
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1276: (in Mem36[esp_14 - 20 + 0x00000000:word32] : word32)
+  Class: Eq_438
+  DataType: word32
+  OrigDataType: word32
+T_1277: (in 0x00000008 : word32)
+  Class: Eq_1277
+  DataType: ui32
+  OrigDataType: ui32
+T_1278: (in fp - 0x00000008 : word32)
+  Class: Eq_1278
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1279: (in fs : selector)
+  Class: Eq_1279
+  DataType: (ptr32 Eq_1279)
+  OrigDataType: (ptr32 (segment (0 T_1281 t0000)))
+T_1280: (in 0x00000000 : word32)
+  Class: Eq_1280
+  DataType: (memptr (ptr32 Eq_1279) ptr32)
+  OrigDataType: (memptr T_1279 (struct (0 T_1281 t0000)))
+T_1281: (in Mem41[fs:0x00000000:word32] : word32)
+  Class: Eq_1278
+  DataType: ptr32
+  OrigDataType: word32
+T_1282: (in fp + 0x00000008 : word32)
   Class: Eq_1241
   DataType: ptr32
   OrigDataType: ptr32
-T_1246: (in 4 : int32)
-  Class: Eq_1246
-  DataType: int32
-  OrigDataType: int32
-T_1247: (in esp_14 - 4 : word32)
-  Class: Eq_1247
-  DataType: (ptr32 (ptr32 Eq_189))
-  OrigDataType: (ptr32 (struct (0 T_1250 t0000)))
-T_1248: (in 0x00000000 : word32)
-  Class: Eq_1248
-  DataType: word32
-  OrigDataType: word32
-T_1249: (in esp_14 - 4 + 0x00000000 : word32)
-  Class: Eq_1249
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1250: (in Mem17[esp_14 - 4 + 0x00000000:word32] : word32)
-  Class: Eq_189
-  DataType: (ptr32 Eq_189)
-  OrigDataType: word32
-T_1251: (in 8 : int32)
-  Class: Eq_1251
-  DataType: int32
-  OrigDataType: int32
-T_1252: (in esp_14 - 8 : word32)
-  Class: Eq_1252
-  DataType: (ptr32 ptr32)
-  OrigDataType: (ptr32 (struct (0 T_1255 t0000)))
-T_1253: (in 0x00000000 : word32)
-  Class: Eq_1253
-  DataType: word32
-  OrigDataType: word32
-T_1254: (in esp_14 - 8 + 0x00000000 : word32)
-  Class: Eq_1254
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1255: (in Mem20[esp_14 - 8 + 0x00000000:word32] : word32)
-  Class: Eq_385
-  DataType: ptr32
-  OrigDataType: word32
-T_1256: (in 12 : int32)
-  Class: Eq_1256
-  DataType: int32
-  OrigDataType: int32
-T_1257: (in esp_14 - 12 : word32)
-  Class: Eq_1257
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1260 t0000)))
-T_1258: (in 0x00000000 : word32)
-  Class: Eq_1258
-  DataType: word32
-  OrigDataType: word32
-T_1259: (in esp_14 - 12 + 0x00000000 : word32)
-  Class: Eq_1259
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1260: (in Mem23[esp_14 - 12 + 0x00000000:word32] : word32)
-  Class: Eq_386
-  DataType: word32
-  OrigDataType: word32
-T_1261: (in 10003000 : ptr32)
-  Class: Eq_1261
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1262 t0000)))
-T_1262: (in Mem23[0x10003000:word32] : word32)
-  Class: Eq_1262
-  DataType: ui32
-  OrigDataType: word32
-T_1263: (in 0x00000008 : word32)
-  Class: Eq_1263
-  DataType: int32
-  OrigDataType: int32
-T_1264: (in fp + 0x00000008 : word32)
-  Class: Eq_1264
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1265: (in globals->dw10003000 ^ fp + 0x00000008 : word32)
-  Class: Eq_1265
-  DataType: ui32
-  OrigDataType: ui32
-T_1266: (in 16 : int32)
-  Class: Eq_1266
-  DataType: int32
-  OrigDataType: int32
-T_1267: (in esp_14 - 16 : word32)
-  Class: Eq_1267
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1270 t0000)))
-T_1268: (in 0x00000000 : word32)
-  Class: Eq_1268
-  DataType: word32
-  OrigDataType: word32
-T_1269: (in esp_14 - 16 + 0x00000000 : word32)
-  Class: Eq_1269
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1270: (in Mem32[esp_14 - 16 + 0x00000000:word32] : word32)
-  Class: Eq_1265
-  DataType: ui32
-  OrigDataType: word32
-T_1271: (in 20 : int32)
-  Class: Eq_1271
-  DataType: int32
-  OrigDataType: int32
-T_1272: (in esp_14 - 20 : word32)
-  Class: Eq_1272
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1275 t0000)))
-T_1273: (in 0x00000000 : word32)
-  Class: Eq_1273
-  DataType: word32
-  OrigDataType: word32
-T_1274: (in esp_14 - 20 + 0x00000000 : word32)
-  Class: Eq_1274
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1275: (in Mem36[esp_14 - 20 + 0x00000000:word32] : word32)
-  Class: Eq_437
-  DataType: word32
-  OrigDataType: word32
-T_1276: (in 0x00000008 : word32)
-  Class: Eq_1276
-  DataType: ui32
-  OrigDataType: ui32
-T_1277: (in fp - 0x00000008 : word32)
-  Class: Eq_1277
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1278: (in fs : selector)
-  Class: Eq_1278
-  DataType: (ptr32 Eq_1278)
-  OrigDataType: (ptr32 (segment (0 T_1280 t0000)))
-T_1279: (in 0x00000000 : word32)
-  Class: Eq_1279
-  DataType: (memptr (ptr32 Eq_1278) ptr32)
-  OrigDataType: (memptr T_1278 (struct (0 T_1280 t0000)))
-T_1280: (in Mem41[fs:0x00000000:word32] : word32)
-  Class: Eq_1277
-  DataType: ptr32
-  OrigDataType: word32
-T_1281: (in fp + 0x00000008 : word32)
-  Class: Eq_1240
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1282: (in edi : word32)
-  Class: Eq_1282
-  DataType: word32
-  OrigDataType: word32
-T_1283: (in 0x00000010 : word32)
+T_1283: (in edi : word32)
   Class: Eq_1283
-  DataType: ui32
-  OrigDataType: ui32
-T_1284: (in ebp - 0x00000010 : word32)
-  Class: Eq_1284
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1287 t0000)))
-T_1285: (in 0x00000000 : word32)
-  Class: Eq_1285
   DataType: word32
   OrigDataType: word32
-T_1286: (in ebp - 0x00000010 + 0x00000000 : word32)
+T_1284: (in 0x00000010 : word32)
+  Class: Eq_1284
+  DataType: ui32
+  OrigDataType: ui32
+T_1285: (in ebp - 0x00000010 : word32)
+  Class: Eq_1285
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_1288 t0000)))
+T_1286: (in 0x00000000 : word32)
   Class: Eq_1286
   DataType: word32
   OrigDataType: word32
-T_1287: (in Mem0[ebp - 0x00000010 + 0x00000000:word32] : word32)
+T_1287: (in ebp - 0x00000010 + 0x00000000 : word32)
   Class: Eq_1287
   DataType: word32
   OrigDataType: word32
-T_1288: (in fs : selector)
+T_1288: (in Mem0[ebp - 0x00000010 + 0x00000000:word32] : word32)
   Class: Eq_1288
-  DataType: (ptr32 Eq_1288)
-  OrigDataType: (ptr32 (segment (0 T_1290 t0000)))
-T_1289: (in 0x00000000 : ptr32)
+  DataType: word32
+  OrigDataType: word32
+T_1289: (in fs : selector)
   Class: Eq_1289
-  DataType: Eq_1289
-  OrigDataType: (union (ptr32 u0) ((memptr T_1288 (struct (0 word32 dw0000))) u1))
-T_1290: (in Mem8[fs:0x00000000:word32] : word32)
-  Class: Eq_1287
+  DataType: (ptr32 Eq_1289)
+  OrigDataType: (ptr32 (segment (0 T_1291 t0000)))
+T_1290: (in 0x00000000 : ptr32)
+  Class: Eq_1290
+  DataType: Eq_1290
+  OrigDataType: (union (ptr32 u0) ((memptr T_1289 (struct (0 word32 dw0000))) u1))
+T_1291: (in Mem8[fs:0x00000000:word32] : word32)
+  Class: Eq_1288
   DataType: word32
   OrigDataType: word32
-T_1291: (in 0x00000000 : word32)
-  Class: Eq_1291
-  DataType: word32
-  OrigDataType: word32
-T_1292: (in ebp + 0x00000000 : word32)
+T_1292: (in 0x00000000 : word32)
   Class: Eq_1292
+  DataType: word32
+  OrigDataType: word32
+T_1293: (in ebp + 0x00000000 : word32)
+  Class: Eq_1293
   DataType: ptr32
   OrigDataType: ptr32
-T_1293: (in Mem22[ebp + 0x00000000:word32] : word32)
-  Class: Eq_513
+T_1294: (in Mem22[ebp + 0x00000000:word32] : word32)
+  Class: Eq_514
   DataType: word32
   OrigDataType: word32
-T_1294: (in dwArg08 : word32)
-  Class: Eq_1282
+T_1295: (in dwArg08 : word32)
+  Class: Eq_1283
   DataType: word32
   OrigDataType: word32
-T_1295: (in eax_9 : ui32)
-  Class: Eq_1262
+T_1296: (in eax_9 : ui32)
+  Class: Eq_1263
   DataType: ui32
   OrigDataType: ui32
-T_1296: (in 10003000 : ptr32)
-  Class: Eq_1296
+T_1297: (in 10003000 : ptr32)
+  Class: Eq_1297
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1297 t0000)))
-T_1297: (in Mem6[0x10003000:word32] : word32)
-  Class: Eq_1262
+  OrigDataType: (ptr32 (struct (0 T_1298 t0000)))
+T_1298: (in Mem6[0x10003000:word32] : word32)
+  Class: Eq_1263
   DataType: ui32
   OrigDataType: word32
-T_1298: (in 0xBB40E64E : word32)
-  Class: Eq_1262
+T_1299: (in 0xBB40E64E : word32)
+  Class: Eq_1263
   DataType: ui32
   OrigDataType: word32
-T_1299: (in eax_9 == 0xBB40E64E : bool)
-  Class: Eq_1299
+T_1300: (in eax_9 == 0xBB40E64E : bool)
+  Class: Eq_1300
   DataType: bool
   OrigDataType: bool
-T_1300: (in GetSystemTimeAsFileTime : ptr32)
-  Class: Eq_1300
-  DataType: (ptr32 Eq_1300)
-  OrigDataType: (ptr32 (fn T_1306 (T_1305)))
-T_1301: (in signature of GetSystemTimeAsFileTime : void)
-  Class: Eq_1300
-  DataType: (ptr32 Eq_1300)
+T_1301: (in GetSystemTimeAsFileTime : ptr32)
+  Class: Eq_1301
+  DataType: (ptr32 Eq_1301)
+  OrigDataType: (ptr32 (fn T_1307 (T_1306)))
+T_1302: (in signature of GetSystemTimeAsFileTime : void)
+  Class: Eq_1301
+  DataType: (ptr32 Eq_1301)
   OrigDataType: 
-T_1302: (in lpSystemTimeAsFileTime : LPFILETIME)
-  Class: Eq_1302
-  DataType: Eq_1302
-  OrigDataType: 
-T_1303: (in fp : ptr32)
+T_1303: (in lpSystemTimeAsFileTime : LPFILETIME)
   Class: Eq_1303
+  DataType: Eq_1303
+  OrigDataType: 
+T_1304: (in fp : ptr32)
+  Class: Eq_1304
   DataType: ptr32
   OrigDataType: ptr32
-T_1304: (in 0x0000000C : word32)
-  Class: Eq_1304
+T_1305: (in 0x0000000C : word32)
+  Class: Eq_1305
   DataType: ui32
   OrigDataType: ui32
-T_1305: (in fp - 0x0000000C : word32)
-  Class: Eq_1302
-  DataType: Eq_1302
+T_1306: (in fp - 0x0000000C : word32)
+  Class: Eq_1303
+  DataType: Eq_1303
   OrigDataType: LPFILETIME
-T_1306: (in GetSystemTimeAsFileTime(fp - 0x0000000C) : void)
-  Class: Eq_1306
+T_1307: (in GetSystemTimeAsFileTime(fp - 0x0000000C) : void)
+  Class: Eq_1307
   DataType: void
   OrigDataType: void
-T_1307: (in esi_46 : ui32)
-  Class: Eq_1307
-  DataType: ui32
-  OrigDataType: ui32
-T_1308: (in dwLoc08 : word32)
+T_1308: (in esi_46 : ui32)
   Class: Eq_1308
   DataType: ui32
   OrigDataType: ui32
-T_1309: (in 0x00000000 : word32)
+T_1309: (in dwLoc08 : word32)
   Class: Eq_1309
   DataType: ui32
   OrigDataType: ui32
-T_1310: (in dwLoc08 & 0x00000000 : word32)
+T_1310: (in 0x00000000 : word32)
   Class: Eq_1310
   DataType: ui32
   OrigDataType: ui32
-T_1311: (in dwLoc0C : word32)
+T_1311: (in dwLoc08 & 0x00000000 : word32)
   Class: Eq_1311
   DataType: ui32
   OrigDataType: ui32
-T_1312: (in 0x00000000 : word32)
+T_1312: (in dwLoc0C : word32)
   Class: Eq_1312
   DataType: ui32
   OrigDataType: ui32
-T_1313: (in dwLoc0C & 0x00000000 : word32)
+T_1313: (in 0x00000000 : word32)
   Class: Eq_1313
   DataType: ui32
   OrigDataType: ui32
-T_1314: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 : word32)
+T_1314: (in dwLoc0C & 0x00000000 : word32)
   Class: Eq_1314
   DataType: ui32
   OrigDataType: ui32
-T_1315: (in GetCurrentProcessId : ptr32)
+T_1315: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 : word32)
   Class: Eq_1315
-  DataType: (ptr32 Eq_1315)
-  OrigDataType: (ptr32 (fn T_1317 ()))
-T_1316: (in signature of GetCurrentProcessId : void)
-  Class: Eq_1315
-  DataType: (ptr32 Eq_1315)
-  OrigDataType: 
-T_1317: (in GetCurrentProcessId() : DWORD)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: DWORD
-T_1318: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() : word32)
-  Class: Eq_1318
   DataType: ui32
   OrigDataType: ui32
-T_1319: (in GetCurrentThreadId : ptr32)
+T_1316: (in GetCurrentProcessId : ptr32)
+  Class: Eq_1316
+  DataType: (ptr32 Eq_1316)
+  OrigDataType: (ptr32 (fn T_1318 ()))
+T_1317: (in signature of GetCurrentProcessId : void)
+  Class: Eq_1316
+  DataType: (ptr32 Eq_1316)
+  OrigDataType: 
+T_1318: (in GetCurrentProcessId() : DWORD)
+  Class: Eq_137
+  DataType: Eq_137
+  OrigDataType: DWORD
+T_1319: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() : word32)
   Class: Eq_1319
-  DataType: (ptr32 Eq_1319)
-  OrigDataType: (ptr32 (fn T_1321 ()))
-T_1320: (in signature of GetCurrentThreadId : void)
-  Class: Eq_1319
-  DataType: (ptr32 Eq_1319)
-  OrigDataType: 
-T_1321: (in GetCurrentThreadId() : DWORD)
-  Class: Eq_136
-  DataType: Eq_136
-  OrigDataType: DWORD
-T_1322: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() ^ GetCurrentThreadId() : word32)
-  Class: Eq_1322
   DataType: ui32
   OrigDataType: ui32
-T_1323: (in GetTickCount : ptr32)
-  Class: Eq_1323
-  DataType: (ptr32 Eq_1323)
-  OrigDataType: (ptr32 (fn T_1325 ()))
-T_1324: (in signature of GetTickCount : void)
-  Class: Eq_1323
-  DataType: (ptr32 Eq_1323)
+T_1320: (in GetCurrentThreadId : ptr32)
+  Class: Eq_1320
+  DataType: (ptr32 Eq_1320)
+  OrigDataType: (ptr32 (fn T_1322 ()))
+T_1321: (in signature of GetCurrentThreadId : void)
+  Class: Eq_1320
+  DataType: (ptr32 Eq_1320)
   OrigDataType: 
-T_1325: (in GetTickCount() : DWORD)
-  Class: Eq_136
-  DataType: Eq_136
+T_1322: (in GetCurrentThreadId() : DWORD)
+  Class: Eq_137
+  DataType: Eq_137
   OrigDataType: DWORD
-T_1326: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount() : word32)
-  Class: Eq_1307
+T_1323: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() ^ GetCurrentThreadId() : word32)
+  Class: Eq_1323
   DataType: ui32
   OrigDataType: ui32
-T_1327: (in QueryPerformanceCounter : ptr32)
-  Class: Eq_1327
-  DataType: (ptr32 Eq_1327)
-  OrigDataType: (ptr32 (fn T_1332 (T_1331)))
-T_1328: (in signature of QueryPerformanceCounter : void)
-  Class: Eq_1327
-  DataType: (ptr32 Eq_1327)
+T_1324: (in GetTickCount : ptr32)
+  Class: Eq_1324
+  DataType: (ptr32 Eq_1324)
+  OrigDataType: (ptr32 (fn T_1326 ()))
+T_1325: (in signature of GetTickCount : void)
+  Class: Eq_1324
+  DataType: (ptr32 Eq_1324)
   OrigDataType: 
-T_1329: (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
-  Class: Eq_1329
-  DataType: (ptr32 Eq_1329)
+T_1326: (in GetTickCount() : DWORD)
+  Class: Eq_137
+  DataType: Eq_137
+  OrigDataType: DWORD
+T_1327: (in dwLoc08 & 0x00000000 ^ dwLoc0C & 0x00000000 ^ GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount() : word32)
+  Class: Eq_1308
+  DataType: ui32
+  OrigDataType: ui32
+T_1328: (in QueryPerformanceCounter : ptr32)
+  Class: Eq_1328
+  DataType: (ptr32 Eq_1328)
+  OrigDataType: (ptr32 (fn T_1333 (T_1332)))
+T_1329: (in signature of QueryPerformanceCounter : void)
+  Class: Eq_1328
+  DataType: (ptr32 Eq_1328)
   OrigDataType: 
-T_1330: (in 0x00000014 : word32)
+T_1330: (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
   Class: Eq_1330
+  DataType: (ptr32 Eq_1330)
+  OrigDataType: 
+T_1331: (in 0x00000014 : word32)
+  Class: Eq_1331
   DataType: ui32
   OrigDataType: ui32
-T_1331: (in fp - 0x00000014 : word32)
-  Class: Eq_1329
-  DataType: (ptr32 Eq_1329)
+T_1332: (in fp - 0x00000014 : word32)
+  Class: Eq_1330
+  DataType: (ptr32 Eq_1330)
   OrigDataType: (ptr32 LARGE_INTEGER)
-T_1332: (in QueryPerformanceCounter(fp - 0x00000014) : BOOL)
-  Class: Eq_803
-  DataType: Eq_803
+T_1333: (in QueryPerformanceCounter(fp - 0x00000014) : BOOL)
+  Class: Eq_804
+  DataType: Eq_804
   OrigDataType: BOOL
-T_1333: (in esi_54 : ui32)
-  Class: Eq_1262
+T_1334: (in esi_54 : ui32)
+  Class: Eq_1263
   DataType: ui32
   OrigDataType: ui32
-T_1334: (in dwLoc10 : word32)
-  Class: Eq_1334
-  DataType: word32
-  OrigDataType: word32
-T_1335: (in dwLoc14 : word32)
+T_1335: (in dwLoc10 : word32)
   Class: Eq_1335
   DataType: word32
   OrigDataType: word32
-T_1336: (in dwLoc10 ^ dwLoc14 : word32)
+T_1336: (in dwLoc14 : word32)
   Class: Eq_1336
+  DataType: word32
+  OrigDataType: word32
+T_1337: (in dwLoc10 ^ dwLoc14 : word32)
+  Class: Eq_1337
   DataType: ui32
   OrigDataType: ui32
-T_1337: (in esi_46 ^ (dwLoc10 ^ dwLoc14) : word32)
-  Class: Eq_1262
+T_1338: (in esi_46 ^ (dwLoc10 ^ dwLoc14) : word32)
+  Class: Eq_1263
   DataType: ui32
   OrigDataType: ui32
-T_1338: (in 0xBB40E64E : word32)
-  Class: Eq_1262
+T_1339: (in 0xBB40E64E : word32)
+  Class: Eq_1263
   DataType: ui32
   OrigDataType: word32
-T_1339: (in esi_54 != 0xBB40E64E : bool)
-  Class: Eq_1339
-  DataType: bool
-  OrigDataType: bool
-T_1340: (in 0xFFFF0000 : word32)
+T_1340: (in esi_54 != 0xBB40E64E : bool)
   Class: Eq_1340
-  DataType: ui32
-  OrigDataType: ui32
-T_1341: (in eax_9 & 0xFFFF0000 : word32)
-  Class: Eq_1341
-  DataType: ui32
-  OrigDataType: ui32
-T_1342: (in 0x00000000 : word32)
-  Class: Eq_1341
-  DataType: ui32
-  OrigDataType: word32
-T_1343: (in (eax_9 & 0xFFFF0000) == 0x00000000 : bool)
-  Class: Eq_1343
   DataType: bool
   OrigDataType: bool
-T_1344: (in ~eax_9 : word32)
-  Class: Eq_1344
+T_1341: (in 0xFFFF0000 : word32)
+  Class: Eq_1341
   DataType: ui32
   OrigDataType: ui32
-T_1345: (in 10003004 : ptr32)
+T_1342: (in eax_9 & 0xFFFF0000 : word32)
+  Class: Eq_1342
+  DataType: ui32
+  OrigDataType: ui32
+T_1343: (in 0x00000000 : word32)
+  Class: Eq_1342
+  DataType: ui32
+  OrigDataType: word32
+T_1344: (in (eax_9 & 0xFFFF0000) == 0x00000000 : bool)
+  Class: Eq_1344
+  DataType: bool
+  OrigDataType: bool
+T_1345: (in ~eax_9 : word32)
   Class: Eq_1345
+  DataType: ui32
+  OrigDataType: ui32
+T_1346: (in 10003004 : ptr32)
+  Class: Eq_1346
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1346 t0000)))
-T_1346: (in Mem76[0x10003004:word32] : word32)
-  Class: Eq_1344
+  OrigDataType: (ptr32 (struct (0 T_1347 t0000)))
+T_1347: (in Mem76[0x10003004:word32] : word32)
+  Class: Eq_1345
   DataType: ui32
   OrigDataType: word32
-T_1347: (in 0xFFFF0000 : word32)
-  Class: Eq_1347
-  DataType: ui32
-  OrigDataType: ui32
-T_1348: (in esi_54 & 0xFFFF0000 : word32)
+T_1348: (in 0xFFFF0000 : word32)
   Class: Eq_1348
   DataType: ui32
   OrigDataType: ui32
-T_1349: (in 0x00000000 : word32)
-  Class: Eq_1348
+T_1349: (in esi_54 & 0xFFFF0000 : word32)
+  Class: Eq_1349
+  DataType: ui32
+  OrigDataType: ui32
+T_1350: (in 0x00000000 : word32)
+  Class: Eq_1349
   DataType: ui32
   OrigDataType: word32
-T_1350: (in (esi_54 & 0xFFFF0000) != 0x00000000 : bool)
-  Class: Eq_1350
+T_1351: (in (esi_54 & 0xFFFF0000) != 0x00000000 : bool)
+  Class: Eq_1351
   DataType: bool
   OrigDataType: bool
-T_1351: (in 0xBB40E64F : word32)
-  Class: Eq_1262
+T_1352: (in 0xBB40E64F : word32)
+  Class: Eq_1263
   DataType: ui32
   OrigDataType: word32
-T_1352: (in 10003000 : ptr32)
-  Class: Eq_1352
+T_1353: (in 10003000 : ptr32)
+  Class: Eq_1353
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1353 t0000)))
-T_1353: (in Mem69[0x10003000:word32] : word32)
-  Class: Eq_1262
+  OrigDataType: (ptr32 (struct (0 T_1354 t0000)))
+T_1354: (in Mem69[0x10003000:word32] : word32)
+  Class: Eq_1263
   DataType: ui32
   OrigDataType: word32
-T_1354: (in ~esi_54 : word32)
-  Class: Eq_1344
+T_1355: (in ~esi_54 : word32)
+  Class: Eq_1345
   DataType: ui32
   OrigDataType: ui32
-T_1355: (in 10003004 : ptr32)
-  Class: Eq_1355
+T_1356: (in 10003004 : ptr32)
+  Class: Eq_1356
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1356 t0000)))
-T_1356: (in Mem71[0x10003004:word32] : word32)
-  Class: Eq_1344
+  OrigDataType: (ptr32 (struct (0 T_1357 t0000)))
+T_1357: (in Mem71[0x10003004:word32] : word32)
+  Class: Eq_1345
   DataType: ui32
   OrigDataType: word32
-T_1357: (in 0x00000010 : word32)
-  Class: Eq_1357
-  DataType: word32
-  OrigDataType: word32
-T_1358: (in esi_54 << 0x00000010 : word32)
+T_1358: (in 0x00000010 : word32)
   Class: Eq_1358
-  DataType: ui32
-  OrigDataType: ui32
-T_1359: (in esi_54 | esi_54 << 0x00000010 : word32)
-  Class: Eq_1262
-  DataType: ui32
-  OrigDataType: ui32
-T_1360:
-  Class: Eq_1360
   DataType: word32
-  OrigDataType: (struct 0004 (0 T_1057 t0000))
+  OrigDataType: word32
+T_1359: (in esi_54 << 0x00000010 : word32)
+  Class: Eq_1359
+  DataType: ui32
+  OrigDataType: ui32
+T_1360: (in esi_54 | esi_54 << 0x00000010 : word32)
+  Class: Eq_1263
+  DataType: ui32
+  OrigDataType: ui32
 T_1361:
   Class: Eq_1361
-  DataType: Eq_1361
+  DataType: word32
+  OrigDataType: (struct 0004 (0 T_1058 t0000))
+T_1362:
+  Class: Eq_1362
+  DataType: Eq_1362
   OrigDataType: 
 */
 typedef struct Globals {
 	word32 dwFFFFFFFF;	// FFFFFFFF
-	Eq_306 t10002098;	// 10002098
-	Eq_307 t1000209C;	// 1000209C
-	Eq_247 t100020A0;	// 100020A0
+	Eq_307 t10002098;	// 10002098
+	Eq_308 t1000209C;	// 1000209C
+	Eq_248 t100020A0;	// 100020A0
 	word32 dw100020A8;	// 100020A8
 	word32 dw100020CC;	// 100020CC
 	char str100020E0[];	// 100020E0
@@ -5881,12 +5887,12 @@ typedef struct Globals {
 	word32 a100021D8[1];	// 100021D8
 	ui32 dw10003000;	// 10003000
 	ui32 dw10003004;	// 10003004
-	Eq_136 t10003008;	// 10003008
+	Eq_137 t10003008;	// 10003008
 	PyMethodDef methods[5];	// 10003010
 	int32 dw10003070;	// 10003070
 	word32 * ptr100033A4;	// 100033A4
 	word32 dw100033A8;	// 100033A8
-	Eq_191 t100033AC;	// 100033AC
+	Eq_192 t100033AC;	// 100033AC
 	word32 * ptr100033B0;	// 100033B0
 	word32 * ptr100033B4;	// 100033B4
 	<anonymous> * ptr100033B8;	// 100033B8
@@ -5918,193 +5924,195 @@ typedef PyObject Eq_99;
 
 typedef PyObject Eq_100;
 
-typedef PyObject * (Eq_103)(PyObject *, char *);
+typedef PyObject Eq_101;
 
-typedef PyObject Eq_109;
+typedef PyObject * (Eq_103)(PyObject *, char *);
 
 typedef PyObject Eq_110;
 
-typedef PyObject * (Eq_122)(char *, PyMethodDef *, char *, PyObject *, int32);
+typedef PyObject Eq_111;
 
-typedef PyMethodDef Eq_125;
+typedef PyObject * (Eq_123)(char *, PyMethodDef *, char *, PyObject *, int32);
 
-typedef PyObject Eq_127;
+typedef PyMethodDef Eq_126;
 
-typedef PyObject Eq_134;
+typedef PyObject Eq_128;
 
-typedef union Eq_136 {
-	ptr32 u0;
-	DWORD u1;
-} Eq_136;
+typedef PyObject Eq_135;
 
 typedef union Eq_137 {
-	ui32 u0;
-	ptr32 u1;
+	ptr32 u0;
+	DWORD u1;
 } Eq_137;
 
-typedef struct Eq_138 {
-	word32 dw0000;	// 0
-	Eq_137 t0008;	// 8
+typedef union Eq_138 {
+	ui32 u0;
+	ptr32 u1;
 } Eq_138;
 
-typedef LPVOID Eq_140;
+typedef struct Eq_139 {
+	word32 dw0000;	// 0
+	Eq_138 t0008;	// 8
+} Eq_139;
 
-typedef LONG Eq_150;
+typedef LPVOID Eq_141;
 
-typedef struct Eq_182 {
-	struct Eq_184 * ptr0018;	// 18
-} Eq_182;
+typedef LONG Eq_151;
 
-typedef struct Eq_184 {
-	Eq_150 t0004;	// 4
-} Eq_184;
+typedef struct Eq_183 {
+	struct Eq_185 * ptr0018;	// 18
+} Eq_183;
 
-typedef LONG (Eq_189)(LONG *, LONG, LONG);
+typedef struct Eq_185 {
+	Eq_151 t0004;	// 4
+} Eq_185;
 
-typedef LONG Eq_191;
+typedef LONG (Eq_190)(LONG *, LONG, LONG);
 
-typedef void (Eq_212)(Eq_136);
+typedef LONG Eq_192;
 
-typedef word32 * (Eq_225)(word32 *);
+typedef void (Eq_213)(Eq_137);
 
-typedef void (Eq_234)(int32);
+typedef word32 * (Eq_226)(word32 *);
 
-typedef int32 (Eq_245)(PVFV *, PVFV *);
+typedef void (Eq_235)(int32);
 
-typedef PVFV Eq_247;
+typedef int32 (Eq_246)(PVFV *, PVFV *);
 
 typedef PVFV Eq_248;
 
-typedef LONG (Eq_277)(LONG *, LONG);
+typedef PVFV Eq_249;
 
-typedef LONG Eq_279;
+typedef LONG (Eq_278)(LONG *, LONG);
 
-typedef void (Eq_304)(PVFV *, PVFV *);
+typedef LONG Eq_280;
 
-typedef PVFV Eq_306;
+typedef void (Eq_305)(PVFV *, PVFV *);
 
 typedef PVFV Eq_307;
 
-typedef struct Eq_320 {
-	Eq_136 t0000;	// 0
-	Eq_137 t0004;	// 4
-} Eq_320;
+typedef PVFV Eq_308;
 
-typedef void (Eq_344)(word32 *);
+typedef struct Eq_321 {
+	Eq_137 t0000;	// 0
+	Eq_138 t0004;	// 4
+} Eq_321;
 
-typedef word32 * (Eq_355)();
+typedef void (Eq_345)(word32 *);
 
-typedef word32 (Eq_382)( *, ptr32, word32, ptr32, ptr32);
+typedef word32 * (Eq_356)();
 
-typedef union Eq_395 {
+typedef word32 (Eq_383)( *, ptr32, word32, ptr32, ptr32);
+
+typedef union Eq_396 {
 	int8 u0;
-	struct Eq_1361 * u1;
-} Eq_395;
+	struct Eq_1362 * u1;
+} Eq_396;
 
-typedef Eq_138 * (Eq_432)( *, ptr32, word32, word32, ui32);
+typedef Eq_139 * (Eq_433)( *, ptr32, word32, word32, ui32);
 
-typedef void (Eq_501)();
+typedef void (Eq_502)();
 
-typedef ptr32 (Eq_510)(Eq_138 *, word32);
+typedef ptr32 (Eq_511)(Eq_139 *, word32);
 
-typedef word32 (Eq_543)(HMODULE, word32);
+typedef word32 (Eq_544)(HMODULE, word32);
 
-typedef HMODULE Eq_545;
+typedef HMODULE Eq_546;
 
-typedef ui32 (Eq_613)(Eq_136, Eq_137, Eq_138 *, Eq_136, LPVOID, word32, word32 *, Eq_136, Eq_137, Eq_136, LPVOID);
+typedef ui32 (Eq_614)(Eq_137, Eq_138, Eq_139 *, Eq_137, LPVOID, word32, word32 *, Eq_137, Eq_138, Eq_137, LPVOID);
 
-typedef BOOL Eq_803;
+typedef BOOL Eq_804;
 
-typedef HANDLE Eq_804;
+typedef HANDLE Eq_805;
 
-typedef BOOL (Eq_809)(LPVOID, Eq_136,  *, ptr32, word32);
+typedef BOOL (Eq_810)(LPVOID, Eq_137,  *, ptr32, word32);
 
-typedef void (Eq_815)();
+typedef void (Eq_816)();
 
-typedef _onexit_t Eq_818;
+typedef _onexit_t Eq_819;
 
-typedef _onexit_t (Eq_938)(_onexit_t, PVFV * *, PVFV * *);
-
-typedef PVFV Eq_941;
+typedef _onexit_t (Eq_939)(_onexit_t, PVFV * *, PVFV * *);
 
 typedef PVFV Eq_942;
 
-typedef void (Eq_1003)(word32);
+typedef PVFV Eq_943;
 
-typedef _onexit_t (Eq_1022)(_onexit_t);
+typedef void (Eq_1004)(word32);
 
-typedef word32 (Eq_1040)( *, ptr32, word32);
+typedef _onexit_t (Eq_1023)(_onexit_t);
 
-typedef struct Eq_1067 {
+typedef word32 (Eq_1041)( *, ptr32, word32);
+
+typedef struct Eq_1068 {
 	word16 w0000;	// 0
 	word32 dw003C;	// 3C
-} Eq_1067;
+} Eq_1068;
 
-typedef struct Eq_1073 {
+typedef struct Eq_1074 {
 	word32 dw0000;	// 0
 	word16 w0018;	// 18
-} Eq_1073;
+} Eq_1074;
 
-typedef struct Eq_1090 {	// size: 40 28
+typedef struct Eq_1091 {	// size: 40 28
 	up32 dw0008;	// 8
 	word32 dw000C;	// C
-} Eq_1090;
-
-typedef struct Eq_1091 {
-	word32 dw003C;	// 3C
 } Eq_1091;
 
-typedef struct Eq_1094 {
+typedef struct Eq_1092 {
+	word32 dw003C;	// 3C
+} Eq_1092;
+
+typedef struct Eq_1095 {
 	word16 w0006;	// 6
 	word16 w0014;	// 14
-} Eq_1094;
+} Eq_1095;
 
-typedef word32 (Eq_1160)(Eq_1067 *);
+typedef word32 (Eq_1161)(Eq_1068 *);
 
-typedef union Eq_1179 {
+typedef union Eq_1180 {
 	ui32 u0;
 	ptr32 u1;
-} Eq_1179;
+} Eq_1180;
 
-typedef struct Eq_1192 {
+typedef struct Eq_1193 {
 	uint32 dw0024;	// 24
-} Eq_1192;
+} Eq_1193;
 
-typedef Eq_1192 * (Eq_1193)(Eq_1091 *, up32, ptr32);
+typedef Eq_1193 * (Eq_1194)(Eq_1092 *, up32, ptr32);
 
-typedef BOOL (Eq_1236)(HMODULE);
+typedef BOOL (Eq_1237)(HMODULE);
 
-typedef struct Eq_1278 {
+typedef struct Eq_1279 {
 	ptr32 ptr0000;	// 0
-} Eq_1278;
+} Eq_1279;
 
-typedef struct Eq_1288 {
+typedef struct Eq_1289 {
 	word32 dw0000;	// 0
-} Eq_1288;
-
-typedef union Eq_1289 {
-	ptr32 u0;
-	word32 Eq_1288::* u1;
 } Eq_1289;
 
-typedef void (Eq_1300)(LPFILETIME);
+typedef union Eq_1290 {
+	ptr32 u0;
+	word32 Eq_1289::* u1;
+} Eq_1290;
 
-typedef LPFILETIME Eq_1302;
+typedef void (Eq_1301)(LPFILETIME);
 
-typedef Eq_136 (Eq_1315)();
+typedef LPFILETIME Eq_1303;
 
-typedef Eq_136 (Eq_1319)();
+typedef Eq_137 (Eq_1316)();
 
-typedef Eq_136 (Eq_1323)();
+typedef Eq_137 (Eq_1320)();
 
-typedef BOOL (Eq_1327)(LARGE_INTEGER *);
+typedef Eq_137 (Eq_1324)();
 
-typedef LARGE_INTEGER Eq_1329;
+typedef BOOL (Eq_1328)(LARGE_INTEGER *);
 
-typedef struct Eq_1361 {
+typedef LARGE_INTEGER Eq_1330;
+
+typedef struct Eq_1362 {
 	word32 dwFFFFFFFC;	// FFFFFFFC
 	word32 * ptr0000;	// 0
 	word32 dw0018;	// 18
 	word32 * ptr0020;	// 20
-} Eq_1361;
+} Eq_1362;
 

--- a/subjects/regressions/snowman-51/switch.h
+++ b/subjects/regressions/snowman-51/switch.h
@@ -6,15 +6,15 @@
 // Equivalence classes ////////////
 Eq_1: (struct "Globals" (10072000 (str char) str10072000) (10072008 (str char) str10072008) (10072010 (str char) str10072010) (10072014 (str char) str10072014) (10072018 (str char) str10072018))
 	globals_t (in globals : (ptr32 (struct "Globals")))
-Eq_13: BOOL
-	T_13 (in eax : Eq_13)
-	T_17 (in 0x00000001 : word32)
-Eq_14: HANDLE
-	T_14 (in hModule : Eq_14)
-Eq_15: DWORD
-	T_15 (in dwReason : Eq_15)
-Eq_16: LPVOID
-	T_16 (in lpReserved : Eq_16)
+Eq_14: BOOL
+	T_14 (in eax : Eq_14)
+	T_18 (in 0x00000001 : word32)
+Eq_15: HANDLE
+	T_15 (in hModule : Eq_15)
+Eq_16: DWORD
+	T_16 (in dwReason : Eq_16)
+Eq_17: LPVOID
+	T_17 (in lpReserved : Eq_17)
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -28,61 +28,65 @@ T_3: (in n : uint32)
   Class: Eq_3
   DataType: uint32
   OrigDataType: uint32
-T_4: (in 0x00000002 : word32)
-  Class: Eq_3
-  DataType: uint32
-  OrigDataType: up32
-T_5: (in n > 0x00000002 : bool)
-  Class: Eq_5
-  DataType: bool
-  OrigDataType: bool
-T_6: (in 0x10072000 : ptr32)
-  Class: Eq_2
-  DataType: (ptr32 char)
-  OrigDataType: ptr32
-T_7: (in 0x00000001 : word32)
-  Class: Eq_7
-  DataType: word32
-  OrigDataType: word32
-T_8: (in n + 0x00000001 : word32)
-  Class: Eq_8
+T_4: (in n : uint32)
+  Class: Eq_4
   DataType: uint32
   OrigDataType: uint32
-T_9: (in 0x10072018 : ptr32)
+T_5: (in 0x00000002 : word32)
+  Class: Eq_4
+  DataType: uint32
+  OrigDataType: up32
+T_6: (in n > 0x00000002 : bool)
+  Class: Eq_6
+  DataType: bool
+  OrigDataType: bool
+T_7: (in 0x10072000 : ptr32)
   Class: Eq_2
   DataType: (ptr32 char)
   OrigDataType: ptr32
-T_10: (in 0x10072014 : ptr32)
+T_8: (in 0x00000001 : word32)
+  Class: Eq_8
+  DataType: word32
+  OrigDataType: word32
+T_9: (in n + 0x00000001 : word32)
+  Class: Eq_9
+  DataType: uint32
+  OrigDataType: uint32
+T_10: (in 0x10072018 : ptr32)
   Class: Eq_2
   DataType: (ptr32 char)
   OrigDataType: ptr32
-T_11: (in 0x10072010 : ptr32)
+T_11: (in 0x10072014 : ptr32)
   Class: Eq_2
   DataType: (ptr32 char)
   OrigDataType: ptr32
-T_12: (in 0x10072008 : ptr32)
+T_12: (in 0x10072010 : ptr32)
   Class: Eq_2
   DataType: (ptr32 char)
   OrigDataType: ptr32
-T_13: (in eax : Eq_13)
-  Class: Eq_13
-  DataType: Eq_13
-  OrigDataType: BOOL
-T_14: (in hModule : Eq_14)
+T_13: (in 0x10072008 : ptr32)
+  Class: Eq_2
+  DataType: (ptr32 char)
+  OrigDataType: ptr32
+T_14: (in eax : Eq_14)
   Class: Eq_14
   DataType: Eq_14
-  OrigDataType: HANDLE
-T_15: (in dwReason : Eq_15)
+  OrigDataType: BOOL
+T_15: (in hModule : Eq_15)
   Class: Eq_15
   DataType: Eq_15
-  OrigDataType: DWORD
-T_16: (in lpReserved : Eq_16)
+  OrigDataType: HANDLE
+T_16: (in dwReason : Eq_16)
   Class: Eq_16
   DataType: Eq_16
+  OrigDataType: DWORD
+T_17: (in lpReserved : Eq_17)
+  Class: Eq_17
+  DataType: Eq_17
   OrigDataType: LPVOID
-T_17: (in 0x00000001 : word32)
-  Class: Eq_13
-  DataType: Eq_13
+T_18: (in 0x00000001 : word32)
+  Class: Eq_14
+  DataType: Eq_14
   OrigDataType: word32
 */
 typedef struct Globals {
@@ -93,11 +97,11 @@ typedef struct Globals {
 	char str10072018[];	// 10072018
 } Eq_1;
 
-typedef BOOL Eq_13;
+typedef BOOL Eq_14;
 
-typedef HANDLE Eq_14;
+typedef HANDLE Eq_15;
 
-typedef DWORD Eq_15;
+typedef DWORD Eq_16;
 
-typedef LPVOID Eq_16;
+typedef LPVOID Eq_17;
 


### PR DESCRIPTION
It should prevent type inference between user-defined parameters and
other expressions and creation of unnecessary unions (this is the fix for #764)