### PR TITLE
Program: Consistent naming convention for the default resources direc…

### DIFF
--- a/src/Core/Program.cs
+++ b/src/Core/Program.cs
@@ -352,7 +352,7 @@ namespace Reko.Core
             this.OutputFilename = OutputFilename ?? Path.ChangeExtension(fileName, ".c");
             this.TypesFilename = TypesFilename ?? Path.ChangeExtension(fileName, ".h");
             this.GlobalsFilename = GlobalsFilename ?? Path.ChangeExtension(fileName, ".globals.c");
-            this.ResourcesDirectory = ResourcesDirectory ?? Path.Combine(dir, "resources");
+            this.ResourcesDirectory = ResourcesDirectory ?? Path.ChangeExtension(fileName, ".resources");
         }
 
         /// <summary>


### PR DESCRIPTION
Use the same name as .c and .h file, thus creating a directory called
`<exeName>.resources`

This makes it possible to load multiple EXE files located in the same directory without having all resources dumped (and mixed) in a single directory called "resources"