### PR TITLE
Fix Covers implementation for FpuStackStorage

### DIFF
--- a/src/Core/Storage.cs
+++ b/src/Core/Storage.cs
@@ -301,10 +301,10 @@ namespace Reko.Core
             return visitor.VisitFpuStackStorage(this, context);
         }
 
-        public override bool Covers(Storage that)
+        public override bool Covers(Storage other)
         {
-            return that is FpuStackStorage &&
-                this.Number == that.Number;
+            return other is FpuStackStorage that &&
+                this.FpuStackOffset == that.FpuStackOffset;
         }
 
         public override bool Equals(object obj)

--- a/src/Core/Storage.cs
+++ b/src/Core/Storage.cs
@@ -68,7 +68,6 @@ namespace Reko.Core
         /// The name of this storage.
         /// </summary>
         public string Name { get; protected set; }
-        public int Number { get; protected set; }
 
         /// <summary>
         /// Returns the bit offset of <paramref name="storage"/> within this 
@@ -531,6 +530,8 @@ namespace Reko.Core
         /// <remarks>
         /// General-purpose registers can use the Domain.Word </remarks>
         public new PrimitiveType DataType => (PrimitiveType) base.DataType;
+
+        public int Number { get; private set; }
 
         public override T Accept<T>(StorageVisitor<T> visitor)
         {

--- a/src/Decompiler/Analysis/CallRewriter.cs
+++ b/src/Decompiler/Analysis/CallRewriter.cs
@@ -248,7 +248,8 @@ namespace Reko.Analysis
             }
 
             var outs = definitions.Select(d => d.Storage)
-                .Where(d => d is RegisterStorage r && !implicitRegs.Contains(r))
+                .OfType<RegisterStorage>()
+                .Where(r => !implicitRegs.Contains(r))
                 .OrderBy(r => r.Number);
             foreach (var o in outs)
             {

--- a/src/UnitTests/Core/StorageTests.cs
+++ b/src/UnitTests/Core/StorageTests.cs
@@ -31,6 +31,8 @@ namespace Reko.UnitTests.Core
         private Storage ax;
         private Storage al;
         private Storage ah;
+        private Storage fpu0;
+        private Storage fpu1;
         private Storage tmpWord32;
 
         private RegisterStorage freg;
@@ -53,6 +55,9 @@ namespace Reko.UnitTests.Core
             this.c = new FlagGroupStorage(freg, 0x1, "c", PrimitiveType.Bool);
             this.z = new FlagGroupStorage(freg, 0x2, "z", PrimitiveType.Bool);
             this.s = new FlagGroupStorage(freg, 0x4, "s", PrimitiveType.Bool);
+
+            this.fpu0 = new FpuStackStorage(0, PrimitiveType.Real64);
+            this.fpu1 = new FpuStackStorage(1, PrimitiveType.Real64);
 
             this.tmpWord32 = new TemporaryStorage("tmp", 0, PrimitiveType.Word32);
         }
@@ -107,6 +112,14 @@ namespace Reko.UnitTests.Core
             var argSmall = new StackArgumentStorage(7, PrimitiveType.Byte);
             Assert.IsTrue(argLarge.Covers(argSmall), $"{argLarge} should cover {argSmall}.");
             Assert.False(argSmall.Covers(argLarge), $"{argSmall} shouldn't cover {argLarge}.");
+        }
+
+        [Test]
+        public void Stg_FpuStackStorageCover()
+        {
+            Assert.True(fpu0.Covers(fpu0), $"{fpu0} should cover {fpu0}.");
+            Assert.False(fpu0.Covers(fpu1), $"{fpu0} shouldn't cover {fpu1}.");
+            Assert.False(fpu1.Covers(fpu0), $"{fpu1} shouldn't cover {fpu0}.");
         }
 
         [Test]


### PR DESCRIPTION
- Create unit test to verify Covers method of `FpuStackStorage`

Expected:

FPU +0 does not cover FPU +1

but was:

FPU +0 covers FPU +1
- Fix `Covers` implementation for `FpuStackStorage`.
Compare `FpuStackOffset` instead of unset `Number` property

