### PR TITLE
TypedDataDumper: do not truncate 64-bit pointer

### DIFF
--- a/src/Core/TypedDataDumper.cs
+++ b/src/Core/TypedDataDumper.cs
@@ -98,7 +98,7 @@ namespace Reko.Core
             case 8:
                 fmt.WriteKeyword("dq");
                 fmt.Write("\t");
-                fmt.Write(string.Format("0x{0:X16}", rdr.ReadUInt32()));
+                fmt.Write(string.Format("0x{0:X16}", rdr.ReadUInt64()));
                 fmt.WriteLine();
                 return;
             }

--- a/src/UnitTests/Core/TypedDataDumperTests.cs
+++ b/src/UnitTests/Core/TypedDataDumperTests.cs
@@ -84,5 +84,20 @@ namespace Reko.UnitTests.Core
 
             Assert.AreEqual("dq\t0x0807060504030201" + cr, sw.ToString());
         }
+
+        [Test]
+        public void Tdd_Ptr64()
+        {
+            var bytes = new byte[]
+            {
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            };
+            Given_TypedDataDumper(bytes);
+
+            var ptr64 = new Pointer(VoidType.Instance, 64);
+            ptr64.Accept(tdd);
+
+            Assert.AreEqual("dq\t0x0807060504030201" + cr, sw.ToString());
+        }
     }
 }


### PR DESCRIPTION
- Create `TypedDataDumper` test to reproduce truncation of 64-bit pointer. This is the similar problem as #836
Expected: `dq 0x0807060504030201`
But was:  `dq 0x0000000004030201`
- Do not truncate 64-bit pointer (`ReadUInt32` -> `ReadUInt64`)