### PR TITLE
Feature: use BTreeDictionary instead of SortedTree for O(n log n) complexity

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -332,6 +332,8 @@
     <Compile Include="IStorageBinder.cs" />
     <Compile Include="Lib\ArticulationPointFinder.cs" />
     <Compile Include="Lib\Bitfield.cs" />
+    <Compile Include="Lib\BTreeDictionary.cs" />
+    <Compile Include="Lib\BTreeDictionaryEx.cs" />
     <Compile Include="Lib\Dijkstra.cs" />
     <Compile Include="Lib\FibonacciHeap.cs" />
     <Compile Include="Lib\Float16.cs" />

--- a/src/Core/ImageMap.cs
+++ b/src/Core/ImageMap.cs
@@ -40,12 +40,12 @@ namespace Reko.Core
         public ImageMap(Address addrBase)
         {
             this.BaseAddress = addrBase ?? throw new ArgumentNullException(nameof(addrBase));
-            this.Items = new SortedList<Address, ImageMapItem>(new ItemComparer());
+            this.Items = new BTreeDictionary<Address, ImageMapItem>(new ItemComparer());
         }
 
         public Address BaseAddress { get; private set; }
 
-        public SortedList<Address, ImageMapItem> Items { get; private set; }
+        public BTreeDictionary<Address, ImageMapItem> Items { get; private set; }
 
         /// <summary>
         /// Adds an image map item at the specified address. 

--- a/src/Core/Lib/BTreeDictionary.cs
+++ b/src/Core/Lib/BTreeDictionary.cs
@@ -1,0 +1,750 @@
+#region License
+/* 
+ * Copyright (C) 1999-2019 John Källén.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace Reko.Core.Lib
+{
+    /// <summary>
+    /// Represents a collection of key/value pairs that are sorted by the keys
+    /// and are accessible by key and by index. It's intended to be a drop-in
+    /// replacement for <see cref="System.Collections.Generic.SortedList{TKey, TValue}"/>.
+    /// </summary>
+    /// <remarks>
+    /// This class implemements most of the same API as <see cref="System.Collections.Generic.SortedList{TKey, TValue}"/>
+    /// but with much better performance. Where n random insertions into a 
+    /// SortedList have a complexity of O(n^2), the BtreeDictionary is 
+    /// organized as a B+tree, and this has a complexity of O(n log n). 
+    /// In addition, benchmark measurements show that BTreeDictionary is
+    /// about twice as fast as SortedDictionary (which also is O(n log n))
+    /// and in addition provides the IndexOf functionality from SortedList
+    /// that SortedDictionary lacks.
+    /// </remarks>
+    public class BTreeDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private Node root;
+        private int version;
+        private int InternalNodeChildren;
+        private int LeafNodeChildren;
+        private readonly KeyCollection keyCollection;
+        private readonly ValueCollection valueCollection;
+
+        public BTreeDictionary() :
+            this(Comparer<TKey>.Default) {
+        }
+
+        public BTreeDictionary(IComparer<TKey> cmp)
+        {
+            this.Comparer = cmp ?? throw new ArgumentNullException(nameof(cmp));
+            this.version = 0;
+            this.InternalNodeChildren = 16;
+            this.LeafNodeChildren = InternalNodeChildren - 1;
+            this.keyCollection = new KeyCollection(this);
+            this.valueCollection = new ValueCollection(this);
+        }
+
+        public BTreeDictionary(IDictionary<TKey,TValue> entries) :
+            this()
+        {
+            if (entries == null)
+                throw new ArgumentNullException(nameof(entries));
+            Populate(entries);
+        }
+
+        public BTreeDictionary(IDictionary<TKey,TValue> entries, IComparer<TKey> comparer) :
+            this(comparer)
+        {
+            if (entries == null)
+                throw new ArgumentNullException(nameof(entries));
+            Populate(entries);
+        }
+
+        private abstract class Node
+        {
+            public int count;       // # of direct children
+            public int totalCount;  // # of recursively reachable children.
+            public TKey[] keys;
+
+            public abstract (Node, Node) Add(TKey key, TValue value, BTreeDictionary<TKey, TValue> tree);
+
+            public abstract (TValue, bool) Get(TKey key, BTreeDictionary<TKey, TValue> tree);
+
+            public abstract (Node, Node) Set(TKey key, TValue value, BTreeDictionary<TKey, TValue> tree);
+
+            public abstract bool Remove(TKey key, BTreeDictionary<TKey, TValue> tree);
+
+            public override string ToString()
+            {
+                return $"{GetType().Name}: {count} items; keys: {string.Join(",",keys)}.";
+            }
+        }
+
+        /// <summary>
+        /// In a B+Tree, the values are held in the leaf nodes of the data structure.
+        /// </summary>
+        private class LeafNode : Node 
+        {
+            public LeafNode nextLeaf;   // leaves are threaded together for ease of enumeration.
+            public TValue[] values;
+
+            public LeafNode(int children)
+            {
+                this.keys = new TKey[children];
+                this.values = new TValue[children];
+            }
+
+            public override (Node, Node) Add(TKey key, TValue value, BTreeDictionary<TKey, TValue> tree)
+            {
+                int idx = Array.BinarySearch(keys, 0, count, key, tree.Comparer);
+                if (idx >= 0)
+                    throw new ArgumentException("Duplicate key.");
+                return Insert(~idx, key, value, tree);
+            }
+
+            public override (TValue, bool) Get(TKey key, BTreeDictionary<TKey, TValue> tree)
+            {
+                int idx = Array.BinarySearch(keys, 0, count, key, tree.Comparer);
+                if (idx < 0)
+                    return (default(TValue), false);
+                return (values[idx], true);
+            }
+
+            public override (Node, Node) Set(TKey key, TValue value, BTreeDictionary<TKey, TValue> tree)
+            {
+                int idx = Array.BinarySearch(keys, 0, count, key, tree.Comparer);
+                if (idx >= 0)
+                {
+                    values[idx] = value;
+                    return (this, null);
+                }
+                return Insert(~idx, key, value, tree);
+            }
+
+            public override bool Remove(TKey key, BTreeDictionary<TKey, TValue> tree)
+            {
+                int idx = Array.BinarySearch(keys, 0, count, key, tree.Comparer);
+                if (idx >= 0)
+                {
+                    --count;
+                    --totalCount;
+                    Array.Copy(keys, idx + 1, keys, idx, count - idx);
+                    Array.Copy(values, idx + 1, values, idx, count - idx);
+                    keys[count] = default(TKey);
+                    values[count] = default(TValue);
+                    return true;
+                }
+                return false;
+            }
+
+            private (Node, Node) Insert(int idx, TKey key, TValue value, BTreeDictionary<TKey, TValue> tree)
+            {
+                if (count == keys.Length)
+                {
+                    var newRight = SplitAndInsert(key, value, tree);
+                    return (this, newRight);
+                }
+                else if (idx < count)
+                {
+                    // Make a hole
+                    Array.Copy(keys, idx, keys, idx + 1, count - idx);
+                    Array.Copy(values, idx, values, idx + 1, count - idx);
+                }
+                keys[idx] = key;
+                values[idx] = value;
+                ++this.count;
+                ++this.totalCount;
+                return (this, null);
+            }
+
+            /// <summary>
+            /// Splits this node into subnodes by creating a new "right" node
+            /// and adds the (key,value) to the appropriate subnode.
+            /// </summary>
+            private Node SplitAndInsert(TKey key, TValue value, BTreeDictionary<TKey, TValue> tree)
+            {
+                var iSplit = (count + 1) / 2;
+                var right = new LeafNode(tree.LeafNodeChildren);
+                right.count = count - iSplit;
+                this.count = iSplit;
+                right.totalCount = right.count;
+                this.totalCount = this.count;
+                Array.Copy(this.keys, iSplit, right.keys, 0, right.count);
+                Array.Clear(this.keys, iSplit, right.count);
+                Array.Copy(this.values, iSplit, right.values, 0, right.count);
+                Array.Clear(this.values, iSplit, right.count);
+                right.nextLeaf = this.nextLeaf;
+                this.nextLeaf = right;
+                if (tree.Comparer.Compare(right.keys[0], key) < 0)
+                    right.Add(key, value, tree);
+                else
+                    this.Add(key, value, tree);
+                return right;
+            }
+        }
+
+        /// <summary>
+        /// In a B+tree, the internals node only contain links to other nodes.
+        /// </summary>
+        private class InternalNode : Node
+        {
+            public Node[] nodes;
+
+            public InternalNode(int children)
+            {
+                this.keys = new TKey[children];
+                this.nodes = new Node[children];
+            }
+
+            public override (Node, Node) Add(TKey key, TValue value, BTreeDictionary<TKey, TValue> tree)
+            {
+                int idx = Array.BinarySearch(keys, 1, count-1, key, tree.Comparer);
+                int iPos;
+                if (idx >= 0)
+                    iPos = idx - 1;
+                else
+                    iPos = (~idx) - 1;
+                var subnode = nodes[iPos];
+                var (leftNode, rightNode) = subnode.Add(key, value, tree);
+                if (rightNode == null)
+                {
+                    this.totalCount = SumNodeCounts(this.nodes, this.count);
+                    return (leftNode, null);
+                }
+                return Insert(iPos + 1, rightNode.keys[0], rightNode,  tree);
+            }
+
+            public Node Add(TKey key, Node node, BTreeDictionary<TKey, TValue> tree)
+            {
+                int idx = Array.BinarySearch(keys, 1, count-1, key, tree.Comparer);
+                if (idx >= 0)
+                    throw new ArgumentException("Duplicate key.");
+                var subnode = nodes[~idx];
+                return Insert(~idx, node.keys[0], node, tree).Item1;
+            }
+
+            public override (TValue, bool) Get(TKey key, BTreeDictionary<TKey, TValue> tree)
+            {
+                int idx = Array.BinarySearch(keys, 1, count - 1, key, tree.Comparer);
+                if (idx >= 0)
+                    return nodes[idx].Get(key, tree);
+                else
+                {
+                    var iPos = (~idx) - 1;
+                    return nodes[iPos].Get(key, tree);
+                }
+            }
+
+            public override (Node, Node) Set(TKey key, TValue value, BTreeDictionary<TKey, TValue> tree)
+            {
+                int idx = Array.BinarySearch(keys, 1, count - 1, key, tree.Comparer);
+                int iPos = (idx >= 0)
+                    ? idx
+                    : (~idx) - 1;
+                var subnode = nodes[iPos];
+                var (leftNode, rightNode) = subnode.Set(key, value, tree);
+                if (rightNode == null)
+                {
+                    this.totalCount = SumNodeCounts(this.nodes, this.count);
+                    tree.Validate(this);
+                    return (leftNode, null);
+                }
+                else
+                {
+                    return Insert(iPos + 1, rightNode.keys[0], rightNode, tree);
+                }
+            }
+
+            public override bool Remove(TKey key, BTreeDictionary<TKey, TValue> tree)
+            {
+                int idx = Array.BinarySearch(keys, 1, count - 1, key, tree.Comparer);
+                bool removed;
+                if (idx >= 0)
+                {
+                    removed = nodes[idx].Remove(key, tree);
+                }
+                else
+                {
+                    var iPos = (~idx) - 1;
+                    removed = nodes[iPos].Remove(key, tree);
+                }
+                --this.totalCount;
+                return removed;
+            }
+
+            private (Node, Node) Insert(int idx, TKey key, Node node, BTreeDictionary<TKey, TValue> tree)
+            {
+                if (count == keys.Length)
+                {
+                    var newRight = SplitAndInsert(key, node, tree);
+                    return (this, newRight);
+                }
+                if (idx < count)
+                {
+                    Array.Copy(keys, idx, keys, idx + 1, count - idx);
+                    Array.Copy(nodes, idx, nodes, idx + 1, count - idx);
+                }
+                keys[idx] = key;
+                nodes[idx] = node;
+                ++this.count;
+                this.totalCount = SumNodeCounts(this.nodes, this.count);
+                return (this, null);
+            }
+
+            private Node SplitAndInsert(TKey key, Node node, BTreeDictionary<TKey, TValue> tree)
+            {
+                var iSplit = (count + 1) / 2;
+                var right = new InternalNode(tree.InternalNodeChildren);
+                right.count = count - iSplit;
+                this.count = iSplit;
+                Array.Copy(this.keys, iSplit, right.keys, 0, right.count);
+                Array.Clear(this.keys, iSplit, right.count);
+                Array.Copy(this.nodes, iSplit, right.nodes, 0, right.count);
+                Array.Clear(this.nodes, iSplit, right.count);
+                if (tree.Comparer.Compare(right.keys[0], key) < 0)
+                {
+                    right.Add(key, node, tree);
+                    this.totalCount = SumNodeCounts(this.nodes, this.count);
+                }
+                else
+                {
+                    this.Add(key, node, tree);
+                    right.totalCount = SumNodeCounts(right.nodes, right.count);
+                }
+                return right;
+            }
+
+            private static int SumNodeCounts(Node[] nodes, int count)
+            {
+                int n = 0;
+                for (int i = 0; i < count; ++i)
+                    n += nodes[i].totalCount;
+                return n;
+            }
+        }
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                if (root == null)
+                    throw new KeyNotFoundException();
+                var (value, found) = root.Get(key, this);
+                if (!found)
+                    throw new KeyNotFoundException();
+                return value;
+            }
+
+            set
+            {
+                EnsureRoot();
+                var (left, right) = root.Set(key, value, this);
+                if (right != null)
+                    root = NewInternalRoot(left, right);
+                ++version;
+                // Validate(root);
+            }
+        }
+
+        public IComparer<TKey> Comparer { get; }
+
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
+
+        public KeyCollection Keys => keyCollection;
+
+        public ValueCollection Values => valueCollection;
+
+        public int Count => root != null ? root.totalCount : 0;
+
+        public bool IsReadOnly => false;
+
+        public void Add(TKey key, TValue value)
+        {
+            EnsureRoot();
+            var (left, right) = root.Add(key, value, this);
+            if (right != null)
+                root = NewInternalRoot(left, right);
+            ++version;
+            // Validate(root);
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        public void Clear()
+        {
+            ++version;
+            root = null;
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            if (root == null)
+                return false;
+            var (value, found) = root.Get(item.Key, this);
+            return found && object.Equals(item.Value, value);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            if (root == null)
+                return false;
+            var (value, found) = root.Get(key, this);
+            return found;
+        }
+
+        public bool ContainsValue(TValue value)
+        {
+            return this.Any(e => e.Value.Equals(value));
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            if (array == null) throw new ArgumentNullException(nameof(array));
+            if (arrayIndex < 0) throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+            if (this.Count > array.Length - arrayIndex) throw new ArgumentException();
+            int iDst = arrayIndex;
+            foreach (var item in this)
+            {
+                array[iDst++] = item;
+            }
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            if (root == null)
+                yield break;
+            // Get the leftmost leaf node.
+            Node node;
+            for (node = root; node is InternalNode intern; node = intern.nodes[0])
+                ;
+            var leaf = (LeafNode)node;
+            int myVersion = this.version;
+            while (leaf != null)
+            {
+                for (int i = 0; i < leaf.count; ++i)
+                {
+                    if (myVersion != this.version)
+                        throw new InvalidOperationException("Collection was modified after the enumerator was instantiated.");
+                    yield return new KeyValuePair<TKey, TValue>(leaf.keys[i], leaf.values[i]);
+                }
+                leaf = leaf.nextLeaf;
+            }
+        }
+
+        /// <summary>
+        /// Determine the 0-based index of <paramref name="key"/>.
+        /// </summary>
+        /// <returns>
+        /// A non-negative number if the key is found. If the key is 
+        /// not found, returns the one's complement of the index the key would
+        /// have had if it were present in the collection.
+        /// </returns>
+        public int IndexOfKey(TKey key)
+        {
+            if (root == null)
+                return ~0;
+            int totalBefore = 0;
+            Node node = root;
+            int i;
+            while (node is InternalNode intern)
+            {
+                for (i = 1; i < intern.count; ++i)
+                {
+                    int c = Comparer.Compare(intern.keys[i], key);
+                    if (c <= 0)
+                    {
+                        totalBefore += intern.nodes[i - 1].totalCount;
+                    }
+                    else
+                    {
+                        node = intern.nodes[i - 1];
+                        break;
+                    }
+                }
+                if (i == intern.count)
+                {
+                    // Key was larger than all nodes.
+                    node = intern.nodes[i - 1];
+                }
+            }
+            // Should have reached a leaf node.
+            var leaf = (LeafNode)node;
+            for (i = 0; i < leaf.count; ++i)
+            {
+                var c = Comparer.Compare(leaf.keys[i], key);
+                if (c == 0)
+                    return totalBefore + i;
+                if (c > 0)
+                    break;
+            }
+            return ~(totalBefore + i);
+        }
+
+        public bool Remove(TKey key)
+        {
+            if (root == null)
+                return false;
+            return root.Remove(key, this);
+        }
+
+        bool ICollection<KeyValuePair<TKey,TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            if (root == null)
+            {
+                value = default(TValue);
+                return false;
+            }
+            bool found;
+            (value, found) = root.Get(key, this);
+            return found;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        private void EnsureRoot()
+        {
+            if (root != null)
+                return;
+            root = new LeafNode(LeafNodeChildren);
+        }
+
+        private KeyValuePair<TKey,TValue> GetEntry(int index)
+        {
+            if (0 <= index && index < this.Count)
+            {
+                Node node = root;
+                int itemsLeft = index;
+                while (node is InternalNode intern)
+                {
+                    for (int i = 0; i < intern.count; ++i)
+                    {
+                        var subNode = intern.nodes[i];
+                        if (itemsLeft < subNode.totalCount)
+                        {
+                            node = subNode;
+                            break;
+                        }
+                        itemsLeft -= subNode.totalCount;
+                    }
+                }
+                var leaf = (LeafNode)node;
+                return new KeyValuePair<TKey, TValue>(leaf.keys[itemsLeft], leaf.values[itemsLeft]);
+            }
+            else
+                throw new ArgumentOutOfRangeException("Index was out of range. Must be non-negative and less than the size of the collection.");
+
+        }
+
+        private InternalNode NewInternalRoot(Node left, Node right)
+        {
+            var intern = new InternalNode(InternalNodeChildren);
+            intern.count = 2;
+            intern.totalCount = left.totalCount + right.totalCount;
+            intern.keys[0] = left.keys[0];
+            intern.keys[1] = right.keys[0];
+            intern.nodes[0] = left;
+            intern.nodes[1] = right;
+            return intern;
+        }
+
+        private void Populate(IDictionary<TKey, TValue> entries)
+        {
+            foreach (var entry in entries)
+            {
+                Add(entry.Key, entry.Value);
+            }
+        }
+
+        #region Debugging code 
+
+        [Conditional("DEBUG")]
+        public void Dump()
+        {
+            if (root == null)
+                Debug.Print("(empty)");
+            Dump(root, 0);
+        }
+
+        [Conditional("DEBUG")]
+        private void Dump(Node n, int depth)
+        {
+            var prefix = new string(' ', depth);
+            switch (n)
+            {
+            case InternalNode inode:
+                for (int i = 0; i < inode.count; ++i)
+                {
+                    Debug.Print("{0}{1}: total nodes: {2}", prefix, inode.keys[i], inode.nodes[i].totalCount);
+                    Dump(inode.nodes[i], depth + 4);
+                }
+                break;
+            case LeafNode leaf:
+                for (int i = 0; i < leaf.count; ++i)
+                {
+                    Debug.Print("{0}{1}: {2}", prefix, leaf.keys[i], leaf.values[i]);
+                }
+                break;
+            default:
+                Debug.Print("{0}huh?", prefix);
+                break;
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private void Validate(Node node)
+        {
+            if (node is LeafNode leaf)
+            {
+                if (leaf.totalCount != leaf.count)
+                    throw new InvalidOperationException($"Leaf node {leaf} has mismatched counts.");
+            }
+            else if (node is InternalNode intern)
+            {
+                int sum = 0;
+                for (int i = 0; i < intern.count; ++i)
+                {
+                    Validate(intern.nodes[i]);
+                    sum += intern.nodes[i].totalCount;
+                }
+                if (sum != intern.totalCount)
+                {
+                    Dump();
+                    Console.WriteLine("# of nodes: {0}", this.Count);
+                    throw new InvalidOperationException($"Internal node {intern} has mismatched counts; expected {sum} but had {intern.totalCount}.");
+                }
+            }
+        }
+        #endregion
+
+        public abstract class Collection<T> : ICollection<T>
+        {
+            protected readonly BTreeDictionary<TKey, TValue> btree;
+
+            protected Collection(BTreeDictionary<TKey, TValue> btree)
+            {
+                this.btree = btree;
+            }
+
+            public int Count => btree.Count;
+
+            public bool IsReadOnly => true;
+
+            public abstract T this[int index] { get; }
+            
+            public void Add(T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotSupportedException();
+            }
+
+            public abstract bool Contains(T item);
+
+            public abstract void CopyTo(T[] array, int arrayIndex);
+
+            public abstract IEnumerator<T> GetEnumerator();
+
+            public bool Remove(T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        public class KeyCollection : Collection<TKey>
+        {
+            internal KeyCollection(BTreeDictionary<TKey, TValue> btree) : 
+                base(btree)
+            {
+            }
+
+            public override TKey this[int index] => btree.GetEntry(index).Key;
+
+            public override bool Contains(TKey item) => btree.ContainsKey(item);
+
+            public override void CopyTo(TKey[] array, int arrayIndex)
+            {
+                if (array == null) throw new ArgumentNullException(nameof(array));
+                if (arrayIndex < 0) throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+                if (btree.Count > array.Length - arrayIndex) throw new ArgumentException();
+                var iDst = arrayIndex;
+                foreach (var item in btree)
+                {
+                    array[iDst++] = item.Key;
+                }
+            }
+
+            public int IndexOf(TKey item) => btree.IndexOfKey(item);
+
+            public override IEnumerator<TKey> GetEnumerator() => btree.Select(e => e.Key).GetEnumerator();
+        }
+
+        public class ValueCollection : Collection<TValue>
+        {
+            internal ValueCollection(BTreeDictionary<TKey, TValue> btree) :
+                base(btree)
+            {
+            }
+
+            public override TValue this[int index] => btree.GetEntry(index).Value;
+
+            public override bool Contains(TValue item) => btree.ContainsValue(item);
+
+            public override void CopyTo(TValue[] array, int arrayIndex)
+            {
+                if (array == null) throw new ArgumentNullException(nameof(array));
+                if (arrayIndex < 0) throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+                if (btree.Count > array.Length - arrayIndex) throw new ArgumentException();
+                var iDst = arrayIndex;
+                foreach (var item in btree)
+                {
+                    array[iDst] = item.Value;
+                }
+            }
+
+            public override IEnumerator<TValue> GetEnumerator() => btree.Select(e => e.Value).GetEnumerator();
+        }
+    }
+}

--- a/src/Core/Lib/BTreeDictionaryEx.cs
+++ b/src/Core/Lib/BTreeDictionaryEx.cs
@@ -1,0 +1,219 @@
+#region License
+/* 
+ * Copyright (C) 1999-2019 John Källén.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+namespace Reko.Core.Lib
+{
+    /// <summary>
+    /// Extension methods on BTreeDictionary that provide support for lower- and
+    /// upper bound searchers.
+    /// </summary>
+    public static class BTreeDictionaryEx
+    {
+        public static bool TryGetLowerBound<K, V>(this BTreeDictionary<K, V> list, K key, out V value)
+        {
+            var cmp = list.Comparer;
+            int lo = 0;
+            int hi = list.Count - 1;
+            value = default(V);
+            bool set = false;
+            while (lo <= hi)
+            {
+                int mid = (hi - lo) / 2 + lo;
+                K k = list.Keys[mid];
+                int c = cmp.Compare(k, key);
+                if (c == 0)
+                {
+                    value = list.Values[mid];
+                    return true;
+                }
+                if (c < 0)
+                {
+                    value = list.Values[mid];
+                    set = true;
+                    lo = mid + 1;
+                }
+                else
+                {
+                    hi = mid - 1;
+                }
+            }
+            return set;
+        }
+
+        public static bool TryGetUpperBound<K, V>(this BTreeDictionary<K, V> list, K key, out V value)
+        {
+            var cmp = list.Comparer;
+            int lo = 0;
+            int hi = list.Count - 1;
+            value = default(V);
+            bool set = false;
+            while (lo <= hi)
+            {
+                int mid = (hi - lo) / 2 + lo;
+                K k = list.Keys[mid];
+                int c = cmp.Compare(k, key);
+                if (c == 0)
+                {
+                    value = list.Values[mid];
+                    return true;
+                }
+                if (c > 0)
+                {
+                    value = list.Values[mid];
+                    set = true;
+                    hi = mid - 1;
+                }
+                else
+                {
+                    lo = mid + 1;
+                }
+            }
+            return set;
+        }
+
+        public static bool TryGetLowerBoundKey<K, V>(this BTreeDictionary<K, V> list, K key, out K closestKey)
+        {
+            var cmp = list.Comparer;
+            int lo = 0;
+            int hi = list.Count - 1;
+            closestKey = default(K);
+            bool set = false;
+            while (lo <= hi)
+            {
+                int mid = (hi - lo) / 2 + lo;
+                K k = list.Keys[mid];
+                int c = cmp.Compare(k, key);
+                if (c == 0)
+                {
+                    closestKey = k;
+                    return true;
+                }
+                if (c < 0)
+                {
+                    closestKey = k;
+                    set = true;
+                    lo = mid + 1;
+                }
+                else
+                {
+                    hi = mid - 1;
+                }
+            }
+            return set;
+        }
+
+        public static bool TryGetUpperBoundKey<K, V>(this BTreeDictionary<K, V> list, K key, out K closestKey)
+        {
+            var cmp = list.Comparer;
+            int lo = 0;
+            int hi = list.Count - 1;
+            closestKey = default(K);
+            bool set = false;
+            while (lo <= hi)
+            {
+                int mid = (hi - lo) / 2 + lo;
+                K k = list.Keys[mid];
+                int c = cmp.Compare(k, key);
+                if (c == 0)
+                {
+                    closestKey = k;
+                    return true;
+                }
+                if (c < 0)
+                {
+                    lo = mid + 1;
+                }
+                else
+                {
+                    closestKey = k;
+                    set = true;
+                    hi = mid - 1;
+                }
+            }
+            return set;
+        }
+
+        public static bool TryGetLowerBoundIndex<K, V>(this BTreeDictionary<K, V> list, K key, out int closestIndex)
+        {
+            var cmp = list.Comparer;
+            int lo = 0;
+            int hi = list.Count - 1;
+            closestIndex = -1;
+            bool set = false;
+            while (lo <= hi)
+            {
+                int mid = (hi - lo) / 2 + lo;
+                K k = list.Keys[mid];
+                int c = cmp.Compare(k, key);
+                if (c == 0)
+                {
+                    closestIndex = mid;
+                    return true;
+                }
+                if (c < 0)
+                {
+                    lo = mid + 1;
+                    closestIndex = mid;
+                    set = true;
+                }
+                else
+                {
+                    hi = mid - 1;
+                }
+            }
+            return set;
+        }
+
+        public static bool TryGetUpperBoundIndex<K, V>(this BTreeDictionary<K, V> list, K key, out int closestIndex)
+        {
+            var cmp = list.Comparer;
+            int lo = 0;
+            int hi = list.Count - 1;
+            closestIndex = -1;
+            bool set = false;
+            while (lo <= hi)
+            {
+                int mid = (hi - lo) / 2 + lo;
+                K k = list.Keys[mid];
+                int c = cmp.Compare(k, key);
+                if (c == 0)
+                {
+                    closestIndex = mid;
+                    return true;
+                }
+                if (c < 0)
+                {
+                    lo = mid + 1;
+                }
+                else
+                {
+                    closestIndex = mid;
+                    set = true;
+                    hi = mid - 1;
+                }
+            }
+            return set;
+        }
+    }
+}

--- a/src/Core/Program.cs
+++ b/src/Core/Program.cs
@@ -30,6 +30,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Reko.Core.Lib;
 
 namespace Reko.Core
 {
@@ -56,7 +57,7 @@ namespace Reko.Core
             this.Architectures = new Dictionary<string, IProcessorArchitecture>();
             this.EntryPoints = new SortedList<Address, ImageSymbol>();
             this.ImageSymbols = new SortedList<Address, ImageSymbol>();
-            this.Procedures = new SortedList<Address, Procedure>();
+            this.Procedures = new BTreeDictionary<Address, Procedure>();
             this.CallGraph = new CallGraph();
             this.EnvironmentMetadata = new TypeLibrary();
             this.ImportReferences = new Dictionary<Address, ImportReference>(new Address.Comparer());		// uint (offset) -> string
@@ -291,7 +292,7 @@ namespace Reko.Core
         /// <summary>
         /// The program's decompiled procedures, ordereds by address.
         /// </summary>
-        public SortedList<Address, Procedure> Procedures { get; private set; }
+        public BTreeDictionary<Address, Procedure> Procedures { get; private set; }
 
         /// <summary>
         /// The program's pseudo procedures, indexed by name and by signature.

--- a/src/UnitTests/Core/Lib/BTreeDictionaryTests.cs
+++ b/src/UnitTests/Core/Lib/BTreeDictionaryTests.cs
@@ -1,0 +1,362 @@
+#region License
+/* 
+ * Copyright (C) 1999-2019 John Källén.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using NUnit.Framework;
+using Reko.Core.Lib;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace Reko.UnitTests.Core.Lib
+{
+    public class BTreeDictionaryTests
+    {
+        private BTreeDictionary<string, int> Given_Dictionary(IEnumerable<int> items)
+        {
+            var btree = new BTreeDictionary<string, int>();
+            foreach (var item in items)
+            {
+                btree.Add(item.ToString(), item);
+            }
+            return btree;
+        }
+
+        [Test]
+        public void BTree_Create()
+        {
+            var btree = new BTreeDictionary<string, int>();
+        }
+
+        [Test]
+        public void BTree_AddItem()
+        {
+            var btree = new BTreeDictionary<string, int>();
+            btree.Add("3", 3);
+            Assert.AreEqual(1, btree.Count);
+        }
+
+        [Test]
+        public void BTree_AddTwoItems()
+        {
+            var btree = new BTreeDictionary<string, int>();
+            btree.Add("3", 3);
+            btree.Add("2", 2);
+            Assert.AreEqual(2, btree.Count);
+        }
+
+        [Test]
+        public void BTree_Enumerate()
+        {
+            var btree = new BTreeDictionary<string, int>();
+            btree.Add("3", 3);
+            btree.Add("2", 2);
+            var e = btree.GetEnumerator();
+            Assert.IsTrue(e.MoveNext());
+            Assert.AreEqual("2", e.Current.Key);
+            Assert.AreEqual(2, e.Current.Value);
+            Assert.IsTrue(e.MoveNext());
+            Assert.AreEqual("3", e.Current.Key);
+            Assert.AreEqual(3, e.Current.Value);
+            Assert.IsFalse(e.MoveNext());
+        }
+
+        [Test]
+        public void BTree_Get()
+        {
+            var btree = new BTreeDictionary<string, int>();
+            btree.Add("3", 3);
+            Assert.AreEqual(3, btree["3"]);
+        }
+
+        [Test]
+        public void BTree_EnumeratorThrowIfMutated()
+        {
+            var btree = new BTreeDictionary<string, int>();
+            btree.Add("3", 3);
+            var e = btree.GetEnumerator();
+            Assert.True(e.MoveNext());
+            btree.Add("2", 2);
+            try
+            {
+                e.MoveNext();
+                Assert.Fail("Should have thrown exception");
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        [Test]
+        public void BTree_SetNonExisting()
+        {
+            var btree = new BTreeDictionary<string, int>();
+            btree["3"] = 3;
+            Assert.AreEqual(3, btree["3"]);
+        }
+
+        [Test]
+        public void BTree_SetExisting()
+        {
+            var btree = new BTreeDictionary<string, int>();
+            btree["3"] = 3;
+            btree["3"] = 2;
+            Assert.AreEqual(2, btree["3"]);
+        }
+
+        [Test]
+        public void BTree_ForceInternalNode()
+        {
+            var btree = new BTreeDictionary<string, int>();
+            foreach (var i in Enumerable.Range(0, 256))
+            {
+                btree.Add(i.ToString(), i);
+            }
+            btree.Add("256", 256);
+        }
+
+        [Test]
+        public void BTree_GetFromDeepTree()
+        {
+            var btree = new BTreeDictionary<string, int>();
+            foreach (var i in Enumerable.Range(0, 1000))
+            {
+                btree.Add(i.ToString(), i);
+            }
+            btree.Dump();
+            Assert.AreEqual(0, btree["0"]);
+            Assert.AreEqual(500, btree["500"]);
+        }
+
+        [Test]
+        public void BTree_ItemsSorted()
+        {
+            var rnd = new Random(42);
+            var btree = new BTreeDictionary<string, int>();
+            while (btree.Count < 500)
+            {
+                var n = rnd.Next(3000);
+                var s = n.ToString();
+                btree[s] = n;
+            }
+            string prev = "";
+            foreach (var item in btree)
+            {
+                var cur = item.Key;
+                Debug.Print("item.Key: {0}", item.Key);
+                Assert.Less(prev, cur);
+                prev = cur;
+            }
+        }
+
+        [Test]
+        public void BTree_IndexOf_Empty()
+        {
+            var btree = new BTreeDictionary<string, int>();
+            int i = btree.Keys.IndexOf("3");
+            Assert.AreEqual(-1, i);
+        }
+
+        [Test]
+        public void BTree_IndexOf_existing_leaf_item()
+        {
+            var btree = new BTreeDictionary<string, int> { { "3", 3 } };
+            int i = btree.Keys.IndexOf("3");
+            Assert.AreEqual(0, i);
+        }
+
+
+        [Test]
+        public void BTree_IndexOf_existing_leaf_item_2()
+        {
+            var btree = new BTreeDictionary<string, int> {
+                { "3", 3 },
+                { "2", 2 }
+            };
+            int i = btree.Keys.IndexOf("3");
+            Assert.AreEqual(1, i);
+        }
+
+        [Test]
+        public void BTree_IndexOf_nonexisting_small_leafitem()
+        {
+            var btree = new BTreeDictionary<string, int> {
+                { "3", 3 },
+                { "2", 2 }
+            };
+            int i = btree.Keys.IndexOf("1");
+            Assert.AreEqual(~0, i);
+        }
+
+        [Test]
+        public void BTree_IndexOf_nonexisting_middle_leafitem()
+        {
+            var btree = new BTreeDictionary<string, int> {
+                { "4", 4 },
+                { "2", 2 }
+            };
+            int i = btree.Keys.IndexOf("3");
+            Assert.AreEqual(~1, i);
+        }
+
+        [Test]
+        public void BTree_IndexOf_nonexisting_large_leafitem()
+        {
+            var btree = new BTreeDictionary<string, int> {
+                { "4", 4 },
+                { "2", 2 }
+            };
+            int i = btree.Keys.IndexOf("5");
+            Assert.AreEqual(~2, i);
+        }
+
+        [Test]
+        public void BTree_IndexOf_existing_item_1_ply_tree()
+        {
+            var btree = Given_Dictionary(Enumerable.Range(0, 20).Select(n => 1 + n * 2));
+            int i = btree.Keys.IndexOf("1");
+            Assert.AreEqual(0, i);
+        }
+
+        [Test]
+        public void BTree_IndexOf_nonexisting_small_item_1_ply_tree()
+        {
+            var btree = Given_Dictionary(Enumerable.Range(0, 20).Select(n => 1 + n * 2));
+            int i = btree.Keys.IndexOf("0");
+            Assert.AreEqual(~0, i);
+        }
+
+        [Test]
+        public void BTree_IndexOf_nonexisting_middle_item_1_ply_tree()
+        {
+            var btree = Given_Dictionary(Enumerable.Range(0, 20).Select(n => 1 + n * 2));
+            int i = btree.Keys.IndexOf("14");
+            Assert.AreEqual(~3, i);
+        }
+
+        [Test]
+        public void BTree_IndexOf_nonexisting_middle_item_1_ply_tree_2()
+        {
+            var btree = Given_Dictionary(Enumerable.Range(0, 20).Select(n => 1 + n * 2));
+            int i = btree.Keys.IndexOf("30");
+            Assert.AreEqual(~12, i);
+        }
+
+        [Test]
+        public void BTree_IndexOf_nonexisting_last_item_1_ply_tree_2()
+        {
+            var btree = Given_Dictionary(Enumerable.Range(0, 20).Select(n => 1 + n * 2));
+            int i = btree.Keys.IndexOf("9999");
+            Assert.AreEqual(~20, i);
+        }
+
+        [Test]
+        public void BTree_IndexOf()
+        {
+            var rnd = new Random(42);
+            var btree = new BTreeDictionary<string, int>();
+            while (btree.Count < 100)
+            {
+                var n = rnd.Next(200);
+                var s = n.ToString();
+                btree[s] = n;
+            }
+            var items = btree.Keys.ToArray();
+            for (int i = 0; i < items.Length; ++i)
+            {
+                Assert.AreEqual(i, btree.Keys.IndexOf(items[i]));
+            }
+        }
+
+        [Test]
+        public void BTree_GetItemByIndex()
+        {
+            var btree = Given_Dictionary(new[] {
+                5,6,9,1,3, 4,2,7,8,0,
+                10,18,17,12,14, 13,11,19,16,15});
+            var items = btree.Keys.ToArray();
+            for (int i = 0; i < btree.Count; ++i)
+            {
+                Assert.AreEqual(items[i], btree.Keys[i]);
+            }
+        }
+
+        [Test]
+        public void BTree_Remove_existing_leaf()
+        {
+            var btree = Given_Dictionary(new[] { 3 });
+            bool removed = btree.Remove("3");
+            Assert.IsTrue(removed);
+            Assert.AreEqual(0, btree.Count);
+            int items = 0;
+            foreach (var entry in btree)
+            {
+                ++items;
+            }
+            Assert.AreEqual(0, items);
+        }
+
+        [Test]
+        public void BTree_Remove_existing_leaf2()
+        {
+            var btree = Given_Dictionary(new[] { 3, 4 });
+            bool removed = btree.Remove("3");
+            Assert.IsTrue(removed);
+            Assert.AreEqual(1, btree.Count);
+            int items = 0;
+            foreach (var entry in btree)
+            {
+                ++items;
+            }
+            Assert.AreEqual(1, items);
+        }
+
+        [Test]
+        public void BTree_Remove_existing_deep_leaf()
+        {
+            var btree = Given_Dictionary(Enumerable.Range(0, 40));
+            bool removed = btree.Remove("3");
+            Assert.IsTrue(removed);
+            Assert.AreEqual(39, btree.Count);
+            int items = 0;
+            foreach (var entry in btree)
+            {
+                ++items;
+            }
+            Assert.AreEqual(39, items);
+        }
+
+        [Test]
+        public void BTree_Remove_Exercise()
+        {
+            var btree = Given_Dictionary(Enumerable.Range(0, 40));
+            foreach (var n in Enumerable.Range(0, 40))
+            {
+                Assert.IsTrue(btree.Remove(n.ToString()));
+            }
+            foreach (var n in Enumerable.Range(0, 40))
+            {
+                btree.Add(n.ToString(), n);
+            }
+            Assert.AreEqual(40, btree.Count);
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Arch\Microchip\PIC18\PIC18LgcyTrad_RewriterTests.cs" />
     <Compile Include="Core\ImportReferenceTests.cs" />
     <Compile Include="Core\Lib\BitfieldTests.cs" />
+    <Compile Include="Core\Lib\BTreeDictionaryTests.cs" />
     <Compile Include="Core\Lib\Float16Tests.cs" />
     <Compile Include="Core\Pascal\PascalLexerTests.cs" />
     <Compile Include="Core\Pascal\PascalParserTests.cs" />

--- a/subjects/regression.log
+++ b/subjects/regression.log
@@ -1621,4 +1621,4 @@ l0800_906A: warning: Non-integral switch expression
 === regressions\snowman-82\flags
 === regressions\snowman-83\flags3
 Stripping SSA identifier numbers
-Decompiled 56 binaries in 78.07 seconds ---
+Decompiled 56 binaries in 70.10 seconds ---


### PR DESCRIPTION
When doing performance testing, I'm noticing that one of the "hotspots" is `SortedList.Add`. This is not surprising as we are using `SortedList` everywhere, and `SortedList` is infamously bad: it is basically [insertion sort](https://en.wikipedia.org/wiki/Insertion_sort) which degenerates to `O(n^2)` complexity when adding non-sorted data.

I spent some time writing another sorted dictionary implementation, based on [B+trees](https://en.wikipedia.org/wiki/B%2B_tree). I've only replaced a few uses of `SortedList` with `BTreeDictionary` but am already seeing 10% performance improvements when running regression tests.

Please review this to make sure there's nothing glaringly obvious missing.