### PR TITLE
Add Project v5 to list of supported project file formats

### DIFF
--- a/src/Core/Serialization/ProjectLoader.cs
+++ b/src/Core/Serialization/ProjectLoader.cs
@@ -113,6 +113,7 @@ namespace Reko.Core.Serialization
 
         private static readonly Tuple<Type, string>[] supportedProjectFileFormats =
         {
+            Tuple.Create(typeof(Project_v5), SerializedLibrary.Namespace_v5),
             Tuple.Create(typeof(Project_v4), SerializedLibrary.Namespace_v4),
             Tuple.Create(typeof(Project_v3), SerializedLibrary.Namespace_v3),
             Tuple.Create(typeof(Project_v2), SerializedLibrary.Namespace_v2),

--- a/subjects/PE/x86/VCExeSample/VCExeSample.dcproject
+++ b/subjects/PE/x86/VCExeSample/VCExeSample.dcproject
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemata.jklnet.org/Reko/v4">
+<project xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemata.jklnet.org/Reko/v5">
   <arch>x86-protected-32</arch>
   <platform>win32</platform>
   <input>
     <filename>VCExeSample.exe</filename>
-    <disassembly>VCExeSample.asm</disassembly>
-    <intermediate-code>VCExeSample.dis</intermediate-code>
-    <output>VCExeSample.c</output>
-    <types-file>VCExeSample.h</types-file>
-    <global-vars>VCExeSample.globals.c</global-vars>
+    <asmDir>.</asmDir>
+    <srcDir>.</srcDir>
+    <includeDir>.</includeDir>
+    <resources>.</resources>
     <user>
       <processor />
       <procedure name="main">
@@ -78,6 +77,7 @@
       </global>
       <onLoad Enabled="false" />
       <registerValues />
+      <extractResources>false</extractResources>
     </user>
   </input>
   <metadata>


### PR DESCRIPTION
- Convert `VCExeSample` project file to new version (`v4` -> `v5`)
- Add Project `v5` to list of supported project file formats