### PR TITLE
Create TypedDataDumper test to reproduce truncation of 64-bit word

### DIFF
--- a/src/Core/TypedDataDumper.cs
+++ b/src/Core/TypedDataDumper.cs
@@ -129,7 +129,7 @@ namespace Reko.Core
             case 8:
                 fmt.WriteKeyword("dq");
                 fmt.Write("\t");
-                fmt.Write(string.Format("0x{0:X16}", rdr.ReadUInt32()));
+                fmt.Write(string.Format("0x{0:X16}", rdr.ReadUInt64()));
                 fmt.WriteLine();
                 return;
             default:

--- a/src/UnitTests/Core/TypedDataDumperTests.cs
+++ b/src/UnitTests/Core/TypedDataDumperTests.cs
@@ -70,5 +70,19 @@ namespace Reko.UnitTests.Core
 
             Assert.AreEqual("db\t0x0D,0x0A,'Hello',0x00" + cr, sw.ToString());
         }
+
+        [Test]
+        public void Tdd_Word64()
+        {
+            var bytes = new byte[]
+            {
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            };
+            Given_TypedDataDumper(bytes);
+
+            PrimitiveType.Word64.Accept(tdd);
+
+            Assert.AreEqual("dq\t0x0807060504030201" + cr, sw.ToString());
+        }
     }
 }


### PR DESCRIPTION
- Create `TypedDataDumper` test to reproduce truncation of 64-bit word
Expected: `dq 0x0807060504030201`
But was:  `dq 0x0000000004030201`
- Do not truncate 64-bit word (`ReadUInt32` -> `ReadUInt64`)