### PR TITLE
Avoid null signature for no decompiled procedure

### DIFF
--- a/src/Decompiler/Scanning/ScannerBase.cs
+++ b/src/Decompiler/Scanning/ScannerBase.cs
@@ -73,6 +73,10 @@ namespace Reko.Scanning
             parsedProc = new Procedure_v1()
             {
                 Name = sProc.Name,
+                Signature = new SerializedSignature
+                {
+                    ParametersValid = false,
+                },
             };
             noDecompiledProcs[addr] = parsedProc;
             if (string.IsNullOrEmpty(sProc.CSignature))

--- a/src/UnitTests/Scanning/ScannerTests.cs
+++ b/src/UnitTests/Scanning/ScannerTests.cs
@@ -619,6 +619,27 @@ fn00001000_exit:
         }
 
         [Test]
+        public void Scanner_NoDecompiledProcedure_NullSignature()
+        {
+            Given_Program(Address.Ptr32(0x1000), new byte[0x2000]);
+            program.User.Procedures.Add(
+                Address.Ptr32(0x2000),
+                new Procedure_v1()
+                {
+                    CSignature = null,
+                    Decompile = false,
+                }
+            );
+
+            var sc = CreateScanner(program);
+            var proc = sc.ScanProcedure(
+                arch,
+                Address.Ptr32(0x2000),
+                "fn000020", arch.CreateProcessorState());
+            Assert.False(proc.Signature.ParametersValid);
+        }
+
+        [Test]
         public void Scanner_EnqueueUserProcedure()
         {
             Given_Program(Address.Ptr32(0x1000), new byte[0x2000]);


### PR DESCRIPTION
- Create scanner test for no decompiled procedure without signature
Expected: creation signature with invalid parameters
Actual: throwing `ArgumentNullException` during `ExternalProcedure` creation
- Avoid null signature for no decompiled procedure