### PR TITLE
Set Conditional Transfer instruction class for FSTSW sequence

### DIFF
--- a/src/Arch/X86/X86Rewriter.Fpu.cs
+++ b/src/Arch/X86/X86Rewriter.Fpu.cs
@@ -497,6 +497,7 @@ namespace Reko.Arch.X86
 
         private void Branch(ConditionCode code, MachineOperand op)
         {
+            this.rtlc = InstrClass.ConditionalTransfer;
             m.Branch(m.Test(code, orw.FlagGroup(FlagM.FPUF)), OperandAsCodeAddress( op), InstrClass.ConditionalTransfer);
         }
 

--- a/src/UnitTests/Arch/Intel/RewriteFpuInstructionTests.cs
+++ b/src/UnitTests/Arch/Intel/RewriteFpuInstructionTests.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 /* 
  * Copyright (C) 1999-2019 John Källén.
  *
@@ -107,7 +107,7 @@ namespace Reko.UnitTests.Arch.Intel
                 m.Jnz("foo");
             });
             AssertCode(
-                "0|L--|00010000(8): 2 instructions",
+                "0|T--|00010000(8): 2 instructions",
                 "1|L--|SCZO = FPUF",
                 "2|T--|if (Test(EQ,FPUF)) branch 00010000"
                 );            
@@ -124,7 +124,7 @@ namespace Reko.UnitTests.Arch.Intel
                 m.Jz("foo");
             });
             AssertCode(
-                "0|L--|00010000(8): 2 instructions",
+                "0|T--|00010000(8): 2 instructions",
                 "1|L--|SCZO = FPUF",
                 "2|T--|if (Test(GE,FPUF)) branch 00010000"
                 );

--- a/src/UnitTests/Arch/Intel/X86RewriterTests.cs
+++ b/src/UnitTests/Arch/Intel/X86RewriterTests.cs
@@ -1000,7 +1000,7 @@ namespace Reko.UnitTests.Arch.Intel
             AssertCode(
                 "0|L--|0C00:0000(2): 1 instructions",
                 "1|L--|FPUF = cond(rArg0 - rArg1)",
-                "2|L--|0C00:0002(7): 2 instructions",
+                "2|T--|0C00:0002(7): 2 instructions",
                 "3|L--|SCZO = FPUF",
                 "4|T--|if (Test(NE,FPUF)) branch 0C00:0000");
         }
@@ -1017,7 +1017,7 @@ namespace Reko.UnitTests.Arch.Intel
                 m.Jnz("foo");
             });
             AssertCode(
-                "0|L--|10000000(12): 3 instructions",
+                "0|T--|10000000(12): 3 instructions",
                 "1|L--|SCZO = FPUF",
                 "2|L--|eax = Mem0[esp + 0x00000004:word32]",
                 "3|T--|if (Test(LE,FPUF)) branch 10000000");


### PR DESCRIPTION
Set Conditional Transfer instruction class for `FSTSW` sequence.
Linear class is not correct