### PR TITLE
SsaTransform: search imported procedures only in Global Memory

### DIFF
--- a/src/Decompiler/Analysis/SsaTransform.cs
+++ b/src/Decompiler/Analysis/SsaTransform.cs
@@ -1099,7 +1099,9 @@ namespace Reko.Analysis
                 c = ea as Constant;
             }
 
-            if (c != null)
+            if (c != null &&
+                // Search imported procedures only in Global Memory
+                access.MemoryId.Storage == MemoryStorage.Instance)
             {
                 var e = importResolver.ResolveToImportedValue(stmCur, c);
                 if (e != null)


### PR DESCRIPTION
Resolving FPU stack access as import reference causes `NotSupportedException` on X86 real mode.
Modification of `SsaTransform` to avoid search imported procedures in FPU stack (in the same way as #687) could fix that