### PR TITLE
Expression Simplifier: Avoid call CreateWord method if data type size is unknown

### DIFF
--- a/src/Core/Types/DataType.cs
+++ b/src/Core/Types/DataType.cs
@@ -104,6 +104,15 @@ namespace Reko.Core.Types
             return dt as T;
         }
 
+        public bool IsWord()
+        {
+            if (BitSize == 0)
+                return false;
+            //$REFACTOR: CreateWord is inefficient.
+            var wordType = PrimitiveType.CreateWord(BitSize);
+            return wordType == this;
+        }
+
         protected void ThrowBadSize()
 		{
 			throw new InvalidOperationException(string.Format("Can't set size of {0}.", GetType().Name));

--- a/src/Decompiler/Evaluation/ExpressionSimplifier.cs
+++ b/src/Decompiler/Evaluation/ExpressionSimplifier.cs
@@ -489,8 +489,7 @@ namespace Reko.Evaluation
                 if (exp.DataType.BitSize == cast.DataType.BitSize)
                 {
                     // Redundant word-casts can be stripped.
-                    var wordType = PrimitiveType.CreateWord(exp.DataType.BitSize);
-                    if (wordType == cast.DataType)
+                    if (cast.DataType.IsWord())
                     {
                         return exp;
                     }

--- a/src/UnitTests/Evaluation/ExpressionSimplifierTests.cs
+++ b/src/UnitTests/Evaluation/ExpressionSimplifierTests.cs
@@ -337,5 +337,18 @@ namespace Reko.UnitTests.Evaluation
             var exp = m.Cast(PrimitiveType.Word32, value);
             Assert.AreEqual("0x00123400", exp.Accept(simplifier).ToString());
         }
+
+        [Test]
+        public void Exs_cast_of_unknown_type()
+        {
+            Given_ExpressionSimplifier();
+            var value = foo;
+            value.DataType = new UnknownType();
+            var exp = m.Cast(new UnknownType(), value);
+
+            var result = exp.Accept(simplifier);
+
+            Assert.AreEqual("(<type-error>) foo_1", result.ToString());
+        }
     }
 }


### PR DESCRIPTION
- Create Expression Simplifier test with cast to unknown type

Expected:

    do nothing

but was:

    throw ArgumentOutOfRangeException during CreateWord method execution

- Expression Simplifier: avoid call `CreateWord` method if data type size is unknown