### PR TITLE
Ignore FPU stack return which was not found in call definitions

### DIFF
--- a/src/Decompiler/Analysis/CallApplicationBuilder.cs
+++ b/src/Decompiler/Analysis/CallApplicationBuilder.cs
@@ -105,6 +105,8 @@ namespace Reko.Analysis
                 if (((FpuStackStorage) de.Value.Storage).FpuStackOffset == fpu.FpuStackOffset)
                     return de.Value.Expression;
             }
+            if (!bindUses)
+                return null;
             throw new NotImplementedException(string.Format("Offsets not matching? SP({0})", fpu.FpuStackOffset));
         }
 

--- a/src/UnitTests/Analysis/CallRewriterTests.cs
+++ b/src/UnitTests/Analysis/CallRewriterTests.cs
@@ -857,6 +857,40 @@ main_exit:
             AssertProcedureCode(sExp, ssa);
         }
 
+        [Test(Description = "Ignore FPU return if it was not found in call definitions")]
+        [Category(Categories.UnitTests)]
+        public void CrwFPUReturnNotFound()
+        {
+            var ret = new FpuStackStorage(0, PrimitiveType.Real64);
+            var ssa = Given_Procedure("main", m =>
+            {
+                m.Label("body");
+                m.Call("fn", 4, new Identifier[] { }, new Identifier[] { });
+                m.Return();
+            });
+            Given_Procedure("fn", m => { });
+            Given_Signature(
+                "fn",
+                FunctionType.Func(
+                    new Identifier(
+                        "ret",
+                        ret.DataType,
+                        ret)));
+
+            When_RewriteCalls(ssa);
+
+            var sExp =
+            #region Expected
+@"main_entry:
+body:
+	fn()
+	return
+main_exit:
+";
+            #endregion
+            AssertProcedureCode(sExp, ssa);
+        }
+
         [Test]
         [Category(Categories.UnitTests)]
         public void CrwExcessRegisterUse()


### PR DESCRIPTION
- Create `CallRewriter` test with FPU return was not found in call definitions.

Expected:
        ignore `FPU` return

but was:
        `System.NotImplementedException : Offsets not matching? SP(0)`
- Ignore `FPU` stack return which was not found in call definitions