### PR TITLE
Modify CallRewiter to use slice instead cast when slicing wider registers

### DIFF
--- a/src/tests/Analysis/CrwEvenOdd.exp
+++ b/src/tests/Analysis/CrwEvenOdd.exp
@@ -65,11 +65,11 @@ l0C00_0019:
 l0C00_001A_thunk_fn0C00_0020:
 	ax_13 = SEQ(0x00, fn0C00_0020(ax - 0x0001))
 	SCZO_15 = <invalid>
-	return (byte) ax_13
+	return SLICE(ax_13, byte, 0)
 	// succ:  fn0C00_0015_exit
 l0C00_001D:
 	ax_18 = SEQ(ah_17, 0x01) (alias)
-	return (byte) ax_18
+	return SLICE(ax_18, byte, 0)
 	// succ:  fn0C00_0015_exit
 fn0C00_0015_exit:
 Register byte fn0C00_0020(Register word16 ax)
@@ -106,10 +106,10 @@ l0C00_0024:
 l0C00_0025_thunk_fn0C00_0015:
 	ax_15 = SEQ(0x00, fn0C00_0015(ax - 0x0001))
 	SCZO_17 = <invalid>
-	return (byte) ax_15
+	return SLICE(ax_15, byte, 0)
 	// succ:  fn0C00_0020_exit
 l0C00_0028:
 	ax_20 = SEQ(ah_19, 0x00) (alias)
-	return (byte) ax_20
+	return SLICE(ax_20, byte, 0)
 	// succ:  fn0C00_0020_exit
 fn0C00_0020_exit:

--- a/subjects/CPM-80/CB80.c
+++ b/subjects/CPM-80/CB80.c
@@ -236,7 +236,7 @@ byte fn05CE(Eq_n bc)
 		fn056B(SEQ(b_n, *globals->t166D), out bc_n);
 		globals->t166D = (word16) globals->t166D + 0x01;
 	}
-	return (byte) bc_n;
+	return SLICE(bc_n, byte, 8);
 }
 
 // 05EF: FlagGroup bool fn05EF(Register Eq_n bc, Register out Eq_n bOut)
@@ -333,7 +333,7 @@ byte fn06CE(byte b, Eq_n c)
 	byte b_n;
 	fn05EF(5676, out b_n);
 	Eq_n bc_n = <invalid>;
-	return (byte) bc_n;
+	return SLICE(bc_n, byte, 8);
 }
 
 // 0722: void fn0722(Register cu8 c, Register byte b)

--- a/subjects/CPM-80/CB80.dis
+++ b/subjects/CPM-80/CB80.dis
@@ -656,7 +656,7 @@ l05D4:
 // SymbolicIn:
 
 l05EE:
-	return (byte) bc_20
+	return SLICE(bc_20, byte, 8)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -880,7 +880,7 @@ l06CE:
 	byte b_35
 	fn05EF(0x162C, out b_35)
 	word16 bc_28 = <invalid>
-	return (byte) bc_28
+	return SLICE(bc_28, byte, 8)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:

--- a/subjects/CPM-80/CB80.h
+++ b/subjects/CPM-80/CB80.h
@@ -2850,7 +2850,7 @@ T_481: (in bc_20 : Eq_473)
   Class: Eq_473
   DataType: Eq_473
   OrigDataType: word16
-T_482: (in (byte) bc_20 : byte)
+T_482: (in SLICE(bc_20, byte, 8) : byte)
   Class: Eq_472
   DataType: byte
   OrigDataType: byte
@@ -3950,7 +3950,7 @@ T_756: (in bc_28 : Eq_230)
   Class: Eq_230
   DataType: Eq_230
   OrigDataType: word16
-T_757: (in (byte) bc_28 : byte)
+T_757: (in SLICE(bc_28, byte, 8) : byte)
   Class: Eq_735
   DataType: byte
   OrigDataType: byte

--- a/subjects/Elf/x86-64/ais3_crackme/ais3_crackme.dis
+++ b/subjects/Elf/x86-64/ais3_crackme/ais3_crackme.dis
@@ -330,7 +330,7 @@ l00000000004005B9:
 // SymbolicIn:
 
 l00000000004005C3:
-	return (word32) rax_113
+	return SLICE(rax_113, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:

--- a/subjects/Elf/x86-64/ais3_crackme/ais3_crackme.h
+++ b/subjects/Elf/x86-64/ais3_crackme/ais3_crackme.h
@@ -773,7 +773,7 @@ T_176: (in 0x0000000000000000 : uint64)
   Class: Eq_80
   DataType: uint64
   OrigDataType: uint64
-T_177: (in (word32) rax_113 : word32)
+T_177: (in SLICE(rax_113, word32, 0) : word32)
   Class: Eq_76
   DataType: word32
   OrigDataType: word32

--- a/subjects/Elf/x86-64/ls/ls.dis
+++ b/subjects/Elf/x86-64/ls/ls.dis
@@ -3197,7 +3197,7 @@ l0000000000404B35:
 	rbpOut = rcx
 	r8Out = r8_210
 	r12Out = 0x0000000000000000
-	return (byte) rax_212
+	return SLICE(rax_212, byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -3272,7 +3272,7 @@ l0000000000404A38:
 	rbpOut = rbp
 	r8Out = r8_116
 	r12Out = r12
-	return (byte) rax_269
+	return SLICE(rax_269, byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -9417,7 +9417,7 @@ l0000000000409CFE:
 // SymbolicIn:
 
 l0000000000409CDC:
-	return (word32) rax_38
+	return SLICE(rax_38, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -11863,7 +11863,7 @@ l000000000040B890:
 	r8Out = r8
 	xmm0Out = xmm0
 	xmm1Out = <invalid>
-	return (word32) (uint64) ebp_170
+	return SLICE((uint64) ebp_170, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -11892,7 +11892,7 @@ l000000000040B84B:
 	r8Out = r8
 	xmm0Out = xmm0
 	xmm1Out = <invalid>
-	return (word32) (uint64) ebp_170
+	return SLICE((uint64) ebp_170, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -12181,7 +12181,7 @@ l000000000040B92A:
 	xmm0Out = xmm0
 	xmm1Out = xmm1
 	xmm2Out = xmm2
-	return (word32) rax_263
+	return SLICE(rax_263, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -13870,7 +13870,7 @@ l000000000040C894:
 	r9Out = r9_270
 	r14bOut = <invalid>
 	r15Out = r15
-	return (word32) rax_100
+	return SLICE(rax_100, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -16957,7 +16957,7 @@ l000000000040E638_1:
 // SymbolicIn:
 
 l000000000040E63C:
-	return (word32) (uint64) Mem0[rax_6:word32]
+	return SLICE((uint64) Mem0[rax_6:word32], word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -18584,7 +18584,7 @@ l0000000000410FDD:
 	r12Out = r8
 	r13bOut = <invalid>
 	word32 r9_32_32_325 = SLICE(r9_266, word32, 32)
-	return (word32) rax_261
+	return SLICE(rax_261, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -18597,7 +18597,7 @@ l0000000000410F4F:
 	r9Out = r9_54
 	r12Out = r12
 	r13bOut = <invalid>
-	return (word32) (uint64) ebp_120
+	return SLICE((uint64) ebp_120, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -18615,7 +18615,7 @@ l0000000000410EF5:
 	r9Out = r9_54
 	r12Out = r12
 	r13bOut = <invalid>
-	return (word32) rax_214
+	return SLICE(rax_214, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -18951,7 +18951,7 @@ l00000000004114B5:
 	r14bOut = <invalid>
 	r15Out = r15_34
 	word32 r9_32_32_324 = SLICE(r9_265, word32, 32)
-	return (word32) rax_260
+	return SLICE(rax_260, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -18967,7 +18967,7 @@ l0000000000411422:
 	r13Out = r13
 	r14bOut = <invalid>
 	r15Out = r15
-	return (word32) (uint64) ebp_121
+	return SLICE((uint64) ebp_121, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -18988,7 +18988,7 @@ l00000000004113C5:
 	r13Out = r13
 	r14bOut = <invalid>
 	r15Out = r15
-	return (word32) rax_215
+	return SLICE(rax_215, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -19077,7 +19077,7 @@ l00000000004117DC:
 // SymbolicIn:
 
 l00000000004117BF:
-	return (word32) rax_10
+	return SLICE(rax_10, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -19108,7 +19108,7 @@ l0000000000411820:
 // SymbolicIn:
 
 l000000000041182F_thunk_fn00000000004117B0:
-	return (word32) (uint64) (uint32) fn00000000004117B0(rsi, rdi_11)
+	return SLICE((uint64) (uint32) fn00000000004117B0(rsi, rdi_11), word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -19139,7 +19139,7 @@ l0000000000411840:
 // SymbolicIn:
 
 l000000000041184F_thunk_fn00000000004117B0:
-	return (word32) (uint64) (uint32) fn00000000004117B0(rsi, rdi_11)
+	return SLICE((uint64) (uint32) fn00000000004117B0(rsi, rdi_11), word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:

--- a/subjects/Elf/x86-64/ls/ls.h
+++ b/subjects/Elf/x86-64/ls/ls.h
@@ -21246,7 +21246,7 @@ T_3648: (in r12 : word64)
   Class: Eq_1605
   DataType: Eq_1605
   OrigDataType: word64
-T_3649: (in (byte) rax_269 : byte)
+T_3649: (in SLICE(rax_269, byte, 0) : byte)
   Class: Eq_3489
   DataType: byte
   OrigDataType: byte
@@ -21758,7 +21758,7 @@ T_3776: (in 0x0000000000000000 : word64)
   Class: Eq_1605
   DataType: uint64
   OrigDataType: word64
-T_3777: (in (byte) rax_212 : byte)
+T_3777: (in SLICE(rax_212, byte, 0) : byte)
   Class: Eq_3489
   DataType: byte
   OrigDataType: byte
@@ -45426,7 +45426,7 @@ T_9693: (in eax_23 == 0x0000005F : bool)
   Class: Eq_9693
   DataType: bool
   OrigDataType: bool
-T_9694: (in (word32) rax_38 : word32)
+T_9694: (in SLICE(rax_38, word32, 0) : word32)
   Class: Eq_9659
   DataType: word32
   OrigDataType: word32
@@ -52870,7 +52870,7 @@ T_11554: (in (uint64) ebp_170 : uint64)
   Class: Eq_11554
   DataType: uint64
   OrigDataType: uint64
-T_11555: (in (word32) (uint64) ebp_170 : word32)
+T_11555: (in SLICE((uint64) ebp_170, word32, 0) : word32)
   Class: Eq_11435
   DataType: word32
   OrigDataType: word32
@@ -52978,7 +52978,7 @@ T_11581: (in (uint64) ebp_170 : uint64)
   Class: Eq_11581
   DataType: uint64
   OrigDataType: uint64
-T_11582: (in (word32) (uint64) ebp_170 : word32)
+T_11582: (in SLICE((uint64) ebp_170, word32, 0) : word32)
   Class: Eq_11435
   DataType: word32
   OrigDataType: word32
@@ -53718,7 +53718,7 @@ T_11766: (in 0x00000000FFFFFFFF : uint64)
   Class: Eq_11606
   DataType: uint64
   OrigDataType: uint64
-T_11767: (in (word32) rax_263 : word32)
+T_11767: (in SLICE(rax_263, word32, 0) : word32)
   Class: Eq_11590
   DataType: word32
   OrigDataType: word32
@@ -62374,7 +62374,7 @@ T_13930: (in SLICE((uint64) (ebp_171 | 0x00415F50[SEQ(rax_48_16_175, (int16) al_
   Class: Eq_13830
   DataType: ui32
   OrigDataType: word32
-T_13931: (in (word32) rax_100 : word32)
+T_13931: (in SLICE(rax_100, word32, 0) : word32)
   Class: Eq_13825
   DataType: word32
   OrigDataType: word32
@@ -72202,7 +72202,7 @@ T_16387: (in (uint64) Mem0[rax_6 + 0x0000000000000000:word32] : uint64)
   Class: Eq_16387
   DataType: uint64
   OrigDataType: uint64
-T_16388: (in (word32) (uint64) Mem0[rax_6 + 0x0000000000000000:word32] : word32)
+T_16388: (in SLICE((uint64) Mem0[rax_6 + 0x0000000000000000:word32], word32, 0) : word32)
   Class: Eq_16379
   DataType: word32
   OrigDataType: word32
@@ -75786,7 +75786,7 @@ T_17283: (in (uint64) ebp_120 : uint64)
   Class: Eq_17283
   DataType: uint64
   OrigDataType: uint64
-T_17284: (in (word32) (uint64) ebp_120 : word32)
+T_17284: (in SLICE((uint64) ebp_120, word32, 0) : word32)
   Class: Eq_17183
   DataType: word32
   OrigDataType: word32
@@ -76174,11 +76174,11 @@ T_17380: (in SLICE(r9_266, word32, 32) : word32)
   Class: Eq_17379
   DataType: word32
   OrigDataType: word32
-T_17381: (in (word32) rax_261 : word32)
+T_17381: (in SLICE(rax_261, word32, 0) : word32)
   Class: Eq_17183
   DataType: word32
   OrigDataType: word32
-T_17382: (in (word32) rax_214 : word32)
+T_17382: (in SLICE(rax_214, word32, 0) : word32)
   Class: Eq_17183
   DataType: word32
   OrigDataType: word32
@@ -76798,7 +76798,7 @@ T_17536: (in (uint64) ebp_121 : uint64)
   Class: Eq_17536
   DataType: uint64
   OrigDataType: uint64
-T_17537: (in (word32) (uint64) ebp_121 : word32)
+T_17537: (in SLICE((uint64) ebp_121, word32, 0) : word32)
   Class: Eq_17432
   DataType: word32
   OrigDataType: word32
@@ -77186,11 +77186,11 @@ T_17633: (in SLICE(r9_265, word32, 32) : word32)
   Class: Eq_17632
   DataType: word32
   OrigDataType: word32
-T_17634: (in (word32) rax_260 : word32)
+T_17634: (in SLICE(rax_260, word32, 0) : word32)
   Class: Eq_17432
   DataType: word32
   OrigDataType: word32
-T_17635: (in (word32) rax_215 : word32)
+T_17635: (in SLICE(rax_215, word32, 0) : word32)
   Class: Eq_17432
   DataType: word32
   OrigDataType: word32
@@ -77294,7 +77294,7 @@ T_17660: (in edi == 0x0000000A : bool)
   Class: Eq_17660
   DataType: bool
   OrigDataType: bool
-T_17661: (in (word32) rax_10 : word32)
+T_17661: (in SLICE(rax_10, word32, 0) : word32)
   Class: Eq_17646
   DataType: word32
   OrigDataType: word32
@@ -77554,7 +77554,7 @@ T_17725: (in (uint64) (uint32) fn00000000004117B0(rsi, rdi_11) : uint64)
   Class: Eq_17725
   DataType: uint64
   OrigDataType: uint64
-T_17726: (in (word32) (uint64) (uint32) fn00000000004117B0(rsi, rdi_11) : word32)
+T_17726: (in SLICE((uint64) (uint32) fn00000000004117B0(rsi, rdi_11), word32, 0) : word32)
   Class: Eq_17713
   DataType: word32
   OrigDataType: word32
@@ -77606,7 +77606,7 @@ T_17738: (in (uint64) (uint32) fn00000000004117B0(rsi, rdi_11) : uint64)
   Class: Eq_17738
   DataType: uint64
   OrigDataType: uint64
-T_17739: (in (word32) (uint64) (uint32) fn00000000004117B0(rsi, rdi_11) : word32)
+T_17739: (in SLICE((uint64) (uint32) fn00000000004117B0(rsi, rdi_11), word32, 0) : word32)
   Class: Eq_17727
   DataType: word32
   OrigDataType: word32

--- a/subjects/Elf/x86-64/pngpixel/pngpixel.dis
+++ b/subjects/Elf/x86-64/pngpixel/pngpixel.dis
@@ -307,7 +307,7 @@ l0000000000400E3A:
 // SymbolicIn:
 
 l0000000000400EE7:
-	return (word32) rax_112
+	return SLICE(rax_112, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:

--- a/subjects/Elf/x86-64/pngpixel/pngpixel.h
+++ b/subjects/Elf/x86-64/pngpixel/pngpixel.h
@@ -1126,7 +1126,7 @@ T_233: (in (uint64) ((word32) SLICE((word32) Mem54[v16_51 + 0x0000000000000001:b
   Class: Eq_141
   DataType: uint64
   OrigDataType: uint64
-T_234: (in (word32) rax_112 : word32)
+T_234: (in SLICE(rax_112, word32, 0) : word32)
   Class: Eq_73
   DataType: word32
   OrigDataType: word32

--- a/subjects/PE/x86-64/varargs_test/varargs_test.dis
+++ b/subjects/PE/x86-64/varargs_test/varargs_test.dis
@@ -559,7 +559,7 @@ l000000014000132D:
 // SymbolicIn:
 
 l0000000140001423:
-	return (word32) rax_224
+	return SLICE(rax_224, word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -590,7 +590,7 @@ l0000000140001434:
 // SymbolicIn:
 
 l0000000140001441_thunk_fn00000001400012BC:
-	return (DWORD) (uint64) (uint32) fn00000001400012BC(rax_6, rsi, rdi)
+	return SLICE((uint64) (uint32) fn00000001400012BC(rax_6, rsi, rdi), DWORD, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -897,7 +897,7 @@ l0000000140001717_thunk_fn0000000140001718:
 	rbxOut = rbx_11
 	r8Out = r8_24
 	xmm1Out = xmm1
-	return (byte) rax_25
+	return SLICE(rax_25, byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -963,7 +963,7 @@ l00000001400016FF:
 	rbxOut = rbx
 	r8Out = r8_100
 	xmm1Out = xmm1
-	return (byte) rax_146
+	return SLICE(rax_146, byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -1486,7 +1486,7 @@ fn0000000140001958_entry:
 // SymbolicIn:
 
 l0000000140001958:
-	return (word32) (uint64) (uint8) (Mem0[0x0000000140003014:word32] == 0x00000000)
+	return SLICE((uint64) (uint8) (Mem0[0x0000000140003014:word32] == 0x00000000), word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -2139,7 +2139,7 @@ fn0000000140001DC4_entry:
 // SymbolicIn:
 
 l0000000140001DC4:
-	return (word32) (uint64) (uint8) (Mem0[0x0000000140003030:word32] != 0x00000000)
+	return SLICE((uint64) (uint8) (Mem0[0x0000000140003030:word32] != 0x00000000), word32, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:

--- a/subjects/PE/x86-64/varargs_test/varargs_test.h
+++ b/subjects/PE/x86-64/varargs_test/varargs_test.h
@@ -220,7 +220,7 @@ Eq_429: (fn void (byte))
 	T_430 (in signature of fn00000001400017D8 : void)
 Eq_437: (union "Eq_437" (DWORD u0) (UINT u1))
 	T_437 (in eax : Eq_437)
-	T_453 (in (DWORD) (uint64) (uint32) fn00000001400012BC(rax_6, rsi, rdi) : DWORD)
+	T_453 (in SLICE((uint64) (uint32) fn00000001400012BC(rax_6, rsi, rdi), DWORD, 0) : DWORD)
 	T_455 (in tArg08 : Eq_437)
 	T_471 (in uExitCode : UINT)
 	T_474 (in tLoc38 : Eq_437)
@@ -1707,7 +1707,7 @@ T_311: (in 0x00000000000000FF : uint64)
   Class: Eq_289
   DataType: uint64
   OrigDataType: uint64
-T_312: (in (word32) rax_224 : word32)
+T_312: (in SLICE(rax_224, word32, 0) : word32)
   Class: Eq_243
   DataType: word32
   OrigDataType: word32
@@ -2271,7 +2271,7 @@ T_452: (in (uint64) (uint32) fn00000001400012BC(rax_6, rsi, rdi) : uint64)
   Class: Eq_452
   DataType: uint64
   OrigDataType: uint64
-T_453: (in (DWORD) (uint64) (uint32) fn00000001400012BC(rax_6, rsi, rdi) : DWORD)
+T_453: (in SLICE((uint64) (uint32) fn00000001400012BC(rax_6, rsi, rdi), DWORD, 0) : DWORD)
   Class: Eq_437
   DataType: Eq_437
   OrigDataType: DWORD
@@ -3283,7 +3283,7 @@ T_705: (in rbx : word64)
   Class: Eq_127
   DataType: Eq_127
   OrigDataType: word64
-T_706: (in (byte) rax_146 : byte)
+T_706: (in SLICE(rax_146, byte, 0) : byte)
   Class: Eq_618
   DataType: byte
   OrigDataType: byte
@@ -3307,7 +3307,7 @@ T_711: (in fn0000000140001718(rcx_18, out r8_24) : word64)
   Class: Eq_149
   DataType: (ptr64 (ptr64 code))
   OrigDataType: word64
-T_712: (in (byte) rax_25 : byte)
+T_712: (in SLICE(rax_25, byte, 0) : byte)
   Class: Eq_618
   DataType: byte
   OrigDataType: byte
@@ -4271,7 +4271,7 @@ T_952: (in (uint64) (uint8) (Mem0[0x0000000140003014:word32] == 0x00000000) : ui
   Class: Eq_952
   DataType: uint64
   OrigDataType: uint64
-T_953: (in (word32) (uint64) (uint8) (Mem0[0x0000000140003014:word32] == 0x00000000) : word32)
+T_953: (in SLICE((uint64) (uint8) (Mem0[0x0000000140003014:word32] == 0x00000000), word32, 0) : word32)
   Class: Eq_946
   DataType: word32
   OrigDataType: word32
@@ -5955,7 +5955,7 @@ T_1373: (in (uint64) (uint8) (Mem0[0x0000000140003030:word32] != 0x00000000) : u
   Class: Eq_1373
   DataType: uint64
   OrigDataType: uint64
-T_1374: (in (word32) (uint64) (uint8) (Mem0[0x0000000140003030:word32] != 0x00000000) : word32)
+T_1374: (in SLICE((uint64) (uint8) (Mem0[0x0000000140003030:word32] != 0x00000000), word32, 0) : word32)
   Class: Eq_1367
   DataType: word32
   OrigDataType: word32

--- a/subjects/PE/x86/ExeDll/Executable.c
+++ b/subjects/PE/x86/ExeDll/Executable.c
@@ -191,7 +191,6 @@ l00401438:
 byte fn0040143F(ptr32 & edxOut)
 {
 	word32 eax_n = fn00401B98();
-	word24 eax_24_8_n = SLICE(eax_n, word24, 8);
 	if (eax_n != 0x00)
 	{
 		ptr32 edx_n = fs->ptr0018->ptr0004;
@@ -200,21 +199,19 @@ byte fn0040143F(ptr32 & edxOut)
 			__lock();
 			ptr32 eax_n;
 			__cmpxchg(globals->dw403338, edx_n, 0x00, out eax_n);
-			word24 eax_24_8_n = SLICE(eax_n, word24, 8);
-			word24 eax_24_8_n = SLICE(eax_n, word24, 8);
 			if (eax_n == 0x00)
 			{
 				edxOut = edx_n;
-				return (byte) SEQ(eax_24_8_n, 0x00);
+				return 0x00;
 			}
 		} while (edx_n != eax_n);
 		edxOut = edx_n;
-		return (byte) SEQ(eax_24_8_n, 0x01);
+		return 0x01;
 	}
 	else
 	{
 		edxOut = edx;
-		return (byte) SEQ(eax_24_8_n, 0x00);
+		return 0x00;
 	}
 }
 
@@ -224,13 +221,12 @@ byte fn00401474(word32 edx, word32 dwArg04)
 	if (dwArg04 == 0x00)
 		globals->b403354 = 0x01;
 	fn004019FE(edx);
-	word24 eax_24_8_n = SLICE(eax_n, word24, 8);
 	if (fn00401C48() == 0x00)
-		return (byte) SEQ(eax_24_8_n, 0x00);
+		return 0x00;
 	if (fn00401C48() != 0x00)
-		return (byte) SEQ(eax_24_8_n, 0x01);
+		return 0x01;
 	fn00401C48();
-	return (byte) SEQ(eax_24_8_n, 0x00);
+	return 0x00;
 }
 
 // 004014AD: void fn004014AD(Register word32 ebx, Register Eq_n edi, Stack Eq_n dwArg04)
@@ -464,19 +460,12 @@ void fn00401774(word32 dwArg04)
 byte fn0040188F()
 {
 	Eq_n eax_n = GetModuleHandleW(null);
-	word24 eax_24_8_n = SLICE(eax_n, word24, 8);
-	if (eax_n == null)
-		return (byte) SEQ(eax_24_8_n, 0x00);
-	eax_24_8_n = 0x5A;
-	if (eax_n->unused != 23117)
-		return (byte) SEQ(eax_24_8_n, 0x00);
+	if (eax_n == null || eax_n->unused != 23117)
+		return 0x00;
 	struct Eq_n * eax_n = eax_n + eax_n->dw003C / 0x0040;
-	eax_24_8_n = SLICE(eax_n, word24, 8);
-	eax_24_8_n = SLICE(eax_n, word24, 8);
-	eax_24_8_n = SLICE(eax_n, word24, 8);
 	word24 eax_24_8_n = SLICE(eax_n, word24, 8);
 	if (eax_n->dw0000 != 0x4550 || (eax_n->w0018 != 0x010B || eax_n->dw0074 <= 0x0E))
-		return (byte) SEQ(eax_24_8_n, 0x00);
+		return 0x00;
 	return (byte) SEQ(eax_24_8_n, eax_n->dw00E8 != 0x00);
 }
 

--- a/subjects/PE/x86/ExeDll/Executable.dis
+++ b/subjects/PE/x86/ExeDll/Executable.dis
@@ -433,7 +433,6 @@ fn0040143F_entry:
 
 l0040143F:
 	word32 eax_4 = fn00401B98()
-	word24 eax_24_8_49 = SLICE(eax_4, word24, 8)
 	branch eax_4 != 0x00000000 l0040144B
 // DataOut:
 // DataOut (flags):
@@ -449,8 +448,6 @@ l00401460:
 	__lock()
 	word32 eax_25
 	__cmpxchg(Mem17[0x00403338:word32], edx_19, 0x00000000, out eax_25)
-	word24 eax_24_8_51 = SLICE(eax_25, word24, 8)
-	word24 eax_24_8_53 = SLICE(eax_25, word24, 8)
 	branch eax_25 != 0x00000000 l0040145C
 // DataOut:
 // DataOut (flags):
@@ -464,21 +461,21 @@ l0040145C:
 
 l00401470:
 	edxOut = edx_19
-	return (byte) SEQ(eax_24_8_53, 0x01)
+	return 0x01
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
 
 l0040146C:
 	edxOut = edx_19
-	return (byte) SEQ(eax_24_8_51, 0x00)
+	return 0x00
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
 
 l00401448:
 	edxOut = edx
-	return (byte) SEQ(eax_24_8_49, 0x00)
+	return 0x00
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -516,7 +513,6 @@ l0040147D:
 
 l00401484:
 	fn004019FE(edx)
-	word24 eax_24_8_53 = SLICE(eax_13, word24, 8)
 	branch fn00401C48() != 0x00 l00401496
 // DataOut:
 // DataOut (flags):
@@ -529,7 +525,7 @@ l00401496:
 // SymbolicIn:
 
 l004014A9:
-	return (byte) SEQ(eax_24_8_53, 0x01)
+	return 0x01
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -541,7 +537,7 @@ l0040149F:
 // SymbolicIn:
 
 l00401492:
-	return (byte) SEQ(eax_24_8_53, 0x00)
+	return 0x00
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -739,7 +735,7 @@ l004015C8:
 	ebpOut = ebp_69
 	esiOut = esi_73
 	ediOut = edi_72
-	return (byte) eax_84
+	return SLICE(eax_84, byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -1343,14 +1339,12 @@ fn0040188F_entry:
 
 l0040188F:
 	word32 eax_6 = GetModuleHandleW(0x00000000)
-	word24 eax_24_8_36 = SLICE(eax_6, word24, 8)
 	branch eax_6 != 0x00000000 l004018A0
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
 
 l004018A0:
-	eax_24_8_36 = 0x00005A (alias)
 	branch Mem5[eax_6:word16] != 0x5A4D l0040189D
 // DataOut:
 // DataOut (flags):
@@ -1358,9 +1352,6 @@ l004018A0:
 
 l004018AA:
 	word32 eax_17 = Mem5[eax_6 + 0x0000003C:word32] + eax_6
-	eax_24_8_36 = SLICE(eax_17, word24, 8) (alias)
-	eax_24_8_36 = SLICE(eax_17, word24, 8) (alias)
-	eax_24_8_36 = SLICE(eax_17, word24, 8) (alias)
 	word24 eax_24_8_43 = SLICE(eax_17, word24, 8)
 	branch Mem5[eax_17:word32] != 0x00004550 l0040189D
 // DataOut:
@@ -1380,13 +1371,13 @@ l004018C2:
 // SymbolicIn:
 
 l004018C8:
-	return (byte) SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000)
+	return SLICE(SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000), byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
 
 l0040189D:
-	return (byte) SEQ(eax_24_8_36, 0x00)
+	return 0x00
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:

--- a/subjects/PE/x86/ExeDll/Executable.h
+++ b/subjects/PE/x86/ExeDll/Executable.h
@@ -4,7 +4,7 @@
 
 /*
 // Equivalence classes ////////////
-Eq_1: (struct "Globals" (100 Eq_723 t0100) (400000 word16 w400000) (40003C (ptr32 Eq_723) ptr40003C) (4018DF (fn LONG ((ptr32 (struct "_EXCEPTION_POINTERS")))) t4018DF) (4020D0 (ptr32 code) ptr4020D0) (4020DC Eq_188 t4020DC) (4020EC Eq_188 t4020EC) (4024C8 (arr word32 1) a4024C8) (403000 ui32 dw403000) (403004 ui32 dw403004) (403010 ui32 dw403010) (403014 word32 dw403014) (403334 uip32 dw403334) (403338 word32 dw403338) (40333C ui32 dw40333C) (403340 ui32 dw403340) (403344 ui32 dw403344) (403348 ui32 dw403348) (40334C ui32 dw40334C) (403350 ui32 dw403350) (403354 byte b403354) (403358 (union "_SLIST_HEADER" ((struct "struct_70" (0 SLIST_ENTRY Next) (4 WORD Depth) (6 WORD CpuId)) u1) (ULONGLONG Alignment)) u403358) (403368 ui32 dw403368) (40336C ui32 dw40336C) (403370 ui32 dw403370))
+Eq_1: (struct "Globals" (100 Eq_704 t0100) (400000 word16 w400000) (40003C (ptr32 Eq_704) ptr40003C) (4018DF (fn LONG ((ptr32 (struct "_EXCEPTION_POINTERS")))) t4018DF) (4020D0 (ptr32 code) ptr4020D0) (4020DC Eq_188 t4020DC) (4020EC Eq_188 t4020EC) (4024C8 (arr word32 1) a4024C8) (403000 ui32 dw403000) (403004 ui32 dw403004) (403010 ui32 dw403010) (403014 word32 dw403014) (403334 uip32 dw403334) (403338 word32 dw403338) (40333C ui32 dw40333C) (403340 ui32 dw403340) (403344 ui32 dw403344) (403348 ui32 dw403348) (40334C ui32 dw40334C) (403350 ui32 dw403350) (403354 byte b403354) (403358 (union "_SLIST_HEADER" ((struct "struct_70" (0 SLIST_ENTRY Next) (4 WORD Depth) (6 WORD CpuId)) u1) (ULONGLONG Alignment)) u403358) (403368 ui32 dw403368) (40336C ui32 dw40336C) (403370 ui32 dw403370))
 	globals_t (in globals : (ptr32 (struct "Globals")))
 Eq_3: (struct "Eq_3" (0 Eq_93 t0000) (8 ui32 dw0008))
 	T_3 (in ebp : (ptr32 Eq_3))
@@ -13,8 +13,8 @@ Eq_3: (struct "Eq_3" (0 Eq_93 t0000) (8 ui32 dw0008))
 	T_99 (in fn00401980(ebx, esi, edi, dwLoc0C, 0x00000014) : word32)
 	T_148 (in ebp_135 : (ptr32 Eq_3))
 	T_251 (in ebp : (ptr32 Eq_3))
-	T_692 (in ebp_13 : (ptr32 Eq_3))
-	T_696 (in fn00401980(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
+	T_673 (in ebp_13 : (ptr32 Eq_3))
+	T_677 (in fn00401980(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
 Eq_5: (fn void (Eq_7))
 	T_5 (in InitializeCriticalSection : ptr32)
 	T_6 (in signature of InitializeCriticalSection : void)
@@ -34,12 +34,12 @@ Eq_18: (fn int32 (int32))
 Eq_58: (struct "Eq_58" (0 ui32 dw0000) (4 word32 dw0004))
 	T_58 (in eax_30 : (ptr32 Eq_58))
 	T_61 (in fn00401050() : word32)
-	T_915 (in eax_4 : (ptr32 Eq_58))
-	T_917 (in fn00401050() : word32)
+	T_896 (in eax_4 : (ptr32 Eq_58))
+	T_898 (in fn00401050() : word32)
 Eq_59: (fn (ptr32 Eq_58) ())
 	T_59 (in fn00401050 : ptr32)
 	T_60 (in signature of fn00401050 : void)
-	T_916 (in fn00401050 : ptr32)
+	T_897 (in fn00401050 : ptr32)
 Eq_80: DWORD
 	T_80 (in eax : Eq_80)
 	T_170 (in eax_292 : Eq_80)
@@ -47,19 +47,19 @@ Eq_80: DWORD
 	T_387 (in eax_242 : Eq_80)
 	T_390 (in fn00401000(ebp_135, eax_221) : word32)
 	T_434 (in Mem294[esp_226 - 4 + 0x00000000:word32] : word32)
-	T_851 (in GetCurrentThreadId() : DWORD)
-	T_855 (in GetCurrentProcessId() : DWORD)
-	T_957 (in ProcessorFeature : DWORD)
-	T_958 (in 0x00000017 : word32)
-	T_1165 (in 0x0000000A : word32)
+	T_832 (in GetCurrentThreadId() : DWORD)
+	T_836 (in GetCurrentProcessId() : DWORD)
+	T_938 (in ProcessorFeature : DWORD)
+	T_939 (in 0x00000017 : word32)
+	T_1138 (in 0x0000000A : word32)
 Eq_84: (fn void ())
 	T_84 (in fn00401663 : ptr32)
 	T_85 (in signature of fn00401663 : void)
 Eq_88: (fn (ptr32 Eq_3) (word32, Eq_91, Eq_91, Eq_93, ui32))
 	T_88 (in fn00401980 : ptr32)
 	T_89 (in signature of fn00401980 : void)
-	T_693 (in fn00401980 : ptr32)
-Eq_91: (union "Eq_91" (byte u0) ((ptr32 Eq_1328) u1))
+	T_674 (in fn00401980 : ptr32)
+Eq_91: (union "Eq_91" (byte u0) ((ptr32 Eq_1301) u1))
 	T_91 (in esi : Eq_91)
 	T_92 (in edi : Eq_91)
 	T_95 (in esi : word32)
@@ -87,14 +87,14 @@ Eq_91: (union "Eq_91" (byte u0) ((ptr32 Eq_1328) u1))
 	T_407 (in Mem174[esp_173 + 0x00000000:word32] : word32)
 	T_422 (in Mem174[esi_167 + 0x00000000:word32] : word32)
 	T_425 (in Mem196[esp_173 + 0x00000000:word32] : word32)
-	T_614 (in edi : Eq_91)
-	T_615 (in dwArg04 : Eq_91)
-	T_616 (in 0x00000000 : word32)
-	T_622 (in 0x00000001 : word32)
-	T_662 (in 0x00000000 : word32)
-	T_783 (in 0x00 : byte)
-	T_1106 (in Mem20[esp_14 - 8 + 0x00000000:word32] : word32)
-	T_1111 (in Mem23[esp_14 - 12 + 0x00000000:word32] : word32)
+	T_595 (in edi : Eq_91)
+	T_596 (in dwArg04 : Eq_91)
+	T_597 (in 0x00000000 : word32)
+	T_603 (in 0x00000001 : word32)
+	T_643 (in 0x00000000 : word32)
+	T_764 (in 0x00 : byte)
+	T_1079 (in Mem20[esp_14 - 8 + 0x00000000:word32] : word32)
+	T_1084 (in Mem23[esp_14 - 12 + 0x00000000:word32] : word32)
 Eq_93: (union "Eq_93" (ui32 u0) (ptr32 u1))
 	T_93 (in dwArg00 : Eq_93)
 	T_97 (in dwLoc0C : word32)
@@ -102,13 +102,13 @@ Eq_93: (union "Eq_93" (ui32 u0) (ptr32 u1))
 	T_253 (in ebpOut : Eq_93)
 	T_258 (in Mem301[esp_288 + -4:word32] : word32)
 	T_259 (in out ebp_302 : ptr32)
-	T_694 (in dwLoc0C : word32)
-	T_751 (in eax_32 - 0x00400000 : word32)
-	T_774 (in out ebp_69 : ptr32)
-	T_1126 (in Mem36[esp_14 - 20 + 0x00000000:word32] : word32)
-	T_1142 (in ebp_19 : Eq_93)
-	T_1145 (in Mem8[ebp + 0x00000000:word32] : word32)
-	T_1148 (in Mem22[ebp + 0x00000000:word32] : word32)
+	T_675 (in dwLoc0C : word32)
+	T_732 (in eax_32 - 0x00400000 : word32)
+	T_755 (in out ebp_69 : ptr32)
+	T_1099 (in Mem36[esp_14 - 20 + 0x00000000:word32] : word32)
+	T_1115 (in ebp_19 : Eq_93)
+	T_1118 (in Mem8[ebp + 0x00000000:word32] : word32)
+	T_1121 (in Mem22[ebp + 0x00000000:word32] : word32)
 Eq_104: (fn byte (word32, word32))
 	T_104 (in fn00401474 : ptr32)
 	T_105 (in signature of fn00401474 : void)
@@ -118,8 +118,8 @@ Eq_135: (fn byte (ptr32))
 Eq_163: (fn void (word32))
 	T_163 (in fn00401774 : ptr32)
 	T_164 (in signature of fn00401774 : void)
-	T_624 (in fn00401774 : ptr32)
-	T_905 (in fn00401774 : ptr32)
+	T_605 (in fn00401774 : ptr32)
+	T_886 (in fn00401774 : ptr32)
 Eq_171: (struct "Eq_171" (FFFFFFFC Eq_93 tFFFFFFFC))
 	T_171 (in esp_288 : (ptr32 Eq_171))
 	T_199 (in esp_84 + 4 : word32)
@@ -148,7 +148,7 @@ Eq_226: PVFV
 Eq_249: (fn ptr32 ((ptr32 Eq_3), Eq_93, Eq_93, ptr32, ptr32))
 	T_249 (in fn004019C6 : ptr32)
 	T_250 (in signature of fn004019C6 : void)
-	T_773 (in fn004019C6 : ptr32)
+	T_754 (in fn004019C6 : ptr32)
 Eq_274: (fn void (Eq_91))
 	T_274 (in fn004015CE : ptr32)
 	T_275 (in signature of fn004015CE : void)
@@ -162,11 +162,11 @@ Eq_310: (fn byte (word32, Eq_91, Eq_91, ptr32, ptr32, ptr32, ptr32, ptr32))
 	T_310 (in fn00401544 : ptr32)
 	T_311 (in signature of fn00401544 : void)
 	T_408 (in fn00401544 : ptr32)
-	T_683 (in fn00401544 : ptr32)
+	T_664 (in fn00401544 : ptr32)
 Eq_350: (fn void ())
 	T_350 (in fn00401976 : ptr32)
 	T_351 (in signature of fn00401976 : void)
-	T_1078 (in fn00401976 : ptr32)
+	T_1051 (in fn00401976 : ptr32)
 Eq_388: (fn Eq_80 ((ptr32 Eq_3), (ptr32 word32)))
 	T_388 (in fn00401000 : ptr32)
 	T_389 (in signature of fn00401000 : void)
@@ -181,35 +181,35 @@ Eq_446: (union "Eq_446" (byte u0) (word32 u1))
 	T_449 (in Mem276[esp_275 + 0x00000000:word32] : word32)
 	T_458 (in bArg08 : Eq_446)
 	T_461 (in Mem278[esp_275 + 0x00000000:byte] : byte)
-	T_796 (in 0x00 : byte)
+	T_777 (in 0x00 : byte)
 Eq_456: (fn void (Eq_446))
 	T_456 (in fn004015EB : ptr32)
 	T_457 (in signature of fn004015EB : void)
 Eq_473: (struct "_EXCEPTION_POINTERS" (0 PEXCEPTION_RECORD ExceptionRecord) (4 PCONTEXT ContextRecord))
 	T_473 (in dwArg04 : (ptr32 Eq_473))
 	T_481 (in ExceptionInfo : (ptr32 (struct "_EXCEPTION_POINTERS")))
-	T_995 (in fp - 0x0000000C : word32)
+	T_976 (in fp - 0x0000000C : word32)
 Eq_474: (fn Eq_476 (Eq_476))
 	T_474 (in SetUnhandledExceptionFilter : ptr32)
 	T_475 (in signature of SetUnhandledExceptionFilter : void)
-	T_990 (in SetUnhandledExceptionFilter : ptr32)
-	T_1068 (in SetUnhandledExceptionFilter : ptr32)
+	T_971 (in SetUnhandledExceptionFilter : ptr32)
+	T_1041 (in SetUnhandledExceptionFilter : ptr32)
 Eq_476: LPTOP_LEVEL_EXCEPTION_FILTER
 	T_476 (in lpTopLevelExceptionFilter : LPTOP_LEVEL_EXCEPTION_FILTER)
 	T_477 (in 0x00000000 : word32)
 	T_478 (in SetUnhandledExceptionFilter(null) : LPTOP_LEVEL_EXCEPTION_FILTER)
-	T_991 (in 0x00000000 : word32)
-	T_992 (in SetUnhandledExceptionFilter(null) : LPTOP_LEVEL_EXCEPTION_FILTER)
-	T_1069 (in 0x004018DF : word32)
-	T_1070 (in SetUnhandledExceptionFilter(&globals->t4018DF) : LPTOP_LEVEL_EXCEPTION_FILTER)
+	T_972 (in 0x00000000 : word32)
+	T_973 (in SetUnhandledExceptionFilter(null) : LPTOP_LEVEL_EXCEPTION_FILTER)
+	T_1042 (in 0x004018DF : word32)
+	T_1043 (in SetUnhandledExceptionFilter(&globals->t4018DF) : LPTOP_LEVEL_EXCEPTION_FILTER)
 Eq_479: (fn Eq_482 ((ptr32 Eq_473)))
 	T_479 (in UnhandledExceptionFilter : ptr32)
 	T_480 (in signature of UnhandledExceptionFilter : void)
-	T_993 (in UnhandledExceptionFilter : ptr32)
+	T_974 (in UnhandledExceptionFilter : ptr32)
 Eq_482: LONG
 	T_482 (in UnhandledExceptionFilter(dwArg04) : LONG)
-	T_996 (in UnhandledExceptionFilter(fp - 0x0000000C) : LONG)
-	T_997 (in 0x00000000 : word32)
+	T_977 (in UnhandledExceptionFilter(fp - 0x0000000C) : LONG)
+	T_978 (in 0x00000000 : word32)
 Eq_483: (fn Eq_491 (Eq_485, Eq_486))
 	T_483 (in TerminateProcess : ptr32)
 	T_484 (in signature of TerminateProcess : void)
@@ -224,13 +224,13 @@ Eq_487: (fn Eq_485 ())
 	T_488 (in signature of GetCurrentProcess : void)
 Eq_491: BOOL
 	T_491 (in TerminateProcess(GetCurrentProcess(), 0xC0000409) : BOOL)
-	T_862 (in QueryPerformanceCounter(fp - 0x00000018) : BOOL)
-	T_959 (in IsProcessorFeaturePresent(0x00000017) : BOOL)
-	T_960 (in 0x00000000 : word32)
-	T_986 (in IsDebuggerPresent() : BOOL)
-	T_987 (in 0x00000001 : word32)
-	T_1166 (in IsProcessorFeaturePresent(0x0000000A) : BOOL)
-	T_1167 (in 0x00000000 : word32)
+	T_843 (in QueryPerformanceCounter(fp - 0x00000018) : BOOL)
+	T_940 (in IsProcessorFeaturePresent(0x00000017) : BOOL)
+	T_941 (in 0x00000000 : word32)
+	T_967 (in IsDebuggerPresent() : BOOL)
+	T_968 (in 0x00000001 : word32)
+	T_1139 (in IsProcessorFeaturePresent(0x0000000A) : BOOL)
+	T_1140 (in 0x00000000 : word32)
 Eq_492: (struct "Eq_492" 0028 (8 up32 dw0008) (C up32 dw000C))
 	T_492 (in eax : (ptr32 Eq_492))
 	T_495 (in edxOut : (ptr32 Eq_492))
@@ -241,151 +241,151 @@ Eq_492: (struct "Eq_492" 0028 (8 up32 dw0008) (C up32 dw000C))
 	T_517 (in (word32) Mem11[ecx_13 + 0x00000006:word16] *s 0x00000028 + edx_16 : word32)
 	T_519 (in 0x00000000 : word32)
 	T_521 (in edx_16 + 0x00000028 : word32)
-	T_749 (in out edx : ptr32)
+	T_730 (in out edx : ptr32)
 Eq_493: (struct "Eq_493" (3C word32 dw003C))
 	T_493 (in dwArg04 : (ptr32 Eq_493))
-	T_745 (in 0x00400000 : ptr32)
+	T_726 (in 0x00400000 : ptr32)
 Eq_497: (struct "Eq_497" (6 word16 w0006) (14 word16 w0014))
 	T_497 (in ecx_13 : (ptr32 Eq_497))
 	T_501 (in Mem11[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
 Eq_537: (fn word32 ())
 	T_537 (in fn00401B98 : ptr32)
 	T_538 (in signature of fn00401B98 : void)
-	T_618 (in fn00401B98 : ptr32)
-	T_779 (in fn00401B98 : ptr32)
-Eq_545: (segment "Eq_545" (18 (ptr32 Eq_547) ptr0018))
-	T_545 (in fs : selector)
-Eq_547: (struct "Eq_547" (4 ptr32 ptr0004))
-	T_547 (in Mem0[fs:0x00000018:word32] : word32)
-Eq_555: (fn void ())
-	T_555 (in __lock : ptr32)
-	T_556 (in signature of __lock : void)
-Eq_559: (fn bool (word32, ptr32, word32, word32))
-	T_559 (in __cmpxchg : ptr32)
-	T_560 (in signature of __cmpxchg : void)
-Eq_586: (fn void (word32))
-	T_586 (in fn004019FE : ptr32)
-	T_587 (in signature of fn004019FE : void)
-Eq_593: (fn byte ())
-	T_593 (in fn00401C48 : ptr32)
-	T_594 (in signature of fn00401C48 : void)
-	T_601 (in fn00401C48 : ptr32)
-	T_611 (in fn00401C48 : ptr32)
-	T_792 (in fn00401C48 : ptr32)
-	T_794 (in fn00401C48 : ptr32)
-Eq_627: (fn void ())
-	T_627 (in int3 : ptr32)
-	T_628 (in signature of int3 : void)
-	T_908 (in int3 : ptr32)
-Eq_634: (fn word32 (ui32, byte))
-	T_634 (in __ror : ptr32)
-	T_635 (in signature of __ror : void)
-	T_804 (in __ror : ptr32)
-Eq_723: (struct "Eq_723" (400000 word32 dw400000) (400018 word16 w400018))
-	T_723 (in eax_25 : (ptr32 Eq_723))
-	T_725 (in Mem19[0x0040003C:word32] : word32)
-Eq_742: (struct "Eq_742" (24 int32 dw0024))
-	T_742 (in eax_40 : (ptr32 Eq_742))
-	T_750 (in fn004013FB(&globals->w400000, eax_32 - 0x00400000, out edx) : word32)
-	T_754 (in 0x00000000 : word32)
-Eq_743: (fn (ptr32 Eq_742) ((ptr32 Eq_493), uint32, (ptr32 Eq_492)))
-	T_743 (in fn004013FB : ptr32)
-	T_744 (in signature of fn004013FB : void)
-Eq_746: (union "Eq_746" (ui32 u0) (ptr32 u1))
-	T_746 (in 0x00400000 : ptr32)
-Eq_821: (union "Eq_821" (bool u0) (word32 u1))
-	T_821 (in -eax_23 == 0x00000000 : bool)
-Eq_826: (fn word32 (ui32))
-	T_826 (in fn00401613 : ptr32)
-	T_827 (in signature of fn00401613 : void)
-Eq_834: (fn void (Eq_836))
-	T_834 (in GetSystemTimeAsFileTime : ptr32)
-	T_835 (in signature of GetSystemTimeAsFileTime : void)
-Eq_836: LPFILETIME
-	T_836 (in lpSystemTimeAsFileTime : LPFILETIME)
-	T_839 (in fp - 0x00000010 : word32)
-Eq_849: (fn Eq_80 ())
-	T_849 (in GetCurrentThreadId : ptr32)
-	T_850 (in signature of GetCurrentThreadId : void)
-Eq_853: (fn Eq_80 ())
-	T_853 (in GetCurrentProcessId : ptr32)
-	T_854 (in signature of GetCurrentProcessId : void)
-Eq_857: (fn Eq_491 ((ptr32 Eq_859)))
-	T_857 (in QueryPerformanceCounter : ptr32)
-	T_858 (in signature of QueryPerformanceCounter : void)
-Eq_859: LARGE_INTEGER
-	T_859 (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
-	T_861 (in fp - 0x00000018 : word32)
-Eq_895: (fn void (Eq_897))
-	T_895 (in InitializeSListHead : ptr32)
-	T_896 (in signature of InitializeSListHead : void)
-Eq_897: PSLIST_HEADER
-	T_897 (in ListHead : PSLIST_HEADER)
-	T_898 (in 0x00403358 : word32)
-Eq_910: (fn (ptr32 Eq_912) ())
-	T_910 (in fn00401739 : ptr32)
-	T_911 (in signature of fn00401739 : void)
-	T_934 (in fn00401739 : ptr32)
-Eq_912: (struct "Eq_912" (0 ui32 dw0000) (4 word32 dw0004))
-	T_912 (in fn00401739() : word32)
-	T_933 (in eax_12 : (ptr32 Eq_912))
-	T_935 (in fn00401739() : word32)
-Eq_955: (fn Eq_491 (Eq_80))
-	T_955 (in IsProcessorFeaturePresent : ptr32)
-	T_956 (in signature of IsProcessorFeaturePresent : void)
-	T_1164 (in IsProcessorFeaturePresent : ptr32)
-Eq_965: (fn (ptr32 void) ((ptr32 void), int32, Eq_969))
-	T_965 (in memset : ptr32)
-	T_966 (in signature of memset : void)
-	T_976 (in memset : ptr32)
-Eq_969: size_t
-	T_969 (in _Size : size_t)
-	T_974 (in 0x000002CC : word32)
-	T_980 (in 0x00000050 : word32)
-Eq_984: (fn Eq_491 ())
-	T_984 (in IsDebuggerPresent : ptr32)
-	T_985 (in signature of IsDebuggerPresent : void)
-Eq_988: (union "Eq_988" (bool u0) (byte u1))
-	T_988 (in IsDebuggerPresent() == 0x00000001 : bool)
-Eq_999: (fn void (word32))
-	T_999 (in __fastfail : ptr32)
-	T_1000 (in signature of __fastfail : void)
-Eq_1011: (union "Eq_1011" (bool u0) (ui32 u1))
-	T_1011 (in -(word32) (bl_90 + 0x01) == 0x00000000 : bool)
-Eq_1017: HMODULE
-	T_1017 (in eax_6 : Eq_1017)
-	T_1022 (in GetModuleHandleW(null) : HMODULE)
-	T_1025 (in 0x00000000 : word32)
-Eq_1018: (fn Eq_1017 (Eq_1020))
-	T_1018 (in GetModuleHandleW : ptr32)
-	T_1019 (in signature of GetModuleHandleW : void)
-Eq_1020: LPCWSTR
-	T_1020 (in lpModuleName : LPCWSTR)
-	T_1021 (in 0x00000000 : word32)
-Eq_1030: (union "Eq_1030" (int32 u0) (word16 u1))
-	T_1030 (in Mem5[eax_6 + 0x00000000:word16] : word16)
-	T_1031 (in 0x5A4D : word16)
-Eq_1036: (struct "Eq_1036" (0 word32 dw0000) (18 word16 w0018) (74 up32 dw0074) (E8 word32 dw00E8))
-	T_1036 (in eax_17 : (ptr32 Eq_1036))
-	T_1040 (in Mem5[eax_6 + 0x0000003C:word32] + eax_6 : word32)
-Eq_1038: HMODULE
-	T_1038 (in eax_6 + 0x0000003C : word32)
-Eq_1129: (segment "Eq_1129" (0 ptr32 ptr0000))
-	T_1129 (in fs : selector)
-Eq_1139: (segment "Eq_1139" (0 word32 dw0000))
-	T_1139 (in fs : selector)
-Eq_1140: (union "Eq_1140" (ptr32 u0) ((memptr (ptr32 Eq_1139) word32) u1))
-	T_1140 (in 0x00000000 : ptr32)
-Eq_1179: (fn void (word32, word32, (ptr32 word32), (ptr32 word32), (ptr32 word32), (ptr32 word32)))
-	T_1179 (in __cpuid : ptr32)
-	T_1180 (in signature of __cpuid : void)
-	T_1197 (in __cpuid : ptr32)
-	T_1251 (in __cpuid : ptr32)
-Eq_1285: (fn word64 (word32))
-	T_1285 (in __xgetbv : ptr32)
-	T_1286 (in signature of __xgetbv : void)
-Eq_1328: (struct "Eq_1328" (0 Eq_91 t0000))
-	T_1328
+	T_599 (in fn00401B98 : ptr32)
+	T_760 (in fn00401B98 : ptr32)
+Eq_543: (segment "Eq_543" (18 (ptr32 Eq_545) ptr0018))
+	T_543 (in fs : selector)
+Eq_545: (struct "Eq_545" (4 ptr32 ptr0004))
+	T_545 (in Mem0[fs:0x00000018:word32] : word32)
+Eq_551: (fn void ())
+	T_551 (in __lock : ptr32)
+	T_552 (in signature of __lock : void)
+Eq_555: (fn bool (word32, ptr32, word32, word32))
+	T_555 (in __cmpxchg : ptr32)
+	T_556 (in signature of __cmpxchg : void)
+Eq_574: (fn void (word32))
+	T_574 (in fn004019FE : ptr32)
+	T_575 (in signature of fn004019FE : void)
+Eq_578: (fn byte ())
+	T_578 (in fn00401C48 : ptr32)
+	T_579 (in signature of fn00401C48 : void)
+	T_586 (in fn00401C48 : ptr32)
+	T_592 (in fn00401C48 : ptr32)
+	T_773 (in fn00401C48 : ptr32)
+	T_775 (in fn00401C48 : ptr32)
+Eq_608: (fn void ())
+	T_608 (in int3 : ptr32)
+	T_609 (in signature of int3 : void)
+	T_889 (in int3 : ptr32)
+Eq_615: (fn word32 (ui32, byte))
+	T_615 (in __ror : ptr32)
+	T_616 (in signature of __ror : void)
+	T_785 (in __ror : ptr32)
+Eq_704: (struct "Eq_704" (400000 word32 dw400000) (400018 word16 w400018))
+	T_704 (in eax_25 : (ptr32 Eq_704))
+	T_706 (in Mem19[0x0040003C:word32] : word32)
+Eq_723: (struct "Eq_723" (24 int32 dw0024))
+	T_723 (in eax_40 : (ptr32 Eq_723))
+	T_731 (in fn004013FB(&globals->w400000, eax_32 - 0x00400000, out edx) : word32)
+	T_735 (in 0x00000000 : word32)
+Eq_724: (fn (ptr32 Eq_723) ((ptr32 Eq_493), uint32, (ptr32 Eq_492)))
+	T_724 (in fn004013FB : ptr32)
+	T_725 (in signature of fn004013FB : void)
+Eq_727: (union "Eq_727" (ui32 u0) (ptr32 u1))
+	T_727 (in 0x00400000 : ptr32)
+Eq_802: (union "Eq_802" (bool u0) (word32 u1))
+	T_802 (in -eax_23 == 0x00000000 : bool)
+Eq_807: (fn word32 (ui32))
+	T_807 (in fn00401613 : ptr32)
+	T_808 (in signature of fn00401613 : void)
+Eq_815: (fn void (Eq_817))
+	T_815 (in GetSystemTimeAsFileTime : ptr32)
+	T_816 (in signature of GetSystemTimeAsFileTime : void)
+Eq_817: LPFILETIME
+	T_817 (in lpSystemTimeAsFileTime : LPFILETIME)
+	T_820 (in fp - 0x00000010 : word32)
+Eq_830: (fn Eq_80 ())
+	T_830 (in GetCurrentThreadId : ptr32)
+	T_831 (in signature of GetCurrentThreadId : void)
+Eq_834: (fn Eq_80 ())
+	T_834 (in GetCurrentProcessId : ptr32)
+	T_835 (in signature of GetCurrentProcessId : void)
+Eq_838: (fn Eq_491 ((ptr32 Eq_840)))
+	T_838 (in QueryPerformanceCounter : ptr32)
+	T_839 (in signature of QueryPerformanceCounter : void)
+Eq_840: LARGE_INTEGER
+	T_840 (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
+	T_842 (in fp - 0x00000018 : word32)
+Eq_876: (fn void (Eq_878))
+	T_876 (in InitializeSListHead : ptr32)
+	T_877 (in signature of InitializeSListHead : void)
+Eq_878: PSLIST_HEADER
+	T_878 (in ListHead : PSLIST_HEADER)
+	T_879 (in 0x00403358 : word32)
+Eq_891: (fn (ptr32 Eq_893) ())
+	T_891 (in fn00401739 : ptr32)
+	T_892 (in signature of fn00401739 : void)
+	T_915 (in fn00401739 : ptr32)
+Eq_893: (struct "Eq_893" (0 ui32 dw0000) (4 word32 dw0004))
+	T_893 (in fn00401739() : word32)
+	T_914 (in eax_12 : (ptr32 Eq_893))
+	T_916 (in fn00401739() : word32)
+Eq_936: (fn Eq_491 (Eq_80))
+	T_936 (in IsProcessorFeaturePresent : ptr32)
+	T_937 (in signature of IsProcessorFeaturePresent : void)
+	T_1137 (in IsProcessorFeaturePresent : ptr32)
+Eq_946: (fn (ptr32 void) ((ptr32 void), int32, Eq_950))
+	T_946 (in memset : ptr32)
+	T_947 (in signature of memset : void)
+	T_957 (in memset : ptr32)
+Eq_950: size_t
+	T_950 (in _Size : size_t)
+	T_955 (in 0x000002CC : word32)
+	T_961 (in 0x00000050 : word32)
+Eq_965: (fn Eq_491 ())
+	T_965 (in IsDebuggerPresent : ptr32)
+	T_966 (in signature of IsDebuggerPresent : void)
+Eq_969: (union "Eq_969" (bool u0) (byte u1))
+	T_969 (in IsDebuggerPresent() == 0x00000001 : bool)
+Eq_980: (fn void (word32))
+	T_980 (in __fastfail : ptr32)
+	T_981 (in signature of __fastfail : void)
+Eq_992: (union "Eq_992" (bool u0) (ui32 u1))
+	T_992 (in -(word32) (bl_90 + 0x01) == 0x00000000 : bool)
+Eq_998: HMODULE
+	T_998 (in eax_6 : Eq_998)
+	T_1003 (in GetModuleHandleW(null) : HMODULE)
+	T_1004 (in 0x00000000 : word32)
+Eq_999: (fn Eq_998 (Eq_1001))
+	T_999 (in GetModuleHandleW : ptr32)
+	T_1000 (in signature of GetModuleHandleW : void)
+Eq_1001: LPCWSTR
+	T_1001 (in lpModuleName : LPCWSTR)
+	T_1002 (in 0x00000000 : word32)
+Eq_1008: (union "Eq_1008" (int32 u0) (word16 u1))
+	T_1008 (in Mem5[eax_6 + 0x00000000:word16] : word16)
+	T_1009 (in 0x5A4D : word16)
+Eq_1012: (struct "Eq_1012" (0 word32 dw0000) (18 word16 w0018) (74 up32 dw0074) (E8 word32 dw00E8))
+	T_1012 (in eax_17 : (ptr32 Eq_1012))
+	T_1016 (in Mem5[eax_6 + 0x0000003C:word32] + eax_6 : word32)
+Eq_1014: HMODULE
+	T_1014 (in eax_6 + 0x0000003C : word32)
+Eq_1102: (segment "Eq_1102" (0 ptr32 ptr0000))
+	T_1102 (in fs : selector)
+Eq_1112: (segment "Eq_1112" (0 word32 dw0000))
+	T_1112 (in fs : selector)
+Eq_1113: (union "Eq_1113" (ptr32 u0) ((memptr (ptr32 Eq_1112) word32) u1))
+	T_1113 (in 0x00000000 : ptr32)
+Eq_1152: (fn void (word32, word32, (ptr32 word32), (ptr32 word32), (ptr32 word32), (ptr32 word32)))
+	T_1152 (in __cpuid : ptr32)
+	T_1153 (in signature of __cpuid : void)
+	T_1170 (in __cpuid : ptr32)
+	T_1224 (in __cpuid : ptr32)
+Eq_1258: (fn word64 (word32))
+	T_1258 (in __xgetbv : ptr32)
+	T_1259 (in signature of __xgetbv : void)
+Eq_1301: (struct "Eq_1301" (0 Eq_91 t0000))
+	T_1301
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -2543,633 +2543,633 @@ T_539: (in fn00401B98() : word32)
   Class: Eq_536
   DataType: word32
   OrigDataType: word32
-T_540: (in eax_24_8_49 : word24)
-  Class: Eq_540
-  DataType: word24
-  OrigDataType: word24
-T_541: (in SLICE(eax_4, word24, 8) : word24)
-  Class: Eq_540
-  DataType: word24
-  OrigDataType: word24
-T_542: (in 0x00000000 : word32)
+T_540: (in 0x00000000 : word32)
   Class: Eq_536
   DataType: word32
   OrigDataType: word32
-T_543: (in eax_4 != 0x00000000 : bool)
-  Class: Eq_543
+T_541: (in eax_4 != 0x00000000 : bool)
+  Class: Eq_541
   DataType: bool
   OrigDataType: bool
-T_544: (in edx_19 : ptr32)
+T_542: (in edx_19 : ptr32)
   Class: Eq_137
   DataType: ptr32
   OrigDataType: word32
-T_545: (in fs : selector)
+T_543: (in fs : selector)
+  Class: Eq_543
+  DataType: (ptr32 Eq_543)
+  OrigDataType: (ptr32 (segment (18 T_545 t0018)))
+T_544: (in 0x00000018 : word32)
+  Class: Eq_544
+  DataType: (memptr (ptr32 Eq_543) (ptr32 Eq_545))
+  OrigDataType: (memptr T_543 (struct (0 T_545 t0000)))
+T_545: (in Mem0[fs:0x00000018:word32] : word32)
   Class: Eq_545
   DataType: (ptr32 Eq_545)
-  OrigDataType: (ptr32 (segment (18 T_547 t0018)))
-T_546: (in 0x00000018 : word32)
+  OrigDataType: (ptr32 (struct (4 T_548 t0004)))
+T_546: (in 0x00000004 : word32)
   Class: Eq_546
-  DataType: (memptr (ptr32 Eq_545) (ptr32 Eq_547))
-  OrigDataType: (memptr T_545 (struct (0 T_547 t0000)))
-T_547: (in Mem0[fs:0x00000018:word32] : word32)
+  DataType: word32
+  OrigDataType: word32
+T_547: (in Mem0[fs:0x00000018:word32] + 0x00000004 : word32)
   Class: Eq_547
-  DataType: (ptr32 Eq_547)
-  OrigDataType: (ptr32 (struct (4 T_550 t0004)))
-T_548: (in 0x00000004 : word32)
-  Class: Eq_548
   DataType: word32
   OrigDataType: word32
-T_549: (in Mem0[fs:0x00000018:word32] + 0x00000004 : word32)
-  Class: Eq_549
-  DataType: word32
-  OrigDataType: word32
-T_550: (in Mem17[Mem0[fs:0x00000018:word32] + 0x00000004:word32] : word32)
+T_548: (in Mem17[Mem0[fs:0x00000018:word32] + 0x00000004:word32] : word32)
   Class: Eq_137
   DataType: ptr32
   OrigDataType: word32
-T_551: (in edx : word32)
+T_549: (in edx : word32)
   Class: Eq_137
   DataType: ptr32
   OrigDataType: word32
-T_552: (in 0x00 : byte)
-  Class: Eq_552
-  DataType: byte
-  OrigDataType: byte
-T_553: (in SEQ(eax_24_8_49, 0x00) : word32)
-  Class: Eq_553
-  DataType: word32
-  OrigDataType: word32
-T_554: (in (byte) SEQ(eax_24_8_49, 0x00) : byte)
+T_550: (in 0x00 : byte)
   Class: Eq_535
   DataType: byte
   OrigDataType: byte
-T_555: (in __lock : ptr32)
-  Class: Eq_555
-  DataType: (ptr32 Eq_555)
-  OrigDataType: (ptr32 (fn T_557 ()))
-T_556: (in signature of __lock : void)
-  Class: Eq_555
-  DataType: (ptr32 Eq_555)
+T_551: (in __lock : ptr32)
+  Class: Eq_551
+  DataType: (ptr32 Eq_551)
+  OrigDataType: (ptr32 (fn T_553 ()))
+T_552: (in signature of __lock : void)
+  Class: Eq_551
+  DataType: (ptr32 Eq_551)
   OrigDataType: 
-T_557: (in __lock() : void)
-  Class: Eq_557
+T_553: (in __lock() : void)
+  Class: Eq_553
   DataType: void
   OrigDataType: void
-T_558: (in eax_25 : ptr32)
+T_554: (in eax_25 : ptr32)
   Class: Eq_137
   DataType: ptr32
   OrigDataType: word32
-T_559: (in __cmpxchg : ptr32)
-  Class: Eq_559
-  DataType: (ptr32 Eq_559)
-  OrigDataType: (ptr32 (fn T_569 (T_566, T_544, T_567, T_568)))
-T_560: (in signature of __cmpxchg : void)
-  Class: Eq_559
-  DataType: (ptr32 Eq_559)
+T_555: (in __cmpxchg : ptr32)
+  Class: Eq_555
+  DataType: (ptr32 Eq_555)
+  OrigDataType: (ptr32 (fn T_565 (T_562, T_542, T_563, T_564)))
+T_556: (in signature of __cmpxchg : void)
+  Class: Eq_555
+  DataType: (ptr32 Eq_555)
   OrigDataType: 
-T_561: (in  : word32)
-  Class: Eq_561
+T_557: (in  : word32)
+  Class: Eq_557
   DataType: word32
   OrigDataType: 
-T_562: (in  : word32)
+T_558: (in  : word32)
   Class: Eq_137
   DataType: ptr32
   OrigDataType: 
-T_563: (in  : word32)
-  Class: Eq_563
+T_559: (in  : word32)
+  Class: Eq_559
   DataType: word32
   OrigDataType: 
-T_564: (in  : word32)
-  Class: Eq_564
+T_560: (in  : word32)
+  Class: Eq_560
   DataType: word32
   OrigDataType: 
-T_565: (in 0x00403338 : ptr32)
-  Class: Eq_565
+T_561: (in 0x00403338 : ptr32)
+  Class: Eq_561
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_566 t0000)))
-T_566: (in Mem17[0x00403338:word32] : word32)
-  Class: Eq_561
+  OrigDataType: (ptr32 (struct (0 T_562 t0000)))
+T_562: (in Mem17[0x00403338:word32] : word32)
+  Class: Eq_557
   DataType: word32
   OrigDataType: word32
-T_567: (in 0x00000000 : word32)
-  Class: Eq_563
+T_563: (in 0x00000000 : word32)
+  Class: Eq_559
   DataType: word32
   OrigDataType: word32
-T_568: (in out eax_25 : word32)
-  Class: Eq_564
+T_564: (in out eax_25 : word32)
+  Class: Eq_560
   DataType: word32
   OrigDataType: word32
-T_569: (in __cmpxchg(globals->dw403338, edx_19, 0x00000000, out eax_25) : bool)
-  Class: Eq_569
+T_565: (in __cmpxchg(globals->dw403338, edx_19, 0x00000000, out eax_25) : bool)
+  Class: Eq_565
   DataType: bool
   OrigDataType: bool
-T_570: (in eax_24_8_51 : word24)
-  Class: Eq_570
-  DataType: word24
-  OrigDataType: word24
-T_571: (in SLICE(eax_25, word24, 8) : word24)
-  Class: Eq_570
-  DataType: word24
-  OrigDataType: word24
-T_572: (in eax_24_8_53 : word24)
-  Class: Eq_572
-  DataType: word24
-  OrigDataType: word24
-T_573: (in SLICE(eax_25, word24, 8) : word24)
-  Class: Eq_572
-  DataType: word24
-  OrigDataType: word24
-T_574: (in 0x00000000 : word32)
+T_566: (in 0x00000000 : word32)
   Class: Eq_137
   DataType: ptr32
   OrigDataType: word32
-T_575: (in eax_25 != 0x00000000 : bool)
-  Class: Eq_575
+T_567: (in eax_25 != 0x00000000 : bool)
+  Class: Eq_567
   DataType: bool
   OrigDataType: bool
-T_576: (in edx_19 == eax_25 : bool)
-  Class: Eq_576
+T_568: (in edx_19 == eax_25 : bool)
+  Class: Eq_568
   DataType: bool
   OrigDataType: bool
-T_577: (in 0x00 : byte)
-  Class: Eq_577
-  DataType: byte
-  OrigDataType: byte
-T_578: (in SEQ(eax_24_8_51, 0x00) : word32)
-  Class: Eq_578
-  DataType: word32
-  OrigDataType: word32
-T_579: (in (byte) SEQ(eax_24_8_51, 0x00) : byte)
+T_569: (in 0x00 : byte)
   Class: Eq_535
   DataType: byte
   OrigDataType: byte
-T_580: (in 0x01 : byte)
-  Class: Eq_580
-  DataType: byte
-  OrigDataType: byte
-T_581: (in SEQ(eax_24_8_53, 0x01) : word32)
-  Class: Eq_581
-  DataType: word32
-  OrigDataType: word32
-T_582: (in (byte) SEQ(eax_24_8_53, 0x01) : byte)
+T_570: (in 0x01 : byte)
   Class: Eq_535
   DataType: byte
   OrigDataType: byte
-T_583: (in al : byte)
-  Class: Eq_583
+T_571: (in al : byte)
+  Class: Eq_571
   DataType: byte
   OrigDataType: byte
-T_584: (in 0x00000000 : word32)
+T_572: (in 0x00000000 : word32)
   Class: Eq_107
   DataType: word32
   OrigDataType: word32
-T_585: (in dwArg04 != 0x00000000 : bool)
-  Class: Eq_585
+T_573: (in dwArg04 != 0x00000000 : bool)
+  Class: Eq_573
   DataType: bool
   OrigDataType: bool
-T_586: (in fn004019FE : ptr32)
-  Class: Eq_586
-  DataType: (ptr32 Eq_586)
-  OrigDataType: (ptr32 (fn T_589 (T_106)))
-T_587: (in signature of fn004019FE : void)
-  Class: Eq_586
-  DataType: (ptr32 Eq_586)
+T_574: (in fn004019FE : ptr32)
+  Class: Eq_574
+  DataType: (ptr32 Eq_574)
+  OrigDataType: (ptr32 (fn T_577 (T_106)))
+T_575: (in signature of fn004019FE : void)
+  Class: Eq_574
+  DataType: (ptr32 Eq_574)
   OrigDataType: 
-T_588: (in edx : word32)
+T_576: (in edx : word32)
   Class: Eq_106
   DataType: word32
   OrigDataType: word32
-T_589: (in fn004019FE(edx) : void)
-  Class: Eq_589
+T_577: (in fn004019FE(edx) : void)
+  Class: Eq_577
   DataType: void
   OrigDataType: void
-T_590: (in eax_24_8_53 : word24)
-  Class: Eq_590
-  DataType: word24
-  OrigDataType: word24
-T_591: (in eax_13 : word32)
-  Class: Eq_591
-  DataType: word32
-  OrigDataType: word32
-T_592: (in SLICE(eax_13, word24, 8) : word24)
-  Class: Eq_590
-  DataType: word24
-  OrigDataType: word24
-T_593: (in fn00401C48 : ptr32)
-  Class: Eq_593
-  DataType: (ptr32 Eq_593)
-  OrigDataType: (ptr32 (fn T_595 ()))
-T_594: (in signature of fn00401C48 : void)
-  Class: Eq_593
-  DataType: (ptr32 Eq_593)
+T_578: (in fn00401C48 : ptr32)
+  Class: Eq_578
+  DataType: (ptr32 Eq_578)
+  OrigDataType: (ptr32 (fn T_580 ()))
+T_579: (in signature of fn00401C48 : void)
+  Class: Eq_578
+  DataType: (ptr32 Eq_578)
   OrigDataType: 
-T_595: (in fn00401C48() : byte)
-  Class: Eq_595
+T_580: (in fn00401C48() : byte)
+  Class: Eq_580
   DataType: byte
   OrigDataType: byte
-T_596: (in 0x00 : byte)
-  Class: Eq_595
+T_581: (in 0x00 : byte)
+  Class: Eq_580
   DataType: byte
   OrigDataType: byte
-T_597: (in fn00401C48() != 0x00 : bool)
-  Class: Eq_597
+T_582: (in fn00401C48() != 0x00 : bool)
+  Class: Eq_582
   DataType: bool
   OrigDataType: bool
-T_598: (in 0x01 : byte)
-  Class: Eq_598
+T_583: (in 0x01 : byte)
+  Class: Eq_583
   DataType: byte
   OrigDataType: byte
-T_599: (in 00403354 : ptr32)
-  Class: Eq_599
+T_584: (in 00403354 : ptr32)
+  Class: Eq_584
   DataType: (ptr32 byte)
-  OrigDataType: (ptr32 (struct (0 T_600 t0000)))
-T_600: (in Mem10[0x00403354:byte] : byte)
-  Class: Eq_598
+  OrigDataType: (ptr32 (struct (0 T_585 t0000)))
+T_585: (in Mem10[0x00403354:byte] : byte)
+  Class: Eq_583
   DataType: byte
   OrigDataType: byte
-T_601: (in fn00401C48 : ptr32)
-  Class: Eq_593
-  DataType: (ptr32 Eq_593)
-  OrigDataType: (ptr32 (fn T_602 ()))
-T_602: (in fn00401C48() : byte)
-  Class: Eq_595
+T_586: (in fn00401C48 : ptr32)
+  Class: Eq_578
+  DataType: (ptr32 Eq_578)
+  OrigDataType: (ptr32 (fn T_587 ()))
+T_587: (in fn00401C48() : byte)
+  Class: Eq_580
   DataType: byte
   OrigDataType: byte
-T_603: (in 0x00 : byte)
-  Class: Eq_595
+T_588: (in 0x00 : byte)
+  Class: Eq_580
   DataType: byte
   OrigDataType: byte
-T_604: (in fn00401C48() != 0x00 : bool)
-  Class: Eq_604
+T_589: (in fn00401C48() != 0x00 : bool)
+  Class: Eq_589
   DataType: bool
   OrigDataType: bool
-T_605: (in 0x00 : byte)
-  Class: Eq_605
+T_590: (in 0x00 : byte)
+  Class: Eq_571
   DataType: byte
   OrigDataType: byte
-T_606: (in SEQ(eax_24_8_53, 0x00) : word32)
-  Class: Eq_606
-  DataType: word32
-  OrigDataType: word32
-T_607: (in (byte) SEQ(eax_24_8_53, 0x00) : byte)
-  Class: Eq_583
+T_591: (in 0x01 : byte)
+  Class: Eq_571
   DataType: byte
   OrigDataType: byte
-T_608: (in 0x01 : byte)
-  Class: Eq_608
+T_592: (in fn00401C48 : ptr32)
+  Class: Eq_578
+  DataType: (ptr32 Eq_578)
+  OrigDataType: (ptr32 (fn T_593 ()))
+T_593: (in fn00401C48() : byte)
+  Class: Eq_580
   DataType: byte
   OrigDataType: byte
-T_609: (in SEQ(eax_24_8_53, 0x01) : word32)
-  Class: Eq_609
-  DataType: word32
-  OrigDataType: word32
-T_610: (in (byte) SEQ(eax_24_8_53, 0x01) : byte)
-  Class: Eq_583
-  DataType: byte
-  OrigDataType: byte
-T_611: (in fn00401C48 : ptr32)
-  Class: Eq_593
-  DataType: (ptr32 Eq_593)
-  OrigDataType: (ptr32 (fn T_612 ()))
-T_612: (in fn00401C48() : byte)
-  Class: Eq_595
-  DataType: byte
-  OrigDataType: byte
-T_613: (in ebx : word32)
+T_594: (in ebx : word32)
   Class: Eq_82
   DataType: word32
   OrigDataType: word32
-T_614: (in edi : Eq_91)
+T_595: (in edi : Eq_91)
   Class: Eq_91
   DataType: Eq_91
   OrigDataType: word32
-T_615: (in dwArg04 : Eq_91)
+T_596: (in dwArg04 : Eq_91)
   Class: Eq_91
   DataType: Eq_91
   OrigDataType: word32
-T_616: (in 0x00000000 : word32)
+T_597: (in 0x00000000 : word32)
   Class: Eq_91
   DataType: byte
   OrigDataType: word32
-T_617: (in dwArg04 == 0x00000000 : bool)
-  Class: Eq_617
+T_598: (in dwArg04 == 0x00000000 : bool)
+  Class: Eq_598
   DataType: bool
   OrigDataType: bool
-T_618: (in fn00401B98 : ptr32)
+T_599: (in fn00401B98 : ptr32)
   Class: Eq_537
   DataType: (ptr32 Eq_537)
-  OrigDataType: (ptr32 (fn T_619 ()))
-T_619: (in fn00401B98() : word32)
+  OrigDataType: (ptr32 (fn T_600 ()))
+T_600: (in fn00401B98() : word32)
   Class: Eq_536
   DataType: word32
   OrigDataType: word32
-T_620: (in 0x00000000 : word32)
+T_601: (in 0x00000000 : word32)
   Class: Eq_536
   DataType: word32
   OrigDataType: word32
-T_621: (in fn00401B98() == 0x00000000 : bool)
-  Class: Eq_621
+T_602: (in fn00401B98() == 0x00000000 : bool)
+  Class: Eq_602
   DataType: bool
   OrigDataType: bool
-T_622: (in 0x00000001 : word32)
+T_603: (in 0x00000001 : word32)
   Class: Eq_91
   DataType: byte
   OrigDataType: word32
-T_623: (in dwArg04 != 0x00000001 : bool)
-  Class: Eq_623
+T_604: (in dwArg04 != 0x00000001 : bool)
+  Class: Eq_604
   DataType: bool
   OrigDataType: bool
-T_624: (in fn00401774 : ptr32)
+T_605: (in fn00401774 : ptr32)
   Class: Eq_163
   DataType: (ptr32 Eq_163)
-  OrigDataType: (ptr32 (fn T_626 (T_625)))
-T_625: (in 0x00000005 : word32)
+  OrigDataType: (ptr32 (fn T_607 (T_606)))
+T_606: (in 0x00000005 : word32)
   Class: Eq_165
   DataType: word32
   OrigDataType: word32
-T_626: (in fn00401774(0x00000005) : void)
+T_607: (in fn00401774(0x00000005) : void)
   Class: Eq_169
   DataType: void
   OrigDataType: void
-T_627: (in int3 : ptr32)
-  Class: Eq_627
-  DataType: (ptr32 Eq_627)
-  OrigDataType: (ptr32 (fn T_629 ()))
-T_628: (in signature of int3 : void)
-  Class: Eq_627
-  DataType: (ptr32 Eq_627)
+T_608: (in int3 : ptr32)
+  Class: Eq_608
+  DataType: (ptr32 Eq_608)
+  OrigDataType: (ptr32 (fn T_610 ()))
+T_609: (in signature of int3 : void)
+  Class: Eq_608
+  DataType: (ptr32 Eq_608)
   OrigDataType: 
-T_629: (in int3() : void)
-  Class: Eq_629
+T_610: (in int3() : void)
+  Class: Eq_610
   DataType: void
   OrigDataType: void
-T_630: (in eax_55 : ui32)
-  Class: Eq_630
+T_611: (in eax_55 : ui32)
+  Class: Eq_611
   DataType: ui32
   OrigDataType: ui32
-T_631: (in 00403004 : ptr32)
+T_612: (in 00403004 : ptr32)
+  Class: Eq_612
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_613 t0000)))
+T_613: (in Mem11[0x00403004:word32] : word32)
+  Class: Eq_611
+  DataType: ui32
+  OrigDataType: word32
+T_614: (in eax_76 : ui32)
+  Class: Eq_614
+  DataType: ui32
+  OrigDataType: ui32
+T_615: (in __ror : ptr32)
+  Class: Eq_615
+  DataType: (ptr32 Eq_615)
+  OrigDataType: (ptr32 (fn T_627 (T_622, T_626)))
+T_616: (in signature of __ror : void)
+  Class: Eq_615
+  DataType: (ptr32 Eq_615)
+  OrigDataType: 
+T_617: (in  : word32)
+  Class: Eq_617
+  DataType: ui32
+  OrigDataType: 
+T_618: (in  : byte)
+  Class: Eq_618
+  DataType: byte
+  OrigDataType: 
+T_619: (in 0x0000001F : word32)
+  Class: Eq_619
+  DataType: ui32
+  OrigDataType: ui32
+T_620: (in eax_55 & 0x0000001F : word32)
+  Class: Eq_620
+  DataType: ui32
+  OrigDataType: ui32
+T_621: (in 0xFFFFFFFF : word32)
+  Class: Eq_621
+  DataType: ui32
+  OrigDataType: ui32
+T_622: (in eax_55 & 0x0000001F | 0xFFFFFFFF : word32)
+  Class: Eq_617
+  DataType: ui32
+  OrigDataType: ui32
+T_623: (in 0x00000020 : word32)
+  Class: Eq_623
+  DataType: word32
+  OrigDataType: word32
+T_624: (in eax_55 & 0x0000001F : word32)
+  Class: Eq_624
+  DataType: ui32
+  OrigDataType: ui32
+T_625: (in 0x00000020 - (eax_55 & 0x0000001F) : word32)
+  Class: Eq_625
+  DataType: word32
+  OrigDataType: word32
+T_626: (in SLICE(0x00000020 - (eax_55 & 0x0000001F), byte, 0) : byte)
+  Class: Eq_618
+  DataType: byte
+  OrigDataType: byte
+T_627: (in __ror(eax_55 & 0x0000001F | 0xFFFFFFFF, (byte) (0x00000020 - (eax_55 & 0x0000001F))) : word32)
+  Class: Eq_627
+  DataType: word32
+  OrigDataType: word32
+T_628: (in 00403004 : ptr32)
+  Class: Eq_628
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_629 t0000)))
+T_629: (in Mem68[0x00403004:word32] : word32)
+  Class: Eq_611
+  DataType: ui32
+  OrigDataType: word32
+T_630: (in __ror(eax_55 & 0x0000001F | 0xFFFFFFFF, (byte) (0x00000020 - (eax_55 & 0x0000001F))) ^ globals->dw403004 : word32)
+  Class: Eq_614
+  DataType: ui32
+  OrigDataType: ui32
+T_631: (in 0x0040333C : ptr32)
   Class: Eq_631
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 (struct (0 T_632 t0000)))
-T_632: (in Mem11[0x00403004:word32] : word32)
-  Class: Eq_630
+T_632: (in Mem83[0x0040333C:word32] : word32)
+  Class: Eq_614
   DataType: ui32
   OrigDataType: word32
-T_633: (in eax_76 : ui32)
+T_633: (in 0x00403340 : word32)
   Class: Eq_633
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_634 t0000)))
+T_634: (in Mem87[0x00403340:word32] : word32)
+  Class: Eq_614
   DataType: ui32
-  OrigDataType: ui32
-T_634: (in __ror : ptr32)
-  Class: Eq_634
-  DataType: (ptr32 Eq_634)
-  OrigDataType: (ptr32 (fn T_646 (T_641, T_645)))
-T_635: (in signature of __ror : void)
-  Class: Eq_634
-  DataType: (ptr32 Eq_634)
-  OrigDataType: 
-T_636: (in  : word32)
-  Class: Eq_636
+  OrigDataType: word32
+T_635: (in 0x00403344 : word32)
+  Class: Eq_635
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_636 t0000)))
+T_636: (in Mem91[0x00403344:word32] : word32)
+  Class: Eq_614
   DataType: ui32
-  OrigDataType: 
-T_637: (in  : byte)
+  OrigDataType: word32
+T_637: (in 0x00403348 : ptr32)
   Class: Eq_637
-  DataType: byte
-  OrigDataType: 
-T_638: (in 0x0000001F : word32)
-  Class: Eq_638
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_638 t0000)))
+T_638: (in Mem99[0x00403348:word32] : word32)
+  Class: Eq_614
   DataType: ui32
-  OrigDataType: ui32
-T_639: (in eax_55 & 0x0000001F : word32)
+  OrigDataType: word32
+T_639: (in 0x0040334C : word32)
   Class: Eq_639
-  DataType: ui32
-  OrigDataType: ui32
-T_640: (in 0xFFFFFFFF : word32)
-  Class: Eq_640
-  DataType: ui32
-  OrigDataType: ui32
-T_641: (in eax_55 & 0x0000001F | 0xFFFFFFFF : word32)
-  Class: Eq_636
-  DataType: ui32
-  OrigDataType: ui32
-T_642: (in 0x00000020 : word32)
-  Class: Eq_642
-  DataType: word32
-  OrigDataType: word32
-T_643: (in eax_55 & 0x0000001F : word32)
-  Class: Eq_643
-  DataType: ui32
-  OrigDataType: ui32
-T_644: (in 0x00000020 - (eax_55 & 0x0000001F) : word32)
-  Class: Eq_644
-  DataType: word32
-  OrigDataType: word32
-T_645: (in SLICE(0x00000020 - (eax_55 & 0x0000001F), byte, 0) : byte)
-  Class: Eq_637
-  DataType: byte
-  OrigDataType: byte
-T_646: (in __ror(eax_55 & 0x0000001F | 0xFFFFFFFF, (byte) (0x00000020 - (eax_55 & 0x0000001F))) : word32)
-  Class: Eq_646
-  DataType: word32
-  OrigDataType: word32
-T_647: (in 00403004 : ptr32)
-  Class: Eq_647
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_648 t0000)))
-T_648: (in Mem68[0x00403004:word32] : word32)
-  Class: Eq_630
+  OrigDataType: (ptr32 (struct (0 T_640 t0000)))
+T_640: (in Mem103[0x0040334C:word32] : word32)
+  Class: Eq_614
   DataType: ui32
   OrigDataType: word32
-T_649: (in __ror(eax_55 & 0x0000001F | 0xFFFFFFFF, (byte) (0x00000020 - (eax_55 & 0x0000001F))) ^ globals->dw403004 : word32)
-  Class: Eq_633
-  DataType: ui32
-  OrigDataType: ui32
-T_650: (in 0x0040333C : ptr32)
-  Class: Eq_650
+T_641: (in 0x00403350 : word32)
+  Class: Eq_641
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_651 t0000)))
-T_651: (in Mem83[0x0040333C:word32] : word32)
-  Class: Eq_633
+  OrigDataType: (ptr32 (struct (0 T_642 t0000)))
+T_642: (in Mem107[0x00403350:word32] : word32)
+  Class: Eq_614
   DataType: ui32
   OrigDataType: word32
-T_652: (in 0x00403340 : word32)
-  Class: Eq_652
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_653 t0000)))
-T_653: (in Mem87[0x00403340:word32] : word32)
-  Class: Eq_633
-  DataType: ui32
-  OrigDataType: word32
-T_654: (in 0x00403344 : word32)
-  Class: Eq_654
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_655 t0000)))
-T_655: (in Mem91[0x00403344:word32] : word32)
-  Class: Eq_633
-  DataType: ui32
-  OrigDataType: word32
-T_656: (in 0x00403348 : ptr32)
-  Class: Eq_656
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_657 t0000)))
-T_657: (in Mem99[0x00403348:word32] : word32)
-  Class: Eq_633
-  DataType: ui32
-  OrigDataType: word32
-T_658: (in 0x0040334C : word32)
-  Class: Eq_658
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_659 t0000)))
-T_659: (in Mem103[0x0040334C:word32] : word32)
-  Class: Eq_633
-  DataType: ui32
-  OrigDataType: word32
-T_660: (in 0x00403350 : word32)
-  Class: Eq_660
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_661 t0000)))
-T_661: (in Mem107[0x00403350:word32] : word32)
-  Class: Eq_633
-  DataType: ui32
-  OrigDataType: word32
-T_662: (in 0x00000000 : word32)
+T_643: (in 0x00000000 : word32)
   Class: Eq_91
   DataType: byte
   OrigDataType: word32
-T_663: (in dwArg04 != 0x00000000 : bool)
-  Class: Eq_663
+T_644: (in dwArg04 != 0x00000000 : bool)
+  Class: Eq_644
   DataType: bool
   OrigDataType: bool
-T_664: (in esp_115 : (ptr32 word32))
-  Class: Eq_664
+T_645: (in esp_115 : (ptr32 word32))
+  Class: Eq_645
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_674 t0000)))
-T_665: (in eax_116 : word32)
-  Class: Eq_665
+  OrigDataType: (ptr32 (struct (0 T_655 t0000)))
+T_646: (in eax_116 : word32)
+  Class: Eq_646
   DataType: word32
   OrigDataType: word32
-T_666: (in edx_119 : word32)
-  Class: Eq_666
+T_647: (in edx_119 : word32)
+  Class: Eq_647
   DataType: word32
   OrigDataType: word32
-T_667: (in initialize_onexit_table : ptr32)
-  Class: Eq_667
+T_648: (in initialize_onexit_table : ptr32)
+  Class: Eq_648
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_668: (in signature of initialize_onexit_table : void)
-  Class: Eq_668
-  DataType: Eq_668
+T_649: (in signature of initialize_onexit_table : void)
+  Class: Eq_649
+  DataType: Eq_649
   OrigDataType: 
-T_669: (in 0x00000000 : word32)
-  Class: Eq_665
+T_650: (in 0x00000000 : word32)
+  Class: Eq_646
   DataType: word32
   OrigDataType: word32
-T_670: (in eax_116 == 0x00000000 : bool)
-  Class: Eq_670
+T_651: (in eax_116 == 0x00000000 : bool)
+  Class: Eq_651
   DataType: bool
   OrigDataType: bool
-T_671: (in 0x00403348 : word32)
-  Class: Eq_671
+T_652: (in 0x00403348 : word32)
+  Class: Eq_652
   DataType: word32
   OrigDataType: word32
-T_672: (in 0x00000000 : word32)
-  Class: Eq_672
+T_653: (in 0x00000000 : word32)
+  Class: Eq_653
   DataType: word32
   OrigDataType: word32
-T_673: (in esp_115 + 0x00000000 : word32)
-  Class: Eq_673
+T_654: (in esp_115 + 0x00000000 : word32)
+  Class: Eq_654
   DataType: word32
   OrigDataType: word32
-T_674: (in Mem127[esp_115 + 0x00000000:word32] : word32)
-  Class: Eq_671
+T_655: (in Mem127[esp_115 + 0x00000000:word32] : word32)
+  Class: Eq_652
   DataType: word32
   OrigDataType: word32
-T_675: (in edx_132 : word32)
-  Class: Eq_675
+T_656: (in edx_132 : word32)
+  Class: Eq_656
   DataType: word32
   OrigDataType: word32
-T_676: (in initialize_onexit_table : ptr32)
-  Class: Eq_676
+T_657: (in initialize_onexit_table : ptr32)
+  Class: Eq_657
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_677: (in signature of initialize_onexit_table : void)
-  Class: Eq_677
-  DataType: Eq_677
+T_658: (in signature of initialize_onexit_table : void)
+  Class: Eq_658
+  DataType: Eq_658
   OrigDataType: 
-T_678: (in edi_232 : word32)
-  Class: Eq_678
+T_659: (in edi_232 : word32)
+  Class: Eq_659
   DataType: word32
   OrigDataType: word32
-T_679: (in ebp_230 : word32)
-  Class: Eq_679
+T_660: (in ebp_230 : word32)
+  Class: Eq_660
   DataType: word32
   OrigDataType: word32
-T_680: (in esi_231 : word32)
-  Class: Eq_680
+T_661: (in esi_231 : word32)
+  Class: Eq_661
   DataType: word32
   OrigDataType: word32
-T_681: (in edx_228 : word32)
-  Class: Eq_681
+T_662: (in edx_228 : word32)
+  Class: Eq_662
   DataType: word32
   OrigDataType: word32
-T_682: (in ebx_229 : word32)
-  Class: Eq_682
+T_663: (in ebx_229 : word32)
+  Class: Eq_663
   DataType: word32
   OrigDataType: word32
-T_683: (in fn00401544 : ptr32)
+T_664: (in fn00401544 : ptr32)
   Class: Eq_310
   DataType: (ptr32 Eq_310)
-  OrigDataType: (ptr32 (fn T_689 (T_613, T_615, T_614, T_684, T_685, T_686, T_687, T_688)))
-T_684: (in out edx_228 : ptr32)
+  OrigDataType: (ptr32 (fn T_670 (T_594, T_596, T_595, T_665, T_666, T_667, T_668, T_669)))
+T_665: (in out edx_228 : ptr32)
   Class: Eq_315
   DataType: ptr32
   OrigDataType: ptr32
-T_685: (in out ebx_229 : ptr32)
+T_666: (in out ebx_229 : ptr32)
   Class: Eq_262
   DataType: ptr32
   OrigDataType: ptr32
-T_686: (in out ebp_230 : ptr32)
+T_667: (in out ebp_230 : ptr32)
   Class: Eq_317
   DataType: ptr32
   OrigDataType: ptr32
-T_687: (in out esi_231 : ptr32)
+T_668: (in out esi_231 : ptr32)
   Class: Eq_318
   DataType: ptr32
   OrigDataType: ptr32
-T_688: (in out edi_232 : ptr32)
+T_669: (in out edi_232 : ptr32)
   Class: Eq_319
   DataType: ptr32
   OrigDataType: ptr32
-T_689: (in fn00401544(ebx, dwArg04, edi, out edx_228, out ebx_229, out ebp_230, out esi_231, out edi_232) : byte)
+T_670: (in fn00401544(ebx, dwArg04, edi, out edx_228, out ebx_229, out ebp_230, out esi_231, out edi_232) : byte)
   Class: Eq_326
   DataType: byte
   OrigDataType: byte
-T_690: (in al : byte)
-  Class: Eq_690
+T_671: (in al : byte)
+  Class: Eq_671
   DataType: byte
   OrigDataType: byte
-T_691: (in eax_84 : word32)
-  Class: Eq_691
+T_672: (in eax_84 : word32)
+  Class: Eq_672
   DataType: word32
   OrigDataType: word32
-T_692: (in ebp_13 : (ptr32 Eq_3))
+T_673: (in ebp_13 : (ptr32 Eq_3))
   Class: Eq_3
   DataType: (ptr32 Eq_3)
-  OrigDataType: (ptr32 (struct (8 T_741 t0008)))
-T_693: (in fn00401980 : ptr32)
+  OrigDataType: (ptr32 (struct (8 T_722 t0008)))
+T_674: (in fn00401980 : ptr32)
   Class: Eq_88
   DataType: (ptr32 Eq_88)
-  OrigDataType: (ptr32 (fn T_696 (T_312, T_313, T_314, T_694, T_695)))
-T_694: (in dwLoc0C : word32)
+  OrigDataType: (ptr32 (fn T_677 (T_312, T_313, T_314, T_675, T_676)))
+T_675: (in dwLoc0C : word32)
   Class: Eq_93
   DataType: Eq_93
   OrigDataType: ui32
-T_695: (in 0x00000008 : word32)
+T_676: (in 0x00000008 : word32)
   Class: Eq_94
   DataType: ui32
   OrigDataType: word32
-T_696: (in fn00401980(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
+T_677: (in fn00401980(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
   Class: Eq_3
   DataType: (ptr32 Eq_3)
+  OrigDataType: word32
+T_678: (in 0x00000004 : word32)
+  Class: Eq_678
+  DataType: ui32
+  OrigDataType: ui32
+T_679: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_679
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_682 t0000)))
+T_680: (in 0x00000000 : word32)
+  Class: Eq_680
+  DataType: word32
+  OrigDataType: word32
+T_681: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_681
+  DataType: word32
+  OrigDataType: word32
+T_682: (in Mem7[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_682
+  DataType: ui32
+  OrigDataType: ui32
+T_683: (in 0x00000000 : word32)
+  Class: Eq_683
+  DataType: ui32
+  OrigDataType: ui32
+T_684: (in *(ebp_13 - 0x00000004) & 0x00000000 : word32)
+  Class: Eq_684
+  DataType: ui32
+  OrigDataType: ui32
+T_685: (in 0x00000004 : word32)
+  Class: Eq_685
+  DataType: ui32
+  OrigDataType: ui32
+T_686: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_686
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_689 t0000)))
+T_687: (in 0x00000000 : word32)
+  Class: Eq_687
+  DataType: word32
+  OrigDataType: word32
+T_688: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_688
+  DataType: ptr32
+  OrigDataType: ptr32
+T_689: (in Mem19[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_684
+  DataType: ui32
+  OrigDataType: word32
+T_690: (in eax_24_8_85 : word24)
+  Class: Eq_690
+  DataType: word24
+  OrigDataType: word24
+T_691: (in 0x00005A : word24)
+  Class: Eq_690
+  DataType: word24
+  OrigDataType: word24
+T_692: (in 00400000 : ptr32)
+  Class: Eq_692
+  DataType: (ptr32 word16)
+  OrigDataType: (ptr32 (struct (0 T_693 t0000)))
+T_693: (in Mem19[0x00400000:word16] : word16)
+  Class: Eq_693
+  DataType: word16
+  OrigDataType: word16
+T_694: (in 0x5A4D : word16)
+  Class: Eq_693
+  DataType: word16
+  OrigDataType: word16
+T_695: (in globals->w400000 != 0x5A4D : bool)
+  Class: Eq_695
+  DataType: bool
+  OrigDataType: bool
+T_696: (in 0xFFFFFFFE : word32)
+  Class: Eq_696
+  DataType: word32
   OrigDataType: word32
 T_697: (in 0x00000004 : word32)
   Class: Eq_697
@@ -3177,7 +3177,7 @@ T_697: (in 0x00000004 : word32)
   OrigDataType: ui32
 T_698: (in ebp_13 - 0x00000004 : word32)
   Class: Eq_698
-  DataType: (ptr32 ui32)
+  DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_701 t0000)))
 T_699: (in 0x00000000 : word32)
   Class: Eq_699
@@ -3185,2519 +3185,2411 @@ T_699: (in 0x00000000 : word32)
   OrigDataType: word32
 T_700: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
   Class: Eq_700
+  DataType: ptr32
+  OrigDataType: ptr32
+T_701: (in Mem57[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_696
   DataType: word32
   OrigDataType: word32
-T_701: (in Mem7[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_701
-  DataType: ui32
-  OrigDataType: ui32
-T_702: (in 0x00000000 : word32)
+T_702: (in 0x00 : byte)
   Class: Eq_702
-  DataType: ui32
-  OrigDataType: ui32
-T_703: (in *(ebp_13 - 0x00000004) & 0x00000000 : word32)
-  Class: Eq_703
-  DataType: ui32
-  OrigDataType: ui32
-T_704: (in 0x00000004 : word32)
-  Class: Eq_704
-  DataType: ui32
-  OrigDataType: ui32
-T_705: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_705
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_708 t0000)))
-T_706: (in 0x00000000 : word32)
-  Class: Eq_706
-  DataType: word32
-  OrigDataType: word32
-T_707: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_707
-  DataType: ptr32
-  OrigDataType: ptr32
-T_708: (in Mem19[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_703
-  DataType: ui32
-  OrigDataType: word32
-T_709: (in eax_24_8_85 : word24)
-  Class: Eq_709
-  DataType: word24
-  OrigDataType: word24
-T_710: (in 0x00005A : word24)
-  Class: Eq_709
-  DataType: word24
-  OrigDataType: word24
-T_711: (in 00400000 : ptr32)
-  Class: Eq_711
-  DataType: (ptr32 word16)
-  OrigDataType: (ptr32 (struct (0 T_712 t0000)))
-T_712: (in Mem19[0x00400000:word16] : word16)
-  Class: Eq_712
-  DataType: word16
-  OrigDataType: word16
-T_713: (in 0x5A4D : word16)
-  Class: Eq_712
-  DataType: word16
-  OrigDataType: word16
-T_714: (in globals->w400000 != 0x5A4D : bool)
-  Class: Eq_714
-  DataType: bool
-  OrigDataType: bool
-T_715: (in 0xFFFFFFFE : word32)
-  Class: Eq_715
-  DataType: word32
-  OrigDataType: word32
-T_716: (in 0x00000004 : word32)
-  Class: Eq_716
-  DataType: ui32
-  OrigDataType: ui32
-T_717: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_717
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_720 t0000)))
-T_718: (in 0x00000000 : word32)
-  Class: Eq_718
-  DataType: word32
-  OrigDataType: word32
-T_719: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_719
-  DataType: ptr32
-  OrigDataType: ptr32
-T_720: (in Mem57[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_715
-  DataType: word32
-  OrigDataType: word32
-T_721: (in 0x00 : byte)
-  Class: Eq_721
   DataType: byte
   OrigDataType: byte
-T_722: (in SEQ(eax_24_8_85, 0x00) : word32)
-  Class: Eq_691
+T_703: (in SEQ(eax_24_8_85, 0x00) : word32)
+  Class: Eq_672
   DataType: word32
   OrigDataType: word32
-T_723: (in eax_25 : (ptr32 Eq_723))
-  Class: Eq_723
-  DataType: (ptr32 Eq_723)
-  OrigDataType: (ptr32 (struct (400000 T_730 t400000) (400018 T_735 t400018)))
-T_724: (in 0040003C : ptr32)
-  Class: Eq_724
-  DataType: (ptr32 (ptr32 Eq_723))
-  OrigDataType: (ptr32 (struct (0 T_725 t0000)))
-T_725: (in Mem19[0x0040003C:word32] : word32)
-  Class: Eq_723
-  DataType: (ptr32 Eq_723)
+T_704: (in eax_25 : (ptr32 Eq_704))
+  Class: Eq_704
+  DataType: (ptr32 Eq_704)
+  OrigDataType: (ptr32 (struct (400000 T_711 t400000) (400018 T_716 t400018)))
+T_705: (in 0040003C : ptr32)
+  Class: Eq_705
+  DataType: (ptr32 (ptr32 Eq_704))
+  OrigDataType: (ptr32 (struct (0 T_706 t0000)))
+T_706: (in Mem19[0x0040003C:word32] : word32)
+  Class: Eq_704
+  DataType: (ptr32 Eq_704)
   OrigDataType: word32
-T_726: (in SLICE(eax_25, word24, 8) : word24)
-  Class: Eq_709
+T_707: (in SLICE(eax_25, word24, 8) : word24)
+  Class: Eq_690
   DataType: word24
   OrigDataType: word24
-T_727: (in SLICE(eax_25, word24, 8) : word24)
-  Class: Eq_709
+T_708: (in SLICE(eax_25, word24, 8) : word24)
+  Class: Eq_690
   DataType: word24
   OrigDataType: word24
-T_728: (in 0x00400000 : word32)
-  Class: Eq_728
+T_709: (in 0x00400000 : word32)
+  Class: Eq_709
   DataType: word32
   OrigDataType: word32
-T_729: (in eax_25 + 0x00400000 : word32)
-  Class: Eq_729
+T_710: (in eax_25 + 0x00400000 : word32)
+  Class: Eq_710
   DataType: word32
   OrigDataType: word32
-T_730: (in Mem19[eax_25 + 0x00400000:word32] : word32)
-  Class: Eq_730
+T_711: (in Mem19[eax_25 + 0x00400000:word32] : word32)
+  Class: Eq_711
   DataType: word32
   OrigDataType: word32
-T_731: (in 0x00004550 : word32)
-  Class: Eq_730
+T_712: (in 0x00004550 : word32)
+  Class: Eq_711
   DataType: word32
   OrigDataType: word32
-T_732: (in eax_25->dw400000 != 0x00004550 : bool)
-  Class: Eq_732
+T_713: (in eax_25->dw400000 != 0x00004550 : bool)
+  Class: Eq_713
   DataType: bool
   OrigDataType: bool
-T_733: (in 0x00400018 : word32)
-  Class: Eq_733
+T_714: (in 0x00400018 : word32)
+  Class: Eq_714
   DataType: word32
   OrigDataType: word32
-T_734: (in eax_25 + 0x00400018 : word32)
-  Class: Eq_734
+T_715: (in eax_25 + 0x00400018 : word32)
+  Class: Eq_715
   DataType: ptr32
   OrigDataType: ptr32
-T_735: (in Mem19[eax_25 + 0x00400018:word16] : word16)
-  Class: Eq_735
+T_716: (in Mem19[eax_25 + 0x00400018:word16] : word16)
+  Class: Eq_716
   DataType: word16
   OrigDataType: word16
-T_736: (in 0x010B : word16)
-  Class: Eq_735
+T_717: (in 0x010B : word16)
+  Class: Eq_716
   DataType: word16
   OrigDataType: word16
-T_737: (in eax_25->w400018 != 0x010B : bool)
-  Class: Eq_737
+T_718: (in eax_25->w400018 != 0x010B : bool)
+  Class: Eq_718
   DataType: bool
   OrigDataType: bool
-T_738: (in eax_32 : ui32)
-  Class: Eq_738
+T_719: (in eax_32 : ui32)
+  Class: Eq_719
   DataType: ui32
   OrigDataType: ui32
-T_739: (in 0x00000008 : word32)
-  Class: Eq_739
+T_720: (in 0x00000008 : word32)
+  Class: Eq_720
   DataType: word32
   OrigDataType: word32
-T_740: (in ebp_13 + 0x00000008 : word32)
-  Class: Eq_740
+T_721: (in ebp_13 + 0x00000008 : word32)
+  Class: Eq_721
   DataType: ptr32
   OrigDataType: ptr32
-T_741: (in Mem19[ebp_13 + 0x00000008:word32] : word32)
-  Class: Eq_738
+T_722: (in Mem19[ebp_13 + 0x00000008:word32] : word32)
+  Class: Eq_719
   DataType: ui32
   OrigDataType: word32
-T_742: (in eax_40 : (ptr32 Eq_742))
-  Class: Eq_742
-  DataType: (ptr32 Eq_742)
-  OrigDataType: (ptr32 (struct (24 T_758 t0024)))
-T_743: (in fn004013FB : ptr32)
-  Class: Eq_743
-  DataType: (ptr32 Eq_743)
-  OrigDataType: (ptr32 (fn T_750 (T_745, T_747, T_749)))
-T_744: (in signature of fn004013FB : void)
-  Class: Eq_743
-  DataType: (ptr32 Eq_743)
+T_723: (in eax_40 : (ptr32 Eq_723))
+  Class: Eq_723
+  DataType: (ptr32 Eq_723)
+  OrigDataType: (ptr32 (struct (24 T_739 t0024)))
+T_724: (in fn004013FB : ptr32)
+  Class: Eq_724
+  DataType: (ptr32 Eq_724)
+  OrigDataType: (ptr32 (fn T_731 (T_726, T_728, T_730)))
+T_725: (in signature of fn004013FB : void)
+  Class: Eq_724
+  DataType: (ptr32 Eq_724)
   OrigDataType: 
-T_745: (in 0x00400000 : ptr32)
+T_726: (in 0x00400000 : ptr32)
   Class: Eq_493
   DataType: (ptr32 Eq_493)
   OrigDataType: ptr32
-T_746: (in 0x00400000 : ptr32)
-  Class: Eq_746
+T_727: (in 0x00400000 : ptr32)
+  Class: Eq_727
   DataType: ui32
   OrigDataType: (union (ui32 u0) (ptr32 u1))
-T_747: (in eax_32 - 0x00400000 : word32)
+T_728: (in eax_32 - 0x00400000 : word32)
   Class: Eq_494
   DataType: uint32
   OrigDataType: ui32
-T_748: (in edx : word32)
+T_729: (in edx : word32)
   Class: Eq_315
   DataType: ptr32
   OrigDataType: word32
-T_749: (in out edx : ptr32)
+T_730: (in out edx : ptr32)
   Class: Eq_492
   DataType: (ptr32 Eq_492)
   OrigDataType: ptr32
-T_750: (in fn004013FB(&globals->w400000, eax_32 - 0x00400000, out edx) : word32)
-  Class: Eq_742
-  DataType: (ptr32 Eq_742)
+T_731: (in fn004013FB(&globals->w400000, eax_32 - 0x00400000, out edx) : word32)
+  Class: Eq_723
+  DataType: (ptr32 Eq_723)
   OrigDataType: word32
-T_751: (in eax_32 - 0x00400000 : word32)
+T_732: (in eax_32 - 0x00400000 : word32)
   Class: Eq_93
   DataType: Eq_93
   OrigDataType: ui32
-T_752: (in SLICE(eax_40, word24, 8) : word24)
-  Class: Eq_709
+T_733: (in SLICE(eax_40, word24, 8) : word24)
+  Class: Eq_690
   DataType: word24
   OrigDataType: word24
-T_753: (in SLICE(eax_40, word24, 8) : word24)
-  Class: Eq_709
+T_734: (in SLICE(eax_40, word24, 8) : word24)
+  Class: Eq_690
   DataType: word24
   OrigDataType: word24
-T_754: (in 0x00000000 : word32)
+T_735: (in 0x00000000 : word32)
+  Class: Eq_723
+  DataType: (ptr32 Eq_723)
+  OrigDataType: word32
+T_736: (in eax_40 == null : bool)
+  Class: Eq_736
+  DataType: bool
+  OrigDataType: bool
+T_737: (in 0x00000024 : word32)
+  Class: Eq_737
+  DataType: word32
+  OrigDataType: word32
+T_738: (in eax_40 + 0x00000024 : word32)
+  Class: Eq_738
+  DataType: word32
+  OrigDataType: word32
+T_739: (in Mem39[eax_40 + 0x00000024:word32] : word32)
+  Class: Eq_739
+  DataType: int32
+  OrigDataType: int32
+T_740: (in 0x00000000 : word32)
+  Class: Eq_739
+  DataType: int32
+  OrigDataType: int32
+T_741: (in eax_40->dw0024 < 0x00000000 : bool)
+  Class: Eq_741
+  DataType: bool
+  OrigDataType: bool
+T_742: (in 0xFFFFFFFE : word32)
   Class: Eq_742
-  DataType: (ptr32 Eq_742)
-  OrigDataType: word32
-T_755: (in eax_40 == null : bool)
-  Class: Eq_755
-  DataType: bool
-  OrigDataType: bool
-T_756: (in 0x00000024 : word32)
-  Class: Eq_756
   DataType: word32
   OrigDataType: word32
-T_757: (in eax_40 + 0x00000024 : word32)
-  Class: Eq_757
-  DataType: word32
-  OrigDataType: word32
-T_758: (in Mem39[eax_40 + 0x00000024:word32] : word32)
-  Class: Eq_758
-  DataType: int32
-  OrigDataType: int32
-T_759: (in 0x00000000 : word32)
-  Class: Eq_758
-  DataType: int32
-  OrigDataType: int32
-T_760: (in eax_40->dw0024 < 0x00000000 : bool)
-  Class: Eq_760
-  DataType: bool
-  OrigDataType: bool
-T_761: (in 0xFFFFFFFE : word32)
-  Class: Eq_761
-  DataType: word32
-  OrigDataType: word32
-T_762: (in 0x00000004 : word32)
-  Class: Eq_762
+T_743: (in 0x00000004 : word32)
+  Class: Eq_743
   DataType: ui32
   OrigDataType: ui32
-T_763: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_763
+T_744: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_744
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_766 t0000)))
-T_764: (in 0x00000000 : word32)
-  Class: Eq_764
+  OrigDataType: (ptr32 (struct (0 T_747 t0000)))
+T_745: (in 0x00000000 : word32)
+  Class: Eq_745
   DataType: word32
   OrigDataType: word32
-T_765: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_765
+T_746: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_746
   DataType: ptr32
   OrigDataType: ptr32
-T_766: (in Mem61[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_761
+T_747: (in Mem61[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_742
   DataType: word32
   OrigDataType: word32
-T_767: (in 0x01 : byte)
-  Class: Eq_767
+T_748: (in 0x01 : byte)
+  Class: Eq_748
   DataType: byte
   OrigDataType: byte
-T_768: (in SEQ(eax_24_8_85, 0x01) : word32)
-  Class: Eq_691
+T_749: (in SEQ(eax_24_8_85, 0x01) : word32)
+  Class: Eq_672
   DataType: word32
   OrigDataType: word32
-T_769: (in ebp_69 : ptr32)
+T_750: (in ebp_69 : ptr32)
   Class: Eq_317
   DataType: ptr32
   OrigDataType: word32
-T_770: (in edi_72 : ptr32)
+T_751: (in edi_72 : ptr32)
   Class: Eq_319
   DataType: ptr32
   OrigDataType: word32
-T_771: (in esi_73 : ptr32)
+T_752: (in esi_73 : ptr32)
   Class: Eq_318
   DataType: ptr32
   OrigDataType: word32
-T_772: (in ebx_70 : ptr32)
+T_753: (in ebx_70 : ptr32)
   Class: Eq_262
   DataType: ptr32
   OrigDataType: word32
-T_773: (in fn004019C6 : ptr32)
+T_754: (in fn004019C6 : ptr32)
   Class: Eq_249
   DataType: (ptr32 Eq_249)
-  OrigDataType: (ptr32 (fn T_777 (T_692, T_694, T_774, T_775, T_776)))
-T_774: (in out ebp_69 : ptr32)
+  OrigDataType: (ptr32 (fn T_758 (T_673, T_675, T_755, T_756, T_757)))
+T_755: (in out ebp_69 : ptr32)
   Class: Eq_93
   DataType: Eq_93
   OrigDataType: ptr32
-T_775: (in out esi_73 : ptr32)
+T_756: (in out esi_73 : ptr32)
   Class: Eq_254
   DataType: ptr32
   OrigDataType: ptr32
-T_776: (in out edi_72 : ptr32)
+T_757: (in out edi_72 : ptr32)
   Class: Eq_255
   DataType: ptr32
   OrigDataType: ptr32
-T_777: (in fn004019C6(ebp_13, dwLoc0C, out ebp_69, out esi_73, out edi_72) : word32)
+T_758: (in fn004019C6(ebp_13, dwLoc0C, out ebp_69, out esi_73, out edi_72) : word32)
   Class: Eq_262
   DataType: ptr32
   OrigDataType: word32
-T_778: (in (byte) eax_84 : byte)
-  Class: Eq_690
+T_759: (in SLICE(eax_84, byte, 0) : byte)
+  Class: Eq_671
   DataType: byte
   OrigDataType: byte
-T_779: (in fn00401B98 : ptr32)
+T_760: (in fn00401B98 : ptr32)
   Class: Eq_537
   DataType: (ptr32 Eq_537)
-  OrigDataType: (ptr32 (fn T_780 ()))
-T_780: (in fn00401B98() : word32)
+  OrigDataType: (ptr32 (fn T_761 ()))
+T_761: (in fn00401B98() : word32)
   Class: Eq_536
   DataType: word32
   OrigDataType: word32
-T_781: (in 0x00000000 : word32)
+T_762: (in 0x00000000 : word32)
   Class: Eq_536
   DataType: word32
   OrigDataType: word32
-T_782: (in fn00401B98() == 0x00000000 : bool)
-  Class: Eq_782
+T_763: (in fn00401B98() == 0x00000000 : bool)
+  Class: Eq_763
   DataType: bool
   OrigDataType: bool
-T_783: (in 0x00 : byte)
+T_764: (in 0x00 : byte)
   Class: Eq_91
   DataType: byte
   OrigDataType: byte
-T_784: (in bArg04 != 0x00 : bool)
-  Class: Eq_784
+T_765: (in bArg04 != 0x00 : bool)
+  Class: Eq_765
   DataType: bool
   OrigDataType: bool
-T_785: (in 0x00000000 : word32)
-  Class: Eq_561
+T_766: (in 0x00000000 : word32)
+  Class: Eq_557
   DataType: word32
   OrigDataType: word32
-T_786: (in 0x00403338 : ptr32)
-  Class: Eq_786
+T_767: (in 0x00403338 : ptr32)
+  Class: Eq_767
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_787 t0000)))
-T_787: (in Mem23[0x00403338:word32] : word32)
-  Class: Eq_561
+  OrigDataType: (ptr32 (struct (0 T_768 t0000)))
+T_768: (in Mem23[0x00403338:word32] : word32)
+  Class: Eq_557
   DataType: word32
   OrigDataType: word32
-T_788: (in 00403354 : ptr32)
-  Class: Eq_788
+T_769: (in 00403354 : ptr32)
+  Class: Eq_769
   DataType: (ptr32 byte)
-  OrigDataType: (ptr32 (struct (0 T_789 t0000)))
-T_789: (in Mem6[0x00403354:byte] : byte)
-  Class: Eq_598
+  OrigDataType: (ptr32 (struct (0 T_770 t0000)))
+T_770: (in Mem6[0x00403354:byte] : byte)
+  Class: Eq_583
   DataType: byte
   OrigDataType: byte
-T_790: (in 0x00 : byte)
-  Class: Eq_598
+T_771: (in 0x00 : byte)
+  Class: Eq_583
   DataType: byte
   OrigDataType: byte
-T_791: (in globals->b403354 == 0x00 : bool)
-  Class: Eq_791
+T_772: (in globals->b403354 == 0x00 : bool)
+  Class: Eq_772
   DataType: bool
   OrigDataType: bool
-T_792: (in fn00401C48 : ptr32)
-  Class: Eq_593
-  DataType: (ptr32 Eq_593)
-  OrigDataType: (ptr32 (fn T_793 ()))
-T_793: (in fn00401C48() : byte)
-  Class: Eq_595
+T_773: (in fn00401C48 : ptr32)
+  Class: Eq_578
+  DataType: (ptr32 Eq_578)
+  OrigDataType: (ptr32 (fn T_774 ()))
+T_774: (in fn00401C48() : byte)
+  Class: Eq_580
   DataType: byte
   OrigDataType: byte
-T_794: (in fn00401C48 : ptr32)
-  Class: Eq_593
-  DataType: (ptr32 Eq_593)
-  OrigDataType: (ptr32 (fn T_795 ()))
-T_795: (in fn00401C48() : byte)
-  Class: Eq_595
+T_775: (in fn00401C48 : ptr32)
+  Class: Eq_578
+  DataType: (ptr32 Eq_578)
+  OrigDataType: (ptr32 (fn T_776 ()))
+T_776: (in fn00401C48() : byte)
+  Class: Eq_580
   DataType: byte
   OrigDataType: byte
-T_796: (in 0x00 : byte)
+T_777: (in 0x00 : byte)
   Class: Eq_446
   DataType: byte
   OrigDataType: byte
-T_797: (in bArg08 != 0x00 : bool)
-  Class: Eq_797
+T_778: (in bArg08 != 0x00 : bool)
+  Class: Eq_778
   DataType: bool
   OrigDataType: bool
-T_798: (in eax : ui32)
-  Class: Eq_798
+T_779: (in eax : ui32)
+  Class: Eq_779
   DataType: ui32
   OrigDataType: word32
-T_799: (in dwArg04 : ui32)
-  Class: Eq_799
+T_780: (in dwArg04 : ui32)
+  Class: Eq_780
   DataType: ui32
   OrigDataType: ui32
-T_800: (in eax_23 : word32)
+T_781: (in eax_23 : word32)
+  Class: Eq_781
+  DataType: word32
+  OrigDataType: word32
+T_782: (in eax_8 : ui32)
+  Class: Eq_611
+  DataType: ui32
+  OrigDataType: ui32
+T_783: (in 00403004 : ptr32)
+  Class: Eq_783
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_784 t0000)))
+T_784: (in Mem6[0x00403004:word32] : word32)
+  Class: Eq_611
+  DataType: ui32
+  OrigDataType: word32
+T_785: (in __ror : ptr32)
+  Class: Eq_615
+  DataType: (ptr32 Eq_615)
+  OrigDataType: (ptr32 (fn T_792 (T_788, T_791)))
+T_786: (in 0040333C : ptr32)
+  Class: Eq_786
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_787 t0000)))
+T_787: (in Mem6[0x0040333C:word32] : word32)
+  Class: Eq_614
+  DataType: ui32
+  OrigDataType: word32
+T_788: (in eax_8 ^ globals->dw40333C : word32)
+  Class: Eq_617
+  DataType: ui32
+  OrigDataType: ui32
+T_789: (in 0x0000001F : word32)
+  Class: Eq_789
+  DataType: ui32
+  OrigDataType: ui32
+T_790: (in eax_8 & 0x0000001F : word32)
+  Class: Eq_790
+  DataType: ui32
+  OrigDataType: ui32
+T_791: (in SLICE(eax_8 & 0x0000001F, byte, 0) : byte)
+  Class: Eq_618
+  DataType: byte
+  OrigDataType: byte
+T_792: (in __ror(eax_8 ^ globals->dw40333C, (byte) (eax_8 & 0x0000001F)) : word32)
+  Class: Eq_627
+  DataType: word32
+  OrigDataType: word32
+T_793: (in 0xFFFFFFFF : word32)
+  Class: Eq_627
+  DataType: word32
+  OrigDataType: word32
+T_794: (in __ror(eax_8 ^ globals->dw40333C, (byte) (eax_8 & 0x0000001F)) != 0xFFFFFFFF : bool)
+  Class: Eq_794
+  DataType: bool
+  OrigDataType: bool
+T_795: (in register_onexit_function : ptr32)
+  Class: Eq_795
+  DataType: (ptr32 code)
+  OrigDataType: (ptr32 code)
+T_796: (in signature of register_onexit_function : void)
+  Class: Eq_796
+  DataType: Eq_796
+  OrigDataType: 
+T_797: (in crt_atexit : ptr32)
+  Class: Eq_797
+  DataType: (ptr32 code)
+  OrigDataType: (ptr32 code)
+T_798: (in signature of crt_atexit : void)
+  Class: Eq_798
+  DataType: Eq_798
+  OrigDataType: 
+T_799: (in 0x00000000 : word32)
+  Class: Eq_799
+  DataType: word32
+  OrigDataType: word32
+T_800: (in -eax_23 : word32)
   Class: Eq_800
   DataType: word32
   OrigDataType: word32
-T_801: (in eax_8 : ui32)
-  Class: Eq_630
-  DataType: ui32
-  OrigDataType: ui32
-T_802: (in 00403004 : ptr32)
+T_801: (in 0x00000000 : word32)
+  Class: Eq_800
+  DataType: word32
+  OrigDataType: word32
+T_802: (in -eax_23 == 0x00000000 : bool)
   Class: Eq_802
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_803 t0000)))
-T_803: (in Mem6[0x00403004:word32] : word32)
-  Class: Eq_630
-  DataType: ui32
+  DataType: Eq_802
+  OrigDataType: (union (bool u0) (word32 u1))
+T_803: (in 0x00000000 - (-eax_23 == 0x00000000) : word32)
+  Class: Eq_803
+  DataType: word32
   OrigDataType: word32
-T_804: (in __ror : ptr32)
-  Class: Eq_634
-  DataType: (ptr32 Eq_634)
-  OrigDataType: (ptr32 (fn T_811 (T_807, T_810)))
-T_805: (in 0040333C : ptr32)
-  Class: Eq_805
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_806 t0000)))
-T_806: (in Mem6[0x0040333C:word32] : word32)
-  Class: Eq_633
-  DataType: ui32
-  OrigDataType: word32
-T_807: (in eax_8 ^ globals->dw40333C : word32)
-  Class: Eq_636
+T_804: (in ~(0x00000000 - (-eax_23 == 0x00000000)) : word32)
+  Class: Eq_804
   DataType: ui32
   OrigDataType: ui32
-T_808: (in 0x0000001F : word32)
-  Class: Eq_808
+T_805: (in ~(0x00000000 - (-eax_23 == 0x00000000)) & dwArg04 : word32)
+  Class: Eq_779
   DataType: ui32
   OrigDataType: ui32
-T_809: (in eax_8 & 0x0000001F : word32)
+T_806: (in dwArg04 : ui32)
+  Class: Eq_780
+  DataType: ui32
+  OrigDataType: word32
+T_807: (in fn00401613 : ptr32)
+  Class: Eq_807
+  DataType: (ptr32 Eq_807)
+  OrigDataType: (ptr32 (fn T_809 (T_806)))
+T_808: (in signature of fn00401613 : void)
+  Class: Eq_807
+  DataType: (ptr32 Eq_807)
+  OrigDataType: 
+T_809: (in fn00401613(dwArg04) : word32)
   Class: Eq_809
+  DataType: word32
+  OrigDataType: word32
+T_810: (in eax_15 : ui32)
+  Class: Eq_611
   DataType: ui32
   OrigDataType: ui32
-T_810: (in SLICE(eax_8 & 0x0000001F, byte, 0) : byte)
-  Class: Eq_637
-  DataType: byte
-  OrigDataType: byte
-T_811: (in __ror(eax_8 ^ globals->dw40333C, (byte) (eax_8 & 0x0000001F)) : word32)
-  Class: Eq_646
-  DataType: word32
+T_811: (in 00403004 : ptr32)
+  Class: Eq_811
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_812 t0000)))
+T_812: (in Mem13[0x00403004:word32] : word32)
+  Class: Eq_611
+  DataType: ui32
   OrigDataType: word32
-T_812: (in 0xFFFFFFFF : word32)
-  Class: Eq_646
-  DataType: word32
+T_813: (in 0xBB40E64E : word32)
+  Class: Eq_611
+  DataType: ui32
   OrigDataType: word32
-T_813: (in __ror(eax_8 ^ globals->dw40333C, (byte) (eax_8 & 0x0000001F)) != 0xFFFFFFFF : bool)
-  Class: Eq_813
+T_814: (in eax_15 == 0xBB40E64E : bool)
+  Class: Eq_814
   DataType: bool
   OrigDataType: bool
-T_814: (in register_onexit_function : ptr32)
-  Class: Eq_814
-  DataType: (ptr32 code)
-  OrigDataType: (ptr32 code)
-T_815: (in signature of register_onexit_function : void)
+T_815: (in GetSystemTimeAsFileTime : ptr32)
   Class: Eq_815
-  DataType: Eq_815
+  DataType: (ptr32 Eq_815)
+  OrigDataType: (ptr32 (fn T_821 (T_820)))
+T_816: (in signature of GetSystemTimeAsFileTime : void)
+  Class: Eq_815
+  DataType: (ptr32 Eq_815)
   OrigDataType: 
-T_816: (in crt_atexit : ptr32)
-  Class: Eq_816
-  DataType: (ptr32 code)
-  OrigDataType: (ptr32 code)
-T_817: (in signature of crt_atexit : void)
+T_817: (in lpSystemTimeAsFileTime : LPFILETIME)
   Class: Eq_817
   DataType: Eq_817
   OrigDataType: 
-T_818: (in 0x00000000 : word32)
+T_818: (in fp : ptr32)
   Class: Eq_818
-  DataType: word32
-  OrigDataType: word32
-T_819: (in -eax_23 : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_819: (in 0x00000010 : word32)
   Class: Eq_819
-  DataType: word32
-  OrigDataType: word32
-T_820: (in 0x00000000 : word32)
-  Class: Eq_819
-  DataType: word32
-  OrigDataType: word32
-T_821: (in -eax_23 == 0x00000000 : bool)
+  DataType: ui32
+  OrigDataType: ui32
+T_820: (in fp - 0x00000010 : word32)
+  Class: Eq_817
+  DataType: Eq_817
+  OrigDataType: LPFILETIME
+T_821: (in GetSystemTimeAsFileTime(fp - 0x00000010) : void)
   Class: Eq_821
-  DataType: Eq_821
-  OrigDataType: (union (bool u0) (word32 u1))
-T_822: (in 0x00000000 - (-eax_23 == 0x00000000) : word32)
+  DataType: void
+  OrigDataType: void
+T_822: (in v14_43 : ui32)
   Class: Eq_822
-  DataType: word32
-  OrigDataType: word32
-T_823: (in ~(0x00000000 - (-eax_23 == 0x00000000)) : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_823: (in dwLoc0C : word32)
   Class: Eq_823
   DataType: ui32
   OrigDataType: ui32
-T_824: (in ~(0x00000000 - (-eax_23 == 0x00000000)) & dwArg04 : word32)
-  Class: Eq_798
+T_824: (in 0x00000000 : word32)
+  Class: Eq_824
   DataType: ui32
   OrigDataType: ui32
-T_825: (in dwArg04 : ui32)
-  Class: Eq_799
+T_825: (in dwLoc0C & 0x00000000 : word32)
+  Class: Eq_825
   DataType: ui32
-  OrigDataType: word32
-T_826: (in fn00401613 : ptr32)
+  OrigDataType: ui32
+T_826: (in dwLoc10 : word32)
   Class: Eq_826
-  DataType: (ptr32 Eq_826)
-  OrigDataType: (ptr32 (fn T_828 (T_825)))
-T_827: (in signature of fn00401613 : void)
-  Class: Eq_826
-  DataType: (ptr32 Eq_826)
-  OrigDataType: 
-T_828: (in fn00401613(dwArg04) : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_827: (in 0x00000000 : word32)
+  Class: Eq_827
+  DataType: ui32
+  OrigDataType: ui32
+T_828: (in dwLoc10 & 0x00000000 : word32)
   Class: Eq_828
-  DataType: word32
-  OrigDataType: word32
-T_829: (in eax_15 : ui32)
-  Class: Eq_630
   DataType: ui32
   OrigDataType: ui32
-T_830: (in 00403004 : ptr32)
+T_829: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 : word32)
+  Class: Eq_829
+  DataType: ui32
+  OrigDataType: ui32
+T_830: (in GetCurrentThreadId : ptr32)
   Class: Eq_830
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_831 t0000)))
-T_831: (in Mem13[0x00403004:word32] : word32)
-  Class: Eq_630
-  DataType: ui32
-  OrigDataType: word32
-T_832: (in 0xBB40E64E : word32)
-  Class: Eq_630
-  DataType: ui32
-  OrigDataType: word32
-T_833: (in eax_15 == 0xBB40E64E : bool)
+  DataType: (ptr32 Eq_830)
+  OrigDataType: (ptr32 (fn T_832 ()))
+T_831: (in signature of GetCurrentThreadId : void)
+  Class: Eq_830
+  DataType: (ptr32 Eq_830)
+  OrigDataType: 
+T_832: (in GetCurrentThreadId() : DWORD)
+  Class: Eq_80
+  DataType: Eq_80
+  OrigDataType: DWORD
+T_833: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 ^ GetCurrentThreadId() : word32)
   Class: Eq_833
-  DataType: bool
-  OrigDataType: bool
-T_834: (in GetSystemTimeAsFileTime : ptr32)
-  Class: Eq_834
-  DataType: (ptr32 Eq_834)
-  OrigDataType: (ptr32 (fn T_840 (T_839)))
-T_835: (in signature of GetSystemTimeAsFileTime : void)
-  Class: Eq_834
-  DataType: (ptr32 Eq_834)
-  OrigDataType: 
-T_836: (in lpSystemTimeAsFileTime : LPFILETIME)
-  Class: Eq_836
-  DataType: Eq_836
-  OrigDataType: 
-T_837: (in fp : ptr32)
-  Class: Eq_837
-  DataType: ptr32
-  OrigDataType: ptr32
-T_838: (in 0x00000010 : word32)
-  Class: Eq_838
   DataType: ui32
   OrigDataType: ui32
-T_839: (in fp - 0x00000010 : word32)
-  Class: Eq_836
-  DataType: Eq_836
-  OrigDataType: LPFILETIME
-T_840: (in GetSystemTimeAsFileTime(fp - 0x00000010) : void)
+T_834: (in GetCurrentProcessId : ptr32)
+  Class: Eq_834
+  DataType: (ptr32 Eq_834)
+  OrigDataType: (ptr32 (fn T_836 ()))
+T_835: (in signature of GetCurrentProcessId : void)
+  Class: Eq_834
+  DataType: (ptr32 Eq_834)
+  OrigDataType: 
+T_836: (in GetCurrentProcessId() : DWORD)
+  Class: Eq_80
+  DataType: Eq_80
+  OrigDataType: DWORD
+T_837: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 ^ GetCurrentThreadId() ^ GetCurrentProcessId() : word32)
+  Class: Eq_822
+  DataType: ui32
+  OrigDataType: ui32
+T_838: (in QueryPerformanceCounter : ptr32)
+  Class: Eq_838
+  DataType: (ptr32 Eq_838)
+  OrigDataType: (ptr32 (fn T_843 (T_842)))
+T_839: (in signature of QueryPerformanceCounter : void)
+  Class: Eq_838
+  DataType: (ptr32 Eq_838)
+  OrigDataType: 
+T_840: (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
   Class: Eq_840
-  DataType: void
-  OrigDataType: void
-T_841: (in v14_43 : ui32)
+  DataType: (ptr32 Eq_840)
+  OrigDataType: 
+T_841: (in 0x00000018 : word32)
   Class: Eq_841
   DataType: ui32
   OrigDataType: ui32
-T_842: (in dwLoc0C : word32)
-  Class: Eq_842
+T_842: (in fp - 0x00000018 : word32)
+  Class: Eq_840
+  DataType: (ptr32 Eq_840)
+  OrigDataType: (ptr32 LARGE_INTEGER)
+T_843: (in QueryPerformanceCounter(fp - 0x00000018) : BOOL)
+  Class: Eq_491
+  DataType: Eq_491
+  OrigDataType: BOOL
+T_844: (in ecx_55 : ui32)
+  Class: Eq_611
   DataType: ui32
   OrigDataType: ui32
-T_843: (in 0x00000000 : word32)
-  Class: Eq_843
-  DataType: ui32
-  OrigDataType: ui32
-T_844: (in dwLoc0C & 0x00000000 : word32)
-  Class: Eq_844
-  DataType: ui32
-  OrigDataType: ui32
-T_845: (in dwLoc10 : word32)
+T_845: (in dwLoc14 : word32)
   Class: Eq_845
-  DataType: ui32
-  OrigDataType: ui32
-T_846: (in 0x00000000 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_846: (in dwLoc18 : word32)
   Class: Eq_846
-  DataType: ui32
-  OrigDataType: ui32
-T_847: (in dwLoc10 & 0x00000000 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_847: (in dwLoc14 ^ dwLoc18 : word32)
   Class: Eq_847
   DataType: ui32
   OrigDataType: ui32
-T_848: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 : word32)
+T_848: (in dwLoc14 ^ dwLoc18 ^ v14_43 : word32)
   Class: Eq_848
   DataType: ui32
   OrigDataType: ui32
-T_849: (in GetCurrentThreadId : ptr32)
+T_849: (in 0x00000008 : word32)
   Class: Eq_849
-  DataType: (ptr32 Eq_849)
-  OrigDataType: (ptr32 (fn T_851 ()))
-T_850: (in signature of GetCurrentThreadId : void)
-  Class: Eq_849
-  DataType: (ptr32 Eq_849)
-  OrigDataType: 
-T_851: (in GetCurrentThreadId() : DWORD)
-  Class: Eq_80
-  DataType: Eq_80
-  OrigDataType: DWORD
-T_852: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 ^ GetCurrentThreadId() : word32)
-  Class: Eq_852
   DataType: ui32
   OrigDataType: ui32
-T_853: (in GetCurrentProcessId : ptr32)
-  Class: Eq_853
-  DataType: (ptr32 Eq_853)
-  OrigDataType: (ptr32 (fn T_855 ()))
-T_854: (in signature of GetCurrentProcessId : void)
-  Class: Eq_853
-  DataType: (ptr32 Eq_853)
-  OrigDataType: 
-T_855: (in GetCurrentProcessId() : DWORD)
-  Class: Eq_80
-  DataType: Eq_80
-  OrigDataType: DWORD
-T_856: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 ^ GetCurrentThreadId() ^ GetCurrentProcessId() : word32)
-  Class: Eq_841
-  DataType: ui32
-  OrigDataType: ui32
-T_857: (in QueryPerformanceCounter : ptr32)
-  Class: Eq_857
-  DataType: (ptr32 Eq_857)
-  OrigDataType: (ptr32 (fn T_862 (T_861)))
-T_858: (in signature of QueryPerformanceCounter : void)
-  Class: Eq_857
-  DataType: (ptr32 Eq_857)
-  OrigDataType: 
-T_859: (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
-  Class: Eq_859
-  DataType: (ptr32 Eq_859)
-  OrigDataType: 
-T_860: (in 0x00000018 : word32)
-  Class: Eq_860
-  DataType: ui32
-  OrigDataType: ui32
-T_861: (in fp - 0x00000018 : word32)
-  Class: Eq_859
-  DataType: (ptr32 Eq_859)
-  OrigDataType: (ptr32 LARGE_INTEGER)
-T_862: (in QueryPerformanceCounter(fp - 0x00000018) : BOOL)
-  Class: Eq_491
-  DataType: Eq_491
-  OrigDataType: BOOL
-T_863: (in ecx_55 : ui32)
-  Class: Eq_630
-  DataType: ui32
-  OrigDataType: ui32
-T_864: (in dwLoc14 : word32)
-  Class: Eq_864
-  DataType: word32
-  OrigDataType: word32
-T_865: (in dwLoc18 : word32)
-  Class: Eq_865
-  DataType: word32
-  OrigDataType: word32
-T_866: (in dwLoc14 ^ dwLoc18 : word32)
-  Class: Eq_866
-  DataType: ui32
-  OrigDataType: ui32
-T_867: (in dwLoc14 ^ dwLoc18 ^ v14_43 : word32)
-  Class: Eq_867
-  DataType: ui32
-  OrigDataType: ui32
-T_868: (in 0x00000008 : word32)
-  Class: Eq_868
-  DataType: ui32
-  OrigDataType: ui32
-T_869: (in fp - 0x00000008 : word32)
-  Class: Eq_869
+T_850: (in fp - 0x00000008 : word32)
+  Class: Eq_850
   DataType: ptr32
   OrigDataType: ptr32
-T_870: (in dwLoc14 ^ dwLoc18 ^ v14_43 ^ fp - 0x00000008 : word32)
-  Class: Eq_630
+T_851: (in dwLoc14 ^ dwLoc18 ^ v14_43 ^ fp - 0x00000008 : word32)
+  Class: Eq_611
   DataType: ui32
   OrigDataType: ui32
-T_871: (in 0xBB40E64E : word32)
-  Class: Eq_630
+T_852: (in 0xBB40E64E : word32)
+  Class: Eq_611
   DataType: ui32
   OrigDataType: word32
-T_872: (in ecx_55 != 0xBB40E64E : bool)
+T_853: (in ecx_55 != 0xBB40E64E : bool)
+  Class: Eq_853
+  DataType: bool
+  OrigDataType: bool
+T_854: (in 0xFFFF0000 : word32)
+  Class: Eq_854
+  DataType: ui32
+  OrigDataType: ui32
+T_855: (in eax_15 & 0xFFFF0000 : word32)
+  Class: Eq_855
+  DataType: ui32
+  OrigDataType: ui32
+T_856: (in 0x00000000 : word32)
+  Class: Eq_855
+  DataType: ui32
+  OrigDataType: word32
+T_857: (in (eax_15 & 0xFFFF0000) == 0x00000000 : bool)
+  Class: Eq_857
+  DataType: bool
+  OrigDataType: bool
+T_858: (in ~eax_15 : word32)
+  Class: Eq_858
+  DataType: ui32
+  OrigDataType: ui32
+T_859: (in 00403000 : ptr32)
+  Class: Eq_859
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_860 t0000)))
+T_860: (in Mem75[0x00403000:word32] : word32)
+  Class: Eq_858
+  DataType: ui32
+  OrigDataType: word32
+T_861: (in 0xFFFF0000 : word32)
+  Class: Eq_861
+  DataType: ui32
+  OrigDataType: ui32
+T_862: (in ecx_55 & 0xFFFF0000 : word32)
+  Class: Eq_862
+  DataType: ui32
+  OrigDataType: ui32
+T_863: (in 0x00000000 : word32)
+  Class: Eq_862
+  DataType: ui32
+  OrigDataType: word32
+T_864: (in (ecx_55 & 0xFFFF0000) != 0x00000000 : bool)
+  Class: Eq_864
+  DataType: bool
+  OrigDataType: bool
+T_865: (in 0xBB40E64F : word32)
+  Class: Eq_611
+  DataType: ui32
+  OrigDataType: word32
+T_866: (in 00403004 : ptr32)
+  Class: Eq_866
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_867 t0000)))
+T_867: (in Mem71[0x00403004:word32] : word32)
+  Class: Eq_611
+  DataType: ui32
+  OrigDataType: word32
+T_868: (in ~ecx_55 : word32)
+  Class: Eq_858
+  DataType: ui32
+  OrigDataType: ui32
+T_869: (in 00403000 : ptr32)
+  Class: Eq_869
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_870 t0000)))
+T_870: (in Mem73[0x00403000:word32] : word32)
+  Class: Eq_858
+  DataType: ui32
+  OrigDataType: word32
+T_871: (in 0x00004711 : word32)
+  Class: Eq_871
+  DataType: ui32
+  OrigDataType: ui32
+T_872: (in ecx_55 | 0x00004711 : word32)
   Class: Eq_872
-  DataType: bool
-  OrigDataType: bool
-T_873: (in 0xFFFF0000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_873: (in 0x00000010 : word32)
   Class: Eq_873
-  DataType: ui32
-  OrigDataType: ui32
-T_874: (in eax_15 & 0xFFFF0000 : word32)
-  Class: Eq_874
-  DataType: ui32
-  OrigDataType: ui32
-T_875: (in 0x00000000 : word32)
-  Class: Eq_874
-  DataType: ui32
-  OrigDataType: word32
-T_876: (in (eax_15 & 0xFFFF0000) == 0x00000000 : bool)
-  Class: Eq_876
-  DataType: bool
-  OrigDataType: bool
-T_877: (in ~eax_15 : word32)
-  Class: Eq_877
-  DataType: ui32
-  OrigDataType: ui32
-T_878: (in 00403000 : ptr32)
-  Class: Eq_878
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_879 t0000)))
-T_879: (in Mem75[0x00403000:word32] : word32)
-  Class: Eq_877
-  DataType: ui32
-  OrigDataType: word32
-T_880: (in 0xFFFF0000 : word32)
-  Class: Eq_880
-  DataType: ui32
-  OrigDataType: ui32
-T_881: (in ecx_55 & 0xFFFF0000 : word32)
-  Class: Eq_881
-  DataType: ui32
-  OrigDataType: ui32
-T_882: (in 0x00000000 : word32)
-  Class: Eq_881
-  DataType: ui32
-  OrigDataType: word32
-T_883: (in (ecx_55 & 0xFFFF0000) != 0x00000000 : bool)
-  Class: Eq_883
-  DataType: bool
-  OrigDataType: bool
-T_884: (in 0xBB40E64F : word32)
-  Class: Eq_630
-  DataType: ui32
-  OrigDataType: word32
-T_885: (in 00403004 : ptr32)
-  Class: Eq_885
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_886 t0000)))
-T_886: (in Mem71[0x00403004:word32] : word32)
-  Class: Eq_630
-  DataType: ui32
-  OrigDataType: word32
-T_887: (in ~ecx_55 : word32)
-  Class: Eq_877
-  DataType: ui32
-  OrigDataType: ui32
-T_888: (in 00403000 : ptr32)
-  Class: Eq_888
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_889 t0000)))
-T_889: (in Mem73[0x00403000:word32] : word32)
-  Class: Eq_877
-  DataType: ui32
-  OrigDataType: word32
-T_890: (in 0x00004711 : word32)
-  Class: Eq_890
-  DataType: ui32
-  OrigDataType: ui32
-T_891: (in ecx_55 | 0x00004711 : word32)
-  Class: Eq_891
-  DataType: ui32
-  OrigDataType: ui32
-T_892: (in 0x00000010 : word32)
-  Class: Eq_892
   DataType: word32
   OrigDataType: word32
-T_893: (in (ecx_55 | 0x00004711) << 0x00000010 : word32)
-  Class: Eq_893
+T_874: (in (ecx_55 | 0x00004711) << 0x00000010 : word32)
+  Class: Eq_874
   DataType: ui32
   OrigDataType: ui32
-T_894: (in ecx_55 | (ecx_55 | 0x00004711) << 0x00000010 : word32)
-  Class: Eq_630
+T_875: (in ecx_55 | (ecx_55 | 0x00004711) << 0x00000010 : word32)
+  Class: Eq_611
   DataType: ui32
   OrigDataType: ui32
-T_895: (in InitializeSListHead : ptr32)
-  Class: Eq_895
-  DataType: (ptr32 Eq_895)
-  OrigDataType: (ptr32 (fn T_899 (T_898)))
-T_896: (in signature of InitializeSListHead : void)
-  Class: Eq_895
-  DataType: (ptr32 Eq_895)
+T_876: (in InitializeSListHead : ptr32)
+  Class: Eq_876
+  DataType: (ptr32 Eq_876)
+  OrigDataType: (ptr32 (fn T_880 (T_879)))
+T_877: (in signature of InitializeSListHead : void)
+  Class: Eq_876
+  DataType: (ptr32 Eq_876)
   OrigDataType: 
-T_897: (in ListHead : PSLIST_HEADER)
-  Class: Eq_897
-  DataType: Eq_897
+T_878: (in ListHead : PSLIST_HEADER)
+  Class: Eq_878
+  DataType: Eq_878
   OrigDataType: 
-T_898: (in 0x00403358 : word32)
-  Class: Eq_897
-  DataType: Eq_897
+T_879: (in 0x00403358 : word32)
+  Class: Eq_878
+  DataType: Eq_878
   OrigDataType: PSLIST_HEADER
-T_899: (in InitializeSListHead(&globals->u403358) : void)
-  Class: Eq_899
+T_880: (in InitializeSListHead(&globals->u403358) : void)
+  Class: Eq_880
   DataType: void
   OrigDataType: void
-T_900: (in eax_11 : word32)
-  Class: Eq_900
+T_881: (in eax_11 : word32)
+  Class: Eq_881
   DataType: word32
   OrigDataType: word32
-T_901: (in controlfp_s : ptr32)
-  Class: Eq_901
+T_882: (in controlfp_s : ptr32)
+  Class: Eq_882
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_902: (in signature of controlfp_s : void)
-  Class: Eq_902
-  DataType: Eq_902
+T_883: (in signature of controlfp_s : void)
+  Class: Eq_883
+  DataType: Eq_883
   OrigDataType: 
-T_903: (in 0x00000000 : word32)
-  Class: Eq_900
+T_884: (in 0x00000000 : word32)
+  Class: Eq_881
   DataType: word32
   OrigDataType: word32
-T_904: (in eax_11 != 0x00000000 : bool)
-  Class: Eq_904
+T_885: (in eax_11 != 0x00000000 : bool)
+  Class: Eq_885
   DataType: bool
   OrigDataType: bool
-T_905: (in fn00401774 : ptr32)
+T_886: (in fn00401774 : ptr32)
   Class: Eq_163
   DataType: (ptr32 Eq_163)
-  OrigDataType: (ptr32 (fn T_907 (T_906)))
-T_906: (in 0x00000007 : word32)
+  OrigDataType: (ptr32 (fn T_888 (T_887)))
+T_887: (in 0x00000007 : word32)
   Class: Eq_165
   DataType: word32
   OrigDataType: word32
-T_907: (in fn00401774(0x00000007) : void)
+T_888: (in fn00401774(0x00000007) : void)
   Class: Eq_169
   DataType: void
   OrigDataType: void
-T_908: (in int3 : ptr32)
-  Class: Eq_627
-  DataType: (ptr32 Eq_627)
-  OrigDataType: (ptr32 (fn T_909 ()))
-T_909: (in int3() : void)
-  Class: Eq_629
+T_889: (in int3 : ptr32)
+  Class: Eq_608
+  DataType: (ptr32 Eq_608)
+  OrigDataType: (ptr32 (fn T_890 ()))
+T_890: (in int3() : void)
+  Class: Eq_610
   DataType: void
   OrigDataType: void
-T_910: (in fn00401739 : ptr32)
-  Class: Eq_910
-  DataType: (ptr32 Eq_910)
-  OrigDataType: (ptr32 (fn T_912 ()))
-T_911: (in signature of fn00401739 : void)
-  Class: Eq_910
-  DataType: (ptr32 Eq_910)
+T_891: (in fn00401739 : ptr32)
+  Class: Eq_891
+  DataType: (ptr32 Eq_891)
+  OrigDataType: (ptr32 (fn T_893 ()))
+T_892: (in signature of fn00401739 : void)
+  Class: Eq_891
+  DataType: (ptr32 Eq_891)
   OrigDataType: 
-T_912: (in fn00401739() : word32)
-  Class: Eq_912
-  DataType: (ptr32 Eq_912)
+T_893: (in fn00401739() : word32)
+  Class: Eq_893
+  DataType: (ptr32 Eq_893)
   OrigDataType: word32
-T_913: (in eax : ptr32)
-  Class: Eq_913
+T_894: (in eax : ptr32)
+  Class: Eq_894
   DataType: ptr32
   OrigDataType: word32
-T_914: (in 0x00403360 : ptr32)
-  Class: Eq_913
+T_895: (in 0x00403360 : ptr32)
+  Class: Eq_894
   DataType: ptr32
   OrigDataType: ptr32
-T_915: (in eax_4 : (ptr32 Eq_58))
+T_896: (in eax_4 : (ptr32 Eq_58))
   Class: Eq_58
   DataType: (ptr32 Eq_58)
-  OrigDataType: (ptr32 (struct (0 T_924 t0000) (4 T_918 t0004)))
-T_916: (in fn00401050 : ptr32)
+  OrigDataType: (ptr32 (struct (0 T_905 t0000) (4 T_899 t0004)))
+T_897: (in fn00401050 : ptr32)
   Class: Eq_59
   DataType: (ptr32 Eq_59)
-  OrigDataType: (ptr32 (fn T_917 ()))
-T_917: (in fn00401050() : word32)
+  OrigDataType: (ptr32 (fn T_898 ()))
+T_898: (in fn00401050() : word32)
   Class: Eq_58
   DataType: (ptr32 Eq_58)
   OrigDataType: word32
-T_918: (in ecx_6 : word32)
+T_899: (in ecx_6 : word32)
   Class: Eq_64
   DataType: word32
   OrigDataType: word32
-T_919: (in 0x00000004 : word32)
+T_900: (in 0x00000004 : word32)
+  Class: Eq_900
+  DataType: word32
+  OrigDataType: word32
+T_901: (in eax_4 + 0x00000004 : word32)
+  Class: Eq_901
+  DataType: word32
+  OrigDataType: word32
+T_902: (in Mem0[eax_4 + 0x00000004:word32] : word32)
+  Class: Eq_64
+  DataType: word32
+  OrigDataType: word32
+T_903: (in 0x00000000 : word32)
+  Class: Eq_903
+  DataType: word32
+  OrigDataType: word32
+T_904: (in eax_4 + 0x00000000 : word32)
+  Class: Eq_904
+  DataType: ptr32
+  OrigDataType: ptr32
+T_905: (in Mem0[eax_4 + 0x00000000:word32] : word32)
+  Class: Eq_72
+  DataType: ui32
+  OrigDataType: ui32
+T_906: (in 0x00000004 : word32)
+  Class: Eq_906
+  DataType: ui32
+  OrigDataType: ui32
+T_907: (in eax_4->dw0000 | 0x00000004 : word32)
+  Class: Eq_72
+  DataType: ui32
+  OrigDataType: ui32
+T_908: (in 0x00000000 : word32)
+  Class: Eq_908
+  DataType: word32
+  OrigDataType: word32
+T_909: (in eax_4 + 0x00000000 : word32)
+  Class: Eq_909
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 ui32)
+T_910: (in Mem8[eax_4 + 0x00000000:word32] : word32)
+  Class: Eq_72
+  DataType: ui32
+  OrigDataType: ui32
+T_911: (in 0x00000004 : word32)
+  Class: Eq_911
+  DataType: word32
+  OrigDataType: word32
+T_912: (in eax_4 + 0x00000004 : word32)
+  Class: Eq_912
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_913: (in Mem11[eax_4 + 0x00000004:word32] : word32)
+  Class: Eq_64
+  DataType: word32
+  OrigDataType: word32
+T_914: (in eax_12 : (ptr32 Eq_893))
+  Class: Eq_893
+  DataType: (ptr32 Eq_893)
+  OrigDataType: (ptr32 (struct (0 T_923 t0000) (4 T_917 t0004)))
+T_915: (in fn00401739 : ptr32)
+  Class: Eq_891
+  DataType: (ptr32 Eq_891)
+  OrigDataType: (ptr32 (fn T_916 ()))
+T_916: (in fn00401739() : word32)
+  Class: Eq_893
+  DataType: (ptr32 Eq_893)
+  OrigDataType: word32
+T_917: (in ecx_13 : word32)
+  Class: Eq_917
+  DataType: word32
+  OrigDataType: word32
+T_918: (in 0x00000004 : word32)
+  Class: Eq_918
+  DataType: word32
+  OrigDataType: word32
+T_919: (in eax_12 + 0x00000004 : word32)
   Class: Eq_919
   DataType: word32
   OrigDataType: word32
-T_920: (in eax_4 + 0x00000004 : word32)
-  Class: Eq_920
+T_920: (in Mem11[eax_12 + 0x00000004:word32] : word32)
+  Class: Eq_917
   DataType: word32
   OrigDataType: word32
-T_921: (in Mem0[eax_4 + 0x00000004:word32] : word32)
-  Class: Eq_64
+T_921: (in 0x00000000 : word32)
+  Class: Eq_921
   DataType: word32
   OrigDataType: word32
-T_922: (in 0x00000000 : word32)
+T_922: (in eax_12 + 0x00000000 : word32)
   Class: Eq_922
-  DataType: word32
-  OrigDataType: word32
-T_923: (in eax_4 + 0x00000000 : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_923: (in Mem11[eax_12 + 0x00000000:word32] : word32)
   Class: Eq_923
-  DataType: ptr32
-  OrigDataType: ptr32
-T_924: (in Mem0[eax_4 + 0x00000000:word32] : word32)
-  Class: Eq_72
   DataType: ui32
   OrigDataType: ui32
-T_925: (in 0x00000004 : word32)
-  Class: Eq_925
+T_924: (in 0x00000002 : word32)
+  Class: Eq_924
   DataType: ui32
   OrigDataType: ui32
-T_926: (in eax_4->dw0000 | 0x00000004 : word32)
-  Class: Eq_72
+T_925: (in eax_12->dw0000 | 0x00000002 : word32)
+  Class: Eq_923
   DataType: ui32
   OrigDataType: ui32
-T_927: (in 0x00000000 : word32)
+T_926: (in 0x00000000 : word32)
+  Class: Eq_926
+  DataType: word32
+  OrigDataType: word32
+T_927: (in eax_12 + 0x00000000 : word32)
   Class: Eq_927
-  DataType: word32
-  OrigDataType: word32
-T_928: (in eax_4 + 0x00000000 : word32)
-  Class: Eq_928
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
-T_929: (in Mem8[eax_4 + 0x00000000:word32] : word32)
-  Class: Eq_72
+T_928: (in Mem15[eax_12 + 0x00000000:word32] : word32)
+  Class: Eq_923
   DataType: ui32
   OrigDataType: ui32
-T_930: (in 0x00000004 : word32)
+T_929: (in 0x00000004 : word32)
+  Class: Eq_929
+  DataType: word32
+  OrigDataType: word32
+T_930: (in eax_12 + 0x00000004 : word32)
   Class: Eq_930
-  DataType: word32
-  OrigDataType: word32
-T_931: (in eax_4 + 0x00000004 : word32)
-  Class: Eq_931
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_932: (in Mem11[eax_4 + 0x00000004:word32] : word32)
-  Class: Eq_64
+T_931: (in Mem18[eax_12 + 0x00000004:word32] : word32)
+  Class: Eq_917
   DataType: word32
   OrigDataType: word32
-T_933: (in eax_12 : (ptr32 Eq_912))
-  Class: Eq_912
-  DataType: (ptr32 Eq_912)
-  OrigDataType: (ptr32 (struct (0 T_942 t0000) (4 T_936 t0004)))
-T_934: (in fn00401739 : ptr32)
-  Class: Eq_910
-  DataType: (ptr32 Eq_910)
-  OrigDataType: (ptr32 (fn T_935 ()))
-T_935: (in fn00401739() : word32)
-  Class: Eq_912
-  DataType: (ptr32 Eq_912)
+T_932: (in eax : ptr32)
+  Class: Eq_932
+  DataType: ptr32
   OrigDataType: word32
-T_936: (in ecx_13 : word32)
-  Class: Eq_936
-  DataType: word32
-  OrigDataType: word32
-T_937: (in 0x00000004 : word32)
-  Class: Eq_937
-  DataType: word32
-  OrigDataType: word32
-T_938: (in eax_12 + 0x00000004 : word32)
-  Class: Eq_938
-  DataType: word32
-  OrigDataType: word32
-T_939: (in Mem11[eax_12 + 0x00000004:word32] : word32)
-  Class: Eq_936
-  DataType: word32
-  OrigDataType: word32
-T_940: (in 0x00000000 : word32)
-  Class: Eq_940
-  DataType: word32
-  OrigDataType: word32
-T_941: (in eax_12 + 0x00000000 : word32)
-  Class: Eq_941
+T_933: (in 0x00403388 : ptr32)
+  Class: Eq_932
   DataType: ptr32
   OrigDataType: ptr32
-T_942: (in Mem11[eax_12 + 0x00000000:word32] : word32)
-  Class: Eq_942
-  DataType: ui32
-  OrigDataType: ui32
-T_943: (in 0x00000002 : word32)
-  Class: Eq_943
-  DataType: ui32
-  OrigDataType: ui32
-T_944: (in eax_12->dw0000 | 0x00000002 : word32)
-  Class: Eq_942
-  DataType: ui32
-  OrigDataType: ui32
-T_945: (in 0x00000000 : word32)
-  Class: Eq_945
-  DataType: word32
+T_934: (in eax : ptr32)
+  Class: Eq_934
+  DataType: ptr32
   OrigDataType: word32
-T_946: (in eax_12 + 0x00000000 : word32)
-  Class: Eq_946
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 ui32)
-T_947: (in Mem15[eax_12 + 0x00000000:word32] : word32)
-  Class: Eq_942
-  DataType: ui32
-  OrigDataType: ui32
-T_948: (in 0x00000004 : word32)
-  Class: Eq_948
-  DataType: word32
-  OrigDataType: word32
-T_949: (in eax_12 + 0x00000004 : word32)
-  Class: Eq_949
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_950: (in Mem18[eax_12 + 0x00000004:word32] : word32)
+T_935: (in 0x00403384 : ptr32)
+  Class: Eq_934
+  DataType: ptr32
+  OrigDataType: ptr32
+T_936: (in IsProcessorFeaturePresent : ptr32)
   Class: Eq_936
-  DataType: word32
-  OrigDataType: word32
-T_951: (in eax : ptr32)
-  Class: Eq_951
-  DataType: ptr32
-  OrigDataType: word32
-T_952: (in 0x00403388 : ptr32)
-  Class: Eq_951
-  DataType: ptr32
-  OrigDataType: ptr32
-T_953: (in eax : ptr32)
-  Class: Eq_953
-  DataType: ptr32
-  OrigDataType: word32
-T_954: (in 0x00403384 : ptr32)
-  Class: Eq_953
-  DataType: ptr32
-  OrigDataType: ptr32
-T_955: (in IsProcessorFeaturePresent : ptr32)
-  Class: Eq_955
-  DataType: (ptr32 Eq_955)
-  OrigDataType: (ptr32 (fn T_959 (T_958)))
-T_956: (in signature of IsProcessorFeaturePresent : void)
-  Class: Eq_955
-  DataType: (ptr32 Eq_955)
+  DataType: (ptr32 Eq_936)
+  OrigDataType: (ptr32 (fn T_940 (T_939)))
+T_937: (in signature of IsProcessorFeaturePresent : void)
+  Class: Eq_936
+  DataType: (ptr32 Eq_936)
   OrigDataType: 
-T_957: (in ProcessorFeature : DWORD)
+T_938: (in ProcessorFeature : DWORD)
   Class: Eq_80
   DataType: Eq_80
   OrigDataType: 
-T_958: (in 0x00000017 : word32)
+T_939: (in 0x00000017 : word32)
   Class: Eq_80
   DataType: Eq_80
   OrigDataType: DWORD
-T_959: (in IsProcessorFeaturePresent(0x00000017) : BOOL)
+T_940: (in IsProcessorFeaturePresent(0x00000017) : BOOL)
   Class: Eq_491
   DataType: Eq_491
   OrigDataType: BOOL
-T_960: (in 0x00000000 : word32)
+T_941: (in 0x00000000 : word32)
   Class: Eq_491
   DataType: Eq_491
   OrigDataType: word32
-T_961: (in IsProcessorFeaturePresent(0x00000017) == 0x00000000 : bool)
-  Class: Eq_961
+T_942: (in IsProcessorFeaturePresent(0x00000017) == 0x00000000 : bool)
+  Class: Eq_942
   DataType: bool
   OrigDataType: bool
-T_962: (in 0x00000000 : word32)
-  Class: Eq_962
+T_943: (in 0x00000000 : word32)
+  Class: Eq_943
   DataType: ui32
   OrigDataType: word32
-T_963: (in 00403368 : ptr32)
-  Class: Eq_963
+T_944: (in 00403368 : ptr32)
+  Class: Eq_944
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_964 t0000)))
-T_964: (in Mem30[0x00403368:word32] : word32)
-  Class: Eq_962
+  OrigDataType: (ptr32 (struct (0 T_945 t0000)))
+T_945: (in Mem30[0x00403368:word32] : word32)
+  Class: Eq_943
   DataType: ui32
   OrigDataType: word32
-T_965: (in memset : ptr32)
-  Class: Eq_965
-  DataType: (ptr32 Eq_965)
-  OrigDataType: (ptr32 (fn T_975 (T_972, T_973, T_974)))
-T_966: (in signature of memset : void)
-  Class: Eq_965
-  DataType: (ptr32 Eq_965)
+T_946: (in memset : ptr32)
+  Class: Eq_946
+  DataType: (ptr32 Eq_946)
+  OrigDataType: (ptr32 (fn T_956 (T_953, T_954, T_955)))
+T_947: (in signature of memset : void)
+  Class: Eq_946
+  DataType: (ptr32 Eq_946)
   OrigDataType: 
-T_967: (in _Dst : (ptr32 void))
-  Class: Eq_967
+T_948: (in _Dst : (ptr32 void))
+  Class: Eq_948
   DataType: (ptr32 void)
   OrigDataType: 
-T_968: (in _Val : int32)
-  Class: Eq_968
+T_949: (in _Val : int32)
+  Class: Eq_949
   DataType: int32
   OrigDataType: 
-T_969: (in _Size : size_t)
-  Class: Eq_969
-  DataType: Eq_969
+T_950: (in _Size : size_t)
+  Class: Eq_950
+  DataType: Eq_950
   OrigDataType: 
-T_970: (in fp : ptr32)
-  Class: Eq_970
+T_951: (in fp : ptr32)
+  Class: Eq_951
   DataType: ptr32
   OrigDataType: ptr32
-T_971: (in 0x00000328 : word32)
-  Class: Eq_971
+T_952: (in 0x00000328 : word32)
+  Class: Eq_952
   DataType: ui32
   OrigDataType: ui32
-T_972: (in fp - 0x00000328 : word32)
-  Class: Eq_967
+T_953: (in fp - 0x00000328 : word32)
+  Class: Eq_948
   DataType: (ptr32 void)
   OrigDataType: (ptr32 void)
-T_973: (in 0x00000000 : word32)
-  Class: Eq_968
+T_954: (in 0x00000000 : word32)
+  Class: Eq_949
   DataType: int32
   OrigDataType: int32
-T_974: (in 0x000002CC : word32)
-  Class: Eq_969
-  DataType: Eq_969
+T_955: (in 0x000002CC : word32)
+  Class: Eq_950
+  DataType: Eq_950
   OrigDataType: size_t
-T_975: (in memset(fp - 0x00000328, 0x00000000, 0x000002CC) : (ptr32 void))
-  Class: Eq_975
+T_956: (in memset(fp - 0x00000328, 0x00000000, 0x000002CC) : (ptr32 void))
+  Class: Eq_956
   DataType: (ptr32 void)
   OrigDataType: (ptr32 void)
-T_976: (in memset : ptr32)
+T_957: (in memset : ptr32)
+  Class: Eq_946
+  DataType: (ptr32 Eq_946)
+  OrigDataType: (ptr32 (fn T_962 (T_959, T_960, T_961)))
+T_958: (in 0x0000005C : word32)
+  Class: Eq_958
+  DataType: ui32
+  OrigDataType: ui32
+T_959: (in fp - 0x0000005C : word32)
+  Class: Eq_948
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_960: (in 0x00000000 : word32)
+  Class: Eq_949
+  DataType: int32
+  OrigDataType: int32
+T_961: (in 0x00000050 : word32)
+  Class: Eq_950
+  DataType: Eq_950
+  OrigDataType: size_t
+T_962: (in memset(fp - 0x0000005C, 0x00000000, 0x00000050) : (ptr32 void))
+  Class: Eq_956
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_963: (in bl_90 : byte)
+  Class: Eq_963
+  DataType: byte
+  OrigDataType: byte
+T_964: (in 0x00 : byte)
+  Class: Eq_964
+  DataType: byte
+  OrigDataType: byte
+T_965: (in IsDebuggerPresent : ptr32)
   Class: Eq_965
   DataType: (ptr32 Eq_965)
-  OrigDataType: (ptr32 (fn T_981 (T_978, T_979, T_980)))
-T_977: (in 0x0000005C : word32)
-  Class: Eq_977
-  DataType: ui32
-  OrigDataType: ui32
-T_978: (in fp - 0x0000005C : word32)
-  Class: Eq_967
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_979: (in 0x00000000 : word32)
-  Class: Eq_968
-  DataType: int32
-  OrigDataType: int32
-T_980: (in 0x00000050 : word32)
-  Class: Eq_969
-  DataType: Eq_969
-  OrigDataType: size_t
-T_981: (in memset(fp - 0x0000005C, 0x00000000, 0x00000050) : (ptr32 void))
-  Class: Eq_975
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_982: (in bl_90 : byte)
-  Class: Eq_982
-  DataType: byte
-  OrigDataType: byte
-T_983: (in 0x00 : byte)
-  Class: Eq_983
-  DataType: byte
-  OrigDataType: byte
-T_984: (in IsDebuggerPresent : ptr32)
-  Class: Eq_984
-  DataType: (ptr32 Eq_984)
-  OrigDataType: (ptr32 (fn T_986 ()))
-T_985: (in signature of IsDebuggerPresent : void)
-  Class: Eq_984
-  DataType: (ptr32 Eq_984)
+  OrigDataType: (ptr32 (fn T_967 ()))
+T_966: (in signature of IsDebuggerPresent : void)
+  Class: Eq_965
+  DataType: (ptr32 Eq_965)
   OrigDataType: 
-T_986: (in IsDebuggerPresent() : BOOL)
+T_967: (in IsDebuggerPresent() : BOOL)
   Class: Eq_491
   DataType: Eq_491
   OrigDataType: BOOL
-T_987: (in 0x00000001 : word32)
+T_968: (in 0x00000001 : word32)
   Class: Eq_491
   DataType: Eq_491
   OrigDataType: word32
-T_988: (in IsDebuggerPresent() == 0x00000001 : bool)
-  Class: Eq_988
-  DataType: Eq_988
+T_969: (in IsDebuggerPresent() == 0x00000001 : bool)
+  Class: Eq_969
+  DataType: Eq_969
   OrigDataType: (union (bool u0) (byte u1))
-T_989: (in 0x00 - (IsDebuggerPresent() == 0x00000001) : byte)
-  Class: Eq_982
+T_970: (in 0x00 - (IsDebuggerPresent() == 0x00000001) : byte)
+  Class: Eq_963
   DataType: byte
   OrigDataType: byte
-T_990: (in SetUnhandledExceptionFilter : ptr32)
+T_971: (in SetUnhandledExceptionFilter : ptr32)
   Class: Eq_474
   DataType: (ptr32 Eq_474)
-  OrigDataType: (ptr32 (fn T_992 (T_991)))
-T_991: (in 0x00000000 : word32)
+  OrigDataType: (ptr32 (fn T_973 (T_972)))
+T_972: (in 0x00000000 : word32)
   Class: Eq_476
   DataType: Eq_476
   OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_992: (in SetUnhandledExceptionFilter(null) : LPTOP_LEVEL_EXCEPTION_FILTER)
+T_973: (in SetUnhandledExceptionFilter(null) : LPTOP_LEVEL_EXCEPTION_FILTER)
   Class: Eq_476
   DataType: Eq_476
   OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_993: (in UnhandledExceptionFilter : ptr32)
+T_974: (in UnhandledExceptionFilter : ptr32)
   Class: Eq_479
   DataType: (ptr32 Eq_479)
-  OrigDataType: (ptr32 (fn T_996 (T_995)))
-T_994: (in 0x0000000C : word32)
-  Class: Eq_994
+  OrigDataType: (ptr32 (fn T_977 (T_976)))
+T_975: (in 0x0000000C : word32)
+  Class: Eq_975
   DataType: ui32
   OrigDataType: ui32
-T_995: (in fp - 0x0000000C : word32)
+T_976: (in fp - 0x0000000C : word32)
   Class: Eq_473
   DataType: (ptr32 Eq_473)
   OrigDataType: (ptr32 (struct "_EXCEPTION_POINTERS"))
-T_996: (in UnhandledExceptionFilter(fp - 0x0000000C) : LONG)
+T_977: (in UnhandledExceptionFilter(fp - 0x0000000C) : LONG)
   Class: Eq_482
   DataType: Eq_482
   OrigDataType: LONG
-T_997: (in 0x00000000 : word32)
+T_978: (in 0x00000000 : word32)
   Class: Eq_482
   DataType: Eq_482
   OrigDataType: word32
-T_998: (in UnhandledExceptionFilter(fp - 0x0000000C) != 0x00000000 : bool)
-  Class: Eq_998
+T_979: (in UnhandledExceptionFilter(fp - 0x0000000C) != 0x00000000 : bool)
+  Class: Eq_979
   DataType: bool
   OrigDataType: bool
-T_999: (in __fastfail : ptr32)
-  Class: Eq_999
-  DataType: (ptr32 Eq_999)
-  OrigDataType: (ptr32 (fn T_1002 (T_165)))
-T_1000: (in signature of __fastfail : void)
-  Class: Eq_999
-  DataType: (ptr32 Eq_999)
+T_980: (in __fastfail : ptr32)
+  Class: Eq_980
+  DataType: (ptr32 Eq_980)
+  OrigDataType: (ptr32 (fn T_983 (T_165)))
+T_981: (in signature of __fastfail : void)
+  Class: Eq_980
+  DataType: (ptr32 Eq_980)
   OrigDataType: 
-T_1001: (in ecx : word32)
+T_982: (in ecx : word32)
   Class: Eq_165
   DataType: word32
   OrigDataType: 
-T_1002: (in __fastfail(dwArg04) : void)
-  Class: Eq_1002
+T_983: (in __fastfail(dwArg04) : void)
+  Class: Eq_983
   DataType: void
   OrigDataType: void
-T_1003: (in 00403368 : ptr32)
-  Class: Eq_1003
+T_984: (in 00403368 : ptr32)
+  Class: Eq_984
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1004 t0000)))
-T_1004: (in Mem97[0x00403368:word32] : word32)
-  Class: Eq_962
+  OrigDataType: (ptr32 (struct (0 T_985 t0000)))
+T_985: (in Mem97[0x00403368:word32] : word32)
+  Class: Eq_943
   DataType: ui32
   OrigDataType: ui32
-T_1005: (in 0x00000000 : word32)
-  Class: Eq_1005
+T_986: (in 0x00000000 : word32)
+  Class: Eq_986
   DataType: ui32
   OrigDataType: ui32
-T_1006: (in 0x01 : byte)
-  Class: Eq_1006
+T_987: (in 0x01 : byte)
+  Class: Eq_987
   DataType: byte
   OrigDataType: byte
-T_1007: (in bl_90 + 0x01 : byte)
-  Class: Eq_1007
+T_988: (in bl_90 + 0x01 : byte)
+  Class: Eq_988
   DataType: byte
   OrigDataType: byte
-T_1008: (in (word32) (bl_90 + 0x01) : word32)
-  Class: Eq_1008
+T_989: (in (word32) (bl_90 + 0x01) : word32)
+  Class: Eq_989
   DataType: word32
   OrigDataType: word32
-T_1009: (in -(word32) (bl_90 + 0x01) : word32)
-  Class: Eq_1009
+T_990: (in -(word32) (bl_90 + 0x01) : word32)
+  Class: Eq_990
   DataType: word32
   OrigDataType: word32
-T_1010: (in 0x00000000 : word32)
-  Class: Eq_1009
+T_991: (in 0x00000000 : word32)
+  Class: Eq_990
   DataType: word32
   OrigDataType: word32
-T_1011: (in -(word32) (bl_90 + 0x01) == 0x00000000 : bool)
-  Class: Eq_1011
-  DataType: Eq_1011
+T_992: (in -(word32) (bl_90 + 0x01) == 0x00000000 : bool)
+  Class: Eq_992
+  DataType: Eq_992
   OrigDataType: (union (bool u0) (ui32 u1))
-T_1012: (in 0x00000000 - (-((word32) (bl_90 + 0x01)) == 0x00000000) : word32)
-  Class: Eq_1012
+T_993: (in 0x00000000 - (-((word32) (bl_90 + 0x01)) == 0x00000000) : word32)
+  Class: Eq_993
   DataType: ui32
   OrigDataType: ui32
-T_1013: (in globals->dw403368 & 0x00000000 - (-((word32) (bl_90 + 0x01)) == 0x00000000) : word32)
-  Class: Eq_962
+T_994: (in globals->dw403368 & 0x00000000 - (-((word32) (bl_90 + 0x01)) == 0x00000000) : word32)
+  Class: Eq_943
   DataType: ui32
   OrigDataType: ui32
-T_1014: (in 00403368 : ptr32)
-  Class: Eq_1014
+T_995: (in 00403368 : ptr32)
+  Class: Eq_995
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1015 t0000)))
-T_1015: (in Mem108[0x00403368:word32] : word32)
-  Class: Eq_962
+  OrigDataType: (ptr32 (struct (0 T_996 t0000)))
+T_996: (in Mem108[0x00403368:word32] : word32)
+  Class: Eq_943
   DataType: ui32
   OrigDataType: word32
-T_1016: (in al : byte)
-  Class: Eq_1016
+T_997: (in al : byte)
+  Class: Eq_997
   DataType: byte
   OrigDataType: byte
-T_1017: (in eax_6 : Eq_1017)
-  Class: Eq_1017
-  DataType: Eq_1017
+T_998: (in eax_6 : Eq_998)
+  Class: Eq_998
+  DataType: Eq_998
   OrigDataType: HMODULE
-T_1018: (in GetModuleHandleW : ptr32)
-  Class: Eq_1018
-  DataType: (ptr32 Eq_1018)
-  OrigDataType: (ptr32 (fn T_1022 (T_1021)))
-T_1019: (in signature of GetModuleHandleW : void)
-  Class: Eq_1018
-  DataType: (ptr32 Eq_1018)
+T_999: (in GetModuleHandleW : ptr32)
+  Class: Eq_999
+  DataType: (ptr32 Eq_999)
+  OrigDataType: (ptr32 (fn T_1003 (T_1002)))
+T_1000: (in signature of GetModuleHandleW : void)
+  Class: Eq_999
+  DataType: (ptr32 Eq_999)
   OrigDataType: 
-T_1020: (in lpModuleName : LPCWSTR)
-  Class: Eq_1020
-  DataType: Eq_1020
+T_1001: (in lpModuleName : LPCWSTR)
+  Class: Eq_1001
+  DataType: Eq_1001
   OrigDataType: 
-T_1021: (in 0x00000000 : word32)
-  Class: Eq_1020
-  DataType: Eq_1020
+T_1002: (in 0x00000000 : word32)
+  Class: Eq_1001
+  DataType: Eq_1001
   OrigDataType: LPCWSTR
-T_1022: (in GetModuleHandleW(null) : HMODULE)
-  Class: Eq_1017
-  DataType: Eq_1017
+T_1003: (in GetModuleHandleW(null) : HMODULE)
+  Class: Eq_998
+  DataType: Eq_998
   OrigDataType: HMODULE
-T_1023: (in eax_24_8_36 : word24)
-  Class: Eq_1023
-  DataType: word24
-  OrigDataType: word24
-T_1024: (in SLICE(eax_6, word24, 8) : word24)
-  Class: Eq_1023
-  DataType: word24
-  OrigDataType: word24
-T_1025: (in 0x00000000 : word32)
-  Class: Eq_1017
-  DataType: Eq_1017
+T_1004: (in 0x00000000 : word32)
+  Class: Eq_998
+  DataType: Eq_998
   OrigDataType: word32
-T_1026: (in eax_6 != null : bool)
-  Class: Eq_1026
+T_1005: (in eax_6 != null : bool)
+  Class: Eq_1005
   DataType: bool
   OrigDataType: bool
-T_1027: (in 0x00005A : word24)
-  Class: Eq_1023
-  DataType: word24
-  OrigDataType: word24
-T_1028: (in 0x00000000 : word32)
-  Class: Eq_1028
+T_1006: (in 0x00000000 : word32)
+  Class: Eq_1006
   DataType: word32
   OrigDataType: word32
-T_1029: (in eax_6 + 0x00000000 : word32)
-  Class: Eq_1029
+T_1007: (in eax_6 + 0x00000000 : word32)
+  Class: Eq_1007
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
-T_1030: (in Mem5[eax_6 + 0x00000000:word16] : word16)
-  Class: Eq_1030
-  DataType: Eq_1030
+T_1008: (in Mem5[eax_6 + 0x00000000:word16] : word16)
+  Class: Eq_1008
+  DataType: Eq_1008
   OrigDataType: int32
-T_1031: (in 0x5A4D : word16)
-  Class: Eq_1030
+T_1009: (in 0x5A4D : word16)
+  Class: Eq_1008
   DataType: word16
   OrigDataType: word16
-T_1032: (in eax_6->unused != 0x5A4D : bool)
-  Class: Eq_1032
+T_1010: (in eax_6->unused != 0x5A4D : bool)
+  Class: Eq_1010
   DataType: bool
   OrigDataType: bool
-T_1033: (in 0x00 : byte)
-  Class: Eq_1033
+T_1011: (in 0x00 : byte)
+  Class: Eq_997
   DataType: byte
   OrigDataType: byte
-T_1034: (in SEQ(eax_24_8_36, 0x00) : word32)
+T_1012: (in eax_17 : (ptr32 Eq_1012))
+  Class: Eq_1012
+  DataType: (ptr32 Eq_1012)
+  OrigDataType: (ptr32 (struct (0 T_1021 t0000) (18 T_1026 t0018) (74 T_1031 t0074) (E8 T_1036 t00E8)))
+T_1013: (in 0x0000003C : word32)
+  Class: Eq_1013
+  DataType: word32
+  OrigDataType: word32
+T_1014: (in eax_6 + 0x0000003C : word32)
+  Class: Eq_1014
+  DataType: Eq_1014
+  OrigDataType: HMODULE
+T_1015: (in Mem5[eax_6 + 0x0000003C:word32] : word32)
+  Class: Eq_1015
+  DataType: int32
+  OrigDataType: int32
+T_1016: (in Mem5[eax_6 + 0x0000003C:word32] + eax_6 : word32)
+  Class: Eq_1012
+  DataType: (ptr32 Eq_1012)
+  OrigDataType: int32
+T_1017: (in eax_24_8_43 : word24)
+  Class: Eq_1017
+  DataType: word24
+  OrigDataType: word24
+T_1018: (in SLICE(eax_17, word24, 8) : word24)
+  Class: Eq_1017
+  DataType: word24
+  OrigDataType: word24
+T_1019: (in 0x00000000 : word32)
+  Class: Eq_1019
+  DataType: word32
+  OrigDataType: word32
+T_1020: (in eax_17 + 0x00000000 : word32)
+  Class: Eq_1020
+  DataType: int32
+  OrigDataType: int32
+T_1021: (in Mem5[eax_17 + 0x00000000:word32] : word32)
+  Class: Eq_1021
+  DataType: word32
+  OrigDataType: word32
+T_1022: (in 0x00004550 : word32)
+  Class: Eq_1021
+  DataType: word32
+  OrigDataType: word32
+T_1023: (in eax_17->dw0000 != 0x00004550 : bool)
+  Class: Eq_1023
+  DataType: bool
+  OrigDataType: bool
+T_1024: (in 0x00000018 : word32)
+  Class: Eq_1024
+  DataType: word32
+  OrigDataType: word32
+T_1025: (in eax_17 + 0x00000018 : word32)
+  Class: Eq_1025
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1026: (in Mem5[eax_17 + 0x00000018:word16] : word16)
+  Class: Eq_1026
+  DataType: word16
+  OrigDataType: word16
+T_1027: (in 0x010B : word16)
+  Class: Eq_1026
+  DataType: word16
+  OrigDataType: word16
+T_1028: (in eax_17->w0018 != 0x010B : bool)
+  Class: Eq_1028
+  DataType: bool
+  OrigDataType: bool
+T_1029: (in 0x00000074 : word32)
+  Class: Eq_1029
+  DataType: word32
+  OrigDataType: word32
+T_1030: (in eax_17 + 0x00000074 : word32)
+  Class: Eq_1030
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1031: (in Mem5[eax_17 + 0x00000074:word32] : word32)
+  Class: Eq_1031
+  DataType: up32
+  OrigDataType: up32
+T_1032: (in 0x0000000E : word32)
+  Class: Eq_1031
+  DataType: up32
+  OrigDataType: up32
+T_1033: (in eax_17->dw0074 <= 0x0000000E : bool)
+  Class: Eq_1033
+  DataType: bool
+  OrigDataType: bool
+T_1034: (in 0x000000E8 : word32)
   Class: Eq_1034
   DataType: word32
   OrigDataType: word32
-T_1035: (in (byte) SEQ(eax_24_8_36, 0x00) : byte)
-  Class: Eq_1016
+T_1035: (in eax_17 + 0x000000E8 : word32)
+  Class: Eq_1035
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1036: (in Mem5[eax_17 + 0x000000E8:word32] : word32)
+  Class: Eq_1036
+  DataType: word32
+  OrigDataType: word32
+T_1037: (in 0x00000000 : word32)
+  Class: Eq_1036
+  DataType: word32
+  OrigDataType: word32
+T_1038: (in eax_17->dw00E8 != 0x00000000 : bool)
+  Class: Eq_1038
+  DataType: bool
+  OrigDataType: bool
+T_1039: (in SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000) : word32)
+  Class: Eq_1039
+  DataType: word32
+  OrigDataType: word32
+T_1040: (in SLICE(SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000), byte, 0) : byte)
+  Class: Eq_997
   DataType: byte
   OrigDataType: byte
-T_1036: (in eax_17 : (ptr32 Eq_1036))
-  Class: Eq_1036
-  DataType: (ptr32 Eq_1036)
-  OrigDataType: (ptr32 (struct (0 T_1048 t0000) (18 T_1053 t0018) (74 T_1058 t0074) (E8 T_1063 t00E8)))
-T_1037: (in 0x0000003C : word32)
-  Class: Eq_1037
-  DataType: word32
-  OrigDataType: word32
-T_1038: (in eax_6 + 0x0000003C : word32)
-  Class: Eq_1038
-  DataType: Eq_1038
-  OrigDataType: HMODULE
-T_1039: (in Mem5[eax_6 + 0x0000003C:word32] : word32)
-  Class: Eq_1039
-  DataType: int32
-  OrigDataType: int32
-T_1040: (in Mem5[eax_6 + 0x0000003C:word32] + eax_6 : word32)
-  Class: Eq_1036
-  DataType: (ptr32 Eq_1036)
-  OrigDataType: int32
-T_1041: (in SLICE(eax_17, word24, 8) : word24)
-  Class: Eq_1023
-  DataType: word24
-  OrigDataType: word24
-T_1042: (in SLICE(eax_17, word24, 8) : word24)
-  Class: Eq_1023
-  DataType: word24
-  OrigDataType: word24
-T_1043: (in SLICE(eax_17, word24, 8) : word24)
-  Class: Eq_1023
-  DataType: word24
-  OrigDataType: word24
-T_1044: (in eax_24_8_43 : word24)
+T_1041: (in SetUnhandledExceptionFilter : ptr32)
+  Class: Eq_474
+  DataType: (ptr32 Eq_474)
+  OrigDataType: (ptr32 (fn T_1043 (T_1042)))
+T_1042: (in 0x004018DF : word32)
+  Class: Eq_476
+  DataType: Eq_476
+  OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
+T_1043: (in SetUnhandledExceptionFilter(&globals->t4018DF) : LPTOP_LEVEL_EXCEPTION_FILTER)
+  Class: Eq_476
+  DataType: Eq_476
+  OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
+T_1044: (in esi_10 : (ptr32 word32))
   Class: Eq_1044
-  DataType: word24
-  OrigDataType: word24
-T_1045: (in SLICE(eax_17, word24, 8) : word24)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
+T_1045: (in 0x004024C8 : ptr32)
   Class: Eq_1044
-  DataType: word24
-  OrigDataType: word24
-T_1046: (in 0x00000000 : word32)
+  DataType: (ptr32 word32)
+  OrigDataType: ptr32
+T_1046: (in true : bool)
   Class: Eq_1046
-  DataType: word32
-  OrigDataType: word32
-T_1047: (in eax_17 + 0x00000000 : word32)
+  DataType: bool
+  OrigDataType: bool
+T_1047: (in 0x00000004 : word32)
   Class: Eq_1047
   DataType: int32
   OrigDataType: int32
-T_1048: (in Mem5[eax_17 + 0x00000000:word32] : word32)
-  Class: Eq_1048
-  DataType: word32
-  OrigDataType: word32
-T_1049: (in 0x00004550 : word32)
-  Class: Eq_1048
-  DataType: word32
-  OrigDataType: word32
-T_1050: (in eax_17->dw0000 != 0x00004550 : bool)
+T_1048: (in esi_10 + 0x00000004 : word32)
+  Class: Eq_1044
+  DataType: (ptr32 word32)
+  OrigDataType: ptr32
+T_1049: (in 0x004024C8 : ptr32)
+  Class: Eq_1044
+  DataType: (ptr32 word32)
+  OrigDataType: ptr32
+T_1050: (in esi_10 < globals->a4024C8 : bool)
   Class: Eq_1050
   DataType: bool
   OrigDataType: bool
-T_1051: (in 0x00000018 : word32)
-  Class: Eq_1051
-  DataType: word32
-  OrigDataType: word32
-T_1052: (in eax_17 + 0x00000018 : word32)
-  Class: Eq_1052
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1053: (in Mem5[eax_17 + 0x00000018:word16] : word16)
-  Class: Eq_1053
-  DataType: word16
-  OrigDataType: word16
-T_1054: (in 0x010B : word16)
-  Class: Eq_1053
-  DataType: word16
-  OrigDataType: word16
-T_1055: (in eax_17->w0018 != 0x010B : bool)
-  Class: Eq_1055
-  DataType: bool
-  OrigDataType: bool
-T_1056: (in 0x00000074 : word32)
-  Class: Eq_1056
-  DataType: word32
-  OrigDataType: word32
-T_1057: (in eax_17 + 0x00000074 : word32)
-  Class: Eq_1057
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1058: (in Mem5[eax_17 + 0x00000074:word32] : word32)
-  Class: Eq_1058
-  DataType: up32
-  OrigDataType: up32
-T_1059: (in 0x0000000E : word32)
-  Class: Eq_1058
-  DataType: up32
-  OrigDataType: up32
-T_1060: (in eax_17->dw0074 <= 0x0000000E : bool)
-  Class: Eq_1060
-  DataType: bool
-  OrigDataType: bool
-T_1061: (in 0x000000E8 : word32)
-  Class: Eq_1061
-  DataType: word32
-  OrigDataType: word32
-T_1062: (in eax_17 + 0x000000E8 : word32)
-  Class: Eq_1062
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1063: (in Mem5[eax_17 + 0x000000E8:word32] : word32)
-  Class: Eq_1063
-  DataType: word32
-  OrigDataType: word32
-T_1064: (in 0x00000000 : word32)
-  Class: Eq_1063
-  DataType: word32
-  OrigDataType: word32
-T_1065: (in eax_17->dw00E8 != 0x00000000 : bool)
-  Class: Eq_1065
-  DataType: bool
-  OrigDataType: bool
-T_1066: (in SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000) : word32)
-  Class: Eq_1066
-  DataType: word32
-  OrigDataType: word32
-T_1067: (in (byte) SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000) : byte)
-  Class: Eq_1016
-  DataType: byte
-  OrigDataType: byte
-T_1068: (in SetUnhandledExceptionFilter : ptr32)
-  Class: Eq_474
-  DataType: (ptr32 Eq_474)
-  OrigDataType: (ptr32 (fn T_1070 (T_1069)))
-T_1069: (in 0x004018DF : word32)
-  Class: Eq_476
-  DataType: Eq_476
-  OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_1070: (in SetUnhandledExceptionFilter(&globals->t4018DF) : LPTOP_LEVEL_EXCEPTION_FILTER)
-  Class: Eq_476
-  DataType: Eq_476
-  OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_1071: (in esi_10 : (ptr32 word32))
-  Class: Eq_1071
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
-T_1072: (in 0x004024C8 : ptr32)
-  Class: Eq_1071
-  DataType: (ptr32 word32)
-  OrigDataType: ptr32
-T_1073: (in true : bool)
-  Class: Eq_1073
-  DataType: bool
-  OrigDataType: bool
-T_1074: (in 0x00000004 : word32)
-  Class: Eq_1074
-  DataType: int32
-  OrigDataType: int32
-T_1075: (in esi_10 + 0x00000004 : word32)
-  Class: Eq_1071
-  DataType: (ptr32 word32)
-  OrigDataType: ptr32
-T_1076: (in 0x004024C8 : ptr32)
-  Class: Eq_1071
-  DataType: (ptr32 word32)
-  OrigDataType: ptr32
-T_1077: (in esi_10 < globals->a4024C8 : bool)
-  Class: Eq_1077
-  DataType: bool
-  OrigDataType: bool
-T_1078: (in fn00401976 : ptr32)
+T_1051: (in fn00401976 : ptr32)
   Class: Eq_350
   DataType: (ptr32 Eq_350)
-  OrigDataType: (ptr32 (fn T_1079 ()))
-T_1079: (in fn00401976() : void)
+  OrigDataType: (ptr32 (fn T_1052 ()))
+T_1052: (in fn00401976() : void)
   Class: Eq_352
   DataType: void
   OrigDataType: void
-T_1080: (in ecx_27 : word32)
-  Class: Eq_1080
+T_1053: (in ecx_27 : word32)
+  Class: Eq_1053
   DataType: word32
   OrigDataType: word32
-T_1081: (in fn00000000 : ptr32)
-  Class: Eq_1081
+T_1054: (in fn00000000 : ptr32)
+  Class: Eq_1054
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_1082: (in signature of fn00000000 : void)
-  Class: Eq_1082
-  DataType: Eq_1082
+T_1055: (in signature of fn00000000 : void)
+  Class: Eq_1055
+  DataType: Eq_1055
   OrigDataType: 
-T_1083: (in edi_19 : word32)
-  Class: Eq_1083
+T_1056: (in edi_19 : word32)
+  Class: Eq_1056
   DataType: word32
   OrigDataType: word32
-T_1084: (in 0x00000000 : word32)
-  Class: Eq_1084
+T_1057: (in 0x00000000 : word32)
+  Class: Eq_1057
   DataType: word32
   OrigDataType: word32
-T_1085: (in esi_10 + 0x00000000 : word32)
-  Class: Eq_1085
+T_1058: (in esi_10 + 0x00000000 : word32)
+  Class: Eq_1058
   DataType: ptr32
   OrigDataType: ptr32
-T_1086: (in Mem16[esi_10 + 0x00000000:word32] : word32)
-  Class: Eq_1083
+T_1059: (in Mem16[esi_10 + 0x00000000:word32] : word32)
+  Class: Eq_1056
   DataType: word32
   OrigDataType: word32
-T_1087: (in 0x00000000 : word32)
-  Class: Eq_1083
+T_1060: (in 0x00000000 : word32)
+  Class: Eq_1056
   DataType: word32
   OrigDataType: word32
-T_1088: (in edi_19 == 0x00000000 : bool)
-  Class: Eq_1088
+T_1061: (in edi_19 == 0x00000000 : bool)
+  Class: Eq_1061
   DataType: bool
   OrigDataType: bool
-T_1089: (in 004020D0 : ptr32)
-  Class: Eq_1089
+T_1062: (in 004020D0 : ptr32)
+  Class: Eq_1062
   DataType: (ptr32 (ptr32 code))
-  OrigDataType: (ptr32 (struct (0 T_1090 t0000)))
-T_1090: (in Mem0[0x004020D0:word32] : word32)
-  Class: Eq_1090
+  OrigDataType: (ptr32 (struct (0 T_1063 t0000)))
+T_1063: (in Mem0[0x004020D0:word32] : word32)
+  Class: Eq_1063
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_1091: (in ebp : ptr32)
-  Class: Eq_1091
+T_1064: (in ebp : ptr32)
+  Class: Eq_1064
   DataType: ptr32
   OrigDataType: word32
-T_1092: (in esp_14 : ptr32)
-  Class: Eq_1092
+T_1065: (in esp_14 : ptr32)
+  Class: Eq_1065
   DataType: ptr32
   OrigDataType: ptr32
-T_1093: (in fp : ptr32)
-  Class: Eq_1093
+T_1066: (in fp : ptr32)
+  Class: Eq_1066
   DataType: ptr32
   OrigDataType: ptr32
-T_1094: (in 8 : int32)
-  Class: Eq_1094
+T_1067: (in 8 : int32)
+  Class: Eq_1067
   DataType: int32
   OrigDataType: int32
-T_1095: (in fp - 8 : word32)
-  Class: Eq_1095
+T_1068: (in fp - 8 : word32)
+  Class: Eq_1068
   DataType: ptr32
   OrigDataType: ptr32
-T_1096: (in fp - 8 - dwArg08 : word32)
-  Class: Eq_1092
+T_1069: (in fp - 8 - dwArg08 : word32)
+  Class: Eq_1065
   DataType: ptr32
   OrigDataType: ptr32
-T_1097: (in 4 : int32)
-  Class: Eq_1097
+T_1070: (in 4 : int32)
+  Class: Eq_1070
   DataType: int32
   OrigDataType: int32
-T_1098: (in esp_14 - 4 : word32)
-  Class: Eq_1098
+T_1071: (in esp_14 - 4 : word32)
+  Class: Eq_1071
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1101 t0000)))
-T_1099: (in 0x00000000 : word32)
-  Class: Eq_1099
+  OrigDataType: (ptr32 (struct (0 T_1074 t0000)))
+T_1072: (in 0x00000000 : word32)
+  Class: Eq_1072
   DataType: word32
   OrigDataType: word32
-T_1100: (in esp_14 - 4 + 0x00000000 : word32)
-  Class: Eq_1100
+T_1073: (in esp_14 - 4 + 0x00000000 : word32)
+  Class: Eq_1073
   DataType: ptr32
   OrigDataType: ptr32
-T_1101: (in Mem17[esp_14 - 4 + 0x00000000:word32] : word32)
+T_1074: (in Mem17[esp_14 - 4 + 0x00000000:word32] : word32)
   Class: Eq_82
   DataType: word32
   OrigDataType: word32
-T_1102: (in 8 : int32)
-  Class: Eq_1102
+T_1075: (in 8 : int32)
+  Class: Eq_1075
   DataType: int32
   OrigDataType: int32
-T_1103: (in esp_14 - 8 : word32)
-  Class: Eq_1103
+T_1076: (in esp_14 - 8 : word32)
+  Class: Eq_1076
   DataType: (ptr32 Eq_91)
-  OrigDataType: (ptr32 (struct (0 T_1106 t0000)))
-T_1104: (in 0x00000000 : word32)
-  Class: Eq_1104
+  OrigDataType: (ptr32 (struct (0 T_1079 t0000)))
+T_1077: (in 0x00000000 : word32)
+  Class: Eq_1077
   DataType: word32
   OrigDataType: word32
-T_1105: (in esp_14 - 8 + 0x00000000 : word32)
-  Class: Eq_1105
+T_1078: (in esp_14 - 8 + 0x00000000 : word32)
+  Class: Eq_1078
   DataType: ptr32
   OrigDataType: ptr32
-T_1106: (in Mem20[esp_14 - 8 + 0x00000000:word32] : word32)
+T_1079: (in Mem20[esp_14 - 8 + 0x00000000:word32] : word32)
   Class: Eq_91
   DataType: Eq_91
   OrigDataType: word32
-T_1107: (in 12 : int32)
-  Class: Eq_1107
+T_1080: (in 12 : int32)
+  Class: Eq_1080
   DataType: int32
   OrigDataType: int32
-T_1108: (in esp_14 - 12 : word32)
-  Class: Eq_1108
+T_1081: (in esp_14 - 12 : word32)
+  Class: Eq_1081
   DataType: (ptr32 Eq_91)
+  OrigDataType: (ptr32 (struct (0 T_1084 t0000)))
+T_1082: (in 0x00000000 : word32)
+  Class: Eq_1082
+  DataType: word32
+  OrigDataType: word32
+T_1083: (in esp_14 - 12 + 0x00000000 : word32)
+  Class: Eq_1083
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1084: (in Mem23[esp_14 - 12 + 0x00000000:word32] : word32)
+  Class: Eq_91
+  DataType: Eq_91
+  OrigDataType: word32
+T_1085: (in 00403004 : ptr32)
+  Class: Eq_1085
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1086 t0000)))
+T_1086: (in Mem23[0x00403004:word32] : word32)
+  Class: Eq_611
+  DataType: ui32
+  OrigDataType: word32
+T_1087: (in 0x00000008 : word32)
+  Class: Eq_1087
+  DataType: int32
+  OrigDataType: int32
+T_1088: (in fp + 0x00000008 : word32)
+  Class: Eq_1088
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1089: (in globals->dw403004 ^ fp + 0x00000008 : word32)
+  Class: Eq_1089
+  DataType: ui32
+  OrigDataType: ui32
+T_1090: (in 16 : int32)
+  Class: Eq_1090
+  DataType: int32
+  OrigDataType: int32
+T_1091: (in esp_14 - 16 : word32)
+  Class: Eq_1091
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1094 t0000)))
+T_1092: (in 0x00000000 : word32)
+  Class: Eq_1092
+  DataType: word32
+  OrigDataType: word32
+T_1093: (in esp_14 - 16 + 0x00000000 : word32)
+  Class: Eq_1093
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1094: (in Mem32[esp_14 - 16 + 0x00000000:word32] : word32)
+  Class: Eq_1089
+  DataType: ui32
+  OrigDataType: word32
+T_1095: (in 20 : int32)
+  Class: Eq_1095
+  DataType: int32
+  OrigDataType: int32
+T_1096: (in esp_14 - 20 : word32)
+  Class: Eq_1096
+  DataType: (ptr32 Eq_93)
+  OrigDataType: (ptr32 (struct (0 T_1099 t0000)))
+T_1097: (in 0x00000000 : word32)
+  Class: Eq_1097
+  DataType: word32
+  OrigDataType: word32
+T_1098: (in esp_14 - 20 + 0x00000000 : word32)
+  Class: Eq_1098
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1099: (in Mem36[esp_14 - 20 + 0x00000000:word32] : word32)
+  Class: Eq_93
+  DataType: Eq_93
+  OrigDataType: word32
+T_1100: (in 0x00000008 : word32)
+  Class: Eq_1100
+  DataType: ui32
+  OrigDataType: ui32
+T_1101: (in fp - 0x00000008 : word32)
+  Class: Eq_1101
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1102: (in fs : selector)
+  Class: Eq_1102
+  DataType: (ptr32 Eq_1102)
+  OrigDataType: (ptr32 (segment (0 T_1104 t0000)))
+T_1103: (in 0x00000000 : word32)
+  Class: Eq_1103
+  DataType: (memptr (ptr32 Eq_1102) ptr32)
+  OrigDataType: (memptr T_1102 (struct (0 T_1104 t0000)))
+T_1104: (in Mem41[fs:0x00000000:word32] : word32)
+  Class: Eq_1101
+  DataType: ptr32
+  OrigDataType: word32
+T_1105: (in fp + 0x00000008 : word32)
+  Class: Eq_1064
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1106: (in ebx : word32)
+  Class: Eq_1106
+  DataType: word32
+  OrigDataType: word32
+T_1107: (in 0x00000010 : word32)
+  Class: Eq_1107
+  DataType: ui32
+  OrigDataType: ui32
+T_1108: (in ebp - 0x00000010 : word32)
+  Class: Eq_1108
+  DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_1111 t0000)))
 T_1109: (in 0x00000000 : word32)
   Class: Eq_1109
   DataType: word32
   OrigDataType: word32
-T_1110: (in esp_14 - 12 + 0x00000000 : word32)
+T_1110: (in ebp - 0x00000010 + 0x00000000 : word32)
   Class: Eq_1110
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1111: (in Mem23[esp_14 - 12 + 0x00000000:word32] : word32)
-  Class: Eq_91
-  DataType: Eq_91
+  DataType: word32
   OrigDataType: word32
-T_1112: (in 00403004 : ptr32)
+T_1111: (in Mem0[ebp - 0x00000010 + 0x00000000:word32] : word32)
+  Class: Eq_1111
+  DataType: word32
+  OrigDataType: word32
+T_1112: (in fs : selector)
   Class: Eq_1112
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1113 t0000)))
-T_1113: (in Mem23[0x00403004:word32] : word32)
-  Class: Eq_630
-  DataType: ui32
+  DataType: (ptr32 Eq_1112)
+  OrigDataType: (ptr32 (segment (0 T_1114 t0000)))
+T_1113: (in 0x00000000 : ptr32)
+  Class: Eq_1113
+  DataType: Eq_1113
+  OrigDataType: (union (ptr32 u0) ((memptr T_1112 (struct (0 word32 dw0000))) u1))
+T_1114: (in Mem8[fs:0x00000000:word32] : word32)
+  Class: Eq_1111
+  DataType: word32
   OrigDataType: word32
-T_1114: (in 0x00000008 : word32)
-  Class: Eq_1114
-  DataType: int32
-  OrigDataType: int32
-T_1115: (in fp + 0x00000008 : word32)
-  Class: Eq_1115
+T_1115: (in ebp_19 : Eq_93)
+  Class: Eq_93
+  DataType: Eq_93
+  OrigDataType: word32
+T_1116: (in 0x00000000 : word32)
+  Class: Eq_1116
+  DataType: word32
+  OrigDataType: word32
+T_1117: (in ebp + 0x00000000 : word32)
+  Class: Eq_1117
   DataType: ptr32
   OrigDataType: ptr32
-T_1116: (in globals->dw403004 ^ fp + 0x00000008 : word32)
-  Class: Eq_1116
-  DataType: ui32
-  OrigDataType: ui32
-T_1117: (in 16 : int32)
-  Class: Eq_1117
-  DataType: int32
-  OrigDataType: int32
-T_1118: (in esp_14 - 16 : word32)
-  Class: Eq_1118
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1121 t0000)))
+T_1118: (in Mem8[ebp + 0x00000000:word32] : word32)
+  Class: Eq_93
+  DataType: Eq_93
+  OrigDataType: word32
 T_1119: (in 0x00000000 : word32)
   Class: Eq_1119
   DataType: word32
   OrigDataType: word32
-T_1120: (in esp_14 - 16 + 0x00000000 : word32)
+T_1120: (in ebp + 0x00000000 : word32)
   Class: Eq_1120
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1121: (in Mem32[esp_14 - 16 + 0x00000000:word32] : word32)
-  Class: Eq_1116
-  DataType: ui32
-  OrigDataType: word32
-T_1122: (in 20 : int32)
-  Class: Eq_1122
-  DataType: int32
-  OrigDataType: int32
-T_1123: (in esp_14 - 20 : word32)
-  Class: Eq_1123
-  DataType: (ptr32 Eq_93)
-  OrigDataType: (ptr32 (struct (0 T_1126 t0000)))
-T_1124: (in 0x00000000 : word32)
-  Class: Eq_1124
-  DataType: word32
-  OrigDataType: word32
-T_1125: (in esp_14 - 20 + 0x00000000 : word32)
-  Class: Eq_1125
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1126: (in Mem36[esp_14 - 20 + 0x00000000:word32] : word32)
-  Class: Eq_93
-  DataType: Eq_93
-  OrigDataType: word32
-T_1127: (in 0x00000008 : word32)
-  Class: Eq_1127
-  DataType: ui32
-  OrigDataType: ui32
-T_1128: (in fp - 0x00000008 : word32)
-  Class: Eq_1128
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1129: (in fs : selector)
-  Class: Eq_1129
-  DataType: (ptr32 Eq_1129)
-  OrigDataType: (ptr32 (segment (0 T_1131 t0000)))
-T_1130: (in 0x00000000 : word32)
-  Class: Eq_1130
-  DataType: (memptr (ptr32 Eq_1129) ptr32)
-  OrigDataType: (memptr T_1129 (struct (0 T_1131 t0000)))
-T_1131: (in Mem41[fs:0x00000000:word32] : word32)
-  Class: Eq_1128
-  DataType: ptr32
-  OrigDataType: word32
-T_1132: (in fp + 0x00000008 : word32)
-  Class: Eq_1091
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1133: (in ebx : word32)
-  Class: Eq_1133
-  DataType: word32
-  OrigDataType: word32
-T_1134: (in 0x00000010 : word32)
-  Class: Eq_1134
-  DataType: ui32
-  OrigDataType: ui32
-T_1135: (in ebp - 0x00000010 : word32)
-  Class: Eq_1135
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1138 t0000)))
-T_1136: (in 0x00000000 : word32)
-  Class: Eq_1136
-  DataType: word32
-  OrigDataType: word32
-T_1137: (in ebp - 0x00000010 + 0x00000000 : word32)
-  Class: Eq_1137
-  DataType: word32
-  OrigDataType: word32
-T_1138: (in Mem0[ebp - 0x00000010 + 0x00000000:word32] : word32)
-  Class: Eq_1138
-  DataType: word32
-  OrigDataType: word32
-T_1139: (in fs : selector)
-  Class: Eq_1139
-  DataType: (ptr32 Eq_1139)
-  OrigDataType: (ptr32 (segment (0 T_1141 t0000)))
-T_1140: (in 0x00000000 : ptr32)
-  Class: Eq_1140
-  DataType: Eq_1140
-  OrigDataType: (union (ptr32 u0) ((memptr T_1139 (struct (0 word32 dw0000))) u1))
-T_1141: (in Mem8[fs:0x00000000:word32] : word32)
-  Class: Eq_1138
-  DataType: word32
-  OrigDataType: word32
-T_1142: (in ebp_19 : Eq_93)
-  Class: Eq_93
-  DataType: Eq_93
-  OrigDataType: word32
-T_1143: (in 0x00000000 : word32)
-  Class: Eq_1143
-  DataType: word32
-  OrigDataType: word32
-T_1144: (in ebp + 0x00000000 : word32)
-  Class: Eq_1144
-  DataType: ptr32
-  OrigDataType: ptr32
-T_1145: (in Mem8[ebp + 0x00000000:word32] : word32)
-  Class: Eq_93
-  DataType: Eq_93
-  OrigDataType: word32
-T_1146: (in 0x00000000 : word32)
-  Class: Eq_1146
-  DataType: word32
-  OrigDataType: word32
-T_1147: (in ebp + 0x00000000 : word32)
-  Class: Eq_1147
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_1148: (in Mem22[ebp + 0x00000000:word32] : word32)
+T_1121: (in Mem22[ebp + 0x00000000:word32] : word32)
   Class: Eq_93
   DataType: Eq_93
   OrigDataType: word32
-T_1149: (in dwArg0C : word32)
+T_1122: (in dwArg0C : word32)
   Class: Eq_254
   DataType: ptr32
   OrigDataType: word32
-T_1150: (in dwArg08 : word32)
+T_1123: (in dwArg08 : word32)
   Class: Eq_255
   DataType: ptr32
   OrigDataType: word32
-T_1151: (in dwArg10 : word32)
-  Class: Eq_1133
+T_1124: (in dwArg10 : word32)
+  Class: Eq_1106
   DataType: word32
   OrigDataType: word32
-T_1152: (in 0040336C : ptr32)
-  Class: Eq_1152
+T_1125: (in 0040336C : ptr32)
+  Class: Eq_1125
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1153 t0000)))
-T_1153: (in Mem6[0x0040336C:word32] : word32)
-  Class: Eq_1153
+  OrigDataType: (ptr32 (struct (0 T_1126 t0000)))
+T_1126: (in Mem6[0x0040336C:word32] : word32)
+  Class: Eq_1126
   DataType: ui32
   OrigDataType: ui32
-T_1154: (in 0x00000000 : word32)
-  Class: Eq_1154
+T_1127: (in 0x00000000 : word32)
+  Class: Eq_1127
   DataType: ui32
   OrigDataType: ui32
-T_1155: (in globals->dw40336C & 0x00000000 : word32)
-  Class: Eq_1153
+T_1128: (in globals->dw40336C & 0x00000000 : word32)
+  Class: Eq_1126
   DataType: ui32
   OrigDataType: ui32
-T_1156: (in 0040336C : ptr32)
-  Class: Eq_1156
+T_1129: (in 0040336C : ptr32)
+  Class: Eq_1129
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1157 t0000)))
-T_1157: (in Mem9[0x0040336C:word32] : word32)
-  Class: Eq_1153
+  OrigDataType: (ptr32 (struct (0 T_1130 t0000)))
+T_1130: (in Mem9[0x0040336C:word32] : word32)
+  Class: Eq_1126
   DataType: ui32
   OrigDataType: word32
-T_1158: (in 00403010 : ptr32)
-  Class: Eq_1158
+T_1131: (in 00403010 : ptr32)
+  Class: Eq_1131
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1159 t0000)))
-T_1159: (in Mem14[0x00403010:word32] : word32)
-  Class: Eq_1159
+  OrigDataType: (ptr32 (struct (0 T_1132 t0000)))
+T_1132: (in Mem14[0x00403010:word32] : word32)
+  Class: Eq_1132
   DataType: ui32
   OrigDataType: ui32
-T_1160: (in 0x00000001 : word32)
-  Class: Eq_1160
+T_1133: (in 0x00000001 : word32)
+  Class: Eq_1133
   DataType: ui32
   OrigDataType: ui32
-T_1161: (in globals->dw403010 | 0x00000001 : word32)
-  Class: Eq_1159
+T_1134: (in globals->dw403010 | 0x00000001 : word32)
+  Class: Eq_1132
   DataType: ui32
   OrigDataType: ui32
-T_1162: (in 00403010 : ptr32)
-  Class: Eq_1162
+T_1135: (in 00403010 : ptr32)
+  Class: Eq_1135
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1163 t0000)))
-T_1163: (in Mem18[0x00403010:word32] : word32)
-  Class: Eq_1159
+  OrigDataType: (ptr32 (struct (0 T_1136 t0000)))
+T_1136: (in Mem18[0x00403010:word32] : word32)
+  Class: Eq_1132
   DataType: ui32
   OrigDataType: word32
-T_1164: (in IsProcessorFeaturePresent : ptr32)
-  Class: Eq_955
-  DataType: (ptr32 Eq_955)
-  OrigDataType: (ptr32 (fn T_1166 (T_1165)))
-T_1165: (in 0x0000000A : word32)
+T_1137: (in IsProcessorFeaturePresent : ptr32)
+  Class: Eq_936
+  DataType: (ptr32 Eq_936)
+  OrigDataType: (ptr32 (fn T_1139 (T_1138)))
+T_1138: (in 0x0000000A : word32)
   Class: Eq_80
   DataType: Eq_80
   OrigDataType: DWORD
-T_1166: (in IsProcessorFeaturePresent(0x0000000A) : BOOL)
+T_1139: (in IsProcessorFeaturePresent(0x0000000A) : BOOL)
   Class: Eq_491
   DataType: Eq_491
   OrigDataType: BOOL
-T_1167: (in 0x00000000 : word32)
+T_1140: (in 0x00000000 : word32)
   Class: Eq_491
   DataType: Eq_491
   OrigDataType: word32
-T_1168: (in IsProcessorFeaturePresent(0x0000000A) == 0x00000000 : bool)
-  Class: Eq_1168
+T_1141: (in IsProcessorFeaturePresent(0x0000000A) == 0x00000000 : bool)
+  Class: Eq_1141
   DataType: bool
   OrigDataType: bool
-T_1169: (in edi_101 : ui32)
+T_1142: (in edi_101 : ui32)
+  Class: Eq_1142
+  DataType: ui32
+  OrigDataType: ui32
+T_1143: (in 00403010 : ptr32)
+  Class: Eq_1143
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1144 t0000)))
+T_1144: (in Mem28[0x00403010:word32] : word32)
+  Class: Eq_1132
+  DataType: ui32
+  OrigDataType: ui32
+T_1145: (in 0x00000002 : word32)
+  Class: Eq_1145
+  DataType: ui32
+  OrigDataType: ui32
+T_1146: (in globals->dw403010 | 0x00000002 : word32)
+  Class: Eq_1132
+  DataType: ui32
+  OrigDataType: ui32
+T_1147: (in 00403010 : ptr32)
+  Class: Eq_1147
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1148 t0000)))
+T_1148: (in Mem32[0x00403010:word32] : word32)
+  Class: Eq_1132
+  DataType: ui32
+  OrigDataType: word32
+T_1149: (in 0x00000001 : word32)
+  Class: Eq_1126
+  DataType: ui32
+  OrigDataType: word32
+T_1150: (in 0040336C : ptr32)
+  Class: Eq_1150
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1151 t0000)))
+T_1151: (in Mem41[0x0040336C:word32] : word32)
+  Class: Eq_1126
+  DataType: ui32
+  OrigDataType: word32
+T_1152: (in __cpuid : ptr32)
+  Class: Eq_1152
+  DataType: (ptr32 Eq_1152)
+  OrigDataType: (ptr32 (fn T_1169 (T_1160, T_1161, T_1163, T_1165, T_1167, T_1168)))
+T_1153: (in signature of __cpuid : void)
+  Class: Eq_1152
+  DataType: (ptr32 Eq_1152)
+  OrigDataType: 
+T_1154: (in  : word32)
+  Class: Eq_1154
+  DataType: word32
+  OrigDataType: 
+T_1155: (in  : word32)
+  Class: Eq_1155
+  DataType: word32
+  OrigDataType: 
+T_1156: (in  : ptr32)
+  Class: Eq_1156
+  DataType: (ptr32 word32)
+  OrigDataType: 
+T_1157: (in  : ptr32)
+  Class: Eq_1157
+  DataType: (ptr32 word32)
+  OrigDataType: 
+T_1158: (in  : ptr32)
+  Class: Eq_1158
+  DataType: (ptr32 word32)
+  OrigDataType: 
+T_1159: (in  : ptr32)
+  Class: Eq_1159
+  DataType: (ptr32 word32)
+  OrigDataType: 
+T_1160: (in 0x00000000 : word32)
+  Class: Eq_1154
+  DataType: word32
+  OrigDataType: word32
+T_1161: (in 0x00000000 : word32)
+  Class: Eq_1155
+  DataType: word32
+  OrigDataType: word32
+T_1162: (in 0x00000000 : word32)
+  Class: Eq_1162
+  DataType: word32
+  OrigDataType: word32
+T_1163: (in &0x00000000 : ptr32)
+  Class: Eq_1156
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1164: (in 0x00000001 : word32)
+  Class: Eq_1164
+  DataType: word32
+  OrigDataType: word32
+T_1165: (in &0x00000001 : ptr32)
+  Class: Eq_1157
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1166: (in 0x00000000 : word32)
+  Class: Eq_1166
+  DataType: word32
+  OrigDataType: word32
+T_1167: (in &0x00000000 : ptr32)
+  Class: Eq_1158
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1168: (in &edx : ptr32)
+  Class: Eq_1159
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1169: (in __cpuid(0x00000000, 0x00000000, &0x00000000, &0x00000001, &0x00000000, &edx) : void)
   Class: Eq_1169
-  DataType: ui32
-  OrigDataType: ui32
-T_1170: (in 00403010 : ptr32)
-  Class: Eq_1170
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1171 t0000)))
-T_1171: (in Mem28[0x00403010:word32] : word32)
-  Class: Eq_1159
-  DataType: ui32
-  OrigDataType: ui32
-T_1172: (in 0x00000002 : word32)
-  Class: Eq_1172
-  DataType: ui32
-  OrigDataType: ui32
-T_1173: (in globals->dw403010 | 0x00000002 : word32)
-  Class: Eq_1159
-  DataType: ui32
-  OrigDataType: ui32
-T_1174: (in 00403010 : ptr32)
-  Class: Eq_1174
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1175 t0000)))
-T_1175: (in Mem32[0x00403010:word32] : word32)
-  Class: Eq_1159
-  DataType: ui32
-  OrigDataType: word32
-T_1176: (in 0x00000001 : word32)
-  Class: Eq_1153
-  DataType: ui32
-  OrigDataType: word32
-T_1177: (in 0040336C : ptr32)
-  Class: Eq_1177
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1178 t0000)))
-T_1178: (in Mem41[0x0040336C:word32] : word32)
-  Class: Eq_1153
-  DataType: ui32
-  OrigDataType: word32
-T_1179: (in __cpuid : ptr32)
-  Class: Eq_1179
-  DataType: (ptr32 Eq_1179)
-  OrigDataType: (ptr32 (fn T_1196 (T_1187, T_1188, T_1190, T_1192, T_1194, T_1195)))
-T_1180: (in signature of __cpuid : void)
-  Class: Eq_1179
-  DataType: (ptr32 Eq_1179)
-  OrigDataType: 
-T_1181: (in  : word32)
-  Class: Eq_1181
-  DataType: word32
-  OrigDataType: 
-T_1182: (in  : word32)
-  Class: Eq_1182
-  DataType: word32
-  OrigDataType: 
-T_1183: (in  : ptr32)
-  Class: Eq_1183
-  DataType: (ptr32 word32)
-  OrigDataType: 
-T_1184: (in  : ptr32)
-  Class: Eq_1184
-  DataType: (ptr32 word32)
-  OrigDataType: 
-T_1185: (in  : ptr32)
-  Class: Eq_1185
-  DataType: (ptr32 word32)
-  OrigDataType: 
-T_1186: (in  : ptr32)
-  Class: Eq_1186
-  DataType: (ptr32 word32)
-  OrigDataType: 
-T_1187: (in 0x00000000 : word32)
-  Class: Eq_1181
-  DataType: word32
-  OrigDataType: word32
-T_1188: (in 0x00000000 : word32)
-  Class: Eq_1182
-  DataType: word32
-  OrigDataType: word32
-T_1189: (in 0x00000000 : word32)
-  Class: Eq_1189
-  DataType: word32
-  OrigDataType: word32
-T_1190: (in &0x00000000 : ptr32)
-  Class: Eq_1183
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1191: (in 0x00000001 : word32)
-  Class: Eq_1191
-  DataType: word32
-  OrigDataType: word32
-T_1192: (in &0x00000001 : ptr32)
-  Class: Eq_1184
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1193: (in 0x00000000 : word32)
-  Class: Eq_1193
-  DataType: word32
-  OrigDataType: word32
-T_1194: (in &0x00000000 : ptr32)
-  Class: Eq_1185
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1195: (in &edx : ptr32)
-  Class: Eq_1186
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1196: (in __cpuid(0x00000000, 0x00000000, &0x00000000, &0x00000001, &0x00000000, &edx) : void)
-  Class: Eq_1196
   DataType: void
   OrigDataType: void
-T_1197: (in __cpuid : ptr32)
-  Class: Eq_1179
-  DataType: (ptr32 Eq_1179)
-  OrigDataType: (ptr32 (fn T_1207 (T_1198, T_1199, T_1201, T_1203, T_1205, T_1206)))
-T_1198: (in 0x00000001 : word32)
-  Class: Eq_1181
+T_1170: (in __cpuid : ptr32)
+  Class: Eq_1152
+  DataType: (ptr32 Eq_1152)
+  OrigDataType: (ptr32 (fn T_1180 (T_1171, T_1172, T_1174, T_1176, T_1178, T_1179)))
+T_1171: (in 0x00000001 : word32)
+  Class: Eq_1154
   DataType: word32
   OrigDataType: word32
-T_1199: (in 0x00000000 : word32)
-  Class: Eq_1182
+T_1172: (in 0x00000000 : word32)
+  Class: Eq_1155
   DataType: word32
   OrigDataType: word32
-T_1200: (in 0x00000001 : word32)
-  Class: Eq_1200
+T_1173: (in 0x00000001 : word32)
+  Class: Eq_1173
   DataType: word32
   OrigDataType: word32
-T_1201: (in &0x00000001 : ptr32)
-  Class: Eq_1183
+T_1174: (in &0x00000001 : ptr32)
+  Class: Eq_1156
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
+T_1175: (in 0x00000001 : word32)
+  Class: Eq_1175
+  DataType: word32
+  OrigDataType: word32
+T_1176: (in &0x00000001 : ptr32)
+  Class: Eq_1157
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1177: (in 0x00000000 : word32)
+  Class: Eq_1177
+  DataType: word32
+  OrigDataType: word32
+T_1178: (in &0x00000000 : ptr32)
+  Class: Eq_1158
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1179: (in &edx : ptr32)
+  Class: Eq_1159
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1180: (in __cpuid(0x00000001, 0x00000000, &0x00000001, &0x00000001, &0x00000000, &edx) : void)
+  Class: Eq_1169
+  DataType: void
+  OrigDataType: void
+T_1181: (in bLoc14_258 : byte)
+  Class: Eq_1181
+  DataType: byte
+  OrigDataType: byte
+T_1182: (in dwLoc14 : word32)
+  Class: Eq_1182
+  DataType: ui32
+  OrigDataType: ui32
+T_1183: (in 0x00000000 : word32)
+  Class: Eq_1183
+  DataType: ui32
+  OrigDataType: ui32
+T_1184: (in dwLoc14 & 0x00000000 : word32)
+  Class: Eq_1184
+  DataType: ui32
+  OrigDataType: ui32
+T_1185: (in SLICE(dwLoc14 & 0x00000000, byte, 0) : byte)
+  Class: Eq_1181
+  DataType: byte
+  OrigDataType: byte
+T_1186: (in 0x49656E69 : word32)
+  Class: Eq_1186
+  DataType: word32
+  OrigDataType: word32
+T_1187: (in edx ^ 0x49656E69 : word32)
+  Class: Eq_1187
+  DataType: ui32
+  OrigDataType: ui32
+T_1188: (in 0x6C65746E : word32)
+  Class: Eq_1188
+  DataType: ui32
+  OrigDataType: ui32
+T_1189: (in edx ^ 0x49656E69 | 0x6C65746E : word32)
+  Class: Eq_1189
+  DataType: ui32
+  OrigDataType: ui32
+T_1190: (in 0x756E6546 : word32)
+  Class: Eq_1190
+  DataType: ui32
+  OrigDataType: ui32
+T_1191: (in edx ^ 0x49656E69 | 0x6C65746E | 0x756E6546 : word32)
+  Class: Eq_1191
+  DataType: ui32
+  OrigDataType: ui32
+T_1192: (in 0x00000000 : word32)
+  Class: Eq_1191
+  DataType: ui32
+  OrigDataType: word32
+T_1193: (in (edx ^ 0x49656E69 | 0x6C65746E | 0x756E6546) != 0x00000000 : bool)
+  Class: Eq_1193
+  DataType: bool
+  OrigDataType: bool
+T_1194: (in 00403370 : ptr32)
+  Class: Eq_1194
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1195 t0000)))
+T_1195: (in Mem81[0x00403370:word32] : word32)
+  Class: Eq_1142
+  DataType: ui32
+  OrigDataType: word32
+T_1196: (in 0x00000000 : word32)
+  Class: Eq_1196
+  DataType: word32
+  OrigDataType: word32
+T_1197: (in 0x000106C0 : word32)
+  Class: Eq_1196
+  DataType: word32
+  OrigDataType: word32
+T_1198: (in 0x00000000 == 0x000106C0 : bool)
+  Class: Eq_1198
+  DataType: bool
+  OrigDataType: bool
+T_1199: (in edi_100 : ui32)
+  Class: Eq_1142
+  DataType: ui32
+  OrigDataType: ui32
+T_1200: (in 00403370 : ptr32)
+  Class: Eq_1200
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1201 t0000)))
+T_1201: (in Mem81[0x00403370:word32] : word32)
+  Class: Eq_1142
+  DataType: ui32
+  OrigDataType: word32
 T_1202: (in 0x00000001 : word32)
   Class: Eq_1202
-  DataType: word32
-  OrigDataType: word32
-T_1203: (in &0x00000001 : ptr32)
-  Class: Eq_1184
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1204: (in 0x00000000 : word32)
-  Class: Eq_1204
-  DataType: word32
-  OrigDataType: word32
-T_1205: (in &0x00000000 : ptr32)
-  Class: Eq_1185
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1206: (in &edx : ptr32)
-  Class: Eq_1186
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1207: (in __cpuid(0x00000001, 0x00000000, &0x00000001, &0x00000001, &0x00000000, &edx) : void)
-  Class: Eq_1196
-  DataType: void
-  OrigDataType: void
-T_1208: (in bLoc14_258 : byte)
-  Class: Eq_1208
-  DataType: byte
-  OrigDataType: byte
-T_1209: (in dwLoc14 : word32)
-  Class: Eq_1209
   DataType: ui32
   OrigDataType: ui32
+T_1203: (in edi_100 | 0x00000001 : word32)
+  Class: Eq_1142
+  DataType: ui32
+  OrigDataType: ui32
+T_1204: (in 00403370 : ptr32)
+  Class: Eq_1204
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1205 t0000)))
+T_1205: (in Mem104[0x00403370:word32] : word32)
+  Class: Eq_1142
+  DataType: ui32
+  OrigDataType: word32
+T_1206: (in edi_100 | 0x00000001 : word32)
+  Class: Eq_1142
+  DataType: ui32
+  OrigDataType: ui32
+T_1207: (in 0x00000000 : word32)
+  Class: Eq_1207
+  DataType: word32
+  OrigDataType: word32
+T_1208: (in 0x00020660 : word32)
+  Class: Eq_1207
+  DataType: word32
+  OrigDataType: word32
+T_1209: (in 0x00000000 == 0x00020660 : bool)
+  Class: Eq_1209
+  DataType: bool
+  OrigDataType: bool
 T_1210: (in 0x00000000 : word32)
   Class: Eq_1210
-  DataType: ui32
-  OrigDataType: ui32
-T_1211: (in dwLoc14 & 0x00000000 : word32)
-  Class: Eq_1211
-  DataType: ui32
-  OrigDataType: ui32
-T_1212: (in SLICE(dwLoc14 & 0x00000000, byte, 0) : byte)
-  Class: Eq_1208
-  DataType: byte
-  OrigDataType: byte
-T_1213: (in 0x49656E69 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_1211: (in 0x00020670 : word32)
+  Class: Eq_1210
+  DataType: word32
+  OrigDataType: word32
+T_1212: (in 0x00000000 == 0x00020670 : bool)
+  Class: Eq_1212
+  DataType: bool
+  OrigDataType: bool
+T_1213: (in 0x00000000 : word32)
   Class: Eq_1213
   DataType: word32
   OrigDataType: word32
-T_1214: (in edx ^ 0x49656E69 : word32)
-  Class: Eq_1214
-  DataType: ui32
-  OrigDataType: ui32
-T_1215: (in 0x6C65746E : word32)
-  Class: Eq_1215
-  DataType: ui32
-  OrigDataType: ui32
-T_1216: (in edx ^ 0x49656E69 | 0x6C65746E : word32)
-  Class: Eq_1216
-  DataType: ui32
-  OrigDataType: ui32
-T_1217: (in 0x756E6546 : word32)
-  Class: Eq_1217
-  DataType: ui32
-  OrigDataType: ui32
-T_1218: (in edx ^ 0x49656E69 | 0x6C65746E | 0x756E6546 : word32)
-  Class: Eq_1218
-  DataType: ui32
-  OrigDataType: ui32
-T_1219: (in 0x00000000 : word32)
-  Class: Eq_1218
-  DataType: ui32
+T_1214: (in 0x00030650 : word32)
+  Class: Eq_1213
+  DataType: word32
   OrigDataType: word32
-T_1220: (in (edx ^ 0x49656E69 | 0x6C65746E | 0x756E6546) != 0x00000000 : bool)
+T_1215: (in 0x00000000 == 0x00030650 : bool)
+  Class: Eq_1215
+  DataType: bool
+  OrigDataType: bool
+T_1216: (in 0x00000000 : word32)
+  Class: Eq_1216
+  DataType: word32
+  OrigDataType: word32
+T_1217: (in 0x00030660 : word32)
+  Class: Eq_1216
+  DataType: word32
+  OrigDataType: word32
+T_1218: (in 0x00000000 == 0x00030660 : bool)
+  Class: Eq_1218
+  DataType: bool
+  OrigDataType: bool
+T_1219: (in true : bool)
+  Class: Eq_1219
+  DataType: bool
+  OrigDataType: bool
+T_1220: (in true : bool)
   Class: Eq_1220
   DataType: bool
   OrigDataType: bool
-T_1221: (in 00403370 : ptr32)
+T_1221: (in 0x00000000 : word32)
   Class: Eq_1221
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1222 t0000)))
-T_1222: (in Mem81[0x00403370:word32] : word32)
-  Class: Eq_1169
-  DataType: ui32
-  OrigDataType: word32
-T_1223: (in 0x00000000 : word32)
-  Class: Eq_1223
   DataType: word32
   OrigDataType: word32
-T_1224: (in 0x000106C0 : word32)
-  Class: Eq_1223
+T_1222: (in 0x00000000 : word32)
+  Class: Eq_1221
   DataType: word32
   OrigDataType: word32
-T_1225: (in 0x00000000 == 0x000106C0 : bool)
-  Class: Eq_1225
+T_1223: (in 0x00000000 == 0x00000000 : bool)
+  Class: Eq_1223
   DataType: bool
   OrigDataType: bool
-T_1226: (in edi_100 : ui32)
-  Class: Eq_1169
-  DataType: ui32
-  OrigDataType: ui32
-T_1227: (in 00403370 : ptr32)
-  Class: Eq_1227
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1228 t0000)))
-T_1228: (in Mem81[0x00403370:word32] : word32)
-  Class: Eq_1169
-  DataType: ui32
+T_1224: (in __cpuid : ptr32)
+  Class: Eq_1152
+  DataType: (ptr32 Eq_1152)
+  OrigDataType: (ptr32 (fn T_1234 (T_1225, T_1226, T_1228, T_1230, T_1232, T_1233)))
+T_1225: (in 0x00000007 : word32)
+  Class: Eq_1154
+  DataType: word32
   OrigDataType: word32
+T_1226: (in 0x00000000 : word32)
+  Class: Eq_1155
+  DataType: word32
+  OrigDataType: word32
+T_1227: (in 0x00000007 : word32)
+  Class: Eq_1227
+  DataType: word32
+  OrigDataType: word32
+T_1228: (in &0x00000007 : ptr32)
+  Class: Eq_1156
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_1229: (in 0x00000001 : word32)
   Class: Eq_1229
-  DataType: ui32
-  OrigDataType: ui32
-T_1230: (in edi_100 | 0x00000001 : word32)
-  Class: Eq_1169
-  DataType: ui32
-  OrigDataType: ui32
-T_1231: (in 00403370 : ptr32)
+  DataType: word32
+  OrigDataType: word32
+T_1230: (in &0x00000001 : ptr32)
+  Class: Eq_1157
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1231: (in 0x00000000 : word32)
   Class: Eq_1231
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1232 t0000)))
-T_1232: (in Mem104[0x00403370:word32] : word32)
-  Class: Eq_1169
-  DataType: ui32
+  DataType: word32
   OrigDataType: word32
-T_1233: (in edi_100 | 0x00000001 : word32)
+T_1232: (in &0x00000000 : ptr32)
+  Class: Eq_1158
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1233: (in &edx : ptr32)
+  Class: Eq_1159
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1234: (in __cpuid(0x00000007, 0x00000000, &0x00000007, &0x00000001, &0x00000000, &edx) : void)
   Class: Eq_1169
+  DataType: void
+  OrigDataType: void
+T_1235: (in 0x01 : byte)
+  Class: Eq_1181
+  DataType: byte
+  OrigDataType: byte
+T_1236: (in 0x00000000 : word32)
+  Class: Eq_1236
+  DataType: word32
+  OrigDataType: word32
+T_1237: (in 0x00000000 : word32)
+  Class: Eq_1236
+  DataType: word32
+  OrigDataType: word32
+T_1238: (in 0x00000000 == 0x00000000 : bool)
+  Class: Eq_1238
+  DataType: bool
+  OrigDataType: bool
+T_1239: (in 0x00000002 : word32)
+  Class: Eq_1239
   DataType: ui32
   OrigDataType: ui32
-T_1234: (in 0x00000000 : word32)
-  Class: Eq_1234
-  DataType: word32
+T_1240: (in edi_101 | 0x00000002 : word32)
+  Class: Eq_1142
+  DataType: ui32
+  OrigDataType: ui32
+T_1241: (in 00403370 : ptr32)
+  Class: Eq_1241
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1242 t0000)))
+T_1242: (in Mem150[0x00403370:word32] : word32)
+  Class: Eq_1142
+  DataType: ui32
   OrigDataType: word32
-T_1235: (in 0x00020660 : word32)
-  Class: Eq_1234
-  DataType: word32
-  OrigDataType: word32
-T_1236: (in 0x00000000 == 0x00020660 : bool)
-  Class: Eq_1236
-  DataType: bool
-  OrigDataType: bool
-T_1237: (in 0x00000000 : word32)
-  Class: Eq_1237
-  DataType: word32
-  OrigDataType: word32
-T_1238: (in 0x00020670 : word32)
-  Class: Eq_1237
-  DataType: word32
-  OrigDataType: word32
-T_1239: (in 0x00000000 == 0x00020670 : bool)
-  Class: Eq_1239
-  DataType: bool
-  OrigDataType: bool
-T_1240: (in 0x00000000 : word32)
-  Class: Eq_1240
-  DataType: word32
-  OrigDataType: word32
-T_1241: (in 0x00030650 : word32)
-  Class: Eq_1240
-  DataType: word32
-  OrigDataType: word32
-T_1242: (in 0x00000000 == 0x00030650 : bool)
-  Class: Eq_1242
-  DataType: bool
-  OrigDataType: bool
-T_1243: (in 0x00000000 : word32)
+T_1243: (in 00403010 : ptr32)
   Class: Eq_1243
-  DataType: word32
-  OrigDataType: word32
-T_1244: (in 0x00030660 : word32)
-  Class: Eq_1243
-  DataType: word32
-  OrigDataType: word32
-T_1245: (in 0x00000000 == 0x00030660 : bool)
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1244 t0000)))
+T_1244: (in Mem152[0x00403010:word32] : word32)
+  Class: Eq_1132
+  DataType: ui32
+  OrigDataType: ui32
+T_1245: (in 0x00000004 : word32)
   Class: Eq_1245
-  DataType: bool
-  OrigDataType: bool
-T_1246: (in true : bool)
-  Class: Eq_1246
-  DataType: bool
-  OrigDataType: bool
-T_1247: (in true : bool)
+  DataType: ui32
+  OrigDataType: ui32
+T_1246: (in globals->dw403010 | 0x00000004 : word32)
+  Class: Eq_1132
+  DataType: ui32
+  OrigDataType: ui32
+T_1247: (in 00403010 : ptr32)
   Class: Eq_1247
-  DataType: bool
-  OrigDataType: bool
-T_1248: (in 0x00000000 : word32)
-  Class: Eq_1248
-  DataType: word32
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1248 t0000)))
+T_1248: (in Mem162[0x00403010:word32] : word32)
+  Class: Eq_1132
+  DataType: ui32
   OrigDataType: word32
-T_1249: (in 0x00000000 : word32)
-  Class: Eq_1248
-  DataType: word32
+T_1249: (in 0x00000002 : word32)
+  Class: Eq_1126
+  DataType: ui32
   OrigDataType: word32
-T_1250: (in 0x00000000 == 0x00000000 : bool)
+T_1250: (in 0040336C : ptr32)
   Class: Eq_1250
-  DataType: bool
-  OrigDataType: bool
-T_1251: (in __cpuid : ptr32)
-  Class: Eq_1179
-  DataType: (ptr32 Eq_1179)
-  OrigDataType: (ptr32 (fn T_1261 (T_1252, T_1253, T_1255, T_1257, T_1259, T_1260)))
-T_1252: (in 0x00000007 : word32)
-  Class: Eq_1181
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1251 t0000)))
+T_1251: (in Mem164[0x0040336C:word32] : word32)
+  Class: Eq_1126
+  DataType: ui32
+  OrigDataType: word32
+T_1252: (in 0x00000000 : word32)
+  Class: Eq_1252
   DataType: word32
   OrigDataType: word32
 T_1253: (in 0x00000000 : word32)
-  Class: Eq_1182
+  Class: Eq_1252
   DataType: word32
   OrigDataType: word32
-T_1254: (in 0x00000007 : word32)
+T_1254: (in 0x00000000 == 0x00000000 : bool)
   Class: Eq_1254
-  DataType: word32
-  OrigDataType: word32
-T_1255: (in &0x00000007 : ptr32)
-  Class: Eq_1183
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1256: (in 0x00000001 : word32)
-  Class: Eq_1256
-  DataType: word32
-  OrigDataType: word32
-T_1257: (in &0x00000001 : ptr32)
-  Class: Eq_1184
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1258: (in 0x00000000 : word32)
-  Class: Eq_1258
-  DataType: word32
-  OrigDataType: word32
-T_1259: (in &0x00000000 : ptr32)
-  Class: Eq_1185
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1260: (in &edx : ptr32)
-  Class: Eq_1186
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1261: (in __cpuid(0x00000007, 0x00000000, &0x00000007, &0x00000001, &0x00000000, &edx) : void)
-  Class: Eq_1196
-  DataType: void
-  OrigDataType: void
-T_1262: (in 0x01 : byte)
-  Class: Eq_1208
-  DataType: byte
-  OrigDataType: byte
-T_1263: (in 0x00000000 : word32)
-  Class: Eq_1263
-  DataType: word32
-  OrigDataType: word32
-T_1264: (in 0x00000000 : word32)
-  Class: Eq_1263
-  DataType: word32
-  OrigDataType: word32
-T_1265: (in 0x00000000 == 0x00000000 : bool)
-  Class: Eq_1265
   DataType: bool
   OrigDataType: bool
-T_1266: (in 0x00000002 : word32)
-  Class: Eq_1266
+T_1255: (in 0x00000000 : word32)
+  Class: Eq_1255
+  DataType: word32
+  OrigDataType: word32
+T_1256: (in 0x00000000 : word32)
+  Class: Eq_1255
+  DataType: word32
+  OrigDataType: word32
+T_1257: (in 0x00000000 == 0x00000000 : bool)
+  Class: Eq_1257
+  DataType: bool
+  OrigDataType: bool
+T_1258: (in __xgetbv : ptr32)
+  Class: Eq_1258
+  DataType: (ptr32 Eq_1258)
+  OrigDataType: (ptr32 (fn T_1262 (T_1261)))
+T_1259: (in signature of __xgetbv : void)
+  Class: Eq_1258
+  DataType: (ptr32 Eq_1258)
+  OrigDataType: 
+T_1260: (in  : word32)
+  Class: Eq_1260
+  DataType: word32
+  OrigDataType: 
+T_1261: (in 0x00000000 : word32)
+  Class: Eq_1260
+  DataType: word32
+  OrigDataType: word32
+T_1262: (in __xgetbv(0x00000000) : word64)
+  Class: Eq_1262
+  DataType: word64
+  OrigDataType: word64
+T_1263: (in SLICE(__xgetbv(0x00000000), word32, 0) : word32)
+  Class: Eq_1263
   DataType: ui32
   OrigDataType: ui32
-T_1267: (in edi_101 | 0x00000002 : word32)
-  Class: Eq_1169
+T_1264: (in 0x00000006 : word32)
+  Class: Eq_1264
   DataType: ui32
   OrigDataType: ui32
-T_1268: (in 00403370 : ptr32)
-  Class: Eq_1268
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1269 t0000)))
-T_1269: (in Mem150[0x00403370:word32] : word32)
-  Class: Eq_1169
+T_1265: (in (word32) __xgetbv(0x00000000) & 0x00000006 : word32)
+  Class: Eq_1265
+  DataType: ui32
+  OrigDataType: ui32
+T_1266: (in 0x00000006 : word32)
+  Class: Eq_1265
   DataType: ui32
   OrigDataType: word32
+T_1267: (in ((word32) __xgetbv(0x00000000) & 0x00000006) != 0x00000006 : bool)
+  Class: Eq_1267
+  DataType: bool
+  OrigDataType: bool
+T_1268: (in false : bool)
+  Class: Eq_1268
+  DataType: bool
+  OrigDataType: bool
+T_1269: (in eax_187 : ui32)
+  Class: Eq_1132
+  DataType: ui32
+  OrigDataType: ui32
 T_1270: (in 00403010 : ptr32)
   Class: Eq_1270
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 (struct (0 T_1271 t0000)))
-T_1271: (in Mem152[0x00403010:word32] : word32)
-  Class: Eq_1159
+T_1271: (in Mem177[0x00403010:word32] : word32)
+  Class: Eq_1132
   DataType: ui32
-  OrigDataType: ui32
-T_1272: (in 0x00000004 : word32)
-  Class: Eq_1272
+  OrigDataType: word32
+T_1272: (in 0x00000003 : word32)
+  Class: Eq_1126
   DataType: ui32
-  OrigDataType: ui32
-T_1273: (in globals->dw403010 | 0x00000004 : word32)
-  Class: Eq_1159
-  DataType: ui32
-  OrigDataType: ui32
-T_1274: (in 00403010 : ptr32)
-  Class: Eq_1274
+  OrigDataType: word32
+T_1273: (in 0040336C : ptr32)
+  Class: Eq_1273
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1275 t0000)))
-T_1275: (in Mem162[0x00403010:word32] : word32)
-  Class: Eq_1159
+  OrigDataType: (ptr32 (struct (0 T_1274 t0000)))
+T_1274: (in Mem189[0x0040336C:word32] : word32)
+  Class: Eq_1126
   DataType: ui32
   OrigDataType: word32
-T_1276: (in 0x00000002 : word32)
-  Class: Eq_1153
+T_1275: (in 0x00000008 : word32)
+  Class: Eq_1275
   DataType: ui32
-  OrigDataType: word32
-T_1277: (in 0040336C : ptr32)
+  OrigDataType: ui32
+T_1276: (in eax_187 | 0x00000008 : word32)
+  Class: Eq_1132
+  DataType: ui32
+  OrigDataType: ui32
+T_1277: (in 00403010 : ptr32)
   Class: Eq_1277
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 (struct (0 T_1278 t0000)))
-T_1278: (in Mem164[0x0040336C:word32] : word32)
-  Class: Eq_1153
+T_1278: (in Mem192[0x00403010:word32] : word32)
+  Class: Eq_1132
   DataType: ui32
   OrigDataType: word32
-T_1279: (in 0x00000000 : word32)
+T_1279: (in 0x20 : byte)
   Class: Eq_1279
-  DataType: word32
-  OrigDataType: word32
-T_1280: (in 0x00000000 : word32)
-  Class: Eq_1279
-  DataType: word32
-  OrigDataType: word32
-T_1281: (in 0x00000000 == 0x00000000 : bool)
-  Class: Eq_1281
+  DataType: byte
+  OrigDataType: byte
+T_1280: (in bLoc14_258 & 0x20 : byte)
+  Class: Eq_1280
+  DataType: byte
+  OrigDataType: byte
+T_1281: (in 0x00 : byte)
+  Class: Eq_1280
+  DataType: byte
+  OrigDataType: byte
+T_1282: (in (bLoc14_258 & 0x20) == 0x00 : bool)
+  Class: Eq_1282
   DataType: bool
   OrigDataType: bool
-T_1282: (in 0x00000000 : word32)
-  Class: Eq_1282
-  DataType: word32
+T_1283: (in 0x00000005 : word32)
+  Class: Eq_1126
+  DataType: ui32
   OrigDataType: word32
-T_1283: (in 0x00000000 : word32)
-  Class: Eq_1282
-  DataType: word32
-  OrigDataType: word32
-T_1284: (in 0x00000000 == 0x00000000 : bool)
+T_1284: (in 0040336C : ptr32)
   Class: Eq_1284
-  DataType: bool
-  OrigDataType: bool
-T_1285: (in __xgetbv : ptr32)
-  Class: Eq_1285
-  DataType: (ptr32 Eq_1285)
-  OrigDataType: (ptr32 (fn T_1289 (T_1288)))
-T_1286: (in signature of __xgetbv : void)
-  Class: Eq_1285
-  DataType: (ptr32 Eq_1285)
-  OrigDataType: 
-T_1287: (in  : word32)
-  Class: Eq_1287
-  DataType: word32
-  OrigDataType: 
-T_1288: (in 0x00000000 : word32)
-  Class: Eq_1287
-  DataType: word32
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1285 t0000)))
+T_1285: (in Mem197[0x0040336C:word32] : word32)
+  Class: Eq_1126
+  DataType: ui32
   OrigDataType: word32
-T_1289: (in __xgetbv(0x00000000) : word64)
+T_1286: (in eax_187 | 0x00000008 : word32)
+  Class: Eq_1286
+  DataType: ui32
+  OrigDataType: ui32
+T_1287: (in 0x00000020 : word32)
+  Class: Eq_1287
+  DataType: ui32
+  OrigDataType: ui32
+T_1288: (in eax_187 | 0x00000008 | 0x00000020 : word32)
+  Class: Eq_1132
+  DataType: ui32
+  OrigDataType: ui32
+T_1289: (in 00403010 : ptr32)
   Class: Eq_1289
-  DataType: word64
-  OrigDataType: word64
-T_1290: (in SLICE(__xgetbv(0x00000000), word32, 0) : word32)
-  Class: Eq_1290
-  DataType: ui32
-  OrigDataType: ui32
-T_1291: (in 0x00000006 : word32)
-  Class: Eq_1291
-  DataType: ui32
-  OrigDataType: ui32
-T_1292: (in (word32) __xgetbv(0x00000000) & 0x00000006 : word32)
-  Class: Eq_1292
-  DataType: ui32
-  OrigDataType: ui32
-T_1293: (in 0x00000006 : word32)
-  Class: Eq_1292
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1290 t0000)))
+T_1290: (in Mem198[0x00403010:word32] : word32)
+  Class: Eq_1132
   DataType: ui32
   OrigDataType: word32
-T_1294: (in ((word32) __xgetbv(0x00000000) & 0x00000006) != 0x00000006 : bool)
-  Class: Eq_1294
-  DataType: bool
-  OrigDataType: bool
-T_1295: (in false : bool)
+T_1291: (in eax : uint32)
+  Class: Eq_1291
+  DataType: uint32
+  OrigDataType: word32
+T_1292: (in 00403014 : ptr32)
+  Class: Eq_1292
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_1293 t0000)))
+T_1293: (in Mem0[0x00403014:word32] : word32)
+  Class: Eq_1293
+  DataType: word32
+  OrigDataType: word32
+T_1294: (in 0x00000000 : word32)
+  Class: Eq_1293
+  DataType: word32
+  OrigDataType: word32
+T_1295: (in globals->dw403014 != 0x00000000 : bool)
   Class: Eq_1295
   DataType: bool
   OrigDataType: bool
-T_1296: (in eax_187 : ui32)
-  Class: Eq_1159
-  DataType: ui32
-  OrigDataType: ui32
-T_1297: (in 00403010 : ptr32)
-  Class: Eq_1297
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1298 t0000)))
-T_1298: (in Mem177[0x00403010:word32] : word32)
-  Class: Eq_1159
-  DataType: ui32
-  OrigDataType: word32
-T_1299: (in 0x00000003 : word32)
-  Class: Eq_1153
-  DataType: ui32
-  OrigDataType: word32
-T_1300: (in 0040336C : ptr32)
-  Class: Eq_1300
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1301 t0000)))
-T_1301: (in Mem189[0x0040336C:word32] : word32)
-  Class: Eq_1153
-  DataType: ui32
-  OrigDataType: word32
-T_1302: (in 0x00000008 : word32)
-  Class: Eq_1302
-  DataType: ui32
-  OrigDataType: ui32
-T_1303: (in eax_187 | 0x00000008 : word32)
-  Class: Eq_1159
-  DataType: ui32
-  OrigDataType: ui32
-T_1304: (in 00403010 : ptr32)
-  Class: Eq_1304
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1305 t0000)))
-T_1305: (in Mem192[0x00403010:word32] : word32)
-  Class: Eq_1159
-  DataType: ui32
-  OrigDataType: word32
-T_1306: (in 0x20 : byte)
-  Class: Eq_1306
-  DataType: byte
-  OrigDataType: byte
-T_1307: (in bLoc14_258 & 0x20 : byte)
-  Class: Eq_1307
-  DataType: byte
-  OrigDataType: byte
-T_1308: (in 0x00 : byte)
-  Class: Eq_1307
-  DataType: byte
-  OrigDataType: byte
-T_1309: (in (bLoc14_258 & 0x20) == 0x00 : bool)
-  Class: Eq_1309
-  DataType: bool
-  OrigDataType: bool
-T_1310: (in 0x00000005 : word32)
-  Class: Eq_1153
-  DataType: ui32
-  OrigDataType: word32
-T_1311: (in 0040336C : ptr32)
-  Class: Eq_1311
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1312 t0000)))
-T_1312: (in Mem197[0x0040336C:word32] : word32)
-  Class: Eq_1153
-  DataType: ui32
-  OrigDataType: word32
-T_1313: (in eax_187 | 0x00000008 : word32)
-  Class: Eq_1313
-  DataType: ui32
-  OrigDataType: ui32
-T_1314: (in 0x00000020 : word32)
-  Class: Eq_1314
-  DataType: ui32
-  OrigDataType: ui32
-T_1315: (in eax_187 | 0x00000008 | 0x00000020 : word32)
-  Class: Eq_1159
-  DataType: ui32
-  OrigDataType: ui32
-T_1316: (in 00403010 : ptr32)
-  Class: Eq_1316
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1317 t0000)))
-T_1317: (in Mem198[0x00403010:word32] : word32)
-  Class: Eq_1159
-  DataType: ui32
-  OrigDataType: word32
-T_1318: (in eax : uint32)
-  Class: Eq_1318
-  DataType: uint32
-  OrigDataType: word32
-T_1319: (in 00403014 : ptr32)
-  Class: Eq_1319
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1320 t0000)))
-T_1320: (in Mem0[0x00403014:word32] : word32)
-  Class: Eq_1320
-  DataType: word32
-  OrigDataType: word32
-T_1321: (in 0x00000000 : word32)
-  Class: Eq_1320
-  DataType: word32
-  OrigDataType: word32
-T_1322: (in globals->dw403014 != 0x00000000 : bool)
-  Class: Eq_1322
-  DataType: bool
-  OrigDataType: bool
-T_1323: (in (uint8) (Mem0[0x00403014:word32] != 0x00000000) : uint8)
-  Class: Eq_1323
+T_1296: (in (uint8) (Mem0[0x00403014:word32] != 0x00000000) : uint8)
+  Class: Eq_1296
   DataType: uint8
   OrigDataType: uint8
-T_1324: (in (uint32) (uint8) (Mem0[0x00403014:word32] != 0x00000000) : uint32)
-  Class: Eq_1318
+T_1297: (in (uint32) (uint8) (Mem0[0x00403014:word32] != 0x00000000) : uint32)
+  Class: Eq_1291
   DataType: uint32
   OrigDataType: uint32
-T_1325: (in al : byte)
-  Class: Eq_1325
+T_1298: (in al : byte)
+  Class: Eq_1298
   DataType: byte
   OrigDataType: byte
-T_1326: (in 0x01 : byte)
-  Class: Eq_1325
+T_1299: (in 0x01 : byte)
+  Class: Eq_1298
   DataType: byte
   OrigDataType: byte
-T_1327:
-  Class: Eq_1327
+T_1300:
+  Class: Eq_1300
   DataType: word32
-  OrigDataType: (struct 0004 (0 T_1086 t0000))
-T_1328:
-  Class: Eq_1328
-  DataType: Eq_1328
+  OrigDataType: (struct 0004 (0 T_1059 t0000))
+T_1301:
+  Class: Eq_1301
+  DataType: Eq_1301
   OrigDataType: 
 */
 typedef Eq_1struct _EXCEPTION_POINTERS;
@@ -5705,9 +5597,9 @@ union _SLIST_HEADER {
 	struct struct_70 u1;
 	ULONGLONG Alignment;
 }struct Globals {
-	Eq_723 t0100;	// 100
+	Eq_704 t0100;	// 100
 	word16 w400000;	// 400000
-	struct Eq_723 * ptr40003C;	// 40003C
+	struct Eq_704 * ptr40003C;	// 40003C
 	LONG t4018DF(struct _EXCEPTION_POINTERS * ExceptionInfo);	// 4018DF
 	<anonymous> * ptr4020D0;	// 4020D0
 	Eq_188 t4020DC;	// 4020DC
@@ -5762,7 +5654,7 @@ typedef Eq_3 * (Eq_88)(word32, Eq_91, Eq_91, Eq_93, ui32);
 
 typedef union Eq_91 {
 	byte u0;
-	struct Eq_1328 * u1;
+	struct Eq_1301 * u1;
 } Eq_91;
 
 typedef union Eq_93 {
@@ -5854,130 +5746,130 @@ typedef struct Eq_497 {
 
 typedef word32 (Eq_537)();
 
+typedef struct Eq_543 {
+	struct Eq_545 * ptr0018;	// 18
+} Eq_543;
+
 typedef struct Eq_545 {
-	struct Eq_547 * ptr0018;	// 18
+	ptr32 ptr0004;	// 4
 } Eq_545;
 
-typedef struct Eq_547 {
-	ptr32 ptr0004;	// 4
-} Eq_547;
+typedef void (Eq_551)();
 
-typedef void (Eq_555)();
+typedef bool (Eq_555)(word32, ptr32, word32, word32);
 
-typedef bool (Eq_559)(word32, ptr32, word32, word32);
+typedef void (Eq_574)(word32);
 
-typedef void (Eq_586)(word32);
+typedef byte (Eq_578)();
 
-typedef byte (Eq_593)();
+typedef void (Eq_608)();
 
-typedef void (Eq_627)();
+typedef word32 (Eq_615)(ui32, byte);
 
-typedef word32 (Eq_634)(ui32, byte);
-
-typedef struct Eq_723 {
+typedef struct Eq_704 {
 	word32 dw400000;	// 400000
 	word16 w400018;	// 400018
+} Eq_704;
+
+typedef struct Eq_723 {
+	int32 dw0024;	// 24
 } Eq_723;
 
-typedef struct Eq_742 {
-	int32 dw0024;	// 24
-} Eq_742;
+typedef Eq_723 * (Eq_724)(Eq_493 *, uint32, Eq_492 *);
 
-typedef Eq_742 * (Eq_743)(Eq_493 *, uint32, Eq_492 *);
-
-typedef union Eq_746 {
+typedef union Eq_727 {
 	ui32 u0;
 	ptr32 u1;
-} Eq_746;
+} Eq_727;
 
-typedef union Eq_821 {
+typedef union Eq_802 {
 	bool u0;
 	word32 u1;
-} Eq_821;
+} Eq_802;
 
-typedef word32 (Eq_826)(ui32);
+typedef word32 (Eq_807)(ui32);
 
-typedef void (Eq_834)(LPFILETIME);
+typedef void (Eq_815)(LPFILETIME);
 
-typedef LPFILETIME Eq_836;
+typedef LPFILETIME Eq_817;
 
-typedef DWORD (Eq_849)();
+typedef DWORD (Eq_830)();
 
-typedef DWORD (Eq_853)();
+typedef DWORD (Eq_834)();
 
-typedef BOOL (Eq_857)(LARGE_INTEGER *);
+typedef BOOL (Eq_838)(LARGE_INTEGER *);
 
-typedef LARGE_INTEGER Eq_859;
+typedef LARGE_INTEGER Eq_840;
 
-typedef void (Eq_895)(PSLIST_HEADER);
+typedef void (Eq_876)(PSLIST_HEADER);
 
-typedef PSLIST_HEADER Eq_897;
+typedef PSLIST_HEADER Eq_878;
 
-typedef Eq_912 * (Eq_910)();
+typedef Eq_893 * (Eq_891)();
 
-typedef struct Eq_912 {
+typedef struct Eq_893 {
 	ui32 dw0000;	// 0
 	word32 dw0004;	// 4
-} Eq_912;
+} Eq_893;
 
-typedef BOOL (Eq_955)(DWORD);
+typedef BOOL (Eq_936)(DWORD);
 
-typedef void (Eq_965)(void, int32, size_t);
+typedef void (Eq_946)(void, int32, size_t);
 
-typedef size_t Eq_969;
+typedef size_t Eq_950;
 
-typedef BOOL (Eq_984)();
+typedef BOOL (Eq_965)();
 
-typedef union Eq_988 {
+typedef union Eq_969 {
 	bool u0;
 	byte u1;
-} Eq_988;
+} Eq_969;
 
-typedef void (Eq_999)(word32);
+typedef void (Eq_980)(word32);
 
-typedef union Eq_1011 {
+typedef union Eq_992 {
 	bool u0;
 	ui32 u1;
-} Eq_1011;
+} Eq_992;
 
-typedef HMODULE Eq_1017;
+typedef HMODULE Eq_998;
 
-typedef HMODULE (Eq_1018)(LPCWSTR);
+typedef HMODULE (Eq_999)(LPCWSTR);
 
-typedef LPCWSTR Eq_1020;
+typedef LPCWSTR Eq_1001;
 
-typedef union Eq_1030 {
+typedef union Eq_1008 {
 	int32 u0;
 	word16 u1;
-} Eq_1030;
+} Eq_1008;
 
-typedef struct Eq_1036 {
+typedef struct Eq_1012 {
 	word32 dw0000;	// 0
 	word16 w0018;	// 18
 	up32 dw0074;	// 74
 	word32 dw00E8;	// E8
-} Eq_1036;
+} Eq_1012;
 
-typedef HMODULE Eq_1038;
+typedef HMODULE Eq_1014;
 
-typedef struct Eq_1129 {
+typedef struct Eq_1102 {
 	ptr32 ptr0000;	// 0
-} Eq_1129;
+} Eq_1102;
 
-typedef struct Eq_1139 {
+typedef struct Eq_1112 {
 	word32 dw0000;	// 0
-} Eq_1139;
+} Eq_1112;
 
-typedef union Eq_1140 {
+typedef union Eq_1113 {
 	ptr32 u0;
-	word32 Eq_1139::* u1;
-} Eq_1140;
+	word32 Eq_1112::* u1;
+} Eq_1113;
 
-typedef void (Eq_1179)(word32, word32, word32 *, word32 *, word32 *, word32 *);
+typedef void (Eq_1152)(word32, word32, word32 *, word32 *, word32 *, word32 *);
 
-typedef word64 (Eq_1285)(word32);
+typedef word64 (Eq_1258)(word32);
 
-typedef struct Eq_1328 {
+typedef struct Eq_1301 {
 	Eq_91 t0000;	// 0
-} Eq_1328;
+} Eq_1301;
 

--- a/subjects/PE/x86/import-ordinals/main.c
+++ b/subjects/PE/x86/import-ordinals/main.c
@@ -194,7 +194,6 @@ l00401433:
 byte fn0040143A(ptr32 & edxOut)
 {
 	word32 eax_n = fn00401B98();
-	word24 eax_24_8_n = SLICE(eax_n, word24, 8);
 	if (eax_n != 0x00)
 	{
 		ptr32 edx_n = fs->ptr0018->ptr0004;
@@ -203,21 +202,19 @@ byte fn0040143A(ptr32 & edxOut)
 			__lock();
 			ptr32 eax_n;
 			__cmpxchg(globals->dw403338, edx_n, 0x00, out eax_n);
-			word24 eax_24_8_n = SLICE(eax_n, word24, 8);
-			word24 eax_24_8_n = SLICE(eax_n, word24, 8);
 			if (eax_n == 0x00)
 			{
 				edxOut = edx_n;
-				return (byte) SEQ(eax_24_8_n, 0x00);
+				return 0x00;
 			}
 		} while (edx_n != eax_n);
 		edxOut = edx_n;
-		return (byte) SEQ(eax_24_8_n, 0x01);
+		return 0x01;
 	}
 	else
 	{
 		edxOut = edx;
-		return (byte) SEQ(eax_24_8_n, 0x00);
+		return 0x00;
 	}
 }
 
@@ -227,13 +224,12 @@ byte fn0040146F(word32 edx, word32 dwArg04)
 	if (dwArg04 == 0x00)
 		globals->b403354 = 0x01;
 	fn004019FE(edx);
-	word24 eax_24_8_n = SLICE(eax_n, word24, 8);
 	if (fn00401C46() == 0x00)
-		return (byte) SEQ(eax_24_8_n, 0x00);
+		return 0x00;
 	if (fn00401C46() != 0x00)
-		return (byte) SEQ(eax_24_8_n, 0x01);
+		return 0x01;
 	fn00401C46();
-	return (byte) SEQ(eax_24_8_n, 0x00);
+	return 0x00;
 }
 
 // 0040153F: Register byte fn0040153F(Register word32 ebx, Register Eq_n esi, Register Eq_n edi, Register out ptr32 edxOut, Register out ptr32 ebxOut, Register out ptr32 ebpOut, Register out ptr32 esiOut, Register out ptr32 ediOut)
@@ -349,19 +345,12 @@ void fn0040176D(word32 dwArg04)
 byte fn0040188B()
 {
 	Eq_n eax_n = GetModuleHandleW(null);
-	word24 eax_24_8_n = SLICE(eax_n, word24, 8);
-	if (eax_n == null)
-		return (byte) SEQ(eax_24_8_n, 0x00);
-	eax_24_8_n = 0x5A;
-	if (eax_n->unused != 23117)
-		return (byte) SEQ(eax_24_8_n, 0x00);
+	if (eax_n == null || eax_n->unused != 23117)
+		return 0x00;
 	struct Eq_n * eax_n = eax_n + eax_n->dw003C / 0x0040;
-	eax_24_8_n = SLICE(eax_n, word24, 8);
-	eax_24_8_n = SLICE(eax_n, word24, 8);
-	eax_24_8_n = SLICE(eax_n, word24, 8);
 	word24 eax_24_8_n = SLICE(eax_n, word24, 8);
 	if (eax_n->dw0000 != 0x4550 || (eax_n->w0018 != 0x010B || eax_n->dw0074 <= 0x0E))
-		return (byte) SEQ(eax_24_8_n, 0x00);
+		return 0x00;
 	return (byte) SEQ(eax_24_8_n, eax_n->dw00E8 != 0x00);
 }
 

--- a/subjects/PE/x86/import-ordinals/main.dis
+++ b/subjects/PE/x86/import-ordinals/main.dis
@@ -424,7 +424,6 @@ fn0040143A_entry:
 
 l0040143A:
 	word32 eax_4 = fn00401B98()
-	word24 eax_24_8_49 = SLICE(eax_4, word24, 8)
 	branch eax_4 != 0x00000000 l00401446
 // DataOut:
 // DataOut (flags):
@@ -440,8 +439,6 @@ l0040145B:
 	__lock()
 	word32 eax_25
 	__cmpxchg(Mem17[0x00403338:word32], edx_19, 0x00000000, out eax_25)
-	word24 eax_24_8_51 = SLICE(eax_25, word24, 8)
-	word24 eax_24_8_53 = SLICE(eax_25, word24, 8)
 	branch eax_25 != 0x00000000 l00401457
 // DataOut:
 // DataOut (flags):
@@ -455,21 +452,21 @@ l00401457:
 
 l0040146B:
 	edxOut = edx_19
-	return (byte) SEQ(eax_24_8_53, 0x01)
+	return 0x01
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
 
 l00401467:
 	edxOut = edx_19
-	return (byte) SEQ(eax_24_8_51, 0x00)
+	return 0x00
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
 
 l00401443:
 	edxOut = edx
-	return (byte) SEQ(eax_24_8_49, 0x00)
+	return 0x00
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -507,7 +504,6 @@ l00401478:
 
 l0040147F:
 	fn004019FE(edx)
-	word24 eax_24_8_53 = SLICE(eax_13, word24, 8)
 	branch fn00401C46() != 0x00 l00401491
 // DataOut:
 // DataOut (flags):
@@ -520,7 +516,7 @@ l00401491:
 // SymbolicIn:
 
 l004014A4:
-	return (byte) SEQ(eax_24_8_53, 0x01)
+	return 0x01
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -532,7 +528,7 @@ l0040149A:
 // SymbolicIn:
 
 l0040148D:
-	return (byte) SEQ(eax_24_8_53, 0x00)
+	return 0x00
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -622,7 +618,7 @@ l004015C3:
 	ebpOut = ebp_69
 	esiOut = esi_73
 	ediOut = edi_72
-	return (byte) eax_84
+	return SLICE(eax_84, byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -918,14 +914,12 @@ fn0040188B_entry:
 
 l0040188B:
 	word32 eax_6 = GetModuleHandleW(0x00000000)
-	word24 eax_24_8_36 = SLICE(eax_6, word24, 8)
 	branch eax_6 != 0x00000000 l0040189C
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
 
 l0040189C:
-	eax_24_8_36 = 0x00005A (alias)
 	branch Mem5[eax_6:word16] != 0x5A4D l00401899
 // DataOut:
 // DataOut (flags):
@@ -933,9 +927,6 @@ l0040189C:
 
 l004018A6:
 	word32 eax_17 = Mem5[eax_6 + 0x0000003C:word32] + eax_6
-	eax_24_8_36 = SLICE(eax_17, word24, 8) (alias)
-	eax_24_8_36 = SLICE(eax_17, word24, 8) (alias)
-	eax_24_8_36 = SLICE(eax_17, word24, 8) (alias)
 	word24 eax_24_8_43 = SLICE(eax_17, word24, 8)
 	branch Mem5[eax_17:word32] != 0x00004550 l00401899
 // DataOut:
@@ -955,13 +946,13 @@ l004018BE:
 // SymbolicIn:
 
 l004018C4:
-	return (byte) SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000)
+	return SLICE(SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000), byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
 
 l00401899:
-	return (byte) SEQ(eax_24_8_36, 0x00)
+	return 0x00
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:

--- a/subjects/PE/x86/import-ordinals/main.h
+++ b/subjects/PE/x86/import-ordinals/main.h
@@ -4,7 +4,7 @@
 
 /*
 // Equivalence classes ////////////
-Eq_1: (struct "Globals" (100 Eq_669 t0100) (400000 word16 w400000) (40003C (ptr32 Eq_669) ptr40003C) (401731 code t401731) (4020D4 (ptr32 code) ptr4020D4) (4020E0 Eq_229 t4020E0) (4020F0 Eq_229 t4020F0) (403000 ui32 dw403000) (403004 ui32 dw403004) (403010 ui32 dw403010) (403014 word32 dw403014) (403334 uip32 dw403334) (403338 word32 dw403338) (403354 byte b403354) (403368 ui32 dw403368) (40336C ui32 dw40336C) (403370 ui32 dw403370))
+Eq_1: (struct "Globals" (100 Eq_650 t0100) (400000 word16 w400000) (40003C (ptr32 Eq_650) ptr40003C) (401731 code t401731) (4020D4 (ptr32 code) ptr4020D4) (4020E0 Eq_229 t4020E0) (4020F0 Eq_229 t4020F0) (403000 ui32 dw403000) (403004 ui32 dw403004) (403010 ui32 dw403010) (403014 word32 dw403014) (403334 uip32 dw403334) (403338 word32 dw403338) (403354 byte b403354) (403368 ui32 dw403368) (40336C ui32 dw40336C) (403370 ui32 dw403370))
 	globals_t (in globals : (ptr32 (struct "Globals")))
 Eq_33: (struct "Eq_33" (0 word32 dw0000) (4 word32 dw0004))
 	T_33 (in eax_30 : (ptr32 Eq_33))
@@ -18,8 +18,8 @@ Eq_57: (struct "Eq_57" (0 Eq_134 t0000) (8 ui32 dw0008))
 	T_140 (in fn00401980(ebx, esi, edi, dwLoc0C, 0x00000014) : word32)
 	T_189 (in ebp_135 : (ptr32 Eq_57))
 	T_292 (in ebp : (ptr32 Eq_57))
-	T_638 (in ebp_13 : (ptr32 Eq_57))
-	T_642 (in fn00401980(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
+	T_619 (in ebp_13 : (ptr32 Eq_57))
+	T_623 (in fn00401980(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
 Eq_110: (fn void (ptr32, (ptr32 word32), word32))
 	T_110 (in fn00401010 : ptr32)
 	T_111 (in signature of fn00401010 : void)
@@ -30,19 +30,19 @@ Eq_121: DWORD
 	T_429 (in eax_242 : Eq_121)
 	T_432 (in fn00401040(ecx_227, ebp_135, eax_221) : word32)
 	T_476 (in Mem294[esp_226 - 4 + 0x00000000:word32] : word32)
-	T_766 (in GetCurrentThreadId() : DWORD)
-	T_770 (in GetCurrentProcessId() : DWORD)
-	T_816 (in ProcessorFeature : DWORD)
-	T_817 (in 0x00000017 : word32)
-	T_1007 (in 0x0000000A : word32)
+	T_747 (in GetCurrentThreadId() : DWORD)
+	T_751 (in GetCurrentProcessId() : DWORD)
+	T_797 (in ProcessorFeature : DWORD)
+	T_798 (in 0x00000017 : word32)
+	T_980 (in 0x0000000A : word32)
 Eq_125: (fn void ())
 	T_125 (in fn0040165E : ptr32)
 	T_126 (in signature of fn0040165E : void)
 Eq_129: (fn (ptr32 Eq_57) (word32, Eq_132, Eq_132, Eq_134, ui32))
 	T_129 (in fn00401980 : ptr32)
 	T_130 (in signature of fn00401980 : void)
-	T_639 (in fn00401980 : ptr32)
-Eq_132: (union "Eq_132" (byte u0) ((ptr32 Eq_1169) u1))
+	T_620 (in fn00401980 : ptr32)
+Eq_132: (union "Eq_132" (byte u0) ((ptr32 Eq_1142) u1))
 	T_132 (in esi : Eq_132)
 	T_133 (in edi : Eq_132)
 	T_136 (in esi : word32)
@@ -70,9 +70,9 @@ Eq_132: (union "Eq_132" (byte u0) ((ptr32 Eq_1169) u1))
 	T_449 (in Mem174[esp_173 + 0x00000000:word32] : word32)
 	T_464 (in Mem174[esi_167 + 0x00000000:word32] : word32)
 	T_467 (in Mem196[esp_173 + 0x00000000:word32] : word32)
-	T_729 (in 0x00 : byte)
-	T_948 (in Mem20[esp_14 - 8 + 0x00000000:word32] : word32)
-	T_953 (in Mem23[esp_14 - 12 + 0x00000000:word32] : word32)
+	T_710 (in 0x00 : byte)
+	T_921 (in Mem20[esp_14 - 8 + 0x00000000:word32] : word32)
+	T_926 (in Mem23[esp_14 - 12 + 0x00000000:word32] : word32)
 Eq_134: (union "Eq_134" (ui32 u0) (ptr32 u1))
 	T_134 (in dwArg00 : Eq_134)
 	T_138 (in dwLoc0C : word32)
@@ -80,13 +80,13 @@ Eq_134: (union "Eq_134" (ui32 u0) (ptr32 u1))
 	T_294 (in ebpOut : Eq_134)
 	T_299 (in Mem301[esp_288 + -4:word32] : word32)
 	T_300 (in out ebp_302 : ptr32)
-	T_640 (in dwLoc0C : word32)
-	T_697 (in eax_32 - 0x00400000 : word32)
-	T_720 (in out ebp_69 : ptr32)
-	T_968 (in Mem36[esp_14 - 20 + 0x00000000:word32] : word32)
-	T_984 (in ebp_19 : Eq_134)
-	T_987 (in Mem8[ebp + 0x00000000:word32] : word32)
-	T_990 (in Mem22[ebp + 0x00000000:word32] : word32)
+	T_621 (in dwLoc0C : word32)
+	T_678 (in eax_32 - 0x00400000 : word32)
+	T_701 (in out ebp_69 : ptr32)
+	T_941 (in Mem36[esp_14 - 20 + 0x00000000:word32] : word32)
+	T_957 (in ebp_19 : Eq_134)
+	T_960 (in Mem8[ebp + 0x00000000:word32] : word32)
+	T_963 (in Mem22[ebp + 0x00000000:word32] : word32)
 Eq_145: (fn byte (word32, word32))
 	T_145 (in fn0040146F : ptr32)
 	T_146 (in signature of fn0040146F : void)
@@ -124,7 +124,7 @@ Eq_267: PVFV
 Eq_290: (fn ptr32 ((ptr32 Eq_57), Eq_134, Eq_134, ptr32, ptr32))
 	T_290 (in fn004019C6 : ptr32)
 	T_291 (in signature of fn004019C6 : void)
-	T_719 (in fn004019C6 : ptr32)
+	T_700 (in fn004019C6 : ptr32)
 Eq_315: (fn void (Eq_132))
 	T_315 (in fn004015C9 : ptr32)
 	T_316 (in signature of fn004015C9 : void)
@@ -155,7 +155,7 @@ Eq_488: (union "Eq_488" (byte u0) (word32 u1))
 	T_491 (in Mem276[esp_275 + 0x00000000:word32] : word32)
 	T_500 (in bArg08 : Eq_488)
 	T_503 (in Mem278[esp_275 + 0x00000000:byte] : byte)
-	T_742 (in 0x00 : byte)
+	T_723 (in 0x00 : byte)
 Eq_498: (fn void (Eq_488))
 	T_498 (in fn004015E6 : ptr32)
 	T_499 (in signature of fn004015E6 : void)
@@ -169,147 +169,147 @@ Eq_515: (struct "Eq_515" 0028 (8 up32 dw0008) (C up32 dw000C))
 	T_540 (in (word32) Mem11[ecx_13 + 0x00000006:word16] *s 0x00000028 + edx_16 : word32)
 	T_542 (in 0x00000000 : word32)
 	T_544 (in edx_16 + 0x00000028 : word32)
-	T_695 (in out edx : ptr32)
+	T_676 (in out edx : ptr32)
 Eq_516: (struct "Eq_516" (3C word32 dw003C))
 	T_516 (in dwArg04 : (ptr32 Eq_516))
-	T_691 (in 0x00400000 : ptr32)
+	T_672 (in 0x00400000 : ptr32)
 Eq_520: (struct "Eq_520" (6 word16 w0006) (14 word16 w0014))
 	T_520 (in ecx_13 : (ptr32 Eq_520))
 	T_524 (in Mem11[dwArg04 + 0x0000003C:word32] + dwArg04 : word32)
 Eq_560: (fn word32 ())
 	T_560 (in fn00401B98 : ptr32)
 	T_561 (in signature of fn00401B98 : void)
-	T_725 (in fn00401B98 : ptr32)
-Eq_568: (segment "Eq_568" (18 (ptr32 Eq_570) ptr0018))
-	T_568 (in fs : selector)
-Eq_570: (struct "Eq_570" (4 ptr32 ptr0004))
-	T_570 (in Mem0[fs:0x00000018:word32] : word32)
-Eq_578: (fn void ())
-	T_578 (in __lock : ptr32)
-	T_579 (in signature of __lock : void)
-Eq_582: (fn bool (word32, ptr32, word32, word32))
-	T_582 (in __cmpxchg : ptr32)
-	T_583 (in signature of __cmpxchg : void)
-Eq_609: (fn void (word32))
-	T_609 (in fn004019FE : ptr32)
-	T_610 (in signature of fn004019FE : void)
-Eq_616: (fn byte ())
-	T_616 (in fn00401C46 : ptr32)
-	T_617 (in signature of fn00401C46 : void)
-	T_624 (in fn00401C46 : ptr32)
-	T_634 (in fn00401C46 : ptr32)
-	T_738 (in fn00401C46 : ptr32)
-	T_740 (in fn00401C46 : ptr32)
-Eq_669: (struct "Eq_669" (400000 word32 dw400000) (400018 word16 w400018))
-	T_669 (in eax_25 : (ptr32 Eq_669))
-	T_671 (in Mem19[0x0040003C:word32] : word32)
-Eq_688: (struct "Eq_688" (24 int32 dw0024))
-	T_688 (in eax_40 : (ptr32 Eq_688))
-	T_696 (in fn004013F6(&globals->w400000, eax_32 - 0x00400000, out edx) : word32)
-	T_700 (in 0x00000000 : word32)
-Eq_689: (fn (ptr32 Eq_688) ((ptr32 Eq_516), uint32, (ptr32 Eq_515)))
-	T_689 (in fn004013F6 : ptr32)
-	T_690 (in signature of fn004013F6 : void)
-Eq_692: (union "Eq_692" (ui32 u0) (ptr32 u1))
-	T_692 (in 0x00400000 : ptr32)
-Eq_749: (fn void (Eq_751))
-	T_749 (in GetSystemTimeAsFileTime : ptr32)
-	T_750 (in signature of GetSystemTimeAsFileTime : void)
-Eq_751: LPFILETIME
-	T_751 (in lpSystemTimeAsFileTime : LPFILETIME)
-	T_754 (in fp - 0x00000010 : word32)
-Eq_764: (fn Eq_121 ())
-	T_764 (in GetCurrentThreadId : ptr32)
-	T_765 (in signature of GetCurrentThreadId : void)
-Eq_768: (fn Eq_121 ())
-	T_768 (in GetCurrentProcessId : ptr32)
-	T_769 (in signature of GetCurrentProcessId : void)
-Eq_772: (fn Eq_777 ((ptr32 Eq_774)))
-	T_772 (in QueryPerformanceCounter : ptr32)
-	T_773 (in signature of QueryPerformanceCounter : void)
-Eq_774: LARGE_INTEGER
-	T_774 (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
-	T_776 (in fp - 0x00000018 : word32)
-Eq_777: BOOL
-	T_777 (in QueryPerformanceCounter(fp - 0x00000018) : BOOL)
-	T_818 (in IsProcessorFeaturePresent(0x00000017) : BOOL)
-	T_819 (in 0x00000000 : word32)
-	T_845 (in IsDebuggerPresent() : BOOL)
-	T_846 (in 0x00000001 : word32)
-	T_1008 (in IsProcessorFeaturePresent(0x0000000A) : BOOL)
-	T_1009 (in 0x00000000 : word32)
-Eq_814: (fn Eq_777 (Eq_121))
-	T_814 (in IsProcessorFeaturePresent : ptr32)
-	T_815 (in signature of IsProcessorFeaturePresent : void)
-	T_1006 (in IsProcessorFeaturePresent : ptr32)
-Eq_824: (fn (ptr32 void) ((ptr32 void), int32, Eq_828))
-	T_824 (in memset : ptr32)
-	T_825 (in signature of memset : void)
-	T_835 (in memset : ptr32)
-Eq_828: size_t
-	T_828 (in _Size : size_t)
-	T_833 (in 0x000002CC : word32)
-	T_839 (in 0x00000050 : word32)
-Eq_843: (fn Eq_777 ())
-	T_843 (in IsDebuggerPresent : ptr32)
-	T_844 (in signature of IsDebuggerPresent : void)
-Eq_847: (union "Eq_847" (bool u0) (byte u1))
-	T_847 (in IsDebuggerPresent() == 0x00000001 : bool)
-Eq_849: (fn Eq_851 (Eq_851))
-	T_849 (in SetUnhandledExceptionFilter : ptr32)
-	T_850 (in signature of SetUnhandledExceptionFilter : void)
-Eq_851: LPTOP_LEVEL_EXCEPTION_FILTER
-	T_851 (in lpTopLevelExceptionFilter : LPTOP_LEVEL_EXCEPTION_FILTER)
-	T_852 (in 0x00000000 : word32)
-	T_853 (in SetUnhandledExceptionFilter(null) : LPTOP_LEVEL_EXCEPTION_FILTER)
-Eq_854: (fn Eq_859 ((ptr32 Eq_856)))
-	T_854 (in UnhandledExceptionFilter : ptr32)
-	T_855 (in signature of UnhandledExceptionFilter : void)
-Eq_856: (struct "_EXCEPTION_POINTERS" (0 PEXCEPTION_RECORD ExceptionRecord) (4 PCONTEXT ContextRecord))
-	T_856 (in ExceptionInfo : (ptr32 (struct "_EXCEPTION_POINTERS")))
-	T_858 (in fp - 0x0000000C : word32)
-Eq_859: LONG
-	T_859 (in UnhandledExceptionFilter(fp - 0x0000000C) : LONG)
-	T_860 (in 0x00000000 : word32)
-Eq_862: (fn void (word32))
-	T_862 (in __fastfail : ptr32)
-	T_863 (in signature of __fastfail : void)
-Eq_874: (union "Eq_874" (bool u0) (ui32 u1))
-	T_874 (in -(word32) (bl_90 + 0x01) == 0x00000000 : bool)
-Eq_880: HMODULE
-	T_880 (in eax_6 : Eq_880)
-	T_885 (in GetModuleHandleW(null) : HMODULE)
-	T_888 (in 0x00000000 : word32)
-Eq_881: (fn Eq_880 (Eq_883))
-	T_881 (in GetModuleHandleW : ptr32)
-	T_882 (in signature of GetModuleHandleW : void)
-Eq_883: LPCWSTR
-	T_883 (in lpModuleName : LPCWSTR)
-	T_884 (in 0x00000000 : word32)
-Eq_893: (union "Eq_893" (int32 u0) (word16 u1))
-	T_893 (in Mem5[eax_6 + 0x00000000:word16] : word16)
-	T_894 (in 0x5A4D : word16)
-Eq_899: (struct "Eq_899" (0 word32 dw0000) (18 word16 w0018) (74 up32 dw0074) (E8 word32 dw00E8))
-	T_899 (in eax_17 : (ptr32 Eq_899))
-	T_903 (in Mem5[eax_6 + 0x0000003C:word32] + eax_6 : word32)
-Eq_901: HMODULE
-	T_901 (in eax_6 + 0x0000003C : word32)
-Eq_971: (segment "Eq_971" (0 ptr32 ptr0000))
-	T_971 (in fs : selector)
-Eq_981: (segment "Eq_981" (0 word32 dw0000))
-	T_981 (in fs : selector)
-Eq_982: (union "Eq_982" (ptr32 u0) ((memptr (ptr32 Eq_981) word32) u1))
-	T_982 (in 0x00000000 : ptr32)
-Eq_1021: (fn void (word32, word32, (ptr32 word32), (ptr32 word32), (ptr32 word32), (ptr32 word32)))
-	T_1021 (in __cpuid : ptr32)
-	T_1022 (in signature of __cpuid : void)
-	T_1039 (in __cpuid : ptr32)
-	T_1093 (in __cpuid : ptr32)
-Eq_1127: (fn word64 (word32))
-	T_1127 (in __xgetbv : ptr32)
-	T_1128 (in signature of __xgetbv : void)
-Eq_1169: (struct "Eq_1169" (0 Eq_132 t0000))
-	T_1169
+	T_706 (in fn00401B98 : ptr32)
+Eq_566: (segment "Eq_566" (18 (ptr32 Eq_568) ptr0018))
+	T_566 (in fs : selector)
+Eq_568: (struct "Eq_568" (4 ptr32 ptr0004))
+	T_568 (in Mem0[fs:0x00000018:word32] : word32)
+Eq_574: (fn void ())
+	T_574 (in __lock : ptr32)
+	T_575 (in signature of __lock : void)
+Eq_578: (fn bool (word32, ptr32, word32, word32))
+	T_578 (in __cmpxchg : ptr32)
+	T_579 (in signature of __cmpxchg : void)
+Eq_597: (fn void (word32))
+	T_597 (in fn004019FE : ptr32)
+	T_598 (in signature of fn004019FE : void)
+Eq_601: (fn byte ())
+	T_601 (in fn00401C46 : ptr32)
+	T_602 (in signature of fn00401C46 : void)
+	T_609 (in fn00401C46 : ptr32)
+	T_615 (in fn00401C46 : ptr32)
+	T_719 (in fn00401C46 : ptr32)
+	T_721 (in fn00401C46 : ptr32)
+Eq_650: (struct "Eq_650" (400000 word32 dw400000) (400018 word16 w400018))
+	T_650 (in eax_25 : (ptr32 Eq_650))
+	T_652 (in Mem19[0x0040003C:word32] : word32)
+Eq_669: (struct "Eq_669" (24 int32 dw0024))
+	T_669 (in eax_40 : (ptr32 Eq_669))
+	T_677 (in fn004013F6(&globals->w400000, eax_32 - 0x00400000, out edx) : word32)
+	T_681 (in 0x00000000 : word32)
+Eq_670: (fn (ptr32 Eq_669) ((ptr32 Eq_516), uint32, (ptr32 Eq_515)))
+	T_670 (in fn004013F6 : ptr32)
+	T_671 (in signature of fn004013F6 : void)
+Eq_673: (union "Eq_673" (ui32 u0) (ptr32 u1))
+	T_673 (in 0x00400000 : ptr32)
+Eq_730: (fn void (Eq_732))
+	T_730 (in GetSystemTimeAsFileTime : ptr32)
+	T_731 (in signature of GetSystemTimeAsFileTime : void)
+Eq_732: LPFILETIME
+	T_732 (in lpSystemTimeAsFileTime : LPFILETIME)
+	T_735 (in fp - 0x00000010 : word32)
+Eq_745: (fn Eq_121 ())
+	T_745 (in GetCurrentThreadId : ptr32)
+	T_746 (in signature of GetCurrentThreadId : void)
+Eq_749: (fn Eq_121 ())
+	T_749 (in GetCurrentProcessId : ptr32)
+	T_750 (in signature of GetCurrentProcessId : void)
+Eq_753: (fn Eq_758 ((ptr32 Eq_755)))
+	T_753 (in QueryPerformanceCounter : ptr32)
+	T_754 (in signature of QueryPerformanceCounter : void)
+Eq_755: LARGE_INTEGER
+	T_755 (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
+	T_757 (in fp - 0x00000018 : word32)
+Eq_758: BOOL
+	T_758 (in QueryPerformanceCounter(fp - 0x00000018) : BOOL)
+	T_799 (in IsProcessorFeaturePresent(0x00000017) : BOOL)
+	T_800 (in 0x00000000 : word32)
+	T_826 (in IsDebuggerPresent() : BOOL)
+	T_827 (in 0x00000001 : word32)
+	T_981 (in IsProcessorFeaturePresent(0x0000000A) : BOOL)
+	T_982 (in 0x00000000 : word32)
+Eq_795: (fn Eq_758 (Eq_121))
+	T_795 (in IsProcessorFeaturePresent : ptr32)
+	T_796 (in signature of IsProcessorFeaturePresent : void)
+	T_979 (in IsProcessorFeaturePresent : ptr32)
+Eq_805: (fn (ptr32 void) ((ptr32 void), int32, Eq_809))
+	T_805 (in memset : ptr32)
+	T_806 (in signature of memset : void)
+	T_816 (in memset : ptr32)
+Eq_809: size_t
+	T_809 (in _Size : size_t)
+	T_814 (in 0x000002CC : word32)
+	T_820 (in 0x00000050 : word32)
+Eq_824: (fn Eq_758 ())
+	T_824 (in IsDebuggerPresent : ptr32)
+	T_825 (in signature of IsDebuggerPresent : void)
+Eq_828: (union "Eq_828" (bool u0) (byte u1))
+	T_828 (in IsDebuggerPresent() == 0x00000001 : bool)
+Eq_830: (fn Eq_832 (Eq_832))
+	T_830 (in SetUnhandledExceptionFilter : ptr32)
+	T_831 (in signature of SetUnhandledExceptionFilter : void)
+Eq_832: LPTOP_LEVEL_EXCEPTION_FILTER
+	T_832 (in lpTopLevelExceptionFilter : LPTOP_LEVEL_EXCEPTION_FILTER)
+	T_833 (in 0x00000000 : word32)
+	T_834 (in SetUnhandledExceptionFilter(null) : LPTOP_LEVEL_EXCEPTION_FILTER)
+Eq_835: (fn Eq_840 ((ptr32 Eq_837)))
+	T_835 (in UnhandledExceptionFilter : ptr32)
+	T_836 (in signature of UnhandledExceptionFilter : void)
+Eq_837: (struct "_EXCEPTION_POINTERS" (0 PEXCEPTION_RECORD ExceptionRecord) (4 PCONTEXT ContextRecord))
+	T_837 (in ExceptionInfo : (ptr32 (struct "_EXCEPTION_POINTERS")))
+	T_839 (in fp - 0x0000000C : word32)
+Eq_840: LONG
+	T_840 (in UnhandledExceptionFilter(fp - 0x0000000C) : LONG)
+	T_841 (in 0x00000000 : word32)
+Eq_843: (fn void (word32))
+	T_843 (in __fastfail : ptr32)
+	T_844 (in signature of __fastfail : void)
+Eq_855: (union "Eq_855" (bool u0) (ui32 u1))
+	T_855 (in -(word32) (bl_90 + 0x01) == 0x00000000 : bool)
+Eq_861: HMODULE
+	T_861 (in eax_6 : Eq_861)
+	T_866 (in GetModuleHandleW(null) : HMODULE)
+	T_867 (in 0x00000000 : word32)
+Eq_862: (fn Eq_861 (Eq_864))
+	T_862 (in GetModuleHandleW : ptr32)
+	T_863 (in signature of GetModuleHandleW : void)
+Eq_864: LPCWSTR
+	T_864 (in lpModuleName : LPCWSTR)
+	T_865 (in 0x00000000 : word32)
+Eq_871: (union "Eq_871" (int32 u0) (word16 u1))
+	T_871 (in Mem5[eax_6 + 0x00000000:word16] : word16)
+	T_872 (in 0x5A4D : word16)
+Eq_875: (struct "Eq_875" (0 word32 dw0000) (18 word16 w0018) (74 up32 dw0074) (E8 word32 dw00E8))
+	T_875 (in eax_17 : (ptr32 Eq_875))
+	T_879 (in Mem5[eax_6 + 0x0000003C:word32] + eax_6 : word32)
+Eq_877: HMODULE
+	T_877 (in eax_6 + 0x0000003C : word32)
+Eq_944: (segment "Eq_944" (0 ptr32 ptr0000))
+	T_944 (in fs : selector)
+Eq_954: (segment "Eq_954" (0 word32 dw0000))
+	T_954 (in fs : selector)
+Eq_955: (union "Eq_955" (ptr32 u0) ((memptr (ptr32 Eq_954) word32) u1))
+	T_955 (in 0x00000000 : ptr32)
+Eq_994: (fn void (word32, word32, (ptr32 word32), (ptr32 word32), (ptr32 word32), (ptr32 word32)))
+	T_994 (in __cpuid : ptr32)
+	T_995 (in signature of __cpuid : void)
+	T_1012 (in __cpuid : ptr32)
+	T_1066 (in __cpuid : ptr32)
+Eq_1100: (fn word64 (word32))
+	T_1100 (in __xgetbv : ptr32)
+	T_1101 (in signature of __xgetbv : void)
+Eq_1142: (struct "Eq_1142" (0 Eq_132 t0000))
+	T_1142
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -2559,325 +2559,325 @@ T_562: (in fn00401B98() : word32)
   Class: Eq_559
   DataType: word32
   OrigDataType: word32
-T_563: (in eax_24_8_49 : word24)
-  Class: Eq_563
-  DataType: word24
-  OrigDataType: word24
-T_564: (in SLICE(eax_4, word24, 8) : word24)
-  Class: Eq_563
-  DataType: word24
-  OrigDataType: word24
-T_565: (in 0x00000000 : word32)
+T_563: (in 0x00000000 : word32)
   Class: Eq_559
   DataType: word32
   OrigDataType: word32
-T_566: (in eax_4 != 0x00000000 : bool)
-  Class: Eq_566
+T_564: (in eax_4 != 0x00000000 : bool)
+  Class: Eq_564
   DataType: bool
   OrigDataType: bool
-T_567: (in edx_19 : ptr32)
+T_565: (in edx_19 : ptr32)
   Class: Eq_178
   DataType: ptr32
   OrigDataType: word32
-T_568: (in fs : selector)
+T_566: (in fs : selector)
+  Class: Eq_566
+  DataType: (ptr32 Eq_566)
+  OrigDataType: (ptr32 (segment (18 T_568 t0018)))
+T_567: (in 0x00000018 : word32)
+  Class: Eq_567
+  DataType: (memptr (ptr32 Eq_566) (ptr32 Eq_568))
+  OrigDataType: (memptr T_566 (struct (0 T_568 t0000)))
+T_568: (in Mem0[fs:0x00000018:word32] : word32)
   Class: Eq_568
   DataType: (ptr32 Eq_568)
-  OrigDataType: (ptr32 (segment (18 T_570 t0018)))
-T_569: (in 0x00000018 : word32)
+  OrigDataType: (ptr32 (struct (4 T_571 t0004)))
+T_569: (in 0x00000004 : word32)
   Class: Eq_569
-  DataType: (memptr (ptr32 Eq_568) (ptr32 Eq_570))
-  OrigDataType: (memptr T_568 (struct (0 T_570 t0000)))
-T_570: (in Mem0[fs:0x00000018:word32] : word32)
+  DataType: word32
+  OrigDataType: word32
+T_570: (in Mem0[fs:0x00000018:word32] + 0x00000004 : word32)
   Class: Eq_570
-  DataType: (ptr32 Eq_570)
-  OrigDataType: (ptr32 (struct (4 T_573 t0004)))
-T_571: (in 0x00000004 : word32)
-  Class: Eq_571
   DataType: word32
   OrigDataType: word32
-T_572: (in Mem0[fs:0x00000018:word32] + 0x00000004 : word32)
-  Class: Eq_572
-  DataType: word32
-  OrigDataType: word32
-T_573: (in Mem17[Mem0[fs:0x00000018:word32] + 0x00000004:word32] : word32)
+T_571: (in Mem17[Mem0[fs:0x00000018:word32] + 0x00000004:word32] : word32)
   Class: Eq_178
   DataType: ptr32
   OrigDataType: word32
-T_574: (in edx : word32)
+T_572: (in edx : word32)
   Class: Eq_178
   DataType: ptr32
   OrigDataType: word32
-T_575: (in 0x00 : byte)
-  Class: Eq_575
-  DataType: byte
-  OrigDataType: byte
-T_576: (in SEQ(eax_24_8_49, 0x00) : word32)
-  Class: Eq_576
-  DataType: word32
-  OrigDataType: word32
-T_577: (in (byte) SEQ(eax_24_8_49, 0x00) : byte)
+T_573: (in 0x00 : byte)
   Class: Eq_558
   DataType: byte
   OrigDataType: byte
-T_578: (in __lock : ptr32)
-  Class: Eq_578
-  DataType: (ptr32 Eq_578)
-  OrigDataType: (ptr32 (fn T_580 ()))
-T_579: (in signature of __lock : void)
-  Class: Eq_578
-  DataType: (ptr32 Eq_578)
+T_574: (in __lock : ptr32)
+  Class: Eq_574
+  DataType: (ptr32 Eq_574)
+  OrigDataType: (ptr32 (fn T_576 ()))
+T_575: (in signature of __lock : void)
+  Class: Eq_574
+  DataType: (ptr32 Eq_574)
   OrigDataType: 
-T_580: (in __lock() : void)
-  Class: Eq_580
+T_576: (in __lock() : void)
+  Class: Eq_576
   DataType: void
   OrigDataType: void
-T_581: (in eax_25 : ptr32)
+T_577: (in eax_25 : ptr32)
   Class: Eq_178
   DataType: ptr32
   OrigDataType: word32
-T_582: (in __cmpxchg : ptr32)
-  Class: Eq_582
-  DataType: (ptr32 Eq_582)
-  OrigDataType: (ptr32 (fn T_592 (T_589, T_567, T_590, T_591)))
-T_583: (in signature of __cmpxchg : void)
-  Class: Eq_582
-  DataType: (ptr32 Eq_582)
+T_578: (in __cmpxchg : ptr32)
+  Class: Eq_578
+  DataType: (ptr32 Eq_578)
+  OrigDataType: (ptr32 (fn T_588 (T_585, T_565, T_586, T_587)))
+T_579: (in signature of __cmpxchg : void)
+  Class: Eq_578
+  DataType: (ptr32 Eq_578)
   OrigDataType: 
-T_584: (in  : word32)
-  Class: Eq_584
+T_580: (in  : word32)
+  Class: Eq_580
   DataType: word32
   OrigDataType: 
-T_585: (in  : word32)
+T_581: (in  : word32)
   Class: Eq_178
   DataType: ptr32
   OrigDataType: 
-T_586: (in  : word32)
-  Class: Eq_586
+T_582: (in  : word32)
+  Class: Eq_582
   DataType: word32
   OrigDataType: 
-T_587: (in  : word32)
-  Class: Eq_587
+T_583: (in  : word32)
+  Class: Eq_583
   DataType: word32
   OrigDataType: 
-T_588: (in 0x00403338 : ptr32)
-  Class: Eq_588
+T_584: (in 0x00403338 : ptr32)
+  Class: Eq_584
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_589 t0000)))
-T_589: (in Mem17[0x00403338:word32] : word32)
-  Class: Eq_584
+  OrigDataType: (ptr32 (struct (0 T_585 t0000)))
+T_585: (in Mem17[0x00403338:word32] : word32)
+  Class: Eq_580
   DataType: word32
   OrigDataType: word32
-T_590: (in 0x00000000 : word32)
-  Class: Eq_586
+T_586: (in 0x00000000 : word32)
+  Class: Eq_582
   DataType: word32
   OrigDataType: word32
-T_591: (in out eax_25 : word32)
-  Class: Eq_587
+T_587: (in out eax_25 : word32)
+  Class: Eq_583
   DataType: word32
   OrigDataType: word32
-T_592: (in __cmpxchg(globals->dw403338, edx_19, 0x00000000, out eax_25) : bool)
-  Class: Eq_592
+T_588: (in __cmpxchg(globals->dw403338, edx_19, 0x00000000, out eax_25) : bool)
+  Class: Eq_588
   DataType: bool
   OrigDataType: bool
-T_593: (in eax_24_8_51 : word24)
-  Class: Eq_593
-  DataType: word24
-  OrigDataType: word24
-T_594: (in SLICE(eax_25, word24, 8) : word24)
-  Class: Eq_593
-  DataType: word24
-  OrigDataType: word24
-T_595: (in eax_24_8_53 : word24)
-  Class: Eq_595
-  DataType: word24
-  OrigDataType: word24
-T_596: (in SLICE(eax_25, word24, 8) : word24)
-  Class: Eq_595
-  DataType: word24
-  OrigDataType: word24
-T_597: (in 0x00000000 : word32)
+T_589: (in 0x00000000 : word32)
   Class: Eq_178
   DataType: ptr32
   OrigDataType: word32
-T_598: (in eax_25 != 0x00000000 : bool)
-  Class: Eq_598
+T_590: (in eax_25 != 0x00000000 : bool)
+  Class: Eq_590
   DataType: bool
   OrigDataType: bool
-T_599: (in edx_19 == eax_25 : bool)
-  Class: Eq_599
+T_591: (in edx_19 == eax_25 : bool)
+  Class: Eq_591
   DataType: bool
   OrigDataType: bool
-T_600: (in 0x00 : byte)
-  Class: Eq_600
-  DataType: byte
-  OrigDataType: byte
-T_601: (in SEQ(eax_24_8_51, 0x00) : word32)
-  Class: Eq_601
-  DataType: word32
-  OrigDataType: word32
-T_602: (in (byte) SEQ(eax_24_8_51, 0x00) : byte)
+T_592: (in 0x00 : byte)
   Class: Eq_558
   DataType: byte
   OrigDataType: byte
-T_603: (in 0x01 : byte)
-  Class: Eq_603
-  DataType: byte
-  OrigDataType: byte
-T_604: (in SEQ(eax_24_8_53, 0x01) : word32)
-  Class: Eq_604
-  DataType: word32
-  OrigDataType: word32
-T_605: (in (byte) SEQ(eax_24_8_53, 0x01) : byte)
+T_593: (in 0x01 : byte)
   Class: Eq_558
   DataType: byte
   OrigDataType: byte
-T_606: (in al : byte)
-  Class: Eq_606
+T_594: (in al : byte)
+  Class: Eq_594
   DataType: byte
   OrigDataType: byte
-T_607: (in 0x00000000 : word32)
+T_595: (in 0x00000000 : word32)
   Class: Eq_148
   DataType: word32
   OrigDataType: word32
-T_608: (in dwArg04 != 0x00000000 : bool)
-  Class: Eq_608
+T_596: (in dwArg04 != 0x00000000 : bool)
+  Class: Eq_596
   DataType: bool
   OrigDataType: bool
-T_609: (in fn004019FE : ptr32)
-  Class: Eq_609
-  DataType: (ptr32 Eq_609)
-  OrigDataType: (ptr32 (fn T_612 (T_147)))
-T_610: (in signature of fn004019FE : void)
-  Class: Eq_609
-  DataType: (ptr32 Eq_609)
+T_597: (in fn004019FE : ptr32)
+  Class: Eq_597
+  DataType: (ptr32 Eq_597)
+  OrigDataType: (ptr32 (fn T_600 (T_147)))
+T_598: (in signature of fn004019FE : void)
+  Class: Eq_597
+  DataType: (ptr32 Eq_597)
   OrigDataType: 
-T_611: (in edx : word32)
+T_599: (in edx : word32)
   Class: Eq_147
   DataType: word32
   OrigDataType: word32
-T_612: (in fn004019FE(edx) : void)
-  Class: Eq_612
+T_600: (in fn004019FE(edx) : void)
+  Class: Eq_600
   DataType: void
   OrigDataType: void
-T_613: (in eax_24_8_53 : word24)
-  Class: Eq_613
-  DataType: word24
-  OrigDataType: word24
-T_614: (in eax_13 : word32)
-  Class: Eq_614
-  DataType: word32
-  OrigDataType: word32
-T_615: (in SLICE(eax_13, word24, 8) : word24)
-  Class: Eq_613
-  DataType: word24
-  OrigDataType: word24
-T_616: (in fn00401C46 : ptr32)
-  Class: Eq_616
-  DataType: (ptr32 Eq_616)
-  OrigDataType: (ptr32 (fn T_618 ()))
-T_617: (in signature of fn00401C46 : void)
-  Class: Eq_616
-  DataType: (ptr32 Eq_616)
+T_601: (in fn00401C46 : ptr32)
+  Class: Eq_601
+  DataType: (ptr32 Eq_601)
+  OrigDataType: (ptr32 (fn T_603 ()))
+T_602: (in signature of fn00401C46 : void)
+  Class: Eq_601
+  DataType: (ptr32 Eq_601)
   OrigDataType: 
-T_618: (in fn00401C46() : byte)
-  Class: Eq_618
+T_603: (in fn00401C46() : byte)
+  Class: Eq_603
   DataType: byte
   OrigDataType: byte
-T_619: (in 0x00 : byte)
-  Class: Eq_618
+T_604: (in 0x00 : byte)
+  Class: Eq_603
   DataType: byte
   OrigDataType: byte
-T_620: (in fn00401C46() != 0x00 : bool)
-  Class: Eq_620
+T_605: (in fn00401C46() != 0x00 : bool)
+  Class: Eq_605
   DataType: bool
   OrigDataType: bool
-T_621: (in 0x01 : byte)
-  Class: Eq_621
+T_606: (in 0x01 : byte)
+  Class: Eq_606
   DataType: byte
   OrigDataType: byte
-T_622: (in 00403354 : ptr32)
-  Class: Eq_622
+T_607: (in 00403354 : ptr32)
+  Class: Eq_607
   DataType: (ptr32 byte)
-  OrigDataType: (ptr32 (struct (0 T_623 t0000)))
-T_623: (in Mem10[0x00403354:byte] : byte)
-  Class: Eq_621
+  OrigDataType: (ptr32 (struct (0 T_608 t0000)))
+T_608: (in Mem10[0x00403354:byte] : byte)
+  Class: Eq_606
   DataType: byte
   OrigDataType: byte
-T_624: (in fn00401C46 : ptr32)
-  Class: Eq_616
-  DataType: (ptr32 Eq_616)
-  OrigDataType: (ptr32 (fn T_625 ()))
-T_625: (in fn00401C46() : byte)
-  Class: Eq_618
+T_609: (in fn00401C46 : ptr32)
+  Class: Eq_601
+  DataType: (ptr32 Eq_601)
+  OrigDataType: (ptr32 (fn T_610 ()))
+T_610: (in fn00401C46() : byte)
+  Class: Eq_603
   DataType: byte
   OrigDataType: byte
-T_626: (in 0x00 : byte)
-  Class: Eq_618
+T_611: (in 0x00 : byte)
+  Class: Eq_603
   DataType: byte
   OrigDataType: byte
-T_627: (in fn00401C46() != 0x00 : bool)
-  Class: Eq_627
+T_612: (in fn00401C46() != 0x00 : bool)
+  Class: Eq_612
   DataType: bool
   OrigDataType: bool
-T_628: (in 0x00 : byte)
-  Class: Eq_628
+T_613: (in 0x00 : byte)
+  Class: Eq_594
   DataType: byte
   OrigDataType: byte
-T_629: (in SEQ(eax_24_8_53, 0x00) : word32)
-  Class: Eq_629
-  DataType: word32
-  OrigDataType: word32
-T_630: (in (byte) SEQ(eax_24_8_53, 0x00) : byte)
-  Class: Eq_606
+T_614: (in 0x01 : byte)
+  Class: Eq_594
   DataType: byte
   OrigDataType: byte
-T_631: (in 0x01 : byte)
-  Class: Eq_631
+T_615: (in fn00401C46 : ptr32)
+  Class: Eq_601
+  DataType: (ptr32 Eq_601)
+  OrigDataType: (ptr32 (fn T_616 ()))
+T_616: (in fn00401C46() : byte)
+  Class: Eq_603
   DataType: byte
   OrigDataType: byte
-T_632: (in SEQ(eax_24_8_53, 0x01) : word32)
-  Class: Eq_632
-  DataType: word32
-  OrigDataType: word32
-T_633: (in (byte) SEQ(eax_24_8_53, 0x01) : byte)
-  Class: Eq_606
+T_617: (in al : byte)
+  Class: Eq_617
   DataType: byte
   OrigDataType: byte
-T_634: (in fn00401C46 : ptr32)
-  Class: Eq_616
-  DataType: (ptr32 Eq_616)
-  OrigDataType: (ptr32 (fn T_635 ()))
-T_635: (in fn00401C46() : byte)
+T_618: (in eax_84 : word32)
   Class: Eq_618
-  DataType: byte
-  OrigDataType: byte
-T_636: (in al : byte)
-  Class: Eq_636
-  DataType: byte
-  OrigDataType: byte
-T_637: (in eax_84 : word32)
-  Class: Eq_637
   DataType: word32
   OrigDataType: word32
-T_638: (in ebp_13 : (ptr32 Eq_57))
+T_619: (in ebp_13 : (ptr32 Eq_57))
   Class: Eq_57
   DataType: (ptr32 Eq_57)
-  OrigDataType: (ptr32 (struct (8 T_687 t0008)))
-T_639: (in fn00401980 : ptr32)
+  OrigDataType: (ptr32 (struct (8 T_668 t0008)))
+T_620: (in fn00401980 : ptr32)
   Class: Eq_129
   DataType: (ptr32 Eq_129)
-  OrigDataType: (ptr32 (fn T_642 (T_353, T_354, T_355, T_640, T_641)))
-T_640: (in dwLoc0C : word32)
+  OrigDataType: (ptr32 (fn T_623 (T_353, T_354, T_355, T_621, T_622)))
+T_621: (in dwLoc0C : word32)
   Class: Eq_134
   DataType: Eq_134
   OrigDataType: ui32
-T_641: (in 0x00000008 : word32)
+T_622: (in 0x00000008 : word32)
   Class: Eq_135
   DataType: ui32
   OrigDataType: word32
-T_642: (in fn00401980(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
+T_623: (in fn00401980(ebx, esi, edi, dwLoc0C, 0x00000008) : word32)
   Class: Eq_57
   DataType: (ptr32 Eq_57)
+  OrigDataType: word32
+T_624: (in 0x00000004 : word32)
+  Class: Eq_624
+  DataType: ui32
+  OrigDataType: ui32
+T_625: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_625
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_628 t0000)))
+T_626: (in 0x00000000 : word32)
+  Class: Eq_626
+  DataType: word32
+  OrigDataType: word32
+T_627: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_627
+  DataType: word32
+  OrigDataType: word32
+T_628: (in Mem7[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_628
+  DataType: ui32
+  OrigDataType: ui32
+T_629: (in 0x00000000 : word32)
+  Class: Eq_629
+  DataType: ui32
+  OrigDataType: ui32
+T_630: (in *(ebp_13 - 0x00000004) & 0x00000000 : word32)
+  Class: Eq_630
+  DataType: ui32
+  OrigDataType: ui32
+T_631: (in 0x00000004 : word32)
+  Class: Eq_631
+  DataType: ui32
+  OrigDataType: ui32
+T_632: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_632
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_635 t0000)))
+T_633: (in 0x00000000 : word32)
+  Class: Eq_633
+  DataType: word32
+  OrigDataType: word32
+T_634: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_634
+  DataType: ptr32
+  OrigDataType: ptr32
+T_635: (in Mem19[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_630
+  DataType: ui32
+  OrigDataType: word32
+T_636: (in eax_24_8_85 : word24)
+  Class: Eq_636
+  DataType: word24
+  OrigDataType: word24
+T_637: (in 0x00005A : word24)
+  Class: Eq_636
+  DataType: word24
+  OrigDataType: word24
+T_638: (in 00400000 : ptr32)
+  Class: Eq_638
+  DataType: (ptr32 word16)
+  OrigDataType: (ptr32 (struct (0 T_639 t0000)))
+T_639: (in Mem19[0x00400000:word16] : word16)
+  Class: Eq_639
+  DataType: word16
+  OrigDataType: word16
+T_640: (in 0x5A4D : word16)
+  Class: Eq_639
+  DataType: word16
+  OrigDataType: word16
+T_641: (in globals->w400000 != 0x5A4D : bool)
+  Class: Eq_641
+  DataType: bool
+  OrigDataType: bool
+T_642: (in 0xFFFFFFFE : word32)
+  Class: Eq_642
+  DataType: word32
   OrigDataType: word32
 T_643: (in 0x00000004 : word32)
   Class: Eq_643
@@ -2885,7 +2885,7 @@ T_643: (in 0x00000004 : word32)
   OrigDataType: ui32
 T_644: (in ebp_13 - 0x00000004 : word32)
   Class: Eq_644
-  DataType: (ptr32 ui32)
+  DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_647 t0000)))
 T_645: (in 0x00000000 : word32)
   Class: Eq_645
@@ -2893,2105 +2893,1997 @@ T_645: (in 0x00000000 : word32)
   OrigDataType: word32
 T_646: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
   Class: Eq_646
+  DataType: ptr32
+  OrigDataType: ptr32
+T_647: (in Mem57[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_642
   DataType: word32
   OrigDataType: word32
-T_647: (in Mem7[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_647
-  DataType: ui32
-  OrigDataType: ui32
-T_648: (in 0x00000000 : word32)
+T_648: (in 0x00 : byte)
   Class: Eq_648
-  DataType: ui32
-  OrigDataType: ui32
-T_649: (in *(ebp_13 - 0x00000004) & 0x00000000 : word32)
-  Class: Eq_649
-  DataType: ui32
-  OrigDataType: ui32
-T_650: (in 0x00000004 : word32)
-  Class: Eq_650
-  DataType: ui32
-  OrigDataType: ui32
-T_651: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_651
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_654 t0000)))
-T_652: (in 0x00000000 : word32)
-  Class: Eq_652
-  DataType: word32
-  OrigDataType: word32
-T_653: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_653
-  DataType: ptr32
-  OrigDataType: ptr32
-T_654: (in Mem19[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_649
-  DataType: ui32
-  OrigDataType: word32
-T_655: (in eax_24_8_85 : word24)
-  Class: Eq_655
-  DataType: word24
-  OrigDataType: word24
-T_656: (in 0x00005A : word24)
-  Class: Eq_655
-  DataType: word24
-  OrigDataType: word24
-T_657: (in 00400000 : ptr32)
-  Class: Eq_657
-  DataType: (ptr32 word16)
-  OrigDataType: (ptr32 (struct (0 T_658 t0000)))
-T_658: (in Mem19[0x00400000:word16] : word16)
-  Class: Eq_658
-  DataType: word16
-  OrigDataType: word16
-T_659: (in 0x5A4D : word16)
-  Class: Eq_658
-  DataType: word16
-  OrigDataType: word16
-T_660: (in globals->w400000 != 0x5A4D : bool)
-  Class: Eq_660
-  DataType: bool
-  OrigDataType: bool
-T_661: (in 0xFFFFFFFE : word32)
-  Class: Eq_661
-  DataType: word32
-  OrigDataType: word32
-T_662: (in 0x00000004 : word32)
-  Class: Eq_662
-  DataType: ui32
-  OrigDataType: ui32
-T_663: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_663
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_666 t0000)))
-T_664: (in 0x00000000 : word32)
-  Class: Eq_664
-  DataType: word32
-  OrigDataType: word32
-T_665: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_665
-  DataType: ptr32
-  OrigDataType: ptr32
-T_666: (in Mem57[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_661
-  DataType: word32
-  OrigDataType: word32
-T_667: (in 0x00 : byte)
-  Class: Eq_667
   DataType: byte
   OrigDataType: byte
-T_668: (in SEQ(eax_24_8_85, 0x00) : word32)
-  Class: Eq_637
+T_649: (in SEQ(eax_24_8_85, 0x00) : word32)
+  Class: Eq_618
   DataType: word32
   OrigDataType: word32
-T_669: (in eax_25 : (ptr32 Eq_669))
-  Class: Eq_669
-  DataType: (ptr32 Eq_669)
-  OrigDataType: (ptr32 (struct (400000 T_676 t400000) (400018 T_681 t400018)))
-T_670: (in 0040003C : ptr32)
-  Class: Eq_670
-  DataType: (ptr32 (ptr32 Eq_669))
-  OrigDataType: (ptr32 (struct (0 T_671 t0000)))
-T_671: (in Mem19[0x0040003C:word32] : word32)
-  Class: Eq_669
-  DataType: (ptr32 Eq_669)
+T_650: (in eax_25 : (ptr32 Eq_650))
+  Class: Eq_650
+  DataType: (ptr32 Eq_650)
+  OrigDataType: (ptr32 (struct (400000 T_657 t400000) (400018 T_662 t400018)))
+T_651: (in 0040003C : ptr32)
+  Class: Eq_651
+  DataType: (ptr32 (ptr32 Eq_650))
+  OrigDataType: (ptr32 (struct (0 T_652 t0000)))
+T_652: (in Mem19[0x0040003C:word32] : word32)
+  Class: Eq_650
+  DataType: (ptr32 Eq_650)
   OrigDataType: word32
-T_672: (in SLICE(eax_25, word24, 8) : word24)
-  Class: Eq_655
+T_653: (in SLICE(eax_25, word24, 8) : word24)
+  Class: Eq_636
   DataType: word24
   OrigDataType: word24
-T_673: (in SLICE(eax_25, word24, 8) : word24)
-  Class: Eq_655
+T_654: (in SLICE(eax_25, word24, 8) : word24)
+  Class: Eq_636
   DataType: word24
   OrigDataType: word24
-T_674: (in 0x00400000 : word32)
-  Class: Eq_674
+T_655: (in 0x00400000 : word32)
+  Class: Eq_655
   DataType: word32
   OrigDataType: word32
-T_675: (in eax_25 + 0x00400000 : word32)
-  Class: Eq_675
+T_656: (in eax_25 + 0x00400000 : word32)
+  Class: Eq_656
   DataType: word32
   OrigDataType: word32
-T_676: (in Mem19[eax_25 + 0x00400000:word32] : word32)
-  Class: Eq_676
+T_657: (in Mem19[eax_25 + 0x00400000:word32] : word32)
+  Class: Eq_657
   DataType: word32
   OrigDataType: word32
-T_677: (in 0x00004550 : word32)
-  Class: Eq_676
+T_658: (in 0x00004550 : word32)
+  Class: Eq_657
   DataType: word32
   OrigDataType: word32
-T_678: (in eax_25->dw400000 != 0x00004550 : bool)
-  Class: Eq_678
+T_659: (in eax_25->dw400000 != 0x00004550 : bool)
+  Class: Eq_659
   DataType: bool
   OrigDataType: bool
-T_679: (in 0x00400018 : word32)
-  Class: Eq_679
+T_660: (in 0x00400018 : word32)
+  Class: Eq_660
   DataType: word32
   OrigDataType: word32
-T_680: (in eax_25 + 0x00400018 : word32)
-  Class: Eq_680
+T_661: (in eax_25 + 0x00400018 : word32)
+  Class: Eq_661
   DataType: ptr32
   OrigDataType: ptr32
-T_681: (in Mem19[eax_25 + 0x00400018:word16] : word16)
-  Class: Eq_681
+T_662: (in Mem19[eax_25 + 0x00400018:word16] : word16)
+  Class: Eq_662
   DataType: word16
   OrigDataType: word16
-T_682: (in 0x010B : word16)
-  Class: Eq_681
+T_663: (in 0x010B : word16)
+  Class: Eq_662
   DataType: word16
   OrigDataType: word16
-T_683: (in eax_25->w400018 != 0x010B : bool)
-  Class: Eq_683
+T_664: (in eax_25->w400018 != 0x010B : bool)
+  Class: Eq_664
   DataType: bool
   OrigDataType: bool
-T_684: (in eax_32 : ui32)
-  Class: Eq_684
+T_665: (in eax_32 : ui32)
+  Class: Eq_665
   DataType: ui32
   OrigDataType: ui32
-T_685: (in 0x00000008 : word32)
-  Class: Eq_685
+T_666: (in 0x00000008 : word32)
+  Class: Eq_666
   DataType: word32
   OrigDataType: word32
-T_686: (in ebp_13 + 0x00000008 : word32)
-  Class: Eq_686
+T_667: (in ebp_13 + 0x00000008 : word32)
+  Class: Eq_667
   DataType: ptr32
   OrigDataType: ptr32
-T_687: (in Mem19[ebp_13 + 0x00000008:word32] : word32)
-  Class: Eq_684
+T_668: (in Mem19[ebp_13 + 0x00000008:word32] : word32)
+  Class: Eq_665
   DataType: ui32
   OrigDataType: word32
-T_688: (in eax_40 : (ptr32 Eq_688))
-  Class: Eq_688
-  DataType: (ptr32 Eq_688)
-  OrigDataType: (ptr32 (struct (24 T_704 t0024)))
-T_689: (in fn004013F6 : ptr32)
-  Class: Eq_689
-  DataType: (ptr32 Eq_689)
-  OrigDataType: (ptr32 (fn T_696 (T_691, T_693, T_695)))
-T_690: (in signature of fn004013F6 : void)
-  Class: Eq_689
-  DataType: (ptr32 Eq_689)
+T_669: (in eax_40 : (ptr32 Eq_669))
+  Class: Eq_669
+  DataType: (ptr32 Eq_669)
+  OrigDataType: (ptr32 (struct (24 T_685 t0024)))
+T_670: (in fn004013F6 : ptr32)
+  Class: Eq_670
+  DataType: (ptr32 Eq_670)
+  OrigDataType: (ptr32 (fn T_677 (T_672, T_674, T_676)))
+T_671: (in signature of fn004013F6 : void)
+  Class: Eq_670
+  DataType: (ptr32 Eq_670)
   OrigDataType: 
-T_691: (in 0x00400000 : ptr32)
+T_672: (in 0x00400000 : ptr32)
   Class: Eq_516
   DataType: (ptr32 Eq_516)
   OrigDataType: ptr32
-T_692: (in 0x00400000 : ptr32)
-  Class: Eq_692
+T_673: (in 0x00400000 : ptr32)
+  Class: Eq_673
   DataType: ui32
   OrigDataType: (union (ui32 u0) (ptr32 u1))
-T_693: (in eax_32 - 0x00400000 : word32)
+T_674: (in eax_32 - 0x00400000 : word32)
   Class: Eq_517
   DataType: uint32
   OrigDataType: ui32
-T_694: (in edx : word32)
+T_675: (in edx : word32)
   Class: Eq_356
   DataType: ptr32
   OrigDataType: word32
-T_695: (in out edx : ptr32)
+T_676: (in out edx : ptr32)
   Class: Eq_515
   DataType: (ptr32 Eq_515)
   OrigDataType: ptr32
-T_696: (in fn004013F6(&globals->w400000, eax_32 - 0x00400000, out edx) : word32)
-  Class: Eq_688
-  DataType: (ptr32 Eq_688)
+T_677: (in fn004013F6(&globals->w400000, eax_32 - 0x00400000, out edx) : word32)
+  Class: Eq_669
+  DataType: (ptr32 Eq_669)
   OrigDataType: word32
-T_697: (in eax_32 - 0x00400000 : word32)
+T_678: (in eax_32 - 0x00400000 : word32)
   Class: Eq_134
   DataType: Eq_134
   OrigDataType: ui32
-T_698: (in SLICE(eax_40, word24, 8) : word24)
-  Class: Eq_655
+T_679: (in SLICE(eax_40, word24, 8) : word24)
+  Class: Eq_636
   DataType: word24
   OrigDataType: word24
-T_699: (in SLICE(eax_40, word24, 8) : word24)
-  Class: Eq_655
+T_680: (in SLICE(eax_40, word24, 8) : word24)
+  Class: Eq_636
   DataType: word24
   OrigDataType: word24
-T_700: (in 0x00000000 : word32)
+T_681: (in 0x00000000 : word32)
+  Class: Eq_669
+  DataType: (ptr32 Eq_669)
+  OrigDataType: word32
+T_682: (in eax_40 == null : bool)
+  Class: Eq_682
+  DataType: bool
+  OrigDataType: bool
+T_683: (in 0x00000024 : word32)
+  Class: Eq_683
+  DataType: word32
+  OrigDataType: word32
+T_684: (in eax_40 + 0x00000024 : word32)
+  Class: Eq_684
+  DataType: word32
+  OrigDataType: word32
+T_685: (in Mem39[eax_40 + 0x00000024:word32] : word32)
+  Class: Eq_685
+  DataType: int32
+  OrigDataType: int32
+T_686: (in 0x00000000 : word32)
+  Class: Eq_685
+  DataType: int32
+  OrigDataType: int32
+T_687: (in eax_40->dw0024 < 0x00000000 : bool)
+  Class: Eq_687
+  DataType: bool
+  OrigDataType: bool
+T_688: (in 0xFFFFFFFE : word32)
   Class: Eq_688
-  DataType: (ptr32 Eq_688)
-  OrigDataType: word32
-T_701: (in eax_40 == null : bool)
-  Class: Eq_701
-  DataType: bool
-  OrigDataType: bool
-T_702: (in 0x00000024 : word32)
-  Class: Eq_702
   DataType: word32
   OrigDataType: word32
-T_703: (in eax_40 + 0x00000024 : word32)
-  Class: Eq_703
-  DataType: word32
-  OrigDataType: word32
-T_704: (in Mem39[eax_40 + 0x00000024:word32] : word32)
-  Class: Eq_704
-  DataType: int32
-  OrigDataType: int32
-T_705: (in 0x00000000 : word32)
-  Class: Eq_704
-  DataType: int32
-  OrigDataType: int32
-T_706: (in eax_40->dw0024 < 0x00000000 : bool)
-  Class: Eq_706
-  DataType: bool
-  OrigDataType: bool
-T_707: (in 0xFFFFFFFE : word32)
-  Class: Eq_707
-  DataType: word32
-  OrigDataType: word32
-T_708: (in 0x00000004 : word32)
-  Class: Eq_708
+T_689: (in 0x00000004 : word32)
+  Class: Eq_689
   DataType: ui32
   OrigDataType: ui32
-T_709: (in ebp_13 - 0x00000004 : word32)
-  Class: Eq_709
+T_690: (in ebp_13 - 0x00000004 : word32)
+  Class: Eq_690
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_712 t0000)))
-T_710: (in 0x00000000 : word32)
-  Class: Eq_710
+  OrigDataType: (ptr32 (struct (0 T_693 t0000)))
+T_691: (in 0x00000000 : word32)
+  Class: Eq_691
   DataType: word32
   OrigDataType: word32
-T_711: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
-  Class: Eq_711
+T_692: (in ebp_13 - 0x00000004 + 0x00000000 : word32)
+  Class: Eq_692
   DataType: ptr32
   OrigDataType: ptr32
-T_712: (in Mem61[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
-  Class: Eq_707
+T_693: (in Mem61[ebp_13 - 0x00000004 + 0x00000000:word32] : word32)
+  Class: Eq_688
   DataType: word32
   OrigDataType: word32
-T_713: (in 0x01 : byte)
-  Class: Eq_713
+T_694: (in 0x01 : byte)
+  Class: Eq_694
   DataType: byte
   OrigDataType: byte
-T_714: (in SEQ(eax_24_8_85, 0x01) : word32)
-  Class: Eq_637
+T_695: (in SEQ(eax_24_8_85, 0x01) : word32)
+  Class: Eq_618
   DataType: word32
   OrigDataType: word32
-T_715: (in ebp_69 : ptr32)
+T_696: (in ebp_69 : ptr32)
   Class: Eq_358
   DataType: ptr32
   OrigDataType: word32
-T_716: (in edi_72 : ptr32)
+T_697: (in edi_72 : ptr32)
   Class: Eq_360
   DataType: ptr32
   OrigDataType: word32
-T_717: (in esi_73 : ptr32)
+T_698: (in esi_73 : ptr32)
   Class: Eq_359
   DataType: ptr32
   OrigDataType: word32
-T_718: (in ebx_70 : ptr32)
+T_699: (in ebx_70 : ptr32)
   Class: Eq_303
   DataType: ptr32
   OrigDataType: word32
-T_719: (in fn004019C6 : ptr32)
+T_700: (in fn004019C6 : ptr32)
   Class: Eq_290
   DataType: (ptr32 Eq_290)
-  OrigDataType: (ptr32 (fn T_723 (T_638, T_640, T_720, T_721, T_722)))
-T_720: (in out ebp_69 : ptr32)
+  OrigDataType: (ptr32 (fn T_704 (T_619, T_621, T_701, T_702, T_703)))
+T_701: (in out ebp_69 : ptr32)
   Class: Eq_134
   DataType: Eq_134
   OrigDataType: ptr32
-T_721: (in out esi_73 : ptr32)
+T_702: (in out esi_73 : ptr32)
   Class: Eq_295
   DataType: ptr32
   OrigDataType: ptr32
-T_722: (in out edi_72 : ptr32)
+T_703: (in out edi_72 : ptr32)
   Class: Eq_296
   DataType: ptr32
   OrigDataType: ptr32
-T_723: (in fn004019C6(ebp_13, dwLoc0C, out ebp_69, out esi_73, out edi_72) : word32)
+T_704: (in fn004019C6(ebp_13, dwLoc0C, out ebp_69, out esi_73, out edi_72) : word32)
   Class: Eq_303
   DataType: ptr32
   OrigDataType: word32
-T_724: (in (byte) eax_84 : byte)
-  Class: Eq_636
+T_705: (in SLICE(eax_84, byte, 0) : byte)
+  Class: Eq_617
   DataType: byte
   OrigDataType: byte
-T_725: (in fn00401B98 : ptr32)
+T_706: (in fn00401B98 : ptr32)
   Class: Eq_560
   DataType: (ptr32 Eq_560)
-  OrigDataType: (ptr32 (fn T_726 ()))
-T_726: (in fn00401B98() : word32)
+  OrigDataType: (ptr32 (fn T_707 ()))
+T_707: (in fn00401B98() : word32)
   Class: Eq_559
   DataType: word32
   OrigDataType: word32
-T_727: (in 0x00000000 : word32)
+T_708: (in 0x00000000 : word32)
   Class: Eq_559
   DataType: word32
   OrigDataType: word32
-T_728: (in fn00401B98() == 0x00000000 : bool)
-  Class: Eq_728
+T_709: (in fn00401B98() == 0x00000000 : bool)
+  Class: Eq_709
   DataType: bool
   OrigDataType: bool
-T_729: (in 0x00 : byte)
+T_710: (in 0x00 : byte)
   Class: Eq_132
   DataType: byte
   OrigDataType: byte
-T_730: (in bArg04 != 0x00 : bool)
-  Class: Eq_730
+T_711: (in bArg04 != 0x00 : bool)
+  Class: Eq_711
   DataType: bool
   OrigDataType: bool
-T_731: (in 0x00000000 : word32)
-  Class: Eq_584
+T_712: (in 0x00000000 : word32)
+  Class: Eq_580
   DataType: word32
   OrigDataType: word32
-T_732: (in 0x00403338 : ptr32)
-  Class: Eq_732
+T_713: (in 0x00403338 : ptr32)
+  Class: Eq_713
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_733 t0000)))
-T_733: (in Mem23[0x00403338:word32] : word32)
-  Class: Eq_584
+  OrigDataType: (ptr32 (struct (0 T_714 t0000)))
+T_714: (in Mem23[0x00403338:word32] : word32)
+  Class: Eq_580
   DataType: word32
   OrigDataType: word32
-T_734: (in 00403354 : ptr32)
-  Class: Eq_734
+T_715: (in 00403354 : ptr32)
+  Class: Eq_715
   DataType: (ptr32 byte)
-  OrigDataType: (ptr32 (struct (0 T_735 t0000)))
-T_735: (in Mem6[0x00403354:byte] : byte)
-  Class: Eq_621
+  OrigDataType: (ptr32 (struct (0 T_716 t0000)))
+T_716: (in Mem6[0x00403354:byte] : byte)
+  Class: Eq_606
   DataType: byte
   OrigDataType: byte
-T_736: (in 0x00 : byte)
-  Class: Eq_621
+T_717: (in 0x00 : byte)
+  Class: Eq_606
   DataType: byte
   OrigDataType: byte
-T_737: (in globals->b403354 == 0x00 : bool)
-  Class: Eq_737
+T_718: (in globals->b403354 == 0x00 : bool)
+  Class: Eq_718
   DataType: bool
   OrigDataType: bool
-T_738: (in fn00401C46 : ptr32)
-  Class: Eq_616
-  DataType: (ptr32 Eq_616)
-  OrigDataType: (ptr32 (fn T_739 ()))
-T_739: (in fn00401C46() : byte)
-  Class: Eq_618
+T_719: (in fn00401C46 : ptr32)
+  Class: Eq_601
+  DataType: (ptr32 Eq_601)
+  OrigDataType: (ptr32 (fn T_720 ()))
+T_720: (in fn00401C46() : byte)
+  Class: Eq_603
   DataType: byte
   OrigDataType: byte
-T_740: (in fn00401C46 : ptr32)
-  Class: Eq_616
-  DataType: (ptr32 Eq_616)
-  OrigDataType: (ptr32 (fn T_741 ()))
-T_741: (in fn00401C46() : byte)
-  Class: Eq_618
+T_721: (in fn00401C46 : ptr32)
+  Class: Eq_601
+  DataType: (ptr32 Eq_601)
+  OrigDataType: (ptr32 (fn T_722 ()))
+T_722: (in fn00401C46() : byte)
+  Class: Eq_603
   DataType: byte
   OrigDataType: byte
-T_742: (in 0x00 : byte)
+T_723: (in 0x00 : byte)
   Class: Eq_488
   DataType: byte
   OrigDataType: byte
-T_743: (in bArg08 != 0x00 : bool)
-  Class: Eq_743
+T_724: (in bArg08 != 0x00 : bool)
+  Class: Eq_724
   DataType: bool
   OrigDataType: bool
-T_744: (in eax_15 : ui32)
-  Class: Eq_744
+T_725: (in eax_15 : ui32)
+  Class: Eq_725
   DataType: ui32
   OrigDataType: ui32
-T_745: (in 00403004 : ptr32)
-  Class: Eq_745
+T_726: (in 00403004 : ptr32)
+  Class: Eq_726
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_746 t0000)))
-T_746: (in Mem13[0x00403004:word32] : word32)
-  Class: Eq_744
+  OrigDataType: (ptr32 (struct (0 T_727 t0000)))
+T_727: (in Mem13[0x00403004:word32] : word32)
+  Class: Eq_725
   DataType: ui32
   OrigDataType: word32
-T_747: (in 0xBB40E64E : word32)
-  Class: Eq_744
+T_728: (in 0xBB40E64E : word32)
+  Class: Eq_725
   DataType: ui32
   OrigDataType: word32
-T_748: (in eax_15 == 0xBB40E64E : bool)
-  Class: Eq_748
+T_729: (in eax_15 == 0xBB40E64E : bool)
+  Class: Eq_729
   DataType: bool
   OrigDataType: bool
-T_749: (in GetSystemTimeAsFileTime : ptr32)
-  Class: Eq_749
-  DataType: (ptr32 Eq_749)
-  OrigDataType: (ptr32 (fn T_755 (T_754)))
-T_750: (in signature of GetSystemTimeAsFileTime : void)
-  Class: Eq_749
-  DataType: (ptr32 Eq_749)
+T_730: (in GetSystemTimeAsFileTime : ptr32)
+  Class: Eq_730
+  DataType: (ptr32 Eq_730)
+  OrigDataType: (ptr32 (fn T_736 (T_735)))
+T_731: (in signature of GetSystemTimeAsFileTime : void)
+  Class: Eq_730
+  DataType: (ptr32 Eq_730)
   OrigDataType: 
-T_751: (in lpSystemTimeAsFileTime : LPFILETIME)
-  Class: Eq_751
-  DataType: Eq_751
+T_732: (in lpSystemTimeAsFileTime : LPFILETIME)
+  Class: Eq_732
+  DataType: Eq_732
   OrigDataType: 
-T_752: (in fp : ptr32)
-  Class: Eq_752
+T_733: (in fp : ptr32)
+  Class: Eq_733
   DataType: ptr32
   OrigDataType: ptr32
-T_753: (in 0x00000010 : word32)
-  Class: Eq_753
+T_734: (in 0x00000010 : word32)
+  Class: Eq_734
   DataType: ui32
   OrigDataType: ui32
-T_754: (in fp - 0x00000010 : word32)
-  Class: Eq_751
-  DataType: Eq_751
+T_735: (in fp - 0x00000010 : word32)
+  Class: Eq_732
+  DataType: Eq_732
   OrigDataType: LPFILETIME
-T_755: (in GetSystemTimeAsFileTime(fp - 0x00000010) : void)
-  Class: Eq_755
+T_736: (in GetSystemTimeAsFileTime(fp - 0x00000010) : void)
+  Class: Eq_736
   DataType: void
   OrigDataType: void
-T_756: (in v14_43 : ui32)
+T_737: (in v14_43 : ui32)
+  Class: Eq_737
+  DataType: ui32
+  OrigDataType: ui32
+T_738: (in dwLoc0C : word32)
+  Class: Eq_738
+  DataType: ui32
+  OrigDataType: ui32
+T_739: (in 0x00000000 : word32)
+  Class: Eq_739
+  DataType: ui32
+  OrigDataType: ui32
+T_740: (in dwLoc0C & 0x00000000 : word32)
+  Class: Eq_740
+  DataType: ui32
+  OrigDataType: ui32
+T_741: (in dwLoc10 : word32)
+  Class: Eq_741
+  DataType: ui32
+  OrigDataType: ui32
+T_742: (in 0x00000000 : word32)
+  Class: Eq_742
+  DataType: ui32
+  OrigDataType: ui32
+T_743: (in dwLoc10 & 0x00000000 : word32)
+  Class: Eq_743
+  DataType: ui32
+  OrigDataType: ui32
+T_744: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 : word32)
+  Class: Eq_744
+  DataType: ui32
+  OrigDataType: ui32
+T_745: (in GetCurrentThreadId : ptr32)
+  Class: Eq_745
+  DataType: (ptr32 Eq_745)
+  OrigDataType: (ptr32 (fn T_747 ()))
+T_746: (in signature of GetCurrentThreadId : void)
+  Class: Eq_745
+  DataType: (ptr32 Eq_745)
+  OrigDataType: 
+T_747: (in GetCurrentThreadId() : DWORD)
+  Class: Eq_121
+  DataType: Eq_121
+  OrigDataType: DWORD
+T_748: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 ^ GetCurrentThreadId() : word32)
+  Class: Eq_748
+  DataType: ui32
+  OrigDataType: ui32
+T_749: (in GetCurrentProcessId : ptr32)
+  Class: Eq_749
+  DataType: (ptr32 Eq_749)
+  OrigDataType: (ptr32 (fn T_751 ()))
+T_750: (in signature of GetCurrentProcessId : void)
+  Class: Eq_749
+  DataType: (ptr32 Eq_749)
+  OrigDataType: 
+T_751: (in GetCurrentProcessId() : DWORD)
+  Class: Eq_121
+  DataType: Eq_121
+  OrigDataType: DWORD
+T_752: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 ^ GetCurrentThreadId() ^ GetCurrentProcessId() : word32)
+  Class: Eq_737
+  DataType: ui32
+  OrigDataType: ui32
+T_753: (in QueryPerformanceCounter : ptr32)
+  Class: Eq_753
+  DataType: (ptr32 Eq_753)
+  OrigDataType: (ptr32 (fn T_758 (T_757)))
+T_754: (in signature of QueryPerformanceCounter : void)
+  Class: Eq_753
+  DataType: (ptr32 Eq_753)
+  OrigDataType: 
+T_755: (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
+  Class: Eq_755
+  DataType: (ptr32 Eq_755)
+  OrigDataType: 
+T_756: (in 0x00000018 : word32)
   Class: Eq_756
   DataType: ui32
   OrigDataType: ui32
-T_757: (in dwLoc0C : word32)
-  Class: Eq_757
-  DataType: ui32
-  OrigDataType: ui32
-T_758: (in 0x00000000 : word32)
+T_757: (in fp - 0x00000018 : word32)
+  Class: Eq_755
+  DataType: (ptr32 Eq_755)
+  OrigDataType: (ptr32 LARGE_INTEGER)
+T_758: (in QueryPerformanceCounter(fp - 0x00000018) : BOOL)
   Class: Eq_758
+  DataType: Eq_758
+  OrigDataType: BOOL
+T_759: (in ecx_55 : ui32)
+  Class: Eq_725
   DataType: ui32
   OrigDataType: ui32
-T_759: (in dwLoc0C & 0x00000000 : word32)
-  Class: Eq_759
-  DataType: ui32
-  OrigDataType: ui32
-T_760: (in dwLoc10 : word32)
+T_760: (in dwLoc14 : word32)
   Class: Eq_760
-  DataType: ui32
-  OrigDataType: ui32
-T_761: (in 0x00000000 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_761: (in dwLoc18 : word32)
   Class: Eq_761
-  DataType: ui32
-  OrigDataType: ui32
-T_762: (in dwLoc10 & 0x00000000 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_762: (in dwLoc14 ^ dwLoc18 : word32)
   Class: Eq_762
   DataType: ui32
   OrigDataType: ui32
-T_763: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 : word32)
+T_763: (in dwLoc14 ^ dwLoc18 ^ v14_43 : word32)
   Class: Eq_763
   DataType: ui32
   OrigDataType: ui32
-T_764: (in GetCurrentThreadId : ptr32)
+T_764: (in 0x00000008 : word32)
   Class: Eq_764
-  DataType: (ptr32 Eq_764)
-  OrigDataType: (ptr32 (fn T_766 ()))
-T_765: (in signature of GetCurrentThreadId : void)
-  Class: Eq_764
-  DataType: (ptr32 Eq_764)
-  OrigDataType: 
-T_766: (in GetCurrentThreadId() : DWORD)
-  Class: Eq_121
-  DataType: Eq_121
-  OrigDataType: DWORD
-T_767: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 ^ GetCurrentThreadId() : word32)
-  Class: Eq_767
   DataType: ui32
   OrigDataType: ui32
-T_768: (in GetCurrentProcessId : ptr32)
-  Class: Eq_768
-  DataType: (ptr32 Eq_768)
-  OrigDataType: (ptr32 (fn T_770 ()))
-T_769: (in signature of GetCurrentProcessId : void)
-  Class: Eq_768
-  DataType: (ptr32 Eq_768)
-  OrigDataType: 
-T_770: (in GetCurrentProcessId() : DWORD)
-  Class: Eq_121
-  DataType: Eq_121
-  OrigDataType: DWORD
-T_771: (in dwLoc0C & 0x00000000 ^ dwLoc10 & 0x00000000 ^ GetCurrentThreadId() ^ GetCurrentProcessId() : word32)
-  Class: Eq_756
-  DataType: ui32
-  OrigDataType: ui32
-T_772: (in QueryPerformanceCounter : ptr32)
-  Class: Eq_772
-  DataType: (ptr32 Eq_772)
-  OrigDataType: (ptr32 (fn T_777 (T_776)))
-T_773: (in signature of QueryPerformanceCounter : void)
-  Class: Eq_772
-  DataType: (ptr32 Eq_772)
-  OrigDataType: 
-T_774: (in lpPerformanceCount : (ptr32 LARGE_INTEGER))
-  Class: Eq_774
-  DataType: (ptr32 Eq_774)
-  OrigDataType: 
-T_775: (in 0x00000018 : word32)
-  Class: Eq_775
-  DataType: ui32
-  OrigDataType: ui32
-T_776: (in fp - 0x00000018 : word32)
-  Class: Eq_774
-  DataType: (ptr32 Eq_774)
-  OrigDataType: (ptr32 LARGE_INTEGER)
-T_777: (in QueryPerformanceCounter(fp - 0x00000018) : BOOL)
-  Class: Eq_777
-  DataType: Eq_777
-  OrigDataType: BOOL
-T_778: (in ecx_55 : ui32)
-  Class: Eq_744
-  DataType: ui32
-  OrigDataType: ui32
-T_779: (in dwLoc14 : word32)
-  Class: Eq_779
-  DataType: word32
-  OrigDataType: word32
-T_780: (in dwLoc18 : word32)
-  Class: Eq_780
-  DataType: word32
-  OrigDataType: word32
-T_781: (in dwLoc14 ^ dwLoc18 : word32)
-  Class: Eq_781
-  DataType: ui32
-  OrigDataType: ui32
-T_782: (in dwLoc14 ^ dwLoc18 ^ v14_43 : word32)
-  Class: Eq_782
-  DataType: ui32
-  OrigDataType: ui32
-T_783: (in 0x00000008 : word32)
-  Class: Eq_783
-  DataType: ui32
-  OrigDataType: ui32
-T_784: (in fp - 0x00000008 : word32)
-  Class: Eq_784
+T_765: (in fp - 0x00000008 : word32)
+  Class: Eq_765
   DataType: ptr32
   OrigDataType: ptr32
-T_785: (in dwLoc14 ^ dwLoc18 ^ v14_43 ^ fp - 0x00000008 : word32)
-  Class: Eq_744
+T_766: (in dwLoc14 ^ dwLoc18 ^ v14_43 ^ fp - 0x00000008 : word32)
+  Class: Eq_725
   DataType: ui32
   OrigDataType: ui32
-T_786: (in 0xBB40E64E : word32)
-  Class: Eq_744
+T_767: (in 0xBB40E64E : word32)
+  Class: Eq_725
   DataType: ui32
   OrigDataType: word32
-T_787: (in ecx_55 != 0xBB40E64E : bool)
+T_768: (in ecx_55 != 0xBB40E64E : bool)
+  Class: Eq_768
+  DataType: bool
+  OrigDataType: bool
+T_769: (in 0xFFFF0000 : word32)
+  Class: Eq_769
+  DataType: ui32
+  OrigDataType: ui32
+T_770: (in eax_15 & 0xFFFF0000 : word32)
+  Class: Eq_770
+  DataType: ui32
+  OrigDataType: ui32
+T_771: (in 0x00000000 : word32)
+  Class: Eq_770
+  DataType: ui32
+  OrigDataType: word32
+T_772: (in (eax_15 & 0xFFFF0000) == 0x00000000 : bool)
+  Class: Eq_772
+  DataType: bool
+  OrigDataType: bool
+T_773: (in ~eax_15 : word32)
+  Class: Eq_773
+  DataType: ui32
+  OrigDataType: ui32
+T_774: (in 00403000 : ptr32)
+  Class: Eq_774
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_775 t0000)))
+T_775: (in Mem75[0x00403000:word32] : word32)
+  Class: Eq_773
+  DataType: ui32
+  OrigDataType: word32
+T_776: (in 0xFFFF0000 : word32)
+  Class: Eq_776
+  DataType: ui32
+  OrigDataType: ui32
+T_777: (in ecx_55 & 0xFFFF0000 : word32)
+  Class: Eq_777
+  DataType: ui32
+  OrigDataType: ui32
+T_778: (in 0x00000000 : word32)
+  Class: Eq_777
+  DataType: ui32
+  OrigDataType: word32
+T_779: (in (ecx_55 & 0xFFFF0000) != 0x00000000 : bool)
+  Class: Eq_779
+  DataType: bool
+  OrigDataType: bool
+T_780: (in 0xBB40E64F : word32)
+  Class: Eq_725
+  DataType: ui32
+  OrigDataType: word32
+T_781: (in 00403004 : ptr32)
+  Class: Eq_781
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_782 t0000)))
+T_782: (in Mem71[0x00403004:word32] : word32)
+  Class: Eq_725
+  DataType: ui32
+  OrigDataType: word32
+T_783: (in ~ecx_55 : word32)
+  Class: Eq_773
+  DataType: ui32
+  OrigDataType: ui32
+T_784: (in 00403000 : ptr32)
+  Class: Eq_784
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_785 t0000)))
+T_785: (in Mem73[0x00403000:word32] : word32)
+  Class: Eq_773
+  DataType: ui32
+  OrigDataType: word32
+T_786: (in 0x00004711 : word32)
+  Class: Eq_786
+  DataType: ui32
+  OrigDataType: ui32
+T_787: (in ecx_55 | 0x00004711 : word32)
   Class: Eq_787
-  DataType: bool
-  OrigDataType: bool
-T_788: (in 0xFFFF0000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_788: (in 0x00000010 : word32)
   Class: Eq_788
-  DataType: ui32
-  OrigDataType: ui32
-T_789: (in eax_15 & 0xFFFF0000 : word32)
-  Class: Eq_789
-  DataType: ui32
-  OrigDataType: ui32
-T_790: (in 0x00000000 : word32)
-  Class: Eq_789
-  DataType: ui32
+  DataType: word32
   OrigDataType: word32
-T_791: (in (eax_15 & 0xFFFF0000) == 0x00000000 : bool)
+T_789: (in (ecx_55 | 0x00004711) << 0x00000010 : word32)
+  Class: Eq_789
+  DataType: ui32
+  OrigDataType: ui32
+T_790: (in ecx_55 | (ecx_55 | 0x00004711) << 0x00000010 : word32)
+  Class: Eq_725
+  DataType: ui32
+  OrigDataType: ui32
+T_791: (in eax : ptr32)
   Class: Eq_791
-  DataType: bool
-  OrigDataType: bool
-T_792: (in ~eax_15 : word32)
-  Class: Eq_792
-  DataType: ui32
-  OrigDataType: ui32
-T_793: (in 00403000 : ptr32)
+  DataType: ptr32
+  OrigDataType: word32
+T_792: (in 0x00403384 : ptr32)
+  Class: Eq_791
+  DataType: ptr32
+  OrigDataType: ptr32
+T_793: (in eax : ptr32)
   Class: Eq_793
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_794 t0000)))
-T_794: (in Mem75[0x00403000:word32] : word32)
-  Class: Eq_792
-  DataType: ui32
+  DataType: ptr32
   OrigDataType: word32
-T_795: (in 0xFFFF0000 : word32)
+T_794: (in 0x00403380 : ptr32)
+  Class: Eq_793
+  DataType: ptr32
+  OrigDataType: ptr32
+T_795: (in IsProcessorFeaturePresent : ptr32)
   Class: Eq_795
-  DataType: ui32
-  OrigDataType: ui32
-T_796: (in ecx_55 & 0xFFFF0000 : word32)
-  Class: Eq_796
-  DataType: ui32
-  OrigDataType: ui32
-T_797: (in 0x00000000 : word32)
-  Class: Eq_796
-  DataType: ui32
+  DataType: (ptr32 Eq_795)
+  OrigDataType: (ptr32 (fn T_799 (T_798)))
+T_796: (in signature of IsProcessorFeaturePresent : void)
+  Class: Eq_795
+  DataType: (ptr32 Eq_795)
+  OrigDataType: 
+T_797: (in ProcessorFeature : DWORD)
+  Class: Eq_121
+  DataType: Eq_121
+  OrigDataType: 
+T_798: (in 0x00000017 : word32)
+  Class: Eq_121
+  DataType: Eq_121
+  OrigDataType: DWORD
+T_799: (in IsProcessorFeaturePresent(0x00000017) : BOOL)
+  Class: Eq_758
+  DataType: Eq_758
+  OrigDataType: BOOL
+T_800: (in 0x00000000 : word32)
+  Class: Eq_758
+  DataType: Eq_758
   OrigDataType: word32
-T_798: (in (ecx_55 & 0xFFFF0000) != 0x00000000 : bool)
-  Class: Eq_798
+T_801: (in IsProcessorFeaturePresent(0x00000017) == 0x00000000 : bool)
+  Class: Eq_801
   DataType: bool
   OrigDataType: bool
-T_799: (in 0xBB40E64F : word32)
-  Class: Eq_744
+T_802: (in 0x00000000 : word32)
+  Class: Eq_802
   DataType: ui32
   OrigDataType: word32
-T_800: (in 00403004 : ptr32)
-  Class: Eq_800
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_801 t0000)))
-T_801: (in Mem71[0x00403004:word32] : word32)
-  Class: Eq_744
-  DataType: ui32
-  OrigDataType: word32
-T_802: (in ~ecx_55 : word32)
-  Class: Eq_792
-  DataType: ui32
-  OrigDataType: ui32
-T_803: (in 00403000 : ptr32)
+T_803: (in 00403368 : ptr32)
   Class: Eq_803
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 (struct (0 T_804 t0000)))
-T_804: (in Mem73[0x00403000:word32] : word32)
-  Class: Eq_792
+T_804: (in Mem30[0x00403368:word32] : word32)
+  Class: Eq_802
   DataType: ui32
   OrigDataType: word32
-T_805: (in 0x00004711 : word32)
+T_805: (in memset : ptr32)
   Class: Eq_805
-  DataType: ui32
-  OrigDataType: ui32
-T_806: (in ecx_55 | 0x00004711 : word32)
-  Class: Eq_806
-  DataType: ui32
-  OrigDataType: ui32
-T_807: (in 0x00000010 : word32)
+  DataType: (ptr32 Eq_805)
+  OrigDataType: (ptr32 (fn T_815 (T_812, T_813, T_814)))
+T_806: (in signature of memset : void)
+  Class: Eq_805
+  DataType: (ptr32 Eq_805)
+  OrigDataType: 
+T_807: (in _Dst : (ptr32 void))
   Class: Eq_807
-  DataType: word32
-  OrigDataType: word32
-T_808: (in (ecx_55 | 0x00004711) << 0x00000010 : word32)
+  DataType: (ptr32 void)
+  OrigDataType: 
+T_808: (in _Val : int32)
   Class: Eq_808
-  DataType: ui32
-  OrigDataType: ui32
-T_809: (in ecx_55 | (ecx_55 | 0x00004711) << 0x00000010 : word32)
-  Class: Eq_744
-  DataType: ui32
-  OrigDataType: ui32
-T_810: (in eax : ptr32)
-  Class: Eq_810
-  DataType: ptr32
-  OrigDataType: word32
-T_811: (in 0x00403384 : ptr32)
+  DataType: int32
+  OrigDataType: 
+T_809: (in _Size : size_t)
+  Class: Eq_809
+  DataType: Eq_809
+  OrigDataType: 
+T_810: (in fp : ptr32)
   Class: Eq_810
   DataType: ptr32
   OrigDataType: ptr32
-T_812: (in eax : ptr32)
-  Class: Eq_812
-  DataType: ptr32
-  OrigDataType: word32
-T_813: (in 0x00403380 : ptr32)
-  Class: Eq_812
-  DataType: ptr32
-  OrigDataType: ptr32
-T_814: (in IsProcessorFeaturePresent : ptr32)
-  Class: Eq_814
-  DataType: (ptr32 Eq_814)
-  OrigDataType: (ptr32 (fn T_818 (T_817)))
-T_815: (in signature of IsProcessorFeaturePresent : void)
-  Class: Eq_814
-  DataType: (ptr32 Eq_814)
-  OrigDataType: 
-T_816: (in ProcessorFeature : DWORD)
-  Class: Eq_121
-  DataType: Eq_121
-  OrigDataType: 
-T_817: (in 0x00000017 : word32)
-  Class: Eq_121
-  DataType: Eq_121
-  OrigDataType: DWORD
-T_818: (in IsProcessorFeaturePresent(0x00000017) : BOOL)
-  Class: Eq_777
-  DataType: Eq_777
-  OrigDataType: BOOL
+T_811: (in 0x00000328 : word32)
+  Class: Eq_811
+  DataType: ui32
+  OrigDataType: ui32
+T_812: (in fp - 0x00000328 : word32)
+  Class: Eq_807
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_813: (in 0x00000000 : word32)
+  Class: Eq_808
+  DataType: int32
+  OrigDataType: int32
+T_814: (in 0x000002CC : word32)
+  Class: Eq_809
+  DataType: Eq_809
+  OrigDataType: size_t
+T_815: (in memset(fp - 0x00000328, 0x00000000, 0x000002CC) : (ptr32 void))
+  Class: Eq_815
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_816: (in memset : ptr32)
+  Class: Eq_805
+  DataType: (ptr32 Eq_805)
+  OrigDataType: (ptr32 (fn T_821 (T_818, T_819, T_820)))
+T_817: (in 0x0000005C : word32)
+  Class: Eq_817
+  DataType: ui32
+  OrigDataType: ui32
+T_818: (in fp - 0x0000005C : word32)
+  Class: Eq_807
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
 T_819: (in 0x00000000 : word32)
-  Class: Eq_777
-  DataType: Eq_777
-  OrigDataType: word32
-T_820: (in IsProcessorFeaturePresent(0x00000017) == 0x00000000 : bool)
-  Class: Eq_820
-  DataType: bool
-  OrigDataType: bool
-T_821: (in 0x00000000 : word32)
-  Class: Eq_821
-  DataType: ui32
-  OrigDataType: word32
-T_822: (in 00403368 : ptr32)
+  Class: Eq_808
+  DataType: int32
+  OrigDataType: int32
+T_820: (in 0x00000050 : word32)
+  Class: Eq_809
+  DataType: Eq_809
+  OrigDataType: size_t
+T_821: (in memset(fp - 0x0000005C, 0x00000000, 0x00000050) : (ptr32 void))
+  Class: Eq_815
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_822: (in bl_90 : byte)
   Class: Eq_822
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_823 t0000)))
-T_823: (in Mem30[0x00403368:word32] : word32)
-  Class: Eq_821
-  DataType: ui32
-  OrigDataType: word32
-T_824: (in memset : ptr32)
-  Class: Eq_824
-  DataType: (ptr32 Eq_824)
-  OrigDataType: (ptr32 (fn T_834 (T_831, T_832, T_833)))
-T_825: (in signature of memset : void)
-  Class: Eq_824
-  DataType: (ptr32 Eq_824)
-  OrigDataType: 
-T_826: (in _Dst : (ptr32 void))
-  Class: Eq_826
-  DataType: (ptr32 void)
-  OrigDataType: 
-T_827: (in _Val : int32)
-  Class: Eq_827
-  DataType: int32
-  OrigDataType: 
-T_828: (in _Size : size_t)
-  Class: Eq_828
-  DataType: Eq_828
-  OrigDataType: 
-T_829: (in fp : ptr32)
-  Class: Eq_829
-  DataType: ptr32
-  OrigDataType: ptr32
-T_830: (in 0x00000328 : word32)
-  Class: Eq_830
-  DataType: ui32
-  OrigDataType: ui32
-T_831: (in fp - 0x00000328 : word32)
-  Class: Eq_826
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_832: (in 0x00000000 : word32)
-  Class: Eq_827
-  DataType: int32
-  OrigDataType: int32
-T_833: (in 0x000002CC : word32)
-  Class: Eq_828
-  DataType: Eq_828
-  OrigDataType: size_t
-T_834: (in memset(fp - 0x00000328, 0x00000000, 0x000002CC) : (ptr32 void))
-  Class: Eq_834
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_835: (in memset : ptr32)
-  Class: Eq_824
-  DataType: (ptr32 Eq_824)
-  OrigDataType: (ptr32 (fn T_840 (T_837, T_838, T_839)))
-T_836: (in 0x0000005C : word32)
-  Class: Eq_836
-  DataType: ui32
-  OrigDataType: ui32
-T_837: (in fp - 0x0000005C : word32)
-  Class: Eq_826
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_838: (in 0x00000000 : word32)
-  Class: Eq_827
-  DataType: int32
-  OrigDataType: int32
-T_839: (in 0x00000050 : word32)
-  Class: Eq_828
-  DataType: Eq_828
-  OrigDataType: size_t
-T_840: (in memset(fp - 0x0000005C, 0x00000000, 0x00000050) : (ptr32 void))
-  Class: Eq_834
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_841: (in bl_90 : byte)
-  Class: Eq_841
   DataType: byte
   OrigDataType: byte
-T_842: (in 0x00 : byte)
-  Class: Eq_842
+T_823: (in 0x00 : byte)
+  Class: Eq_823
   DataType: byte
   OrigDataType: byte
-T_843: (in IsDebuggerPresent : ptr32)
-  Class: Eq_843
-  DataType: (ptr32 Eq_843)
-  OrigDataType: (ptr32 (fn T_845 ()))
-T_844: (in signature of IsDebuggerPresent : void)
-  Class: Eq_843
-  DataType: (ptr32 Eq_843)
+T_824: (in IsDebuggerPresent : ptr32)
+  Class: Eq_824
+  DataType: (ptr32 Eq_824)
+  OrigDataType: (ptr32 (fn T_826 ()))
+T_825: (in signature of IsDebuggerPresent : void)
+  Class: Eq_824
+  DataType: (ptr32 Eq_824)
   OrigDataType: 
-T_845: (in IsDebuggerPresent() : BOOL)
-  Class: Eq_777
-  DataType: Eq_777
+T_826: (in IsDebuggerPresent() : BOOL)
+  Class: Eq_758
+  DataType: Eq_758
   OrigDataType: BOOL
-T_846: (in 0x00000001 : word32)
-  Class: Eq_777
-  DataType: Eq_777
+T_827: (in 0x00000001 : word32)
+  Class: Eq_758
+  DataType: Eq_758
   OrigDataType: word32
-T_847: (in IsDebuggerPresent() == 0x00000001 : bool)
-  Class: Eq_847
-  DataType: Eq_847
+T_828: (in IsDebuggerPresent() == 0x00000001 : bool)
+  Class: Eq_828
+  DataType: Eq_828
   OrigDataType: (union (bool u0) (byte u1))
-T_848: (in 0x00 - (IsDebuggerPresent() == 0x00000001) : byte)
-  Class: Eq_841
+T_829: (in 0x00 - (IsDebuggerPresent() == 0x00000001) : byte)
+  Class: Eq_822
   DataType: byte
   OrigDataType: byte
-T_849: (in SetUnhandledExceptionFilter : ptr32)
-  Class: Eq_849
-  DataType: (ptr32 Eq_849)
-  OrigDataType: (ptr32 (fn T_853 (T_852)))
-T_850: (in signature of SetUnhandledExceptionFilter : void)
-  Class: Eq_849
-  DataType: (ptr32 Eq_849)
+T_830: (in SetUnhandledExceptionFilter : ptr32)
+  Class: Eq_830
+  DataType: (ptr32 Eq_830)
+  OrigDataType: (ptr32 (fn T_834 (T_833)))
+T_831: (in signature of SetUnhandledExceptionFilter : void)
+  Class: Eq_830
+  DataType: (ptr32 Eq_830)
   OrigDataType: 
-T_851: (in lpTopLevelExceptionFilter : LPTOP_LEVEL_EXCEPTION_FILTER)
-  Class: Eq_851
-  DataType: Eq_851
+T_832: (in lpTopLevelExceptionFilter : LPTOP_LEVEL_EXCEPTION_FILTER)
+  Class: Eq_832
+  DataType: Eq_832
   OrigDataType: 
-T_852: (in 0x00000000 : word32)
-  Class: Eq_851
-  DataType: Eq_851
+T_833: (in 0x00000000 : word32)
+  Class: Eq_832
+  DataType: Eq_832
   OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_853: (in SetUnhandledExceptionFilter(null) : LPTOP_LEVEL_EXCEPTION_FILTER)
-  Class: Eq_851
-  DataType: Eq_851
+T_834: (in SetUnhandledExceptionFilter(null) : LPTOP_LEVEL_EXCEPTION_FILTER)
+  Class: Eq_832
+  DataType: Eq_832
   OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_854: (in UnhandledExceptionFilter : ptr32)
-  Class: Eq_854
-  DataType: (ptr32 Eq_854)
-  OrigDataType: (ptr32 (fn T_859 (T_858)))
-T_855: (in signature of UnhandledExceptionFilter : void)
-  Class: Eq_854
-  DataType: (ptr32 Eq_854)
+T_835: (in UnhandledExceptionFilter : ptr32)
+  Class: Eq_835
+  DataType: (ptr32 Eq_835)
+  OrigDataType: (ptr32 (fn T_840 (T_839)))
+T_836: (in signature of UnhandledExceptionFilter : void)
+  Class: Eq_835
+  DataType: (ptr32 Eq_835)
   OrigDataType: 
-T_856: (in ExceptionInfo : (ptr32 (struct "_EXCEPTION_POINTERS")))
-  Class: Eq_856
-  DataType: (ptr32 Eq_856)
+T_837: (in ExceptionInfo : (ptr32 (struct "_EXCEPTION_POINTERS")))
+  Class: Eq_837
+  DataType: (ptr32 Eq_837)
   OrigDataType: 
-T_857: (in 0x0000000C : word32)
-  Class: Eq_857
+T_838: (in 0x0000000C : word32)
+  Class: Eq_838
   DataType: ui32
   OrigDataType: ui32
-T_858: (in fp - 0x0000000C : word32)
-  Class: Eq_856
-  DataType: (ptr32 Eq_856)
+T_839: (in fp - 0x0000000C : word32)
+  Class: Eq_837
+  DataType: (ptr32 Eq_837)
   OrigDataType: (ptr32 (struct "_EXCEPTION_POINTERS"))
-T_859: (in UnhandledExceptionFilter(fp - 0x0000000C) : LONG)
-  Class: Eq_859
-  DataType: Eq_859
+T_840: (in UnhandledExceptionFilter(fp - 0x0000000C) : LONG)
+  Class: Eq_840
+  DataType: Eq_840
   OrigDataType: LONG
-T_860: (in 0x00000000 : word32)
-  Class: Eq_859
-  DataType: Eq_859
+T_841: (in 0x00000000 : word32)
+  Class: Eq_840
+  DataType: Eq_840
   OrigDataType: word32
-T_861: (in UnhandledExceptionFilter(fp - 0x0000000C) != 0x00000000 : bool)
-  Class: Eq_861
+T_842: (in UnhandledExceptionFilter(fp - 0x0000000C) != 0x00000000 : bool)
+  Class: Eq_842
   DataType: bool
   OrigDataType: bool
-T_862: (in __fastfail : ptr32)
-  Class: Eq_862
-  DataType: (ptr32 Eq_862)
-  OrigDataType: (ptr32 (fn T_865 (T_206)))
-T_863: (in signature of __fastfail : void)
-  Class: Eq_862
-  DataType: (ptr32 Eq_862)
+T_843: (in __fastfail : ptr32)
+  Class: Eq_843
+  DataType: (ptr32 Eq_843)
+  OrigDataType: (ptr32 (fn T_846 (T_206)))
+T_844: (in signature of __fastfail : void)
+  Class: Eq_843
+  DataType: (ptr32 Eq_843)
   OrigDataType: 
-T_864: (in ecx : word32)
+T_845: (in ecx : word32)
   Class: Eq_206
   DataType: word32
   OrigDataType: 
-T_865: (in __fastfail(dwArg04) : void)
-  Class: Eq_865
+T_846: (in __fastfail(dwArg04) : void)
+  Class: Eq_846
   DataType: void
   OrigDataType: void
-T_866: (in 00403368 : ptr32)
-  Class: Eq_866
+T_847: (in 00403368 : ptr32)
+  Class: Eq_847
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_867 t0000)))
-T_867: (in Mem97[0x00403368:word32] : word32)
-  Class: Eq_821
+  OrigDataType: (ptr32 (struct (0 T_848 t0000)))
+T_848: (in Mem97[0x00403368:word32] : word32)
+  Class: Eq_802
   DataType: ui32
   OrigDataType: ui32
-T_868: (in 0x00000000 : word32)
-  Class: Eq_868
+T_849: (in 0x00000000 : word32)
+  Class: Eq_849
   DataType: ui32
   OrigDataType: ui32
-T_869: (in 0x01 : byte)
-  Class: Eq_869
+T_850: (in 0x01 : byte)
+  Class: Eq_850
   DataType: byte
   OrigDataType: byte
-T_870: (in bl_90 + 0x01 : byte)
-  Class: Eq_870
+T_851: (in bl_90 + 0x01 : byte)
+  Class: Eq_851
   DataType: byte
   OrigDataType: byte
-T_871: (in (word32) (bl_90 + 0x01) : word32)
-  Class: Eq_871
+T_852: (in (word32) (bl_90 + 0x01) : word32)
+  Class: Eq_852
   DataType: word32
   OrigDataType: word32
-T_872: (in -(word32) (bl_90 + 0x01) : word32)
-  Class: Eq_872
+T_853: (in -(word32) (bl_90 + 0x01) : word32)
+  Class: Eq_853
   DataType: word32
   OrigDataType: word32
-T_873: (in 0x00000000 : word32)
-  Class: Eq_872
+T_854: (in 0x00000000 : word32)
+  Class: Eq_853
   DataType: word32
   OrigDataType: word32
-T_874: (in -(word32) (bl_90 + 0x01) == 0x00000000 : bool)
-  Class: Eq_874
-  DataType: Eq_874
+T_855: (in -(word32) (bl_90 + 0x01) == 0x00000000 : bool)
+  Class: Eq_855
+  DataType: Eq_855
   OrigDataType: (union (bool u0) (ui32 u1))
-T_875: (in 0x00000000 - (-((word32) (bl_90 + 0x01)) == 0x00000000) : word32)
-  Class: Eq_875
+T_856: (in 0x00000000 - (-((word32) (bl_90 + 0x01)) == 0x00000000) : word32)
+  Class: Eq_856
   DataType: ui32
   OrigDataType: ui32
-T_876: (in globals->dw403368 & 0x00000000 - (-((word32) (bl_90 + 0x01)) == 0x00000000) : word32)
-  Class: Eq_821
+T_857: (in globals->dw403368 & 0x00000000 - (-((word32) (bl_90 + 0x01)) == 0x00000000) : word32)
+  Class: Eq_802
   DataType: ui32
   OrigDataType: ui32
-T_877: (in 00403368 : ptr32)
-  Class: Eq_877
+T_858: (in 00403368 : ptr32)
+  Class: Eq_858
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_878 t0000)))
-T_878: (in Mem108[0x00403368:word32] : word32)
-  Class: Eq_821
+  OrigDataType: (ptr32 (struct (0 T_859 t0000)))
+T_859: (in Mem108[0x00403368:word32] : word32)
+  Class: Eq_802
   DataType: ui32
   OrigDataType: word32
-T_879: (in al : byte)
-  Class: Eq_879
+T_860: (in al : byte)
+  Class: Eq_860
   DataType: byte
   OrigDataType: byte
-T_880: (in eax_6 : Eq_880)
-  Class: Eq_880
-  DataType: Eq_880
+T_861: (in eax_6 : Eq_861)
+  Class: Eq_861
+  DataType: Eq_861
   OrigDataType: HMODULE
-T_881: (in GetModuleHandleW : ptr32)
-  Class: Eq_881
-  DataType: (ptr32 Eq_881)
-  OrigDataType: (ptr32 (fn T_885 (T_884)))
-T_882: (in signature of GetModuleHandleW : void)
-  Class: Eq_881
-  DataType: (ptr32 Eq_881)
+T_862: (in GetModuleHandleW : ptr32)
+  Class: Eq_862
+  DataType: (ptr32 Eq_862)
+  OrigDataType: (ptr32 (fn T_866 (T_865)))
+T_863: (in signature of GetModuleHandleW : void)
+  Class: Eq_862
+  DataType: (ptr32 Eq_862)
   OrigDataType: 
-T_883: (in lpModuleName : LPCWSTR)
-  Class: Eq_883
-  DataType: Eq_883
+T_864: (in lpModuleName : LPCWSTR)
+  Class: Eq_864
+  DataType: Eq_864
   OrigDataType: 
-T_884: (in 0x00000000 : word32)
-  Class: Eq_883
-  DataType: Eq_883
+T_865: (in 0x00000000 : word32)
+  Class: Eq_864
+  DataType: Eq_864
   OrigDataType: LPCWSTR
-T_885: (in GetModuleHandleW(null) : HMODULE)
-  Class: Eq_880
-  DataType: Eq_880
+T_866: (in GetModuleHandleW(null) : HMODULE)
+  Class: Eq_861
+  DataType: Eq_861
   OrigDataType: HMODULE
-T_886: (in eax_24_8_36 : word24)
-  Class: Eq_886
-  DataType: word24
-  OrigDataType: word24
-T_887: (in SLICE(eax_6, word24, 8) : word24)
-  Class: Eq_886
-  DataType: word24
-  OrigDataType: word24
-T_888: (in 0x00000000 : word32)
-  Class: Eq_880
-  DataType: Eq_880
+T_867: (in 0x00000000 : word32)
+  Class: Eq_861
+  DataType: Eq_861
   OrigDataType: word32
-T_889: (in eax_6 != null : bool)
-  Class: Eq_889
+T_868: (in eax_6 != null : bool)
+  Class: Eq_868
   DataType: bool
   OrigDataType: bool
-T_890: (in 0x00005A : word24)
-  Class: Eq_886
-  DataType: word24
-  OrigDataType: word24
-T_891: (in 0x00000000 : word32)
-  Class: Eq_891
+T_869: (in 0x00000000 : word32)
+  Class: Eq_869
   DataType: word32
   OrigDataType: word32
-T_892: (in eax_6 + 0x00000000 : word32)
-  Class: Eq_892
+T_870: (in eax_6 + 0x00000000 : word32)
+  Class: Eq_870
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
-T_893: (in Mem5[eax_6 + 0x00000000:word16] : word16)
-  Class: Eq_893
-  DataType: Eq_893
+T_871: (in Mem5[eax_6 + 0x00000000:word16] : word16)
+  Class: Eq_871
+  DataType: Eq_871
   OrigDataType: int32
-T_894: (in 0x5A4D : word16)
-  Class: Eq_893
+T_872: (in 0x5A4D : word16)
+  Class: Eq_871
   DataType: word16
   OrigDataType: word16
-T_895: (in eax_6->unused != 0x5A4D : bool)
-  Class: Eq_895
+T_873: (in eax_6->unused != 0x5A4D : bool)
+  Class: Eq_873
   DataType: bool
   OrigDataType: bool
-T_896: (in 0x00 : byte)
-  Class: Eq_896
+T_874: (in 0x00 : byte)
+  Class: Eq_860
   DataType: byte
   OrigDataType: byte
-T_897: (in SEQ(eax_24_8_36, 0x00) : word32)
+T_875: (in eax_17 : (ptr32 Eq_875))
+  Class: Eq_875
+  DataType: (ptr32 Eq_875)
+  OrigDataType: (ptr32 (struct (0 T_884 t0000) (18 T_889 t0018) (74 T_894 t0074) (E8 T_899 t00E8)))
+T_876: (in 0x0000003C : word32)
+  Class: Eq_876
+  DataType: word32
+  OrigDataType: word32
+T_877: (in eax_6 + 0x0000003C : word32)
+  Class: Eq_877
+  DataType: Eq_877
+  OrigDataType: HMODULE
+T_878: (in Mem5[eax_6 + 0x0000003C:word32] : word32)
+  Class: Eq_878
+  DataType: int32
+  OrigDataType: int32
+T_879: (in Mem5[eax_6 + 0x0000003C:word32] + eax_6 : word32)
+  Class: Eq_875
+  DataType: (ptr32 Eq_875)
+  OrigDataType: int32
+T_880: (in eax_24_8_43 : word24)
+  Class: Eq_880
+  DataType: word24
+  OrigDataType: word24
+T_881: (in SLICE(eax_17, word24, 8) : word24)
+  Class: Eq_880
+  DataType: word24
+  OrigDataType: word24
+T_882: (in 0x00000000 : word32)
+  Class: Eq_882
+  DataType: word32
+  OrigDataType: word32
+T_883: (in eax_17 + 0x00000000 : word32)
+  Class: Eq_883
+  DataType: int32
+  OrigDataType: int32
+T_884: (in Mem5[eax_17 + 0x00000000:word32] : word32)
+  Class: Eq_884
+  DataType: word32
+  OrigDataType: word32
+T_885: (in 0x00004550 : word32)
+  Class: Eq_884
+  DataType: word32
+  OrigDataType: word32
+T_886: (in eax_17->dw0000 != 0x00004550 : bool)
+  Class: Eq_886
+  DataType: bool
+  OrigDataType: bool
+T_887: (in 0x00000018 : word32)
+  Class: Eq_887
+  DataType: word32
+  OrigDataType: word32
+T_888: (in eax_17 + 0x00000018 : word32)
+  Class: Eq_888
+  DataType: ptr32
+  OrigDataType: ptr32
+T_889: (in Mem5[eax_17 + 0x00000018:word16] : word16)
+  Class: Eq_889
+  DataType: word16
+  OrigDataType: word16
+T_890: (in 0x010B : word16)
+  Class: Eq_889
+  DataType: word16
+  OrigDataType: word16
+T_891: (in eax_17->w0018 != 0x010B : bool)
+  Class: Eq_891
+  DataType: bool
+  OrigDataType: bool
+T_892: (in 0x00000074 : word32)
+  Class: Eq_892
+  DataType: word32
+  OrigDataType: word32
+T_893: (in eax_17 + 0x00000074 : word32)
+  Class: Eq_893
+  DataType: ptr32
+  OrigDataType: ptr32
+T_894: (in Mem5[eax_17 + 0x00000074:word32] : word32)
+  Class: Eq_894
+  DataType: up32
+  OrigDataType: up32
+T_895: (in 0x0000000E : word32)
+  Class: Eq_894
+  DataType: up32
+  OrigDataType: up32
+T_896: (in eax_17->dw0074 <= 0x0000000E : bool)
+  Class: Eq_896
+  DataType: bool
+  OrigDataType: bool
+T_897: (in 0x000000E8 : word32)
   Class: Eq_897
   DataType: word32
   OrigDataType: word32
-T_898: (in (byte) SEQ(eax_24_8_36, 0x00) : byte)
-  Class: Eq_879
-  DataType: byte
-  OrigDataType: byte
-T_899: (in eax_17 : (ptr32 Eq_899))
+T_898: (in eax_17 + 0x000000E8 : word32)
+  Class: Eq_898
+  DataType: ptr32
+  OrigDataType: ptr32
+T_899: (in Mem5[eax_17 + 0x000000E8:word32] : word32)
   Class: Eq_899
-  DataType: (ptr32 Eq_899)
-  OrigDataType: (ptr32 (struct (0 T_911 t0000) (18 T_916 t0018) (74 T_921 t0074) (E8 T_926 t00E8)))
-T_900: (in 0x0000003C : word32)
-  Class: Eq_900
   DataType: word32
   OrigDataType: word32
-T_901: (in eax_6 + 0x0000003C : word32)
+T_900: (in 0x00000000 : word32)
+  Class: Eq_899
+  DataType: word32
+  OrigDataType: word32
+T_901: (in eax_17->dw00E8 != 0x00000000 : bool)
   Class: Eq_901
-  DataType: Eq_901
-  OrigDataType: HMODULE
-T_902: (in Mem5[eax_6 + 0x0000003C:word32] : word32)
-  Class: Eq_902
-  DataType: int32
-  OrigDataType: int32
-T_903: (in Mem5[eax_6 + 0x0000003C:word32] + eax_6 : word32)
-  Class: Eq_899
-  DataType: (ptr32 Eq_899)
-  OrigDataType: int32
-T_904: (in SLICE(eax_17, word24, 8) : word24)
-  Class: Eq_886
-  DataType: word24
-  OrigDataType: word24
-T_905: (in SLICE(eax_17, word24, 8) : word24)
-  Class: Eq_886
-  DataType: word24
-  OrigDataType: word24
-T_906: (in SLICE(eax_17, word24, 8) : word24)
-  Class: Eq_886
-  DataType: word24
-  OrigDataType: word24
-T_907: (in eax_24_8_43 : word24)
-  Class: Eq_907
-  DataType: word24
-  OrigDataType: word24
-T_908: (in SLICE(eax_17, word24, 8) : word24)
-  Class: Eq_907
-  DataType: word24
-  OrigDataType: word24
-T_909: (in 0x00000000 : word32)
-  Class: Eq_909
-  DataType: word32
-  OrigDataType: word32
-T_910: (in eax_17 + 0x00000000 : word32)
-  Class: Eq_910
-  DataType: int32
-  OrigDataType: int32
-T_911: (in Mem5[eax_17 + 0x00000000:word32] : word32)
-  Class: Eq_911
-  DataType: word32
-  OrigDataType: word32
-T_912: (in 0x00004550 : word32)
-  Class: Eq_911
-  DataType: word32
-  OrigDataType: word32
-T_913: (in eax_17->dw0000 != 0x00004550 : bool)
-  Class: Eq_913
   DataType: bool
   OrigDataType: bool
-T_914: (in 0x00000018 : word32)
+T_902: (in SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000) : word32)
+  Class: Eq_902
+  DataType: word32
+  OrigDataType: word32
+T_903: (in SLICE(SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000), byte, 0) : byte)
+  Class: Eq_860
+  DataType: byte
+  OrigDataType: byte
+T_904: (in 004020D4 : ptr32)
+  Class: Eq_904
+  DataType: (ptr32 (ptr32 code))
+  OrigDataType: (ptr32 (struct (0 T_905 t0000)))
+T_905: (in Mem0[0x004020D4:word32] : word32)
+  Class: Eq_905
+  DataType: (ptr32 code)
+  OrigDataType: (ptr32 code)
+T_906: (in ebp : ptr32)
+  Class: Eq_906
+  DataType: ptr32
+  OrigDataType: word32
+T_907: (in esp_14 : ptr32)
+  Class: Eq_907
+  DataType: ptr32
+  OrigDataType: ptr32
+T_908: (in fp : ptr32)
+  Class: Eq_908
+  DataType: ptr32
+  OrigDataType: ptr32
+T_909: (in 8 : int32)
+  Class: Eq_909
+  DataType: int32
+  OrigDataType: int32
+T_910: (in fp - 8 : word32)
+  Class: Eq_910
+  DataType: ptr32
+  OrigDataType: ptr32
+T_911: (in fp - 8 - dwArg08 : word32)
+  Class: Eq_907
+  DataType: ptr32
+  OrigDataType: ptr32
+T_912: (in 4 : int32)
+  Class: Eq_912
+  DataType: int32
+  OrigDataType: int32
+T_913: (in esp_14 - 4 : word32)
+  Class: Eq_913
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_916 t0000)))
+T_914: (in 0x00000000 : word32)
   Class: Eq_914
   DataType: word32
   OrigDataType: word32
-T_915: (in eax_17 + 0x00000018 : word32)
+T_915: (in esp_14 - 4 + 0x00000000 : word32)
   Class: Eq_915
   DataType: ptr32
   OrigDataType: ptr32
-T_916: (in Mem5[eax_17 + 0x00000018:word16] : word16)
-  Class: Eq_916
-  DataType: word16
-  OrigDataType: word16
-T_917: (in 0x010B : word16)
-  Class: Eq_916
-  DataType: word16
-  OrigDataType: word16
-T_918: (in eax_17->w0018 != 0x010B : bool)
-  Class: Eq_918
-  DataType: bool
-  OrigDataType: bool
-T_919: (in 0x00000074 : word32)
-  Class: Eq_919
-  DataType: word32
-  OrigDataType: word32
-T_920: (in eax_17 + 0x00000074 : word32)
-  Class: Eq_920
-  DataType: ptr32
-  OrigDataType: ptr32
-T_921: (in Mem5[eax_17 + 0x00000074:word32] : word32)
-  Class: Eq_921
-  DataType: up32
-  OrigDataType: up32
-T_922: (in 0x0000000E : word32)
-  Class: Eq_921
-  DataType: up32
-  OrigDataType: up32
-T_923: (in eax_17->dw0074 <= 0x0000000E : bool)
-  Class: Eq_923
-  DataType: bool
-  OrigDataType: bool
-T_924: (in 0x000000E8 : word32)
-  Class: Eq_924
-  DataType: word32
-  OrigDataType: word32
-T_925: (in eax_17 + 0x000000E8 : word32)
-  Class: Eq_925
-  DataType: ptr32
-  OrigDataType: ptr32
-T_926: (in Mem5[eax_17 + 0x000000E8:word32] : word32)
-  Class: Eq_926
-  DataType: word32
-  OrigDataType: word32
-T_927: (in 0x00000000 : word32)
-  Class: Eq_926
-  DataType: word32
-  OrigDataType: word32
-T_928: (in eax_17->dw00E8 != 0x00000000 : bool)
-  Class: Eq_928
-  DataType: bool
-  OrigDataType: bool
-T_929: (in SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000) : word32)
-  Class: Eq_929
-  DataType: word32
-  OrigDataType: word32
-T_930: (in (byte) SEQ(eax_24_8_43, Mem5[eax_17 + 0x000000E8:word32] != 0x00000000) : byte)
-  Class: Eq_879
-  DataType: byte
-  OrigDataType: byte
-T_931: (in 004020D4 : ptr32)
-  Class: Eq_931
-  DataType: (ptr32 (ptr32 code))
-  OrigDataType: (ptr32 (struct (0 T_932 t0000)))
-T_932: (in Mem0[0x004020D4:word32] : word32)
-  Class: Eq_932
-  DataType: (ptr32 code)
-  OrigDataType: (ptr32 code)
-T_933: (in ebp : ptr32)
-  Class: Eq_933
-  DataType: ptr32
-  OrigDataType: word32
-T_934: (in esp_14 : ptr32)
-  Class: Eq_934
-  DataType: ptr32
-  OrigDataType: ptr32
-T_935: (in fp : ptr32)
-  Class: Eq_935
-  DataType: ptr32
-  OrigDataType: ptr32
-T_936: (in 8 : int32)
-  Class: Eq_936
-  DataType: int32
-  OrigDataType: int32
-T_937: (in fp - 8 : word32)
-  Class: Eq_937
-  DataType: ptr32
-  OrigDataType: ptr32
-T_938: (in fp - 8 - dwArg08 : word32)
-  Class: Eq_934
-  DataType: ptr32
-  OrigDataType: ptr32
-T_939: (in 4 : int32)
-  Class: Eq_939
-  DataType: int32
-  OrigDataType: int32
-T_940: (in esp_14 - 4 : word32)
-  Class: Eq_940
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_943 t0000)))
-T_941: (in 0x00000000 : word32)
-  Class: Eq_941
-  DataType: word32
-  OrigDataType: word32
-T_942: (in esp_14 - 4 + 0x00000000 : word32)
-  Class: Eq_942
-  DataType: ptr32
-  OrigDataType: ptr32
-T_943: (in Mem17[esp_14 - 4 + 0x00000000:word32] : word32)
+T_916: (in Mem17[esp_14 - 4 + 0x00000000:word32] : word32)
   Class: Eq_123
   DataType: word32
   OrigDataType: word32
-T_944: (in 8 : int32)
-  Class: Eq_944
+T_917: (in 8 : int32)
+  Class: Eq_917
   DataType: int32
   OrigDataType: int32
-T_945: (in esp_14 - 8 : word32)
-  Class: Eq_945
+T_918: (in esp_14 - 8 : word32)
+  Class: Eq_918
   DataType: (ptr32 Eq_132)
-  OrigDataType: (ptr32 (struct (0 T_948 t0000)))
-T_946: (in 0x00000000 : word32)
-  Class: Eq_946
+  OrigDataType: (ptr32 (struct (0 T_921 t0000)))
+T_919: (in 0x00000000 : word32)
+  Class: Eq_919
   DataType: word32
   OrigDataType: word32
-T_947: (in esp_14 - 8 + 0x00000000 : word32)
-  Class: Eq_947
+T_920: (in esp_14 - 8 + 0x00000000 : word32)
+  Class: Eq_920
   DataType: ptr32
   OrigDataType: ptr32
-T_948: (in Mem20[esp_14 - 8 + 0x00000000:word32] : word32)
+T_921: (in Mem20[esp_14 - 8 + 0x00000000:word32] : word32)
   Class: Eq_132
   DataType: Eq_132
   OrigDataType: word32
-T_949: (in 12 : int32)
-  Class: Eq_949
+T_922: (in 12 : int32)
+  Class: Eq_922
   DataType: int32
   OrigDataType: int32
-T_950: (in esp_14 - 12 : word32)
-  Class: Eq_950
+T_923: (in esp_14 - 12 : word32)
+  Class: Eq_923
   DataType: (ptr32 Eq_132)
+  OrigDataType: (ptr32 (struct (0 T_926 t0000)))
+T_924: (in 0x00000000 : word32)
+  Class: Eq_924
+  DataType: word32
+  OrigDataType: word32
+T_925: (in esp_14 - 12 + 0x00000000 : word32)
+  Class: Eq_925
+  DataType: ptr32
+  OrigDataType: ptr32
+T_926: (in Mem23[esp_14 - 12 + 0x00000000:word32] : word32)
+  Class: Eq_132
+  DataType: Eq_132
+  OrigDataType: word32
+T_927: (in 00403004 : ptr32)
+  Class: Eq_927
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_928 t0000)))
+T_928: (in Mem23[0x00403004:word32] : word32)
+  Class: Eq_725
+  DataType: ui32
+  OrigDataType: word32
+T_929: (in 0x00000008 : word32)
+  Class: Eq_929
+  DataType: int32
+  OrigDataType: int32
+T_930: (in fp + 0x00000008 : word32)
+  Class: Eq_930
+  DataType: ptr32
+  OrigDataType: ptr32
+T_931: (in globals->dw403004 ^ fp + 0x00000008 : word32)
+  Class: Eq_931
+  DataType: ui32
+  OrigDataType: ui32
+T_932: (in 16 : int32)
+  Class: Eq_932
+  DataType: int32
+  OrigDataType: int32
+T_933: (in esp_14 - 16 : word32)
+  Class: Eq_933
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_936 t0000)))
+T_934: (in 0x00000000 : word32)
+  Class: Eq_934
+  DataType: word32
+  OrigDataType: word32
+T_935: (in esp_14 - 16 + 0x00000000 : word32)
+  Class: Eq_935
+  DataType: ptr32
+  OrigDataType: ptr32
+T_936: (in Mem32[esp_14 - 16 + 0x00000000:word32] : word32)
+  Class: Eq_931
+  DataType: ui32
+  OrigDataType: word32
+T_937: (in 20 : int32)
+  Class: Eq_937
+  DataType: int32
+  OrigDataType: int32
+T_938: (in esp_14 - 20 : word32)
+  Class: Eq_938
+  DataType: (ptr32 Eq_134)
+  OrigDataType: (ptr32 (struct (0 T_941 t0000)))
+T_939: (in 0x00000000 : word32)
+  Class: Eq_939
+  DataType: word32
+  OrigDataType: word32
+T_940: (in esp_14 - 20 + 0x00000000 : word32)
+  Class: Eq_940
+  DataType: ptr32
+  OrigDataType: ptr32
+T_941: (in Mem36[esp_14 - 20 + 0x00000000:word32] : word32)
+  Class: Eq_134
+  DataType: Eq_134
+  OrigDataType: word32
+T_942: (in 0x00000008 : word32)
+  Class: Eq_942
+  DataType: ui32
+  OrigDataType: ui32
+T_943: (in fp - 0x00000008 : word32)
+  Class: Eq_943
+  DataType: ptr32
+  OrigDataType: ptr32
+T_944: (in fs : selector)
+  Class: Eq_944
+  DataType: (ptr32 Eq_944)
+  OrigDataType: (ptr32 (segment (0 T_946 t0000)))
+T_945: (in 0x00000000 : word32)
+  Class: Eq_945
+  DataType: (memptr (ptr32 Eq_944) ptr32)
+  OrigDataType: (memptr T_944 (struct (0 T_946 t0000)))
+T_946: (in Mem41[fs:0x00000000:word32] : word32)
+  Class: Eq_943
+  DataType: ptr32
+  OrigDataType: word32
+T_947: (in fp + 0x00000008 : word32)
+  Class: Eq_906
+  DataType: ptr32
+  OrigDataType: ptr32
+T_948: (in ebx : word32)
+  Class: Eq_948
+  DataType: word32
+  OrigDataType: word32
+T_949: (in 0x00000010 : word32)
+  Class: Eq_949
+  DataType: ui32
+  OrigDataType: ui32
+T_950: (in ebp - 0x00000010 : word32)
+  Class: Eq_950
+  DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_953 t0000)))
 T_951: (in 0x00000000 : word32)
   Class: Eq_951
   DataType: word32
   OrigDataType: word32
-T_952: (in esp_14 - 12 + 0x00000000 : word32)
+T_952: (in ebp - 0x00000010 + 0x00000000 : word32)
   Class: Eq_952
-  DataType: ptr32
-  OrigDataType: ptr32
-T_953: (in Mem23[esp_14 - 12 + 0x00000000:word32] : word32)
-  Class: Eq_132
-  DataType: Eq_132
+  DataType: word32
   OrigDataType: word32
-T_954: (in 00403004 : ptr32)
+T_953: (in Mem0[ebp - 0x00000010 + 0x00000000:word32] : word32)
+  Class: Eq_953
+  DataType: word32
+  OrigDataType: word32
+T_954: (in fs : selector)
   Class: Eq_954
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_955 t0000)))
-T_955: (in Mem23[0x00403004:word32] : word32)
-  Class: Eq_744
-  DataType: ui32
+  DataType: (ptr32 Eq_954)
+  OrigDataType: (ptr32 (segment (0 T_956 t0000)))
+T_955: (in 0x00000000 : ptr32)
+  Class: Eq_955
+  DataType: Eq_955
+  OrigDataType: (union (ptr32 u0) ((memptr T_954 (struct (0 word32 dw0000))) u1))
+T_956: (in Mem8[fs:0x00000000:word32] : word32)
+  Class: Eq_953
+  DataType: word32
   OrigDataType: word32
-T_956: (in 0x00000008 : word32)
-  Class: Eq_956
-  DataType: int32
-  OrigDataType: int32
-T_957: (in fp + 0x00000008 : word32)
-  Class: Eq_957
+T_957: (in ebp_19 : Eq_134)
+  Class: Eq_134
+  DataType: Eq_134
+  OrigDataType: word32
+T_958: (in 0x00000000 : word32)
+  Class: Eq_958
+  DataType: word32
+  OrigDataType: word32
+T_959: (in ebp + 0x00000000 : word32)
+  Class: Eq_959
   DataType: ptr32
   OrigDataType: ptr32
-T_958: (in globals->dw403004 ^ fp + 0x00000008 : word32)
-  Class: Eq_958
-  DataType: ui32
-  OrigDataType: ui32
-T_959: (in 16 : int32)
-  Class: Eq_959
-  DataType: int32
-  OrigDataType: int32
-T_960: (in esp_14 - 16 : word32)
-  Class: Eq_960
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_963 t0000)))
+T_960: (in Mem8[ebp + 0x00000000:word32] : word32)
+  Class: Eq_134
+  DataType: Eq_134
+  OrigDataType: word32
 T_961: (in 0x00000000 : word32)
   Class: Eq_961
   DataType: word32
   OrigDataType: word32
-T_962: (in esp_14 - 16 + 0x00000000 : word32)
+T_962: (in ebp + 0x00000000 : word32)
   Class: Eq_962
-  DataType: ptr32
-  OrigDataType: ptr32
-T_963: (in Mem32[esp_14 - 16 + 0x00000000:word32] : word32)
-  Class: Eq_958
-  DataType: ui32
-  OrigDataType: word32
-T_964: (in 20 : int32)
-  Class: Eq_964
-  DataType: int32
-  OrigDataType: int32
-T_965: (in esp_14 - 20 : word32)
-  Class: Eq_965
-  DataType: (ptr32 Eq_134)
-  OrigDataType: (ptr32 (struct (0 T_968 t0000)))
-T_966: (in 0x00000000 : word32)
-  Class: Eq_966
-  DataType: word32
-  OrigDataType: word32
-T_967: (in esp_14 - 20 + 0x00000000 : word32)
-  Class: Eq_967
-  DataType: ptr32
-  OrigDataType: ptr32
-T_968: (in Mem36[esp_14 - 20 + 0x00000000:word32] : word32)
-  Class: Eq_134
-  DataType: Eq_134
-  OrigDataType: word32
-T_969: (in 0x00000008 : word32)
-  Class: Eq_969
-  DataType: ui32
-  OrigDataType: ui32
-T_970: (in fp - 0x00000008 : word32)
-  Class: Eq_970
-  DataType: ptr32
-  OrigDataType: ptr32
-T_971: (in fs : selector)
-  Class: Eq_971
-  DataType: (ptr32 Eq_971)
-  OrigDataType: (ptr32 (segment (0 T_973 t0000)))
-T_972: (in 0x00000000 : word32)
-  Class: Eq_972
-  DataType: (memptr (ptr32 Eq_971) ptr32)
-  OrigDataType: (memptr T_971 (struct (0 T_973 t0000)))
-T_973: (in Mem41[fs:0x00000000:word32] : word32)
-  Class: Eq_970
-  DataType: ptr32
-  OrigDataType: word32
-T_974: (in fp + 0x00000008 : word32)
-  Class: Eq_933
-  DataType: ptr32
-  OrigDataType: ptr32
-T_975: (in ebx : word32)
-  Class: Eq_975
-  DataType: word32
-  OrigDataType: word32
-T_976: (in 0x00000010 : word32)
-  Class: Eq_976
-  DataType: ui32
-  OrigDataType: ui32
-T_977: (in ebp - 0x00000010 : word32)
-  Class: Eq_977
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_980 t0000)))
-T_978: (in 0x00000000 : word32)
-  Class: Eq_978
-  DataType: word32
-  OrigDataType: word32
-T_979: (in ebp - 0x00000010 + 0x00000000 : word32)
-  Class: Eq_979
-  DataType: word32
-  OrigDataType: word32
-T_980: (in Mem0[ebp - 0x00000010 + 0x00000000:word32] : word32)
-  Class: Eq_980
-  DataType: word32
-  OrigDataType: word32
-T_981: (in fs : selector)
-  Class: Eq_981
-  DataType: (ptr32 Eq_981)
-  OrigDataType: (ptr32 (segment (0 T_983 t0000)))
-T_982: (in 0x00000000 : ptr32)
-  Class: Eq_982
-  DataType: Eq_982
-  OrigDataType: (union (ptr32 u0) ((memptr T_981 (struct (0 word32 dw0000))) u1))
-T_983: (in Mem8[fs:0x00000000:word32] : word32)
-  Class: Eq_980
-  DataType: word32
-  OrigDataType: word32
-T_984: (in ebp_19 : Eq_134)
-  Class: Eq_134
-  DataType: Eq_134
-  OrigDataType: word32
-T_985: (in 0x00000000 : word32)
-  Class: Eq_985
-  DataType: word32
-  OrigDataType: word32
-T_986: (in ebp + 0x00000000 : word32)
-  Class: Eq_986
-  DataType: ptr32
-  OrigDataType: ptr32
-T_987: (in Mem8[ebp + 0x00000000:word32] : word32)
-  Class: Eq_134
-  DataType: Eq_134
-  OrigDataType: word32
-T_988: (in 0x00000000 : word32)
-  Class: Eq_988
-  DataType: word32
-  OrigDataType: word32
-T_989: (in ebp + 0x00000000 : word32)
-  Class: Eq_989
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_990: (in Mem22[ebp + 0x00000000:word32] : word32)
+T_963: (in Mem22[ebp + 0x00000000:word32] : word32)
   Class: Eq_134
   DataType: Eq_134
   OrigDataType: word32
-T_991: (in dwArg0C : word32)
+T_964: (in dwArg0C : word32)
   Class: Eq_295
   DataType: ptr32
   OrigDataType: word32
-T_992: (in dwArg08 : word32)
+T_965: (in dwArg08 : word32)
   Class: Eq_296
   DataType: ptr32
   OrigDataType: word32
-T_993: (in dwArg10 : word32)
-  Class: Eq_975
+T_966: (in dwArg10 : word32)
+  Class: Eq_948
   DataType: word32
   OrigDataType: word32
-T_994: (in 0040336C : ptr32)
-  Class: Eq_994
+T_967: (in 0040336C : ptr32)
+  Class: Eq_967
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_995 t0000)))
-T_995: (in Mem6[0x0040336C:word32] : word32)
-  Class: Eq_995
+  OrigDataType: (ptr32 (struct (0 T_968 t0000)))
+T_968: (in Mem6[0x0040336C:word32] : word32)
+  Class: Eq_968
   DataType: ui32
   OrigDataType: ui32
-T_996: (in 0x00000000 : word32)
-  Class: Eq_996
+T_969: (in 0x00000000 : word32)
+  Class: Eq_969
   DataType: ui32
   OrigDataType: ui32
-T_997: (in globals->dw40336C & 0x00000000 : word32)
-  Class: Eq_995
+T_970: (in globals->dw40336C & 0x00000000 : word32)
+  Class: Eq_968
   DataType: ui32
   OrigDataType: ui32
-T_998: (in 0040336C : ptr32)
-  Class: Eq_998
+T_971: (in 0040336C : ptr32)
+  Class: Eq_971
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_999 t0000)))
-T_999: (in Mem9[0x0040336C:word32] : word32)
-  Class: Eq_995
+  OrigDataType: (ptr32 (struct (0 T_972 t0000)))
+T_972: (in Mem9[0x0040336C:word32] : word32)
+  Class: Eq_968
   DataType: ui32
   OrigDataType: word32
-T_1000: (in 00403010 : ptr32)
-  Class: Eq_1000
+T_973: (in 00403010 : ptr32)
+  Class: Eq_973
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1001 t0000)))
-T_1001: (in Mem14[0x00403010:word32] : word32)
-  Class: Eq_1001
+  OrigDataType: (ptr32 (struct (0 T_974 t0000)))
+T_974: (in Mem14[0x00403010:word32] : word32)
+  Class: Eq_974
   DataType: ui32
   OrigDataType: ui32
-T_1002: (in 0x00000001 : word32)
-  Class: Eq_1002
+T_975: (in 0x00000001 : word32)
+  Class: Eq_975
   DataType: ui32
   OrigDataType: ui32
-T_1003: (in globals->dw403010 | 0x00000001 : word32)
-  Class: Eq_1001
+T_976: (in globals->dw403010 | 0x00000001 : word32)
+  Class: Eq_974
   DataType: ui32
   OrigDataType: ui32
-T_1004: (in 00403010 : ptr32)
-  Class: Eq_1004
+T_977: (in 00403010 : ptr32)
+  Class: Eq_977
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1005 t0000)))
-T_1005: (in Mem18[0x00403010:word32] : word32)
-  Class: Eq_1001
+  OrigDataType: (ptr32 (struct (0 T_978 t0000)))
+T_978: (in Mem18[0x00403010:word32] : word32)
+  Class: Eq_974
   DataType: ui32
   OrigDataType: word32
-T_1006: (in IsProcessorFeaturePresent : ptr32)
-  Class: Eq_814
-  DataType: (ptr32 Eq_814)
-  OrigDataType: (ptr32 (fn T_1008 (T_1007)))
-T_1007: (in 0x0000000A : word32)
+T_979: (in IsProcessorFeaturePresent : ptr32)
+  Class: Eq_795
+  DataType: (ptr32 Eq_795)
+  OrigDataType: (ptr32 (fn T_981 (T_980)))
+T_980: (in 0x0000000A : word32)
   Class: Eq_121
   DataType: Eq_121
   OrigDataType: DWORD
-T_1008: (in IsProcessorFeaturePresent(0x0000000A) : BOOL)
-  Class: Eq_777
-  DataType: Eq_777
+T_981: (in IsProcessorFeaturePresent(0x0000000A) : BOOL)
+  Class: Eq_758
+  DataType: Eq_758
   OrigDataType: BOOL
-T_1009: (in 0x00000000 : word32)
-  Class: Eq_777
-  DataType: Eq_777
+T_982: (in 0x00000000 : word32)
+  Class: Eq_758
+  DataType: Eq_758
   OrigDataType: word32
-T_1010: (in IsProcessorFeaturePresent(0x0000000A) == 0x00000000 : bool)
-  Class: Eq_1010
+T_983: (in IsProcessorFeaturePresent(0x0000000A) == 0x00000000 : bool)
+  Class: Eq_983
   DataType: bool
   OrigDataType: bool
-T_1011: (in edi_101 : ui32)
+T_984: (in edi_101 : ui32)
+  Class: Eq_984
+  DataType: ui32
+  OrigDataType: ui32
+T_985: (in 00403010 : ptr32)
+  Class: Eq_985
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_986 t0000)))
+T_986: (in Mem28[0x00403010:word32] : word32)
+  Class: Eq_974
+  DataType: ui32
+  OrigDataType: ui32
+T_987: (in 0x00000002 : word32)
+  Class: Eq_987
+  DataType: ui32
+  OrigDataType: ui32
+T_988: (in globals->dw403010 | 0x00000002 : word32)
+  Class: Eq_974
+  DataType: ui32
+  OrigDataType: ui32
+T_989: (in 00403010 : ptr32)
+  Class: Eq_989
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_990 t0000)))
+T_990: (in Mem32[0x00403010:word32] : word32)
+  Class: Eq_974
+  DataType: ui32
+  OrigDataType: word32
+T_991: (in 0x00000001 : word32)
+  Class: Eq_968
+  DataType: ui32
+  OrigDataType: word32
+T_992: (in 0040336C : ptr32)
+  Class: Eq_992
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_993 t0000)))
+T_993: (in Mem41[0x0040336C:word32] : word32)
+  Class: Eq_968
+  DataType: ui32
+  OrigDataType: word32
+T_994: (in __cpuid : ptr32)
+  Class: Eq_994
+  DataType: (ptr32 Eq_994)
+  OrigDataType: (ptr32 (fn T_1011 (T_1002, T_1003, T_1005, T_1007, T_1009, T_1010)))
+T_995: (in signature of __cpuid : void)
+  Class: Eq_994
+  DataType: (ptr32 Eq_994)
+  OrigDataType: 
+T_996: (in  : word32)
+  Class: Eq_996
+  DataType: word32
+  OrigDataType: 
+T_997: (in  : word32)
+  Class: Eq_997
+  DataType: word32
+  OrigDataType: 
+T_998: (in  : ptr32)
+  Class: Eq_998
+  DataType: (ptr32 word32)
+  OrigDataType: 
+T_999: (in  : ptr32)
+  Class: Eq_999
+  DataType: (ptr32 word32)
+  OrigDataType: 
+T_1000: (in  : ptr32)
+  Class: Eq_1000
+  DataType: (ptr32 word32)
+  OrigDataType: 
+T_1001: (in  : ptr32)
+  Class: Eq_1001
+  DataType: (ptr32 word32)
+  OrigDataType: 
+T_1002: (in 0x00000000 : word32)
+  Class: Eq_996
+  DataType: word32
+  OrigDataType: word32
+T_1003: (in 0x00000000 : word32)
+  Class: Eq_997
+  DataType: word32
+  OrigDataType: word32
+T_1004: (in 0x00000000 : word32)
+  Class: Eq_1004
+  DataType: word32
+  OrigDataType: word32
+T_1005: (in &0x00000000 : ptr32)
+  Class: Eq_998
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1006: (in 0x00000001 : word32)
+  Class: Eq_1006
+  DataType: word32
+  OrigDataType: word32
+T_1007: (in &0x00000001 : ptr32)
+  Class: Eq_999
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1008: (in 0x00000000 : word32)
+  Class: Eq_1008
+  DataType: word32
+  OrigDataType: word32
+T_1009: (in &0x00000000 : ptr32)
+  Class: Eq_1000
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1010: (in &edx : ptr32)
+  Class: Eq_1001
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1011: (in __cpuid(0x00000000, 0x00000000, &0x00000000, &0x00000001, &0x00000000, &edx) : void)
   Class: Eq_1011
-  DataType: ui32
-  OrigDataType: ui32
-T_1012: (in 00403010 : ptr32)
-  Class: Eq_1012
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1013 t0000)))
-T_1013: (in Mem28[0x00403010:word32] : word32)
-  Class: Eq_1001
-  DataType: ui32
-  OrigDataType: ui32
-T_1014: (in 0x00000002 : word32)
-  Class: Eq_1014
-  DataType: ui32
-  OrigDataType: ui32
-T_1015: (in globals->dw403010 | 0x00000002 : word32)
-  Class: Eq_1001
-  DataType: ui32
-  OrigDataType: ui32
-T_1016: (in 00403010 : ptr32)
-  Class: Eq_1016
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1017 t0000)))
-T_1017: (in Mem32[0x00403010:word32] : word32)
-  Class: Eq_1001
-  DataType: ui32
-  OrigDataType: word32
-T_1018: (in 0x00000001 : word32)
-  Class: Eq_995
-  DataType: ui32
-  OrigDataType: word32
-T_1019: (in 0040336C : ptr32)
-  Class: Eq_1019
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1020 t0000)))
-T_1020: (in Mem41[0x0040336C:word32] : word32)
-  Class: Eq_995
-  DataType: ui32
-  OrigDataType: word32
-T_1021: (in __cpuid : ptr32)
-  Class: Eq_1021
-  DataType: (ptr32 Eq_1021)
-  OrigDataType: (ptr32 (fn T_1038 (T_1029, T_1030, T_1032, T_1034, T_1036, T_1037)))
-T_1022: (in signature of __cpuid : void)
-  Class: Eq_1021
-  DataType: (ptr32 Eq_1021)
-  OrigDataType: 
-T_1023: (in  : word32)
-  Class: Eq_1023
-  DataType: word32
-  OrigDataType: 
-T_1024: (in  : word32)
-  Class: Eq_1024
-  DataType: word32
-  OrigDataType: 
-T_1025: (in  : ptr32)
-  Class: Eq_1025
-  DataType: (ptr32 word32)
-  OrigDataType: 
-T_1026: (in  : ptr32)
-  Class: Eq_1026
-  DataType: (ptr32 word32)
-  OrigDataType: 
-T_1027: (in  : ptr32)
-  Class: Eq_1027
-  DataType: (ptr32 word32)
-  OrigDataType: 
-T_1028: (in  : ptr32)
-  Class: Eq_1028
-  DataType: (ptr32 word32)
-  OrigDataType: 
-T_1029: (in 0x00000000 : word32)
-  Class: Eq_1023
-  DataType: word32
-  OrigDataType: word32
-T_1030: (in 0x00000000 : word32)
-  Class: Eq_1024
-  DataType: word32
-  OrigDataType: word32
-T_1031: (in 0x00000000 : word32)
-  Class: Eq_1031
-  DataType: word32
-  OrigDataType: word32
-T_1032: (in &0x00000000 : ptr32)
-  Class: Eq_1025
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1033: (in 0x00000001 : word32)
-  Class: Eq_1033
-  DataType: word32
-  OrigDataType: word32
-T_1034: (in &0x00000001 : ptr32)
-  Class: Eq_1026
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1035: (in 0x00000000 : word32)
-  Class: Eq_1035
-  DataType: word32
-  OrigDataType: word32
-T_1036: (in &0x00000000 : ptr32)
-  Class: Eq_1027
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1037: (in &edx : ptr32)
-  Class: Eq_1028
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1038: (in __cpuid(0x00000000, 0x00000000, &0x00000000, &0x00000001, &0x00000000, &edx) : void)
-  Class: Eq_1038
   DataType: void
   OrigDataType: void
-T_1039: (in __cpuid : ptr32)
-  Class: Eq_1021
-  DataType: (ptr32 Eq_1021)
-  OrigDataType: (ptr32 (fn T_1049 (T_1040, T_1041, T_1043, T_1045, T_1047, T_1048)))
-T_1040: (in 0x00000001 : word32)
-  Class: Eq_1023
+T_1012: (in __cpuid : ptr32)
+  Class: Eq_994
+  DataType: (ptr32 Eq_994)
+  OrigDataType: (ptr32 (fn T_1022 (T_1013, T_1014, T_1016, T_1018, T_1020, T_1021)))
+T_1013: (in 0x00000001 : word32)
+  Class: Eq_996
   DataType: word32
   OrigDataType: word32
-T_1041: (in 0x00000000 : word32)
-  Class: Eq_1024
+T_1014: (in 0x00000000 : word32)
+  Class: Eq_997
   DataType: word32
   OrigDataType: word32
-T_1042: (in 0x00000001 : word32)
-  Class: Eq_1042
+T_1015: (in 0x00000001 : word32)
+  Class: Eq_1015
   DataType: word32
   OrigDataType: word32
-T_1043: (in &0x00000001 : ptr32)
-  Class: Eq_1025
+T_1016: (in &0x00000001 : ptr32)
+  Class: Eq_998
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
+T_1017: (in 0x00000001 : word32)
+  Class: Eq_1017
+  DataType: word32
+  OrigDataType: word32
+T_1018: (in &0x00000001 : ptr32)
+  Class: Eq_999
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1019: (in 0x00000000 : word32)
+  Class: Eq_1019
+  DataType: word32
+  OrigDataType: word32
+T_1020: (in &0x00000000 : ptr32)
+  Class: Eq_1000
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1021: (in &edx : ptr32)
+  Class: Eq_1001
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1022: (in __cpuid(0x00000001, 0x00000000, &0x00000001, &0x00000001, &0x00000000, &edx) : void)
+  Class: Eq_1011
+  DataType: void
+  OrigDataType: void
+T_1023: (in bLoc14_258 : byte)
+  Class: Eq_1023
+  DataType: byte
+  OrigDataType: byte
+T_1024: (in dwLoc14 : word32)
+  Class: Eq_1024
+  DataType: ui32
+  OrigDataType: ui32
+T_1025: (in 0x00000000 : word32)
+  Class: Eq_1025
+  DataType: ui32
+  OrigDataType: ui32
+T_1026: (in dwLoc14 & 0x00000000 : word32)
+  Class: Eq_1026
+  DataType: ui32
+  OrigDataType: ui32
+T_1027: (in SLICE(dwLoc14 & 0x00000000, byte, 0) : byte)
+  Class: Eq_1023
+  DataType: byte
+  OrigDataType: byte
+T_1028: (in 0x49656E69 : word32)
+  Class: Eq_1028
+  DataType: word32
+  OrigDataType: word32
+T_1029: (in edx ^ 0x49656E69 : word32)
+  Class: Eq_1029
+  DataType: ui32
+  OrigDataType: ui32
+T_1030: (in 0x6C65746E : word32)
+  Class: Eq_1030
+  DataType: ui32
+  OrigDataType: ui32
+T_1031: (in edx ^ 0x49656E69 | 0x6C65746E : word32)
+  Class: Eq_1031
+  DataType: ui32
+  OrigDataType: ui32
+T_1032: (in 0x756E6546 : word32)
+  Class: Eq_1032
+  DataType: ui32
+  OrigDataType: ui32
+T_1033: (in edx ^ 0x49656E69 | 0x6C65746E | 0x756E6546 : word32)
+  Class: Eq_1033
+  DataType: ui32
+  OrigDataType: ui32
+T_1034: (in 0x00000000 : word32)
+  Class: Eq_1033
+  DataType: ui32
+  OrigDataType: word32
+T_1035: (in (edx ^ 0x49656E69 | 0x6C65746E | 0x756E6546) != 0x00000000 : bool)
+  Class: Eq_1035
+  DataType: bool
+  OrigDataType: bool
+T_1036: (in 00403370 : ptr32)
+  Class: Eq_1036
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1037 t0000)))
+T_1037: (in Mem81[0x00403370:word32] : word32)
+  Class: Eq_984
+  DataType: ui32
+  OrigDataType: word32
+T_1038: (in 0x00000000 : word32)
+  Class: Eq_1038
+  DataType: word32
+  OrigDataType: word32
+T_1039: (in 0x000106C0 : word32)
+  Class: Eq_1038
+  DataType: word32
+  OrigDataType: word32
+T_1040: (in 0x00000000 == 0x000106C0 : bool)
+  Class: Eq_1040
+  DataType: bool
+  OrigDataType: bool
+T_1041: (in edi_100 : ui32)
+  Class: Eq_984
+  DataType: ui32
+  OrigDataType: ui32
+T_1042: (in 00403370 : ptr32)
+  Class: Eq_1042
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1043 t0000)))
+T_1043: (in Mem81[0x00403370:word32] : word32)
+  Class: Eq_984
+  DataType: ui32
+  OrigDataType: word32
 T_1044: (in 0x00000001 : word32)
   Class: Eq_1044
-  DataType: word32
-  OrigDataType: word32
-T_1045: (in &0x00000001 : ptr32)
-  Class: Eq_1026
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1046: (in 0x00000000 : word32)
-  Class: Eq_1046
-  DataType: word32
-  OrigDataType: word32
-T_1047: (in &0x00000000 : ptr32)
-  Class: Eq_1027
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1048: (in &edx : ptr32)
-  Class: Eq_1028
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1049: (in __cpuid(0x00000001, 0x00000000, &0x00000001, &0x00000001, &0x00000000, &edx) : void)
-  Class: Eq_1038
-  DataType: void
-  OrigDataType: void
-T_1050: (in bLoc14_258 : byte)
-  Class: Eq_1050
-  DataType: byte
-  OrigDataType: byte
-T_1051: (in dwLoc14 : word32)
-  Class: Eq_1051
   DataType: ui32
   OrigDataType: ui32
+T_1045: (in edi_100 | 0x00000001 : word32)
+  Class: Eq_984
+  DataType: ui32
+  OrigDataType: ui32
+T_1046: (in 00403370 : ptr32)
+  Class: Eq_1046
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1047 t0000)))
+T_1047: (in Mem104[0x00403370:word32] : word32)
+  Class: Eq_984
+  DataType: ui32
+  OrigDataType: word32
+T_1048: (in edi_100 | 0x00000001 : word32)
+  Class: Eq_984
+  DataType: ui32
+  OrigDataType: ui32
+T_1049: (in 0x00000000 : word32)
+  Class: Eq_1049
+  DataType: word32
+  OrigDataType: word32
+T_1050: (in 0x00020660 : word32)
+  Class: Eq_1049
+  DataType: word32
+  OrigDataType: word32
+T_1051: (in 0x00000000 == 0x00020660 : bool)
+  Class: Eq_1051
+  DataType: bool
+  OrigDataType: bool
 T_1052: (in 0x00000000 : word32)
   Class: Eq_1052
-  DataType: ui32
-  OrigDataType: ui32
-T_1053: (in dwLoc14 & 0x00000000 : word32)
-  Class: Eq_1053
-  DataType: ui32
-  OrigDataType: ui32
-T_1054: (in SLICE(dwLoc14 & 0x00000000, byte, 0) : byte)
-  Class: Eq_1050
-  DataType: byte
-  OrigDataType: byte
-T_1055: (in 0x49656E69 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_1053: (in 0x00020670 : word32)
+  Class: Eq_1052
+  DataType: word32
+  OrigDataType: word32
+T_1054: (in 0x00000000 == 0x00020670 : bool)
+  Class: Eq_1054
+  DataType: bool
+  OrigDataType: bool
+T_1055: (in 0x00000000 : word32)
   Class: Eq_1055
   DataType: word32
   OrigDataType: word32
-T_1056: (in edx ^ 0x49656E69 : word32)
-  Class: Eq_1056
-  DataType: ui32
-  OrigDataType: ui32
-T_1057: (in 0x6C65746E : word32)
-  Class: Eq_1057
-  DataType: ui32
-  OrigDataType: ui32
-T_1058: (in edx ^ 0x49656E69 | 0x6C65746E : word32)
-  Class: Eq_1058
-  DataType: ui32
-  OrigDataType: ui32
-T_1059: (in 0x756E6546 : word32)
-  Class: Eq_1059
-  DataType: ui32
-  OrigDataType: ui32
-T_1060: (in edx ^ 0x49656E69 | 0x6C65746E | 0x756E6546 : word32)
-  Class: Eq_1060
-  DataType: ui32
-  OrigDataType: ui32
-T_1061: (in 0x00000000 : word32)
-  Class: Eq_1060
-  DataType: ui32
+T_1056: (in 0x00030650 : word32)
+  Class: Eq_1055
+  DataType: word32
   OrigDataType: word32
-T_1062: (in (edx ^ 0x49656E69 | 0x6C65746E | 0x756E6546) != 0x00000000 : bool)
+T_1057: (in 0x00000000 == 0x00030650 : bool)
+  Class: Eq_1057
+  DataType: bool
+  OrigDataType: bool
+T_1058: (in 0x00000000 : word32)
+  Class: Eq_1058
+  DataType: word32
+  OrigDataType: word32
+T_1059: (in 0x00030660 : word32)
+  Class: Eq_1058
+  DataType: word32
+  OrigDataType: word32
+T_1060: (in 0x00000000 == 0x00030660 : bool)
+  Class: Eq_1060
+  DataType: bool
+  OrigDataType: bool
+T_1061: (in true : bool)
+  Class: Eq_1061
+  DataType: bool
+  OrigDataType: bool
+T_1062: (in true : bool)
   Class: Eq_1062
   DataType: bool
   OrigDataType: bool
-T_1063: (in 00403370 : ptr32)
+T_1063: (in 0x00000000 : word32)
   Class: Eq_1063
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1064 t0000)))
-T_1064: (in Mem81[0x00403370:word32] : word32)
-  Class: Eq_1011
-  DataType: ui32
-  OrigDataType: word32
-T_1065: (in 0x00000000 : word32)
-  Class: Eq_1065
   DataType: word32
   OrigDataType: word32
-T_1066: (in 0x000106C0 : word32)
-  Class: Eq_1065
+T_1064: (in 0x00000000 : word32)
+  Class: Eq_1063
   DataType: word32
   OrigDataType: word32
-T_1067: (in 0x00000000 == 0x000106C0 : bool)
-  Class: Eq_1067
+T_1065: (in 0x00000000 == 0x00000000 : bool)
+  Class: Eq_1065
   DataType: bool
   OrigDataType: bool
-T_1068: (in edi_100 : ui32)
-  Class: Eq_1011
-  DataType: ui32
-  OrigDataType: ui32
-T_1069: (in 00403370 : ptr32)
-  Class: Eq_1069
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1070 t0000)))
-T_1070: (in Mem81[0x00403370:word32] : word32)
-  Class: Eq_1011
-  DataType: ui32
+T_1066: (in __cpuid : ptr32)
+  Class: Eq_994
+  DataType: (ptr32 Eq_994)
+  OrigDataType: (ptr32 (fn T_1076 (T_1067, T_1068, T_1070, T_1072, T_1074, T_1075)))
+T_1067: (in 0x00000007 : word32)
+  Class: Eq_996
+  DataType: word32
   OrigDataType: word32
+T_1068: (in 0x00000000 : word32)
+  Class: Eq_997
+  DataType: word32
+  OrigDataType: word32
+T_1069: (in 0x00000007 : word32)
+  Class: Eq_1069
+  DataType: word32
+  OrigDataType: word32
+T_1070: (in &0x00000007 : ptr32)
+  Class: Eq_998
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_1071: (in 0x00000001 : word32)
   Class: Eq_1071
-  DataType: ui32
-  OrigDataType: ui32
-T_1072: (in edi_100 | 0x00000001 : word32)
-  Class: Eq_1011
-  DataType: ui32
-  OrigDataType: ui32
-T_1073: (in 00403370 : ptr32)
+  DataType: word32
+  OrigDataType: word32
+T_1072: (in &0x00000001 : ptr32)
+  Class: Eq_999
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1073: (in 0x00000000 : word32)
   Class: Eq_1073
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1074 t0000)))
-T_1074: (in Mem104[0x00403370:word32] : word32)
-  Class: Eq_1011
-  DataType: ui32
+  DataType: word32
   OrigDataType: word32
-T_1075: (in edi_100 | 0x00000001 : word32)
+T_1074: (in &0x00000000 : ptr32)
+  Class: Eq_1000
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1075: (in &edx : ptr32)
+  Class: Eq_1001
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1076: (in __cpuid(0x00000007, 0x00000000, &0x00000007, &0x00000001, &0x00000000, &edx) : void)
   Class: Eq_1011
+  DataType: void
+  OrigDataType: void
+T_1077: (in 0x01 : byte)
+  Class: Eq_1023
+  DataType: byte
+  OrigDataType: byte
+T_1078: (in 0x00000000 : word32)
+  Class: Eq_1078
+  DataType: word32
+  OrigDataType: word32
+T_1079: (in 0x00000000 : word32)
+  Class: Eq_1078
+  DataType: word32
+  OrigDataType: word32
+T_1080: (in 0x00000000 == 0x00000000 : bool)
+  Class: Eq_1080
+  DataType: bool
+  OrigDataType: bool
+T_1081: (in 0x00000002 : word32)
+  Class: Eq_1081
   DataType: ui32
   OrigDataType: ui32
-T_1076: (in 0x00000000 : word32)
-  Class: Eq_1076
-  DataType: word32
+T_1082: (in edi_101 | 0x00000002 : word32)
+  Class: Eq_984
+  DataType: ui32
+  OrigDataType: ui32
+T_1083: (in 00403370 : ptr32)
+  Class: Eq_1083
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1084 t0000)))
+T_1084: (in Mem150[0x00403370:word32] : word32)
+  Class: Eq_984
+  DataType: ui32
   OrigDataType: word32
-T_1077: (in 0x00020660 : word32)
-  Class: Eq_1076
-  DataType: word32
-  OrigDataType: word32
-T_1078: (in 0x00000000 == 0x00020660 : bool)
-  Class: Eq_1078
-  DataType: bool
-  OrigDataType: bool
-T_1079: (in 0x00000000 : word32)
-  Class: Eq_1079
-  DataType: word32
-  OrigDataType: word32
-T_1080: (in 0x00020670 : word32)
-  Class: Eq_1079
-  DataType: word32
-  OrigDataType: word32
-T_1081: (in 0x00000000 == 0x00020670 : bool)
-  Class: Eq_1081
-  DataType: bool
-  OrigDataType: bool
-T_1082: (in 0x00000000 : word32)
-  Class: Eq_1082
-  DataType: word32
-  OrigDataType: word32
-T_1083: (in 0x00030650 : word32)
-  Class: Eq_1082
-  DataType: word32
-  OrigDataType: word32
-T_1084: (in 0x00000000 == 0x00030650 : bool)
-  Class: Eq_1084
-  DataType: bool
-  OrigDataType: bool
-T_1085: (in 0x00000000 : word32)
+T_1085: (in 00403010 : ptr32)
   Class: Eq_1085
-  DataType: word32
-  OrigDataType: word32
-T_1086: (in 0x00030660 : word32)
-  Class: Eq_1085
-  DataType: word32
-  OrigDataType: word32
-T_1087: (in 0x00000000 == 0x00030660 : bool)
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1086 t0000)))
+T_1086: (in Mem152[0x00403010:word32] : word32)
+  Class: Eq_974
+  DataType: ui32
+  OrigDataType: ui32
+T_1087: (in 0x00000004 : word32)
   Class: Eq_1087
-  DataType: bool
-  OrigDataType: bool
-T_1088: (in true : bool)
-  Class: Eq_1088
-  DataType: bool
-  OrigDataType: bool
-T_1089: (in true : bool)
+  DataType: ui32
+  OrigDataType: ui32
+T_1088: (in globals->dw403010 | 0x00000004 : word32)
+  Class: Eq_974
+  DataType: ui32
+  OrigDataType: ui32
+T_1089: (in 00403010 : ptr32)
   Class: Eq_1089
-  DataType: bool
-  OrigDataType: bool
-T_1090: (in 0x00000000 : word32)
-  Class: Eq_1090
-  DataType: word32
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1090 t0000)))
+T_1090: (in Mem162[0x00403010:word32] : word32)
+  Class: Eq_974
+  DataType: ui32
   OrigDataType: word32
-T_1091: (in 0x00000000 : word32)
-  Class: Eq_1090
-  DataType: word32
+T_1091: (in 0x00000002 : word32)
+  Class: Eq_968
+  DataType: ui32
   OrigDataType: word32
-T_1092: (in 0x00000000 == 0x00000000 : bool)
+T_1092: (in 0040336C : ptr32)
   Class: Eq_1092
-  DataType: bool
-  OrigDataType: bool
-T_1093: (in __cpuid : ptr32)
-  Class: Eq_1021
-  DataType: (ptr32 Eq_1021)
-  OrigDataType: (ptr32 (fn T_1103 (T_1094, T_1095, T_1097, T_1099, T_1101, T_1102)))
-T_1094: (in 0x00000007 : word32)
-  Class: Eq_1023
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
+T_1093: (in Mem164[0x0040336C:word32] : word32)
+  Class: Eq_968
+  DataType: ui32
+  OrigDataType: word32
+T_1094: (in 0x00000000 : word32)
+  Class: Eq_1094
   DataType: word32
   OrigDataType: word32
 T_1095: (in 0x00000000 : word32)
-  Class: Eq_1024
+  Class: Eq_1094
   DataType: word32
   OrigDataType: word32
-T_1096: (in 0x00000007 : word32)
+T_1096: (in 0x00000000 == 0x00000000 : bool)
   Class: Eq_1096
-  DataType: word32
-  OrigDataType: word32
-T_1097: (in &0x00000007 : ptr32)
-  Class: Eq_1025
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1098: (in 0x00000001 : word32)
-  Class: Eq_1098
-  DataType: word32
-  OrigDataType: word32
-T_1099: (in &0x00000001 : ptr32)
-  Class: Eq_1026
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1100: (in 0x00000000 : word32)
-  Class: Eq_1100
-  DataType: word32
-  OrigDataType: word32
-T_1101: (in &0x00000000 : ptr32)
-  Class: Eq_1027
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1102: (in &edx : ptr32)
-  Class: Eq_1028
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1103: (in __cpuid(0x00000007, 0x00000000, &0x00000007, &0x00000001, &0x00000000, &edx) : void)
-  Class: Eq_1038
-  DataType: void
-  OrigDataType: void
-T_1104: (in 0x01 : byte)
-  Class: Eq_1050
-  DataType: byte
-  OrigDataType: byte
-T_1105: (in 0x00000000 : word32)
-  Class: Eq_1105
-  DataType: word32
-  OrigDataType: word32
-T_1106: (in 0x00000000 : word32)
-  Class: Eq_1105
-  DataType: word32
-  OrigDataType: word32
-T_1107: (in 0x00000000 == 0x00000000 : bool)
-  Class: Eq_1107
   DataType: bool
   OrigDataType: bool
-T_1108: (in 0x00000002 : word32)
-  Class: Eq_1108
+T_1097: (in 0x00000000 : word32)
+  Class: Eq_1097
+  DataType: word32
+  OrigDataType: word32
+T_1098: (in 0x00000000 : word32)
+  Class: Eq_1097
+  DataType: word32
+  OrigDataType: word32
+T_1099: (in 0x00000000 == 0x00000000 : bool)
+  Class: Eq_1099
+  DataType: bool
+  OrigDataType: bool
+T_1100: (in __xgetbv : ptr32)
+  Class: Eq_1100
+  DataType: (ptr32 Eq_1100)
+  OrigDataType: (ptr32 (fn T_1104 (T_1103)))
+T_1101: (in signature of __xgetbv : void)
+  Class: Eq_1100
+  DataType: (ptr32 Eq_1100)
+  OrigDataType: 
+T_1102: (in  : word32)
+  Class: Eq_1102
+  DataType: word32
+  OrigDataType: 
+T_1103: (in 0x00000000 : word32)
+  Class: Eq_1102
+  DataType: word32
+  OrigDataType: word32
+T_1104: (in __xgetbv(0x00000000) : word64)
+  Class: Eq_1104
+  DataType: word64
+  OrigDataType: word64
+T_1105: (in SLICE(__xgetbv(0x00000000), word32, 0) : word32)
+  Class: Eq_1105
   DataType: ui32
   OrigDataType: ui32
-T_1109: (in edi_101 | 0x00000002 : word32)
-  Class: Eq_1011
+T_1106: (in 0x00000006 : word32)
+  Class: Eq_1106
   DataType: ui32
   OrigDataType: ui32
-T_1110: (in 00403370 : ptr32)
-  Class: Eq_1110
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1111 t0000)))
-T_1111: (in Mem150[0x00403370:word32] : word32)
-  Class: Eq_1011
+T_1107: (in (word32) __xgetbv(0x00000000) & 0x00000006 : word32)
+  Class: Eq_1107
+  DataType: ui32
+  OrigDataType: ui32
+T_1108: (in 0x00000006 : word32)
+  Class: Eq_1107
   DataType: ui32
   OrigDataType: word32
+T_1109: (in ((word32) __xgetbv(0x00000000) & 0x00000006) != 0x00000006 : bool)
+  Class: Eq_1109
+  DataType: bool
+  OrigDataType: bool
+T_1110: (in false : bool)
+  Class: Eq_1110
+  DataType: bool
+  OrigDataType: bool
+T_1111: (in eax_187 : ui32)
+  Class: Eq_974
+  DataType: ui32
+  OrigDataType: ui32
 T_1112: (in 00403010 : ptr32)
   Class: Eq_1112
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 (struct (0 T_1113 t0000)))
-T_1113: (in Mem152[0x00403010:word32] : word32)
-  Class: Eq_1001
+T_1113: (in Mem177[0x00403010:word32] : word32)
+  Class: Eq_974
   DataType: ui32
-  OrigDataType: ui32
-T_1114: (in 0x00000004 : word32)
-  Class: Eq_1114
+  OrigDataType: word32
+T_1114: (in 0x00000003 : word32)
+  Class: Eq_968
   DataType: ui32
-  OrigDataType: ui32
-T_1115: (in globals->dw403010 | 0x00000004 : word32)
-  Class: Eq_1001
-  DataType: ui32
-  OrigDataType: ui32
-T_1116: (in 00403010 : ptr32)
-  Class: Eq_1116
+  OrigDataType: word32
+T_1115: (in 0040336C : ptr32)
+  Class: Eq_1115
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1117 t0000)))
-T_1117: (in Mem162[0x00403010:word32] : word32)
-  Class: Eq_1001
+  OrigDataType: (ptr32 (struct (0 T_1116 t0000)))
+T_1116: (in Mem189[0x0040336C:word32] : word32)
+  Class: Eq_968
   DataType: ui32
   OrigDataType: word32
-T_1118: (in 0x00000002 : word32)
-  Class: Eq_995
+T_1117: (in 0x00000008 : word32)
+  Class: Eq_1117
   DataType: ui32
-  OrigDataType: word32
-T_1119: (in 0040336C : ptr32)
+  OrigDataType: ui32
+T_1118: (in eax_187 | 0x00000008 : word32)
+  Class: Eq_974
+  DataType: ui32
+  OrigDataType: ui32
+T_1119: (in 00403010 : ptr32)
   Class: Eq_1119
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 (struct (0 T_1120 t0000)))
-T_1120: (in Mem164[0x0040336C:word32] : word32)
-  Class: Eq_995
+T_1120: (in Mem192[0x00403010:word32] : word32)
+  Class: Eq_974
   DataType: ui32
   OrigDataType: word32
-T_1121: (in 0x00000000 : word32)
+T_1121: (in 0x20 : byte)
   Class: Eq_1121
-  DataType: word32
-  OrigDataType: word32
-T_1122: (in 0x00000000 : word32)
-  Class: Eq_1121
-  DataType: word32
-  OrigDataType: word32
-T_1123: (in 0x00000000 == 0x00000000 : bool)
-  Class: Eq_1123
+  DataType: byte
+  OrigDataType: byte
+T_1122: (in bLoc14_258 & 0x20 : byte)
+  Class: Eq_1122
+  DataType: byte
+  OrigDataType: byte
+T_1123: (in 0x00 : byte)
+  Class: Eq_1122
+  DataType: byte
+  OrigDataType: byte
+T_1124: (in (bLoc14_258 & 0x20) == 0x00 : bool)
+  Class: Eq_1124
   DataType: bool
   OrigDataType: bool
-T_1124: (in 0x00000000 : word32)
-  Class: Eq_1124
-  DataType: word32
+T_1125: (in 0x00000005 : word32)
+  Class: Eq_968
+  DataType: ui32
   OrigDataType: word32
-T_1125: (in 0x00000000 : word32)
-  Class: Eq_1124
-  DataType: word32
-  OrigDataType: word32
-T_1126: (in 0x00000000 == 0x00000000 : bool)
+T_1126: (in 0040336C : ptr32)
   Class: Eq_1126
-  DataType: bool
-  OrigDataType: bool
-T_1127: (in __xgetbv : ptr32)
-  Class: Eq_1127
-  DataType: (ptr32 Eq_1127)
-  OrigDataType: (ptr32 (fn T_1131 (T_1130)))
-T_1128: (in signature of __xgetbv : void)
-  Class: Eq_1127
-  DataType: (ptr32 Eq_1127)
-  OrigDataType: 
-T_1129: (in  : word32)
-  Class: Eq_1129
-  DataType: word32
-  OrigDataType: 
-T_1130: (in 0x00000000 : word32)
-  Class: Eq_1129
-  DataType: word32
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1127 t0000)))
+T_1127: (in Mem197[0x0040336C:word32] : word32)
+  Class: Eq_968
+  DataType: ui32
   OrigDataType: word32
-T_1131: (in __xgetbv(0x00000000) : word64)
+T_1128: (in eax_187 | 0x00000008 : word32)
+  Class: Eq_1128
+  DataType: ui32
+  OrigDataType: ui32
+T_1129: (in 0x00000020 : word32)
+  Class: Eq_1129
+  DataType: ui32
+  OrigDataType: ui32
+T_1130: (in eax_187 | 0x00000008 | 0x00000020 : word32)
+  Class: Eq_974
+  DataType: ui32
+  OrigDataType: ui32
+T_1131: (in 00403010 : ptr32)
   Class: Eq_1131
-  DataType: word64
-  OrigDataType: word64
-T_1132: (in SLICE(__xgetbv(0x00000000), word32, 0) : word32)
-  Class: Eq_1132
-  DataType: ui32
-  OrigDataType: ui32
-T_1133: (in 0x00000006 : word32)
-  Class: Eq_1133
-  DataType: ui32
-  OrigDataType: ui32
-T_1134: (in (word32) __xgetbv(0x00000000) & 0x00000006 : word32)
-  Class: Eq_1134
-  DataType: ui32
-  OrigDataType: ui32
-T_1135: (in 0x00000006 : word32)
-  Class: Eq_1134
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1132 t0000)))
+T_1132: (in Mem198[0x00403010:word32] : word32)
+  Class: Eq_974
   DataType: ui32
   OrigDataType: word32
-T_1136: (in ((word32) __xgetbv(0x00000000) & 0x00000006) != 0x00000006 : bool)
-  Class: Eq_1136
-  DataType: bool
-  OrigDataType: bool
-T_1137: (in false : bool)
+T_1133: (in eax : uint32)
+  Class: Eq_1133
+  DataType: uint32
+  OrigDataType: word32
+T_1134: (in 00403014 : ptr32)
+  Class: Eq_1134
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_1135 t0000)))
+T_1135: (in Mem0[0x00403014:word32] : word32)
+  Class: Eq_1135
+  DataType: word32
+  OrigDataType: word32
+T_1136: (in 0x00000000 : word32)
+  Class: Eq_1135
+  DataType: word32
+  OrigDataType: word32
+T_1137: (in globals->dw403014 != 0x00000000 : bool)
   Class: Eq_1137
   DataType: bool
   OrigDataType: bool
-T_1138: (in eax_187 : ui32)
-  Class: Eq_1001
-  DataType: ui32
-  OrigDataType: ui32
-T_1139: (in 00403010 : ptr32)
-  Class: Eq_1139
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1140 t0000)))
-T_1140: (in Mem177[0x00403010:word32] : word32)
-  Class: Eq_1001
-  DataType: ui32
-  OrigDataType: word32
-T_1141: (in 0x00000003 : word32)
-  Class: Eq_995
-  DataType: ui32
-  OrigDataType: word32
-T_1142: (in 0040336C : ptr32)
-  Class: Eq_1142
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1143 t0000)))
-T_1143: (in Mem189[0x0040336C:word32] : word32)
-  Class: Eq_995
-  DataType: ui32
-  OrigDataType: word32
-T_1144: (in 0x00000008 : word32)
-  Class: Eq_1144
-  DataType: ui32
-  OrigDataType: ui32
-T_1145: (in eax_187 | 0x00000008 : word32)
-  Class: Eq_1001
-  DataType: ui32
-  OrigDataType: ui32
-T_1146: (in 00403010 : ptr32)
-  Class: Eq_1146
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1147 t0000)))
-T_1147: (in Mem192[0x00403010:word32] : word32)
-  Class: Eq_1001
-  DataType: ui32
-  OrigDataType: word32
-T_1148: (in 0x20 : byte)
-  Class: Eq_1148
-  DataType: byte
-  OrigDataType: byte
-T_1149: (in bLoc14_258 & 0x20 : byte)
-  Class: Eq_1149
-  DataType: byte
-  OrigDataType: byte
-T_1150: (in 0x00 : byte)
-  Class: Eq_1149
-  DataType: byte
-  OrigDataType: byte
-T_1151: (in (bLoc14_258 & 0x20) == 0x00 : bool)
-  Class: Eq_1151
-  DataType: bool
-  OrigDataType: bool
-T_1152: (in 0x00000005 : word32)
-  Class: Eq_995
-  DataType: ui32
-  OrigDataType: word32
-T_1153: (in 0040336C : ptr32)
-  Class: Eq_1153
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1154 t0000)))
-T_1154: (in Mem197[0x0040336C:word32] : word32)
-  Class: Eq_995
-  DataType: ui32
-  OrigDataType: word32
-T_1155: (in eax_187 | 0x00000008 : word32)
-  Class: Eq_1155
-  DataType: ui32
-  OrigDataType: ui32
-T_1156: (in 0x00000020 : word32)
-  Class: Eq_1156
-  DataType: ui32
-  OrigDataType: ui32
-T_1157: (in eax_187 | 0x00000008 | 0x00000020 : word32)
-  Class: Eq_1001
-  DataType: ui32
-  OrigDataType: ui32
-T_1158: (in 00403010 : ptr32)
-  Class: Eq_1158
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1159 t0000)))
-T_1159: (in Mem198[0x00403010:word32] : word32)
-  Class: Eq_1001
-  DataType: ui32
-  OrigDataType: word32
-T_1160: (in eax : uint32)
-  Class: Eq_1160
-  DataType: uint32
-  OrigDataType: word32
-T_1161: (in 00403014 : ptr32)
-  Class: Eq_1161
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1162 t0000)))
-T_1162: (in Mem0[0x00403014:word32] : word32)
-  Class: Eq_1162
-  DataType: word32
-  OrigDataType: word32
-T_1163: (in 0x00000000 : word32)
-  Class: Eq_1162
-  DataType: word32
-  OrigDataType: word32
-T_1164: (in globals->dw403014 != 0x00000000 : bool)
-  Class: Eq_1164
-  DataType: bool
-  OrigDataType: bool
-T_1165: (in (uint8) (Mem0[0x00403014:word32] != 0x00000000) : uint8)
-  Class: Eq_1165
+T_1138: (in (uint8) (Mem0[0x00403014:word32] != 0x00000000) : uint8)
+  Class: Eq_1138
   DataType: uint8
   OrigDataType: uint8
-T_1166: (in (uint32) (uint8) (Mem0[0x00403014:word32] != 0x00000000) : uint32)
-  Class: Eq_1160
+T_1139: (in (uint32) (uint8) (Mem0[0x00403014:word32] != 0x00000000) : uint32)
+  Class: Eq_1133
   DataType: uint32
   OrigDataType: uint32
-T_1167: (in al : byte)
-  Class: Eq_1167
+T_1140: (in al : byte)
+  Class: Eq_1140
   DataType: byte
   OrigDataType: byte
-T_1168: (in 0x01 : byte)
-  Class: Eq_1167
+T_1141: (in 0x01 : byte)
+  Class: Eq_1140
   DataType: byte
   OrigDataType: byte
-T_1169:
-  Class: Eq_1169
-  DataType: Eq_1169
+T_1142:
+  Class: Eq_1142
+  DataType: Eq_1142
   OrigDataType: 
 */
 typedef struct Globals {
-	Eq_669 t0100;	// 100
+	Eq_650 t0100;	// 100
 	word16 w400000;	// 400000
-	struct Eq_669 * ptr40003C;	// 40003C
+	struct Eq_650 * ptr40003C;	// 40003C
 	<anonymous> t401731;	// 401731
 	<anonymous> * ptr4020D4;	// 4020D4
 	Eq_229 t4020E0;	// 4020E0
@@ -5030,7 +4922,7 @@ typedef Eq_57 * (Eq_129)(word32, Eq_132, Eq_132, Eq_134, ui32);
 
 typedef union Eq_132 {
 	byte u0;
-	struct Eq_1169 * u1;
+	struct Eq_1142 * u1;
 } Eq_132;
 
 typedef union Eq_134 {
@@ -5099,123 +4991,123 @@ typedef struct Eq_520 {
 
 typedef word32 (Eq_560)();
 
+typedef struct Eq_566 {
+	struct Eq_568 * ptr0018;	// 18
+} Eq_566;
+
 typedef struct Eq_568 {
-	struct Eq_570 * ptr0018;	// 18
+	ptr32 ptr0004;	// 4
 } Eq_568;
 
-typedef struct Eq_570 {
-	ptr32 ptr0004;	// 4
-} Eq_570;
+typedef void (Eq_574)();
 
-typedef void (Eq_578)();
+typedef bool (Eq_578)(word32, ptr32, word32, word32);
 
-typedef bool (Eq_582)(word32, ptr32, word32, word32);
+typedef void (Eq_597)(word32);
 
-typedef void (Eq_609)(word32);
+typedef byte (Eq_601)();
 
-typedef byte (Eq_616)();
-
-typedef struct Eq_669 {
+typedef struct Eq_650 {
 	word32 dw400000;	// 400000
 	word16 w400018;	// 400018
+} Eq_650;
+
+typedef struct Eq_669 {
+	int32 dw0024;	// 24
 } Eq_669;
 
-typedef struct Eq_688 {
-	int32 dw0024;	// 24
-} Eq_688;
+typedef Eq_669 * (Eq_670)(Eq_516 *, uint32, Eq_515 *);
 
-typedef Eq_688 * (Eq_689)(Eq_516 *, uint32, Eq_515 *);
-
-typedef union Eq_692 {
+typedef union Eq_673 {
 	ui32 u0;
 	ptr32 u1;
-} Eq_692;
+} Eq_673;
 
-typedef void (Eq_749)(LPFILETIME);
+typedef void (Eq_730)(LPFILETIME);
 
-typedef LPFILETIME Eq_751;
+typedef LPFILETIME Eq_732;
 
-typedef DWORD (Eq_764)();
+typedef DWORD (Eq_745)();
 
-typedef DWORD (Eq_768)();
+typedef DWORD (Eq_749)();
 
-typedef BOOL (Eq_772)(LARGE_INTEGER *);
+typedef BOOL (Eq_753)(LARGE_INTEGER *);
 
-typedef LARGE_INTEGER Eq_774;
+typedef LARGE_INTEGER Eq_755;
 
-typedef BOOL Eq_777;
+typedef BOOL Eq_758;
 
-typedef BOOL (Eq_814)(DWORD);
+typedef BOOL (Eq_795)(DWORD);
 
-typedef void (Eq_824)(void, int32, size_t);
+typedef void (Eq_805)(void, int32, size_t);
 
-typedef size_t Eq_828;
+typedef size_t Eq_809;
 
-typedef BOOL (Eq_843)();
+typedef BOOL (Eq_824)();
 
-typedef union Eq_847 {
+typedef union Eq_828 {
 	bool u0;
 	byte u1;
-} Eq_847;
+} Eq_828;
 
-typedef LPTOP_LEVEL_EXCEPTION_FILTER (Eq_849)(LPTOP_LEVEL_EXCEPTION_FILTER);
+typedef LPTOP_LEVEL_EXCEPTION_FILTER (Eq_830)(LPTOP_LEVEL_EXCEPTION_FILTER);
 
-typedef LPTOP_LEVEL_EXCEPTION_FILTER Eq_851;
+typedef LPTOP_LEVEL_EXCEPTION_FILTER Eq_832;
 
-typedef LONG (Eq_854)(_EXCEPTION_POINTERS *);
+typedef LONG (Eq_835)(_EXCEPTION_POINTERS *);
 
 typedef struct _EXCEPTION_POINTERS {
 	PEXCEPTION_RECORD ExceptionRecord;	// 0
 	PCONTEXT ContextRecord;	// 4
-} Eq_856;
+} Eq_837;
 
-typedef LONG Eq_859;
+typedef LONG Eq_840;
 
-typedef void (Eq_862)(word32);
+typedef void (Eq_843)(word32);
 
-typedef union Eq_874 {
+typedef union Eq_855 {
 	bool u0;
 	ui32 u1;
-} Eq_874;
+} Eq_855;
 
-typedef HMODULE Eq_880;
+typedef HMODULE Eq_861;
 
-typedef HMODULE (Eq_881)(LPCWSTR);
+typedef HMODULE (Eq_862)(LPCWSTR);
 
-typedef LPCWSTR Eq_883;
+typedef LPCWSTR Eq_864;
 
-typedef union Eq_893 {
+typedef union Eq_871 {
 	int32 u0;
 	word16 u1;
-} Eq_893;
+} Eq_871;
 
-typedef struct Eq_899 {
+typedef struct Eq_875 {
 	word32 dw0000;	// 0
 	word16 w0018;	// 18
 	up32 dw0074;	// 74
 	word32 dw00E8;	// E8
-} Eq_899;
+} Eq_875;
 
-typedef HMODULE Eq_901;
+typedef HMODULE Eq_877;
 
-typedef struct Eq_971 {
+typedef struct Eq_944 {
 	ptr32 ptr0000;	// 0
-} Eq_971;
+} Eq_944;
 
-typedef struct Eq_981 {
+typedef struct Eq_954 {
 	word32 dw0000;	// 0
-} Eq_981;
+} Eq_954;
 
-typedef union Eq_982 {
+typedef union Eq_955 {
 	ptr32 u0;
-	word32 Eq_981::* u1;
-} Eq_982;
+	word32 Eq_954::* u1;
+} Eq_955;
 
-typedef void (Eq_1021)(word32, word32, word32 *, word32 *, word32 *, word32 *);
+typedef void (Eq_994)(word32, word32, word32 *, word32 *, word32 *, word32 *);
 
-typedef word64 (Eq_1127)(word32);
+typedef word64 (Eq_1100)(word32);
 
-typedef struct Eq_1169 {
+typedef struct Eq_1142 {
 	Eq_132 t0000;	// 0
-} Eq_1169;
+} Eq_1142;
 

--- a/subjects/regressions/reko-90/PP.c
+++ b/subjects/regressions/reko-90/PP.c
@@ -3077,7 +3077,7 @@ byte fn0800-2085(Eq_n ds, Eq_n ptrArg02, Eq_n ptrArg06)
 	*((word32) es_bx_n + 0x04) = (byte) (ax_n + (cx_n + 0x04) >> 0x08);
 	*((word32) es_bx_n + 0x05) = bLoc0C_n + bLoc0E_n;
 	fn0800-2688(ds, (uint32) (uint16) (cx_n + 0x04), 0x00, 0x00);
-	return (byte) SEQ(ch_n, cl_n);
+	return ch_n;
 }
 
 // 0800:2201: void fn0800-2201(Register Eq_n ds, Stack Eq_n ptrArg02)
@@ -3318,7 +3318,7 @@ byte fn0800-23EC(Eq_n ds, Eq_n ptrArg02, union Eq_n & bpOut, ptr16 & siOut, unio
 	bpOut = ss->*bp_n;
 	siOut = si_n;
 	dsOut = ds_n;
-	return (byte) SEQ(ch_n, cl_n);
+	return ch_n;
 }
 
 // 0800:24FE: Register Eq_n fn0800-24FE(Register Eq_n ds, Stack Eq_n ptrArg02)
@@ -5780,7 +5780,7 @@ byte fn0800-3C99(Eq_n ds, Eq_n dwArg02, Eq_n wArg06, Eq_n wArg08, union Eq_n & b
 	bpOut = ss->*bp_n;
 	siOut = si_n;
 	dsOut = ds_n;
-	return (byte) cx_n;
+	return SLICE(cx_n, byte, 8);
 }
 
 // 0800:3DCF: Register word16 fn0800-3DCF(Register Eq_n ds, Stack Eq_n ptrArg02, Register out Eq_n chOut, Register out ptr16 dxOut, Register out ptr16 diOut, Register out Eq_n dsOut)
@@ -6079,7 +6079,7 @@ byte fn0800-4110(Eq_n ds, Eq_n dwArg02, Eq_n wArg06, Eq_n wArg08, Eq_n dwArg0A, 
 	siOut = si_n;
 	diOut = di_n;
 	dsOut = ds;
-	return (byte) cx_n;
+	return SLICE(cx_n, byte, 8);
 }
 
 // 0800:4152: Register byte fn0800-4152(Register Eq_n ds, Stack Eq_n dwArg02, Stack Eq_n wArg06, Stack Eq_n wArg08, Stack Eq_n dwArg0A, Register out ptr16 siOut, Register out Eq_n dsOut)
@@ -6101,7 +6101,7 @@ byte fn0800-4152(Eq_n ds, Eq_n dwArg02, Eq_n wArg06, Eq_n wArg08, Eq_n dwArg0A, 
 	}
 	siOut = si_n;
 	dsOut = ds;
-	return (byte) ax_n;
+	return SLICE(ax_n, byte, 8);
 }
 
 // 0800:4194: void fn0800-4194(Register Eq_n ds, Stack Eq_n dwArg02)
@@ -10492,7 +10492,7 @@ l0800_nC57:
 				ax_n = (uint16) (uint8) fn0800-8624(ds, (byte) (*((word32) ds + 11843) >> 0x08), out di_n, out ds);
 			}
 			dsOut = ds;
-			return (byte) ax_n;
+			return SLICE(ax_n, byte, 8);
 		}
 	}
 	word16 di_n;
@@ -10614,7 +10614,7 @@ byte fn0800-7C78(Eq_n ds, union Eq_n & dsOut)
 		{
 l0800_nEAA:
 			dsOut = ds;
-			return (byte) ax_n;
+			return SLICE(ax_n, byte, 8);
 		}
 	}
 	word16 di_n;
@@ -10924,7 +10924,7 @@ byte fn0800-8359(Eq_n ds, struct Eq_n & dsOut)
 	ds_n->w29FF = v17_n;
 	ds_n->w2A01 = (word16) ((bool) (v17_n < 0x00) + ds_n->w2A01);
 	dsOut = ds_n;
-	return (byte) SEQ(SLICE(ax_n, byte, 8), al_n);
+	return al_n;
 }
 
 // 0800:83A1: void fn0800-83A1(Register Eq_n ds, Stack Eq_n ptrArg02, Stack Eq_n wArg06)
@@ -11112,7 +11112,7 @@ byte fn0800-8624(Eq_n ds, Eq_n bArg02, union Eq_n & diOut, union Eq_n & dsOut)
 	}
 	diOut = di;
 	dsOut = ds;
-	return (byte) ax_n;
+	return SLICE(ax_n, byte, 8);
 }
 
 // 0800:867A: Register word16 fn0800-867A(Stack Eq_n wArg04, Stack Eq_n psegArg06, Stack Eq_n wArg08, Stack Eq_n psegArg0A, Register out (ptr16 Eq_n) dsOut)
@@ -17146,9 +17146,9 @@ Eq_n fn1483-0C11(byte * ds_si, word16 * es_di, Eq_n al, word16 cx, Eq_n bx, Eq_n
 		{
 			Eq_n Top_n;
 			word16 di_n;
-			word32 eax_n = SEQ(ebx_16_n, fn1483-0CA0(di_n, ss_bp_n, al_n, ah_n, ax_n, si_n, ds_n, out di_n, out Top_n));
+			eax_n = SEQ(ebx_16_n, fn1483-0CA0(di_n, ss_bp_n, al_n, ah_n, ax_n, si_n, ds_n, out di_n, out Top_n));
 			TopOut = Top_n;
-			return (word16) eax_n;
+			return fn1483-0CA0(di_n, ss_bp_n, al_n, ah_n, ax_n, si_n, ds_n, out di_n, out Top_n);
 		}
 		else
 		{

--- a/subjects/regressions/reko-90/PP.dis
+++ b/subjects/regressions/reko-90/PP.dis
@@ -6208,7 +6208,7 @@ l0800_21C1:
 	Mem415[es_bx_411 + 0x0004:byte] = SLICE(ax_28 + (cx_50 + 0x0004) >>u 0x08, byte, 0)
 	Mem418[es_bx_411 + 0x0005:byte] = bLoc0C_618 + bLoc0E_619
 	fn0800_2688(ds, (uint32) (uint16) (cx_50 + 0x0004), 0x0000, 0x0000)
-	return (byte) SEQ(ch_729, cl_453)
+	return ch_729
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -6758,7 +6758,7 @@ l0800_249F:
 	bpOut = Mem394[ss:bp_362:word16]
 	siOut = si_369
 	dsOut = ds_366
-	return (byte) SEQ(ch_545, cl_397)
+	return ch_545
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -12191,7 +12191,7 @@ l0800_3DB2:
 	bpOut = Mem378[ss:bp_226:word16]
 	siOut = si_381
 	dsOut = ds_366
-	return (byte) cx_365
+	return SLICE(cx_365, byte, 8)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -12797,7 +12797,7 @@ l0800_4150:
 	siOut = si_134
 	diOut = di_124
 	dsOut = ds
-	return (byte) cx_121
+	return SLICE(cx_121, byte, 8)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -12852,7 +12852,7 @@ l0800_417A:
 l0800_4192:
 	siOut = si_134
 	dsOut = ds
-	return (byte) ax_116
+	return SLICE(ax_116, byte, 8)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -20529,7 +20529,7 @@ l0800_7C65:
 
 l0800_7C73:
 	dsOut = ds
-	return (byte) ax_53
+	return SLICE(ax_53, byte, 8)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -20809,7 +20809,7 @@ l0800_7EA0:
 
 l0800_7EAA:
 	dsOut = ds
-	return (byte) ax_53
+	return SLICE(ax_53, byte, 8)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -21726,7 +21726,7 @@ l0800_8359:
 	Mem46[ds_24:0x29FF:word16] = v17_45
 	Mem50[ds_24:0x2A01:word16] = Mem46[ds_24:0x2A01:word16] + (v17_45 <u 0x0000)
 	dsOut = ds_24
-	return (byte) SEQ(SLICE(ax_43, byte, 8), al_30)
+	return al_30
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -22293,7 +22293,7 @@ l0800_863C:
 l0800_8678:
 	diOut = di
 	dsOut = ds
-	return (byte) ax_10
+	return SLICE(ax_10, byte, 8)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -27091,7 +27091,7 @@ l0800_97D7:
 
 l0800_97F6:
 	dxOut = wArg02
-	return (byte) ax_26
+	return SLICE(ax_26, byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -30290,7 +30290,7 @@ l0800_A565:
 
 l0800_A57D:
 	dxOut = wArg02
-	return (byte) ax_20
+	return SLICE(ax_20, byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -30336,7 +30336,7 @@ l0800_A58B:
 // SymbolicIn:
 
 l0800_A59B:
-	return (byte) ax_17
+	return SLICE(ax_17, byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -30578,7 +30578,7 @@ l0800_A6B2:
 	cxOut = cx
 	dxOut = dx
 	dsOut = ds
-	return (byte) si_105
+	return SLICE(si_105, byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -33313,7 +33313,7 @@ l0800_B197:
 
 l0800_B29A:
 	cxOut = cx_110
-	return (byte) ax_325
+	return SLICE(ax_325, byte, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -36981,7 +36981,7 @@ l1483_0C53_thunk_fn1483_0C55:
 	int8 Top_27
 	word32 eax_25 = fn1483_0C55(out Top_27)
 	TopOut = Top_27
-	return (word16) eax_25
+	return SLICE(eax_25, word16, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -37022,9 +37022,9 @@ l1483_0C6C:
 l1483_0C85_thunk_fn1483_0CA0:
 	int8 Top_104
 	word16 di_191
-	word32 eax_162 = SEQ(ebx_16_16, fn1483_0CA0(SEQ(es_60, di_68), ss_bp_187, al_96, ah_97, ax_69, si_61, ds_57, out di_191, out Top_104))
+	eax_162 = SEQ(ebx_16_16, fn1483_0CA0(SEQ(es_60, di_68), ss_bp_187, al_96, ah_97, ax_69, si_61, ds_57, out di_191, out Top_104)) (alias)
 	TopOut = Top_104
-	return (word16) eax_162
+	return fn1483_0CA0(SEQ(es_60, di_68), ss_bp_187, al_96, ah_97, ax_69, si_61, ds_57, out di_191, out Top_104)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:
@@ -37045,7 +37045,7 @@ l1483_0C8F_thunk_fn1483_0C91:
 	selector es_194
 	word32 eax_130 = (uint32) (uint16) fn1483_0C91(SEQ(ds, bx), SEQ(ss, bp), ax, cx_91 - 0x0001, si_61 + 0x0001, di_68 + 0x0001, stackArg0, out di_193, out es_194, out Top_132)
 	TopOut = Top_132
-	return (word16) eax_130
+	return SLICE(eax_130, word16, 0)
 // DataOut:
 // DataOut (flags):
 // SymbolicIn:


### PR DESCRIPTION
- Create `CallRewriter` test with slicing wider register

Expected:

`return SLICE(ret, word16, 16)`

but was:

`return (word16) ret`

- Modify `CallRewiter` to use slice instead cast when slicing wider registers