### PR TITLE
Make ExpressionTypeAscender work with nested structs

### DIFF
--- a/src/Core/Expressions/ExpressionTypeAscenderBase.cs
+++ b/src/Core/Expressions/ExpressionTypeAscenderBase.cs
@@ -211,10 +211,14 @@ namespace Reko.Core.Expressions
             var dtField = field.DataType.ResolveAs<DataType>();
             if (dtField == null)
                 return null;
-            //$TODO This really should be offset != field.Offset
-            // However doing so causes a regression in hello_ppc.exe
-            if (offset >= field.Offset + dtField.Size)
-                return null;
+            // If we access beyond the start of the field, we can't have the
+            // same type as the field.
+            if (offset != field.Offset)
+            {
+                // Check if field is nested structure
+                var ptrField = factory.CreatePointer(dtField, ptrLeft.BitSize);
+                return GetPossibleFieldType(ptrField, offset - field.Offset);
+            }
             return factory.CreatePointer(dtField, dtLeft.BitSize);
         }
 

--- a/src/UnitTests/Typing/ExpressionTypeAscenderTests.cs
+++ b/src/UnitTests/Typing/ExpressionTypeAscenderTests.cs
@@ -231,6 +231,23 @@ namespace Reko.UnitTests.Typing
                 "Typing/ExaUsrGlobals_Addr32.txt");
         }
 
+        [Test(Description = "Pointers should be processed as globals")]
+        public void ExaUsrGlobals_Structure_SecondField()
+        {
+            var str = new StructureType
+            {
+                Fields =
+                {
+                    { 0, PrimitiveType.Int32 },
+                    { 4, PrimitiveType.Real32 },
+                },
+            };
+            Given_GlobalVariable(
+                Address.Ptr32(0x10001200), str);
+            RunTest(Address.Ptr32(0x10001204),
+                "Typing/ExaUsrGlobals_Structure_SecondField.txt");
+        }
+
         [Test(Description = "Operand sizes of a widening multiplication shouldn't affect the size of the product.")]
         public void ExaWideningFMul()
         {

--- a/src/tests/Typing/ExaUsrGlobals_Structure_SecondField.exp
+++ b/src/tests/Typing/ExaUsrGlobals_Structure_SecondField.exp
@@ -1,0 +1,10 @@
+// Equivalence classes ////////////
+// Type Variables ////////////
+globals_t: (in globals : ptr32)
+  Class: Eq_1
+  DataType: 
+  OrigDataType: 
+T_2: (in 10001204 : ptr32)
+  Class: Eq_2
+  DataType: (ptr32 real32)
+  OrigDataType: (ptr32 real32)

--- a/src/tests/Typing/TycoStructMembers.exp
+++ b/src/tests/Typing/TycoStructMembers.exp
@@ -57,21 +57,21 @@ T_11: (in 0xE<32> : word32)
   OrigDataType: word32
 T_12: (in ptr + 0xE<32> : word32)
   Class: Eq_12
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_13: (in Mem0[ptr + 0xE<32>:word16] : word16)
   Class: Eq_13
-  DataType: ui32
-  OrigDataType: ui32
+  DataType: cui16
+  OrigDataType: cui16
 T_14: (in 0xFF<16> : word16)
   Class: Eq_14
-  DataType: (union (ui32 u1) (word16 u0))
-  OrigDataType: (union (ui32 u0) (word16 u1))
+  DataType: cui16
+  OrigDataType: cui16
 T_15: (in Mem0[ptr + 0xE<32>:word16] | 0xFF<16> : word16)
   Class: Eq_15
-  DataType: ui32
-  OrigDataType: ui32
+  DataType: cui16
+  OrigDataType: cui16
 T_16: (in b16 : word16)
   Class: Eq_15
-  DataType: (union (ui32 u1) (word16 u0))
-  OrigDataType: (union (ui32 u1) (word16 u0))
+  DataType: cui16
+  OrigDataType: cui16

--- a/subjects/Elf/MIPS/redir/redir.reko/redir.h
+++ b/subjects/Elf/MIPS/redir/redir.reko/redir.h
@@ -76,7 +76,7 @@ Eq_1357: (fn Eq_1371 (int32, ptr32, ptr32, ptr32, ptr32, ptr32))
 	T_5709 (in print_log : ptr32)
 	T_5746 (in print_log : ptr32)
 	T_5873 (in print_log : ptr32)
-Eq_1371: (union "Eq_1371" (word16 u0) ((ptr32 char) u1) ((ptr32 Eq_8254) u2) ((ptr32 Eq_8255) u3) ((ptr32 Eq_4855) u4) ((ptr32 void) u5))
+Eq_1371: (union "Eq_1371" (word16 u0) ((ptr32 char) u1) ((ptr32 Eq_8254) u2) ((ptr32 Eq_8255) u3) ((ptr32 Eq_4855) u4) ((ptr32 void) u5) ((arr Eq_1371) u6))
 	T_1371 (in print_log(3<i32>, 0x409DD4<32>, out r5_44, out r6_45, out r7_46, out r25_47) : word32)
 	T_1391 (in print_log(3<i32>, 0x409E04<32>, out r5_49, out r6_50, out r7_51, out r25_52) : word32)
 	T_1396 (in r4 : Eq_1371)
@@ -544,7 +544,7 @@ Eq_1462: (fn int32 (Eq_1464))
 	T_3508 (in close : ptr32)
 	T_3517 (in close : ptr32)
 	T_5694 (in close : ptr32)
-Eq_1464: (union "Eq_1464" (int8 u0) (int32 u1) (uint32 u2) ((arr byte) u3) ((arr int8) u4) ((arr int8) u5) ((arr int8) u6) ((arr int8) u7) ((arr byte) u8))
+Eq_1464: (union "Eq_1464" (int8 u0) (int32 u1) (uint32 u2) ((arr Eq_8256) u3) ((arr int8) u4) ((arr byte) u5))
 	T_1464 (in r4 : int32)
 	T_1465 (in 0<32> : word32)
 	T_1468 (in 1<i32> : int32)
@@ -992,7 +992,7 @@ Eq_2862: (fn int32 ((ptr32 Eq_2864), (ptr32 char), int32))
 	T_2988 (in strncasecmp : ptr32)
 	T_3367 (in strncasecmp : ptr32)
 	T_4077 (in strncasecmp : ptr32)
-Eq_2864: (struct "Eq_2864" 0001 (0 Eq_8256 t0000) (1 int8 b0001))
+Eq_2864: (struct "Eq_2864" 0001 (0 Eq_8257 t0000) (1 int8 b0001))
 	T_2864 (in r4 : (ptr32 char))
 	T_2867 (in 0x409FF4<32> : word32)
 	T_2908 (in fp + -2064<i32> : word32)
@@ -1014,11 +1014,11 @@ Eq_2864: (struct "Eq_2864" 0001 (0 Eq_8256 t0000) (1 int8 b0001))
 	T_3485 (in dwLoc18_205 + 3<i32> : word32)
 	T_3488 (in Mem156[r4 + 0x1788<32>:word32] : word32)
 	T_4079 (in r4 + 276<i32> : word32)
-Eq_2874: (fn void (Eq_1371, (ptr32 Eq_8257), word32))
+Eq_2874: (fn void (Eq_1371, (ptr32 Eq_8258), word32))
 	T_2874 (in request_get_content_length : ptr32)
 	T_2875 (in signature of request_get_content_length : void)
 	T_2996 (in request_get_content_length : ptr32)
-Eq_2916: (fn void (Eq_1371, (ptr32 Eq_8257), word32))
+Eq_2916: (fn void (Eq_1371, (ptr32 Eq_8258), word32))
 	T_2916 (in request_get_host : ptr32)
 	T_2917 (in signature of request_get_host : void)
 Eq_2924: (fn void (Eq_1371, word32))
@@ -1131,18 +1131,18 @@ Eq_3999: (struct "Eq_3999" (410 (arr Eq_1371) a0410))
 	T_3999 (in r4 + 4<i32> : word32)
 Eq_4009: (struct "Eq_4009" (410 (arr word32) a0410))
 	T_4009 (in r4 + 4<i32> : word32)
-Eq_4045: (struct "Eq_4045" (410 (arr (ptr32 void)) a0410))
+Eq_4045: (struct "Eq_4045" (0 int8 b0000) (410 (arr (ptr32 (ptr32 (ptr32 void)))) a0410))
 	T_4045 (in r4 + 4<i32> : word32)
 Eq_4131: (struct "Eq_4131" (410 (arr word32) a0410))
 	T_4131 (in r4 + 4<i32> : word32)
-Eq_4239: (fn int32 (Eq_1371, (ptr32 Eq_8257), int32))
+Eq_4239: (fn int32 (Eq_1371, (ptr32 Eq_8258), int32))
 	T_4239 (in strncpy : ptr32)
 	T_4240 (in signature of strncpy : void)
 	T_4252 (in strncpy : ptr32)
 	T_4259 (in strncpy : ptr32)
 	T_4345 (in strncpy : ptr32)
 	T_4783 (in strncpy : ptr32)
-Eq_4280: (fn (ptr32 Eq_8257) ((ptr32 Eq_8257), (ptr32 char)))
+Eq_4280: (fn (ptr32 Eq_8258) ((ptr32 Eq_8258), (ptr32 char)))
 	T_4280 (in strpbrk : ptr32)
 	T_4281 (in signature of strpbrk : void)
 	T_4308 (in strpbrk : ptr32)
@@ -1156,7 +1156,7 @@ Eq_4426: (union "Eq_4426" (char u0) (int8 u1) (Eq_4427 u2))
 	T_4426 (in dwLoc18_184 + 0<32> : word32)
 Eq_4427: (union "Eq_4427" (char u0) (int8 u1))
 	T_4427 (in Mem56[dwLoc18_184 + 0<32>:int8] : int8)
-Eq_4449: (fn uint32 ((ptr32 Eq_8257), (ptr32 (ptr32 char)), int32))
+Eq_4449: (fn uint32 ((ptr32 Eq_8258), (ptr32 (ptr32 char)), int32))
 	T_4449 (in strtoul : ptr32)
 	T_4450 (in signature of strtoul : void)
 	T_4530 (in strtoul : ptr32)
@@ -1834,10 +1834,12 @@ Eq_8254: (struct "Eq_8254" (0 char b0000) (4 Eq_1464 t0004) (8 Eq_1371 t0008) (A
 	T_8254
 Eq_8255: (union "Eq_8255" (char u0) (int8 u1))
 	T_8255
-Eq_8256: (union "Eq_8256" (char u0) (int8 u1) (Eq_3396 u2) (Eq_3402 u3) (Eq_3414 u4) (Eq_3426 u5))
+Eq_8256: (struct "Eq_8256" (0 (arr int8) a0000) (410 (arr (ptr32 (ptr32 (ptr32 void)))) a0410))
 	T_8256
-Eq_8257: (union "Eq_8257" (char u0) (int8 u1) (Eq_4323 u2) (Eq_4427 u3))
+Eq_8257: (union "Eq_8257" (char u0) (int8 u1) (Eq_3396 u2) (Eq_3402 u3) (Eq_3414 u4) (Eq_3426 u5))
 	T_8257
+Eq_8258: (union "Eq_8258" (char u0) (int8 u1) (Eq_4323 u2) (Eq_4427 u3))
+	T_8258
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -8909,8 +8911,8 @@ T_1767: (in -304<i32> : int32)
   OrigDataType: int32
 T_1768: (in fp + -304<i32> : word32)
   Class: Eq_1768
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8204)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8202))
 T_1769: (in 5<8> : byte)
   Class: Eq_1769
   DataType: byte
@@ -8969,8 +8971,8 @@ T_1782: (in -304<i32> : int32)
   OrigDataType: int32
 T_1783: (in fp + -304<i32> : word32)
   Class: Eq_1783
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8205)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8202))
 T_1784: (in r2_527 >> 5<8> : word32)
   Class: Eq_1784
   DataType: uint32
@@ -9457,8 +9459,8 @@ T_1904: (in -176<i32> : int32)
   OrigDataType: int32
 T_1905: (in fp + -176<i32> : word32)
   Class: Eq_1905
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8206)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8203))
 T_1906: (in 5<8> : byte)
   Class: Eq_1906
   DataType: byte
@@ -9517,8 +9519,8 @@ T_1919: (in -176<i32> : int32)
   OrigDataType: int32
 T_1920: (in fp + -176<i32> : word32)
   Class: Eq_1920
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8207)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8203))
 T_1921: (in r2_577 >> 5<8> : word32)
   Class: Eq_1921
   DataType: uint32
@@ -9557,8 +9559,8 @@ T_1929: (in -304<i32> : int32)
   OrigDataType: int32
 T_1930: (in fp + -304<i32> : word32)
   Class: Eq_1930
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8208)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8202))
 T_1931: (in 5<8> : byte)
   Class: Eq_1931
   DataType: byte
@@ -9617,8 +9619,8 @@ T_1944: (in -304<i32> : int32)
   OrigDataType: int32
 T_1945: (in fp + -304<i32> : word32)
   Class: Eq_1945
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8209)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8202))
 T_1946: (in r2_596 >> 5<8> : word32)
   Class: Eq_1946
   DataType: uint32
@@ -9665,8 +9667,8 @@ T_1956: (in -176<i32> : int32)
   OrigDataType: int32
 T_1957: (in fp + -176<i32> : word32)
   Class: Eq_1957
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8210)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8203))
 T_1958: (in 5<8> : byte)
   Class: Eq_1958
   DataType: byte
@@ -9725,8 +9727,8 @@ T_1971: (in -176<i32> : int32)
   OrigDataType: int32
 T_1972: (in fp + -176<i32> : word32)
   Class: Eq_1972
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8211)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8203))
 T_1973: (in r2_630 >> 5<8> : word32)
   Class: Eq_1973
   DataType: uint32
@@ -9765,8 +9767,8 @@ T_1981: (in -304<i32> : int32)
   OrigDataType: int32
 T_1982: (in fp + -304<i32> : word32)
   Class: Eq_1982
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8212)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8202))
 T_1983: (in 5<8> : byte)
   Class: Eq_1983
   DataType: byte
@@ -9825,8 +9827,8 @@ T_1996: (in -304<i32> : int32)
   OrigDataType: int32
 T_1997: (in fp + -304<i32> : word32)
   Class: Eq_1997
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8213)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8202))
 T_1998: (in r2_649 >> 5<8> : word32)
   Class: Eq_1998
   DataType: uint32
@@ -9849,8 +9851,8 @@ T_2002: (in -304<i32> : int32)
   OrigDataType: int32
 T_2003: (in fp + -304<i32> : word32)
   Class: Eq_2003
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8214)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8202))
 T_2004: (in 0<32> : word32)
   Class: Eq_2004
   DataType: word32
@@ -9993,8 +9995,8 @@ T_2038: (in -304<i32> : int32)
   OrigDataType: int32
 T_2039: (in fp + -304<i32> : word32)
   Class: Eq_2039
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8215)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8202))
 T_2040: (in 0<32> : word32)
   Class: Eq_2040
   DataType: word32
@@ -10417,8 +10419,8 @@ T_2144: (in -304<i32> : int32)
   OrigDataType: int32
 T_2145: (in fp + -304<i32> : word32)
   Class: Eq_2145
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8216)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8202))
 T_2146: (in 4<32> : word32)
   Class: Eq_2146
   DataType: word32
@@ -10645,8 +10647,8 @@ T_2201: (in -176<i32> : int32)
   OrigDataType: int32
 T_2202: (in fp + -176<i32> : word32)
   Class: Eq_2202
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8217)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8203))
 T_2203: (in 0<32> : word32)
   Class: Eq_2203
   DataType: word32
@@ -10769,8 +10771,8 @@ T_2232: (in -176<i32> : int32)
   OrigDataType: int32
 T_2233: (in fp + -176<i32> : word32)
   Class: Eq_2233
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 T_8218)
+  DataType: (ptr32 (arr int32))
+  OrigDataType: (ptr32 (arr T_8203))
 T_2234: (in 4<32> : word32)
   Class: Eq_2234
   DataType: word32
@@ -13343,9 +13345,9 @@ T_2876: (in r4 : Eq_1371)
   Class: Eq_1371
   DataType: Eq_1371
   OrigDataType: (ptr32 (struct (554 T_4461 t0554)))
-T_2877: (in r5 : (ptr32 Eq_8257))
+T_2877: (in r5 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_2878: (in ra : word32)
   Class: Eq_1399
@@ -13357,7 +13359,7 @@ T_2879: (in -2064<i32> : int32)
   OrigDataType: int32
 T_2880: (in fp + -2064<i32> : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: ptr32
 T_2881: (in request_get_content_length(dwLoc20_525, fp + -2064<i32>, ra) : void)
   Class: Eq_2881
@@ -13511,9 +13513,9 @@ T_2918: (in r4 : Eq_1371)
   Class: Eq_1371
   DataType: Eq_1371
   OrigDataType: (ptr32 (struct (4 T_8234 t0004)))
-T_2919: (in r5 : (ptr32 Eq_8257))
+T_2919: (in r5 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_2920: (in ra : word32)
   Class: Eq_1399
@@ -13525,7 +13527,7 @@ T_2921: (in -2064<i32> : int32)
   OrigDataType: int32
 T_2922: (in fp + -2064<i32> : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: ptr32
 T_2923: (in request_get_host(dwLoc20_525, fp + -2064<i32>, ra) : void)
   Class: Eq_2923
@@ -13829,7 +13831,7 @@ T_2997: (in -2064<i32> : int32)
   OrigDataType: int32
 T_2998: (in fp + -2064<i32> : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: ptr32
 T_2999: (in request_get_content_length(dwLoc20_525, fp + -2064<i32>, ra) : void)
   Class: Eq_2881
@@ -17969,7 +17971,7 @@ T_4032: (in (word32) bArg0B_150 : word32)
   OrigDataType: word32
 T_4033: (in (byte) (word32) bArg0B_150 : byte)
   Class: Eq_4033
-  DataType: byte
+  DataType: int8
   OrigDataType: byte
 T_4034: (in 4<i32> : int32)
   Class: Eq_4034
@@ -17977,7 +17979,7 @@ T_4034: (in 4<i32> : int32)
   OrigDataType: int32
 T_4035: (in r4 + 4<i32> : word32)
   Class: Eq_4035
-  DataType: (ptr32 (arr byte))
+  DataType: (ptr32 (arr int8))
   OrigDataType: (ptr32 (struct (0 (arr T_8221) a0000)))
 T_4036: (in 0x558<32> : word32)
   Class: Eq_4036
@@ -18001,11 +18003,11 @@ T_4040: (in Mem48[r4 + 0x558<32>:word32] + 1296<i32> : word32)
   OrigDataType: int32
 T_4041: (in (word32) r4 + 4<i32> + ((word32) (*((word32) r4 + 1368<i32>)) + 1296<i32>) : word32)
   Class: Eq_4041
-  DataType: (ptr32 byte)
+  DataType: (ptr32 int8)
   OrigDataType: (ptr32 (struct (0 T_4042 t0000)))
 T_4042: (in Mem64[r4 + 4<i32> + (Mem48[r4 + 0x558<32>:word32] + 1296<i32>):byte] : byte)
   Class: Eq_4033
-  DataType: byte
+  DataType: int8
   OrigDataType: byte
 T_4043: (in memcpy : ptr32)
   Class: Eq_2619
@@ -18017,8 +18019,8 @@ T_4044: (in 4<i32> : int32)
   OrigDataType: int32
 T_4045: (in r4 + 4<i32> : word32)
   Class: Eq_4045
-  DataType: (ptr32 Eq_4045)
-  OrigDataType: (ptr32 (struct (410 (arr T_8223) a0410)))
+  DataType: (ptr32 (arr (struct "Eq_4045")))
+  OrigDataType: (ptr32 (arr (struct "Eq_4045")))
 T_4046: (in 1040<i32> : int32)
   Class: Eq_4046
   DataType: int32
@@ -18440,7 +18442,7 @@ T_4150: (in (word32) r4 + 4<i32> + (dwLoc18_153 + 1296<i32>) : word32)
   DataType: (ptr32 int8)
   OrigDataType: (ptr32 (struct (0 T_4151 t0000)))
 T_4151: (in Mem22[r4 + 4<i32> + (dwLoc18_153 + 1296<i32>):int8] : int8)
-  Class: Eq_4151
+  Class: Eq_4033
   DataType: int8
   OrigDataType: int8
 T_4152: (in (word32) Mem22[r4 + 4<i32> + (dwLoc18_153 + 1296<i32>):int8] : word32)
@@ -18525,8 +18527,8 @@ T_4171: (in 4<i32> : int32)
   OrigDataType: int32
 T_4172: (in r4 + 4<i32> : word32)
   Class: Eq_4172
-  DataType: (ptr32 (arr int8))
-  OrigDataType: (ptr32 (struct (0 (arr T_8227) a0000)))
+  DataType: (ptr32 (arr (arr int8)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr int8) a0000))))
 T_4173: (in 1296<i32> : int32)
   Class: Eq_4173
   DataType: int32
@@ -18540,7 +18542,7 @@ T_4175: (in (word32) r4 + 4<i32> + (dwLoc18_153 + 1296<i32>) : word32)
   DataType: (ptr32 int8)
   OrigDataType: (ptr32 (struct (0 T_4176 t0000)))
 T_4176: (in Mem22[r4 + 4<i32> + (dwLoc18_153 + 1296<i32>):int8] : int8)
-  Class: Eq_4176
+  Class: Eq_4033
   DataType: int8
   OrigDataType: int8
 T_4177: (in (word32) Mem22[r4 + 4<i32> + (dwLoc18_153 + 1296<i32>):int8] : word32)
@@ -18573,8 +18575,8 @@ T_4183: (in 4<i32> : int32)
   OrigDataType: int32
 T_4184: (in r4 + 4<i32> : word32)
   Class: Eq_4184
-  DataType: (ptr32 (arr int8))
-  OrigDataType: (ptr32 (struct (0 (arr T_8229) a0000)))
+  DataType: (ptr32 (arr (arr int8)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr int8) a0000))))
 T_4185: (in 1296<i32> : int32)
   Class: Eq_4185
   DataType: int32
@@ -18588,7 +18590,7 @@ T_4187: (in (word32) r4 + 4<i32> + (dwLoc18_153 + 1296<i32>) : word32)
   DataType: (ptr32 int8)
   OrigDataType: (ptr32 (struct (0 T_4188 t0000)))
 T_4188: (in Mem72[r4 + 4<i32> + (dwLoc18_153 + 1296<i32>):int8] : int8)
-  Class: Eq_4188
+  Class: Eq_4033
   DataType: int8
   OrigDataType: int8
 T_4189: (in (word32) Mem72[r4 + 4<i32> + (dwLoc18_153 + 1296<i32>):int8] : word32)
@@ -18629,8 +18631,8 @@ T_4197: (in 4<i32> : int32)
   OrigDataType: int32
 T_4198: (in r4 + 4<i32> : word32)
   Class: Eq_4198
-  DataType: (ptr32 (arr int8))
-  OrigDataType: (ptr32 (struct (0 (arr T_8231) a0000)))
+  DataType: (ptr32 (arr (arr int8)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr int8) a0000))))
 T_4199: (in 1296<i32> : int32)
   Class: Eq_4199
   DataType: int32
@@ -18644,7 +18646,7 @@ T_4201: (in (word32) r4 + 4<i32> + (dwLoc18_153 + 1296<i32>) : word32)
   DataType: (ptr32 int8)
   OrigDataType: (ptr32 (struct (0 T_4202 t0000)))
 T_4202: (in Mem72[r4 + 4<i32> + (dwLoc18_153 + 1296<i32>):int8] : int8)
-  Class: Eq_4202
+  Class: Eq_4033
   DataType: int8
   OrigDataType: int8
 T_4203: (in (word32) Mem72[r4 + 4<i32> + (dwLoc18_153 + 1296<i32>):int8] : word32)
@@ -18697,8 +18699,8 @@ T_4214: (in 4<i32> : int32)
   OrigDataType: int32
 T_4215: (in r4 + 4<i32> : word32)
   Class: Eq_4215
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr int8)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr int8) a0000))))
 T_4216: (in 2<8> : byte)
   Class: Eq_4216
   DataType: byte
@@ -18779,9 +18781,9 @@ T_4235: (in r2 : ptr32)
   Class: Eq_2718
   DataType: ptr32
   OrigDataType: word32
-T_4236: (in r2_26 : (ptr32 Eq_8257))
+T_4236: (in r2_26 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_4237: (in strsep : ptr32)
   Class: Eq_4237
@@ -18805,7 +18807,7 @@ T_4241: (in r4 : (ptr32 char))
   OrigDataType: 
 T_4242: (in r5 : (ptr32 char))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: 
 T_4243: (in n : int32)
   Class: Eq_4243
@@ -18831,9 +18833,9 @@ T_4248: (in r2 : word32)
   Class: Eq_3934
   DataType: word32
   OrigDataType: word32
-T_4249: (in r2_26 : (ptr32 Eq_8257))
+T_4249: (in r2_26 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_4250: (in strsep : ptr32)
   Class: Eq_4250
@@ -18859,9 +18861,9 @@ T_4255: (in r25_34 : Eq_1371)
   Class: Eq_1371
   DataType: Eq_1371
   OrigDataType: word32
-T_4256: (in r2_26 : (ptr32 Eq_8257))
+T_4256: (in r2_26 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_4257: (in strsep : ptr32)
   Class: Eq_4257
@@ -18951,9 +18953,9 @@ T_4278: (in r4 == -20<i32> : bool)
   Class: Eq_4278
   DataType: bool
   OrigDataType: bool
-T_4279: (in r2_48 : (ptr32 Eq_8257))
+T_4279: (in r2_48 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_4280: (in strpbrk : ptr32)
   Class: Eq_4280
@@ -18965,7 +18967,7 @@ T_4281: (in signature of strpbrk : void)
   OrigDataType: 
 T_4282: (in r4 : (ptr32 char))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: 
 T_4283: (in r5 : (ptr32 char))
   Class: Eq_4283
@@ -18977,15 +18979,15 @@ T_4284: (in 0x40A46C<32> : word32)
   OrigDataType: (ptr32 char)
 T_4285: (in strpbrk(r5, " \t") : (ptr32 char))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
-T_4286: (in dwLoc18_192 : (ptr32 Eq_8257))
+T_4286: (in dwLoc18_192 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 (struct 0001 (0 (union (char u0) (int8 u1) (T_4315 u2) (T_4323 u3)) u0000)))
 T_4287: (in 0<32> : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: word32
 T_4288: (in r2_48 != null : bool)
   Class: Eq_4288
@@ -18997,7 +18999,7 @@ T_4289: (in 256<i32> : int32)
   OrigDataType: int32
 T_4290: (in r5 + 256<i32> : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: ptr32
 T_4291: (in dwLoc18_192 < &r5->u0 + 256<i32> : bool)
   Class: Eq_4291
@@ -19063,9 +19065,9 @@ T_4306: (in print_log(2<i32>, 0x40A470<32>, out r5_173, out r6_176, out r7_177, 
   Class: Eq_1371
   DataType: Eq_1371
   OrigDataType: word32
-T_4307: (in r2_90 : (ptr32 Eq_8257))
+T_4307: (in r2_90 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_4308: (in strpbrk : ptr32)
   Class: Eq_4280
@@ -19077,11 +19079,11 @@ T_4309: (in 0x40A468<32> : word32)
   OrigDataType: (ptr32 char)
 T_4310: (in strpbrk(dwLoc18_192, " \n\r") : (ptr32 char))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_4311: (in 0<32> : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: word32
 T_4312: (in r2_90 != null : bool)
   Class: Eq_4312
@@ -19117,7 +19119,7 @@ T_4319: (in 1<i32> : int32)
   OrigDataType: int32
 T_4320: (in dwLoc18_192 + 1<i32> : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: ptr32
 T_4321: (in 0<32> : word32)
   Class: Eq_4321
@@ -19379,9 +19381,9 @@ T_4385: (in r4 == -20<i32> : bool)
   Class: Eq_4385
   DataType: bool
   OrigDataType: bool
-T_4386: (in r2_48 : (ptr32 Eq_8257))
+T_4386: (in r2_48 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_4387: (in strpbrk : ptr32)
   Class: Eq_4280
@@ -19393,15 +19395,15 @@ T_4388: (in 0x40A46C<32> : word32)
   OrigDataType: (ptr32 char)
 T_4389: (in strpbrk(r5, " \t") : (ptr32 char))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
-T_4390: (in dwLoc18_184 : (ptr32 Eq_8257))
+T_4390: (in dwLoc18_184 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 (struct 0001 (0 (union (char u0) (int8 u1) (T_4419 u2) (T_4427 u3)) u0000)))
 T_4391: (in 0<32> : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: word32
 T_4392: (in r2_48 != null : bool)
   Class: Eq_4392
@@ -19413,7 +19415,7 @@ T_4393: (in 256<i32> : int32)
   OrigDataType: int32
 T_4394: (in r5 + 256<i32> : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: ptr32
 T_4395: (in dwLoc18_184 < &r5->u0 + 256<i32> : bool)
   Class: Eq_4395
@@ -19479,9 +19481,9 @@ T_4410: (in print_log(2<i32>, 0x40A564<32>, out r5_165, out r6_168, out r7_169, 
   Class: Eq_1371
   DataType: Eq_1371
   OrigDataType: word32
-T_4411: (in r2_90 : (ptr32 Eq_8257))
+T_4411: (in r2_90 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_4412: (in strpbrk : ptr32)
   Class: Eq_4280
@@ -19493,11 +19495,11 @@ T_4413: (in 0x40A468<32> : word32)
   OrigDataType: (ptr32 char)
 T_4414: (in strpbrk(dwLoc18_184, " \n\r") : (ptr32 char))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_4415: (in 0<32> : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: word32
 T_4416: (in r2_90 != null : bool)
   Class: Eq_4416
@@ -19533,7 +19535,7 @@ T_4423: (in 1<i32> : int32)
   OrigDataType: int32
 T_4424: (in dwLoc18_184 + 1<i32> : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: ptr32
 T_4425: (in 0<32> : word32)
   Class: Eq_4425
@@ -19641,7 +19643,7 @@ T_4450: (in signature of strtoul : void)
   OrigDataType: 
 T_4451: (in nptr : (ptr32 char))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: 
 T_4452: (in endptr : (ptr32 (ptr32 char)))
   Class: Eq_4452
@@ -19943,9 +19945,9 @@ T_4526: (in *((word32) r4 + 1368<i32>) >= 0<32> : bool)
   Class: Eq_4526
   DataType: bool
   OrigDataType: bool
-T_4527: (in r4 : (ptr32 Eq_8257))
+T_4527: (in r4 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 char)
 T_4528: (in r5 : (ptr32 int8))
   Class: Eq_4528
@@ -20619,9 +20621,9 @@ T_4695: (in signature of strspn : void)
   Class: Eq_4695
   DataType: Eq_4695
   OrigDataType: 
-T_4696: (in r2_266 : (ptr32 Eq_8257))
+T_4696: (in r2_266 : (ptr32 Eq_8258))
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: (ptr32 (struct (0 char b0000)))
 T_4697: (in 1<i32> : int32)
   Class: Eq_4697
@@ -20633,7 +20635,7 @@ T_4698: (in r2_242 + 1<i32> : word32)
   OrigDataType: ptr32
 T_4699: (in r2_242 + 1<i32> + r2_259 : word32)
   Class: Eq_2877
-  DataType: (ptr32 Eq_8257)
+  DataType: (ptr32 Eq_8258)
   OrigDataType: ptr32
 T_4700: (in r25_274 : word32)
   Class: Eq_4700
@@ -21937,12 +21939,12 @@ T_5024: (in 0<32> : word32)
   OrigDataType: word32
 T_5025: (in r5 + 0<32> : word32)
   Class: Eq_5025
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_1371))
+  OrigDataType: (ptr32 (arr Eq_1371))
 T_5026: (in Mem142[r5 + 0<32>:word32] : word32)
   Class: Eq_1371
   DataType: Eq_1371
-  OrigDataType: word32
+  OrigDataType: (union ((ptr32 (struct (0 char b0000))) u1) ((ptr32 char) u2) ((arr Eq_1371) u0))
 T_5027: (in properties_print_usage(r5[0<i32>]) : void)
   Class: Eq_5027
   DataType: void
@@ -34721,12 +34723,12 @@ T_8220:
   OrigDataType: (struct 0004 (0 T_4017 t0000))
 T_8221:
   Class: Eq_8221
-  DataType: byte
+  DataType: int8
   OrigDataType: (struct 0001 (0 T_4042 t0000))
 T_8222:
   Class: Eq_1464
   DataType: Eq_1464
-  OrigDataType: (arr byte)
+  OrigDataType: (arr (struct "Eq_4045" (0 int8 b0000) (410 (arr (ptr32 (ptr32 (ptr32 void)))) a0410)))
 T_8223:
   Class: Eq_8223
   DataType: (ptr32 void)
@@ -34736,37 +34738,37 @@ T_8224:
   DataType: word32
   OrigDataType: (struct 0004 (0 T_4136 t0000))
 T_8225:
-  Class: Eq_8225
+  Class: Eq_8221
   DataType: int8
   OrigDataType: (struct 0001 (0 T_4151 t0000))
 T_8226:
   Class: Eq_1464
   DataType: Eq_1464
-  OrigDataType: (arr int8)
+  OrigDataType: (arr (struct (0 (arr int8) a0000)))
 T_8227:
-  Class: Eq_8227
+  Class: Eq_8221
   DataType: int8
   OrigDataType: (struct 0001 (0 T_4176 t0000))
 T_8228:
   Class: Eq_1464
   DataType: Eq_1464
-  OrigDataType: (arr int8)
+  OrigDataType: (arr Eq_8221)
 T_8229:
-  Class: Eq_8229
+  Class: Eq_8221
   DataType: int8
   OrigDataType: (struct 0001 (0 T_4188 t0000))
 T_8230:
   Class: Eq_1464
   DataType: Eq_1464
-  OrigDataType: (arr int8)
+  OrigDataType: (arr Eq_8221)
 T_8231:
-  Class: Eq_8231
+  Class: Eq_8221
   DataType: int8
   OrigDataType: (struct 0001 (0 T_4202 t0000))
 T_8232:
   Class: Eq_1464
   DataType: Eq_1464
-  OrigDataType: (arr int8)
+  OrigDataType: (arr Eq_8221)
 T_8233:
   Class: Eq_8233
   DataType: byte
@@ -34867,6 +34869,10 @@ T_8257:
   Class: Eq_8257
   DataType: Eq_8257
   OrigDataType: 
+T_8258:
+  Class: Eq_8258
+  DataType: Eq_8258
+  OrigDataType: 
 */
 typedef struct Globals {
 	<anonymous> tFFFFFFFF;	// FFFFFFFF
@@ -34946,6 +34952,7 @@ typedef union Eq_1371 {
 	union Eq_8255 * u3;
 	struct Eq_4855 * u4;
 	void * u5;
+	Eq_1371 u6[];
 } Eq_1371;
 
 typedef void (Eq_1392)(word32);
@@ -34979,12 +34986,9 @@ typedef union Eq_1464 {
 	int8 u0;
 	int32 u1;
 	uint32 u2;
-	byte u3[];
+	Eq_8256 u3[];
 	int8 u4[];
-	int8 u5[];
-	int8 u6[];
-	int8 u7[];
-	byte u8[];
+	byte u5[];
 } Eq_1464;
 
 typedef void (Eq_1473)(int32);
@@ -35132,13 +35136,13 @@ typedef void (Eq_2766)(Eq_1371);
 typedef int32 (Eq_2862)(Eq_2864 *, char *, int32);
 
 typedef struct Eq_2864 {	// size: 1 1
-	Eq_8256 t0000;	// 0
+	Eq_8257 t0000;	// 0
 	int8 b0001;	// 1
 } Eq_2864;
 
-typedef void (Eq_2874)(Eq_1371, Eq_8257 *, word32);
+typedef void (Eq_2874)(Eq_1371, Eq_8258 *, word32);
 
-typedef void (Eq_2916)(Eq_1371, Eq_8257 *, word32);
+typedef void (Eq_2916)(Eq_1371, Eq_8258 *, word32);
 
 typedef void (Eq_2924)(Eq_1371, word32);
 
@@ -35292,16 +35296,17 @@ typedef struct Eq_4009 {
 } Eq_4009;
 
 typedef struct Eq_4045 {
-	void * a0410[];	// 410
+	int8 b0000;	// 0
+	void *** a0410[];	// 410
 } Eq_4045;
 
 typedef struct Eq_4131 {
 	word32 a0410[];	// 410
 } Eq_4131;
 
-typedef int32 (Eq_4239)(Eq_1371, Eq_8257 *, int32);
+typedef int32 (Eq_4239)(Eq_1371, Eq_8258 *, int32);
 
-typedef Eq_8257 * (Eq_4280)(Eq_8257 *, char *);
+typedef Eq_8258 * (Eq_4280)(Eq_8258 *, char *);
 
 typedef union Eq_4322 {
 	char u0;
@@ -35325,7 +35330,7 @@ typedef union Eq_4427 {
 	int8 u1;
 } Eq_4427;
 
-typedef uint32 (Eq_4449)(Eq_8257 *, char * *, int32);
+typedef uint32 (Eq_4449)(Eq_8258 *, char * *, int32);
 
 typedef int32 (Eq_4479)(char *, Eq_1371, int32);
 
@@ -35971,19 +35976,24 @@ typedef union Eq_8255 {
 	int8 u1;
 } Eq_8255;
 
-typedef union Eq_8256 {
+typedef struct Eq_8256 {
+	int8 a0000[];	// 0
+	void *** a0410[];	// 410
+} Eq_8256;
+
+typedef union Eq_8257 {
 	char u0;
 	int8 u1;
 	Eq_3396 u2;
 	Eq_3402 u3;
 	Eq_3414 u4;
 	Eq_3426 u5;
-} Eq_8256;
+} Eq_8257;
 
-typedef union Eq_8257 {
+typedef union Eq_8258 {
 	char u0;
 	int8 u1;
 	Eq_4323 u2;
 	Eq_4427 u3;
-} Eq_8257;
+} Eq_8258;
 

--- a/subjects/Elf/MIPS/redir/redir.reko/redir_text.c
+++ b/subjects/Elf/MIPS/redir/redir.reko/redir_text.c
@@ -1614,7 +1614,7 @@ void request_save_line(Eq_n r4, void * r5, Eq_n r6, word32 ra)
 		}
 		else
 		{
-			(word32) r4 + 4 + ((word32) (*((word32) r4 + 0x0558)) + 0x0510) = (byte *) (byte) (word32) bArg0B_n;
+			(word32) r4 + 4 + ((word32) (*((word32) r4 + 0x0558)) + 0x0510) = (int8 *) (byte) (word32) bArg0B_n;
 			memcpy(*((word32) ((word32) r4 + 4) + (*((word32) r4 + 0x0558) * 0x04 + 1040)), r5, r6);
 		}
 	}

--- a/subjects/Elf/MIPS/swlswr/test.reko/test.h
+++ b/subjects/Elf/MIPS/swlswr/test.reko/test.h
@@ -659,8 +659,8 @@ T_149: (in 1<32> : word32)
   OrigDataType: word32
 T_150: (in r2_38 + 1<32> : word32)
   Class: Eq_150
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_151: (in Mem53[r2_38 + 1<32>:word32] : word32)
   Class: Eq_148
   DataType: word32

--- a/subjects/Elf/Msp430/a.reko/a.h
+++ b/subjects/Elf/Msp430/a.reko/a.h
@@ -1119,7 +1119,7 @@ Eq_1215: (union "Eq_1215" (word16 u0) ((ptr24 Eq_3900) u1))
 	T_1215 (in r11_24 + 6<i16> : word20)
 Eq_1240: (union "Eq_1240" (ptr16 u0) (word20 u1))
 	T_1240 (in 0208 : ptr16)
-Eq_1252: (union "Eq_1252" (word16 u0) ((ptr20 word20) u1) ((ptr20 word16) u2) ((ptr20 Eq_3901) u3))
+Eq_1252: (union "Eq_1252" (word16 u0) ((ptr20 word16) u1) ((ptr20 Eq_3901) u2))
 	T_1252 (in r15 : Eq_1252)
 	T_1301 (in 0<16> : word16)
 	T_1302 (in r15_111 : Eq_1252)
@@ -1453,9 +1453,6 @@ Eq_2359: (union "Eq_2359" (ui20 u0) (word16 u1))
 	T_2359 (in 8<16> : word16)
 Eq_2392: (union "Eq_2392" (cup16 u0) (word20 u1))
 	T_2392 (in r15 + 6<i16> : word20)
-Eq_2420: (union "Eq_2420" (word20 u0) (word16 u1))
-	T_2420 (in Mem42[r15 + 8<i16>:word16] : word16)
-	T_2421 (in 0<16> : word16)
 Eq_2424: (union "Eq_2424" (int20 u0) (word16 u1))
 	T_2424 (in 8<16> : word16)
 Eq_2471: (union "Eq_2471" (ui20 u0) (word16 u1))
@@ -2153,7 +2150,7 @@ Eq_3882: (struct "Eq_3882" (0 Eq_444 t0000) (2 Eq_444 t0002) (4 Eq_444 t0004) (1
 	T_3882
 Eq_3883: (struct "Eq_3883" (0 Eq_444 t0000) (2 Eq_444 t0002) (4 Eq_444 t0004) (6 Eq_444 t0006) (28 cup16 w0028) (2A cup16 w002A) (2C Eq_1502 t002C) (2E ci16 w002E) (30 ci16 w0030))
 	T_3883
-Eq_3884: (struct "Eq_3884" (0 Eq_444 t0000) (2 Eq_444 t0002) (6 Eq_444 t0006) (8 Eq_2420 t0008) (28 word16 w0028) (2C Eq_1502 t002C) (2E word16 w002E))
+Eq_3884: (struct "Eq_3884" (0 Eq_444 t0000) (2 Eq_444 t0002) (6 Eq_444 t0006) (8 word16 w0008) (28 word16 w0028) (2C Eq_1502 t002C) (2E word16 w002E))
 	T_3884
 Eq_3885: (union "Eq_3885" (up24 u0) (word20 u1))
 	T_3885
@@ -11978,12 +11975,12 @@ T_2418: (in 8<i16> : int16)
   OrigDataType: int16
 T_2419: (in r15 + 8<i16> : word20)
   Class: Eq_2419
-  DataType: (ptr20 word20)
-  OrigDataType: (ptr20 word20)
+  DataType: ptr20
+  OrigDataType: ptr20
 T_2420: (in Mem42[r15 + 8<i16>:word16] : word16)
   Class: Eq_2420
-  DataType: Eq_2420
-  OrigDataType: word20
+  DataType: word16
+  OrigDataType: word16
 T_2421: (in 0<16> : word16)
   Class: Eq_2420
   DataType: word16
@@ -12003,7 +12000,7 @@ T_2424: (in 8<16> : word16)
 T_2425: (in r15 + 8<16> : word20)
   Class: Eq_1252
   DataType: Eq_1252
-  OrigDataType: (ptr20 word20)
+  OrigDataType: (ptr20 word16)
 T_2426: (in xTaskRemoveFromEventList((word24) r15 + 8<i32>) : word20)
   Class: Eq_2121
   DataType: word20
@@ -18995,9 +18992,8 @@ typedef union Eq_1240 {
 
 typedef union Eq_1252 {
 	word16 u0;
-	word20 * u1;
-	word16 * u2;
-	struct Eq_3901 * u3;
+	word16 * u1;
+	struct Eq_3901 * u2;
 } Eq_1252;
 
 typedef union Eq_1253 {
@@ -19424,11 +19420,6 @@ typedef union Eq_2392 {
 	cup16 u0;
 	word20 u1;
 } Eq_2392;
-
-typedef union Eq_2420 {
-	word20 u0;
-	word16 u1;
-} Eq_2420;
 
 typedef union Eq_2424 {
 	int20 u0;
@@ -20589,7 +20580,7 @@ typedef struct Eq_3884 {
 	Eq_444 t0000;	// 0
 	Eq_444 t0002;	// 2
 	Eq_444 t0006;	// 6
-	Eq_2420 t0008;	// 8
+	word16 w0008;	// 8
 	word16 w0028;	// 28
 	Eq_1502 t002C;	// 2C
 	word16 w002E;	// 2E

--- a/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize.h
+++ b/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize.h
@@ -2936,7 +2936,7 @@ Eq_8136: (union "Eq_8136" (byte u0) ((arr Eq_8136) u1) (Eq_8165 u2))
 	T_8140
 Eq_8155: (struct "Eq_8155" (0 char b0000) (1 int8 b0001) (2 int8 b0002))
 	T_8155
-Eq_8156: (union "Eq_8156" (char u0) (int8 u1) (Eq_2661 u2) (Eq_2763 u3) (Eq_2767 u4))
+Eq_8156: (union "Eq_8156" (char u0) (int8 u1) ((arr byte) u2) (Eq_2661 u3) (Eq_2763 u4) (Eq_2767 u5))
 	T_8156
 Eq_8157: (struct "Eq_8157" (0 (arr Eq_754) a0000) (4 Eq_127 t0004))
 	T_8157
@@ -4164,11 +4164,11 @@ T_301: (in Mem39[o1 + 1<32> + i1_24:byte] : byte)
 T_302: (in o1 + 1<32> : word32)
   Class: Eq_279
   DataType: (ptr32 Eq_279)
-  OrigDataType: ptr32
+  OrigDataType: (ptr32 (arr T_8107))
 T_303: (in o1 + 1<32> : word32)
   Class: Eq_127
   DataType: Eq_127
-  OrigDataType: ptr32
+  OrigDataType: (ptr32 (arr T_8107))
 T_304: (in o0 : Eq_304)
   Class: Eq_304
   DataType: Eq_304
@@ -10284,7 +10284,7 @@ T_1831: (in abspath : ptr32)
 T_1832: (in sp_101 + 0x60<32> : word32)
   Class: Eq_127
   DataType: Eq_127
-  OrigDataType: ptr32
+  OrigDataType: (ptr32 (arr T_8112))
 T_1833: (in out i6_201 : ptr32)
   Class: Eq_1107
   DataType: (ptr32 Eq_1107)
@@ -10760,7 +10760,7 @@ T_1950: (in abspath : ptr32)
 T_1951: (in sp_117 + 0x60<32> : word32)
   Class: Eq_127
   DataType: Eq_127
-  OrigDataType: ptr32
+  OrigDataType: (ptr32 (arr T_8114))
 T_1952: (in out i6_1129 : ptr32)
   Class: Eq_1107
   DataType: (ptr32 Eq_1107)
@@ -12220,7 +12220,7 @@ T_2315: (in 0x29A40<32> : word32)
 T_2316: (in sp_570 + 0x60<32> : word32)
   Class: Eq_127
   DataType: Eq_127
-  OrigDataType: ptr32
+  OrigDataType: (ptr32 (arr T_8118))
 T_2317: (in out l1_1140 : ptr32)
   Class: Eq_754
   DataType: Eq_754
@@ -13727,8 +13727,8 @@ T_2692: (in 0x17230<32> : word32)
   OrigDataType: word32
 T_2693: (in sp_25 + 0x60<32> : word32)
   Class: Eq_2693
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_8121)
+  DataType: (ptr32 (arr word32))
+  OrigDataType: (ptr32 (arr T_2639))
 T_2694: (in 4<32> : ui32)
   Class: Eq_2694
   DataType: ui32
@@ -13747,8 +13747,8 @@ T_2697: (in 0x17238<32> : word32)
   OrigDataType: word32
 T_2698: (in sp_25 + 0x60<32> : word32)
   Class: Eq_2698
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_8122)
+  DataType: (ptr32 (arr word32))
+  OrigDataType: (ptr32 (arr T_2639))
 T_2699: (in 1<32> : word32)
   Class: Eq_2699
   DataType: word32
@@ -13775,8 +13775,8 @@ T_2704: (in 0x17240<32> : word32)
   OrigDataType: word32
 T_2705: (in sp_25 + 0x60<32> : word32)
   Class: Eq_2705
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_8123)
+  DataType: (ptr32 (arr word32))
+  OrigDataType: (ptr32 (arr T_2639))
 T_2706: (in 2<32> : word32)
   Class: Eq_2706
   DataType: word32
@@ -13803,8 +13803,8 @@ T_2711: (in 0<32> : word32)
   OrigDataType: word32
 T_2712: (in sp_25 + 0x60<32> : word32)
   Class: Eq_2712
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_8124)
+  DataType: (ptr32 (arr word32))
+  OrigDataType: (ptr32 (arr T_2639))
 T_2713: (in l0_155 + 3<32> : word32)
   Class: Eq_2713
   DataType: ui32
@@ -13827,8 +13827,8 @@ T_2717: (in 0<32> : word32)
   OrigDataType: word32
 T_2718: (in sp_25 + 0x60<32> : word32)
   Class: Eq_2718
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_8125)
+  DataType: (ptr32 (arr word32))
+  OrigDataType: (ptr32 (arr T_2639))
 T_2719: (in 4<32> : word32)
   Class: Eq_2719
   DataType: word32
@@ -13936,7 +13936,7 @@ T_2744: (in o2 : size_t)
 T_2745: (in sp_25 + 0x60<32> : word32)
   Class: Eq_127
   DataType: Eq_127
-  OrigDataType: (ptr32 void)
+  OrigDataType: (ptr32 (arr T_2639))
 T_2746: (in 5<32> : word32)
   Class: Eq_2746
   DataType: word32
@@ -14148,7 +14148,7 @@ T_2797: (in out l0_119 : ptr32)
 T_2798: (in out i0_111 : ptr32)
   Class: Eq_279
   DataType: (ptr32 Eq_279)
-  OrigDataType: (ptr32 (struct 0001 (0 (union (char u0) (int8 u1) (T_2649 u2) (T_2661 u3) (T_2763 u4) (T_2767 u5)) u0000)))
+  OrigDataType: (ptr32 (struct 0001 (0 (union (char u0) (int8 u1) ((arr byte) u6) (T_2649 u2) (T_2661 u3) (T_2763 u4) (T_2767 u5)) u0000)))
 T_2799: (in out i6_117 : ptr32)
   Class: Eq_280
   DataType: ptr32
@@ -14159,8 +14159,8 @@ T_2800: (in dupnstr(i0_111, i0_107 - i0_111, out l0_119, out i0_111, out i6_117)
   OrigDataType: word32
 T_2801: (in sp_25 + 0x60<32> : word32)
   Class: Eq_2801
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_8126)
+  DataType: (ptr32 (arr word32))
+  OrigDataType: (ptr32 (arr T_2639))
 T_2802: (in 4<32> : ui32)
   Class: Eq_2802
   DataType: ui32
@@ -21664,7 +21664,7 @@ T_4676: (in strcmp : ptr32)
 T_4677: (in sp_279 + 0x60<32> : word32)
   Class: Eq_127
   DataType: Eq_127
-  OrigDataType: (ptr32 char)
+  OrigDataType: (ptr32 (union (char u1) ((arr T_8129) u0)))
 T_4678: (in strcmp(sp_279->a0060, o1_293) : int32)
   Class: Eq_701
   DataType: int32
@@ -29879,12 +29879,12 @@ T_6730: (in 0<32> : word32)
   OrigDataType: word32
 T_6731: (in i1_156 + 0<32> : word32)
   Class: Eq_6731
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_6732: (in Mem402[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_6733: (in o1_1434 : (ptr32 ptr32))
   Class: Eq_6204
   DataType: (ptr32 ptr32)
@@ -30239,12 +30239,12 @@ T_6820: (in 0<32> : word32)
   OrigDataType: word32
 T_6821: (in i1_156 + 0<32> : word32)
   Class: Eq_6821
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_6822: (in Mem1270[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_6823: (in 0<32> : word32)
   Class: Eq_6823
   DataType: word32
@@ -30315,12 +30315,12 @@ T_6839: (in 0<32> : word32)
   OrigDataType: word32
 T_6840: (in i1_156 + 0<32> : word32)
   Class: Eq_6840
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_6841: (in Mem1270[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_6842: (in 0<32> : word32)
   Class: Eq_6842
   DataType: word32
@@ -30623,12 +30623,12 @@ T_6916: (in 0<32> : word32)
   OrigDataType: word32
 T_6917: (in i1_156 + 0<32> : word32)
   Class: Eq_6917
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_6918: (in Mem1270[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_6919: (in o2_1268 + 1<32> : word32)
   Class: Eq_6919
   DataType: ui32
@@ -30891,12 +30891,12 @@ T_6983: (in 0<32> : word32)
   OrigDataType: word32
 T_6984: (in i1_156 + 0<32> : word32)
   Class: Eq_6984
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_6985: (in Mem402[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_6986: (in 0<32> : word32)
   Class: Eq_6986
   DataType: word32
@@ -30955,12 +30955,12 @@ T_6999: (in 0<32> : word32)
   OrigDataType: word32
 T_7000: (in i1_156 + 0<32> : word32)
   Class: Eq_7000
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_7001: (in Mem402[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_7002: (in 0x2B2C0<32> : word32)
   Class: Eq_7002
   DataType: (ptr32 Eq_127)
@@ -31511,12 +31511,12 @@ T_7138: (in 0<32> : word32)
   OrigDataType: word32
 T_7139: (in i1_156 + 0<32> : word32)
   Class: Eq_7139
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_7140: (in Mem707[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_7141: (in fprintf(&globals->t2B640, "%s: invalid option -- %c\n", i1_156[0<i32>], l0_127) : int32)
   Class: Eq_7141
   DataType: int32
@@ -31551,12 +31551,12 @@ T_7148: (in 0<32> : word32)
   OrigDataType: word32
 T_7149: (in i1_156 + 0<32> : word32)
   Class: Eq_7149
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_7150: (in Mem707[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_7151: (in fprintf(&globals->t2B640, "%s: illegal option -- %c\n", i1_156[0<i32>], l0_127) : int32)
   Class: Eq_7151
   DataType: int32
@@ -32371,12 +32371,12 @@ T_7353: (in 0<32> : word32)
   OrigDataType: word32
 T_7354: (in i1_156 + 0<32> : word32)
   Class: Eq_7354
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_7355: (in Mem707[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_7356: (in fprintf(&globals->t2B640, "%s: option requires an argument -- %c\n", i1_156[0<i32>], l0_127) : int32)
   Class: Eq_7356
   DataType: int32
@@ -32707,12 +32707,12 @@ T_7437: (in 0<32> : word32)
   OrigDataType: word32
 T_7438: (in i1_156 + 0<32> : word32)
   Class: Eq_7438
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_7439: (in Mem707[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_7440: (in 0x18<32> : word32)
   Class: Eq_7440
   DataType: word32
@@ -32879,12 +32879,12 @@ T_7480: (in 0<32> : word32)
   OrigDataType: word32
 T_7481: (in i1_156 + 0<32> : word32)
   Class: Eq_7481
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_7482: (in Mem874[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_7483: (in o1_1177 : (ptr32 ptr32))
   Class: Eq_6204
   DataType: (ptr32 ptr32)
@@ -33183,12 +33183,12 @@ T_7556: (in 0<32> : word32)
   OrigDataType: word32
 T_7557: (in i1_156 + 0<32> : word32)
   Class: Eq_7557
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_7558: (in Mem874[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_7559: (in 0<32> : word32)
   Class: Eq_7559
   DataType: word32
@@ -33387,12 +33387,12 @@ T_7607: (in 0<32> : word32)
   OrigDataType: word32
 T_7608: (in i1_156 + 0<32> : word32)
   Class: Eq_7608
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_6265))
+  OrigDataType: (ptr32 (arr T_6726))
 T_7609: (in Mem874[i1_156 + 0<32>:word32] : word32)
   Class: Eq_6265
   DataType: Eq_6265
-  OrigDataType: (ptr32 char)
+  OrigDataType: (union ((ptr32 char) u1) ((arr T_6726) u0))
 T_7610: (in 2<32> : word32)
   Class: Eq_7610
   DataType: word32
@@ -37463,9 +37463,10 @@ typedef struct Eq_8155 {
 typedef union Eq_8156 {
 	char u0;
 	int8 u1;
-	Eq_2661 u2;
-	Eq_2763 u3;
-	Eq_2767 u4;
+	byte u2[];
+	Eq_2661 u3;
+	Eq_2763 u4;
+	Eq_2767 u5;
 } Eq_8156;
 
 typedef struct Eq_8157 {

--- a/subjects/Elf/x86-64/ls/ls.reko/ls.globals.c
+++ b/subjects/Elf/x86-64/ls/ls.reko/ls.globals.c
@@ -347,12 +347,12 @@ Eq_n g_t61AF00 =
 	{
 	};
 word64 g_qw61AF10 = 0x00;
-union Eq_n * g_ptr61AF18 = null;
+DIR * g_ptr61AF18 = null;
 int64 g_qw61AF20 = 0;
 Eq_n g_t61AF60 = 
 	{
 	};
-union Eq_n * g_ptr61AF78 = null;
+DIR * g_ptr61AF78 = null;
 word64 * g_ptr61AF80 = null;
 Eq_n g_t61AFC0 = 
 	{

--- a/subjects/Elf/x86-64/ls/ls.reko/ls.h
+++ b/subjects/Elf/x86-64/ls/ls.reko/ls.h
@@ -4,7 +4,7 @@
 
 /*
 // Equivalence classes ////////////
-Eq_1: (struct "Globals" (FFBED370 word32 dwFFBED370) (4021F0 Eq_1222 t4021F0) (402640 Eq_1221 t402640) (4028C0 Eq_3452 t4028C0) (404980 code t404980) (404990 code t404990) (409E40 code t409E40) (40A200 Eq_47 t40A200) (40AC60 code t40AC60) (40AC70 code t40AC70) (410800 code t410800) (411E60 Eq_3455 t411E60) (411ED0 Eq_3456 t411ED0) (411F40 (arr (ptr64 code)) a411F40) (412C00 (arr word32) a412C00) (412C38 (str char) str412C38) (412C60 (arr word32) a412C60) (412C95 (str char) str412C95) (412CA0 (str char) str412CA0) (412CA7 (str char) str412CA7) (412CC0 (arr word32 13) a412CC0) (412CF0 word32 dw412CF0) (412D00 (arr Eq_18) a412D00) (412EC0 (arr word32) a412EC0) (412F00 (arr Eq_18) a412F00) (412F50 (arr word32) a412F50) (412F80 (arr Eq_18) a412F80) (412FB0 (arr word32) a412FB0) (412FE0 (arr Eq_18) a412FE0) (413010 (arr word32) a413010) (413040 (arr Eq_18) a413040) (413080 Eq_847 t413080) (4135E0 (arr Eq_18) a4135E0) (4136B0 (arr word32) a4136B0) (4136C0 (arr Eq_18) a4136C0) (413700 (arr word64) a413700) (413733 byte b413733) (413736 (str char) str413736) (41373F (str char) str41373F) (41375A (str char) str41375A) (413766 (str char) str413766) (413769 (str char) str413769) (413774 (str char) str413774) (413779 (str char) str413779) (4137B1 byte b4137B1) (413800 (str char) str413800) (41381C (str char) str41381C) (41382E (str char) str41382E) (41383C (str char) str41383C) (413844 (str char) str413844) (4138E1 (str char) str4138E1) (4138E4 (str char) str4138E4) (4138F5 (str char) str4138F5) (41397F (str char) str41397F) (413992 (str char) str413992) (413A21 (str char) str413A21) (413C07 byte b413C07) (415BC8 (str char) str415BC8) (415C58 (str char) str415C58) (415D68 (str char) str415D68) (415E6A (str char) str415E6A) (415EE0 Eq_10908 t415EE0) (415EF4 Eq_13 t415EF4) (415EF8 Eq_12 t415EF8) (415EFC Eq_10935 t415EFC) (415F00 Eq_10944 t415F00) (415F04 Eq_14 t415F04) (415F08 Eq_11295 t415F08) (415F0C Eq_11229 t415F0C) (415F18 (str char) str415F18) (415F1E (str char) str415F1E) (415F24 (str char) str415F24) (415F2E (str char) str415F2E) (415F50 (arr ui32) a415F50) (415F60 (arr Eq_18) a415F60) (415F84 real32 r415F84) (415F90 real80 r415F90) (415FA0 void v415FA0) (415FD8 byte b415FD8) (415FE0 byte b415FE0) (416068 (arr (ptr64 code)) a416068) (416460 (arr word32) a416460) (416480 (arr Eq_18) a416480) (4164E8 (arr (ptr64 code)) a4164E8) (416919 (str char) str416919) (416B48 (ptr64 code) ptr416B48) (416BE0 (str char) str416BE0) (416BF0 (str char) str416BF0) (416C18 (arr (ptr64 code)) a416C18) (416DC8 (str char) str416DC8) (416E38 (arr (ptr64 code)) a416E38) (416FE8 (str char) str416FE8) (417002 (str char) str417002) (417012 (str char) str417012) (61A3A8 (ptr64 void) ptr61A3A8) (61A3C0 byte b61A3C0) (61A3C4 word32 dw61A3C4) (61A3D0 Eq_18 t61A3D0) (61A3D8 Eq_18 t61A3D8) (61A3E0 word64 qw61A3E0) (61A3E8 Eq_18 t61A3E8) (61A3F0 word64 qw61A3F0) (61A3F8 (ptr64 byte) ptr61A3F8) (61A408 word64 qw61A408) (61A410 (struct "Eq_2867" (0 Eq_18 t0000) (8 Eq_18 t0008)) t61A410) (61A420 (struct "Eq_2867") t61A420) (61A450 word64 qw61A450) (61A458 Eq_18 t61A458) (61A550 (struct "Eq_2867") t61A550) (61A560 Eq_368 t61A560) (61A568 byte b61A568) (61A569 byte b61A569) (61A56A char b61A56A) (61A56C word32 dw61A56C) (61A570 uint64 qw61A570) (61A578 (ptr64 code) ptr61A578) (61A580 word32 dw61A580) (61A5A0 Eq_15268 t61A5A0) (61A5D8 Eq_18 t61A5D8) (61A5E0 word64 qw61A5E0) (61A5E8 Eq_18 t61A5E8) (61A5F0 Eq_15285 t61A5F0) (61A600 (ptr64 char) ptr61A600) (61A610 (ptr64 Eq_2123) ptr61A610) (61A620 word32 dw61A620) (61A640 Eq_18 t61A640) (61A648 Eq_18 t61A648) (61A650 (ptr64 Eq_2123) ptr61A650) (61A660 Eq_18 t61A660) (61A668 word64 qw61A668) (61A670 word64 qw61A670) (61A678 word64 qw61A678) (61A748 Eq_18 t61A748) (61AF00 Eq_1218 t61AF00) (61AF10 word64 qw61AF10) (61AF18 (ptr64 Eq_1873) ptr61AF18) (61AF20 int64 qw61AF20) (61AF60 Eq_1218 t61AF60) (61AF78 (ptr64 Eq_1873) ptr61AF78) (61AF80 (ptr64 word64) ptr61AF80) (61AFC0 Eq_1218 t61AFC0) (61B018 Eq_18 t61B018) (61B020 Eq_18 t61B020) (61B028 Eq_18 t61B028) (61B030 word32 dw61B030) (61B034 word32 dw61B034) (61B038 word32 dw61B038) (61B040 (arr word32) a61B040) (61B0C0 byte b61B0C0) (61B0C1 byte b61B0C1) (61B0C8 Eq_18 t61B0C8) (61B0D0 byte b61B0D0) (61B0D8 Eq_18 t61B0D8) (61B0E0 (ptr64 Eq_2352) ptr61B0E0) (61B0E8 (ptr64 Eq_2352) ptr61B0E8) (61B0F0 byte b61B0F0) (61B0F8 Eq_18 t61B0F8) (61B100 Eq_18 t61B100) (61B108 word32 dw61B108) (61B10C byte b61B10C) (61B10D byte b61B10D) (61B10E byte b61B10E) (61B110 word32 dw61B110) (61B114 byte b61B114) (61B115 byte b61B115) (61B118 Eq_18 t61B118) (61B120 Eq_18 t61B120) (61B128 byte b61B128) (61B129 byte b61B129) (61B12C up32 dw61B12C) (61B130 byte b61B130) (61B134 word32 dw61B134) (61B138 Eq_368 t61B138) (61B140 word32 dw61B140) (61B144 byte b61B144) (61B145 byte b61B145) (61B146 byte b61B146) (61B147 byte b61B147) (61B148 word32 dw61B148) (61B14C word32 dw61B14C) (61B150 up32 dw61B150) (61B154 Eq_3944 t61B154) (61B158 Eq_18 t61B158) (61B15C Eq_18 t61B15C) (61B160 int32 dw61B160) (61B164 int32 dw61B164) (61B168 int32 dw61B168) (61B16C Eq_18 t61B16C) (61B170 Eq_18 t61B170) (61B174 int32 dw61B174) (61B178 Eq_18 t61B178) (61B17C byte b61B17C) (61B17D byte b61B17D) (61B180 int64 qw61B180) (61B188 Eq_67 t61B188) (61B190 Eq_18 t61B190) (61B198 byte b61B198) (61B1A0 uint64 qw61B1A0) (61B1A8 Eq_18 t61B1A8) (61B1B0 Eq_18 t61B1B0) (61B1B8 Eq_18 t61B1B8) (61B1C0 Eq_18 t61B1C0) (61B1C8 Eq_18 t61B1C8) (61B1E8 Eq_18 t61B1E8) (61B1F8 Eq_18 t61B1F8) (61B200 Eq_18 t61B200) (61B320 Eq_2352 t61B320) (61B358 Eq_18 t61B358) (C34C00 (str char) strC34C00) (C34C10 Eq_2123 tC34C10) (C34C50 Eq_2123 tC34C50))
+Eq_1: (struct "Globals" (FFBED370 word32 dwFFBED370) (4021F0 Eq_1222 t4021F0) (402640 Eq_1221 t402640) (4028C0 Eq_3452 t4028C0) (404980 code t404980) (404990 code t404990) (409E40 code t409E40) (40A200 Eq_47 t40A200) (40AC60 code t40AC60) (40AC70 code t40AC70) (410800 code t410800) (411E60 Eq_3455 t411E60) (411ED0 Eq_3456 t411ED0) (411F40 (arr (ptr64 code)) a411F40) (412C00 (arr word32) a412C00) (412C38 (str char) str412C38) (412C60 (arr word32) a412C60) (412C95 (str char) str412C95) (412CA0 (str char) str412CA0) (412CA7 (str char) str412CA7) (412CC0 (arr word32 13) a412CC0) (412CF0 word32 dw412CF0) (412D00 (arr Eq_17550) a412D00) (412EC0 (arr word32) a412EC0) (412F00 (arr Eq_18) a412F00) (412F50 (arr word32) a412F50) (412F80 (arr Eq_18) a412F80) (412FB0 (arr word32) a412FB0) (412FE0 (arr Eq_18) a412FE0) (413010 (arr word32) a413010) (413040 (arr Eq_18) a413040) (413080 Eq_847 t413080) (4135E0 (arr Eq_18) a4135E0) (4136B0 (arr word32) a4136B0) (4136C0 (arr Eq_18) a4136C0) (413700 (arr word64) a413700) (413733 byte b413733) (413736 (str char) str413736) (41373F (str char) str41373F) (41375A (str char) str41375A) (413766 (str char) str413766) (413769 (str char) str413769) (413774 (str char) str413774) (413779 (str char) str413779) (4137B1 byte b4137B1) (413800 (str char) str413800) (41381C (str char) str41381C) (41382E (str char) str41382E) (41383C (str char) str41383C) (413844 (str char) str413844) (4138E1 (str char) str4138E1) (4138E4 (str char) str4138E4) (4138F5 (str char) str4138F5) (41397F (str char) str41397F) (413992 (str char) str413992) (413A21 (str char) str413A21) (413C07 byte b413C07) (415BC8 (str char) str415BC8) (415C58 (str char) str415C58) (415D68 (str char) str415D68) (415E6A (str char) str415E6A) (415EE0 Eq_10908 t415EE0) (415EF4 Eq_13 t415EF4) (415EF8 Eq_12 t415EF8) (415EFC Eq_10935 t415EFC) (415F00 Eq_10944 t415F00) (415F04 Eq_14 t415F04) (415F08 Eq_11295 t415F08) (415F0C Eq_11229 t415F0C) (415F18 (str char) str415F18) (415F1E (str char) str415F1E) (415F24 (str char) str415F24) (415F2E (str char) str415F2E) (415F50 (arr ui32) a415F50) (415F60 (arr Eq_18) a415F60) (415F84 real32 r415F84) (415F90 real80 r415F90) (415FA0 void v415FA0) (415FD8 byte b415FD8) (415FE0 byte b415FE0) (416068 (arr (ptr64 code)) a416068) (416460 (arr word32) a416460) (416480 (arr Eq_18) a416480) (4164E8 (arr (ptr64 code)) a4164E8) (416919 (str char) str416919) (416B48 (ptr64 code) ptr416B48) (416BE0 (str char) str416BE0) (416BF0 (str char) str416BF0) (416C18 (arr (ptr64 code)) a416C18) (416DC8 (str char) str416DC8) (416E38 (arr (ptr64 code)) a416E38) (416FE8 (str char) str416FE8) (417002 (str char) str417002) (417012 (str char) str417012) (61A3A8 (ptr64 void) ptr61A3A8) (61A3C0 byte b61A3C0) (61A3C4 word32 dw61A3C4) (61A3D0 Eq_18 t61A3D0) (61A3D8 Eq_18 t61A3D8) (61A3E0 word64 qw61A3E0) (61A3E8 Eq_18 t61A3E8) (61A3F0 word64 qw61A3F0) (61A3F8 (ptr64 byte) ptr61A3F8) (61A408 word64 qw61A408) (61A410 (struct "Eq_2867" (0 Eq_18 t0000) (8 Eq_18 t0008)) t61A410) (61A420 (struct "Eq_2867") t61A420) (61A450 word64 qw61A450) (61A458 Eq_18 t61A458) (61A550 (struct "Eq_2867") t61A550) (61A560 Eq_368 t61A560) (61A568 byte b61A568) (61A569 byte b61A569) (61A56A char b61A56A) (61A56C word32 dw61A56C) (61A570 uint64 qw61A570) (61A578 (ptr64 code) ptr61A578) (61A580 word32 dw61A580) (61A5A0 Eq_15268 t61A5A0) (61A5D8 Eq_18 t61A5D8) (61A5E0 word64 qw61A5E0) (61A5E8 Eq_18 t61A5E8) (61A5F0 Eq_15285 t61A5F0) (61A600 (ptr64 char) ptr61A600) (61A610 (ptr64 Eq_2123) ptr61A610) (61A620 word32 dw61A620) (61A640 Eq_18 t61A640) (61A648 Eq_18 t61A648) (61A650 (ptr64 Eq_2123) ptr61A650) (61A660 Eq_18 t61A660) (61A668 word64 qw61A668) (61A670 word64 qw61A670) (61A678 word64 qw61A678) (61A748 Eq_18 t61A748) (61AF00 Eq_1218 t61AF00) (61AF10 word64 qw61AF10) (61AF18 (ptr64 Eq_1873) ptr61AF18) (61AF20 int64 qw61AF20) (61AF60 Eq_1218 t61AF60) (61AF78 (ptr64 Eq_1873) ptr61AF78) (61AF80 (ptr64 word64) ptr61AF80) (61AFC0 Eq_1218 t61AFC0) (61B018 Eq_18 t61B018) (61B020 Eq_18 t61B020) (61B028 Eq_18 t61B028) (61B030 word32 dw61B030) (61B034 word32 dw61B034) (61B038 word32 dw61B038) (61B040 (arr word32) a61B040) (61B0C0 byte b61B0C0) (61B0C1 byte b61B0C1) (61B0C8 Eq_18 t61B0C8) (61B0D0 byte b61B0D0) (61B0D8 Eq_18 t61B0D8) (61B0E0 (ptr64 Eq_2352) ptr61B0E0) (61B0E8 (ptr64 Eq_2352) ptr61B0E8) (61B0F0 byte b61B0F0) (61B0F8 Eq_18 t61B0F8) (61B100 Eq_18 t61B100) (61B108 word32 dw61B108) (61B10C byte b61B10C) (61B10D byte b61B10D) (61B10E byte b61B10E) (61B110 word32 dw61B110) (61B114 byte b61B114) (61B115 byte b61B115) (61B118 Eq_18 t61B118) (61B120 Eq_18 t61B120) (61B128 byte b61B128) (61B129 byte b61B129) (61B12C up32 dw61B12C) (61B130 byte b61B130) (61B134 word32 dw61B134) (61B138 Eq_368 t61B138) (61B140 word32 dw61B140) (61B144 byte b61B144) (61B145 byte b61B145) (61B146 byte b61B146) (61B147 byte b61B147) (61B148 word32 dw61B148) (61B14C word32 dw61B14C) (61B150 up32 dw61B150) (61B154 Eq_3944 t61B154) (61B158 Eq_18 t61B158) (61B15C Eq_18 t61B15C) (61B160 int32 dw61B160) (61B164 int32 dw61B164) (61B168 int32 dw61B168) (61B16C Eq_18 t61B16C) (61B170 Eq_18 t61B170) (61B174 int32 dw61B174) (61B178 Eq_18 t61B178) (61B17C byte b61B17C) (61B17D byte b61B17D) (61B180 int64 qw61B180) (61B188 Eq_67 t61B188) (61B190 Eq_18 t61B190) (61B198 byte b61B198) (61B1A0 uint64 qw61B1A0) (61B1A8 Eq_18 t61B1A8) (61B1B0 Eq_18 t61B1B0) (61B1B8 Eq_18 t61B1B8) (61B1C0 Eq_18 t61B1C0) (61B1C8 Eq_18 t61B1C8) (61B1E8 Eq_18 t61B1E8) (61B1F8 Eq_18 t61B1F8) (61B200 Eq_18 t61B200) (61B320 Eq_2352 t61B320) (61B358 Eq_18 t61B358) (C34C00 (str char) strC34C00) (C34C10 Eq_2123 tC34C10) (C34C50 Eq_2123 tC34C50))
 	globals_t (in globals : (ptr64 (struct "Globals")))
 Eq_11: (segment "Eq_11" (28 word64 qw0028))
 	T_11 (in fs : (ptr32 Eq_11))
@@ -160,7 +160,7 @@ Eq_15: (union "Eq_15" (real64 u0) (up64 u1))
 Eq_16: (fn void (Eq_18))
 	T_16 (in fn000000000040D6A0 : ptr64)
 	T_17 (in signature of fn000000000040D6A0 : void)
-Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u3) ((ptr64 int32) u4) ((ptr64 Eq_17608) u5) ((ptr64 Eq_17610) u6) ((ptr64 Eq_17612) u7) ((ptr64 Eq_17613) u8) ((ptr64 Eq_17614) u9) ((ptr64 Eq_17619) u10) ((ptr64 code) u11) (size_t u12) (time_t u13) (Eq_17620 u14) (Eq_17623 u15))
+Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u3) ((ptr64 int32) u4) ((ptr64 Eq_17608) u5) ((ptr64 Eq_17610) u6) ((ptr64 Eq_17612) u7) ((ptr64 Eq_17613) u8) ((ptr64 Eq_17614) u9) ((ptr64 Eq_17619) u10) ((ptr64 code) u11) ((arr Eq_18) u12) (size_t u13) (time_t u14) (Eq_17620 u15) (Eq_17623 u16))
 	T_18 (in rdi : Eq_18)
 	T_21 (in Mem23[rsi + 0<64>:word64] : word64)
 	T_29 (in setlocale(6<u64>, "") : (ptr64 char))
@@ -896,7 +896,7 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_4384 (in fp - 0x2088<64> - (rax_48 + 0x1F<64> & 0xFFFFFFFFFFFFFFF0<64>) + 0xF<64> & 0xFFFFFFFFFFFFFFF0<64> : word64)
 	T_4386 (in 0xFFFFFFFFFFFFFFFF<64> : word64)
 	T_4388 (in rax_48 + 1<64> : word64)
-	T_4391 (in fn000000000040E6F0(0xFFFFFFFFFFFFFFFF<64>, rsi, (word64) rax_48 + 1<i32>, v24_71, rdx, fs, out rsi_52, out r8_46) : word64)
+	T_4391 (in fn000000000040E6F0(0xFFFFFFFFFFFFFFFF<64>, rsi, (word32) rax_48 + 1<i32>, v24_71, rdx, fs, out rsi_52, out r8_46) : word64)
 	T_4404 (in __ctype_get_mb_cur_max() : size_t)
 	T_4413 (in __ctype_get_mb_cur_max() : size_t)
 	T_4417 (in r13_287 : word64)
@@ -972,20 +972,20 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_5098 (in rax_24 : Eq_18)
 	T_5102 (in rdi : Eq_18)
 	T_5108 (in Mem16[rdi + 0x18<64>:word64] : word64)
-	T_5109 (in fn000000000040CD70(fp - 0x2B8<64>, *((word64) rdi + 24<i32>)) : word64)
+	T_5109 (in fn000000000040CD70(fp - 0x2B8<64>, *((word32) rdi + 24<i32>)) : word64)
 	T_5112 (in strlen(rax_24) : size_t)
 	T_5117 (in Mem16[0x000000000061B178<p64>:word32] : word32)
 	T_5142 (in rcx_141 : Eq_18)
 	T_5150 (in Mem16[rdi + 0<64>:word64] : word64)
 	T_5153 (in fn00000000004052D0(fp - 0x2C0<64>, globals->ptr61B0E8, *rdi, null, r12, fs, out r8_139) : word64)
 	T_5171 (in Mem16[rdi + 0xA8<64>:word64] : word64)
-	T_5172 (in strlen(*((word64) rdi + 168<i32>)) : size_t)
+	T_5172 (in strlen(*((word32) rdi + 168<i32>)) : size_t)
 	T_5177 (in Mem16[0x000000000061B16C<p64>:word32] : word32)
 	T_5184 (in rax_64 : Eq_18)
 	T_5192 (in fp - 0x2B8<64> : word64)
 	T_5195 (in Mem16[rdi + 0x50<64>:word64] : word64)
 	T_5198 (in out r8_241 : ptr64)
-	T_5199 (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x2B8<64>, *((word64) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_241) : word64)
+	T_5199 (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x2B8<64>, *((word32) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_241) : word64)
 	T_5202 (in strlen(rax_64) : size_t)
 	T_5240 (in rax : Eq_18)
 	T_5244 (in r8Out : Eq_18)
@@ -1054,7 +1054,7 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_5429 (in rax_175 : Eq_18)
 	T_5444 (in Mem163[0x000000000061B1A8<p64>:word64] : word64)
 	T_5447 (in Mem163[0x000000000061B1A8<p64>:word64][rbp_156 * 8<64>] : word64)
-	T_5449 (in fn0000000000405D50(*((word64) globals->t61B1A8 + rbp_156 * 8<64>), r12_17, fs, rLoc4, out r8_126) : word64)
+	T_5449 (in fn0000000000405D50(*((word32) globals->t61B1A8 + rbp_156 * 8<64>), r12_17, fs, rLoc4, out r8_126) : word64)
 	T_5451 (in Mem163[0x000000000061B1B0<p64>:word64] : word64)
 	T_5452 (in 0<64> : word64)
 	T_5454 (in rdx_291 : Eq_18)
@@ -1146,7 +1146,7 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_6455 (in fp - 0x1278<64> : word64)
 	T_6458 (in Mem105[rdi + 0x50<64>:word64] : word64)
 	T_6461 (in out r8_1589 : ptr64)
-	T_6462 (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x1278<64>, *((word64) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_1589) : word64)
+	T_6462 (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x1278<64>, *((word32) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_1589) : word64)
 	T_6464 (in rdx_303 : Eq_18)
 	T_6481 (in rbp_109 : Eq_18)
 	T_6487 (in rcx_292 : Eq_18)
@@ -1157,7 +1157,7 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_6531 (in r14_1182 + 1<64> : word64)
 	T_6541 (in rdx_303 + 1<64> : word64)
 	T_6554 (in Mem323[rdi + 0x20<64>:word64] : word64)
-	T_6555 (in fn000000000040CD70(fp - 0x1278<64>, *((word64) rdi + 32<i32>)) : word64)
+	T_6555 (in fn000000000040CD70(fp - 0x1278<64>, *((word32) rdi + 32<i32>)) : word64)
 	T_6558 (in 0xFFFFFFFFFFFFFFFF<64> : word64)
 	T_6564 (in rbp_1180 : Eq_18)
 	T_6566 (in strlen(rbp_109) : size_t)
@@ -1187,22 +1187,22 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_6723 (in Mem556[0x000000000061B158<p64>:word32] : word32)
 	T_6732 (in rax_589 : Eq_18)
 	T_6747 (in (uint64) (SEQ(SLICE(rax_566 >>u 0xC<64>, word24, 8), SLICE(rax_566 >>u 0xC<64>, byte, 0) & 0<8>) | (word32) SLICE(rax_566, byte, 0)) : uint64)
-	T_6748 (in fn000000000040CD70((word64) rsp_328 + 112<i32>, (uint64) (SEQ(SLICE(rax_566 >> 0xC<64>, word24, 8), (byte) (rax_566 >> 0xC<64>) & 0<8>) | (word32) ((byte) rax_566))) : word64)
+	T_6748 (in fn000000000040CD70((word32) rsp_328 + 112<i32>, (uint64) (SEQ(SLICE(rax_566 >> 0xC<64>, word24, 8), (byte) (rax_566 >> 0xC<64>) & 0<8>) | (word32) ((byte) rax_566))) : word64)
 	T_6755 (in Mem556[0x000000000061B158<p64>:word32] : word32)
 	T_6778 (in (uint64) (SLICE((uint64) (SLICE(rdx_598 >>u 0x20<64>, word32, 0) & 0xFFFFF000<32>), word32, 0) | SLICE((uint64) (SLICE((uint64) SLICE(rdx_598 >>u 8<64>, word32, 0), word32, 0) & 0xFFF<32>), word32, 0)) : uint64)
-	T_6779 (in fn000000000040CD70((word64) rsp_328 + 80<i32>, (uint64) ((word32) (uint64) ((word32) (rdx_598 >> 0x20<64>) & 0xFFFFF000<32>) | (word32) ((uint64) ((word32) ((uint64) ((word32) (rdx_598 >> 8<64>))) & 0xFFF<32>)))) : word64)
+	T_6779 (in fn000000000040CD70((word32) rsp_328 + 80<i32>, (uint64) ((word32) (uint64) ((word32) (rdx_598 >> 0x20<64>) & 0xFFFFF000<32>) | (word32) ((uint64) ((word32) ((uint64) ((word32) (rdx_598 >> 8<64>))) & 0xFFF<32>)))) : word64)
 	T_6783 (in rax_693 : Eq_18)
 	T_6791 (in rsp_328 + 0x70<64> : word64)
 	T_6794 (in Mem556[rdi + 0x40<64>:word64] : word64)
 	T_6797 (in out r8_1590 : ptr64)
-	T_6798 (in fn000000000040BD70(1<u64>, (word32) (uint64) globals->dw61B134, (word64) rsp_328 + 112<i32>, *((word64) rdi + 64<i32>), globals->t61A560, fs, rLoc4, out r8_1590) : word64)
+	T_6798 (in fn000000000040BD70(1<u64>, (word32) (uint64) globals->dw61B134, (word32) rsp_328 + 112<i32>, *((word32) rdi + 64<i32>), globals->t61A560, fs, rLoc4, out r8_1590) : word64)
 	T_6801 (in r14_559 + 1<64> : word64)
 	T_6811 (in rbp_1180 + 1<64> : word64)
 	T_6825 (in rcx_736 : Eq_18)
-	T_6829 (in (word64) rbp_1180 + 1<i32> + (uint64) eax_732 : word64)
+	T_6829 (in (word32) rbp_1180 + 1<i32> + (uint64) eax_732 : word64)
 	T_6830 (in rdx_737 : Eq_18)
 	T_6832 (in rdx_737 + 1<64> : word64)
-	T_6843 (in (word64) rbp_1180 + 1<i32> + (int64) eax_732 : word64)
+	T_6843 (in (word32) rbp_1180 + 1<i32> + (int64) eax_732 : word64)
 	T_6880 (in rdi_454 : Eq_18)
 	T_6881 (in 0x413764<u64> : uint64)
 	T_6882 (in edx_465 : Eq_18)
@@ -1216,12 +1216,12 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_6938 (in r9_913 : Eq_18)
 	T_6939 (in rax_763 : Eq_18)
 	T_6940 (in 0<64> : word64)
-	T_6951 (in fn000000000040CCD0((word64) rsp_328 + 80<i32>, *((word64) rsp_328 + 48<i32>)) : word64)
+	T_6951 (in fn000000000040CCD0((word32) rsp_328 + 80<i32>, *((word32) rsp_328 + 48<i32>)) : word64)
 	T_6972 (in Mem788[rsp_328 + 0x10<64>:word64] : word64)
 	T_6990 (in Mem788[rsp_328 + 0x10<64>:word64] : word64)
 	T_7000 (in rax_874 : Eq_18)
 	T_7007 (in 0x61A3D0<32>[(int64) edi_837 * 8<64>] : word64)
-	T_7008 (in fn0000000000406A80(rax_763, (&globals->t61A3D0)[(int64) edi_837], r13_656, fs) : word64)
+	T_7008 (in fn0000000000406A80(rax_763, (&globals->t61A3D0)[(int64) edi_837].t0000, r13_656, fs) : word64)
 	T_7009 (in 0<64> : word64)
 	T_7025 (in 0<u64> : uint64)
 	T_7035 (in Mem466[rsp_328 + 0x10<64>:word32] : word32)
@@ -1247,22 +1247,22 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_7152 (in Mem1056[0x000000000061B018<p64>:word64] + 4<64> : word64)
 	T_7154 (in Mem1097[0x000000000061B018<p64>:word64] : word64)
 	T_7155 (in rcx_1106 : Eq_18)
-	T_7160 (in (word64) r13_1040 + 4<i32> + rax_1075 : word64)
+	T_7160 (in (word32) r13_1040 + 4<i32> + rax_1075 : word64)
 	T_7163 (in out rcx_1106 : ptr64)
 	T_7188 (in Mem639[rsp_328 + 8<64>:word64] : word64)
 	T_7194 (in 0xFFFFFFFFFFFFFFFF<64> : word64)
-	T_7203 (in (word64) rbp_1180 + 1<i32> + (int64) globals->t61B154 : word64)
+	T_7203 (in (word32) rbp_1180 + 1<i32> + (int64) globals->t61B154 : word64)
 	T_7206 (in Mem926[rsp_328 + 0x10<64>:word64] : word64)
 	T_7211 (in rax_928 : Eq_18)
-	T_7217 (in localtime((word64) rsp_328 + 40<i32>) : (ptr64 (struct "tm")))
+	T_7217 (in localtime((word32) rsp_328 + 40<i32>) : (ptr64 (struct "tm")))
 	T_7218 (in 0<64> : word64)
 	T_7222 (in 0xFFFFFFFFFFFFFFFF<64> : word64)
 	T_7228 (in strlen(r13_656) : size_t)
-	T_7250 (in localtime((word64) rsp_328 + 48<i32>) : (ptr64 (struct "tm")))
+	T_7250 (in localtime((word32) rsp_328 + 48<i32>) : (ptr64 (struct "tm")))
 	T_7263 (in rax_948 : Eq_18)
 	T_7266 (in Mem927[0x000000000061A3D0<p64>:word64] : word64)
 	T_7268 (in rsp_328 + 0x70<64> : word64)
-	T_7269 (in fn0000000000406A80(rax_928, globals->t61A3D0, (word64) rsp_328 + 112<i32>, fs) : word64)
+	T_7269 (in fn0000000000406A80(rax_928, globals->t61A3D0, (word32) rsp_328 + 112<i32>, fs) : word64)
 	T_7275 (in r9_960 : Eq_18)
 	T_7278 (in Mem927[rsp_328 + 0x10<64>:word64] : word64)
 	T_7279 (in 0<64> : word64)
@@ -1274,7 +1274,7 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_7346 (in fp - 0x2B8<64> : word64)
 	T_7349 (in Mem17[rdi + 0x50<64>:word64] : word64)
 	T_7352 (in out r8_282 : ptr64)
-	T_7353 (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x2B8<64>, *((word64) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_282) : word64)
+	T_7353 (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x2B8<64>, *((word32) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_282) : word64)
 	T_7360 (in 0x413779<u64> : uint64)
 	T_7369 (in rdi_36 : Eq_18)
 	T_7372 (in Mem17[rdi + 0x18<64>:word64] : word64)
@@ -1687,7 +1687,7 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_10463 (in SEQ(rax_32_32_81, strlen(rbx_62)) : word64)
 	T_10464 (in rax_94 : Eq_18)
 	T_10469 (in rsi_52 + 1<64> + r14_12 + rax_85 : word64)
-	T_10470 (in malloc((word64) rax_85 + ((word64) r14_12.u1 + ((word64) rsi_52 + 1<i32>))) : (ptr64 void))
+	T_10470 (in malloc((word32) rax_85 + ((word64) r14_12.u1 + ((word32) rsi_52 + 1<i32>))) : (ptr64 void))
 	T_10471 (in 0<64> : word64)
 	T_10473 (in 0<u64> : uint64)
 	T_10474 (in rax_109 : Eq_18)
@@ -1921,7 +1921,7 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_11869 (in qwLoc10 : word64)
 	T_11878 (in out rsi_23 : ptr64)
 	T_11887 (in Mem13[rdi + 0x20<64>:word64] : word64)
-	T_11889 (in *((word64) rdi + 32<i32>) - 1<64> : word64)
+	T_11889 (in *((word32) rdi + 32<i32>) - 1<64> : word64)
 	T_11892 (in Mem41[rdi + 0x20<64>:word64] : word64)
 	T_11900 (in rax_44 : Eq_18)
 	T_11903 (in Mem41[rdi + 0x18<64>:word64] : word64)
@@ -1963,8 +1963,8 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_12502 (in rdi : (ptr64 void))
 	T_12503 (in rsi : (ptr64 void))
 	T_12504 (in rdx : size_t)
-	T_12507 (in (word64) rsi + 647<i32> - r11_66 : word64)
-	T_12508 (in memcpy((word64) rsi + 647<i32> - r11_66, r15_478, r11_66) : (ptr64 void))
+	T_12507 (in (word32) rsi + 647<i32> - r11_66 : word64)
+	T_12508 (in memcpy((word32) rsi + 647<i32> - r11_66, r15_478, r11_66) : (ptr64 void))
 	T_12515 (in 0xFFFFFFFFFFFFFFFF<64> : word64)
 	T_12519 (in rax_875 : Eq_18)
 	T_12521 (in strlen(rsi) : size_t)
@@ -1984,7 +1984,7 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_12579 (in r14_1095 : Eq_18)
 	T_12580 (in r9_1107 : word64)
 	T_12581 (in r12_1038 + r8_1044 : word64)
-	T_12663 (in (word64) rsi + 648<i32> - r15_1031 : word64)
+	T_12663 (in (word32) rsi + 648<i32> - r15_1031 : word64)
 	T_12666 (in rdi : (ptr64 void))
 	T_12667 (in src : (ptr64 void))
 	T_12668 (in cb : size_t)
@@ -2222,7 +2222,7 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_14121 (in rdx[(qwLoc58 + 1<64>) * 8<64>] : word64)
 	T_14129 (in rdi + qwLoc40_295 * 8<64> : word64)
 	T_14131 (in rdx_132 << 3<64> : word64)
-	T_14132 (in memcpy(r15_209, (word64) rdi + qwLoc40_295 * 8<64>, rdx_132 << 3<64>) : (ptr64 void))
+	T_14132 (in memcpy(r15_209, (word32) rdi + qwLoc40_295 * 8<64>, rdx_132 << 3<64>) : (ptr64 void))
 	T_14133 (in rdx_132 << 3<64> : word64)
 	T_14137 (in Mem127[qwLoc38 + 0<64>:word64] : word64)
 	T_14140 (in rdi[r14_111 * 8<64>] : word64)
@@ -2232,7 +2232,7 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_14152 (in rdx + qwLoc58 * 8<64> : word64)
 	T_14156 (in rdi + r15_144 * 8<64> : word64)
 	T_14158 (in r15_186 * 8<64> : word64)
-	T_14159 (in memcpy((word64) rdi + r15_144 * 8<64>, rsi_188, r15_186 * 8<64>) : (ptr64 void))
+	T_14159 (in memcpy((word32) rdi + r15_144 * 8<64>, rsi_188, r15_186 * 8<64>) : (ptr64 void))
 	T_14160 (in r15_186 * 8<64> : word64)
 	T_14163 (in rdi[r14_143 * 8<64>] : word64)
 	T_14166 (in Mem225[rdi + 0<64>:word64] : word64)
@@ -2495,7 +2495,7 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_15487 (in out r13_138 : ptr64)
 	T_15488 (in out r14_139 : ptr64)
 	T_15489 (in out r15_305 : ptr64)
-	T_15490 (in fn000000000040D8A0(rcx_181, rdx_185, rsi_186, rax_170, r8d_193, (word32) (uint64) ebp_183, fs, *rsp_150, *((word128) rsp_150 + 8<i32>), *((word128) rsp_150 + 16<i32>), out rbx_302, out rbp_303, out rsi_209, out r8_141, out r9_142, out r12_304, out r13_138, out r14_139, out r15_305) : word64)
+	T_15490 (in fn000000000040D8A0(rcx_181, rdx_185, rsi_186, rax_170, r8d_193, (word32) (uint64) ebp_183, fs, *rsp_150, *((word32) rsp_150 + 8<i32>), *((word32) rsp_150 + 16<i32>), out rbx_302, out rbp_303, out rsi_209, out r8_141, out r9_142, out r12_304, out r13_138, out r14_139, out r15_305) : word64)
 	T_15496 (in rax_63 : Eq_18)
 	T_15498 (in r14_57 << 4<64> : word64)
 	T_15499 (in fn0000000000410C90(r14_57 << 4<64>, r12_107) : word64)
@@ -2657,12 +2657,12 @@ Eq_18: (union "Eq_18" (byte u0) (word16 u1) ((ptr64 char) u2) ((ptr64 wchar_t) u
 	T_16962 (in r15_44 : Eq_18)
 	T_16963 (in 0<64> : word64)
 	T_16977 (in strlen(r14_29) : size_t)
-	T_16979 (in (word64) r14_29 + 1<i32> + SEQ(rax_32_32_455, strlen(r14_29)) : word64)
+	T_16979 (in (word32) r14_29 + 1<i32> + SEQ(rax_32_32_455, strlen(r14_29)) : word64)
 	T_16982 (in rbp_457 : Eq_18)
 	T_16986 (in strlen(r14_29) : size_t)
-	T_16988 (in (word64) r14_29 + 1<i32> + SEQ(rax_32_32_455, strlen(r14_29)) : word64)
+	T_16988 (in (word32) r14_29 + 1<i32> + SEQ(rax_32_32_455, strlen(r14_29)) : word64)
 	T_16992 (in strlen(rbp_457) : size_t)
-	T_16994 (in (word64) rbp_457 + 1<i32> + SEQ(rax_32_32_455, strlen(rbp_457)) : word64)
+	T_16994 (in (word32) rbp_457 + 1<i32> + SEQ(rax_32_32_455, strlen(rbp_457)) : word64)
 	T_17001 (in 8<u64> : uint64)
 	T_17002 (in 0x416FF3<u64> : uint64)
 	T_17008 (in rax_52 : Eq_18)
@@ -3418,7 +3418,7 @@ Eq_1594: (union "Eq_1594" (uint64 u0) (ptr64 u1))
 	T_3630 (in r12 : word64)
 	T_3756 (in 0<64> : word64)
 Eq_1611: (union "Eq_1611" (bool u0) (word32 u1))
-	T_1611 (in SLICE(cond((byte) (uint64) (uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) - 1<8>), bool, 1) : bool)
+	T_1611 (in SLICE(cond((byte) (uint64) (uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) - 1<8>), bool, 1) : bool)
 Eq_1657: (fn int32 ((ptr64 Eq_1659), Eq_1660))
 	T_1657 (in sigismember : ptr64)
 	T_1658 (in signature of sigismember : void)
@@ -3452,12 +3452,9 @@ Eq_1698: (union "Eq_1698" (int32 u0) (int64 u1) (uint64 u2))
 	T_9741 (in rax_39 : Eq_1698)
 	T_9742 (in SEQ(rax_32_32, eax_32) : word64)
 	T_9766 (in SEQ(rax_32_32_157, strlen(r14_119)) : word64)
-Eq_1718: (union "Eq_1718" (byte u0) (word16 u1))
-	T_1718 (in SLICE((word32) Mem1324[rax_1319 + 0<64>:byte], byte, 0) : byte)
-	T_1721 (in Mem1328[rsp_1190 + 0x31<64>:byte] : byte)
 Eq_1772: (union "Eq_1772" (bool u0) (word32 u1))
 	T_1772 (in SLICE(cond((byte) (uint64) (uint8) fn00000000004049E0(rax_1335, 1<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1342, out ebx_4208, out rbp_1214, out r8_1054, out r12_1109) - 1<8>), bool, 1) : bool)
-Eq_1873: (union "Eq_1873" (word64 u0) (DIR u1))
+Eq_1873: DIR
 	T_1873 (in rax_2479 : (ptr64 Eq_1873))
 	T_1875 (in Mem2471[0x000000000061AF18<p64>:word64] : word64)
 	T_1906 (in rax_2554 : (ptr64 Eq_1873))
@@ -4290,9 +4287,9 @@ Eq_4374: (union "Eq_4374" ((ptr64 wchar_t) u0) ((ptr64 mbstate_t) u1))
 Eq_4375: (union "Eq_4375" ((ptr64 wchar_t) u0) ((ptr64 mbstate_t) u1))
 	T_4375 (in fp - 0x2088<64> : word64)
 Eq_4379: (union "Eq_4379" ((ptr64 wchar_t) u0) ((ptr64 mbstate_t) u1))
-	T_4379 (in (word64) rax_48 + 31<i32> & 0xFFFFFFFFFFFFFFF0<64> : word64)
+	T_4379 (in (word32) rax_48 + 31<i32> & 0xFFFFFFFFFFFFFFF0<64> : word64)
 Eq_4380: (union "Eq_4380" ((ptr64 wchar_t) u0) ((ptr64 mbstate_t) u1))
-	T_4380 (in fp - 0x2088<64> - ((word64) rax_48 + 31<i32> & 0xFFFFFFFFFFFFFFF0<64>) : word64)
+	T_4380 (in fp - 0x2088<64> - ((word32) rax_48 + 31<i32> & 0xFFFFFFFFFFFFFFF0<64>) : word64)
 Eq_4381: (union "Eq_4381" ((ptr64 wchar_t) u0) ((ptr64 mbstate_t) u1))
 	T_4381 (in 0xF<64> : word64)
 Eq_4382: (union "Eq_4382" (ui64 u0) (ptr64 u1))
@@ -4324,13 +4321,13 @@ Eq_4433: (fn (ptr64 (ptr64 uint16)) ())
 	T_14836 (in __ctype_b_loc : ptr64)
 	T_16348 (in __ctype_b_loc : ptr64)
 	T_16595 (in __ctype_b_loc : ptr64)
-Eq_4440: (union "Eq_4440" (int64 u0) (uint64 u1) (byte u2) (Eq_17626 u3))
+Eq_4440: (union "Eq_4440" (int64 u0) (uint64 u1) (byte u2) (Eq_17625 u3))
 	T_4440 (in 0xFF<8> : byte)
-Eq_4441: (union "Eq_4441" (int64 u0) (uint64 u1) (byte u2) (Eq_17627 u3))
+Eq_4441: (union "Eq_4441" (int64 u0) (uint64 u1) (byte u2) (Eq_17626 u3))
 	T_4441 (in r12 - 0xFF<8> : word64)
 Eq_4443: (union "Eq_4443" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4443 (in rax_300 + 0<64> : word64)
-Eq_4455: (union "Eq_4455" (int64 u0) (uint64 u1) (byte u2) (Eq_17628 u3))
+Eq_4455: (union "Eq_4455" (int64 u0) (uint64 u1) (byte u2) (Eq_17627 u3))
 	T_4455 (in ((word16) (word32) rcx_299[SEQ(rdx_32_32_427, (word32) *rax_300)] & 0x4000<16>) < 1<16> : bool)
 Eq_4457: (union "Eq_4457" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4457 (in 1<64> : word64)
@@ -4338,7 +4335,7 @@ Eq_4494: (union "Eq_4494" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4494 (in rbx_137 + 0<64> : word64)
 Eq_4496: (union "Eq_4496" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4496 (in 1<64> : word64)
-Eq_4498: (union "Eq_4498" (int64 u0) (uint64 u1) (byte u2) (Eq_17629 u3))
+Eq_4498: (union "Eq_4498" (int64 u0) (uint64 u1) (byte u2) (Eq_17628 u3))
 	T_4498 (in 1<64> : word64)
 Eq_4500: (union "Eq_4500" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4500 (in 1<64> : word64)
@@ -4346,7 +4343,7 @@ Eq_4510: (union "Eq_4510" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4510 (in rbx_137 + 0<64> : word64)
 Eq_4512: (union "Eq_4512" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4512 (in 1<64> : word64)
-Eq_4514: (union "Eq_4514" (int64 u0) (uint64 u1) (byte u2) (Eq_17630 u3))
+Eq_4514: (union "Eq_4514" (int64 u0) (uint64 u1) (byte u2) (Eq_17629 u3))
 	T_4514 (in 1<64> : word64)
 Eq_4516: (union "Eq_4516" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4516 (in 1<64> : word64)
@@ -4360,7 +4357,7 @@ Eq_4519: (union "Eq_4519" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4596 (in 0xFFFFFFFFFFFFFFFF<64> : word64)
 Eq_4524: (union "Eq_4524" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4524 (in rbx_137 + 0<64> : word64)
-Eq_4526: (union "Eq_4526" (int64 u0) (uint64 u1) (byte u2) (Eq_17631 u3))
+Eq_4526: (union "Eq_4526" (int64 u0) (uint64 u1) (byte u2) (Eq_17630 u3))
 	T_4526 (in 1<64> : word64)
 Eq_4528: (union "Eq_4528" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4528 (in 1<64> : word64)
@@ -4394,7 +4391,7 @@ Eq_4546: (fn void ())
 	T_17366 (in __stack_chk_fail : ptr64)
 Eq_4551: (union "Eq_4551" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4551 (in rbx_137 + 0<64> : word64)
-Eq_4554: (union "Eq_4554" (int64 u0) (uint64 u1) (byte u2) (Eq_17632 u3))
+Eq_4554: (union "Eq_4554" (int64 u0) (uint64 u1) (byte u2) (Eq_17631 u3))
 	T_4554 (in 1<64> : word64)
 Eq_4556: (union "Eq_4556" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4556 (in 1<64> : word64)
@@ -4414,7 +4411,7 @@ Eq_4573: (union "Eq_4573" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4573 (in rdx_238 - 1<64> : word64)
 Eq_4575: (union "Eq_4575" ((ptr64 char) u0) ((ptr64 void) u1) (size_t u2))
 	T_4575 (in rdx_238 - 1<64> + 0<64> : word64)
-Eq_4578: (union "Eq_4578" (int64 u0) (uint64 u1) (byte u2) (Eq_17633 u3))
+Eq_4578: (union "Eq_4578" (int64 u0) (uint64 u1) (byte u2) (Eq_17632 u3))
 	T_4578 (in rax_251 : Eq_4578)
 	T_4579 (in (int64) eax_224 : int64)
 Eq_4583: (fn Eq_18 (Eq_4585, Eq_18, Eq_18, Eq_4588))
@@ -4566,7 +4563,7 @@ Eq_5099: (fn Eq_18 (Eq_5101, Eq_18))
 	T_8751 (in fn000000000040CD70 : ptr64)
 	T_8839 (in fn000000000040CD70 : ptr64)
 	T_8869 (in fn000000000040CD70 : ptr64)
-Eq_5101: (union "Eq_5101" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17636) u3) (time_t u4) (Eq_17637 u5))
+Eq_5101: (union "Eq_5101" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17635) u3) (time_t u4) (Eq_17636 u5))
 	T_5101 (in rsi : Eq_5101)
 	T_5105 (in fp - 0x2B8<64> : word64)
 	T_6551 (in fp - 0x1278<64> : word64)
@@ -4587,9 +4584,9 @@ Eq_5155: (union "Eq_5155" (int64 u0) (uint64 u1))
 	T_5155 (in qwLoc02C0 : word64)
 Eq_5163: (union "Eq_5163" (int64 u0) (uint64 u1))
 	T_5163 (in rax_102 : Eq_5163)
-	T_5175 (in SEQ(rax_32_32_100, strlen(*((word64) rdi + 168<i32>))) + 1<64> : word64)
+	T_5175 (in SEQ(rax_32_32_100, strlen(*((word32) rdi + 168<i32>))) + 1<64> : word64)
 	T_5180 (in (int64) globals->t61B16C + 1<64> : word64)
-Eq_5222: (union "Eq_5222" (word32 u0) ((ptr64 Eq_17638) u1))
+Eq_5222: (union "Eq_5222" (word32 u0) ((ptr64 Eq_17637) u1))
 	T_5222 (in Mem16[rdi + 0x28<64>:word32] : word32)
 	T_6001 (in Mem25[rdi + 0x28<64>:word32] : word32)
 	T_6702 (in Mem556[rdi + 0x28<64>:word32] : word32)
@@ -4621,7 +4618,7 @@ Eq_5297: (union "Eq_5297" (int64 u0) (uint64 u1))
 	T_5527 (in rbp_47 - rax_71 : word64)
 Eq_5332: (struct "Eq_5332" 0018 (0 word64 qw0000))
 	T_5332 (in rdx_105 : (ptr64 Eq_5332))
-	T_5337 (in (word64) rsi_101 + rcx_98 * 0x18<64> + 0x10<64> : word64)
+	T_5337 (in (word32) rsi_101 + rcx_98 * 0x18<64> + 0x10<64> : word64)
 	T_5338 (in rsi_106 : (ptr64 Eq_5332))
 	T_5341 (in rsi_101 + rbp_47 * 0x18<64> : word64)
 	T_5346 (in rdx_105 + 0x18<64> : word64)
@@ -4638,7 +4635,7 @@ Eq_5467: (union "Eq_5467" (ui64 u0) (ptr64 u1))
 	T_5470 (in (rax_292 << 3<64>) + rdx_291 : word64)
 	T_5494 (in rax_296 - 0x18<64> : word64)
 Eq_5489: (union "Eq_5489" (bool u0) (byte u1))
-	T_5489 (in *((word64) rsi_191 + 8<i32>) < r13_190 : bool)
+	T_5489 (in *((word32) rsi_191 + 8<i32>) < r13_190 : bool)
 	T_5492 (in Mem259[rsi_191 + 0<64>:byte] : byte)
 Eq_5548: (fn int32 (Eq_18, Eq_5551, Eq_18, (ptr64 char), word32))
 	T_5548 (in __sprintf_chk : ptr64)
@@ -4741,96 +4738,96 @@ Eq_6389: (struct "Eq_6389" (0 byte b0000) (1 byte b0001) (2 byte b0002) (3 byte 
 Eq_6390: (struct "Eq_6390" (18 word32 dw0018))
 	T_6390 (in rdi : (ptr64 Eq_6390))
 	T_6395 (in rdi + 0x10<64> : word64)
-Eq_6391: (union "Eq_6391" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17640) u3) (time_t u4) (Eq_17641 u5))
+Eq_6391: (union "Eq_6391" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17639) u3) (time_t u4) (Eq_17640 u5))
 	T_6391 (in fp : ptr64)
-Eq_6431: (union "Eq_6431" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17643) u3) (time_t u4) (Eq_17644 u5))
+Eq_6431: (union "Eq_6431" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17642) u3) (time_t u4) (Eq_17643 u5))
 	T_6431 (in rsp_328 : Eq_6431)
 	T_6433 (in fp - 0x12E8<64> : word64)
 	T_6862 (in fp - 0x12F0<64> : word64)
 	T_6913 (in rsp_328 + 0xFFFFFFFFFFFFFFF8<64> : word64)
 Eq_6568: (union "Eq_6568" (int64 u0) (uint64 u1))
 	T_6568 (in (uint64) (uint32) strlen(rbp_109) : uint64)
-Eq_6592: (union "Eq_6592" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17640) u3) (time_t u4) (Eq_17645 u5))
+Eq_6592: (union "Eq_6592" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17639) u3) (time_t u4) (Eq_17644 u5))
 	T_6592 (in 0xE88<64> : word64)
-Eq_6599: (union "Eq_6599" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17640) u3) (time_t u4) (Eq_17646 u5))
+Eq_6599: (union "Eq_6599" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17639) u3) (time_t u4) (Eq_17645 u5))
 	T_6599 (in fp - 0xE88<64> : word64)
-Eq_6621: (union "Eq_6621" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17640) u3) (time_t u4) (Eq_17647 u5))
+Eq_6621: (union "Eq_6621" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17639) u3) (time_t u4) (Eq_17646 u5))
 	T_6621 (in 0xE88<64> : word64)
-Eq_6628: (union "Eq_6628" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17649) u3) (time_t u4) (Eq_17650 u5))
+Eq_6628: (union "Eq_6628" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17648) u3) (time_t u4) (Eq_17649 u5))
 	T_6628 (in rdx_143 : Eq_6628)
 	T_6629 (in fp - 0xE88<64> : word64)
 	T_6668 (in rdx_143 + 4<64> : word64)
 	T_6674 (in rbp_160 : Eq_6628)
 	T_6676 (in rdx_143 + 2<64> : word64)
-Eq_6637: (union "Eq_6637" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17640) u3) (time_t u4) (Eq_17651 u5))
+Eq_6637: (union "Eq_6637" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17639) u3) (time_t u4) (Eq_17650 u5))
 	T_6637 (in 0x1278<64> : word64)
-Eq_6649: (union "Eq_6649" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17654 u5))
+Eq_6649: (union "Eq_6649" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17653 u5))
 	T_6649 (in rdx_143 + 0<64> : word64)
 Eq_6658: (union "Eq_6658" (ui64 u0) (word32 u1))
 	T_6658 (in SLICE((uint64) ~(word32) rcx_146, word32, 0) : word32)
-Eq_6667: (union "Eq_6667" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17655 u5))
+Eq_6667: (union "Eq_6667" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17654 u5))
 	T_6667 (in 4<64> : word64)
-Eq_6675: (union "Eq_6675" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17656 u5))
+Eq_6675: (union "Eq_6675" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17655 u5))
 	T_6675 (in 2<64> : word64)
-Eq_6692: (union "Eq_6692" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17657 u5))
+Eq_6692: (union "Eq_6692" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17656 u5))
 	T_6692 (in 3<8> : byte)
-Eq_6693: (union "Eq_6693" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17658 u5))
+Eq_6693: (union "Eq_6693" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17657 u5))
 	T_6693 (in rbp_160 - 3<8> : word64)
-Eq_6697: (union "Eq_6697" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17659 u5))
+Eq_6697: (union "Eq_6697" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17658 u5))
 	T_6697 (in al_172 * 2<8> < 0<8> : bool)
-Eq_6810: (union "Eq_6810" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17660 u5))
+Eq_6810: (union "Eq_6810" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17659 u5))
 	T_6810 (in 1<64> : word64)
-Eq_6812: (union "Eq_6812" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17661 u5))
+Eq_6812: (union "Eq_6812" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17660 u5))
 	T_6812 (in 1<64> : word64)
-Eq_6813: (union "Eq_6813" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17662 u5))
+Eq_6813: (union "Eq_6813" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17661 u5))
 	T_6813 (in r13_656 - 1<64> : word64)
-Eq_6815: (union "Eq_6815" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17663 u5))
+Eq_6815: (union "Eq_6815" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17662 u5))
 	T_6815 (in r13_656 - 1<64> + 0<64> : word64)
-Eq_6826: (union "Eq_6826" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17664 u5))
+Eq_6826: (union "Eq_6826" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17663 u5))
 	T_6826 (in 1<64> : word64)
-Eq_6827: (union "Eq_6827" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17665 u5))
+Eq_6827: (union "Eq_6827" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17664 u5))
 	T_6827 (in rbp_1180 + 1<64> : word64)
-Eq_6828: (union "Eq_6828" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17666 u5))
+Eq_6828: (union "Eq_6828" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17665 u5))
 	T_6828 (in (uint64) eax_732 : uint64)
-Eq_6831: (union "Eq_6831" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17667 u5))
+Eq_6831: (union "Eq_6831" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17666 u5))
 	T_6831 (in 1<64> : word64)
-Eq_6834: (union "Eq_6834" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17668 u5))
+Eq_6834: (union "Eq_6834" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17667 u5))
 	T_6834 (in 1<64> : word64)
-Eq_6835: (union "Eq_6835" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17669 u5))
+Eq_6835: (union "Eq_6835" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17668 u5))
 	T_6835 (in rdx_737 - 1<64> : word64)
-Eq_6837: (union "Eq_6837" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17670 u5))
+Eq_6837: (union "Eq_6837" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17669 u5))
 	T_6837 (in rdx_737 - 1<64> + 0<64> : word64)
-Eq_6840: (union "Eq_6840" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17671 u5))
+Eq_6840: (union "Eq_6840" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17670 u5))
 	T_6840 (in 1<64> : word64)
-Eq_6841: (union "Eq_6841" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17672 u5))
+Eq_6841: (union "Eq_6841" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17671 u5))
 	T_6841 (in rbp_1180 + 1<64> : word64)
-Eq_6842: (union "Eq_6842" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17673 u5))
+Eq_6842: (union "Eq_6842" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17672 u5))
 	T_6842 (in (int64) eax_732 : int64)
 Eq_6844: (fn word64 (byte, word32, Eq_4846, (ptr32 Eq_11)))
 	T_6844 (in fn00000000004057B0 : ptr64)
 	T_6845 (in signature of fn00000000004057B0 : void)
 	T_6896 (in fn00000000004057B0 : ptr64)
-Eq_6861: (union "Eq_6861" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17674 u5))
+Eq_6861: (union "Eq_6861" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17673 u5))
 	T_6861 (in 0x12F0<64> : word64)
-Eq_6912: (union "Eq_6912" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17675 u5))
+Eq_6912: (union "Eq_6912" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17674 u5))
 	T_6912 (in 0xFFFFFFFFFFFFFFF8<64> : word64)
-Eq_6935: (union "Eq_6935" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17676 u5))
+Eq_6935: (union "Eq_6935" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17675 u5))
 	T_6935 (in rbp_1180 + 0<64> : word64)
 Eq_6942: (fn Eq_18 (Eq_6944, int64))
 	T_6942 (in fn000000000040CCD0 : ptr64)
 	T_6943 (in signature of fn000000000040CCD0 : void)
-Eq_6944: (union "Eq_6944" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17679 u5))
+Eq_6944: (union "Eq_6944" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17678 u5))
 	T_6944 (in rsi : Eq_6944)
 	T_6947 (in rsp_328 + 0x50<64> : word64)
-Eq_6946: (union "Eq_6946" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17653) u3) (time_t u4) (Eq_17680 u5))
+Eq_6946: (union "Eq_6946" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17652) u3) (time_t u4) (Eq_17679 u5))
 	T_6946 (in 0x50<64> : word64)
-Eq_6949: (union "Eq_6949" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17681 u5))
+Eq_6949: (union "Eq_6949" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17680 u5))
 	T_6949 (in rsp_328 + 0x30<64> : word64)
-Eq_6961: (union "Eq_6961" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17682 u5))
+Eq_6961: (union "Eq_6961" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17681 u5))
 	T_6961 (in rsp_328 + 0x30<64> : word64)
-Eq_6967: (union "Eq_6967" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17683 u5))
+Eq_6967: (union "Eq_6967" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17682 u5))
 	T_6967 (in rsp_328 + 0x38<64> : word64)
-Eq_6971: (union "Eq_6971" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17684 u5))
+Eq_6971: (union "Eq_6971" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17683 u5))
 	T_6971 (in rsp_328 + 0x10<64> : word64)
 Eq_6973: (fn void ((ptr64 Eq_6975)))
 	T_6973 (in fn000000000040AB30 : ptr64)
@@ -4839,19 +4836,19 @@ Eq_6975: (struct "timespec" 0008 (0 int32 tv_sec) (4 int32 tv_nsec) (8 int64 qw0
 	T_6975 (in rdi : (ptr64 Eq_6975))
 	T_6976 (in 0x61B180<u64> : uint64)
 	T_10599 (in rsi : (ptr64 (struct "timespec" 0008)))
-Eq_6983: (union "Eq_6983" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17685 u5))
+Eq_6983: (union "Eq_6983" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17684 u5))
 	T_6983 (in rsp_328 + 0x30<64> : word64)
-Eq_6986: (union "Eq_6986" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17686 u5))
+Eq_6986: (union "Eq_6986" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17685 u5))
 	T_6986 (in rsp_328 + 0x38<64> : word64)
-Eq_6989: (union "Eq_6989" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17687 u5))
+Eq_6989: (union "Eq_6989" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17686 u5))
 	T_6989 (in rsp_328 + 0x10<64> : word64)
 Eq_7001: (fn Eq_18 (Eq_18, Eq_18, Eq_18, (ptr32 Eq_11)))
 	T_7001 (in fn0000000000406A80 : ptr64)
 	T_7002 (in signature of fn0000000000406A80 : void)
 	T_7264 (in fn0000000000406A80 : ptr64)
-Eq_7031: (union "Eq_7031" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17688 u5))
+Eq_7031: (union "Eq_7031" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17687 u5))
 	T_7031 (in rsp_328 + 0x18<64> : word64)
-Eq_7034: (union "Eq_7034" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17689 u5))
+Eq_7034: (union "Eq_7034" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17688 u5))
 	T_7034 (in rsp_328 + 0x10<64> : word64)
 Eq_7037: (fn Eq_18 (Eq_7039))
 	T_7037 (in fn000000000040CB40 : ptr64)
@@ -4862,18 +4859,18 @@ Eq_7039: (union "Eq_7039" (uint64 u0) (word32 u1))
 	T_7040 (in (uint64) eax_456 : uint64)
 	T_8897 (in (uint64) r13d_1561 : uint64)
 	T_13272 (in SLICE(rdi, word32, 0) : word32)
-Eq_7044: (union "Eq_7044" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17690 u5))
+Eq_7044: (union "Eq_7044" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17689 u5))
 	T_7044 (in rsp_328 + 0x10<64> : word64)
-Eq_7048: (union "Eq_7048" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17691 u5))
+Eq_7048: (union "Eq_7048" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17690 u5))
 	T_7048 (in r13_656 + 0<64> : word64)
 Eq_7052: (struct "Eq_7052" (0 byte b0000) (1 byte b0001))
 	T_7052 (in rax_1012 : word64)
 	T_7053 (in rax_874 + r13_656 : word64)
-Eq_7065: (union "Eq_7065" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17692 u5))
+Eq_7065: (union "Eq_7065" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17691 u5))
 	T_7065 (in rax_1012 + 1<64> : word64)
 	T_7066 (in r13_1008 : Eq_7065)
 	T_7231 (in r13_656 + (uint64) ((uint32) strlen(r13_656)) : word64)
-Eq_7068: (union "Eq_7068" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17693 u5))
+Eq_7068: (union "Eq_7068" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17692 u5))
 	T_7068 (in fp - 0xE88<64> : word64)
 Eq_7084: (fn word64 ((ptr64 Eq_18), Eq_18, (ptr64 Eq_2075), byte, Eq_18, (ptr32 Eq_11), Eq_18, ptr64))
 	T_7084 (in fn0000000000406540 : ptr64)
@@ -4885,45 +4882,45 @@ Eq_7119: (fn word64 (Eq_18, Eq_4903, Eq_4904, byte))
 	T_7120 (in signature of fn0000000000405D00 : void)
 	T_7172 (in fn0000000000405D00 : ptr64)
 	T_7415 (in fn0000000000405D00 : ptr64)
-Eq_7187: (union "Eq_7187" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17694 u5))
+Eq_7187: (union "Eq_7187" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17693 u5))
 	T_7187 (in rsp_328 + 8<64> : word64)
-Eq_7190: (union "Eq_7190" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17695 u5))
+Eq_7190: (union "Eq_7190" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17694 u5))
 	T_7190 (in rsp_328 + 0<64> : word64)
-Eq_7198: (union "Eq_7198" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17696 u5))
+Eq_7198: (union "Eq_7198" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17695 u5))
 	T_7198 (in 1<64> : word64)
-Eq_7199: (union "Eq_7199" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17697 u5))
+Eq_7199: (union "Eq_7199" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17696 u5))
 	T_7199 (in rbp_1180 + 1<64> : word64)
-Eq_7202: (union "Eq_7202" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17698 u5))
+Eq_7202: (union "Eq_7202" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17697 u5))
 	T_7202 (in (int64) Mem642[0x000000000061B154<p64>:word32] : int64)
-Eq_7205: (union "Eq_7205" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17699 u5))
+Eq_7205: (union "Eq_7205" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17698 u5))
 	T_7205 (in rsp_328 + 0x10<64> : word64)
-Eq_7209: (union "Eq_7209" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17700 u5))
+Eq_7209: (union "Eq_7209" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17699 u5))
 	T_7209 (in rsp_328 + 0x28<64> : word64)
 Eq_7212: (fn Eq_18 (Eq_7214))
 	T_7212 (in localtime : ptr64)
 	T_7213 (in signature of localtime : void)
 	T_7247 (in localtime : ptr64)
-Eq_7214: (union "Eq_7214" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17701 u5))
+Eq_7214: (union "Eq_7214" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17700 u5))
 	T_7214 (in t : time_t)
 	T_7216 (in rsp_328 + 0x28<64> : word64)
 	T_7249 (in rsp_328 + 0x30<64> : word64)
-Eq_7215: (union "Eq_7215" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17702 u5))
+Eq_7215: (union "Eq_7215" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17701 u5))
 	T_7215 (in 0x28<64> : word64)
-Eq_7230: (union "Eq_7230" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17703 u5))
+Eq_7230: (union "Eq_7230" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17702 u5))
 	T_7230 (in (uint64) (uint32) strlen(r13_656) : uint64)
-Eq_7248: (union "Eq_7248" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17704 u5))
+Eq_7248: (union "Eq_7248" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17703 u5))
 	T_7248 (in 0x30<64> : word64)
-Eq_7253: (union "Eq_7253" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17705 u5))
+Eq_7253: (union "Eq_7253" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17704 u5))
 	T_7253 (in r13_656 + 0<64> : word64)
-Eq_7267: (union "Eq_7267" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17706 u5))
+Eq_7267: (union "Eq_7267" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17705 u5))
 	T_7267 (in 0x70<64> : word64)
-Eq_7277: (union "Eq_7277" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17707 u5))
+Eq_7277: (union "Eq_7277" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17706 u5))
 	T_7277 (in rsp_328 + 0x10<64> : word64)
-Eq_7282: (union "Eq_7282" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17708 u5))
+Eq_7282: (union "Eq_7282" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17707 u5))
 	T_7282 (in rsp_328 + 0x10<64> : word64)
-Eq_7287: (union "Eq_7287" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17709 u5))
+Eq_7287: (union "Eq_7287" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17708 u5))
 	T_7287 (in 0x70<64> : word64)
-Eq_7297: (union "Eq_7297" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17634) u2) ((ptr64 Eq_17678) u3) (time_t u4) (Eq_17710 u5))
+Eq_7297: (union "Eq_7297" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17633) u2) ((ptr64 Eq_17677) u3) (time_t u4) (Eq_17709 u5))
 	T_7297 (in 0xE88<64> : word64)
 Eq_7312: (fn (ptr64 Eq_18) ())
 	T_7312 (in fn0000000000406A30 : ptr64)
@@ -4984,20 +4981,20 @@ Eq_8039: (struct "stat" (0 word64 qw0000) (18 word32 dw0018))
 	T_8039 (in r15_586 : (ptr64 Eq_8039))
 	T_8088 (in r14_121 + 0x10<64> : word64)
 	T_8458 (in r14_121 + 0x10<64> : word64)
-	T_8582 (in (word64) r9_113 + (rcx_117 << 6<64>) + 0x10<64> : word64)
+	T_8582 (in (word32) r9_113 + (rcx_117 << 6<64>) + 0x10<64> : word64)
 	T_8588 (in __statbuf : (ptr64 (struct "stat")))
 	T_8612 (in rsi : (ptr64 Eq_8039))
-Eq_8053: (union "Eq_8053" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17713 u3))
+Eq_8053: (union "Eq_8053" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17712 u3))
 	T_8053 (in fp : ptr64)
-Eq_8054: (union "Eq_8054" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17714 u3))
+Eq_8054: (union "Eq_8054" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17713 u3))
 	T_8054 (in 0x3A8<64> : word64)
-Eq_8055: (union "Eq_8055" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17715 u3))
+Eq_8055: (union "Eq_8055" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17714 u3))
 	T_8055 (in fp - 0x3A8<64> : word64)
-Eq_8066: (union "Eq_8066" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17716 u3))
+Eq_8066: (union "Eq_8066" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17715 u3))
 	T_8066 (in SEQ(rax_32_32_2022, strlen(rdi)) + 0x20<64> + SEQ(rax_32_32_2022, strlen(rcx)) & 0xFFFFFFFFFFFFFFF0<64> : word64)
-Eq_8067: (union "Eq_8067" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17717 u3))
+Eq_8067: (union "Eq_8067" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17716 u3))
 	T_8067 (in fp - 0x3A8<64> - ((SEQ(rax_32_32_2022, strlen(rdi)) + 0x20<64>) + SEQ(rax_32_32_2022, strlen(rcx)) & 0xFFFFFFFFFFFFFFF0<64>) : word64)
-Eq_8068: (union "Eq_8068" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17718 u3))
+Eq_8068: (union "Eq_8068" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17717 u3))
 	T_8068 (in 0xF<64> : word64)
 Eq_8069: (union "Eq_8069" (ui64 u0) (ptr64 u1))
 	T_8069 (in fp - 0x3A8<64> - ((SEQ(rax_32_32_2022, strlen(rdi)) + 0x20<64>) + SEQ(rax_32_32_2022, strlen(rcx)) & 0xFFFFFFFFFFFFFFF0<64>) + 0xF<64> : word64)
@@ -5026,11 +5023,11 @@ Eq_8332: security_context_t
 Eq_8347: (fn word32 ((ptr64 Eq_8332), Eq_18))
 	T_8347 (in fn0000000000411820 : ptr64)
 	T_8348 (in signature of fn0000000000411820 : void)
-Eq_8518: (union "Eq_8518" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17719 u3))
+Eq_8518: (union "Eq_8518" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17718 u3))
 	T_8518 (in 0x2D8<64> : word64)
-Eq_8530: (union "Eq_8530" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17720 u3))
+Eq_8530: (union "Eq_8530" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17719 u3))
 	T_8530 (in fp - 0x2D8<64> : word64)
-Eq_8556: (union "Eq_8556" (byte u0) (Eq_17721 u1))
+Eq_8556: (union "Eq_8556" (byte u0) (Eq_17720 u1))
 	T_8556 (in al_613 : Eq_8556)
 	T_8567 (in *__errno_location() == 2<32> : bool)
 	T_8578 (in (word32) (uint64) ((word32) (uint64) r14_121[5<i32>] & 0xF000<32>) != 0x4000<32> : bool)
@@ -5052,34 +5049,34 @@ Eq_8667: (fn word64 (Eq_4846, (ptr32 Eq_11)))
 	T_8667 (in fn00000000004061B0 : ptr64)
 	T_8668 (in signature of fn00000000004061B0 : void)
 	T_8700 (in fn00000000004061B0 : ptr64)
-Eq_8734: (union "Eq_8734" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17722 u3))
+Eq_8734: (union "Eq_8734" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17721 u3))
 	T_8734 (in 0x2F8<64> : word64)
-Eq_8752: (union "Eq_8752" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17723 u3))
+Eq_8752: (union "Eq_8752" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17722 u3))
 	T_8752 (in 0x2D8<64> : word64)
-Eq_8814: (union "Eq_8814" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17724 u3))
+Eq_8814: (union "Eq_8814" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17723 u3))
 	T_8814 (in 0x2D8<64> : word64)
-Eq_8840: (union "Eq_8840" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17725 u3))
+Eq_8840: (union "Eq_8840" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17724 u3))
 	T_8840 (in 0x2D8<64> : word64)
-Eq_8910: (union "Eq_8910" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17726 u3))
+Eq_8910: (union "Eq_8910" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17725 u3))
 	T_8910 (in rdx_1608 : Eq_8910)
 	T_8911 (in fp - 0x2D8<64> : word64)
 	T_8933 (in rdx_1608 + 4<64> : word64)
 	T_8982 (in rdx_1608 + 2<64> : word64)
-Eq_8914: (union "Eq_8914" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17727 u3))
+Eq_8914: (union "Eq_8914" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17726 u3))
 	T_8914 (in rdx_1608 + 0<64> : word64)
 Eq_8923: (union "Eq_8923" (ui64 u0) (word32 u1))
 	T_8923 (in SLICE((uint64) ~(word32) rcx_1611, word32, 0) : word32)
-Eq_8932: (union "Eq_8932" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17728 u3))
+Eq_8932: (union "Eq_8932" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17727 u3))
 	T_8932 (in 4<64> : word64)
-Eq_8970: (union "Eq_8970" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17729 u3))
+Eq_8970: (union "Eq_8970" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17728 u3))
 	T_8970 (in 3<8> : byte)
-Eq_8971: (union "Eq_8971" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17730 u3))
+Eq_8971: (union "Eq_8971" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17729 u3))
 	T_8971 (in rdx_1608 - 3<8> : word64)
-Eq_8975: (union "Eq_8975" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17731 u3))
+Eq_8975: (union "Eq_8975" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17730 u3))
 	T_8975 (in al_1637 * 2<8> < 0<8> : bool)
-Eq_8976: (union "Eq_8976" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17732 u3))
+Eq_8976: (union "Eq_8976" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17731 u3))
 	T_8976 (in rdx_1608 - 3<8> - (al_1637 * 2<8> < 0<8>) : word64)
-Eq_8981: (union "Eq_8981" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17733 u3))
+Eq_8981: (union "Eq_8981" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17732 u3))
 	T_8981 (in 2<64> : word64)
 Eq_8998: (fn Eq_18 (Eq_18, Eq_18))
 	T_8998 (in fn0000000000409D20 : ptr64)
@@ -5090,7 +5087,7 @@ Eq_9046: (fn int64 (Eq_18))
 Eq_9066: (fn (ptr64 char) (Eq_18, Eq_18, Eq_18))
 	T_9066 (in stpncpy : ptr64)
 	T_9067 (in signature of stpncpy : void)
-Eq_9107: (union "Eq_9107" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17712) u2) (Eq_17734 u3))
+Eq_9107: (union "Eq_9107" (byte u0) ((ptr64 char) u1) ((ptr64 Eq_17710) u2) (Eq_17733 u3))
 	T_9107 (in 0x388<64> : word64)
 Eq_9629: (fn int32 (Eq_18))
 	T_9629 (in acl_extended_file : ptr64)
@@ -5272,7 +5269,7 @@ Eq_11056: (union "Eq_11056" (int64 u0) (uint64 u1))
 	T_11084 (in Mem107[rdi + 0x18<64>:word64] + 1<64> : word64)
 	T_11087 (in Mem109[rdi + 0x18<64>:word64] : word64)
 	T_11128 (in Mem154[rsi + 0x18<64>:word64] : word64)
-	T_11130 (in *((word64) rsi + 24<i32>) - 1<64> : word64)
+	T_11130 (in *((word32) rsi + 24<i32>) - 1<64> : word64)
 	T_11133 (in Mem163[rsi + 0x18<64>:word64] : word64)
 	T_11262 (in 0<64> : word64)
 	T_11265 (in Mem205[rax_47 + 0x18<64>:word64] : word64)
@@ -5494,7 +5491,7 @@ Eq_12409: (fn void (uint16))
 Eq_12444: (fn bool (real64))
 	T_12444 (in PARITY_EVEN : ptr64)
 	T_12445 (in signature of PARITY_EVEN : void)
-Eq_12457: (union "Eq_12457" (byte u0) (Eq_17735 u1))
+Eq_12457: (union "Eq_12457" (byte u0) (Eq_17734 u1))
 	T_12457 (in dl_271 : Eq_12457)
 	T_12470 (in (word32) (uint64) ((word32) ecx_141 + (word32) ((uint64) ((word32) ((uint64) eax_223) & 1<32>))) > 2<32> : bool)
 	T_12481 (in SLICE((uint64) (SEQ(edx_24_8_280, ecx_141 > 0<32>) & SEQ(esi_24_8_282, SLICE((uint64) eax_33, word32, 0) == 0<32>)), byte, 0) : byte)
@@ -5823,7 +5820,7 @@ Eq_14501: (union "Eq_14501" (uint64 u0) (ptr64 u1))
 	T_15391 (in out r12_151 : ptr64)
 	T_15486 (in out r12_304 : ptr64)
 	T_15660 (in out r12_78 : ptr64)
-Eq_14605: (union "Eq_14605" (byte u0) (Eq_17736 u1))
+Eq_14605: (union "Eq_14605" (byte u0) (Eq_17735 u1))
 	T_14605 (in al_261 : Eq_14605)
 	T_14607 (in rcx != 0<u64> : bool)
 	T_15174 (in rbp_236 != r15_1446 : bool)
@@ -5851,7 +5848,7 @@ Eq_14695: (union "Eq_14695" (int64 u0) (uint64 u1) (ptr64 u2) (size_t u3))
 	T_15086 (in rbx_363 + rax_398 : word64)
 	T_15159 (in rax_405 + 1<64> : word64)
 	T_15166 (in 1<64> : word64)
-Eq_14724: (struct "Eq_14724" 0001 (0 Eq_17737 t0000))
+Eq_14724: (struct "Eq_14724" 0001 (0 Eq_17736 t0000))
 	T_14724 (in 0x22<8> : byte)
 	T_14727 (in Mem191[rdi + 0<64>:byte] : byte)
 	T_15244 (in SLICE(rsi_1281, byte, 0) : byte)
@@ -5860,7 +5857,7 @@ Eq_14724: (struct "Eq_14724" 0001 (0 Eq_17737 t0000))
 	T_15262 (in Mem213[rdi + 0<64>:byte] : byte)
 	T_17590
 	T_17591
-Eq_14739: (struct "Eq_14739" 0001 (0 Eq_17738 t0000))
+Eq_14739: (struct "Eq_14739" 0001 (0 Eq_17737 t0000))
 	T_14739 (in Mem102[qwLoc88_1469 + 0<64>:byte] : byte)
 	T_17586
 	T_17587
@@ -6171,10 +6168,28 @@ Eq_17547: (struct "Eq_17547" 0010 (0 word64 qw0000))
 	T_17547
 Eq_17548: (struct "Eq_17548" 0010 (0 (ptr64 byte) ptr0000))
 	T_17548
+Eq_17550: (struct "Eq_17550" 0008 (0 Eq_18 t0000))
+	T_17550
 Eq_17556: (struct "Eq_17556" 0002 (0 byte b0000))
 	T_17556
+Eq_17557: (struct "Eq_17557" 0008 (0 Eq_18 t0000))
+	T_17557
 Eq_17558: (struct "Eq_17558" 0008 (0 byte b0000))
 	T_17558
+Eq_17561: (struct "Eq_17561" 0008 (0 Eq_18 t0000))
+	T_17561
+Eq_17562: (struct "Eq_17562" 0008 (0 Eq_18 t0000))
+	T_17562
+Eq_17563: (struct "Eq_17563" 0008 (0 Eq_18 t0000))
+	T_17563
+Eq_17564: (struct "Eq_17564" 0008 (0 Eq_18 t0000))
+	T_17564
+Eq_17566: (struct "Eq_17566" 0008 (0 Eq_18 t0000))
+	T_17566
+Eq_17578: (struct "Eq_17578" 0008 (0 Eq_18 t0000))
+	T_17578
+Eq_17579: (struct "Eq_17579" 0008 (0 Eq_18 t0000))
+	T_17579
 Eq_17580: (struct "Eq_17580" 0008 (0 Eq_18 t0000))
 	T_17580
 Eq_17601: (struct "Eq_17601" 0002 (0 byte b0000))
@@ -6215,9 +6230,9 @@ Eq_17622: (union "Eq_17622" (bool u0) (byte u1))
 	T_17622
 Eq_17623: (union "Eq_17623" ((ptr64 char) u0) ((ptr64 Eq_17621) u1) (size_t u2) (Eq_17622 u3))
 	T_17623
-Eq_17624: (struct "Eq_17624" (0 Eq_18 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (18 Eq_18 t0018) (20 Eq_18 t0020) (28 Eq_18 t0028) (2F byte b002F) (30 Eq_1345 t0030) (31 Eq_1718 t0031) (32 byte b0032) (38 Eq_18 t0038) (40 Eq_18 t0040) (42 word16 w0042) (48 Eq_18 t0048) (C8 word32 dw00C8))
+Eq_17624: (struct "Eq_17624" (0 Eq_18 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (18 Eq_18 t0018) (20 Eq_18 t0020) (28 Eq_18 t0028) (2F byte b002F) (30 Eq_1345 t0030) (31 byte b0031) (32 byte b0032) (38 Eq_18 t0038) (40 Eq_18 t0040) (42 word16 w0042) (48 Eq_18 t0048) (C8 word32 dw00C8))
 	T_17624
-Eq_17625: (struct "_DIR" (0 Eq_18 t0000) (8 Eq_18 t0008))
+Eq_17625: (union "Eq_17625" (bool u0) (byte u1))
 	T_17625
 Eq_17626: (union "Eq_17626" (bool u0) (byte u1))
 	T_17626
@@ -6233,27 +6248,27 @@ Eq_17631: (union "Eq_17631" (bool u0) (byte u1))
 	T_17631
 Eq_17632: (union "Eq_17632" (bool u0) (byte u1))
 	T_17632
-Eq_17633: (union "Eq_17633" (bool u0) (byte u1))
+Eq_17633: (struct "Eq_17633" 0001)
 	T_17633
-Eq_17634: (struct "Eq_17634" 0001)
+Eq_17634: (union "Eq_17634" (byte u0) (word64 u1) (word32 u2))
 	T_17634
-Eq_17635: (union "Eq_17635" (byte u0) (word64 u1) (word32 u2))
+Eq_17635: (struct "stat" 0004 (0 Eq_17634 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (14 byte b0014) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
 	T_17635
-Eq_17636: (struct "stat" 0004 (0 Eq_17635 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (14 byte b0014) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
+Eq_17636: (union "Eq_17636" (bool u0) (byte u1))
 	T_17636
-Eq_17637: (union "Eq_17637" (bool u0) (byte u1))
+Eq_17637: (struct "Eq_17637" (0 real32 r0000) (4 real32 r0004) (8 real32 r0008) (10 byte b0010))
 	T_17637
-Eq_17638: (struct "Eq_17638" (0 real32 r0000) (4 real32 r0004) (8 real32 r0008) (10 byte b0010))
+Eq_17638: (union "Eq_17638" (byte u0) (word32 u1))
 	T_17638
-Eq_17639: (union "Eq_17639" (byte u0) (word32 u1))
+Eq_17639: (struct "Eq_17639" 0004 (0 Eq_17638 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
 	T_17639
-Eq_17640: (struct "Eq_17640" 0004 (0 Eq_17639 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
+Eq_17640: (union "Eq_17640" (bool u0) (byte u1))
 	T_17640
-Eq_17641: (union "Eq_17641" (bool u0) (byte u1))
+Eq_17641: (union "Eq_17641" (byte u0) (word32 u1))
 	T_17641
-Eq_17642: (union "Eq_17642" (byte u0) (word32 u1))
+Eq_17642: (struct "Eq_17642" 0004 (0 Eq_17641 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (14 byte b0014) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
 	T_17642
-Eq_17643: (struct "Eq_17643" 0004 (0 Eq_17642 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (14 byte b0014) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
+Eq_17643: (union "Eq_17643" (bool u0) (byte u1))
 	T_17643
 Eq_17644: (union "Eq_17644" (bool u0) (byte u1))
 	T_17644
@@ -6261,19 +6276,19 @@ Eq_17645: (union "Eq_17645" (bool u0) (byte u1))
 	T_17645
 Eq_17646: (union "Eq_17646" (bool u0) (byte u1))
 	T_17646
-Eq_17647: (union "Eq_17647" (bool u0) (byte u1))
+Eq_17647: (union "Eq_17647" (byte u0) (word32 u1))
 	T_17647
-Eq_17648: (union "Eq_17648" (byte u0) (word32 u1))
+Eq_17648: (struct "Eq_17648" 0004 (0 Eq_17647 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (14 byte b0014) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
 	T_17648
-Eq_17649: (struct "Eq_17649" 0004 (0 Eq_17648 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (14 byte b0014) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
+Eq_17649: (union "Eq_17649" (bool u0) (byte u1))
 	T_17649
 Eq_17650: (union "Eq_17650" (bool u0) (byte u1))
 	T_17650
-Eq_17651: (union "Eq_17651" (bool u0) (byte u1))
+Eq_17651: (union "Eq_17651" (byte u0) (word32 u1))
 	T_17651
-Eq_17652: (union "Eq_17652" (byte u0) (word32 u1))
+Eq_17652: (struct "Eq_17652" 0004 (0 Eq_17651 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (14 byte b0014) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
 	T_17652
-Eq_17653: (struct "Eq_17653" 0004 (0 Eq_17652 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (14 byte b0014) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
+Eq_17653: (union "Eq_17653" (bool u0) (byte u1))
 	T_17653
 Eq_17654: (union "Eq_17654" (bool u0) (byte u1))
 	T_17654
@@ -6319,11 +6334,11 @@ Eq_17674: (union "Eq_17674" (bool u0) (byte u1))
 	T_17674
 Eq_17675: (union "Eq_17675" (bool u0) (byte u1))
 	T_17675
-Eq_17676: (union "Eq_17676" (bool u0) (byte u1))
+Eq_17676: (union "Eq_17676" (byte u0) (word32 u1))
 	T_17676
-Eq_17677: (union "Eq_17677" (byte u0) (word32 u1))
+Eq_17677: (struct "Eq_17677" 0004 (0 Eq_17676 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (14 byte b0014) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
 	T_17677
-Eq_17678: (struct "Eq_17678" 0004 (0 Eq_17677 t0000) (8 Eq_18 t0008) (10 Eq_18 t0010) (14 byte b0014) (18 uint64 qw0018) (28 word64 qw0028) (30 int64 qw0030) (38 Eq_67 t0038))
+Eq_17678: (union "Eq_17678" (bool u0) (byte u1))
 	T_17678
 Eq_17679: (union "Eq_17679" (bool u0) (byte u1))
 	T_17679
@@ -6387,11 +6402,9 @@ Eq_17708: (union "Eq_17708" (bool u0) (byte u1))
 	T_17708
 Eq_17709: (union "Eq_17709" (bool u0) (byte u1))
 	T_17709
-Eq_17710: (union "Eq_17710" (bool u0) (byte u1))
+Eq_17710: (union "Eq_17710" (word64 u0) (word32 u1))
 	T_17710
-Eq_17711: (union "Eq_17711" (word64 u0) (word32 u1))
-	T_17711
-Eq_17712: (struct "stat" 0004 (0 Eq_17711 t0000))
+Eq_17712: (union "Eq_17712" (bool u0) (byte u1))
 	T_17712
 Eq_17713: (union "Eq_17713" (bool u0) (byte u1))
 	T_17713
@@ -6439,12 +6452,10 @@ Eq_17734: (union "Eq_17734" (bool u0) (byte u1))
 	T_17734
 Eq_17735: (union "Eq_17735" (bool u0) (byte u1))
 	T_17735
-Eq_17736: (union "Eq_17736" (bool u0) (byte u1))
+Eq_17736: (union "Eq_17736" (byte u0) ((arr Eq_14724) u1))
 	T_17736
-Eq_17737: (union "Eq_17737" (byte u0) ((arr Eq_14724) u1))
+Eq_17737: (union "Eq_17737" (byte u0) ((arr Eq_14739) u1))
 	T_17737
-Eq_17738: (union "Eq_17738" (byte u0) ((arr Eq_14739) u1))
-	T_17738
 // Type Variables ////////////
 globals_t: (in globals : (ptr64 (struct "Globals")))
   Class: Eq_1
@@ -12082,7 +12093,7 @@ T_1409: (in 0<64> : word64)
   Class: Eq_18
   DataType: byte
   OrigDataType: word64
-T_1410: (in *((word64) rax_2300 + 24<i32>) != 0<64> : bool)
+T_1410: (in *((word32) rax_2300 + 24<i32>) != 0<64> : bool)
   Class: Eq_1410
   DataType: bool
   OrigDataType: bool
@@ -12309,7 +12320,7 @@ T_1465: (in rsp_1190 + 0x38<64> : word64)
 T_1466: (in Mem1235[rsp_1190 + 0x38<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_77
-  OrigDataType: word64
+  OrigDataType: word32
 T_1467: (in r15_1233 : uint64)
   Class: Eq_1467
   DataType: uint64
@@ -12377,7 +12388,7 @@ T_1482: (in rsp_1190 + 0x38<64> : word64)
 T_1483: (in Mem1193[rsp_1190 + 0x38<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_77
-  OrigDataType: word64
+  OrigDataType: word32
 T_1484: (in 5<32> : word32)
   Class: Eq_1366
   DataType: up32
@@ -12858,19 +12869,19 @@ T_1603: (in out r12_1109 : ptr64)
   Class: Eq_1594
   DataType: Eq_1594
   OrigDataType: (union (uint64 u0) (ptr64 u1))
-T_1604: (in fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) : byte)
+T_1604: (in fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) : byte)
   Class: Eq_1604
   DataType: byte
   OrigDataType: byte
-T_1605: (in (uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) : uint8)
+T_1605: (in (uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) : uint8)
   Class: Eq_1605
   DataType: uint8
   OrigDataType: uint8
-T_1606: (in (uint64) (uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) : uint64)
+T_1606: (in (uint64) (uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) : uint64)
   Class: Eq_1606
   DataType: uint64
   OrigDataType: uint64
-T_1607: (in SLICE((uint64) (uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109), byte, 0) : byte)
+T_1607: (in SLICE((uint64) (uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109), byte, 0) : byte)
   Class: Eq_1607
   DataType: byte
   OrigDataType: byte
@@ -12878,27 +12889,27 @@ T_1608: (in 1<8> : byte)
   Class: Eq_1608
   DataType: byte
   OrigDataType: byte
-T_1609: (in (byte) (uint64) (uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) - 1<8> : byte)
+T_1609: (in (byte) (uint64) (uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) - 1<8> : byte)
   Class: Eq_1609
   DataType: byte
   OrigDataType: byte
-T_1610: (in cond((byte) (uint64) (uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) - 1<8>) : byte)
+T_1610: (in cond((byte) (uint64) (uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) - 1<8>) : byte)
   Class: Eq_1610
   DataType: byte
   OrigDataType: byte
-T_1611: (in SLICE(cond((byte) (uint64) (uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) - 1<8>), bool, 1) : bool)
+T_1611: (in SLICE(cond((byte) (uint64) (uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109) - 1<8>), bool, 1) : bool)
   Class: Eq_1611
   DataType: Eq_1611
   OrigDataType: (union (bool u0) (word32 u1))
-T_1612: (in 0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1) : word32)
+T_1612: (in 0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1) : word32)
   Class: Eq_1612
   DataType: word32
   OrigDataType: word32
-T_1613: (in (uint64) (0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1)) : uint64)
+T_1613: (in (uint64) (0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1)) : uint64)
   Class: Eq_1613
   DataType: uint64
   OrigDataType: uint64
-T_1614: (in SLICE((uint64) (0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1)), word32, 0) : word32)
+T_1614: (in SLICE((uint64) (0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1)), word32, 0) : word32)
   Class: Eq_1614
   DataType: ui32
   OrigDataType: ui32
@@ -12906,15 +12917,15 @@ T_1615: (in 5<32> : word32)
   Class: Eq_1615
   DataType: ui32
   OrigDataType: ui32
-T_1616: (in (word32) (uint64) (0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1)) & 5<32> : word32)
+T_1616: (in (word32) (uint64) (0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1)) & 5<32> : word32)
   Class: Eq_1616
   DataType: ui32
   OrigDataType: ui32
-T_1617: (in (uint64) (SLICE((uint64) (0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1)), word32, 0) & 5<32>) : uint64)
+T_1617: (in (uint64) (SLICE((uint64) (0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1)), word32, 0) & 5<32>) : uint64)
   Class: Eq_1617
   DataType: uint64
   OrigDataType: uint64
-T_1618: (in SLICE((uint64) (SLICE((uint64) (0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word64) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1)), word32, 0) & 5<32>), word32, 0) : word32)
+T_1618: (in SLICE((uint64) (SLICE((uint64) (0<32> - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word32) r13_1144 + 16<i32>, 0<8>, (byte) rsp_1190.u0 + 56<i32>, rdi_1198, out ebx_4206, out rbp_1214, out r8_1054, out r12_1109))) - 1<8>), bool, 1)), word32, 0) & 5<32>), word32, 0) : word32)
   Class: Eq_1366
   DataType: up32
   OrigDataType: word32
@@ -13297,7 +13308,7 @@ T_1712: (in rsp_1190 + 0x38<64> : word64)
 T_1713: (in Mem1324[rsp_1190 + 0x38<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_77
-  OrigDataType: word64
+  OrigDataType: word32
 T_1714: (in 0<64> : word64)
   Class: Eq_1714
   DataType: word64
@@ -13316,7 +13327,7 @@ T_1717: (in (word32) Mem1324[rax_1319 + 0<64>:byte] : word32)
   OrigDataType: word32
 T_1718: (in SLICE((word32) Mem1324[rax_1319 + 0<64>:byte], byte, 0) : byte)
   Class: Eq_1718
-  DataType: Eq_1718
+  DataType: byte
   OrigDataType: byte
 T_1719: (in 0x31<64> : word64)
   Class: Eq_1719
@@ -13324,12 +13335,12 @@ T_1719: (in 0x31<64> : word64)
   OrigDataType: word64
 T_1720: (in rsp_1190 + 0x31<64> : word64)
   Class: Eq_1720
-  DataType: (ptr64 word16)
-  OrigDataType: (ptr64 word16)
+  DataType: ptr64
+  OrigDataType: ptr64
 T_1721: (in Mem1328[rsp_1190 + 0x31<64>:byte] : byte)
   Class: Eq_1718
   DataType: Eq_77
-  OrigDataType: Eq_1718
+  OrigDataType: byte
 T_1722: (in 2<32> : word32)
   Class: Eq_1366
   DataType: up32
@@ -13409,7 +13420,7 @@ T_1740: (in rsp_1190 + 0x38<64> : word64)
 T_1741: (in Mem1347[rsp_1190 + 0x38<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_77
-  OrigDataType: word128
+  OrigDataType: word32
 T_1742: (in 000000000061B120 : ptr64)
   Class: Eq_1742
   DataType: (ptr64 Eq_18)
@@ -13605,7 +13616,7 @@ T_1789: (in rsp_1190 + 0x38<64> : word64)
 T_1790: (in Mem1385[rsp_1190 + 0x38<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_77
-  OrigDataType: word64
+  OrigDataType: word32
 T_1791: (in 0<8> : byte)
   Class: Eq_1439
   DataType: byte
@@ -13649,7 +13660,7 @@ T_1800: (in rsp_1190 + 0x38<64> : word64)
 T_1801: (in Mem1401[rsp_1190 + 0x38<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_77
-  OrigDataType: word64
+  OrigDataType: word32
 T_1802: (in 0<64> : word64)
   Class: Eq_1802
   DataType: word64
@@ -14809,7 +14820,7 @@ T_2090: (in rax_2716 + 8<64> : word64)
 T_2091: (in Mem2729[rax_2716 + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: Eq_77
 T_2092: (in 0x48<64> : word64)
   Class: Eq_2092
   DataType: word64
@@ -14833,7 +14844,7 @@ T_2096: (in rax_2716 + 0<64> : word64)
 T_2097: (in Mem2731[rax_2716 + 0<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: Eq_77
 T_2098: (in fn0000000000405090 : ptr64)
   Class: Eq_2098
   DataType: (ptr64 Eq_2098)
@@ -15133,7 +15144,7 @@ T_2171: (in 000000000061B018 : ptr64)
 T_2172: (in Mem2295[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_2173: (in 0x18<64> : word64)
   Class: Eq_2173
   DataType: word64
@@ -15198,7 +15209,7 @@ T_2188: (in Mem3148[rbx_3149 + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 void)
-T_2189: (in free(*((word64) rbx_3149 + 8<i32>)) : void)
+T_2189: (in free(*((word32) rbx_3149 + 8<i32>)) : void)
   Class: Eq_1505
   DataType: void
   OrigDataType: void
@@ -15425,7 +15436,7 @@ T_2244: (in 1<64> : word64)
 T_2245: (in rax_2716 + 1<64> : word64)
   Class: Eq_1873
   DataType: (ptr64 Eq_1873)
-  OrigDataType: (ptr64 word64)
+  OrigDataType: ptr64
 T_2246: (in 0x28<64> : word64)
   Class: Eq_2246
   DataType: word64
@@ -15453,7 +15464,7 @@ T_2251: (in rax_2716 + 0<64> : word64)
 T_2252: (in Mem2748[rax_2716 + 0<64>:byte] : byte)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: byte
 T_2253: (in __assert_fail : ptr64)
   Class: Eq_2253
   DataType: (ptr64 Eq_2253)
@@ -15753,7 +15764,7 @@ T_2326: (in 000000000061B018 : ptr64)
 T_2327: (in Mem2751[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_2328: (in eax_2761 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
@@ -15829,7 +15840,7 @@ T_2345: (in 000000000061B018 : ptr64)
 T_2346: (in Mem2763[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_2347: (in SEQ(rax_32_32_2848, eax_2761) : word64)
   Class: Eq_1873
   DataType: (ptr64 Eq_1873)
@@ -16242,7 +16253,7 @@ T_2449: (in Mem2506[rbx_2538 + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 void)
-T_2450: (in free(*((word64) rbx_2538 + 8<i32>)) : void)
+T_2450: (in free(*((word32) rbx_2538 + 8<i32>)) : void)
   Class: Eq_1505
   DataType: void
   OrigDataType: void
@@ -16325,7 +16336,7 @@ T_2469: (in 000000000061B018 : ptr64)
 T_2470: (in Mem2875[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_2471: (in rax_2854 : (ptr64 Eq_1873))
   Class: Eq_1873
   DataType: (ptr64 Eq_1873)
@@ -16354,7 +16365,7 @@ T_2477: (in rax_2854 + 8<64> : word64)
   Class: Eq_2475
   DataType: (ptr64 word64)
   OrigDataType: up64
-T_2478: (in globals->ptr61AF80 < (char *) rax_2854 + 8<i32> : bool)
+T_2478: (in globals->ptr61AF80 < &rax_2854->t0008 : bool)
   Class: Eq_2478
   DataType: bool
   OrigDataType: bool
@@ -16546,7 +16557,7 @@ T_2525: (in 0<8> : byte)
   Class: Eq_2524
   DataType: byte
   OrigDataType: byte
-T_2526: (in (&rax_2901->t0014)[(uint64) (uint8) (rax_2901->t0014 == 0x2E<8>) / 21<i32>] == 0<8> : bool)
+T_2526: (in (&rax_2901->t0014)[(uint64) (uint8) (rax_2901->t0014 == 0x2E<8>) / 24<i32>] == 0<8> : bool)
   Class: Eq_2526
   DataType: bool
   OrigDataType: bool
@@ -16973,7 +16984,7 @@ T_2631: (in 000000000061B018 : ptr64)
 T_2632: (in Mem3021[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_2633: (in rax_3026 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
@@ -17085,7 +17096,7 @@ T_2659: (in 000000000061B018 : ptr64)
 T_2660: (in Mem3038[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_2661: (in rax_3039 : (ptr64 byte))
   Class: Eq_2661
   DataType: (ptr64 byte)
@@ -17246,7 +17257,7 @@ T_2700: (in rax_2716 + 8<64> : word64)
   Class: Eq_2475
   DataType: (ptr64 word64)
   OrigDataType: (ptr64 word64)
-T_2701: (in globals->ptr61AF80 < (char *) rax_2716 + 8<i32> : bool)
+T_2701: (in globals->ptr61AF80 < &rax_2716->t0008 : bool)
   Class: Eq_2701
   DataType: bool
   OrigDataType: bool
@@ -17361,7 +17372,7 @@ T_2728: (in rsp_1190 + 8<64> : word64)
 T_2729: (in Mem3280[rsp_1190 + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_77
-  OrigDataType: word128
+  OrigDataType: word32
 T_2730: (in 000000000061B150 : ptr64)
   Class: Eq_2730
   DataType: (ptr64 up32)
@@ -17433,7 +17444,7 @@ T_2746: (in 000000000061B018 : ptr64)
 T_2747: (in Mem3113[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_2748: (in 000000000061B148 : ptr64)
   Class: Eq_2748
   DataType: (ptr64 word32)
@@ -17585,7 +17596,7 @@ T_2784: (in 000000000061B018 : ptr64)
 T_2785: (in Mem3058[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_2786: (in rax_3083 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
@@ -17713,7 +17724,7 @@ T_2816: (in 000000000061B018 : ptr64)
 T_2817: (in Mem3102[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_2818: (in 0x28<64> : word64)
   Class: Eq_2818
   DataType: word64
@@ -22065,7 +22076,7 @@ T_3904: (in freecon(rdi_11) : void)
 T_3905: (in rbx_12 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_3906: (in 0<u64> : uint64)
   Class: Eq_18
   DataType: byte
@@ -22258,7 +22269,7 @@ T_3953: (in Mem6[0x000000000061B1A8<p64>:word64][rbx_12 * 8<64>] : word64)
   Class: Eq_3884
   DataType: (ptr64 Eq_3884)
   OrigDataType: word64
-T_3954: (in fn0000000000404D90(*((word64) globals->t61B1A8 + rbx_12 * 8<64>)) : void)
+T_3954: (in fn0000000000404D90(*((word32) globals->t61B1A8 + rbx_12 * 8<64>)) : void)
   Class: Eq_3954
   DataType: void
   OrigDataType: void
@@ -22330,7 +22341,7 @@ T_3971: (in Mem9[0x000000000061B1A0<p64>:word64] : word64)
   Class: Eq_3969
   DataType: uint64
   OrigDataType: up64
-T_3972: (in (word64) rbx_11 + (rbx_11 >> 1<64>) > globals->qw61B1A0 : bool)
+T_3972: (in (word32) rbx_11 + (rbx_11 >> 1<64>) > globals->qw61B1A0 : bool)
   Class: Eq_3972
   DataType: bool
   OrigDataType: bool
@@ -22389,7 +22400,7 @@ T_3985: (in globals->dw61B148 == 0xFFFFFFFF<32> : bool)
 T_3986: (in rax_39 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_3987: (in 000000000061B1A8 : ptr64)
   Class: Eq_3987
   DataType: (ptr64 Eq_18)
@@ -22401,7 +22412,7 @@ T_3988: (in Mem38[0x000000000061B1A8<p64>:word64] : word64)
 T_3989: (in rdx_40 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_3990: (in 000000000061B1C0 : ptr64)
   Class: Eq_3990
   DataType: (ptr64 Eq_18)
@@ -22633,7 +22644,7 @@ T_4046: (in 1<32> : word32)
 T_4047: (in rdx_74 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_4048: (in 000000000061B1C0 : ptr64)
   Class: Eq_4048
   DataType: (ptr64 Eq_18)
@@ -22661,7 +22672,7 @@ T_4053: (in rdi_128 + rsi_132 * 8<64> : word64)
 T_4054: (in rax_76 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_4055: (in 0<64> : word64)
   Class: Eq_4055
   DataType: word64
@@ -22820,7 +22831,7 @@ T_4093: (in rdi : Eq_18)
   OrigDataType: word64
 T_4094: (in 0x412D00<32> : word32)
   Class: Eq_4094
-  DataType: (ptr32 (arr Eq_18))
+  DataType: (ptr32 (arr Eq_17550))
   OrigDataType: (ptr32 (struct (0 (arr T_17550) a0000)))
 T_4095: (in SLICE(rax_101, word32, 32) : word32)
   Class: Eq_4095
@@ -22898,7 +22909,7 @@ T_4113: (in 0x412D00<32>[(r8_124 + (SEQ(SLICE(rax_101, word32, 32), (word32) Mem
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
-T_4114: (in fn000000000040D690(*((char *) globals->a412D00 + (r8_124 + (SEQ(SLICE(rax_101, word32, 32), (word32) globals->b61B147) + (rax_101 + (uint64) (edx_104 + ecx_90) * 2<64>) * 2<64>) * 2<64>) * 8<64>), rbx_11, rsi_132, rdi_128) : word64)
+T_4114: (in fn000000000040D690(globals->a412D00[r8_124 + (SEQ(SLICE(rax_101, word32, 32), (word32) globals->b61B147) + (rax_101 + (uint64) (edx_104 + ecx_90) * 2<64>) * 2<64>) * 2<64>], rbx_11, rsi_132, rdi_128) : word64)
   Class: Eq_3960
   DataType: word64
   OrigDataType: word64
@@ -23238,7 +23249,7 @@ T_4198: (in 0x2E<8> : byte)
   Class: Eq_4197
   DataType: byte
   OrigDataType: byte
-T_4199: (in *((word64) rax_121 + 1<i32>) == 0x2E<8> : bool)
+T_4199: (in *((word32) rax_121 + 1<i32>) == 0x2E<8> : bool)
   Class: Eq_4199
   DataType: bool
   OrigDataType: bool
@@ -23250,7 +23261,7 @@ T_4201: (in (uint64) (uint8) (Mem25[rax_121 + 1<64>:byte] == 0x2E<8>) : uint64)
   Class: Eq_4201
   DataType: Eq_4201
   OrigDataType: (union (int64 u1) (uint64 u0))
-T_4202: (in (word64) rax_121 + 1<i32> + (uint64) ((uint8) (*((word64) rax_121 + 1<i32>) == 0x2E<8>)) : word64)
+T_4202: (in (word32) rax_121 + 1<i32> + (uint64) ((uint8) (*((word32) rax_121 + 1<i32>) == 0x2E<8>)) : word64)
   Class: Eq_4202
   DataType: (ptr64 byte)
   OrigDataType: (ptr64 (struct (0 T_4203 t0000)))
@@ -23305,7 +23316,7 @@ T_4214: (in 0<u64> : uint64)
 T_4215: (in rax_64 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_4216: (in 0<u64> : uint64)
   Class: Eq_18
   DataType: byte
@@ -23497,7 +23508,7 @@ T_4262: (in rdi : Eq_18)
 T_4263: (in rbx_13 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_4264: (in rdi < rsi : bool)
   Class: Eq_4264
   DataType: bool
@@ -23958,11 +23969,11 @@ T_4378: (in 0xFFFFFFFFFFFFFFF0<64> : word64)
   Class: Eq_4378
   DataType: ui64
   OrigDataType: ui64
-T_4379: (in (word64) rax_48 + 31<i32> & 0xFFFFFFFFFFFFFFF0<64> : word64)
+T_4379: (in (word32) rax_48 + 31<i32> & 0xFFFFFFFFFFFFFFF0<64> : word64)
   Class: Eq_4379
   DataType: Eq_4379
   OrigDataType: (union ((ptr64 wchar_t) u1) ((ptr64 mbstate_t) u0) ((ptr64 mbstate_t) u2))
-T_4380: (in fp - 0x2088<64> - ((word64) rax_48 + 31<i32> & 0xFFFFFFFFFFFFFFF0<64>) : word64)
+T_4380: (in fp - 0x2088<64> - ((word32) rax_48 + 31<i32> & 0xFFFFFFFFFFFFFFF0<64>) : word64)
   Class: Eq_4380
   DataType: Eq_4380
   OrigDataType: (union ((ptr64 wchar_t) u1) ((ptr64 mbstate_t) u0) ((ptr64 mbstate_t) u2))
@@ -24006,11 +24017,11 @@ T_4390: (in out r8_46 : ptr64)
   Class: Eq_4355
   DataType: ptr64
   OrigDataType: ptr64
-T_4391: (in fn000000000040E6F0(0xFFFFFFFFFFFFFFFF<64>, rsi, (word64) rax_48 + 1<i32>, v24_71, rdx, fs, out rsi_52, out r8_46) : word64)
+T_4391: (in fn000000000040E6F0(0xFFFFFFFFFFFFFFFF<64>, rsi, (word32) rax_48 + 1<i32>, v24_71, rdx, fs, out rsi_52, out r8_46) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
-T_4392: (in SLICE(fn000000000040E6F0(0xFFFFFFFFFFFFFFFF<64>, rsi, (word64) rax_48 + 1<i32>, v24_71, rdx, fs, out rsi_52, out r8_46), word32, 32) : word32)
+T_4392: (in SLICE(fn000000000040E6F0(0xFFFFFFFFFFFFFFFF<64>, rsi, (word32) rax_48 + 1<i32>, v24_71, rdx, fs, out rsi_52, out r8_46), word32, 32) : word32)
   Class: Eq_4365
   DataType: word32
   OrigDataType: word32
@@ -26733,7 +26744,7 @@ T_5071: (in 000000000061B018 : ptr64)
 T_5072: (in Mem40[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_5073: (in rax : Eq_5073)
   Class: Eq_5073
   DataType: Eq_5073
@@ -26878,7 +26889,7 @@ T_5108: (in Mem16[rdi + 0x18<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
-T_5109: (in fn000000000040CD70(fp - 0x2B8<64>, *((word64) rdi + 24<i32>)) : word64)
+T_5109: (in fn000000000040CD70(fp - 0x2B8<64>, *((word32) rdi + 24<i32>)) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -26982,7 +26993,7 @@ T_5134: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_5135: (in *((word64) rdi + 176<i32>) == 0<8> : bool)
+T_5135: (in *((word32) rdi + 176<i32>) == 0<8> : bool)
   Class: Eq_5135
   DataType: bool
   OrigDataType: bool
@@ -27130,11 +27141,11 @@ T_5171: (in Mem16[rdi + 0xA8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 char)
-T_5172: (in strlen(*((word64) rdi + 168<i32>)) : size_t)
+T_5172: (in strlen(*((word32) rdi + 168<i32>)) : size_t)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: size_t
-T_5173: (in SEQ(rax_32_32_100, strlen(*((word64) rdi + 168<i32>))) : word64)
+T_5173: (in SEQ(rax_32_32_100, strlen(*((word32) rdi + 168<i32>))) : word64)
   Class: Eq_5173
   DataType: word64
   OrigDataType: word64
@@ -27142,7 +27153,7 @@ T_5174: (in 1<64> : word64)
   Class: Eq_5174
   DataType: word64
   OrigDataType: word64
-T_5175: (in SEQ(rax_32_32_100, strlen(*((word64) rdi + 168<i32>))) + 1<64> : word64)
+T_5175: (in SEQ(rax_32_32_100, strlen(*((word32) rdi + 168<i32>))) + 1<64> : word64)
   Class: Eq_5163
   DataType: Eq_5163
   OrigDataType: word64
@@ -27238,7 +27249,7 @@ T_5198: (in out r8_241 : ptr64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: ptr64
-T_5199: (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x2B8<64>, *((word64) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_241) : word64)
+T_5199: (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x2B8<64>, *((word32) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_241) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -27362,7 +27373,7 @@ T_5229: (in out rsi_242 : ptr64)
   Class: Eq_4906
   DataType: Eq_4906
   OrigDataType: ptr64
-T_5230: (in fn0000000000405C20(rcx_141, (word32) (uint64) *((word64) rdi + 160<i32>), (uint64) *((word64) rdi + 40<i32>), (byte) (word32) *((word64) rdi + 176<i32>), out rsi_242) : word64)
+T_5230: (in fn0000000000405C20(rcx_141, (word32) (uint64) *((word32) rdi + 160<i32>), (uint64) *((word32) rdi + 40<i32>), (byte) (word32) *((word32) rdi + 176<i32>), out rsi_242) : word64)
   Class: Eq_5018
   DataType: word64
   OrigDataType: word64
@@ -27477,7 +27488,7 @@ T_5257: (in r8_126 : Eq_18)
 T_5258: (in rsi_127 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_5259: (in rax_117 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
@@ -27665,7 +27676,7 @@ T_5304: (in rcx_77 >> 1<64> > 0xFFFFFFFF<64> : bool)
 T_5305: (in rax_107 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_5306: (in fn0000000000410C40 : ptr64)
   Class: Eq_410
   DataType: (ptr64 Eq_410)
@@ -27790,7 +27801,7 @@ T_5336: (in 0x10<64> : word64)
   Class: Eq_5336
   DataType: word64
   OrigDataType: word64
-T_5337: (in (word64) rsi_101 + rcx_98 * 0x18<64> + 0x10<64> : word64)
+T_5337: (in (word32) rsi_101 + rcx_98 * 0x18<64> + 0x10<64> : word64)
   Class: Eq_5332
   DataType: (ptr64 Eq_5332)
   OrigDataType: word64
@@ -27913,7 +27924,7 @@ T_5366: (in Mem136[rsi_127 + 8<64>:word64] : word64)
 T_5367: (in rdx_137 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_5368: (in 0<u64> : uint64)
   Class: Eq_18
   DataType: byte
@@ -27921,7 +27932,7 @@ T_5368: (in 0<u64> : uint64)
 T_5369: (in rbp_156 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_5370: (in 0<u64> : uint64)
   Class: Eq_18
   DataType: byte
@@ -27973,7 +27984,7 @@ T_5381: (in Mem163[0x000000000061B0C8<p64>:word64] : word64)
 T_5382: (in rsi_191 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_5383: (in 000000000061B028 : ptr64)
   Class: Eq_5383
   DataType: (ptr64 Eq_18)
@@ -28238,7 +28249,7 @@ T_5448: (in out r8_126 : ptr64)
   Class: Eq_5078
   DataType: ptr64
   OrigDataType: ptr64
-T_5449: (in fn0000000000405D50(*((word64) globals->t61B1A8 + rbp_156 * 8<64>), r12_17, fs, rLoc4, out r8_126) : word64)
+T_5449: (in fn0000000000405D50(*((word32) globals->t61B1A8 + rbp_156 * 8<64>), r12_17, fs, rLoc4, out r8_126) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -28373,7 +28384,7 @@ T_5481: (in rsi_191 + 8<64> : word64)
 T_5482: (in Mem253[rsi_191 + 8<64>:word64] : word64)
   Class: Eq_5479
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_5483: (in 0<64> : word64)
   Class: Eq_5483
   DataType: word64
@@ -28398,7 +28409,7 @@ T_5488: (in Mem254[rsi_191 + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: up64
-T_5489: (in *((word64) rsi_191 + 8<i32>) < r13_190 : bool)
+T_5489: (in *((word32) rsi_191 + 8<i32>) < r13_190 : bool)
   Class: Eq_5489
   DataType: Eq_5489
   OrigDataType: bool
@@ -28973,7 +28984,7 @@ T_5631: (in 2<64> : word64)
 T_5632: (in rax_65 + 2<64> : word64)
   Class: Eq_5566
   DataType: (ptr64 word32)
-  OrigDataType: (ptr64 word32)
+  OrigDataType: ptr64
 T_5633: (in rax_134 : uint64)
   Class: Eq_5530
   DataType: uint64
@@ -29994,7 +30005,7 @@ T_5887: (in 0<8> : byte)
   Class: Eq_5795
   DataType: byte
   OrigDataType: byte
-T_5888: (in *((word64) rdi + 177<i32>) == 0<8> : bool)
+T_5888: (in *((word32) rdi + 177<i32>) == 0<8> : bool)
   Class: Eq_5888
   DataType: bool
   OrigDataType: bool
@@ -30062,7 +30073,7 @@ T_5904: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_5905: (in *((word64) rdi + 176<i32>) != 0<8> : bool)
+T_5905: (in *((word32) rdi + 176<i32>) != 0<8> : bool)
   Class: Eq_5905
   DataType: bool
   OrigDataType: bool
@@ -30318,7 +30329,7 @@ T_5968: (in Mem25[rbp_363 + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 char)
-T_5969: (in strncmp(r15_373 - rdx_379, *((word64) rbp_363 + 8<i32>), rdx_379) : int32)
+T_5969: (in strncmp(r15_373 - rdx_379, *((word32) rbp_363 + 8<i32>), rdx_379) : int32)
   Class: Eq_1703
   DataType: int32
   OrigDataType: int32
@@ -30326,7 +30337,7 @@ T_5970: (in 0<32> : word32)
   Class: Eq_1703
   DataType: int32
   OrigDataType: word32
-T_5971: (in strncmp(r15_373 - rdx_379, *((word64) rbp_363 + 8<i32>), rdx_379) == 0<32> : bool)
+T_5971: (in strncmp(r15_373 - rdx_379, *((word32) rbp_363 + 8<i32>), rdx_379) == 0<32> : bool)
   Class: Eq_5971
   DataType: bool
   OrigDataType: bool
@@ -30426,7 +30437,7 @@ T_5995: (in (uint128) (uint64) (rbp_591 - 1<64> + rcx) : uint128)
   Class: Eq_5995
   DataType: uint128
   OrigDataType: uint128
-T_5996: (in (uint128) (uint64) ((word64) rcx + (rbp_591 - 1<64>)) /u rcx_578 : word64)
+T_5996: (in (uint128) (uint64) ((word32) rcx + (rbp_591 - 1<64>)) /u rcx_578 : word64)
   Class: Eq_5996
   DataType: uint64
   OrigDataType: uint64
@@ -30434,7 +30445,7 @@ T_5997: (in (uint64) ((uint128) (uint64) (rbp_591 - 1<64> + rcx) /u rcx_578) : u
   Class: Eq_5990
   DataType: uint64
   OrigDataType: uint64
-T_5998: (in (uint64) ((uint128) (uint64) rcx /u rcx_578) == (uint64) ((uint128) ((uint64) ((word64) rcx + (rbp_591 - 1<64>))) /u rcx_578) : bool)
+T_5998: (in (uint64) ((uint128) (uint64) rcx /u rcx_578) == (uint64) ((uint128) ((uint64) ((word32) rcx + (rbp_591 - 1<64>))) /u rcx_578) : bool)
   Class: Eq_5998
   DataType: bool
   OrigDataType: bool
@@ -31234,7 +31245,7 @@ T_6197: (in 0<8> : byte)
   Class: Eq_6196
   DataType: byte
   OrigDataType: byte
-T_6198: (in *((word64) rdi + 184<i32>) == 0<8> : bool)
+T_6198: (in *((word32) rdi + 184<i32>) == 0<8> : bool)
   Class: Eq_6198
   DataType: bool
   OrigDataType: bool
@@ -31378,7 +31389,7 @@ T_6233: (in 1<64> : word64)
   Class: Eq_18
   DataType: byte
   OrigDataType: up64
-T_6234: (in *((word64) rdi + 32<i32>) <= 1<64> : bool)
+T_6234: (in *((word32) rdi + 32<i32>) <= 1<64> : bool)
   Class: Eq_6234
   DataType: bool
   OrigDataType: bool
@@ -31970,7 +31981,7 @@ T_6381: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_6382: (in *((word64) rdi + 176<i32>) == 0<8> : bool)
+T_6382: (in *((word32) rdi + 176<i32>) == 0<8> : bool)
   Class: Eq_6382
   DataType: bool
   OrigDataType: bool
@@ -32009,7 +32020,7 @@ T_6390: (in rdi : (ptr64 Eq_6390))
 T_6391: (in fp : ptr64)
   Class: Eq_6391
   DataType: Eq_6391
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6392: (in 0x12A8<64> : word64)
   Class: Eq_6392
   DataType: ui64
@@ -32026,7 +32037,7 @@ T_6395: (in rdi + 0x10<64> : word64)
   Class: Eq_6390
   DataType: (ptr64 Eq_6390)
   OrigDataType: ptr64
-T_6396: (in fn000000000040A600(fp - 0x12A8<64>, (word64) rdi + 16<i32>) : void)
+T_6396: (in fn000000000040A600(fp - 0x12A8<64>, (word32) rdi + 16<i32>) : void)
   Class: Eq_6396
   DataType: void
   OrigDataType: void
@@ -32146,7 +32157,7 @@ T_6425: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_6426: (in *((word64) rdi + 176<i32>) == 0<8> : bool)
+T_6426: (in *((word32) rdi + 176<i32>) == 0<8> : bool)
   Class: Eq_6426
   DataType: bool
   OrigDataType: bool
@@ -32169,7 +32180,7 @@ T_6430: (in globals->b61B144 == 0<8> : bool)
 T_6431: (in rsp_328 : Eq_6431)
   Class: Eq_6431
   DataType: Eq_6431
-  OrigDataType: word64
+  OrigDataType: word32
 T_6432: (in 0x12E8<64> : word64)
   Class: Eq_6432
   DataType: ui64
@@ -32194,14 +32205,14 @@ T_6437: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_6438: (in *((word64) rdi + 176<i32>) != 0<8> : bool)
+T_6438: (in *((word32) rdi + 176<i32>) != 0<8> : bool)
   Class: Eq_6438
   DataType: bool
   OrigDataType: bool
 T_6439: (in r14_1182 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_6440: (in 0x413764<u64> : uint64)
   Class: Eq_18
   DataType: byte
@@ -32222,7 +32233,7 @@ T_6444: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_6445: (in *((word64) rdi + 176<i32>) != 0<8> : bool)
+T_6445: (in *((word32) rdi + 176<i32>) != 0<8> : bool)
   Class: Eq_6445
   DataType: bool
   OrigDataType: bool
@@ -32290,7 +32301,7 @@ T_6461: (in out r8_1589 : ptr64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: ptr64
-T_6462: (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x1278<64>, *((word64) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_1589) : word64)
+T_6462: (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x1278<64>, *((word32) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_1589) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -32369,7 +32380,7 @@ T_6480: (in r15d_281 <= 0<32> : bool)
 T_6481: (in rbp_109 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_6482: (in eax_287 : word32)
   Class: Eq_6482
   DataType: word32
@@ -32413,7 +32424,7 @@ T_6491: (in (word64) rbp_109 + 1<i32> + (uint64) eax_287 : word64)
 T_6492: (in rdx_293 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_6493: (in 1<64> : word64)
   Class: Eq_6493
   DataType: word64
@@ -32662,7 +32673,7 @@ T_6554: (in Mem323[rdi + 0x20<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
-T_6555: (in fn000000000040CD70(fp - 0x1278<64>, *((word64) rdi + 32<i32>)) : word64)
+T_6555: (in fn000000000040CD70(fp - 0x1278<64>, *((word32) rdi + 32<i32>)) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -32789,7 +32800,7 @@ T_6585: (in 000000000061B018 : ptr64)
 T_6586: (in Mem387[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_6587: (in 000000000061A569 : ptr64)
   Class: Eq_6587
   DataType: (ptr64 byte)
@@ -32813,7 +32824,7 @@ T_6591: (in fputs_unlocked : ptr64)
 T_6592: (in 0xE88<64> : word64)
   Class: Eq_6592
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6593: (in fp - 0xE88<64> : word64)
   Class: Eq_18
   DataType: Eq_18
@@ -32841,7 +32852,7 @@ T_6598: (in Mem389[0x000000000061B018<p64>:word64] : word64)
 T_6599: (in fp - 0xE88<64> : word64)
   Class: Eq_6599
   DataType: Eq_6599
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6600: (in rbp_1180 - (fp - 0xE88<64>) : word64)
   Class: Eq_6600
   DataType: int64
@@ -32857,7 +32868,7 @@ T_6602: (in 000000000061B018 : ptr64)
 T_6603: (in Mem418[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_6604: (in 000000000061A569 : ptr64)
   Class: Eq_6604
   DataType: (ptr64 byte)
@@ -32929,11 +32940,11 @@ T_6620: (in __sprintf_chk : ptr64)
 T_6621: (in 0xE88<64> : word64)
   Class: Eq_6621
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6622: (in fp - 0xE88<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6623: (in 1<u64> : uint64)
   Class: Eq_5551
   DataType: int32
@@ -32957,11 +32968,11 @@ T_6627: (in __sprintf_chk(fp - 0xE88<64>, 1<u64>, 0xE3B<u64>, "%*s ", 0<32>) : i
 T_6628: (in rdx_143 : Eq_6628)
   Class: Eq_6628
   DataType: Eq_6628
-  OrigDataType: word64
+  OrigDataType: word32
 T_6629: (in fp - 0xE88<64> : word64)
   Class: Eq_6628
   DataType: Eq_6628
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6630: (in rdi_115 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
@@ -32993,11 +33004,11 @@ T_6636: (in fn000000000040CD70 : ptr64)
 T_6637: (in 0x1278<64> : word64)
   Class: Eq_6637
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6638: (in fp - 0x1278<64> : word64)
   Class: Eq_5101
   DataType: Eq_5101
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6639: (in fn000000000040CD70(fp - 0x1278<64>, rdi_115) : word64)
   Class: Eq_18
   DataType: Eq_18
@@ -33005,7 +33016,7 @@ T_6639: (in fn000000000040CD70(fp - 0x1278<64>, rdi_115) : word64)
 T_6640: (in r13_656 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_6641: (in r14_559 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
@@ -33026,7 +33037,7 @@ T_6645: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_6646: (in *((word64) rdi + 176<i32>) == 0<8> : bool)
+T_6646: (in *((word32) rdi + 176<i32>) == 0<8> : bool)
   Class: Eq_6646
   DataType: bool
   OrigDataType: bool
@@ -33041,7 +33052,7 @@ T_6648: (in 0<64> : word64)
 T_6649: (in rdx_143 + 0<64> : word64)
   Class: Eq_6649
   DataType: Eq_6649
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6650: (in Mem105[rdx_143 + 0<64>:word32] : word32)
   Class: Eq_6650
   DataType: word32
@@ -33113,11 +33124,11 @@ T_6666: (in SLICE(rax_154, word32, 0) : word32)
 T_6667: (in 4<64> : word64)
   Class: Eq_6667
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6668: (in rdx_143 + 4<64> : word64)
   Class: Eq_6628
   DataType: Eq_6628
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6669: (in al_172 : bui8)
   Class: Eq_6669
   DataType: bui8
@@ -33141,15 +33152,15 @@ T_6673: (in eax_155 == 0<32> : bool)
 T_6674: (in rbp_160 : Eq_6628)
   Class: Eq_6628
   DataType: Eq_6628
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6675: (in 2<64> : word64)
   Class: Eq_6675
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6676: (in rdx_143 + 2<64> : word64)
   Class: Eq_6628
   DataType: Eq_6628
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6677: (in ecx_166 : word32)
   Class: Eq_6677
   DataType: word32
@@ -33213,11 +33224,11 @@ T_6691: (in SLICE(ecx_166, byte, 0) : byte)
 T_6692: (in 3<8> : byte)
   Class: Eq_6692
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6693: (in rbp_160 - 3<8> : word64)
   Class: Eq_6693
   DataType: Eq_6693
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6694: (in 2<8> : byte)
   Class: Eq_6694
   DataType: bui8
@@ -33233,11 +33244,11 @@ T_6696: (in 0<8> : byte)
 T_6697: (in al_172 * 2<8> < 0<8> : bool)
   Class: Eq_6697
   DataType: Eq_6697
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6698: (in rbp_160 - 3<8> - (al_172 * 2<8> < 0<8>) : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6699: (in 0x413764<u64> : uint64)
   Class: Eq_18
   DataType: byte
@@ -33266,7 +33277,7 @@ T_6705: (in 0xB000<32> : word32)
   Class: Eq_6705
   DataType: ui32
   OrigDataType: ui32
-T_6706: (in (word32) (uint64) *((word64) rdi + 40<i32>) & 0xB000<32> : word32)
+T_6706: (in (word32) (uint64) *((word32) rdi + 40<i32>) & 0xB000<32> : word32)
   Class: Eq_6706
   DataType: ui32
   OrigDataType: ui32
@@ -33282,7 +33293,7 @@ T_6709: (in 0x2000<32> : word32)
   Class: Eq_6708
   DataType: word32
   OrigDataType: word32
-T_6710: (in (word32) (uint64) ((word32) (uint64) *((word64) rdi + 40<i32>) & 0xB000<32>) == 0x2000<32> : bool)
+T_6710: (in (word32) (uint64) ((word32) (uint64) *((word32) rdi + 40<i32>) & 0xB000<32>) == 0x2000<32> : bool)
   Class: Eq_6710
   DataType: bool
   OrigDataType: bool
@@ -33434,7 +33445,7 @@ T_6747: (in (uint64) (SEQ(SLICE(rax_566 >>u 0xC<64>, word24, 8), SLICE(rax_566 >
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: uint64
-T_6748: (in fn000000000040CD70((word64) rsp_328 + 112<i32>, (uint64) (SEQ(SLICE(rax_566 >> 0xC<64>, word24, 8), (byte) (rax_566 >> 0xC<64>) & 0<8>) | (word32) ((byte) rax_566))) : word64)
+T_6748: (in fn000000000040CD70((word32) rsp_328 + 112<i32>, (uint64) (SEQ(SLICE(rax_566 >> 0xC<64>, word24, 8), (byte) (rax_566 >> 0xC<64>) & 0<8>) | (word32) ((byte) rax_566))) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -33558,7 +33569,7 @@ T_6778: (in (uint64) (SLICE((uint64) (SLICE(rdx_598 >>u 0x20<64>, word32, 0) & 0
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: uint64
-T_6779: (in fn000000000040CD70((word64) rsp_328 + 80<i32>, (uint64) ((word32) (uint64) ((word32) (rdx_598 >> 0x20<64>) & 0xFFFFF000<32>) | (word32) ((uint64) ((word32) ((uint64) ((word32) (rdx_598 >> 8<64>))) & 0xFFF<32>)))) : word64)
+T_6779: (in fn000000000040CD70((word32) rsp_328 + 80<i32>, (uint64) ((word32) (uint64) ((word32) (rdx_598 >> 0x20<64>) & 0xFFFFF000<32>) | (word32) ((uint64) ((word32) ((uint64) ((word32) (rdx_598 >> 8<64>))) & 0xFFF<32>)))) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -33634,7 +33645,7 @@ T_6797: (in out r8_1590 : ptr64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: ptr64
-T_6798: (in fn000000000040BD70(1<u64>, (word32) (uint64) globals->dw61B134, (word64) rsp_328 + 112<i32>, *((word64) rdi + 64<i32>), globals->t61A560, fs, rLoc4, out r8_1590) : word64)
+T_6798: (in fn000000000040BD70(1<u64>, (word32) (uint64) globals->dw61B134, (word32) rsp_328 + 112<i32>, *((word32) rdi + 64<i32>), globals->t61A560, fs, rLoc4, out r8_1590) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -33685,19 +33696,19 @@ T_6809: (in SLICE((word32) Mem750[r14_559 - 1<64> + 0<64>:byte], byte, 0) : byte
 T_6810: (in 1<64> : word64)
   Class: Eq_6810
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6811: (in rbp_1180 + 1<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6812: (in 1<64> : word64)
   Class: Eq_6812
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6813: (in r13_656 - 1<64> : word64)
   Class: Eq_6813
   DataType: Eq_6813
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6814: (in 0<64> : word64)
   Class: Eq_6814
   DataType: word64
@@ -33705,7 +33716,7 @@ T_6814: (in 0<64> : word64)
 T_6815: (in r13_656 - 1<64> + 0<64> : word64)
   Class: Eq_6815
   DataType: Eq_6815
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6816: (in Mem757[r13_656 - 1<64> + 0<64>:byte] : byte)
   Class: Eq_6802
   DataType: Eq_6813
@@ -33745,35 +33756,35 @@ T_6824: (in SLICE((uint64) (eax_730 - 1<32>), word32, 0) : word32)
 T_6825: (in rcx_736 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6826: (in 1<64> : word64)
   Class: Eq_6826
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6827: (in rbp_1180 + 1<64> : word64)
   Class: Eq_6827
   DataType: Eq_6827
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6828: (in (uint64) eax_732 : uint64)
   Class: Eq_6828
   DataType: Eq_6828
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
-T_6829: (in (word64) rbp_1180 + 1<i32> + (uint64) eax_732 : word64)
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
+T_6829: (in (word32) rbp_1180 + 1<i32> + (uint64) eax_732 : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6830: (in rdx_737 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_6831: (in 1<64> : word64)
   Class: Eq_6831
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6832: (in rdx_737 + 1<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6833: (in 0x20<8> : byte)
   Class: Eq_6833
   DataType: byte
@@ -33781,11 +33792,11 @@ T_6833: (in 0x20<8> : byte)
 T_6834: (in 1<64> : word64)
   Class: Eq_6834
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6835: (in rdx_737 - 1<64> : word64)
   Class: Eq_6835
   DataType: Eq_6835
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6836: (in 0<64> : word64)
   Class: Eq_6836
   DataType: word64
@@ -33793,7 +33804,7 @@ T_6836: (in 0<64> : word64)
 T_6837: (in rdx_737 - 1<64> + 0<64> : word64)
   Class: Eq_6837
   DataType: Eq_6837
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6838: (in Mem740[rdx_737 - 1<64> + 0<64>:byte] : byte)
   Class: Eq_6833
   DataType: Eq_6835
@@ -33805,19 +33816,19 @@ T_6839: (in rdx_737 != rcx_736 : bool)
 T_6840: (in 1<64> : word64)
   Class: Eq_6840
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6841: (in rbp_1180 + 1<64> : word64)
   Class: Eq_6841
   DataType: Eq_6841
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6842: (in (int64) eax_732 : int64)
   Class: Eq_6842
   DataType: Eq_6842
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
-T_6843: (in (word64) rbp_1180 + 1<i32> + (int64) eax_732 : word64)
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
+T_6843: (in (word32) rbp_1180 + 1<i32> + (int64) eax_732 : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6844: (in fn00000000004057B0 : ptr64)
   Class: Eq_6844
   DataType: (ptr64 Eq_6844)
@@ -33878,22 +33889,22 @@ T_6858: (in (uint64) Mem418[rdi + 0x2C<64>:word32] : uint64)
   Class: Eq_4846
   DataType: Eq_4846
   OrigDataType: uint64
-T_6859: (in fn00000000004057B0((byte) (word32) *((word64) rdi + 176<i32>), (word32) (uint64) globals->dw61B168, (uint64) *((word64) rdi + 44<i32>), fs) : word64)
+T_6859: (in fn00000000004057B0((byte) (word32) *((word32) rdi + 176<i32>), (word32) (uint64) globals->dw61B168, (uint64) *((word32) rdi + 44<i32>), fs) : word64)
   Class: Eq_6859
   DataType: word64
   OrigDataType: word64
-T_6860: (in SLICE(fn00000000004057B0((byte) (word32) *((word64) rdi + 176<i32>), (word32) (uint64) globals->dw61B168, (uint64) *((word64) rdi + 44<i32>), fs), word32, 32) : word32)
+T_6860: (in SLICE(fn00000000004057B0((byte) (word32) *((word32) rdi + 176<i32>), (word32) (uint64) globals->dw61B168, (uint64) *((word32) rdi + 44<i32>), fs), word32, 32) : word32)
   Class: Eq_4760
   DataType: word32
   OrigDataType: word32
 T_6861: (in 0x12F0<64> : word64)
   Class: Eq_6861
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6862: (in fp - 0x12F0<64> : word64)
   Class: Eq_6431
   DataType: Eq_6431
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6863: (in 000000000061A568 : ptr64)
   Class: Eq_6863
   DataType: (ptr64 byte)
@@ -34002,7 +34013,7 @@ T_6889: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_6890: (in *((word64) rdi + 176<i32>) == 0<8> : bool)
+T_6890: (in *((word32) rdi + 176<i32>) == 0<8> : bool)
   Class: Eq_6890
   DataType: bool
   OrigDataType: bool
@@ -34025,7 +34036,7 @@ T_6894: (in globals->b61B146 != 0<8> : bool)
 T_6895: (in fp - 0xE88<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6896: (in fn00000000004057B0 : ptr64)
   Class: Eq_6844
   DataType: (ptr64 Eq_6844)
@@ -34082,22 +34093,22 @@ T_6909: (in (uint64) Mem496[rdi + 0x2C<64>:word32] : uint64)
   Class: Eq_4846
   DataType: Eq_4846
   OrigDataType: uint64
-T_6910: (in fn00000000004057B0((byte) (word32) *((word64) rdi + 176<i32>), (word32) (uint64) globals->dw61B160, (uint64) *((word64) rdi + 44<i32>), fs) : word64)
+T_6910: (in fn00000000004057B0((byte) (word32) *((word32) rdi + 176<i32>), (word32) (uint64) globals->dw61B160, (uint64) *((word32) rdi + 44<i32>), fs) : word64)
   Class: Eq_6859
   DataType: word64
   OrigDataType: word64
-T_6911: (in SLICE(fn00000000004057B0((byte) (word32) *((word64) rdi + 176<i32>), (word32) (uint64) globals->dw61B160, (uint64) *((word64) rdi + 44<i32>), fs), word32, 32) : word32)
+T_6911: (in SLICE(fn00000000004057B0((byte) (word32) *((word32) rdi + 176<i32>), (word32) (uint64) globals->dw61B160, (uint64) *((word32) rdi + 44<i32>), fs), word32, 32) : word32)
   Class: Eq_4760
   DataType: word32
   OrigDataType: word32
 T_6912: (in 0xFFFFFFFFFFFFFFF8<64> : word64)
   Class: Eq_6912
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6913: (in rsp_328 + 0xFFFFFFFFFFFFFFF8<64> : word64)
   Class: Eq_6431
   DataType: Eq_6431
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6914: (in 000000000061B17D : ptr64)
   Class: Eq_6914
   DataType: (ptr64 byte)
@@ -34117,7 +34128,7 @@ T_6917: (in globals->b61B17D == 0<8> : bool)
 T_6918: (in fp - 0xE88<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6919: (in 000000000061B17D : ptr64)
   Class: Eq_6919
   DataType: (ptr64 byte)
@@ -34137,7 +34148,7 @@ T_6922: (in globals->b61B17D != 0<8> : bool)
 T_6923: (in fp - 0xE88<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6924: (in fn0000000000405700 : ptr64)
   Class: Eq_4867
   DataType: (ptr64 Eq_4867)
@@ -34166,11 +34177,11 @@ T_6930: (in Mem496[rdi + 0xA8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
-T_6931: (in fn0000000000405700(rax_32_32_376, (uint64) globals->t61B16C, *((word64) rdi + 168<i32>), fs) : word64)
+T_6931: (in fn0000000000405700(rax_32_32_376, (uint64) globals->t61B16C, *((word32) rdi + 168<i32>), fs) : word64)
   Class: Eq_4843
   DataType: word64
   OrigDataType: word64
-T_6932: (in SLICE(fn0000000000405700(rax_32_32_376, (uint64) globals->t61B16C, *((word64) rdi + 168<i32>), fs), word32, 32) : word32)
+T_6932: (in SLICE(fn0000000000405700(rax_32_32_376, (uint64) globals->t61B16C, *((word32) rdi + 168<i32>), fs), word32, 32) : word32)
   Class: Eq_4760
   DataType: word32
   OrigDataType: word32
@@ -34185,7 +34196,7 @@ T_6934: (in 0<64> : word64)
 T_6935: (in rbp_1180 + 0<64> : word64)
   Class: Eq_6935
   DataType: Eq_6935
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6936: (in Mem759[rbp_1180 + 0<64>:byte] : byte)
   Class: Eq_6933
   DataType: Eq_18
@@ -34229,11 +34240,11 @@ T_6945: (in rdi : int64)
 T_6946: (in 0x50<64> : word64)
   Class: Eq_6946
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6947: (in rsp_328 + 0x50<64> : word64)
   Class: Eq_6944
   DataType: Eq_6944
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6948: (in 0x30<64> : word64)
   Class: Eq_6948
   DataType: word64
@@ -34241,12 +34252,12 @@ T_6948: (in 0x30<64> : word64)
 T_6949: (in rsp_328 + 0x30<64> : word64)
   Class: Eq_6949
   DataType: Eq_6949
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6950: (in Mem900[rsp_328 + 0x30<64>:word64] : word64)
   Class: Eq_56
   DataType: int64
   OrigDataType: word64
-T_6951: (in fn000000000040CCD0((word64) rsp_328 + 80<i32>, *((word64) rsp_328 + 48<i32>)) : word64)
+T_6951: (in fn000000000040CCD0((word32) rsp_328 + 80<i32>, *((word32) rsp_328 + 48<i32>)) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -34289,7 +34300,7 @@ T_6960: (in 0x30<64> : word64)
 T_6961: (in rsp_328 + 0x30<64> : word64)
   Class: Eq_6961
   DataType: Eq_6961
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6962: (in Mem765[rsp_328 + 0x30<64>:word64] : word64)
   Class: Eq_56
   DataType: int64
@@ -34313,7 +34324,7 @@ T_6966: (in 0x38<64> : word64)
 T_6967: (in rsp_328 + 0x38<64> : word64)
   Class: Eq_6967
   DataType: Eq_6967
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6968: (in Mem765[rsp_328 + 0x38<64>:word32] : word32)
   Class: Eq_67
   DataType: Eq_67
@@ -34329,7 +34340,7 @@ T_6970: (in 0x10<64> : word64)
 T_6971: (in rsp_328 + 0x10<64> : word64)
   Class: Eq_6971
   DataType: Eq_6971
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6972: (in Mem788[rsp_328 + 0x10<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_6431
@@ -34377,7 +34388,7 @@ T_6982: (in 0x30<64> : word64)
 T_6983: (in rsp_328 + 0x30<64> : word64)
   Class: Eq_6983
   DataType: Eq_6983
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6984: (in Mem788[rsp_328 + 0x30<64>:word64] : word64)
   Class: Eq_56
   DataType: int64
@@ -34389,7 +34400,7 @@ T_6985: (in 0x38<64> : word64)
 T_6986: (in rsp_328 + 0x38<64> : word64)
   Class: Eq_6986
   DataType: Eq_6986
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6987: (in Mem788[rsp_328 + 0x38<64>:word32] : word32)
   Class: Eq_67
   DataType: Eq_67
@@ -34401,7 +34412,7 @@ T_6988: (in 0x10<64> : word64)
 T_6989: (in rsp_328 + 0x10<64> : word64)
   Class: Eq_6989
   DataType: Eq_6989
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_6990: (in Mem788[rsp_328 + 0x10<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
@@ -34456,7 +34467,7 @@ T_7002: (in signature of fn0000000000406A80 : void)
   OrigDataType: 
 T_7003: (in 0x61A3D0<32> : word32)
   Class: Eq_7003
-  DataType: (ptr32 (arr Eq_18))
+  DataType: (ptr32 (arr Eq_17561))
   OrigDataType: (ptr32 (struct (0 (arr T_17561) a0000)))
 T_7004: (in (int64) edi_837 : int64)
   Class: Eq_7004
@@ -34474,7 +34485,7 @@ T_7007: (in 0x61A3D0<32>[(int64) edi_837 * 8<64>] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
-T_7008: (in fn0000000000406A80(rax_763, (&globals->t61A3D0)[(int64) edi_837], r13_656, fs) : word64)
+T_7008: (in fn0000000000406A80(rax_763, (&globals->t61A3D0)[(int64) edi_837].t0000, r13_656, fs) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -34569,7 +34580,7 @@ T_7030: (in 0x18<64> : word64)
 T_7031: (in rsp_328 + 0x18<64> : word64)
   Class: Eq_7031
   DataType: Eq_7031
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7032: (in Mem464[rsp_328 + 0x18<64>:word64] : word64)
   Class: Eq_6884
   DataType: Eq_6431
@@ -34581,7 +34592,7 @@ T_7033: (in 0x10<64> : word64)
 T_7034: (in rsp_328 + 0x10<64> : word64)
   Class: Eq_7034
   DataType: Eq_7034
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7035: (in Mem466[rsp_328 + 0x10<64>:word32] : word32)
   Class: Eq_18
   DataType: Eq_6431
@@ -34621,7 +34632,7 @@ T_7043: (in 0x10<64> : word64)
 T_7044: (in rsp_328 + 0x10<64> : word64)
   Class: Eq_7044
   DataType: Eq_7044
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7045: (in Mem466[rsp_328 + 0x10<64>:word32] : word32)
   Class: Eq_18
   DataType: Eq_18
@@ -34637,7 +34648,7 @@ T_7047: (in 0<64> : word64)
 T_7048: (in r13_656 + 0<64> : word64)
   Class: Eq_7048
   DataType: Eq_7048
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7049: (in Mem852[r13_656 + 0<64>:byte] : byte)
   Class: Eq_7049
   DataType: byte
@@ -34709,7 +34720,7 @@ T_7065: (in rax_1012 + 1<64> : word64)
 T_7066: (in r13_1008 : Eq_7065)
   Class: Eq_7065
   DataType: Eq_7065
-  OrigDataType: word64
+  OrigDataType: word32
 T_7067: (in r13_1040 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
@@ -34717,7 +34728,7 @@ T_7067: (in r13_1040 : Eq_18)
 T_7068: (in fp - 0xE88<64> : word64)
   Class: Eq_7068
   DataType: Eq_7068
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7069: (in r13_1008 - (fp - 0xE88<64>) : word64)
   Class: Eq_18
   DataType: Eq_18
@@ -34733,7 +34744,7 @@ T_7071: (in fputs_unlocked : ptr64)
 T_7072: (in fp - 0xE88<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7073: (in 000000000061A610 : ptr64)
   Class: Eq_7073
   DataType: (ptr64 (ptr64 Eq_2123))
@@ -34870,7 +34881,7 @@ T_7106: (in 0<64> : word64)
   Class: Eq_18
   DataType: byte
   OrigDataType: word64
-T_7107: (in *((word64) rdi + 8<i32>) == 0<64> : bool)
+T_7107: (in *((word32) rdi + 8<i32>) == 0<64> : bool)
   Class: Eq_7107
   DataType: bool
   OrigDataType: bool
@@ -34962,7 +34973,7 @@ T_7129: (in SLICE((word32) Mem1056[rdi + 0xB0<64>:byte], byte, 0) : byte)
   Class: Eq_5014
   DataType: byte
   OrigDataType: byte
-T_7130: (in fn0000000000405D00(rcx_1071, rdx_1080, (uint64) *((word64) rdi + 40<i32>), (byte) (word32) *((word64) rdi + 176<i32>)) : word64)
+T_7130: (in fn0000000000405D00(rcx_1071, rdx_1080, (uint64) *((word32) rdi + 40<i32>), (byte) (word32) *((word32) rdi + 176<i32>)) : word64)
   Class: Eq_7130
   DataType: word64
   OrigDataType: word64
@@ -34982,7 +34993,7 @@ T_7134: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_7135: (in *((word64) rdi + 176<i32>) != 0<8> : bool)
+T_7135: (in *((word32) rdi + 176<i32>) != 0<8> : bool)
   Class: Eq_7135
   DataType: bool
   OrigDataType: bool
@@ -35061,7 +35072,7 @@ T_7153: (in 000000000061B018 : ptr64)
 T_7154: (in Mem1097[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_7155: (in rcx_1106 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
@@ -35082,7 +35093,7 @@ T_7159: (in r13_1040 + 4<64> : word64)
   Class: Eq_7159
   DataType: word64
   OrigDataType: word64
-T_7160: (in (word64) r13_1040 + 4<i32> + rax_1075 : word64)
+T_7160: (in (word32) r13_1040 + 4<i32> + rax_1075 : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -35102,7 +35113,7 @@ T_7164: (in out r8_1069 : ptr64)
   Class: Eq_5769
   DataType: ptr64
   OrigDataType: ptr64
-T_7165: (in fn0000000000406540(SEQ(rax_32_32_1100, eax_1091), (word64) r13_1040 + 4<i32> + rax_1075, null, 1<8>, rdi, fs, out rcx_1106, out r8_1069) : word64)
+T_7165: (in fn0000000000406540(SEQ(rax_32_32_1100, eax_1091), (word32) r13_1040 + 4<i32> + rax_1075, null, 1<8>, rdi, fs, out rcx_1106, out r8_1069) : word64)
   Class: Eq_7083
   DataType: word64
   OrigDataType: word64
@@ -35158,7 +35169,7 @@ T_7178: (in 1<8> : byte)
   Class: Eq_5014
   DataType: byte
   OrigDataType: byte
-T_7179: (in fn0000000000405D00(rcx_1106, 0<u64>, (uint64) *((word64) rdi + 164<i32>), 1<8>) : word64)
+T_7179: (in fn0000000000405D00(rcx_1106, 0<u64>, (uint64) *((word32) rdi + 164<i32>), 1<8>) : word64)
   Class: Eq_7130
   DataType: word64
   OrigDataType: word64
@@ -35193,7 +35204,7 @@ T_7186: (in 8<64> : word64)
 T_7187: (in rsp_328 + 8<64> : word64)
   Class: Eq_7187
   DataType: Eq_7187
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7188: (in Mem639[rsp_328 + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_6431
@@ -35205,7 +35216,7 @@ T_7189: (in 0<64> : word64)
 T_7190: (in rsp_328 + 0<64> : word64)
   Class: Eq_7190
   DataType: Eq_7190
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7191: (in Mem642[rsp_328 + 0<64>:word32] : word32)
   Class: Eq_6753
   DataType: Eq_6431
@@ -35237,11 +35248,11 @@ T_7197: (in __sprintf_chk(rbp_1180, 1<u64>, 0xFFFFFFFFFFFFFFFF<64>, "%*s, %*s ",
 T_7198: (in 1<64> : word64)
   Class: Eq_7198
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7199: (in rbp_1180 + 1<64> : word64)
   Class: Eq_7199
   DataType: Eq_7199
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7200: (in 000000000061B154 : ptr64)
   Class: Eq_7200
   DataType: (ptr64 Eq_3944)
@@ -35253,11 +35264,11 @@ T_7201: (in Mem642[0x000000000061B154<p64>:word32] : word32)
 T_7202: (in (int64) Mem642[0x000000000061B154<p64>:word32] : int64)
   Class: Eq_7202
   DataType: Eq_7202
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
-T_7203: (in (word64) rbp_1180 + 1<i32> + (int64) globals->t61B154 : word64)
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
+T_7203: (in (word32) rbp_1180 + 1<i32> + (int64) globals->t61B154 : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7204: (in 0x10<64> : word64)
   Class: Eq_7204
   DataType: word64
@@ -35265,7 +35276,7 @@ T_7204: (in 0x10<64> : word64)
 T_7205: (in rsp_328 + 0x10<64> : word64)
   Class: Eq_7205
   DataType: Eq_7205
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7206: (in Mem926[rsp_328 + 0x10<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_6431
@@ -35281,7 +35292,7 @@ T_7208: (in 0x28<64> : word64)
 T_7209: (in rsp_328 + 0x28<64> : word64)
   Class: Eq_7209
   DataType: Eq_7209
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7210: (in Mem927[rsp_328 + 0x28<64>:word64] : word64)
   Class: Eq_7207
   DataType: Eq_6431
@@ -35305,12 +35316,12 @@ T_7214: (in t : time_t)
 T_7215: (in 0x28<64> : word64)
   Class: Eq_7215
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7216: (in rsp_328 + 0x28<64> : word64)
   Class: Eq_7214
   DataType: Eq_7214
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
-T_7217: (in localtime((word64) rsp_328 + 40<i32>) : (ptr64 (struct "tm")))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
+T_7217: (in localtime((word32) rsp_328 + 40<i32>) : (ptr64 (struct "tm")))
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 (struct "tm"))
@@ -35365,11 +35376,11 @@ T_7229: (in (uint32) strlen(r13_656) : uint32)
 T_7230: (in (uint64) (uint32) strlen(r13_656) : uint64)
   Class: Eq_7230
   DataType: Eq_7230
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7231: (in r13_656 + (uint64) ((uint32) strlen(r13_656)) : word64)
   Class: Eq_7065
   DataType: Eq_7065
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7232: (in r13d_726 : int32)
   Class: Eq_7232
   DataType: int32
@@ -35437,12 +35448,12 @@ T_7247: (in localtime : ptr64)
 T_7248: (in 0x30<64> : word64)
   Class: Eq_7248
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7249: (in rsp_328 + 0x30<64> : word64)
   Class: Eq_7214
   DataType: Eq_7214
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
-T_7250: (in localtime((word64) rsp_328 + 48<i32>) : (ptr64 (struct "tm")))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
+T_7250: (in localtime((word32) rsp_328 + 48<i32>) : (ptr64 (struct "tm")))
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 (struct "tm"))
@@ -35457,7 +35468,7 @@ T_7252: (in 0<64> : word64)
 T_7253: (in r13_656 + 0<64> : word64)
   Class: Eq_7253
   DataType: Eq_7253
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7254: (in Mem765[r13_656 + 0<64>:byte] : byte)
   Class: Eq_7251
   DataType: Eq_18
@@ -35478,7 +35489,7 @@ T_7258: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_7259: (in *((word64) rdi + 176<i32>) == 0<8> : bool)
+T_7259: (in *((word32) rdi + 176<i32>) == 0<8> : bool)
   Class: Eq_7259
   DataType: bool
   OrigDataType: bool
@@ -35513,12 +35524,12 @@ T_7266: (in Mem927[0x000000000061A3D0<p64>:word64] : word64)
 T_7267: (in 0x70<64> : word64)
   Class: Eq_7267
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7268: (in rsp_328 + 0x70<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
-T_7269: (in fn0000000000406A80(rax_928, globals->t61A3D0, (word64) rsp_328 + 112<i32>, fs) : word64)
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
+T_7269: (in fn0000000000406A80(rax_928, globals->t61A3D0, (word32) rsp_328 + 112<i32>, fs) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -35553,7 +35564,7 @@ T_7276: (in 0x10<64> : word64)
 T_7277: (in rsp_328 + 0x10<64> : word64)
   Class: Eq_7277
   DataType: Eq_7277
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7278: (in Mem927[rsp_328 + 0x10<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
@@ -35573,7 +35584,7 @@ T_7281: (in 0x10<64> : word64)
 T_7282: (in rsp_328 + 0x10<64> : word64)
   Class: Eq_7282
   DataType: Eq_7282
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7283: (in Mem968[rsp_328 + 0x10<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_6431
@@ -35593,16 +35604,16 @@ T_7286: (in 0<u64> : uint64)
 T_7287: (in 0x70<64> : word64)
   Class: Eq_7287
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7288: (in rsp_328 + 0x70<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
-T_7289: (in fn000000000040D240(0<u64>, rax_948, (word64) rsp_328 + 112<i32>, fs) : word64)
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
+T_7289: (in fn000000000040D240(0<u64>, rax_948, (word32) rsp_328 + 112<i32>, fs) : word64)
   Class: Eq_4427
   DataType: word64
   OrigDataType: word64
-T_7290: (in SLICE(fn000000000040D240(0<u64>, rax_948, (word64) rsp_328 + 112<i32>, fs), word32, 0) : word32)
+T_7290: (in SLICE(fn000000000040D240(0<u64>, rax_948, (word32) rsp_328 + 112<i32>, fs), word32, 0) : word32)
   Class: Eq_7181
   DataType: word32
   OrigDataType: word32
@@ -35633,11 +35644,11 @@ T_7296: (in r8d_981 >= 0<32> : bool)
 T_7297: (in 0xE88<64> : word64)
   Class: Eq_7297
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7298: (in fp - 0xE88<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17678) u0) ((ptr64 Eq_17634) u4) (time_t u5))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17677) u0) ((ptr64 Eq_17633) u4) (time_t u5))
 T_7299: (in 000000000061B114 : ptr64)
   Class: Eq_7299
   DataType: (ptr64 byte)
@@ -35734,7 +35745,7 @@ T_7322: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_7323: (in *((word64) rdi + 176<i32>) == 0<8> : bool)
+T_7323: (in *((word32) rdi + 176<i32>) == 0<8> : bool)
   Class: Eq_7323
   DataType: bool
   OrigDataType: bool
@@ -35786,7 +35797,7 @@ T_7335: (in 0<8> : byte)
   Class: Eq_5133
   DataType: byte
   OrigDataType: byte
-T_7336: (in *((word64) rdi + 176<i32>) != 0<8> : bool)
+T_7336: (in *((word32) rdi + 176<i32>) != 0<8> : bool)
   Class: Eq_7336
   DataType: bool
   OrigDataType: bool
@@ -35854,7 +35865,7 @@ T_7352: (in out r8_282 : ptr64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: ptr64
-T_7353: (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x2B8<64>, *((word64) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_282) : word64)
+T_7353: (in fn000000000040BD70(0x200<u64>, (word32) (uint64) globals->dw61B140, fp - 0x2B8<64>, *((word32) rdi + 80<i32>), globals->t61B138, fs, rLoc4, out r8_282) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -36158,7 +36169,7 @@ T_7428: (in SLICE((word32) Mem17[rdi + 0xB0<64>:byte], byte, 0) : byte)
   Class: Eq_5014
   DataType: byte
   OrigDataType: byte
-T_7429: (in fn0000000000405D00(rcx_174, (uint64) *((word64) rdi + 160<i32>), (uint64) *((word64) rdi + 40<i32>), (byte) (word32) *((word64) rdi + 176<i32>)) : word64)
+T_7429: (in fn0000000000405D00(rcx_174, (uint64) *((word32) rdi + 160<i32>), (uint64) *((word32) rdi + 40<i32>), (byte) (word32) *((word32) rdi + 176<i32>)) : word64)
   Class: Eq_7130
   DataType: word64
   OrigDataType: word64
@@ -36197,7 +36208,7 @@ T_7437: (in Mem24[0x000000000061B150<p64>:word32] : word32)
 T_7438: (in rbx_522 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_7439: (in 0<u64> : uint64)
   Class: Eq_18
   DataType: byte
@@ -36221,7 +36232,7 @@ T_7443: (in globals->t61B1B0 == 0<64> : bool)
 T_7444: (in rbx_466 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_7445: (in 0<u64> : uint64)
   Class: Eq_18
   DataType: byte
@@ -36513,7 +36524,7 @@ T_7516: (in 0<u64> : uint64)
 T_7517: (in rbx_184 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_7518: (in 1<u64> : uint64)
   Class: Eq_18
   DataType: byte
@@ -36654,7 +36665,7 @@ T_7552: (in Mem469[0x000000000061B1A8<p64>:word64][rbx_466 * 8<64>] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
-T_7553: (in fn0000000000407870(0<u64>, *((word64) globals->t61B1A8 + rbx_466 * 8<64>), fs, rLoc4) : word64)
+T_7553: (in fn0000000000407870(0<u64>, *((word32) globals->t61B1A8 + rbx_466 * 8<64>), fs, rLoc4) : word64)
   Class: Eq_7432
   DataType: word64
   OrigDataType: word64
@@ -36765,7 +36776,7 @@ T_7579: (in Mem24[Mem24[0x000000000061B1A8<p64>:word64] + 0<64>:word64] : word64
 T_7580: (in rbx_31 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_7581: (in 0<u64> : uint64)
   Class: Eq_18
   DataType: byte
@@ -37786,7 +37797,7 @@ T_7835: (in Mem550[0x000000000061B1A8<p64>:word64][rbx_522 * 8<64>] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
-T_7836: (in fn0000000000406B70(*((word64) globals->t61B1A8 + rbx_522 * 8<64>), fs, rLoc4) : word64)
+T_7836: (in fn0000000000406B70(*((word32) globals->t61B1A8 + rbx_522 * 8<64>), fs, rLoc4) : word64)
   Class: Eq_7432
   DataType: word64
   OrigDataType: word64
@@ -37849,7 +37860,7 @@ T_7850: (in 000000000061B018 : ptr64)
 T_7851: (in Mem581[0x000000000061B018<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_7852: (in 1<64> : word64)
   Class: Eq_7852
   DataType: word64
@@ -38653,19 +38664,19 @@ T_8051: (in r15b_439 != 0<8> : bool)
 T_8052: (in rax_495 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_8053: (in fp : ptr64)
   Class: Eq_8053
   DataType: Eq_8053
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8054: (in 0x3A8<64> : word64)
   Class: Eq_8054
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8055: (in fp - 0x3A8<64> : word64)
   Class: Eq_8055
   DataType: Eq_8055
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8056: (in strlen : ptr64)
   Class: Eq_2647
   DataType: (ptr64 Eq_2647)
@@ -38709,15 +38720,15 @@ T_8065: (in 0xFFFFFFFFFFFFFFF0<64> : word64)
 T_8066: (in SEQ(rax_32_32_2022, strlen(rdi)) + 0x20<64> + SEQ(rax_32_32_2022, strlen(rcx)) & 0xFFFFFFFFFFFFFFF0<64> : word64)
   Class: Eq_8066
   DataType: Eq_8066
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8067: (in fp - 0x3A8<64> - ((SEQ(rax_32_32_2022, strlen(rdi)) + 0x20<64>) + SEQ(rax_32_32_2022, strlen(rcx)) & 0xFFFFFFFFFFFFFFF0<64>) : word64)
   Class: Eq_8067
   DataType: Eq_8067
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8068: (in 0xF<64> : word64)
   Class: Eq_8068
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8069: (in fp - 0x3A8<64> - ((SEQ(rax_32_32_2022, strlen(rdi)) + 0x20<64>) + SEQ(rax_32_32_2022, strlen(rcx)) & 0xFFFFFFFFFFFFFFF0<64>) + 0xF<64> : word64)
   Class: Eq_8069
   DataType: Eq_8069
@@ -38993,7 +39004,7 @@ T_8136: (in 000000000061B1B0 : ptr64)
 T_8137: (in Mem2064[0x000000000061B1B0<p64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_8138: (in 0<64> : word64)
   Class: Eq_8138
   DataType: word64
@@ -40517,11 +40528,11 @@ T_8517: (in SLICE((uint64) Mem1365[0x000000000061B140<p64>:word32], word32, 0) :
 T_8518: (in 0x2D8<64> : word64)
   Class: Eq_8518
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8519: (in fp - 0x2D8<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8520: (in 000000000061B138 : ptr64)
   Class: Eq_8520
   DataType: (ptr64 Eq_368)
@@ -40565,7 +40576,7 @@ T_8529: (in r15d_1649 : word32)
 T_8530: (in fp - 0x2D8<64> : word64)
   Class: Eq_8530
   DataType: Eq_8530
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8531: (in SLICE(fp - 0x2D8<64>, word32, 0) : word32)
   Class: Eq_8529
   DataType: word32
@@ -40770,7 +40781,7 @@ T_8581: (in 0x10<64> : word64)
   Class: Eq_8581
   DataType: word64
   OrigDataType: word64
-T_8582: (in (word64) r9_113 + (rcx_117 << 6<64>) + 0x10<64> : word64)
+T_8582: (in (word32) r9_113 + (rcx_117 << 6<64>) + 0x10<64> : word64)
   Class: Eq_8039
   DataType: (ptr64 Eq_8039)
   OrigDataType: word64
@@ -41381,11 +41392,11 @@ T_8733: (in fn000000000040CD70 : ptr64)
 T_8734: (in 0x2F8<64> : word64)
   Class: Eq_8734
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8735: (in fp - 0x2F8<64> : word64)
   Class: Eq_5101
   DataType: Eq_5101
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8736: (in 0x20<64> : word64)
   Class: Eq_8736
   DataType: word64
@@ -41453,11 +41464,11 @@ T_8751: (in fn000000000040CD70 : ptr64)
 T_8752: (in 0x2D8<64> : word64)
   Class: Eq_8752
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8753: (in fp - 0x2D8<64> : word64)
   Class: Eq_5101
   DataType: Eq_5101
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8754: (in 0x18<64> : word64)
   Class: Eq_8754
   DataType: word64
@@ -41701,11 +41712,11 @@ T_8813: (in SLICE((uint64) Mem1748[0x000000000061B134<p64>:word32], word32, 0) :
 T_8814: (in 0x2D8<64> : word64)
   Class: Eq_8814
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8815: (in fp - 0x2D8<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8816: (in 0x40<64> : word64)
   Class: Eq_8816
   DataType: word64
@@ -41805,11 +41816,11 @@ T_8839: (in fn000000000040CD70 : ptr64)
 T_8840: (in 0x2D8<64> : word64)
   Class: Eq_8840
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8841: (in fp - 0x2D8<64> : word64)
   Class: Eq_5101
   DataType: Eq_5101
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8842: (in 0x20<64> : word64)
   Class: Eq_8842
   DataType: word64
@@ -41925,7 +41936,7 @@ T_8869: (in fn000000000040CD70 : ptr64)
 T_8870: (in fp - 0x2D8<64> : word64)
   Class: Eq_5101
   DataType: Eq_5101
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8871: (in 0xC<64> : word64)
   Class: Eq_8871
   DataType: word64
@@ -42061,7 +42072,7 @@ T_8903: (in __sprintf_chk : ptr64)
 T_8904: (in fp - 0x2D8<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8905: (in 1<u64> : uint64)
   Class: Eq_5551
   DataType: int32
@@ -42085,11 +42096,11 @@ T_8909: (in __sprintf_chk(fp - 0x2D8<64>, 1<u64>, 0x15<u64>, "%lu", 0<32>) : int
 T_8910: (in rdx_1608 : Eq_8910)
   Class: Eq_8910
   DataType: Eq_8910
-  OrigDataType: word64
+  OrigDataType: word32
 T_8911: (in fp - 0x2D8<64> : word64)
   Class: Eq_8910
   DataType: Eq_8910
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8912: (in rcx_1611 : uint64)
   Class: Eq_8912
   DataType: uint64
@@ -42101,7 +42112,7 @@ T_8913: (in 0<64> : word64)
 T_8914: (in rdx_1608 + 0<64> : word64)
   Class: Eq_8914
   DataType: Eq_8914
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8915: (in Mem1554[rdx_1608 + 0<64>:word32] : word32)
   Class: Eq_8915
   DataType: word32
@@ -42173,11 +42184,11 @@ T_8931: (in SLICE(rax_1619, word32, 0) : word32)
 T_8932: (in 4<64> : word64)
   Class: Eq_8932
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8933: (in rdx_1608 + 4<64> : word64)
   Class: Eq_8910
   DataType: Eq_8910
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8934: (in al_1637 : bui8)
   Class: Eq_8934
   DataType: bui8
@@ -42325,11 +42336,11 @@ T_8969: (in Mem1894[0x000000000061B154<p64>:word32] : word32)
 T_8970: (in 3<8> : byte)
   Class: Eq_8970
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8971: (in rdx_1608 - 3<8> : word64)
   Class: Eq_8971
   DataType: Eq_8971
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8972: (in 2<8> : byte)
   Class: Eq_8972
   DataType: bui8
@@ -42345,11 +42356,11 @@ T_8974: (in 0<8> : byte)
 T_8975: (in al_1637 * 2<8> < 0<8> : bool)
   Class: Eq_8975
   DataType: Eq_8975
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8976: (in rdx_1608 - 3<8> - (al_1637 * 2<8> < 0<8>) : word64)
   Class: Eq_8976
   DataType: Eq_8976
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8977: (in SLICE(rdx_1608 - 3<8> - (al_1637 * 2<8> <u 0<8>), word32, 0) : word32)
   Class: Eq_8977
   DataType: word32
@@ -42369,11 +42380,11 @@ T_8980: (in SLICE((uint64) (SLICE(rdx_1608 - 3<8> - (al_1637 * 2<8> <u 0<8>), wo
 T_8981: (in 2<64> : word64)
   Class: Eq_8981
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8982: (in rdx_1608 + 2<64> : word64)
   Class: Eq_8910
   DataType: Eq_8910
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_8983: (in 000000000061B164 : ptr64)
   Class: Eq_8983
   DataType: (ptr64 int32)
@@ -42873,11 +42884,11 @@ T_9106: (in 1<u64> : uint64)
 T_9107: (in 0x388<64> : word64)
   Class: Eq_9107
   DataType: byte
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_9108: (in fp - 0x388<64> : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17712) u0))
+  OrigDataType: (union ((union (bool u0) (byte u1)) u2) ((ptr64 char) u1) (byte u3) ((ptr64 Eq_17710) u0))
 T_9109: (in __xstat(1<u64>, r13_1169, fp - 0x388<64>) : int32)
   Class: Eq_1958
   DataType: Eq_1958
@@ -43342,14 +43353,14 @@ T_9224: (in 0<8> : byte)
   Class: Eq_4197
   DataType: byte
   OrigDataType: byte
-T_9225: (in *((word64) rcx + 1<i32>) == 0<8> : bool)
+T_9225: (in *((word32) rcx + 1<i32>) == 0<8> : bool)
   Class: Eq_9225
   DataType: bool
   OrigDataType: bool
 T_9226: (in rsi_502 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_9227: (in 1<64> : word64)
   Class: Eq_9227
   DataType: word64
@@ -43509,7 +43520,7 @@ T_9265: (in Mem550[rax_495 + 0<64>:byte] : byte)
 T_9266: (in rdx_535 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_9267: (in 1<64> : word64)
   Class: Eq_9267
   DataType: (ptr64 byte)
@@ -45445,7 +45456,7 @@ T_9749: (in 0xFFFFFFFFFFFFFFFF<64> : word64)
 T_9750: (in rbx_109 : Eq_9728)
   Class: Eq_9728
   DataType: Eq_9728
-  OrigDataType: word64
+  OrigDataType: word32
 T_9751: (in 0<u64> : uint64)
   Class: Eq_9728
   DataType: uint64
@@ -45606,7 +45617,7 @@ T_9790: (in qwLoc50_170 *s rcx + rdx : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 void)
-T_9791: (in memcmp((word64) rdx + qwLoc50_170 *s rcx, rbp_114, rcx) : int32)
+T_9791: (in memcmp((word32) rdx + qwLoc50_170 *s rcx, rbp_114, rcx) : int32)
   Class: Eq_2861
   DataType: int32
   OrigDataType: int32
@@ -45614,7 +45625,7 @@ T_9792: (in 0<32> : word32)
   Class: Eq_2861
   DataType: int32
   OrigDataType: word32
-T_9793: (in memcmp((word64) rdx + qwLoc50_170 *s rcx, rbp_114, rcx) == 0<32> : bool)
+T_9793: (in memcmp((word32) rdx + qwLoc50_170 *s rcx, rbp_114, rcx) == 0<32> : bool)
   Class: Eq_9793
   DataType: bool
   OrigDataType: bool
@@ -46473,7 +46484,7 @@ T_10006: (in (word32) Mem0[rdi + 0<64>:byte] : word32)
 T_10007: (in rax_11 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_10008: (in SLICE(edx_14, byte, 0) : byte)
   Class: Eq_10008
   DataType: byte
@@ -46489,7 +46500,7 @@ T_10010: (in (byte) edx_14 != 0x2F<8> : bool)
 T_10011: (in rdx_22 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_10012: (in (uint64) edx_14 : uint64)
   Class: Eq_10012
   DataType: uint64
@@ -46726,7 +46737,7 @@ T_10070: (in 0x2F<8> : byte)
   Class: Eq_10069
   DataType: byte
   OrigDataType: byte
-T_10071: (in *((word64) rax_11 + (rdi - 1<64>)) == 0x2F<8> : bool)
+T_10071: (in *((word32) rax_11 + (rdi - 1<64>)) == 0x2F<8> : bool)
   Class: Eq_10071
   DataType: bool
   OrigDataType: bool
@@ -48197,7 +48208,7 @@ T_10437: (in rax_42 == 0<64> : bool)
 T_10438: (in rbx_62 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_10439: (in 0<64> : word64)
   Class: Eq_10439
   DataType: word64
@@ -48322,7 +48333,7 @@ T_10469: (in rsi_52 + 1<64> + r14_12 + rax_85 : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (union (word64 u0) (size_t u1))
-T_10470: (in malloc((word64) rax_85 + ((word64) r14_12.u1 + ((word64) rsi_52 + 1<i32>))) : (ptr64 void))
+T_10470: (in malloc((word32) rax_85 + ((word64) r14_12.u1 + ((word32) rsi_52 + 1<i32>))) : (ptr64 void))
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 void)
@@ -48486,7 +48497,7 @@ T_10510: (in 0x2F<8> : byte)
   Class: Eq_10509
   DataType: byte
   OrigDataType: byte
-T_10511: (in *((word64) rbx_62 + 1<i32>) != 0x2F<8> : bool)
+T_10511: (in *((word32) rbx_62 + 1<i32>) != 0x2F<8> : bool)
   Class: Eq_10511
   DataType: bool
   OrigDataType: bool
@@ -49054,11 +49065,11 @@ T_10652: (in Mem0[rax_7 + 1<64>:byte] : byte)
   Class: Eq_10652
   DataType: byte
   OrigDataType: byte
-T_10653: (in cond(*((word64) rax_7 + 1<i32>)) : byte)
+T_10653: (in cond(*((word32) rax_7 + 1<i32>)) : byte)
   Class: Eq_10653
   DataType: byte
   OrigDataType: byte
-T_10654: (in SLICE(cond(*((word64) rax_7 + 1<i32>)), bool, 2) : bool)
+T_10654: (in SLICE(cond(*((word32) rax_7 + 1<i32>)), bool, 2) : bool)
   Class: Eq_10633
   DataType: bool
   OrigDataType: bool
@@ -49074,7 +49085,7 @@ T_10657: (in 0<8> : byte)
   Class: Eq_10652
   DataType: byte
   OrigDataType: byte
-T_10658: (in *((word64) rax_7 + 1<i32>) != 0<8> : bool)
+T_10658: (in *((word32) rax_7 + 1<i32>) != 0<8> : bool)
   Class: Eq_10658
   DataType: bool
   OrigDataType: bool
@@ -49446,7 +49457,7 @@ T_10750: (in Mem6[rdi + 0x10<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: up64
-T_10751: (in rax_14 >= *((word64) rdi + 16<i32>) : bool)
+T_10751: (in rax_14 >= *((word32) rdi + 16<i32>) : bool)
   Class: Eq_10751
   DataType: bool
   OrigDataType: bool
@@ -50377,7 +50388,7 @@ T_10982: (in SLICE((uint64) edx, byte, 0) : byte)
 T_10983: (in r13_164 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_10984: (in 0<64> : word64)
   Class: Eq_10984
   DataType: word64
@@ -50402,7 +50413,7 @@ T_10989: (in Mem27[rsi + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: up64
-T_10990: (in r13_164 >= *((word64) rsi + 8<i32>) : bool)
+T_10990: (in r13_164 >= *((word32) rsi + 8<i32>) : bool)
   Class: Eq_10990
   DataType: bool
   OrigDataType: bool
@@ -50430,7 +50441,7 @@ T_10996: (in Mem170[rsi + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: up64
-T_10997: (in *((word64) rsi + 8<i32>) > r13_164 : bool)
+T_10997: (in *((word32) rsi + 8<i32>) > r13_164 : bool)
   Class: Eq_10997
   DataType: bool
   OrigDataType: bool
@@ -50689,7 +50700,7 @@ T_11060: (in rdi + 0x18<64> : word64)
 T_11061: (in Mem66[rdi + 0x18<64>:word64] : word64)
   Class: Eq_11056
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_11062: (in 0<64> : word64)
   Class: Eq_18
   DataType: byte
@@ -50793,7 +50804,7 @@ T_11086: (in rdi + 0x18<64> : word64)
 T_11087: (in Mem109[rdi + 0x18<64>:word64] : word64)
   Class: Eq_11056
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_11088: (in rax_111 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
@@ -50962,7 +50973,7 @@ T_11129: (in 1<64> : word64)
   Class: Eq_11129
   DataType: word64
   OrigDataType: word64
-T_11130: (in *((word64) rsi + 24<i32>) - 1<64> : word64)
+T_11130: (in *((word32) rsi + 24<i32>) - 1<64> : word64)
   Class: Eq_11056
   DataType: Eq_11056
   OrigDataType: word64
@@ -50998,7 +51009,7 @@ T_11138: (in Mem163[rsi + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 (struct 0010 (0 word64 qw0000) (8 word64 qw0008)))
-T_11139: (in *((word64) rsi + 8<i32>) > r13_164 : bool)
+T_11139: (in *((word32) rsi + 8<i32>) > r13_164 : bool)
   Class: Eq_11139
   DataType: bool
   OrigDataType: bool
@@ -51158,19 +51169,19 @@ T_11178: (in out xmm2 : ptr64)
   Class: Eq_14
   DataType: Eq_14
   OrigDataType: (union (word128 u0) (ptr64 u1))
-T_11179: (in fn000000000040ADB0((word64) rax_47 + 40<i32>, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2) : byte)
+T_11179: (in fn000000000040ADB0((word32) rax_47 + 40<i32>, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2) : byte)
   Class: Eq_11179
   DataType: byte
   OrigDataType: byte
-T_11180: (in (uint8) fn000000000040ADB0((word64) rax_47 + 40<i32>, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2) : uint8)
+T_11180: (in (uint8) fn000000000040ADB0((word32) rax_47 + 40<i32>, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2) : uint8)
   Class: Eq_11180
   DataType: uint8
   OrigDataType: uint8
-T_11181: (in (uint64) (uint8) fn000000000040ADB0((word64) rax_47 + 40<i32>, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2) : uint64)
+T_11181: (in (uint64) (uint8) fn000000000040ADB0((word32) rax_47 + 40<i32>, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2) : uint64)
   Class: Eq_11181
   DataType: uint64
   OrigDataType: uint64
-T_11182: (in SLICE((uint64) (uint8) fn000000000040ADB0((word64) rax_47 + 40<i32>, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2), byte, 0) : byte)
+T_11182: (in SLICE((uint64) (uint8) fn000000000040ADB0((word32) rax_47 + 40<i32>, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2), byte, 0) : byte)
   Class: Eq_11182
   DataType: byte
   OrigDataType: byte
@@ -51178,7 +51189,7 @@ T_11183: (in 0<8> : byte)
   Class: Eq_11182
   DataType: byte
   OrigDataType: byte
-T_11184: (in (byte) (uint64) (uint8) fn000000000040ADB0((word64) rax_47 + 40<i32>, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2) == 0<8> : bool)
+T_11184: (in (byte) (uint64) (uint8) fn000000000040ADB0((word32) rax_47 + 40<i32>, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2) == 0<8> : bool)
   Class: Eq_11184
   DataType: bool
   OrigDataType: bool
@@ -51569,7 +51580,7 @@ T_11280: (in rax_47 + 8<64> : word64)
 T_11281: (in Mem221[rax_47 + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_11282: (in 0x40<64> : word64)
   Class: Eq_11282
   DataType: word64
@@ -51658,7 +51669,7 @@ T_11303: (in 0<64> : word64)
   Class: Eq_18
   DataType: byte
   OrigDataType: word64
-T_11304: (in *((word64) rdi + 64<i32>) == 0<64> : bool)
+T_11304: (in *((word32) rdi + 64<i32>) == 0<64> : bool)
   Class: Eq_11304
   DataType: bool
   OrigDataType: bool
@@ -51690,14 +51701,14 @@ T_11311: (in 0<64> : word64)
   Class: Eq_18
   DataType: byte
   OrigDataType: word64
-T_11312: (in *((word64) rdi + 32<i32>) != 0<64> : bool)
+T_11312: (in *((word32) rdi + 32<i32>) != 0<64> : bool)
   Class: Eq_11312
   DataType: bool
   OrigDataType: bool
 T_11313: (in r12_19 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_11314: (in 0<64> : word64)
   Class: Eq_11314
   DataType: word64
@@ -51722,7 +51733,7 @@ T_11319: (in Mem14[rdi + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: up64
-T_11320: (in r12_19 >= *((word64) rdi + 8<i32>) : bool)
+T_11320: (in r12_19 >= *((word32) rdi + 8<i32>) : bool)
   Class: Eq_11320
   DataType: bool
   OrigDataType: bool
@@ -51810,7 +51821,7 @@ T_11341: (in Mem14[rdi + 8<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: up64
-T_11342: (in *((word64) rdi + 8<i32>) > r12_57 : bool)
+T_11342: (in *((word32) rdi + 8<i32>) > r12_57 : bool)
   Class: Eq_11342
   DataType: bool
   OrigDataType: bool
@@ -52270,7 +52281,7 @@ T_11456: (in Mem12[rdi + 0x10<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
-T_11457: (in *((word64) rdi + 16<i32>) == rax_71 : bool)
+T_11457: (in *((word32) rdi + 16<i32>) == rax_71 : bool)
   Class: Eq_11457
   DataType: bool
   OrigDataType: bool
@@ -52994,7 +53005,7 @@ T_11637: (in out xmm2_104 : ptr64)
   Class: Eq_14
   DataType: Eq_14
   OrigDataType: (union (word128 u0) (ptr64 u1))
-T_11638: (in fn000000000040ADB0((word64) rdi + 40<i32>, xmm0, xmm1, xmm2, out xmm0_102, out xmm1_103, out xmm2_104) : byte)
+T_11638: (in fn000000000040ADB0((word32) rdi + 40<i32>, xmm0, xmm1, xmm2, out xmm0_102, out xmm1_103, out xmm2_104) : byte)
   Class: Eq_11179
   DataType: byte
   OrigDataType: byte
@@ -53129,7 +53140,7 @@ T_11670: (in rdi + 0x20<64> : word64)
 T_11671: (in Mem270[rdi + 0x20<64>:word64] : word64)
   Class: Eq_11266
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_11672: (in 0x18<64> : word64)
   Class: Eq_11672
   DataType: word64
@@ -53161,7 +53172,7 @@ T_11678: (in rdi + 0x18<64> : word64)
 T_11679: (in Mem272[rdi + 0x18<64>:word64] : word64)
   Class: Eq_11056
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_11680: (in 1<u64> : uint64)
   Class: Eq_11567
   DataType: uint64
@@ -53357,7 +53368,7 @@ T_11727: (in rdi + 0x20<64> : word64)
 T_11728: (in Mem297[rdi + 0x20<64>:word64] : word64)
   Class: Eq_11266
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_11729: (in 1<32> : word32)
   Class: Eq_11552
   DataType: word32
@@ -53998,7 +54009,7 @@ T_11888: (in 1<64> : word64)
   Class: Eq_11888
   DataType: word64
   OrigDataType: word64
-T_11889: (in *((word64) rdi + 32<i32>) - 1<64> : word64)
+T_11889: (in *((word32) rdi + 32<i32>) - 1<64> : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -54270,7 +54281,7 @@ T_11956: (in out xmm2_108 : ptr64)
   Class: Eq_14
   DataType: Eq_14
   OrigDataType: (union (word128 u0) (ptr64 u1))
-T_11957: (in fn000000000040ADB0((word64) rdi + 40<i32>, xmm0_131, xmm1_152, xmm2, out xmm0_106, out xmm1_107, out xmm2_108) : byte)
+T_11957: (in fn000000000040ADB0((word32) rdi + 40<i32>, xmm0_131, xmm1_152, xmm2, out xmm0_106, out xmm1_107, out xmm2_108) : byte)
   Class: Eq_11179
   DataType: byte
   OrigDataType: byte
@@ -54510,7 +54521,7 @@ T_12016: (in Mem48[rax_116 + 4<64>:real32] : real32)
   Class: Eq_12016
   DataType: real32
   OrigDataType: real32
-T_12017: (in (real32) xmm0_131 * *((word64) rax_116 + 4<i32>) : real32)
+T_12017: (in (real32) xmm0_131 * *((word32) rax_116 + 4<i32>) : real32)
   Class: Eq_12017
   DataType: real32
   OrigDataType: real32
@@ -54534,7 +54545,7 @@ T_12022: (in 0<8> : byte)
   Class: Eq_12021
   DataType: byte
   OrigDataType: byte
-T_12023: (in *((word64) rax_116 + 16<i32>) != 0<8> : bool)
+T_12023: (in *((word32) rax_116 + 16<i32>) != 0<8> : bool)
   Class: Eq_12023
   DataType: bool
   OrigDataType: bool
@@ -54574,7 +54585,7 @@ T_12032: (in Mem48[rax_116 + 8<64>:real32] : real32)
   Class: Eq_12032
   DataType: real32
   OrigDataType: real32
-T_12033: (in (real32) xmm0_174 * *((word64) rax_116 + 8<i32>) : real32)
+T_12033: (in (real32) xmm0_174 * *((word32) rax_116 + 8<i32>) : real32)
   Class: Eq_12033
   DataType: real32
   OrigDataType: real32
@@ -55125,7 +55136,7 @@ T_12169: (in 0x413990<u64> : uint64)
 T_12170: (in r8_1044 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_12171: (in rdi_132 : uint64)
   Class: Eq_12171
   DataType: uint64
@@ -56470,11 +56481,11 @@ T_12506: (in rsi + 0x287<64> : word64)
   Class: Eq_12506
   DataType: (ptr64 byte)
   OrigDataType: (ptr64 byte)
-T_12507: (in (word64) rsi + 647<i32> - r11_66 : word64)
+T_12507: (in (word32) rsi + 647<i32> - r11_66 : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 void)
-T_12508: (in memcpy((word64) rsi + 647<i32> - r11_66, r15_478, r11_66) : (ptr64 void))
+T_12508: (in memcpy((word32) rsi + 647<i32> - r11_66, r15_478, r11_66) : (ptr64 void))
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 void)
@@ -57094,7 +57105,7 @@ T_12662: (in rsi + 0x288<64> : word64)
   Class: Eq_12662
   DataType: (ptr64 byte)
   OrigDataType: (ptr64 byte)
-T_12663: (in (word64) rsi + 648<i32> - r15_1031 : word64)
+T_12663: (in (word32) rsi + 648<i32> - r15_1031 : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: ptr64
@@ -58429,7 +58440,7 @@ T_12995: (in r12_13 : (ptr64 Eq_12992))
 T_12996: (in rbx_21 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_12997: (in 0<64> : word64)
   Class: Eq_18
   DataType: byte
@@ -58569,7 +58580,7 @@ T_13030: (in r14b_359 : byte)
 T_13031: (in rbx_103 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_13032: (in fn0000000000411360 : ptr64)
   Class: Eq_13032
   DataType: (ptr64 Eq_13032)
@@ -59414,7 +59425,7 @@ T_13242: (in 0<8> : byte)
   Class: Eq_18
   DataType: byte
   OrigDataType: byte
-T_13243: (in *((word64) rbx_15 + 16<i32>) == 0<8> : bool)
+T_13243: (in *((word32) rbx_15 + 16<i32>) == 0<8> : bool)
   Class: Eq_13243
   DataType: bool
   OrigDataType: bool
@@ -59454,7 +59465,7 @@ T_13252: (in rax_45 + 0x10<64> : word64)
   Class: Eq_6350
   DataType: (ptr64 char)
   OrigDataType: (ptr64 char)
-T_13253: (in strcpy((word64) rax_45 + 16<i32>, r12_31) : (ptr64 char))
+T_13253: (in strcpy((word32) rax_45 + 16<i32>, r12_31) : (ptr64 char))
   Class: Eq_6364
   DataType: (ptr64 char)
   OrigDataType: (ptr64 char)
@@ -59694,7 +59705,7 @@ T_13312: (in 0<8> : byte)
   Class: Eq_18
   DataType: byte
   OrigDataType: byte
-T_13313: (in *((word64) rbx_15 + 16<i32>) == 0<8> : bool)
+T_13313: (in *((word32) rbx_15 + 16<i32>) == 0<8> : bool)
   Class: Eq_13313
   DataType: bool
   OrigDataType: bool
@@ -59734,7 +59745,7 @@ T_13322: (in rax_45 + 0x10<64> : word64)
   Class: Eq_6350
   DataType: (ptr64 char)
   OrigDataType: (ptr64 char)
-T_13323: (in strcpy((word64) rax_45 + 16<i32>, r12_31) : (ptr64 char))
+T_13323: (in strcpy((word32) rax_45 + 16<i32>, r12_31) : (ptr64 char))
   Class: Eq_6364
   DataType: (ptr64 char)
   OrigDataType: (ptr64 char)
@@ -60269,7 +60280,7 @@ T_13455: (in SEQ(rax_32_32, strlen(rdi)) : word64)
 T_13456: (in r13_14 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_13457: (in bl_36 : byte)
   Class: Eq_13457
   DataType: byte
@@ -60613,7 +60624,7 @@ T_13541: (in 0<u64> : uint64)
 T_13542: (in qwLoc48_560 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_13543: (in 0<32> : word32)
   Class: Eq_13543
   DataType: word32
@@ -61281,7 +61292,7 @@ T_13708: (in mempcpy(r13_14, qwLoc60_547, rdx_427) : (ptr64 void))
 T_13709: (in rdx_463 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_13710: (in rsi_464 : uint64)
   Class: Eq_13710
   DataType: uint64
@@ -61549,7 +61560,7 @@ T_13775: (in rdi + rsi : word64)
 T_13776: (in rbp_130 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_13777: (in rax_32_32_134 : word32)
   Class: Eq_13777
   DataType: word32
@@ -62657,7 +62668,7 @@ T_14052: (in fn000000000040D450(rcx, qwLoc48, rdi, rsi >> 3<64>, rdi, out rdx_10
 T_14053: (in r14_111 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_14054: (in 3<64> : word64)
   Class: Eq_14054
   DataType: word64
@@ -62669,7 +62680,7 @@ T_14055: (in rsi >> 3<64> : word64)
 T_14056: (in r15_209 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_14057: (in 8<64> : word64)
   Class: Eq_14057
   DataType: int64
@@ -62842,9 +62853,9 @@ T_14099: (in 8<64> : word64)
   Class: Eq_14099
   DataType: ui64
   OrigDataType: ui64
-T_14100: (in rdi - 8<64> : (arr Eq_18))
+T_14100: (in rdi - 8<64> : (arr Eq_17578))
   Class: Eq_14100
-  DataType: (ptr64 (arr Eq_18))
+  DataType: (ptr64 (arr Eq_17578))
   OrigDataType: (ptr64 (struct (0 (arr T_17578) a0000)))
 T_14101: (in r15_144 : uint64)
   Class: Eq_14101
@@ -62882,9 +62893,9 @@ T_14109: (in 8<64> : word64)
   Class: Eq_14109
   DataType: ui64
   OrigDataType: ui64
-T_14110: (in rdi - 8<64> : (arr Eq_18))
+T_14110: (in rdi - 8<64> : (arr Eq_17579))
   Class: Eq_14110
-  DataType: (ptr64 (arr Eq_18))
+  DataType: (ptr64 (arr Eq_17579))
   OrigDataType: (ptr64 (struct (0 (arr T_17579) a0000)))
 T_14111: (in 8<64> : word64)
   Class: Eq_14111
@@ -62970,7 +62981,7 @@ T_14131: (in rdx_132 << 3<64> : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (union (ui64 u0) (size_t u1))
-T_14132: (in memcpy(r15_209, (word64) rdi + qwLoc40_295 * 8<64>, rdx_132 << 3<64>) : (ptr64 void))
+T_14132: (in memcpy(r15_209, (word32) rdi + qwLoc40_295 * 8<64>, rdx_132 << 3<64>) : (ptr64 void))
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 void)
@@ -63078,7 +63089,7 @@ T_14158: (in r15_186 * 8<64> : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (union (ui64 u0) (size_t u1))
-T_14159: (in memcpy((word64) rdi + r15_144 * 8<64>, rsi_188, r15_186 * 8<64>) : (ptr64 void))
+T_14159: (in memcpy((word32) rdi + r15_144 * 8<64>, rsi_188, r15_186 * 8<64>) : (ptr64 void))
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 void)
@@ -63104,12 +63115,12 @@ T_14164: (in 0<64> : word64)
   OrigDataType: word64
 T_14165: (in rdi + 0<64> : word64)
   Class: Eq_14165
-  DataType: ptr64
-  OrigDataType: ptr64
+  DataType: (ptr64 (arr Eq_18))
+  OrigDataType: (ptr64 (arr Eq_18))
 T_14166: (in Mem225[rdi + 0<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: (arr Eq_18)
 T_14167: (in 8<64> : word64)
   Class: Eq_14167
   DataType: word64
@@ -64030,7 +64041,7 @@ T_14396: (in 0xFFFFFFDF<32> : word32)
   Class: Eq_14396
   DataType: ui32
   OrigDataType: ui32
-T_14397: (in (word32) *((word64) rax_24 + 1<i32>) & 0xFFFFFFDF<32> : word32)
+T_14397: (in (word32) *((word32) rax_24 + 1<i32>) & 0xFFFFFFDF<32> : word32)
   Class: Eq_14397
   DataType: ui32
   OrigDataType: ui32
@@ -64082,7 +64093,7 @@ T_14409: (in 0xFFFFFFDF<32> : word32)
   Class: Eq_14409
   DataType: ui32
   OrigDataType: ui32
-T_14410: (in (word32) *((word64) rax_24 + 2<i32>) & 0xFFFFFFDF<32> : word32)
+T_14410: (in (word32) *((word32) rax_24 + 2<i32>) & 0xFFFFFFDF<32> : word32)
   Class: Eq_14410
   DataType: ui32
   OrigDataType: ui32
@@ -64118,7 +64129,7 @@ T_14418: (in 0x2D<8> : byte)
   Class: Eq_14417
   DataType: byte
   OrigDataType: byte
-T_14419: (in *((word64) rax_24 + 3<i32>) != 0x2D<8> : bool)
+T_14419: (in *((word32) rax_24 + 3<i32>) != 0x2D<8> : bool)
   Class: Eq_14419
   DataType: bool
   OrigDataType: bool
@@ -64138,7 +64149,7 @@ T_14423: (in 0x38<8> : byte)
   Class: Eq_14422
   DataType: byte
   OrigDataType: byte
-T_14424: (in *((word64) rax_24 + 4<i32>) != 0x38<8> : bool)
+T_14424: (in *((word32) rax_24 + 4<i32>) != 0x38<8> : bool)
   Class: Eq_14424
   DataType: bool
   OrigDataType: bool
@@ -64158,7 +64169,7 @@ T_14428: (in 0<8> : byte)
   Class: Eq_14427
   DataType: byte
   OrigDataType: byte
-T_14429: (in *((word64) rax_24 + 5<i32>) != 0<8> : bool)
+T_14429: (in *((word32) rax_24 + 5<i32>) != 0<8> : bool)
   Class: Eq_14429
   DataType: bool
   OrigDataType: bool
@@ -64210,7 +64221,7 @@ T_14441: (in 0xFFFFFFDF<32> : word32)
   Class: Eq_14441
   DataType: ui32
   OrigDataType: ui32
-T_14442: (in (word32) *((word64) rax_24 + 1<i32>) & 0xFFFFFFDF<32> : word32)
+T_14442: (in (word32) *((word32) rax_24 + 1<i32>) & 0xFFFFFFDF<32> : word32)
   Class: Eq_14442
   DataType: ui32
   OrigDataType: ui32
@@ -64246,7 +64257,7 @@ T_14450: (in 0x31<8> : byte)
   Class: Eq_14407
   DataType: byte
   OrigDataType: byte
-T_14451: (in *((word64) rax_24 + 2<i32>) != 0x31<8> : bool)
+T_14451: (in *((word32) rax_24 + 2<i32>) != 0x31<8> : bool)
   Class: Eq_14451
   DataType: bool
   OrigDataType: bool
@@ -64266,7 +64277,7 @@ T_14455: (in 0x38<8> : byte)
   Class: Eq_14417
   DataType: byte
   OrigDataType: byte
-T_14456: (in *((word64) rax_24 + 3<i32>) != 0x38<8> : bool)
+T_14456: (in *((word32) rax_24 + 3<i32>) != 0x38<8> : bool)
   Class: Eq_14456
   DataType: bool
   OrigDataType: bool
@@ -64286,7 +64297,7 @@ T_14460: (in 0x30<8> : byte)
   Class: Eq_14422
   DataType: byte
   OrigDataType: byte
-T_14461: (in *((word64) rax_24 + 4<i32>) != 0x30<8> : bool)
+T_14461: (in *((word32) rax_24 + 4<i32>) != 0x30<8> : bool)
   Class: Eq_14461
   DataType: bool
   OrigDataType: bool
@@ -64306,7 +64317,7 @@ T_14465: (in 0x33<8> : byte)
   Class: Eq_14427
   DataType: byte
   OrigDataType: byte
-T_14466: (in *((word64) rax_24 + 5<i32>) != 0x33<8> : bool)
+T_14466: (in *((word32) rax_24 + 5<i32>) != 0x33<8> : bool)
   Class: Eq_14466
   DataType: bool
   OrigDataType: bool
@@ -64326,7 +64337,7 @@ T_14470: (in 0x30<8> : byte)
   Class: Eq_14469
   DataType: byte
   OrigDataType: byte
-T_14471: (in *((word64) rax_24 + 6<i32>) != 0x30<8> : bool)
+T_14471: (in *((word32) rax_24 + 6<i32>) != 0x30<8> : bool)
   Class: Eq_14471
   DataType: bool
   OrigDataType: bool
@@ -64346,7 +64357,7 @@ T_14475: (in 0<8> : byte)
   Class: Eq_14474
   DataType: byte
   OrigDataType: byte
-T_14476: (in *((word64) rax_24 + 7<i32>) != 0<8> : bool)
+T_14476: (in *((word32) rax_24 + 7<i32>) != 0<8> : bool)
   Class: Eq_14476
   DataType: bool
   OrigDataType: bool
@@ -64809,7 +64820,7 @@ T_14590: (in r9_1074 : Eq_18)
 T_14591: (in rbp_236 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_14592: (in 0<u64> : uint64)
   Class: Eq_18
   DataType: byte
@@ -65340,7 +65351,7 @@ T_14723: (in 1<u64> : uint64)
   OrigDataType: uint64
 T_14724: (in 0x22<8> : byte)
   Class: Eq_14724
-  DataType: (struct "Eq_14724" 0001 (0 Eq_17737 t0000))
+  DataType: (struct "Eq_14724" 0001 (0 Eq_17736 t0000))
   OrigDataType: byte
 T_14725: (in 0<64> : word64)
   Class: Eq_14725
@@ -65353,7 +65364,7 @@ T_14726: (in rdi + 0<64> : word64)
 T_14727: (in Mem191[rdi + 0<64>:byte] : byte)
   Class: Eq_14724
   DataType: Eq_18
-  OrigDataType: (struct "Eq_14724" 0001 (0 Eq_17737 t0000))
+  OrigDataType: (struct "Eq_14724" 0001 (0 Eq_17736 t0000))
 T_14728: (in 1<8> : byte)
   Class: Eq_14544
   DataType: byte
@@ -66406,7 +66417,7 @@ T_14990: (in SLICE(rax_625, word32, 0) : word32)
   Class: Eq_14990
   DataType: ui32
   OrigDataType: ui32
-T_14991: (in *((word64) qwArg08 + SEQ(rdx_32_32_626, edx_622) * 4<64>) & (word32) rax_625 : word32)
+T_14991: (in *((word32) qwArg08 + SEQ(rdx_32_32_626, edx_622) * 4<64>) & (word32) rax_625 : word32)
   Class: Eq_14991
   DataType: ui32
   OrigDataType: ui32
@@ -66414,7 +66425,7 @@ T_14992: (in 0<32> : word32)
   Class: Eq_14991
   DataType: ui32
   OrigDataType: word32
-T_14993: (in (*((word64) qwArg08 + SEQ(rdx_32_32_626, edx_622) * 4<64>) & (word32) rax_625) != 0<32> : bool)
+T_14993: (in (*((word32) qwArg08 + SEQ(rdx_32_32_626, edx_622) * 4<64>) & (word32) rax_625) != 0<32> : bool)
   Class: Eq_14993
   DataType: bool
   OrigDataType: bool
@@ -66677,7 +66688,7 @@ T_15057: (in rax_398 == 1<64> : bool)
 T_15058: (in rdx_467 : Eq_15027)
   Class: Eq_15027
   DataType: Eq_15027
-  OrigDataType: word64
+  OrigDataType: word32
 T_15059: (in 1<u64> : uint64)
   Class: Eq_15027
   DataType: uint64
@@ -67480,7 +67491,7 @@ T_15258: (in 1<u64> : uint64)
   OrigDataType: uint64
 T_15259: (in 0x27<8> : byte)
   Class: Eq_14724
-  DataType: (struct "Eq_14724" 0001 (0 Eq_17737 t0000))
+  DataType: (struct "Eq_14724" 0001 (0 Eq_17736 t0000))
   OrigDataType: byte
 T_15260: (in 0<64> : word64)
   Class: Eq_15260
@@ -67493,7 +67504,7 @@ T_15261: (in rdi + 0<64> : word64)
 T_15262: (in Mem213[rdi + 0<64>:byte] : byte)
   Class: Eq_14724
   DataType: Eq_18
-  OrigDataType: (struct "Eq_14724" 0001 (0 Eq_17737 t0000))
+  OrigDataType: (struct "Eq_14724" 0001 (0 Eq_17736 t0000))
 T_15263: (in 0<8> : byte)
   Class: Eq_14544
   DataType: byte
@@ -67790,7 +67801,7 @@ T_15336: (in r14_57 - rdi_86 << 4<64> : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (union (ui64 u0) (size_t u1))
-T_15337: (in memset((word64) r12_107 + (rdi_86 << 4<64>), 0<u64>, r14_57 - rdi_86 << 4<64>) : (ptr64 void))
+T_15337: (in memset((word32) r12_107 + (rdi_86 << 4<64>), 0<u64>, r14_57 - rdi_86 << 4<64>) : (ptr64 void))
   Class: Eq_15337
   DataType: (ptr64 void)
   OrigDataType: (ptr64 void)
@@ -68050,7 +68061,7 @@ T_15401: (in Mem129[rsp_150 + 0x38<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: up64
-T_15402: (in *((word128) rsp_150 + 56<i32>) > rax_143 : bool)
+T_15402: (in *((word32) rsp_150 + 56<i32>) > rax_143 : bool)
   Class: Eq_15402
   DataType: bool
   OrigDataType: bool
@@ -68105,7 +68116,7 @@ T_15414: (in rsp_150 + 0x38<64> : word64)
 T_15415: (in Mem164[rsp_150 + 0x38<64>:word64] : word64)
   Class: Eq_18
   DataType: Eq_77
-  OrigDataType: word64
+  OrigDataType: word32
 T_15416: (in free : ptr64)
   Class: Eq_1500
   DataType: (ptr64 Eq_1500)
@@ -68402,7 +68413,7 @@ T_15489: (in out r15_305 : ptr64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: ptr64
-T_15490: (in fn000000000040D8A0(rcx_181, rdx_185, rsi_186, rax_170, r8d_193, (word32) (uint64) ebp_183, fs, *rsp_150, *((word128) rsp_150 + 8<i32>), *((word128) rsp_150 + 16<i32>), out rbx_302, out rbp_303, out rsi_209, out r8_141, out r9_142, out r12_304, out r13_138, out r14_139, out r15_305) : word64)
+T_15490: (in fn000000000040D8A0(rcx_181, rdx_185, rsi_186, rax_170, r8d_193, (word32) (uint64) ebp_183, fs, *rsp_150, *((word32) rsp_150 + 8<i32>), *((word32) rsp_150 + 16<i32>), out rbx_302, out rbp_303, out rsi_209, out r8_141, out r9_142, out r12_304, out r13_138, out r14_139, out r15_305) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: word64
@@ -69673,11 +69684,11 @@ T_15806: (in SLICE(rdi, byte, 0) : byte)
 T_15807: (in r12_19 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_15808: (in rbx_105 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_15809: (in rsi_32 : word64)
   Class: Eq_4340
   DataType: word64
@@ -70790,7 +70801,7 @@ T_16086: (in 0x25<8> : byte)
   Class: Eq_16085
   DataType: byte
   OrigDataType: byte
-T_16087: (in *((word64) rax_202 + 1<i32>) != 0x25<8> : bool)
+T_16087: (in *((word32) rax_202 + 1<i32>) != 0x25<8> : bool)
   Class: Eq_16087
   DataType: bool
   OrigDataType: bool
@@ -71857,7 +71868,7 @@ T_16352: (in Mem23[__ctype_b_loc() + 0<64>:word64] : word64)
 T_16353: (in rax_50 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_16354: (in fp : ptr64)
   Class: Eq_16354
   DataType: ptr64
@@ -72434,7 +72445,7 @@ T_16497: (in 0x42<8> : byte)
   Class: Eq_16496
   DataType: byte
   OrigDataType: byte
-T_16498: (in *((word64) r14_81 + 2<i32>) == 0x42<8> : bool)
+T_16498: (in *((word32) r14_81 + 2<i32>) == 0x42<8> : bool)
   Class: Eq_16498
   DataType: bool
   OrigDataType: bool
@@ -72845,7 +72856,7 @@ T_16599: (in Mem23[__ctype_b_loc() + 0<64>:word64] : word64)
 T_16600: (in rax_50 : Eq_18)
   Class: Eq_18
   DataType: Eq_18
-  OrigDataType: word64
+  OrigDataType: word32
 T_16601: (in fp : ptr64)
   Class: Eq_16601
   DataType: ptr64
@@ -73438,7 +73449,7 @@ T_16748: (in 0x42<8> : byte)
   Class: Eq_16496
   DataType: byte
   OrigDataType: byte
-T_16749: (in *((word64) r14_82 + 2<i32>) == 0x42<8> : bool)
+T_16749: (in *((word32) r14_82 + 2<i32>) == 0x42<8> : bool)
   Class: Eq_16749
   DataType: bool
   OrigDataType: bool
@@ -74358,7 +74369,7 @@ T_16978: (in SEQ(rax_32_32_455, strlen(r14_29)) : word64)
   Class: Eq_16978
   DataType: int64
   OrigDataType: int64
-T_16979: (in (word64) r14_29 + 1<i32> + SEQ(rax_32_32_455, strlen(r14_29)) : word64)
+T_16979: (in (word32) r14_29 + 1<i32> + SEQ(rax_32_32_455, strlen(r14_29)) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: ptr64
@@ -74394,7 +74405,7 @@ T_16987: (in SEQ(rax_32_32_455, strlen(r14_29)) : word64)
   Class: Eq_16987
   DataType: int64
   OrigDataType: int64
-T_16988: (in (word64) r14_29 + 1<i32> + SEQ(rax_32_32_455, strlen(r14_29)) : word64)
+T_16988: (in (word32) r14_29 + 1<i32> + SEQ(rax_32_32_455, strlen(r14_29)) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: ptr64
@@ -74418,7 +74429,7 @@ T_16993: (in SEQ(rax_32_32_455, strlen(rbp_457)) : word64)
   Class: Eq_16993
   DataType: int64
   OrigDataType: int64
-T_16994: (in (word64) rbp_457 + 1<i32> + SEQ(rax_32_32_455, strlen(rbp_457)) : word64)
+T_16994: (in (word32) rbp_457 + 1<i32> + SEQ(rax_32_32_455, strlen(rbp_457)) : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: ptr64
@@ -74438,7 +74449,7 @@ T_16998: (in 0<8> : byte)
   Class: Eq_16997
   DataType: byte
   OrigDataType: byte
-T_16999: (in *((word64) r14_29 + 1<i32>) != 0<8> : bool)
+T_16999: (in *((word32) r14_29 + 1<i32>) != 0<8> : bool)
   Class: Eq_16999
   DataType: bool
   OrigDataType: bool
@@ -75297,7 +75308,7 @@ T_17212: (in 2<64> : word64)
 T_17213: (in rdx_188 + 2<64> : word64)
   Class: Eq_17153
   DataType: (ptr64 word32)
-  OrigDataType: (ptr64 word32)
+  OrigDataType: ptr64
 T_17214: (in 0<8> : byte)
   Class: Eq_17214
   DataType: byte
@@ -75617,7 +75628,7 @@ T_17292: (in 2<64> : word64)
 T_17293: (in r10_206 + 2<64> : word64)
   Class: Eq_17182
   DataType: (ptr64 word32)
-  OrigDataType: (ptr64 word32)
+  OrigDataType: ptr64
 T_17294: (in 0xA<32> : word32)
   Class: Eq_17086
   DataType: int32
@@ -75754,7 +75765,7 @@ T_17327: (in fp - 0xB8<64> : word64)
   Class: Eq_18
   DataType: Eq_18
   OrigDataType: (ptr64 char)
-T_17328: (in strcpy((word64) r13_300 + ((0xFFFFFFFFFFFFFFFE<64> - rdx_230) + r14_348), fp - 0xB8<64>) : (ptr64 char))
+T_17328: (in strcpy((word32) r13_300 + ((0xFFFFFFFFFFFFFFFE<64> - rdx_230) + r14_348), fp - 0xB8<64>) : (ptr64 char))
   Class: Eq_6364
   DataType: (ptr64 char)
   OrigDataType: (ptr64 char)
@@ -76644,7 +76655,7 @@ T_17549:
   OrigDataType: (struct 0008 (0 T_3953 t0000))
 T_17550:
   Class: Eq_17550
-  DataType: Eq_18
+  DataType: Eq_17550
   OrigDataType: (struct 0008 (0 T_4113 t0000))
 T_17551:
   Class: Eq_17551
@@ -76672,7 +76683,7 @@ T_17556:
   OrigDataType: (struct 0002 (0 T_4654 t0000))
 T_17557:
   Class: Eq_17557
-  DataType: Eq_18
+  DataType: Eq_17557
   OrigDataType: (struct 0008 (0 T_5447 t0000))
 T_17558:
   Class: Eq_17558
@@ -76688,19 +76699,19 @@ T_17560:
   OrigDataType: (struct 0004 (0 T_5934 t0000))
 T_17561:
   Class: Eq_17561
-  DataType: Eq_18
+  DataType: Eq_17561
   OrigDataType: (struct 0008 (0 T_7007 t0000))
 T_17562:
   Class: Eq_17562
-  DataType: Eq_18
+  DataType: Eq_17562
   OrigDataType: (struct 0008 (0 T_7552 t0000))
 T_17563:
   Class: Eq_17563
-  DataType: Eq_18
+  DataType: Eq_17563
   OrigDataType: (struct 0008 (0 T_7594 t0000))
 T_17564:
   Class: Eq_17564
-  DataType: Eq_18
+  DataType: Eq_17564
   OrigDataType: (struct 0008 (0 T_7743 t0000))
 T_17565:
   Class: Eq_7508
@@ -76708,7 +76719,7 @@ T_17565:
   OrigDataType: (struct 0008 (0 word64 qw0000))
 T_17566:
   Class: Eq_17566
-  DataType: Eq_18
+  DataType: Eq_17566
   OrigDataType: (struct 0008 (0 T_7835 t0000))
 T_17567:
   Class: Eq_18
@@ -76756,11 +76767,11 @@ T_17577:
   OrigDataType: (struct 0008 (0 T_14095 t0000))
 T_17578:
   Class: Eq_17578
-  DataType: Eq_18
+  DataType: Eq_17578
   OrigDataType: (struct 0008 (0 T_14104 t0000))
 T_17579:
   Class: Eq_17579
-  DataType: Eq_18
+  DataType: Eq_17579
   OrigDataType: (struct 0008 (0 T_14113 t0000))
 T_17580:
   Class: Eq_17580
@@ -76789,7 +76800,7 @@ T_17585:
 T_17586:
   Class: Eq_14739
   DataType: Eq_14739
-  OrigDataType: (struct "Eq_14739" 0001 (0 Eq_17738 t0000))
+  OrigDataType: (struct "Eq_14739" 0001 (0 Eq_17737 t0000))
 T_17587:
   Class: Eq_14739
   DataType: Eq_14739
@@ -76805,7 +76816,7 @@ T_17589:
 T_17590:
   Class: Eq_14724
   DataType: Eq_14724
-  OrigDataType: (struct "Eq_14724" 0001 (0 Eq_17737 t0000))
+  OrigDataType: (struct "Eq_14724" 0001 (0 Eq_17736 t0000))
 T_17591:
   Class: Eq_14724
   DataType: Eq_14724
@@ -77288,7 +77299,7 @@ T_17710:
   OrigDataType: 
 T_17711:
   Class: Eq_17711
-  DataType: Eq_17711
+  DataType: Eq_17710
   OrigDataType: 
 T_17712:
   Class: Eq_17712
@@ -77394,10 +77405,6 @@ T_17737:
   Class: Eq_17737
   DataType: Eq_17737
   OrigDataType: 
-T_17738:
-  Class: Eq_17738
-  DataType: Eq_17738
-  OrigDataType: 
 */
 typedef struct Eq_2867;
 struct Globals {
@@ -77423,7 +77430,7 @@ struct Globals {
 	char str412CA7[];	// 412CA7
 	word32 a412CC0[13];	// 412CC0
 	word32 dw412CF0;	// 412CF0
-	Eq_18 a412D00[];	// 412D00
+	Eq_17550 a412D00[];	// 412D00
 	word32 a412EC0[];	// 412EC0
 	Eq_18 a412F00[];	// 412F00
 	word32 a412F50[];	// 412F50
@@ -77536,10 +77543,10 @@ struct Globals {
 	Eq_18 t61A748;	// 61A748
 	Eq_1218 t61AF00;	// 61AF00
 	word64 qw61AF10;	// 61AF10
-	union Eq_1873 * ptr61AF18;	// 61AF18
+	DIR * ptr61AF18;	// 61AF18
 	int64 qw61AF20;	// 61AF20
 	Eq_1218 t61AF60;	// 61AF60
-	union Eq_1873 * ptr61AF78;	// 61AF78
+	DIR * ptr61AF78;	// 61AF78
 	word64 * ptr61AF80;	// 61AF80
 	Eq_1218 t61AFC0;	// 61AFC0
 	Eq_18 t61B018;	// 61B018
@@ -77657,10 +77664,11 @@ typedef union Eq_18 {
 	struct Eq_17614 * u9;
 	union Eq_17619 * u10;
 	<anonymous> * u11;
-	size_t u12;
-	time_t u13;
-	Eq_17620 u14;
-	Eq_17623 u15;
+	Eq_18 u12[];
+	size_t u13;
+	time_t u14;
+	Eq_17620 u15;
+	Eq_17623 u16;
 } Eq_18;
 
 typedef Eq_18 (Eq_23)(Eq_25, char *);
@@ -77917,28 +77925,20 @@ typedef union Eq_1698 {
 	uint64 u2;
 } Eq_1698;
 
-typedef union Eq_1718 {
-	byte u0;
-	word16 u1;
-} Eq_1718;
-
 typedef union Eq_1772 {
 	bool u0;
 	word32 u1;
 } Eq_1772;
 
-typedef union Eq_1873 {
-	word64 u0;
-	DIR u1;
-} Eq_1873;
+typedef DIR Eq_1873;
 
 typedef Eq_18 (Eq_1899)();
 
-typedef Eq_1873 * (Eq_1907)(Eq_18);
+typedef DIR * (Eq_1907)(Eq_18);
 
 typedef word64 (Eq_1913)(Eq_18, Eq_18, word32, Eq_11 *, Eq_77);
 
-typedef int32 (Eq_1942)(Eq_1873 *);
+typedef int32 (Eq_1942)(DIR *);
 
 typedef Eq_1958 (Eq_1952)(Eq_1954, Eq_18, Eq_18);
 
@@ -77969,7 +77969,7 @@ typedef union Eq_1970 {
 	uint32 u1;
 } Eq_1970;
 
-typedef int32 (Eq_1987)(Eq_1873 *);
+typedef int32 (Eq_1987)(DIR *);
 
 typedef Eq_18 (Eq_2025)(Eq_18, Eq_18, Eq_12, Eq_13, Eq_14, int32 *, Eq_2033, Eq_2034, Eq_2035);
 
@@ -78060,7 +78060,7 @@ typedef union Eq_2419 {
 	uint64 u1;
 } Eq_2419;
 
-typedef dirent * (Eq_2505)(Eq_1873 *);
+typedef dirent * (Eq_2505)(DIR *);
 
 typedef void (Eq_2511)();
 
@@ -78297,14 +78297,14 @@ typedef union Eq_4440 {
 	int64 u0;
 	uint64 u1;
 	byte u2;
-	Eq_17626 u3;
+	Eq_17625 u3;
 } Eq_4440;
 
 typedef union Eq_4441 {
 	int64 u0;
 	uint64 u1;
 	byte u2;
-	Eq_17627 u3;
+	Eq_17626 u3;
 } Eq_4441;
 
 typedef union Eq_4443 {
@@ -78317,7 +78317,7 @@ typedef union Eq_4455 {
 	int64 u0;
 	uint64 u1;
 	byte u2;
-	Eq_17628 u3;
+	Eq_17627 u3;
 } Eq_4455;
 
 typedef union Eq_4457 {
@@ -78342,7 +78342,7 @@ typedef union Eq_4498 {
 	int64 u0;
 	uint64 u1;
 	byte u2;
-	Eq_17629 u3;
+	Eq_17628 u3;
 } Eq_4498;
 
 typedef union Eq_4500 {
@@ -78367,7 +78367,7 @@ typedef union Eq_4514 {
 	int64 u0;
 	uint64 u1;
 	byte u2;
-	Eq_17630 u3;
+	Eq_17629 u3;
 } Eq_4514;
 
 typedef union Eq_4516 {
@@ -78392,7 +78392,7 @@ typedef union Eq_4526 {
 	int64 u0;
 	uint64 u1;
 	byte u2;
-	Eq_17631 u3;
+	Eq_17630 u3;
 } Eq_4526;
 
 typedef union Eq_4528 {
@@ -78420,7 +78420,7 @@ typedef union Eq_4554 {
 	int64 u0;
 	uint64 u1;
 	byte u2;
-	Eq_17632 u3;
+	Eq_17631 u3;
 } Eq_4554;
 
 typedef union Eq_4556 {
@@ -78481,7 +78481,7 @@ typedef union Eq_4578 {
 	int64 u0;
 	uint64 u1;
 	byte u2;
-	Eq_17633 u3;
+	Eq_17632 u3;
 } Eq_4578;
 
 typedef Eq_18 (Eq_4583)(Eq_4585, Eq_18, Eq_18, Eq_4588);
@@ -78619,10 +78619,10 @@ typedef Eq_18 (Eq_5099)(Eq_5101, Eq_18);
 typedef union Eq_5101 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
+	struct Eq_17633 * u2;
 	struct stat * u3;
 	time_t u4;
-	Eq_17637 u5;
+	Eq_17636 u5;
 } Eq_5101;
 
 typedef union Eq_5125 {
@@ -78642,7 +78642,7 @@ typedef union Eq_5163 {
 
 typedef union Eq_5222 {
 	word32 u0;
-	struct Eq_17638 * u1;
+	struct Eq_17637 * u1;
 } Eq_5222;
 
 typedef union Eq_5236 {
@@ -78764,19 +78764,19 @@ typedef struct Eq_6390 {
 typedef union Eq_6391 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17640 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17639 * u3;
 	time_t u4;
-	Eq_17641 u5;
+	Eq_17640 u5;
 } Eq_6391;
 
 typedef union Eq_6431 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17643 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17642 * u3;
 	time_t u4;
-	Eq_17644 u5;
+	Eq_17643 u5;
 } Eq_6431;
 
 typedef union Eq_6568 {
@@ -78787,55 +78787,55 @@ typedef union Eq_6568 {
 typedef union Eq_6592 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17640 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17639 * u3;
 	time_t u4;
-	Eq_17645 u5;
+	Eq_17644 u5;
 } Eq_6592;
 
 typedef union Eq_6599 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17640 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17639 * u3;
 	time_t u4;
-	Eq_17646 u5;
+	Eq_17645 u5;
 } Eq_6599;
 
 typedef union Eq_6621 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17640 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17639 * u3;
 	time_t u4;
-	Eq_17647 u5;
+	Eq_17646 u5;
 } Eq_6621;
 
 typedef union Eq_6628 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17649 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17648 * u3;
 	time_t u4;
-	Eq_17650 u5;
+	Eq_17649 u5;
 } Eq_6628;
 
 typedef union Eq_6637 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17640 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17639 * u3;
 	time_t u4;
-	Eq_17651 u5;
+	Eq_17650 u5;
 } Eq_6637;
 
 typedef union Eq_6649 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17654 u5;
+	Eq_17653 u5;
 } Eq_6649;
 
 typedef union Eq_6658 {
@@ -78846,172 +78846,172 @@ typedef union Eq_6658 {
 typedef union Eq_6667 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17655 u5;
+	Eq_17654 u5;
 } Eq_6667;
 
 typedef union Eq_6675 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17656 u5;
+	Eq_17655 u5;
 } Eq_6675;
 
 typedef union Eq_6692 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17657 u5;
+	Eq_17656 u5;
 } Eq_6692;
 
 typedef union Eq_6693 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17658 u5;
+	Eq_17657 u5;
 } Eq_6693;
 
 typedef union Eq_6697 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17659 u5;
+	Eq_17658 u5;
 } Eq_6697;
 
 typedef union Eq_6810 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17660 u5;
+	Eq_17659 u5;
 } Eq_6810;
 
 typedef union Eq_6812 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17661 u5;
+	Eq_17660 u5;
 } Eq_6812;
 
 typedef union Eq_6813 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17662 u5;
+	Eq_17661 u5;
 } Eq_6813;
 
 typedef union Eq_6815 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17663 u5;
+	Eq_17662 u5;
 } Eq_6815;
 
 typedef union Eq_6826 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17664 u5;
+	Eq_17663 u5;
 } Eq_6826;
 
 typedef union Eq_6827 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17665 u5;
+	Eq_17664 u5;
 } Eq_6827;
 
 typedef union Eq_6828 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17666 u5;
+	Eq_17665 u5;
 } Eq_6828;
 
 typedef union Eq_6831 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17667 u5;
+	Eq_17666 u5;
 } Eq_6831;
 
 typedef union Eq_6834 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17668 u5;
+	Eq_17667 u5;
 } Eq_6834;
 
 typedef union Eq_6835 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17669 u5;
+	Eq_17668 u5;
 } Eq_6835;
 
 typedef union Eq_6837 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17670 u5;
+	Eq_17669 u5;
 } Eq_6837;
 
 typedef union Eq_6840 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17671 u5;
+	Eq_17670 u5;
 } Eq_6840;
 
 typedef union Eq_6841 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17672 u5;
+	Eq_17671 u5;
 } Eq_6841;
 
 typedef union Eq_6842 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17673 u5;
+	Eq_17672 u5;
 } Eq_6842;
 
 typedef word64 (Eq_6844)(byte, word32, Eq_4846, Eq_11 *);
@@ -79019,28 +79019,28 @@ typedef word64 (Eq_6844)(byte, word32, Eq_4846, Eq_11 *);
 typedef union Eq_6861 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17674 u5;
+	Eq_17673 u5;
 } Eq_6861;
 
 typedef union Eq_6912 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17675 u5;
+	Eq_17674 u5;
 } Eq_6912;
 
 typedef union Eq_6935 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17676 u5;
+	Eq_17675 u5;
 } Eq_6935;
 
 typedef Eq_18 (Eq_6942)(Eq_6944, int64);
@@ -79048,55 +79048,55 @@ typedef Eq_18 (Eq_6942)(Eq_6944, int64);
 typedef union Eq_6944 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17679 u5;
+	Eq_17678 u5;
 } Eq_6944;
 
 typedef union Eq_6946 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17653 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17652 * u3;
 	time_t u4;
-	Eq_17680 u5;
+	Eq_17679 u5;
 } Eq_6946;
 
 typedef union Eq_6949 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17681 u5;
+	Eq_17680 u5;
 } Eq_6949;
 
 typedef union Eq_6961 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17682 u5;
+	Eq_17681 u5;
 } Eq_6961;
 
 typedef union Eq_6967 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17683 u5;
+	Eq_17682 u5;
 } Eq_6967;
 
 typedef union Eq_6971 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17684 u5;
+	Eq_17683 u5;
 } Eq_6971;
 
 typedef void (Eq_6973)(timespec *);
@@ -79110,28 +79110,28 @@ typedef struct timespec {	// size: 8 8
 typedef union Eq_6983 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17685 u5;
+	Eq_17684 u5;
 } Eq_6983;
 
 typedef union Eq_6986 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17686 u5;
+	Eq_17685 u5;
 } Eq_6986;
 
 typedef union Eq_6989 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17687 u5;
+	Eq_17686 u5;
 } Eq_6989;
 
 typedef Eq_18 (Eq_7001)(Eq_18, Eq_18, Eq_18, Eq_11 *);
@@ -79139,19 +79139,19 @@ typedef Eq_18 (Eq_7001)(Eq_18, Eq_18, Eq_18, Eq_11 *);
 typedef union Eq_7031 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17688 u5;
+	Eq_17687 u5;
 } Eq_7031;
 
 typedef union Eq_7034 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17689 u5;
+	Eq_17688 u5;
 } Eq_7034;
 
 typedef Eq_18 (Eq_7037)(Eq_7039);
@@ -79164,19 +79164,19 @@ typedef union Eq_7039 {
 typedef union Eq_7044 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17690 u5;
+	Eq_17689 u5;
 } Eq_7044;
 
 typedef union Eq_7048 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17691 u5;
+	Eq_17690 u5;
 } Eq_7048;
 
 typedef struct Eq_7052 {
@@ -79187,19 +79187,19 @@ typedef struct Eq_7052 {
 typedef union Eq_7065 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17692 u5;
+	Eq_17691 u5;
 } Eq_7065;
 
 typedef union Eq_7068 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17693 u5;
+	Eq_17692 u5;
 } Eq_7068;
 
 typedef word64 (Eq_7084)(Eq_18 *, Eq_18, obstack *, byte, Eq_18, Eq_11 *, Eq_18, ptr64);
@@ -79209,64 +79209,64 @@ typedef word64 (Eq_7119)(Eq_18, Eq_4903, Eq_4904, byte);
 typedef union Eq_7187 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17694 u5;
+	Eq_17693 u5;
 } Eq_7187;
 
 typedef union Eq_7190 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17695 u5;
+	Eq_17694 u5;
 } Eq_7190;
 
 typedef union Eq_7198 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17696 u5;
+	Eq_17695 u5;
 } Eq_7198;
 
 typedef union Eq_7199 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17697 u5;
+	Eq_17696 u5;
 } Eq_7199;
 
 typedef union Eq_7202 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17698 u5;
+	Eq_17697 u5;
 } Eq_7202;
 
 typedef union Eq_7205 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17699 u5;
+	Eq_17698 u5;
 } Eq_7205;
 
 typedef union Eq_7209 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17700 u5;
+	Eq_17699 u5;
 } Eq_7209;
 
 typedef Eq_18 (Eq_7212)(Eq_7214);
@@ -79274,91 +79274,91 @@ typedef Eq_18 (Eq_7212)(Eq_7214);
 typedef union Eq_7214 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17701 u5;
+	Eq_17700 u5;
 } Eq_7214;
 
 typedef union Eq_7215 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17702 u5;
+	Eq_17701 u5;
 } Eq_7215;
 
 typedef union Eq_7230 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17703 u5;
+	Eq_17702 u5;
 } Eq_7230;
 
 typedef union Eq_7248 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17704 u5;
+	Eq_17703 u5;
 } Eq_7248;
 
 typedef union Eq_7253 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17705 u5;
+	Eq_17704 u5;
 } Eq_7253;
 
 typedef union Eq_7267 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17706 u5;
+	Eq_17705 u5;
 } Eq_7267;
 
 typedef union Eq_7277 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17707 u5;
+	Eq_17706 u5;
 } Eq_7277;
 
 typedef union Eq_7282 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17708 u5;
+	Eq_17707 u5;
 } Eq_7282;
 
 typedef union Eq_7287 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17709 u5;
+	Eq_17708 u5;
 } Eq_7287;
 
 typedef union Eq_7297 {
 	byte u0;
 	char * u1;
-	struct Eq_17634 * u2;
-	struct Eq_17678 * u3;
+	struct Eq_17633 * u2;
+	struct Eq_17677 * u3;
 	time_t u4;
-	Eq_17710 u5;
+	Eq_17709 u5;
 } Eq_7297;
 
 typedef Eq_18 * (Eq_7312)();
@@ -79433,43 +79433,43 @@ typedef struct stat {
 typedef union Eq_8053 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17713 u3;
+	union Eq_17710 * u2;
+	Eq_17712 u3;
 } Eq_8053;
 
 typedef union Eq_8054 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17714 u3;
+	union Eq_17710 * u2;
+	Eq_17713 u3;
 } Eq_8054;
 
 typedef union Eq_8055 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17715 u3;
+	union Eq_17710 * u2;
+	Eq_17714 u3;
 } Eq_8055;
 
 typedef union Eq_8066 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17716 u3;
+	union Eq_17710 * u2;
+	Eq_17715 u3;
 } Eq_8066;
 
 typedef union Eq_8067 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17717 u3;
+	union Eq_17710 * u2;
+	Eq_17716 u3;
 } Eq_8067;
 
 typedef union Eq_8068 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17718 u3;
+	union Eq_17710 * u2;
+	Eq_17717 u3;
 } Eq_8068;
 
 typedef union Eq_8069 {
@@ -79496,20 +79496,20 @@ typedef word32 (Eq_8347)(security_context_t *, Eq_18);
 typedef union Eq_8518 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17719 u3;
+	union Eq_17710 * u2;
+	Eq_17718 u3;
 } Eq_8518;
 
 typedef union Eq_8530 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17720 u3;
+	union Eq_17710 * u2;
+	Eq_17719 u3;
 } Eq_8530;
 
 typedef union Eq_8556 {
 	byte u0;
-	Eq_17721 u1;
+	Eq_17720 u1;
 } Eq_8556;
 
 typedef int32 (Eq_8584)(Eq_8586, Eq_18, stat *);
@@ -79531,43 +79531,43 @@ typedef word64 (Eq_8667)(Eq_4846, Eq_11 *);
 typedef union Eq_8734 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17722 u3;
+	union Eq_17710 * u2;
+	Eq_17721 u3;
 } Eq_8734;
 
 typedef union Eq_8752 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17723 u3;
+	union Eq_17710 * u2;
+	Eq_17722 u3;
 } Eq_8752;
 
 typedef union Eq_8814 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17724 u3;
+	union Eq_17710 * u2;
+	Eq_17723 u3;
 } Eq_8814;
 
 typedef union Eq_8840 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17725 u3;
+	union Eq_17710 * u2;
+	Eq_17724 u3;
 } Eq_8840;
 
 typedef union Eq_8910 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17726 u3;
+	union Eq_17710 * u2;
+	Eq_17725 u3;
 } Eq_8910;
 
 typedef union Eq_8914 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17727 u3;
+	union Eq_17710 * u2;
+	Eq_17726 u3;
 } Eq_8914;
 
 typedef union Eq_8923 {
@@ -79578,43 +79578,43 @@ typedef union Eq_8923 {
 typedef union Eq_8932 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17728 u3;
+	union Eq_17710 * u2;
+	Eq_17727 u3;
 } Eq_8932;
 
 typedef union Eq_8970 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17729 u3;
+	union Eq_17710 * u2;
+	Eq_17728 u3;
 } Eq_8970;
 
 typedef union Eq_8971 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17730 u3;
+	union Eq_17710 * u2;
+	Eq_17729 u3;
 } Eq_8971;
 
 typedef union Eq_8975 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17731 u3;
+	union Eq_17710 * u2;
+	Eq_17730 u3;
 } Eq_8975;
 
 typedef union Eq_8976 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17732 u3;
+	union Eq_17710 * u2;
+	Eq_17731 u3;
 } Eq_8976;
 
 typedef union Eq_8981 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17733 u3;
+	union Eq_17710 * u2;
+	Eq_17732 u3;
 } Eq_8981;
 
 typedef Eq_18 (Eq_8998)(Eq_18, Eq_18);
@@ -79626,8 +79626,8 @@ typedef char * (Eq_9066)(Eq_18, Eq_18, Eq_18);
 typedef union Eq_9107 {
 	byte u0;
 	char * u1;
-	struct stat * u2;
-	Eq_17734 u3;
+	union Eq_17710 * u2;
+	Eq_17733 u3;
 } Eq_9107;
 
 typedef int32 (Eq_9629)(Eq_18);
@@ -79993,7 +79993,7 @@ typedef bool (Eq_12444)(real64);
 
 typedef union Eq_12457 {
 	byte u0;
-	Eq_17735 u1;
+	Eq_17734 u1;
 } Eq_12457;
 
 typedef union Eq_12472 {
@@ -80372,7 +80372,7 @@ typedef union Eq_14501 {
 
 typedef union Eq_14605 {
 	byte u0;
-	Eq_17736 u1;
+	Eq_17735 u1;
 } Eq_14605;
 
 typedef Eq_18 (Eq_14623)(word32, Eq_18, Eq_11 *, ptr64, Eq_14360);
@@ -80399,11 +80399,11 @@ typedef union Eq_14695 {
 } Eq_14695;
 
 typedef struct Eq_14724 {	// size: 1 1
-	Eq_17737 t0000;	// 0
+	Eq_17736 t0000;	// 0
 } Eq_14724;
 
 typedef struct Eq_14739 {	// size: 1 1
-	Eq_17738 t0000;	// 0
+	Eq_17737 t0000;	// 0
 } Eq_14739;
 
 typedef Eq_18 (Eq_14771)(Eq_18, Eq_18, Eq_18, Eq_18, word32, word32, Eq_11 *, Eq_18, Eq_18, Eq_18, Eq_18, Eq_18, Eq_14498, Eq_18, Eq_18, Eq_14501, Eq_18, Eq_18, Eq_18);
@@ -80695,13 +80695,49 @@ typedef struct Eq_17548 {	// size: 16 10
 	byte * ptr0000;	// 0
 } Eq_17548;
 
+typedef struct Eq_17550 {	// size: 8 8
+	Eq_18 t0000;	// 0
+} Eq_17550;
+
 typedef struct Eq_17556 {	// size: 2 2
 	byte b0000;	// 0
 } Eq_17556;
 
+typedef struct Eq_17557 {	// size: 8 8
+	Eq_18 t0000;	// 0
+} Eq_17557;
+
 typedef struct Eq_17558 {	// size: 8 8
 	byte b0000;	// 0
 } Eq_17558;
+
+typedef struct Eq_17561 {	// size: 8 8
+	Eq_18 t0000;	// 0
+} Eq_17561;
+
+typedef struct Eq_17562 {	// size: 8 8
+	Eq_18 t0000;	// 0
+} Eq_17562;
+
+typedef struct Eq_17563 {	// size: 8 8
+	Eq_18 t0000;	// 0
+} Eq_17563;
+
+typedef struct Eq_17564 {	// size: 8 8
+	Eq_18 t0000;	// 0
+} Eq_17564;
+
+typedef struct Eq_17566 {	// size: 8 8
+	Eq_18 t0000;	// 0
+} Eq_17566;
+
+typedef struct Eq_17578 {	// size: 8 8
+	Eq_18 t0000;	// 0
+} Eq_17578;
+
+typedef struct Eq_17579 {	// size: 8 8
+	Eq_18 t0000;	// 0
+} Eq_17579;
 
 typedef struct Eq_17580 {	// size: 8 8
 	Eq_18 t0000;	// 0
@@ -80854,7 +80890,7 @@ typedef struct Eq_17624 {
 	Eq_18 t0028;	// 28
 	byte b002F;	// 2F
 	Eq_1345 t0030;	// 30
-	Eq_1718 t0031;	// 31
+	byte b0031;	// 31
 	byte b0032;	// 32
 	Eq_18 t0038;	// 38
 	Eq_18 t0040;	// 40
@@ -80863,9 +80899,9 @@ typedef struct Eq_17624 {
 	word32 dw00C8;	// C8
 } Eq_17624;
 
-typedef struct _DIR {
-	Eq_18 t0000;	// 0
-	Eq_18 t0008;	// 8
+typedef union Eq_17625 {
+	bool u0;
+	byte u1;
 } Eq_17625;
 
 typedef union Eq_17626 {
@@ -80903,22 +80939,17 @@ typedef union Eq_17632 {
 	byte u1;
 } Eq_17632;
 
-typedef union Eq_17633 {
-	bool u0;
-	byte u1;
+typedef struct Eq_17633 {	// size: 1 1
 } Eq_17633;
 
-typedef struct Eq_17634 {	// size: 1 1
-} Eq_17634;
-
-typedef union Eq_17635 {
+typedef union Eq_17634 {
 	byte u0;
 	word64 u1;
 	word32 u2;
-} Eq_17635;
+} Eq_17634;
 
 typedef struct stat {	// size: 4 4
-	Eq_17635 t0000;	// 0
+	Eq_17634 t0000;	// 0
 	Eq_18 t0008;	// 8
 	Eq_18 t0010;	// 10
 	byte b0014;	// 14
@@ -80926,47 +80957,47 @@ typedef struct stat {	// size: 4 4
 	word64 qw0028;	// 28
 	int64 qw0030;	// 30
 	Eq_67 t0038;	// 38
-} Eq_17636;
+} Eq_17635;
 
-typedef union Eq_17637 {
+typedef union Eq_17636 {
 	bool u0;
 	byte u1;
-} Eq_17637;
+} Eq_17636;
 
-typedef struct Eq_17638 {
+typedef struct Eq_17637 {
 	real32 r0000;	// 0
 	real32 r0004;	// 4
 	real32 r0008;	// 8
 	byte b0010;	// 10
-} Eq_17638;
+} Eq_17637;
 
-typedef union Eq_17639 {
+typedef union Eq_17638 {
 	byte u0;
 	word32 u1;
-} Eq_17639;
+} Eq_17638;
 
-typedef struct Eq_17640 {	// size: 4 4
-	Eq_17639 t0000;	// 0
+typedef struct Eq_17639 {	// size: 4 4
+	Eq_17638 t0000;	// 0
 	Eq_18 t0008;	// 8
 	Eq_18 t0010;	// 10
 	uint64 qw0018;	// 18
 	word64 qw0028;	// 28
 	int64 qw0030;	// 30
 	Eq_67 t0038;	// 38
+} Eq_17639;
+
+typedef union Eq_17640 {
+	bool u0;
+	byte u1;
 } Eq_17640;
 
 typedef union Eq_17641 {
-	bool u0;
-	byte u1;
-} Eq_17641;
-
-typedef union Eq_17642 {
 	byte u0;
 	word32 u1;
-} Eq_17642;
+} Eq_17641;
 
-typedef struct Eq_17643 {	// size: 4 4
-	Eq_17642 t0000;	// 0
+typedef struct Eq_17642 {	// size: 4 4
+	Eq_17641 t0000;	// 0
 	Eq_18 t0008;	// 8
 	Eq_18 t0010;	// 10
 	byte b0014;	// 14
@@ -80974,6 +81005,11 @@ typedef struct Eq_17643 {	// size: 4 4
 	word64 qw0028;	// 28
 	int64 qw0030;	// 30
 	Eq_67 t0038;	// 38
+} Eq_17642;
+
+typedef union Eq_17643 {
+	bool u0;
+	byte u1;
 } Eq_17643;
 
 typedef union Eq_17644 {
@@ -80992,17 +81028,12 @@ typedef union Eq_17646 {
 } Eq_17646;
 
 typedef union Eq_17647 {
-	bool u0;
-	byte u1;
-} Eq_17647;
-
-typedef union Eq_17648 {
 	byte u0;
 	word32 u1;
-} Eq_17648;
+} Eq_17647;
 
-typedef struct Eq_17649 {	// size: 4 4
-	Eq_17648 t0000;	// 0
+typedef struct Eq_17648 {	// size: 4 4
+	Eq_17647 t0000;	// 0
 	Eq_18 t0008;	// 8
 	Eq_18 t0010;	// 10
 	byte b0014;	// 14
@@ -81010,6 +81041,11 @@ typedef struct Eq_17649 {	// size: 4 4
 	word64 qw0028;	// 28
 	int64 qw0030;	// 30
 	Eq_67 t0038;	// 38
+} Eq_17648;
+
+typedef union Eq_17649 {
+	bool u0;
+	byte u1;
 } Eq_17649;
 
 typedef union Eq_17650 {
@@ -81018,17 +81054,12 @@ typedef union Eq_17650 {
 } Eq_17650;
 
 typedef union Eq_17651 {
-	bool u0;
-	byte u1;
-} Eq_17651;
-
-typedef union Eq_17652 {
 	byte u0;
 	word32 u1;
-} Eq_17652;
+} Eq_17651;
 
-typedef struct Eq_17653 {	// size: 4 4
-	Eq_17652 t0000;	// 0
+typedef struct Eq_17652 {	// size: 4 4
+	Eq_17651 t0000;	// 0
 	Eq_18 t0008;	// 8
 	Eq_18 t0010;	// 10
 	byte b0014;	// 14
@@ -81036,6 +81067,11 @@ typedef struct Eq_17653 {	// size: 4 4
 	word64 qw0028;	// 28
 	int64 qw0030;	// 30
 	Eq_67 t0038;	// 38
+} Eq_17652;
+
+typedef union Eq_17653 {
+	bool u0;
+	byte u1;
 } Eq_17653;
 
 typedef union Eq_17654 {
@@ -81149,17 +81185,12 @@ typedef union Eq_17675 {
 } Eq_17675;
 
 typedef union Eq_17676 {
-	bool u0;
-	byte u1;
-} Eq_17676;
-
-typedef union Eq_17677 {
 	byte u0;
 	word32 u1;
-} Eq_17677;
+} Eq_17676;
 
-typedef struct Eq_17678 {	// size: 4 4
-	Eq_17677 t0000;	// 0
+typedef struct Eq_17677 {	// size: 4 4
+	Eq_17676 t0000;	// 0
 	Eq_18 t0008;	// 8
 	Eq_18 t0010;	// 10
 	byte b0014;	// 14
@@ -81167,6 +81198,11 @@ typedef struct Eq_17678 {	// size: 4 4
 	word64 qw0028;	// 28
 	int64 qw0030;	// 30
 	Eq_67 t0038;	// 38
+} Eq_17677;
+
+typedef union Eq_17678 {
+	bool u0;
+	byte u1;
 } Eq_17678;
 
 typedef union Eq_17679 {
@@ -81325,17 +81361,13 @@ typedef union Eq_17709 {
 } Eq_17709;
 
 typedef union Eq_17710 {
-	bool u0;
-	byte u1;
-} Eq_17710;
-
-typedef union Eq_17711 {
 	word64 u0;
 	word32 u1;
-} Eq_17711;
+} Eq_17710;
 
-typedef struct stat {	// size: 4 4
-	Eq_17711 t0000;	// 0
+typedef union Eq_17712 {
+	bool u0;
+	byte u1;
 } Eq_17712;
 
 typedef union Eq_17713 {
@@ -81454,17 +81486,12 @@ typedef union Eq_17735 {
 } Eq_17735;
 
 typedef union Eq_17736 {
-	bool u0;
-	byte u1;
+	byte u0;
+	Eq_14724 u1[];
 } Eq_17736;
 
 typedef union Eq_17737 {
 	byte u0;
-	Eq_14724 u1[];
-} Eq_17737;
-
-typedef union Eq_17738 {
-	byte u0;
 	Eq_14739 u1[];
-} Eq_17738;
+} Eq_17737;
 

--- a/subjects/Elf/x86-64/ls/ls.reko/ls_text.c
+++ b/subjects/Elf/x86-64/ls/ls.reko/ls_text.c
@@ -381,11 +381,11 @@ l00000000004031F9:
 				Eq_n rdx_n = globals->t61B100;
 				rax_n->u0 = 4274276;
 				globals->t61B100 = rax_n;
-				*((word64) rax_n + 8) = rdx_n;
+				*((word32) rax_n + 8) = rdx_n;
 				Eq_n rax_n = fn0000000000410C40(0x10);
 				Eq_n rdx_n = globals->t61B100;
 				rax_n->u0 = 4274275;
-				*((word64) rax_n + 8) = rdx_n;
+				*((word32) rax_n + 8) = rdx_n;
 				globals->t61B100 = rax_n;
 				break;
 			case 0xC6:
@@ -408,7 +408,7 @@ l00000000004031F9:
 				Eq_n rax_n = fn0000000000410C40(0x10);
 				Eq_n rdx_n = globals->t61B100;
 				*rax_n = r15_n;
-				*((word64) rax_n + 8) = rdx_n;
+				*((word32) rax_n + 8) = rdx_n;
 				globals->t61B100 = rax_n;
 				break;
 			case 0xCF:
@@ -594,7 +594,7 @@ l0000000000403A7C:
 				*rax_n = globals->t61A640;
 				Eq_n rdx_n = globals->t61B0F8;
 				globals->t61B0F8 = rax_n;
-				*((word64) rax_n + 8) = rdx_n;
+				*((word32) rax_n + 8) = rdx_n;
 				break;
 			case 0x010C:
 				globals->dw61B12C = (word32) (uint64) globals->a4136B0[fn000000000040A120(rax_32_32_n, 0x004136B0, globals->a4136C0, globals->t61A640, 4274331, 0x04, globals->ptr61A578, fs, out r9_n) * 0x04];
@@ -852,10 +852,10 @@ l000000000040451F:
 										Eq_n rax_n = fn0000000000410C40(0x28);
 										Eq_n rax_n = globals->t61B120;
 										Eq_n rdi_n = *((byte) rsp_n.u0 + 32);
-										((byte) rsp_n.u0 + 56)->u1 = (word128) *((byte) rsp_n.u0 + 56) + 1;
+										((byte) rsp_n.u0 + 56)->u2 = (word32) *((byte) rsp_n.u0 + 56) + 1;
 										globals->t61B120 = rax_n;
-										*((word64) rax_n + 32) = rax_n;
-										*((word64) rax_n + 8) = *((byte) rsp_n.u0 + 64);
+										*((word32) rax_n + 32) = rax_n;
+										*((word32) rax_n + 8) = *((byte) rsp_n.u0 + 64);
 										Eq_n rbx_n = <invalid>;
 										r13_n = rax_n;
 										rsp_n.u0 = <invalid>;
@@ -866,12 +866,12 @@ l000000000040451F:
 									}
 									if (cl_n == 0x3A)
 									{
-										*((byte) rsp_n.u0 + 56) = (word64) rax_n + 1;
+										((byte) rsp_n.u0 + 56)->u2 = (word32) rax_n + 1;
 										goto l000000000040451F;
 									}
 									if (cl_n == 0x00)
 										goto l000000000040478E;
-									*((byte) rsp_n.u0 + 56) = (word64) rax_n + 1;
+									((byte) rsp_n.u0 + 56)->u2 = (word32) rax_n + 1;
 									*((byte) rsp_n.u0 + 48) = (byte) (word32) *rax_n;
 									edx_n = 0x01;
 									break;
@@ -881,14 +881,14 @@ l000000000040451F:
 									r12_n = r12_n;
 									if (*rax_n != 0x00)
 									{
-										*((byte) rsp_n.u0 + 56) = (word64) rax_n + 1;
-										*((byte) rsp_n.u0 + 49) = (byte) (word32) *rax_n;
+										((byte) rsp_n.u0 + 56)->u2 = (word32) rax_n + 1;
+										((byte) rsp_n.u0 + 49)->u0 = (byte) (word32) *rax_n;
 										edx_n = 0x02;
 									}
 									break;
 								case 0x02:
 									Eq_n rax_n = *((byte) rsp_n.u0 + 56);
-									*((byte) rsp_n.u0 + 56) = (word64) rax_n + 1;
+									((byte) rsp_n.u0 + 56)->u2 = (word32) rax_n + 1;
 									uint64 r15_n = 0x00;
 									edx_n = 0x05;
 									if (*rax_n == 0x3D)
@@ -903,7 +903,7 @@ l000000000040451F:
 										} while (strcmp((byte) rsp_n.u0 + 48, rsi_n) != 0x00);
 										Eq_n rdi_n = *((byte) rsp_n.u0 + 32);
 										Eq_n rcx_n = (r14_n << 0x04) + 6398944;
-										*((word64) rcx_n + 8) = *((byte) rsp_n.u0 + 64);
+										*((word32) rcx_n + 8) = *((byte) rsp_n.u0 + 64);
 										Eq_n rbx_n = <invalid>;
 										rsp_n.u0 = <invalid>;
 										ebx_n = (word32) rbx_n;
@@ -921,17 +921,17 @@ l0000000000404857:
 									break;
 								case 0x03:
 									Eq_n rax_n = *((byte) rsp_n.u0 + 56);
-									*((byte) rsp_n.u0 + 56) = (word64) rax_n + 1;
+									((byte) rsp_n.u0 + 56)->u2 = (word32) rax_n + 1;
 									edx_n = 0x05;
 									if (*rax_n == 0x3D)
 									{
 										Eq_n rdi_n = *((byte) rsp_n.u0 + 32);
-										*((word64) r13_n + 24) = *((byte) rsp_n.u0 + 64);
+										*((word32) r13_n + 24) = *((byte) rsp_n.u0 + 64);
 										Eq_n rbx_n = <invalid>;
 										rsp_n.u0 = <invalid>;
 										ebx_n = (word32) rbx_n;
 										word32 ebx_n;
-										edx_n = (word32) (uint64) ((word32) (uint64) (0x00 - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word64) r13_n + 16, 0x00, (byte) rsp_n.u0 + 56, rdi_n, out ebx_n, out rbp_n, out r8_n, out r12_n))) - 0x01), bool, 1)) & 0x05);
+										edx_n = (word32) (uint64) ((word32) (uint64) (0x00 - SLICE(cond((byte) ((uint64) ((uint8) fn00000000004049E0((word32) r13_n + 16, 0x00, (byte) rsp_n.u0 + 56, rdi_n, out ebx_n, out rbp_n, out r8_n, out r12_n))) - 0x01), bool, 1)) & 0x05);
 										goto l000000000040451F;
 									}
 									break;
@@ -944,7 +944,7 @@ l0000000000402985:
 									Eq_n rdi_n = globals->t61B120;
 									while (rdi_n != 0x00)
 									{
-										Eq_n r13_n = *((word64) rdi_n + 32);
+										Eq_n r13_n = *((word32) rdi_n + 32);
 										free(rdi_n);
 										rdi_n = r13_n;
 									}
@@ -1082,7 +1082,7 @@ l00000000004033A0:
 								else
 									__overflow(rdi_n, 0x0A);
 								Eq_n rax_n = globals->t61B190;
-								globals->t61B018 = (word64) globals->t61B018 + 1;
+								globals->t61B018 = (word32) globals->t61B018 + 1;
 								*((byte) rsp_n.u0 + 24) = rax_n;
 							}
 							else
@@ -1136,13 +1136,13 @@ l00000000004034D2:
 							}
 							Eq_n r14_n;
 							Eq_n rcx_n = *((byte) rsp_n.u0 + 24);
-							globals->t61B190 = *((word64) rcx_n + 24);
+							globals->t61B190 = *((word32) rcx_n + 24);
 							if (globals->t61B1C8 != 0x00)
 							{
 								r14_n = *rcx_n;
 								if (r14_n == 0x00)
 								{
-									union Eq_n * rax_n = globals->ptr61AF18;
+									DIR * rax_n = globals->ptr61AF18;
 									if ((word32) (rax_n - globals->qw61AF10) <= 0x0F)
 										__assert_fail("sizeof (struct dev_ino) <= __extension__ ({ struct obstack const *__o = (&dev_ino_obstack); (unsigned) (__o->next_free - __o->object_base); })", "src/ls.c", 0x03D5, "dev_ino_pop");
 									if (globals->qw61AF20 - rax_n < ~0x0F)
@@ -1162,7 +1162,7 @@ l00000000004034D2:
 									free(rax_n);
 									Eq_n rbx_n = *((byte) rsp_n.u0 + 24);
 									free(*rbx_n);
-									free(*((word64) rbx_n + 8));
+									free(*((word32) rbx_n + 8));
 									free(rbx_n);
 l00000000004034C6:
 									*((byte) rsp_n.u0 + 24) = globals->t61B190;
@@ -1172,17 +1172,17 @@ l00000000004034C6:
 							else
 								r14_n = **((byte) rsp_n.u0 + 24);
 							Eq_n rax_n = *((byte) rsp_n.u0 + 24);
-							Eq_n rbx_n = *((word64) rax_n + 8);
-							((byte) rsp_n.u0 + 47)->u0 = (byte) (word32) *((word64) rax_n + 16);
+							Eq_n rbx_n = *((word32) rax_n + 8);
+							((byte) rsp_n.u0 + 47)->u0 = (byte) (word32) *((word32) rax_n + 16);
 							Eq_n rax_n = __errno_location();
 							*rax_n = 0x00;
-							union Eq_n * rax_n = opendir(r14_n);
+							DIR * rax_n = opendir(r14_n);
 							if (rax_n == null)
 							{
 								fn0000000000405810(r14_n, dcgettext(null, 4274584, 0x05), (word32) *((byte) rsp_n.u0 + 47), fs, out r8_n);
 								goto l00000000004034A1;
 							}
-							union Eq_n * rax_n;
+							DIR * rax_n;
 							rax_n = rax_n;
 							if (globals->t61B1C8 == 0x00)
 							{
@@ -1192,34 +1192,34 @@ l00000000004035FF:
 									if (globals->b61A3C0 == 0x00)
 									{
 										FILE * rdi_n = globals->ptr61A610;
-										rax_n = (union Eq_n *) *((char *) rdi_n + 40);
+										rax_n = (DIR *) *((char *) rdi_n + 40);
 										word32 rax_32_32_n = SLICE(rax_n, word32, 32);
 										if (rax_n < *((char *) rdi_n + 48))
 										{
-											*((char *) rdi_n + 40) = (FILE *) ((char *) rax_n + 1);
-											*rax_n = (union Eq_n *) 0x0A;
+											*((char *) rdi_n + 40) = (FILE *) ((char *) &rax_n->t0000 + 1);
+											rax_n->t0000.u0 = 0x0A;
 										}
 										else
 											rax_n = SEQ(rax_32_32_n, __overflow(rdi_n, 0x0A));
-										globals->t61B018 = (word64) globals->t61B018 + 1;
+										globals->t61B018 = (word32) globals->t61B018 + 1;
 									}
 									globals->b61A3C0 = 0x00;
 									word32 rax_32_32_n = SLICE(rax_n, word32, 32);
 									if (globals->b61B130 != 0x00)
 									{
 										Eq_n eax_n = fwrite_unlocked(0x00413771, 0x01, 0x02, globals->ptr61A610);
-										globals->t61B018 = (word64) globals->t61B018 + 2;
+										globals->t61B018 = (word32) globals->t61B018 + 2;
 										rax_n = SEQ(rax_32_32_n, eax_n);
 										if (globals->b61B130 != 0x00)
 										{
 											rax_n = globals->ptr61AF78;
-											if (globals->ptr61AF80 < (char *) rax_n + 8)
+											if (globals->ptr61AF80 < &rax_n->t0008)
 											{
 												_obstack_newchunk(&globals->t61AF60, 0x08);
 												rax_n = globals->ptr61AF78;
 											}
-											*rax_n = (union Eq_n *) globals->t61B018;
-											globals->ptr61AF78 = (union Eq_n *) ((char *) globals->ptr61AF78 + 8);
+											rax_n->t0000 = globals->t61B018;
+											globals->ptr61AF78 = &globals->ptr61AF78->t0008;
 										}
 									}
 									struct Eq_n * rdx_n = globals->ptr61B0E0;
@@ -1230,17 +1230,17 @@ l00000000004035FF:
 									Mem2851[0x000000000061B018<p64>:word64] = Mem2790[0x000000000061B018<p64>:word64] + rax_n;
 									if (globals->b61B130 != 0x00)
 									{
-										union Eq_n * rax_n = globals->ptr61AF78;
-										if (globals->ptr61AF80 < (char *) rax_n + 8)
+										DIR * rax_n = globals->ptr61AF78;
+										if (globals->ptr61AF80 < &rax_n->t0008)
 										{
 											_obstack_newchunk(&globals->t61AF60, 0x08);
 											rax_n = globals->ptr61AF78;
 										}
-										*rax_n = (union Eq_n *) globals->t61B018;
-										globals->ptr61AF78 = (union Eq_n *) ((char *) globals->ptr61AF78 + 8);
+										rax_n->t0000 = globals->t61B018;
+										globals->ptr61AF78 = &globals->ptr61AF78->t0008;
 									}
 									fwrite_unlocked(4274491, 0x01, 0x02, globals->ptr61A610);
-									globals->t61B018 = (word64) globals->t61B018 + 2;
+									globals->t61B018 = (word32) globals->t61B018 + 2;
 								}
 								fn0000000000404DD0();
 								Eq_n eax_n = (word32) *((byte) rsp_n.u0 + 47);
@@ -1263,11 +1263,11 @@ l00000000004036F0:
 												{
 													if (fnmatch(*r15_n, &rax_n->b0013, 0x04) == 0x00)
 														goto l0000000000403770;
-													r15_n = *((word64) r15_n + 8);
+													r15_n = *((word32) r15_n + 8);
 												}
 											}
 										}
-										else if (eax_n == 0x00 || (&rax_n->t0014)[(uint64) ((uint8) (rax_n->t0014 == 0x2E)) / 21] == 0x00)
+										else if (eax_n == 0x00 || (&rax_n->t0014)[(uint64) ((uint8) (rax_n->t0014 == 0x2E)) / 24] == 0x00)
 											goto l0000000000403770;
 									}
 									Eq_n r15_n = globals->t61B100;
@@ -1275,7 +1275,7 @@ l00000000004036F0:
 									{
 										if (fnmatch(*r15_n, &rax_n->b0013, 0x04) == 0x00)
 											goto l0000000000403770;
-										r15_n = *((word64) r15_n + 8);
+										r15_n = *((word32) r15_n + 8);
 									}
 									uint64 rax_n = (uint64) ((word32) rax_n->b0012 - 0x01);
 									word32 esi_n = 0x00;
@@ -1283,7 +1283,7 @@ l00000000004036F0:
 									ui32 rax_32_32_n = SLICE(rax_n, word32, 32);
 									if (al_n <= 0x0D)
 										esi_n = (word32) (uint64) globals->a412C00[SEQ(rax_32_32_n, (word32) al_n) * 0x04];
-									((byte) rsp_n.u0 + 8)->u1 = (word128) *((byte) rsp_n.u0 + 8) + fn0000000000407EA0(r14_n, 0x00, esi_n, &rax_n->b0013, fs, rLoc4);
+									((byte) rsp_n.u0 + 8)->u2 = (word32) *((byte) rsp_n.u0 + 8) + fn0000000000407EA0(r14_n, 0x00, esi_n, &rax_n->b0013, fs, rLoc4);
 									if (globals->dw61B150 == 0x01 && (globals->dw61B148 == ~0x00 && (globals->b61B144 == 0x00 && globals->b61B10E == 0x00)))
 									{
 										word64 r8_n;
@@ -1311,13 +1311,13 @@ l0000000000403770:
 									if (globals->b61B130 != 0x00)
 									{
 										fwrite_unlocked(0x00413771, 0x01, 0x02, globals->ptr61A610);
-										globals->t61B018 = (word64) globals->t61B018 + 2;
+										globals->t61B018 = (word32) globals->t61B018 + 2;
 									}
 									Eq_n rax_n = dcgettext(null, 4274651, 0x05);
 									fputs_unlocked(rax_n, globals->ptr61A610);
 									Eq_n eax_n = strlen(rax_n);
 									FILE * rdi_n = globals->ptr61A610;
-									globals->t61B018 = (word64) globals->t61B018 + SEQ(SLICE(rax_n, word32, 32), eax_n);
+									globals->t61B018 = (word32) globals->t61B018 + SEQ(SLICE(rax_n, word32, 32), eax_n);
 									byte * rax_n = *((char *) rdi_n + 40);
 									if (rax_n < *((char *) rdi_n + 48))
 									{
@@ -1329,12 +1329,12 @@ l0000000000403770:
 									Eq_n r8_n = globals->t61B138;
 									word32 edx_n = (word32) (uint64) globals->dw61B140;
 									Eq_n rdi_n = *((byte) rsp_n.u0 + 8);
-									globals->t61B018 = (word64) globals->t61B018 + 1;
+									globals->t61B018 = (word32) globals->t61B018 + 1;
 									Eq_n rax_n = fn000000000040BD70(0x0200, edx_n, (byte) rsp_n.u0 + 224, rdi_n, r8_n, fs, rLoc4, out r8_n);
 									fputs_unlocked(rax_n, globals->ptr61A610);
 									Eq_n eax_n = strlen(rax_n);
 									FILE * rdi_n = globals->ptr61A610;
-									globals->t61B018 = (word64) globals->t61B018 + SEQ(SLICE(rax_n, word32, 32), eax_n);
+									globals->t61B018 = (word32) globals->t61B018 + SEQ(SLICE(rax_n, word32, 32), eax_n);
 									byte * rax_n = *((char *) rdi_n + 40);
 									if (rax_n < *((char *) rdi_n + 48))
 									{
@@ -1343,14 +1343,14 @@ l0000000000403770:
 									}
 									else
 										__overflow(rdi_n, 0x0A);
-									globals->t61B018 = (word64) globals->t61B018 + 1;
+									globals->t61B018 = (word32) globals->t61B018 + 1;
 								}
 								if (globals->t61B1B0 != 0x00)
 									r8_n = fn00000000004079F0(rax_n, fs, rLoc4);
 l00000000004034A1:
 								Eq_n rbx_n = *((byte) rsp_n.u0 + 24);
 								free(*rbx_n);
-								free(*((word64) rbx_n + 8));
+								free(*((word32) rbx_n + 8));
 								free(rbx_n);
 								globals->b61B0D0 = 0x01;
 								goto l00000000004034C6;
@@ -1375,7 +1375,7 @@ l00000000004034A1:
 							Eq_n rdx_n = *((byte) rsp_n.u0 + 8);
 							Eq_n rdi_n = globals->t61B1C8;
 							*rax_n = *((byte) rsp_n.u0 + 16);
-							*((word64) rax_n + 8) = rdx_n;
+							*((word32) rax_n + 8) = rdx_n;
 							Eq_n rax_n = fn000000000040BB50(rax_n, rdi_n, xmm0, xmm1, xmm2, out r8_n, out xmm0, out xmm1, out xmm2);
 							if (rax_n != 0x00)
 							{
@@ -1394,9 +1394,9 @@ l00000000004034A1:
 									_obstack_newchunk(&globals->t61AF00, 0x10);
 									rax_n = globals->ptr61AF18;
 								}
-								globals->ptr61AF18 = (union Eq_n *) ((char *) rax_n + 16);
-								*((char *) rax_n + 8) = (union Eq_n *) *((byte) rsp_n.u0 + 64);
-								*rax_n = (union Eq_n *) *((byte) rsp_n.u0 + 72);
+								globals->ptr61AF18 = (DIR *) ((char *) &rax_n->t0008 + 8);
+								rax_n->t0008 = *((byte) rsp_n.u0 + 64);
+								rax_n->t0000 = *((byte) rsp_n.u0 + 72);
 								goto l00000000004035FF;
 							}
 l00000000004043BB:
@@ -1405,7 +1405,7 @@ l00000000004043BB:
 					}
 					Eq_n rax_n = globals->t61B190;
 					*((byte) rsp_n.u0 + 24) = rax_n;
-					if ((word32) (uint64) (r13d_n - 0x01) <= 0x00 && (rax_n != 0x00 && *((word64) rax_n + 24) == 0x00))
+					if ((word32) (uint64) (r13d_n - 0x01) <= 0x00 && (rax_n != 0x00 && *((word32) rax_n + 24) == 0x00))
 						globals->b61B0D0 = 0x00;
 					goto l00000000004034D2;
 				}
@@ -1693,15 +1693,15 @@ void fn0000000000404D20(Eq_n edx, Eq_n rsi, Eq_n rdi)
 	Eq_n rax_n = 0x00;
 	if (rsi != 0x00)
 		rax_n = fn0000000000410E30(0x00, rsi);
-	*((word64) rax_n + 8) = rax_n;
+	*((word32) rax_n + 8) = rax_n;
 	Eq_n rax_n = 0x00;
 	if (rdi != 0x00)
 		rax_n = fn0000000000410E30(0x00, rdi);
 	*rax_n = rax_n;
 	Eq_n rax_n = globals->t61B190;
-	*((word64) rax_n + 16) = r13b_n;
+	*((word32) rax_n + 16) = r13b_n;
 	globals->t61B190 = rax_n;
-	*((word64) rax_n + 24) = rax_n;
+	*((word32) rax_n + 24) = rax_n;
 }
 
 // 0000000000404D90: void fn0000000000404D90(Register (ptr64 Eq_n) rdi)
@@ -1721,8 +1721,8 @@ void fn0000000000404DD0()
 	Eq_n rbx_n = 0x00;
 	while (rbx_n < globals->t61B1B0)
 	{
-		fn0000000000404D90(*((word64) globals->t61B1A8 + rbx_n * 0x08));
-		rbx_n = (word64) rbx_n + 1;
+		fn0000000000404D90(*((word32) globals->t61B1A8 + rbx_n * 0x08));
+		rbx_n = (word32) rbx_n + 1;
 	}
 	globals->t61B1B0.u0 = 0x00;
 	globals->b61B17C = 0x00;
@@ -1744,7 +1744,7 @@ word64 fn0000000000404E80(int32 * r8, int32 & r8Out)
 	word32 r8_32_n = SLICE(r8, word32, 32);
 	Eq_n rbx_n = globals->t61B1B0;
 	Eq_n rbp_n = rbx_n;
-	if ((word64) rbx_n + (rbx_n >> 0x01) > globals->qw61B1A0)
+	if ((word32) rbx_n + (rbx_n >> 0x01) > globals->qw61B1A0)
 	{
 		free(globals->t61B1A8);
 		if (rbx_n > 0xAAAAAAAA)
@@ -1758,12 +1758,12 @@ word64 fn0000000000404E80(int32 * r8, int32 & r8Out)
 	{
 		Eq_n rax_n = globals->t61B1A8;
 		Eq_n rdx_n = globals->t61B1C0;
-		Eq_n rcx_n = (word64) rax_n + rbp_n * 0x08;
+		Eq_n rcx_n = (word32) rax_n + rbp_n * 0x08;
 		do
 		{
 			*rax_n = rdx_n;
-			rax_n = (word64) rax_n + 8;
-			rdx_n = (word64) rdx_n + 0x00C0;
+			rax_n = (word32) rax_n + 8;
+			rdx_n = (word32) rdx_n + 0x00C0;
 		} while (rax_n != rcx_n);
 	}
 	int32 * r8_n = r8;
@@ -1785,13 +1785,13 @@ word64 fn0000000000404E80(int32 * r8, int32 & r8Out)
 			if (rsi_n != 0x00)
 			{
 				Eq_n rdx_n = globals->t61B1C0;
-				Eq_n rcx_n = (word64) rdi_n + rsi_n * 0x08;
+				Eq_n rcx_n = (word32) rdi_n + rsi_n * 0x08;
 				Eq_n rax_n = rdi_n;
 				do
 				{
 					*rax_n = rdx_n;
-					rax_n = (word64) rax_n + 8;
-					rdx_n = (word64) rdx_n + 0x00C0;
+					rax_n = (word32) rax_n + 8;
+					rdx_n = (word32) rdx_n + 0x00C0;
 				} while (rax_n != rcx_n);
 			}
 			ecx_n = (word32) (uint64) r8d_n;
@@ -1808,7 +1808,7 @@ word64 fn0000000000404E80(int32 * r8, int32 & r8Out)
 			edx_n = globals->dw61B14C;
 		int64 rax_n = (int64) eax_n;
 		r8_n = SEQ(r8_32_n, (word32) globals->b61B10C);
-		rsi = fn000000000040D690(*((char *) globals->a412D00 + (r8_n + (SEQ(SLICE(rax_n, word32, 32), (word32) globals->b61B147) + (rax_n + (uint64) (edx_n + ecx_n) * 0x02) * 0x02) * 0x02) * 0x08), rbx_n, rsi_n, rdi_n);
+		rsi = fn000000000040D690(globals->a412D00[r8_n + (SEQ(SLICE(rax_n, word32, 32), (word32) globals->b61B147) + (rax_n + (uint64) (edx_n + ecx_n) * 0x02) * 0x02) * 0x02], rbx_n, rsi_n, rdi_n);
 	}
 	r8Out = r8_n;
 	return rsi;
@@ -1834,7 +1834,7 @@ void fn0000000000405090(Eq_n sil, Eq_n rdi)
 				Eq_n rax_n = fn000000000040A390(r15_n);
 				if (*rax_n == 0x2E)
 				{
-					byte al_n = (byte) (word32) ((word64) rax_n + 1 + (uint64) ((uint8) (*((word64) rax_n + 1) == 0x2E)));
+					byte al_n = (byte) (word32) ((word32) rax_n + 1 + (uint64) ((uint8) (*((word32) rax_n + 1) == 0x2E)));
 					if (al_n != 0x2F && al_n != 0x00)
 						goto l00000000004050D8;
 					goto l0000000000405100;
@@ -1870,9 +1870,9 @@ l0000000000405100:
 		Eq_n rax_n = 0x00;
 		do
 		{
-			struct Eq_n * rcx_n = *((word64) rsi_n + rax_n * 0x08);
-			*((word64) rsi_n + rdx_n * 0x08) = rcx_n;
-			rax_n = (word64) rax_n + 1;
+			struct Eq_n * rcx_n = *((word32) rsi_n + rax_n * 0x08);
+			*((word32) rsi_n + rdx_n * 0x08) = rcx_n;
+			rax_n = (word32) rax_n + 1;
 			rdx_n.u0 = (byte) rdx_n.u0 + SEQ(SLICE(rcx_n, word32, 32), (word32) (rcx_n->dw00A0 != 0x09));
 		} while (rax_n != rdi_n);
 	}
@@ -1892,10 +1892,10 @@ void fn0000000000405200(Eq_n rsi, Eq_n rdi)
 			Eq_n rcx_n = globals->t61B0D8;
 			if (rcx_n == 0x00)
 			{
-				rbx_n = (word64) rbx_n + 1;
+				rbx_n = (word32) rbx_n + 1;
 				goto l000000000040527B;
 			}
-			Eq_n rsi_n = (word64) rbx_n + 1;
+			Eq_n rsi_n = (word32) rbx_n + 1;
 			if ((uint64) ((uint128) (uint64) rsi /u rcx_n) > (uint64) ((uint128) ((uint64) rsi_n) /u rcx_n))
 			{
 				FILE * rdi_n = globals->ptr61A610;
@@ -1945,7 +1945,7 @@ FILE * fn00000000004052D0(FILE * rcx, struct Eq_n * rdx, Eq_n rsi, FILE * rdi, E
 	{
 		word64 v24_n = fp - 0x2088 - (rax_n + 0x1F & ~0x0F) + 0x0F & ~0x0F;
 		qwLoc2070_n = v24_n;
-		rax_32_32_n = SLICE(fn000000000040E6F0(~0x00, rsi, (word64) rax_n + 1, v24_n, rdx, fs, out rsi_n, out r8_n), word32, 32);
+		rax_32_32_n = SLICE(fn000000000040E6F0(~0x00, rsi, (word32) rax_n + 1, v24_n, rdx, fs, out rsi_n, out r8_n), word32, 32);
 	}
 	word64 rdx_n;
 	ui32 rdx_32_32_n = SLICE(rdx_n, word32, 32);
@@ -2177,7 +2177,7 @@ Eq_n fn0000000000405700(word32 rax_32_n, Eq_n edx, Eq_n rdi, struct Eq_n * fs)
 		__printf_chk(0x01, 4274014, 0x00);
 		rbp_n.u0 = (int64) ebx_n;
 	}
-	Eq_n rax_n = (word64) globals->t61B018 + ((word64) rbp_n.u0 + 1);
+	Eq_n rax_n = (word32) globals->t61B018 + ((word64) rbp_n.u0 + 1);
 	globals->t61B018 = rax_n;
 	return rax_n;
 }
@@ -2325,7 +2325,7 @@ word64 fn0000000000405D00(Eq_n rcx, Eq_n edx, Eq_n rsi, byte dil)
 		}
 		else
 			rax_56_8_n = SEQ(rax_32_32_n, SLICE(__overflow(rdi_n, SEQ(rsi_32_32_n, (word32) bl_n)), word24, 8));
-		globals->t61B018 = (word64) globals->t61B018 + 1;
+		globals->t61B018 = (word32) globals->t61B018 + 1;
 	}
 	return SEQ(rax_56_8_n, bl_n != 0x00);
 }
@@ -2342,7 +2342,7 @@ Eq_n fn0000000000405D50(Eq_n rdi, Eq_n r12, struct Eq_n * fs, Eq_n rLoc4, ptr64 
 			rbx_n = (int64) globals->t61B178 + 0x01;
 		else
 		{
-			Eq_n rax_n = fn000000000040CD70(fp - 696, *((word64) rdi + 24));
+			Eq_n rax_n = fn000000000040CD70(fp - 696, *((word32) rdi + 24));
 			rax_32_32_n = SLICE(rax_n, word32, 32);
 			rbx_n = SEQ(rax_32_32_n, strlen(rax_n)) + 0x01;
 		}
@@ -2355,10 +2355,10 @@ Eq_n fn0000000000405D50(Eq_n rdi, Eq_n r12, struct Eq_n * fs, Eq_n rLoc4, ptr64 
 		else
 		{
 			rax_n.u1 = 0x02;
-			if (*((word64) rdi + 0x00B0) != 0x00)
+			if (*((word32) rdi + 0x00B0) != 0x00)
 			{
 				word64 r8_n;
-				Eq_n rax_n = fn000000000040BD70(0x0200, (word32) (uint64) globals->dw61B140, fp - 696, *((word64) rdi + 80), globals->t61B138, fs, rLoc4, out r8_n);
+				Eq_n rax_n = fn000000000040BD70(0x0200, (word32) (uint64) globals->dw61B140, fp - 696, *((word32) rdi + 80), globals->t61B138, fs, rLoc4, out r8_n);
 				rax_n = SEQ(SLICE(rax_n, word32, 32), strlen(rax_n)) + 0x01;
 			}
 		}
@@ -2371,7 +2371,7 @@ Eq_n fn0000000000405D50(Eq_n rdi, Eq_n r12, struct Eq_n * fs, Eq_n rLoc4, ptr64 
 		if (globals->dw61B150 != 0x04)
 			rax_n = (int64) globals->t61B16C + 0x01;
 		else
-			rax_n = SEQ(rax_32_32_n, strlen(*((word64) rdi + 0x00A8))) + 0x01;
+			rax_n = SEQ(rax_32_32_n, strlen(*((word32) rdi + 0x00A8))) + 0x01;
 		rbx_n += rax_n;
 	}
 	ptr64 r8_n;
@@ -2380,7 +2380,7 @@ Eq_n fn0000000000405D50(Eq_n rdi, Eq_n r12, struct Eq_n * fs, Eq_n rLoc4, ptr64 
 	if ((word32) (uint64) globals->dw61B12C != 0x00)
 	{
 		word64 rsi_n;
-		word64 rax_n = fn0000000000405C20(rcx_n, (word32) (uint64) *((word64) rdi + 0x00A0), (uint64) *((word64) rdi + 40), (byte) (word32) *((word64) rdi + 0x00B0), out rsi_n);
+		word64 rax_n = fn0000000000405C20(rcx_n, (word32) (uint64) *((word32) rdi + 0x00A0), (uint64) *((word32) rdi + 40), (byte) (word32) *((word32) rdi + 0x00B0), out rsi_n);
 		rbx_n += SEQ(SLICE(rax_n, word32, 32), (word32) (SLICE(rax_n, byte, 0) != 0x00));
 	}
 	if ((rax_n ^ fs->qw0028) != 0x00)
@@ -2432,7 +2432,7 @@ Eq_n fn0000000000405ED0(Eq_n edi, struct Eq_n * fs, Eq_n rLoc4, union Eq_n & r8O
 		Mem56[0x000000000061B028<p64>:word64] = fn0000000000410C90(rbp_n + rbx_n << 0x04, rdi_n);
 	}
 	Eq_n rax_n = globals->t61A660;
-	Eq_n rsi_n = (word64) rax_n + ((word64) rbp_n + 1);
+	Eq_n rsi_n = (word32) rax_n + ((word32) rbp_n + 1);
 	Eq_n rdi_n = rbp_n - rax_n;
 	Eq_n rcx_n = rsi_n *s rdi_n;
 	if (rbp_n <= rsi_n && (rsi_n == (uint64) ((uint128) ((uint64) rcx_n) /u rdi_n) && rcx_n >> 0x01 <= 0xFFFFFFFF))
@@ -2444,12 +2444,12 @@ Eq_n fn0000000000405ED0(Eq_n edi, struct Eq_n * fs, Eq_n rLoc4, union Eq_n & r8O
 			Eq_n rsi_n = globals->t61B028;
 			ui64 rcx_n = rcx_n * 0x08 + 0x08;
 			struct Eq_n * rdx_n;
-			struct Eq_n * rsi_n = (word64) rsi_n + rbp_n * 0x18;
+			struct Eq_n * rsi_n = (word32) rsi_n + rbp_n * 0x18;
 			do
 			{
 				rdx_n->qw0000 = (word64) rax_n;
 				++rdx_n;
-				rax_n = (word64) rax_n + rcx_n;
+				rax_n = (word32) rax_n + rcx_n;
 				rcx_n += 0x08;
 			} while (rdx_n != rsi_n);
 		}
@@ -2465,7 +2465,7 @@ l0000000000406004:
 			{
 				do
 				{
-					Eq_n rax_n = fn0000000000405D50(*((word64) globals->t61B1A8 + rbp_n * 0x08), r12_n, fs, rLoc4, out r8_n);
+					Eq_n rax_n = fn0000000000405D50(*((word32) globals->t61B1A8 + rbp_n * 0x08), r12_n, fs, rLoc4, out r8_n);
 					Eq_n r14_n = globals->t61B1B0;
 					if (rbx_n != 0x00)
 					{
@@ -2483,23 +2483,23 @@ l0000000000406004:
 									r10_n = (uint64) ((uint128) (uint64) rbp_n % rcx_n);
 								else
 									r10_n = (uint64) ((uint128) (uint64) rbp_n /u (uint64) ((uint128) ((uint64) ((word64) rcx_n + (r14_n - 0x01))) /u rcx_n));
-								up64 * rax_n = (word64) *((word64) rsi_n + 16) + r10_n * 0x08;
+								up64 * rax_n = (word32) *((word32) rsi_n + 16) + r10_n * 0x08;
 								up64 rdx_n = (word64) rax_n + (uint64) ((uint8) (r9_n != r10_n)) * 0x02;
 								up64 r9_n = *rax_n;
 								if (rdx_n > r9_n)
 								{
-									*((word64) rsi_n + 8) = (word64) *((word64) rsi_n + 8) + (rdx_n - r9_n);
+									*((word32) rsi_n + 8) = (word32) *((word32) rsi_n + 8) + (rdx_n - r9_n);
 									*rax_n = rdx_n;
-									*rsi_n = *((word64) rsi_n + 8) < r13_n;
+									*rsi_n = *((word32) rsi_n + 8) < r13_n;
 								}
 							}
 							r8_n = rcx_n;
-							rsi_n = (word64) rsi_n + 24;
+							rsi_n = (word32) rsi_n + 24;
 							rcx_n = (word64) rcx_n + 1;
 							rcx_n = rcx_n;
 						} while (rbx_n > rcx_n);
 					}
-					rbp_n = (word64) rbp_n + 1;
+					rbp_n = (word32) rbp_n + 1;
 				} while (rbp_n < r14_n);
 			}
 			if (rbx_n > 0x01)
@@ -2508,7 +2508,7 @@ l0000000000406004:
 				ui64 rax_n = rbx_n * 0x03;
 				if ((rdx_n - 0x18)[rax_n].b0000 == 0x00)
 				{
-					Eq_n rax_n = (word64) rdx_n + (rax_n << 0x03);
+					Eq_n rax_n = (word32) rdx_n + (rax_n << 0x03);
 					do
 					{
 						--rbx_n;
@@ -2524,17 +2524,17 @@ l0000000000406004:
 l00000000004060E0:
 		while (true)
 		{
-			word64 rcx_n[] = *((word64) rsi_n + 16);
+			word64 rcx_n[] = *((word32) rsi_n + 16);
 			rsi_n->u0 = 0x01;
 			Eq_n rdi_n = (byte) rax_n.u0 + 1;
-			*((word64) rsi_n + 8) = rdi_n * 0x03;
+			*((word32) rsi_n + 8) = rdi_n * 0x03;
 			Eq_n rdx_n = 0x00;
 			do
 			{
 				rcx_n[rdx_n] = 0x03;
-				rdx_n = (word64) rdx_n + 1;
+				rdx_n = (word32) rdx_n + 1;
 			} while (rdx_n <= rax_n);
-			rsi_n = (word64) rsi_n + 24;
+			rsi_n = (word32) rsi_n + 24;
 			if (rdi_n == rbx_n)
 				break;
 			rax_n = rdi_n;
@@ -2657,7 +2657,7 @@ union Eq_n * fn0000000000406540(union Eq_n * rax, Eq_n rcx, struct obstack * rdx
 	ui32 r14d_n;
 	ui32 r15d_n;
 	Eq_n rdx_n = *rdi;
-	Eq_n r12_n = *((word64) rdi + 8);
+	Eq_n r12_n = *((word32) rdi + 8);
 	if (sil != 0x00)
 	{
 		if (globals->b61B129 == 0x00)
@@ -2665,8 +2665,8 @@ union Eq_n * fn0000000000406540(union Eq_n * rax, Eq_n rcx, struct obstack * rdx
 			r14b_n = 0x00;
 			goto l00000000004066FF;
 		}
-		r14d_n = (word32) *((word64) rdi + 177);
-		r15d_n = (word32) (uint64) *((word64) rdi + 0x00A4);
+		r14d_n = (word32) *((word32) rdi + 177);
+		r15d_n = (word32) (uint64) *((word32) rdi + 0x00A4);
 		if ((byte) r14d_n == 0x00)
 		{
 			edx_n.u0 = 0x0C;
@@ -2677,9 +2677,9 @@ l00000000004065B0:
 		word32 rax_32_32_n;
 		byte r14b_n = (byte) r14d_n;
 		byte r15b_n = (byte) r15d_n;
-		if (*((word64) rdi + 0x00B0) == 0x00)
+		if (*((word32) rdi + 0x00B0) == 0x00)
 		{
-			uint64 rax_n = (uint64) *((word64) rdi + 0x00A0);
+			uint64 rax_n = (uint64) *((word32) rdi + 0x00A0);
 			ui24 eax_24_8_n = SLICE(rax_n, word24, 8);
 			rax_32_32_n = SLICE(rax_n, word32, 32);
 			edx_n = (word32) (uint64) globals->a412C60[rax_n * 0x04];
@@ -2704,7 +2704,7 @@ l00000000004065B0:
 				}
 				union Eq_n * rax_n = fn0000000000404CD0(0x15);
 				rax_32_32_n = SLICE(rax_n, word32, 32);
-				if ((byte) rax_n != 0x00 && *((word64) rdi + 0x00B8) != 0x00)
+				if ((byte) rax_n != 0x00 && *((word32) rdi + 0x00B8) != 0x00)
 				{
 					edx_n.u0 = 0x15;
 					goto l00000000004066B0;
@@ -2719,7 +2719,7 @@ l00000000004065B0:
 						goto l00000000004066B0;
 					}
 				}
-				if (*((word64) rdi + 32) > 0x01)
+				if (*((word32) rdi + 32) > 0x01)
 				{
 					union Eq_n * rax_n = fn0000000000404CD0(22);
 					rax_32_32_n = SLICE(rax_n, word32, 32);
@@ -2737,14 +2737,14 @@ l00000000004065CF:
 				while (rbp_n != 0x00)
 				{
 					Eq_n rdx_n = *rbp_n;
-					if (rax_n >= rdx_n && strncmp(r15_n - rdx_n, *((word64) rbp_n + 8), rdx_n) == 0x00)
+					if (rax_n >= rdx_n && strncmp(r15_n - rdx_n, *((word32) rbp_n + 8), rdx_n) == 0x00)
 					{
 						if (rbp_n == 0x00)
 							break;
-						rbp_n = (word64) rbp_n + 16;
+						rbp_n = (struct Eq_n *) ((word32) rbp_n + 16);
 						goto l00000000004066C0;
 					}
-					rbp_n = *((word64) rbp_n + 32);
+					rbp_n = *((word32) rbp_n + 32);
 				}
 				edx_n.u0 = 0x05;
 l00000000004066B0:
@@ -2820,7 +2820,7 @@ l00000000004066FF:
 				{
 					fn0000000000406400();
 					rcx_n = globals->t61B0C8;
-					if ((uint64) ((uint128) (uint64) rcx /u rcx_n) != (uint64) ((uint128) ((uint64) ((word64) rcx + (rbp_n - 0x01))) /u rcx_n))
+					if ((uint64) ((uint128) (uint64) rcx /u rcx_n) != (uint64) ((uint128) ((uint64) ((word32) rcx + (rbp_n - 0x01))) /u rcx_n))
 						fn0000000000406440(&globals->t61A550, out rcx_n);
 				}
 				rcxOut = rcx_n;
@@ -2883,17 +2883,17 @@ l00000000004066FF:
 	word32 r14d_n;
 	if (globals->b61B198 != 0x00)
 	{
-		if (*((word64) rdi + 177) != 0x00)
+		if (*((word32) rdi + 177) != 0x00)
 		{
-			r15d_n = (word32) (uint64) *((word64) rdi + 0x00A4);
+			r15d_n = (word32) (uint64) *((word32) rdi + 0x00A4);
 			r14d_n = 0x01;
 			goto l00000000004069F7;
 		}
 		r14d_n = 0x00;
 	}
 	else
-		r14d_n = (word32) *((word64) rdi + 177);
-	r15d_n = (word32) (uint64) *((word64) rdi + 40);
+		r14d_n = (word32) *((word32) rdi + 177);
+	r15d_n = (word32) (uint64) *((word32) rdi + 40);
 l00000000004069F7:
 	r14d_n = (word32) (uint64) (r14d_n ^ 0x01);
 	r12_n = rdx_n;
@@ -2929,7 +2929,7 @@ word64 fn0000000000406A80(Eq_n rdx, Eq_n rsi, Eq_n rdi, struct Eq_n * fs)
 		if (rax_n != null && SEQ(rax_32_32_n, strlen(rsi)) <= 101)
 		{
 			char * rax_n = __mempcpy_chk(fp - 0x0138, rsi, rax_n - rsi, 0x0105);
-			int64 rcx_n = (int64) *((word64) rdx + 16);
+			int64 rcx_n = (int64) *((word32) rdx + 16);
 			strcpy(stpcpy(rax_n, rcx_n + 0x0061A760 + rcx_n * 0xA0), rax_n + 2);
 			rbx_n = fp - 0x0138;
 		}
@@ -2947,9 +2947,9 @@ word64 fn0000000000406B70(Eq_n rdi, struct Eq_n * fs, Eq_n rLoc4)
 	word32 eax_n;
 	bool C_n;
 	word64 rax_n = fs->qw0028;
-	if (*((word64) rdi + 0x00B0) != 0x00)
+	if (*((word32) rdi + 0x00B0) != 0x00)
 	{
-		fn000000000040A600(fp - 4776, (word64) rdi + 16);
+		fn000000000040A600(fp - 4776, (word32) rdi + 16);
 		if (globals->b61B17C == 0x00)
 		{
 l0000000000406BC7:
@@ -2962,7 +2962,7 @@ l0000000000406BC7:
 	}
 	else if (globals->b61B17C == 0x00)
 		goto l0000000000406BC2;
-	word32 eax_n = (word32) (uint64) *((word64) rdi + 0x00B4);
+	word32 eax_n = (word32) (uint64) *((word32) rdi + 0x00B4);
 	if (eax_n != 0x01 && eax_n == 0x02)
 	{
 		eax_n = (word32) (uint64) globals->dw61B14C;
@@ -2974,17 +2974,17 @@ l0000000000406BD6:
 			{
 				if (eax_n != 0x02)
 					abort();
-				rax_32_32_n = (word32) *((word64) rdi + 100);
+				rax_32_32_n = (word32) *((word32) rdi + 100);
 			}
 			else
-				rax_32_32_n = (word32) *((word64) rdi + 116);
+				rax_32_32_n = (word32) *((word32) rdi + 116);
 l0000000000406BF7:
 			Eq_n rbp_n = fp - 0x0E88;
 			if (globals->b61B114 != 0x00)
 			{
-				if (*((word64) rdi + 0x00B0) != 0x00)
+				if (*((word32) rdi + 0x00B0) != 0x00)
 				{
-					Eq_n rdi_n = *((word64) rdi + 24);
+					Eq_n rdi_n = *((word32) rdi + 24);
 					if (rdi_n != 0x00)
 						fn000000000040CD70(fp - 0x1278, rdi_n);
 				}
@@ -2995,11 +2995,11 @@ l0000000000406BF7:
 					uint64 rcx_n = (uint64) *rdx_n;
 					uint64 rax_n = (uint64) ((word32) (uint64) (rcx_n + ~0x01010100 & (word32) ((uint64) (~((word32) rcx_n)))) & 0x80808080);
 					ui32 eax_n = (word32) rax_n;
-					rdx_n = (word64) rdx_n + 4;
+					rdx_n = (word32) rdx_n + 4;
 					bui8 al_n = (byte) eax_n;
 					rax_32_32_n = SLICE(rax_n, word32, 32);
 				} while (eax_n == 0x00);
-				Eq_n rbp_n = (word64) rdx_n + 2;
+				Eq_n rbp_n = (word32) rdx_n + 2;
 				word32 ecx_n = (word32) (uint64) ((word32) (uint64) eax_n >> 0x10);
 				if ((eax_n & 0x8080) == 0x00)
 					al_n = (byte) ecx_n;
@@ -3011,45 +3011,45 @@ l0000000000406BF7:
 			{
 l0000000000406C8F:
 				Eq_n rsp_n = fp - 4840;
-				if (*((word64) rdi + 0x00B0) != 0x00)
-					fn000000000040CD70(fp - 0x1278, *((word64) rdi + 32));
+				if (*((word32) rdi + 0x00B0) != 0x00)
+					fn000000000040CD70(fp - 0x1278, *((word32) rdi + 32));
 				__sprintf_chk(rbp_n, 0x01, ~0x00, "%s %*s ", 0x00);
 				word32 rax_32_32_n = 0x00;
 				Eq_n rbp_n = (word64) rbp_n + (uint64) ((uint32) strlen(rbp_n));
 				if (globals->b61B130 != 0x00)
 				{
 					fwrite_unlocked(0x00413771, 0x01, 0x02, globals->ptr61A610);
-					globals->t61B018 = (word64) globals->t61B018 + 2;
+					globals->t61B018 = (word32) globals->t61B018 + 2;
 				}
 				if (globals->b61A569 != 0x00 || (globals->b61A568 != 0x00 || (globals->b61B146 != 0x00 || globals->b61B17D != 0x00)))
 				{
 					fputs_unlocked(fp - 0x0E88, globals->ptr61A610);
-					globals->t61B018 = (word64) globals->t61B018 + (rbp_n - (fp - 0x0E88));
+					globals->t61B018 = (word32) globals->t61B018 + (rbp_n - (fp - 0x0E88));
 					if (globals->b61A569 != 0x00)
 					{
-						rax_32_32_n = SLICE(fn00000000004057B0((byte) (word32) *((word64) rdi + 0x00B0), (word32) (uint64) globals->dw61B168, (uint64) *((word64) rdi + 44), fs), word32, 32);
+						rax_32_32_n = SLICE(fn00000000004057B0((byte) (word32) *((word32) rdi + 0x00B0), (word32) (uint64) globals->dw61B168, (uint64) *((word32) rdi + 44), fs), word32, 32);
 						rsp_n = fp - 4848;
 					}
 					if (globals->b61A568 != 0x00)
 					{
-						uint64 rax_n = (uint64) *((word64) rdi + 48);
+						uint64 rax_n = (uint64) *((word32) rdi + 48);
 						Eq_n rdx_n = (uint64) globals->dw61B164;
 						word32 eax_n = (word32) rax_n;
 						word32 rax_32_32_n = SLICE(rax_n, word32, 32);
 						Eq_n rdi_n = 4274020;
 						Eq_n edx_n = (word32) rdx_n;
 						uint64 rsi_n = (uint64) eax_n;
-						if (*((word64) rdi + 0x00B0) != 0x00)
+						if (*((word32) rdi + 0x00B0) != 0x00)
 						{
 							rdi_n.u0 = 0x00;
 							if (globals->b61B145 == 0x00)
 							{
-								*((word64) rsp_n + 24) = rsi_n;
-								*((word64) rsp_n + 16) = edx_n;
+								*((word32) rsp_n + 24) = rsi_n;
+								*((word32) rsp_n + 16) = edx_n;
 								Eq_n rax_n = fn000000000040CB40((uint64) eax_n);
 								rax_32_32_n = SLICE(rax_n, word32, 32);
 								rdi_n = rax_n;
-								rdx_n.u0 = (uint64) *((word64) rsp_n + 16);
+								rdx_n.u0 = (uint64) *((word32) rsp_n + 16);
 							}
 						}
 						rax_32_32_n = SLICE(fn0000000000405700(rax_32_32_n, rdx_n, rdi_n, fs), word32, 32);
@@ -3063,35 +3063,35 @@ l0000000000406C8F:
 					else
 					{
 						rbp_n = fp - 0x0E88;
-						rax_32_32_n = SLICE(fn00000000004057B0((byte) (word32) *((word64) rdi + 0x00B0), (word32) (uint64) globals->dw61B160, (uint64) *((word64) rdi + 44), fs), word32, 32);
-						rsp_n = (word64) rsp_n - 8;
+						rax_32_32_n = SLICE(fn00000000004057B0((byte) (word32) *((word32) rdi + 0x00B0), (word32) (uint64) globals->dw61B160, (uint64) *((word32) rdi + 44), fs), word32, 32);
+						rsp_n = (word32) rsp_n - 8;
 						if (globals->b61B17D == 0x00)
 							goto l0000000000406D58;
 					}
 					rbp_n = fp - 0x0E88;
-					rax_32_32_n = SLICE(fn0000000000405700(rax_32_32_n, (uint64) globals->t61B16C, *((word64) rdi + 0x00A8), fs), word32, 32);
+					rax_32_32_n = SLICE(fn0000000000405700(rax_32_32_n, (uint64) globals->t61B16C, *((word32) rdi + 0x00A8), fs), word32, 32);
 				}
 l0000000000406D58:
 				Eq_n r13_n;
 				Eq_n r14_n;
-				if (*((word64) rdi + 0x00B0) != 0x00)
+				if (*((word32) rdi + 0x00B0) != 0x00)
 				{
-					if ((word32) (uint64) ((word32) (uint64) *((word64) rdi + 40) & 0xB000) == 0x2000)
+					if ((word32) (uint64) ((word32) (uint64) *((word32) rdi + 40) & 0xB000) == 0x2000)
 					{
-						uint64 rax_n = *((word64) rdi + 56);
-						int32 r13d_n = (word32) (uint64) ((word64) globals->t61B154 + (word32) ((uint64) ((word32) ((uint64) (~0x01 - globals->t61B15C)) - globals->t61B158)));
-						Eq_n rax_n = fn000000000040CD70((word64) rsp_n + 112, (uint64) (SEQ(SLICE(rax_n >> 0x0C, word24, 8), (byte) (rax_n >> 0x0C) & 0x00) | (word32) ((byte) rax_n)));
-						uint64 rdx_n = *((word64) rdi + 56);
+						uint64 rax_n = *((word32) rdi + 56);
+						int32 r13d_n = (word32) (uint64) ((word32) globals->t61B154 + (word32) ((uint64) ((word32) ((uint64) (~0x01 - globals->t61B15C)) - globals->t61B158)));
+						Eq_n rax_n = fn000000000040CD70((word32) rsp_n + 112, (uint64) (SEQ(SLICE(rax_n >> 0x0C, word24, 8), (byte) (rax_n >> 0x0C) & 0x00) | (word32) ((byte) rax_n)));
+						uint64 rdx_n = *((word32) rdi + 56);
 						word32 r14d_n = (word32) (uint64) globals->t61B158;
-						fn000000000040CD70((word64) rsp_n + 80, (uint64) ((word32) (uint64) ((word32) (rdx_n >> 0x20) & ~0x0FFF) | (word32) ((uint64) ((word32) ((uint64) ((word32) (rdx_n >> 0x08))) & 0x0FFF))));
-						*((word64) rsp_n + 8) = rax_n;
+						fn000000000040CD70((word32) rsp_n + 80, (uint64) ((word32) (uint64) ((word32) (rdx_n >> 0x20) & ~0x0FFF) | (word32) ((uint64) ((word32) ((uint64) ((word32) (rdx_n >> 0x08))) & 0x0FFF))));
+						*((word32) rsp_n + 8) = rax_n;
 						*rsp_n = r14d_n;
 						__sprintf_chk(rbp_n, 0x01, ~0x00, "%*s, %*s ", 0x00);
-						r13_n = (word64) rbp_n + 1 + (int64) globals->t61B154;
+						r13_n = (word32) rbp_n + 1 + (int64) globals->t61B154;
 						goto l0000000000406E9C;
 					}
 					word64 r8_n;
-					Eq_n rax_n = fn000000000040BD70(0x01, (word32) (uint64) globals->dw61B134, (word64) rsp_n + 112, *((word64) rdi + 64), globals->t61A560, fs, rLoc4, out r8_n);
+					Eq_n rax_n = fn000000000040BD70(0x01, (word32) (uint64) globals->dw61B134, (word32) rsp_n + 112, *((word32) rdi + 64), globals->t61A560, fs, rLoc4, out r8_n);
 					rax_32_32_n = SLICE(rax_n, word32, 32);
 					r14_n = rax_n;
 				}
@@ -3102,20 +3102,20 @@ l0000000000406D58:
 				if (r13d_n > 0x00)
 				{
 					word32 eax_n = (word32) (uint64) (eax_n - 0x01);
-					Eq_n rcx_n = (word64) rbp_n + 1 + (uint64) eax_n;
+					Eq_n rcx_n = (word32) rbp_n + 1 + (uint64) eax_n;
 					Eq_n rdx_n = rbp_n;
 					do
 					{
-						rdx_n = (word64) rdx_n + 1;
+						rdx_n = (word32) rdx_n + 1;
 						(rdx_n - 0x01)->u0 = 0x20;
 					} while (rdx_n != rcx_n);
-					rbp_n = (word64) rbp_n + 1 + (int64) eax_n;
+					rbp_n = (word32) rbp_n + 1 + (int64) eax_n;
 				}
 				while (true)
 				{
 					r14_n.u0 = (byte) r14_n.u0 + 1;
 					byte al_n = (byte) (word32) *(r14_n - 0x01);
-					r13_n = (word64) rbp_n + 1;
+					r13_n = (word32) rbp_n + 1;
 					(r13_n - 0x01)->u0 = al_n;
 					if (al_n == 0x00)
 						break;
@@ -3126,9 +3126,9 @@ l0000000000406E9C:
 				word32 rax_32_32_n;
 				Eq_n r13_n;
 				Eq_n r9_n;
-				Eq_n rax_n = localtime((word64) rsp_n + 48);
+				Eq_n rax_n = localtime((word32) rsp_n + 48);
 				r13_n->u0 = 0x01;
-				if (*((word64) rdi + 0x00B0) == 0x00)
+				if (*((word32) rdi + 0x00B0) == 0x00)
 				{
 l0000000000406F80:
 					r9_n.u0 = 4274020;
@@ -3137,22 +3137,22 @@ l0000000000406F80:
 				if (rax_n == 0x00)
 				{
 l0000000000407364:
-					r9_n = fn000000000040CCD0((word64) rsp_n + 80, *((word64) rsp_n + 48));
+					r9_n = fn000000000040CCD0((word32) rsp_n + 80, *((word32) rsp_n + 48));
 l0000000000406F86:
 					if ((word32) (uint64) globals->dw61A3C4 < 0x00)
 					{
-						*((word64) rsp_n + 16) = r9_n;
-						*((word64) rsp_n + 40) = 0x00;
-						Eq_n rax_n = localtime((word64) rsp_n + 40);
+						*((word32) rsp_n + 16) = r9_n;
+						*((word32) rsp_n + 40) = 0x00;
+						Eq_n rax_n = localtime((word32) rsp_n + 40);
 						if (rax_n != 0x00)
 						{
-							Eq_n rax_n = fn0000000000406A80(rax_n, globals->t61A3D0, (word64) rsp_n + 112, fs);
+							Eq_n rax_n = fn0000000000406A80(rax_n, globals->t61A3D0, (word32) rsp_n + 112, fs);
 							int32 r8d_n = (word32) (uint64) globals->dw61A3C4;
-							Eq_n r9_n = *((word64) rsp_n + 16);
+							Eq_n r9_n = *((word32) rsp_n + 16);
 							if (rax_n != 0x00)
 							{
-								*((word64) rsp_n + 16) = r9_n;
-								word32 eax_n = (word32) fn000000000040D240(0x00, rax_n, (word64) rsp_n + 112, fs);
+								*((word32) rsp_n + 16) = r9_n;
+								word32 eax_n = (word32) fn000000000040D240(0x00, rax_n, (word32) rsp_n + 112, fs);
 								globals->dw61A3C4 = eax_n;
 								r8d_n = (word32) (uint64) eax_n;
 							}
@@ -3167,7 +3167,7 @@ l0000000000406F86:
 l0000000000406F96:
 						__sprintf_chk(r13_n, 0x01, ~0x00, "%*s ", 0x00);
 						rax_32_32_n = 0x00;
-						r13_n = (word64) r13_n + (uint64) ((uint32) strlen(r13_n));
+						r13_n = (word32) r13_n + (uint64) ((uint32) strlen(r13_n));
 l0000000000406FBC:
 						Eq_n r13_n = r13_n - (fp - 0x0E88);
 						int32 eax_n = fputs_unlocked(fp - 0x0E88, globals->ptr61A610);
@@ -3175,21 +3175,21 @@ l0000000000406FBC:
 						Eq_n rcx_n;
 						word64 r8_n;
 						word64 rax_n = fn0000000000406540(SEQ(rax_32_32_n, eax_n), r13_n, &globals->t61AFC0, 0x00, rdi, fs, out rcx_n, out r8_n);
-						Eq_n rdx_n = (uint64) *((word64) rdi + 0x00A0);
+						Eq_n rdx_n = (uint64) *((word32) rdi + 0x00A0);
 						word32 rax_32_32_n = SLICE(rax_n, word32, 32);
 						if ((word32) rdx_n != 0x06)
 						{
 							if ((word32) (uint64) globals->dw61B12C != 0x00)
-								fn0000000000405D00(rcx_n, rdx_n, (uint64) *((word64) rdi + 40), (byte) (word32) *((word64) rdi + 0x00B0));
+								fn0000000000405D00(rcx_n, rdx_n, (uint64) *((word32) rdi + 40), (byte) (word32) *((word32) rdi + 0x00B0));
 						}
-						else if (*((word64) rdi + 8) != 0x00)
+						else if (*((word32) rdi + 8) != 0x00)
 						{
 							Eq_n eax_n = fwrite_unlocked(4274046, 0x01, 0x04, globals->ptr61A610);
-							globals->t61B018 = (word64) globals->t61B018 + 4;
+							globals->t61B018 = (word32) globals->t61B018 + 4;
 							Eq_n rcx_n;
-							fn0000000000406540(SEQ(rax_32_32_n, eax_n), (word64) r13_n + 4 + rax_n, null, 0x01, rdi, fs, out rcx_n, out r8_n);
+							fn0000000000406540(SEQ(rax_32_32_n, eax_n), (word32) r13_n + 4 + rax_n, null, 0x01, rdi, fs, out rcx_n, out r8_n);
 							if ((word32) (uint64) globals->dw61B12C != 0x00)
-								fn0000000000405D00(rcx_n, 0x00, (uint64) *((word64) rdi + 0x00A4), 0x01);
+								fn0000000000405D00(rcx_n, 0x00, (uint64) *((word32) rdi + 0x00A4), 0x01);
 						}
 						if ((rax_n ^ fs->qw0028) == 0x00)
 							return r8_n;
@@ -3199,20 +3199,20 @@ l0000000000406FBC:
 				Eq_n r8d_n;
 				Eq_n rdi_n = globals->t61B188;
 				int64 rdx_n = globals->qw61B180;
-				int64 rsi_n = *((word64) rsp_n + 48);
+				int64 rsi_n = *((word32) rsp_n + 48);
 				Eq_n edi_n = (word32) rdi_n;
-				Eq_n ecx_n = *((word64) rsp_n + 56);
+				Eq_n ecx_n = *((word32) rsp_n + 56);
 				if (rsi_n <= rdx_n && (rsi_n < rdx_n || edi_n >= ecx_n))
 					r8d_n = (word32) rdi_n;
 				else
 				{
-					*((word64) rsp_n + 16) = rax_n;
+					*((word32) rsp_n + 16) = rax_n;
 					fn000000000040AB30(&globals->qw61B180);
 					rdx_n = globals->qw61B180;
 					r8d_n = globals->t61B188;
-					rsi_n = (int64) *((word64) rsp_n + 48);
-					ecx_n = *((word64) rsp_n + 56);
-					rax_n = *((word64) rsp_n + 16);
+					rsi_n = (int64) *((word32) rsp_n + 48);
+					ecx_n = *((word32) rsp_n + 56);
+					rax_n = *((word32) rsp_n + 16);
 				}
 				uip32 edi_n;
 				int64 rdi_n = rdx_n + ~0x00F0C2AB;
@@ -3230,7 +3230,7 @@ l0000000000406FBC:
 						edi_n = (word32) (uint64) ((word32) (uint64) ((word32) (uint64) ecx_n - r8d_n) >> 0x1F);
 				}
 l0000000000406F20:
-				Eq_n rax_n = fn0000000000406A80(rax_n, (&globals->t61A3D0)[(int64) edi_n], r13_n, fs);
+				Eq_n rax_n = fn0000000000406A80(rax_n, (&globals->t61A3D0)[(int64) edi_n].t0000, r13_n, fs);
 				if (rax_n != 0x00 || *r13_n == 0x00)
 				{
 					word64 rax_n = rax_n + r13_n;
@@ -3240,15 +3240,15 @@ l0000000000406F20:
 					r13_n = &rax_n->b0001;
 					goto l0000000000406FBC;
 				}
-				if (*((word64) rdi + 0x00B0) == 0x00)
+				if (*((word32) rdi + 0x00B0) == 0x00)
 					goto l0000000000406F80;
 				goto l0000000000407364;
 			}
 			Eq_n r14_n = 4274020;
-			if (*((word64) rdi + 0x00B0) != 0x00)
+			if (*((word32) rdi + 0x00B0) != 0x00)
 			{
 				word64 r8_n;
-				Eq_n rax_n = fn000000000040BD70(0x0200, (word32) (uint64) globals->dw61B140, fp - 0x1278, *((word64) rdi + 80), globals->t61B138, fs, rLoc4, out r8_n);
+				Eq_n rax_n = fn000000000040BD70(0x0200, (word32) (uint64) globals->dw61B140, fp - 0x1278, *((word32) rdi + 80), globals->t61B138, fs, rLoc4, out r8_n);
 				rax_32_32_n = SLICE(rax_n, word32, 32);
 				r14_n = rax_n;
 			}
@@ -3262,14 +3262,14 @@ l0000000000406F20:
 				Eq_n rdx_n = rbp_n;
 				do
 				{
-					rdx_n = (word64) rdx_n + 1;
+					rdx_n = (word32) rdx_n + 1;
 					*(rdx_n - 0x01) = 0x20;
 				} while (rdx_n != rcx_n);
 				rdx_n = (word64) rbp_n + 1 + (int64) eax_n;
 l0000000000406C74:
-				r14_n = (word64) r14_n + 1;
+				r14_n = (word32) r14_n + 1;
 				byte al_n = (byte) (word32) *(r14_n - 0x01);
-				rbp_n = (word64) rdx_n + 1;
+				rbp_n = (word32) rdx_n + 1;
 				*(rbp_n - 0x01) = al_n;
 				if (al_n == 0x00)
 				{
@@ -3281,7 +3281,7 @@ l0000000000406C74:
 			goto l0000000000406C74;
 		}
 l0000000000406E70:
-		rax_32_32_n = (word32) *((word64) rdi + 0x0084);
+		rax_32_32_n = (word32) *((word32) rdi + 0x0084);
 		goto l0000000000406BF7;
 	}
 	goto l0000000000406BC7;
@@ -3294,9 +3294,9 @@ word64 fn0000000000407870(Eq_n rsi, Eq_n rdi, struct Eq_n * fs, Eq_n rLoc4)
 	union Eq_n * rax_n = fn0000000000406A30();
 	if (globals->b61B114 != 0x00)
 	{
-		if (*((word64) rdi + 0x00B0) != 0x00)
+		if (*((word32) rdi + 0x00B0) != 0x00)
 		{
-			Eq_n rdi_n = *((word64) rdi + 24);
+			Eq_n rdi_n = *((word32) rdi + 24);
 			if (rdi_n != 0x00)
 				fn000000000040CD70(fp - 696, rdi_n);
 		}
@@ -3305,10 +3305,10 @@ word64 fn0000000000407870(Eq_n rsi, Eq_n rdi, struct Eq_n * fs, Eq_n rLoc4)
 	}
 	if (globals->b61B144 != 0x00)
 	{
-		if (*((word64) rdi + 0x00B0) != 0x00)
+		if (*((word32) rdi + 0x00B0) != 0x00)
 		{
 			word64 r8_n;
-			fn000000000040BD70(0x0200, (word32) (uint64) globals->dw61B140, fp - 696, *((word64) rdi + 80), globals->t61B138, fs, rLoc4, out r8_n);
+			fn000000000040BD70(0x0200, (word32) (uint64) globals->dw61B140, fp - 696, *((word32) rdi + 80), globals->t61B138, fs, rLoc4, out r8_n);
 		}
 		globals->dw61B150 == 0x04;
 		rax_n = (uint64) (uint32) __printf_chk(0x01, 4274041, 0x00);
@@ -3322,7 +3322,7 @@ word64 fn0000000000407870(Eq_n rsi, Eq_n rdi, struct Eq_n * fs, Eq_n rLoc4)
 	Eq_n rcx_n;
 	fn0000000000406540(rax_n, rsi, null, 0x00, rdi, fs, out rcx_n, out r8_n);
 	if ((word32) (uint64) globals->dw61B12C != 0x00)
-		fn0000000000405D00(rcx_n, (uint64) *((word64) rdi + 0x00A0), (uint64) *((word64) rdi + 40), (byte) (word32) *((word64) rdi + 0x00B0));
+		fn0000000000405D00(rcx_n, (uint64) *((word32) rdi + 0x00A0), (uint64) *((word32) rdi + 40), (byte) (word32) *((word32) rdi + 0x00B0));
 	if ((rax_n ^ fs->qw0028) == 0x00)
 		return r8_n;
 	__stack_chk_fail();
@@ -3342,7 +3342,7 @@ word64 fn00000000004079F0(Eq_n r12, struct Eq_n * fs, Eq_n rLoc4)
 				do
 				{
 					fn0000000000406A30();
-					r8 = fn0000000000406B70(*((word64) globals->t61B1A8 + rbx_n * 0x08), fs, rLoc4);
+					r8 = fn0000000000406B70(*((word32) globals->t61B1A8 + rbx_n * 0x08), fs, rLoc4);
 					FILE * rdi_n = globals->ptr61A610;
 					byte * rax_n = *((char *) rdi_n + 40);
 					if (rax_n < *((char *) rdi_n + 48))
@@ -3352,8 +3352,8 @@ word64 fn00000000004079F0(Eq_n r12, struct Eq_n * fs, Eq_n rLoc4)
 					}
 					else
 						__overflow(rdi_n, 0x0A);
-					globals->t61B018 = (word64) globals->t61B018 + 1;
-					rbx_n = (word64) rbx_n + 1;
+					globals->t61B018 = (word32) globals->t61B018 + 1;
+					rbx_n = (word32) rbx_n + 1;
 				} while (globals->t61B1B0 > rbx_n);
 				return r8;
 			}
@@ -3364,7 +3364,7 @@ word64 fn00000000004079F0(Eq_n r12, struct Eq_n * fs, Eq_n rLoc4)
 			{
 				do
 				{
-					r8 = fn0000000000407870(0x00, *((word64) globals->t61B1A8 + rbx_n * 0x08), fs, rLoc4);
+					r8 = fn0000000000407870(0x00, *((word32) globals->t61B1A8 + rbx_n * 0x08), fs, rLoc4);
 					FILE * rdi_n = globals->ptr61A610;
 					byte * rax_n = *((char *) rdi_n + 40);
 					if (rax_n < *((char *) rdi_n + 48))
@@ -3374,7 +3374,7 @@ word64 fn00000000004079F0(Eq_n r12, struct Eq_n * fs, Eq_n rLoc4)
 					}
 					else
 						__overflow(rdi_n, 0x0A);
-					rbx_n = (word64) rbx_n + 1;
+					rbx_n = (word32) rbx_n + 1;
 				} while (globals->t61B1B0 > rbx_n);
 				return r8;
 			}
@@ -3396,7 +3396,7 @@ word64 fn00000000004079F0(Eq_n r12, struct Eq_n * fs, Eq_n rLoc4)
 					Eq_n r12_n = qwLoc40_n;
 					while (true)
 					{
-						Eq_n r14_n = *((word64) globals->t61B1A8 + r13_n);
+						Eq_n r14_n = *((word32) globals->t61B1A8 + r13_n);
 						word64 r8_n;
 						Eq_n rax_n = fn0000000000405D50(r14_n, r12_n, fs, rLoc4, out r8_n);
 						word64 rcx_n = *((word64) rbp_n + r15_n->ptr0010);
@@ -3419,7 +3419,7 @@ word64 fn00000000004079F0(Eq_n r12, struct Eq_n * fs, Eq_n rLoc4)
 					}
 					else
 						__overflow(rdi_n, 0x0A);
-					Eq_n v32_n = (word64) qwLoc40_n + 1;
+					Eq_n v32_n = (word32) qwLoc40_n + 1;
 					qwLoc40_n = v32_n;
 				} while (v32_n != rdx_n);
 				return r8;
@@ -3444,7 +3444,7 @@ word64 fn00000000004079F0(Eq_n r12, struct Eq_n * fs, Eq_n rLoc4)
 					uint64 rdx_n = (uint64) ((uint128) (uint64) rbx_n % rax_n);
 					if (rdx_n != 0x00)
 					{
-						Eq_n r12_n = (word64) r15_n + r12_n;
+						Eq_n r12_n = (word32) r15_n + r12_n;
 						fn0000000000405200(r12_n, rcx_n + r15_n);
 						r15_n = r12_n;
 					}
@@ -3464,10 +3464,10 @@ word64 fn00000000004079F0(Eq_n r12, struct Eq_n * fs, Eq_n rLoc4)
 							r15_n.u0 = 0x00;
 						}
 					}
-					Eq_n r12_n = *((word64) globals->t61B1A8 + rbx_n * 0x08);
+					Eq_n r12_n = *((word32) globals->t61B1A8 + rbx_n * 0x08);
 					fn0000000000407870(r15_n, r12_n, fs, rLoc4);
 					rcx_n = fn0000000000405D50(r12_n, r12_n, fs, rLoc4, out r8);
-					rbx_n = (word64) rbx_n + 1;
+					rbx_n = (word32) rbx_n + 1;
 					r12_n = r14_n->ptr0010[rdx_n];
 				} while (rbx_n < globals->t61B1B0);
 			}
@@ -3482,19 +3482,19 @@ word64 fn00000000004079F0(Eq_n r12, struct Eq_n * fs, Eq_n rLoc4)
 				Eq_n rbp_n = fn0000000000405D50(r13_n, 0x00, fs, rLoc4, out r8_n);
 				while (true)
 				{
-					rbx_n = (word64) rbx_n + 1;
+					rbx_n = (word32) rbx_n + 1;
 					r8 = fn0000000000407870(r12_n, r13_n, fs, rLoc4);
 					r12_n = rbp_n;
 					if (rbx_n >= globals->t61B1B0)
 						break;
-					r13_n = *((word64) globals->t61B1A8 + rbx_n * 0x08);
+					r13_n = *((word32) globals->t61B1A8 + rbx_n * 0x08);
 					word64 r8_n;
 					Eq_n rax_n = fn0000000000405D50(r13_n, rbp_n, fs, rLoc4, out r8_n);
 					if (rbx_n != 0x00)
 					{
 						byte r14b_n;
 						word32 r15d_n;
-						r12_n = (word64) rbp_n + 2;
+						r12_n = (word32) rbp_n + 2;
 						if (rax_n < globals->t61B0C8)
 						{
 							r15d_n = 0x20;
@@ -3567,7 +3567,7 @@ Eq_n fn0000000000407EA0(Eq_n rcx, word32 edx, word32 esi, Eq_n rdi, struct Eq_n 
 	}
 	struct Eq_n * rdi_n;
 	ui64 rcx_n = rcx_n * 0x03;
-	struct Eq_n * r14_n = (word64) r9_n + (rcx_n << 0x06);
+	struct Eq_n * r14_n = (word32) r9_n + (rcx_n << 0x06);
 	ui32 esi_n = 0xC0;
 	rdi_n = r14_n;
 	if (((byte) r14_n & 0x01) != 0x00)
@@ -3672,14 +3672,14 @@ l0000000000407F68:
 						byte sil_n = (byte) (uint64) esi_n;
 						ecx_n = (word32) (uint64) ecx_n;
 						r12_n = rax_n;
-						if (r15b_n != 0x2E || *((word64) rcx + 1) != 0x00)
+						if (r15b_n != 0x2E || *((word32) rcx + 1) != 0x00)
 						{
 							Eq_n rsi_n = rcx;
 							do
 							{
-								rax_n = (word64) rax_n + 1;
+								rax_n = (word32) rax_n + 1;
 								*(rax_n - 0x01) = r15b_n;
-								rsi_n = (word64) rsi_n + 1;
+								rsi_n = (word32) rsi_n + 1;
 								r15b_n = (byte) (word32) *rsi_n;
 							} while (r15b_n != 0x00);
 							if (rcx < rsi_n && *(rsi_n - 0x01) != 0x2F)
@@ -3696,7 +3696,7 @@ l0000000000407F68:
 							{
 								++rax_n;
 								*(rax_n - (byte *) 0x01) = sil_n;
-								rdx_n = (word64) rdx_n + 1;
+								rdx_n = (word32) rdx_n + 1;
 								sil_n = (byte) (word32) *rdx_n;
 							} while (sil_n != 0x00);
 						}
@@ -4021,7 +4021,7 @@ l00000000004081D2:
 													}
 l00000000004081E1:
 													Eq_n rax_n = fn0000000000410E30(rax_32_32_n, rdi);
-													globals->t61B1B0 = (word64) globals->t61B1B0 + 1;
+													globals->t61B1B0 = (word32) globals->t61B1B0 + 1;
 													r14_n->w0000 = (word16) rax_n;
 l00000000004081F4:
 													if ((rax_n ^ fs->qw0028) == 0x00)
@@ -4107,7 +4107,7 @@ l0000000000408AF5:
 									uint64 rcx_n = (uint64) *rdx_n;
 									uint64 rax_n = (uint64) ((word32) (uint64) (rcx_n + ~0x01010100 & (word32) ((uint64) (~((word32) rcx_n)))) & 0x80808080);
 									ui32 eax_n = (word32) rax_n;
-									rdx_n = (word64) rdx_n + 4;
+									rdx_n = (word32) rdx_n + 4;
 									bui8 al_n = (byte) eax_n;
 									rax_32_32_n = SLICE(rax_n, word32, 32);
 								} while (eax_n == 0x00);
@@ -4115,7 +4115,7 @@ l0000000000408AF5:
 								if ((eax_n & 0x8080) == 0x00)
 									al_n = (byte) ecx_n;
 								if ((eax_n & 0x8080) == 0x00)
-									rdx_n = (word64) rdx_n + 2;
+									rdx_n = (word32) rdx_n + 2;
 								edx_n = (word32) (uint64) ((word32) (rdx_n - 0x03 - (al_n * 0x02 < 0x00)) - r15d_n);
 								goto l0000000000408AF5;
 							}
@@ -4127,7 +4127,7 @@ l00000000004080B8:
 							}
 						}
 l0000000000408001:
-						r15_n = (word64) r9_n + (rcx_n << 0x06) + 0x10;
+						r15_n = (word32) r9_n + (rcx_n << 0x06) + 0x10;
 						esi_n = 0x00;
 						edx_n = (word32) (uint64) __lxstat(0x01, r12_n, r15_n);
 						goto l0000000000408015;
@@ -4265,7 +4265,7 @@ Eq_n fn0000000000409D20(Eq_n rsi, Eq_n rdi)
 {
 	Eq_n rbx_n = 0x0401;
 	if (rsi <= 0x0400)
-		rbx_n = (word64) rsi + 1;
+		rbx_n = (word32) rsi + 1;
 l0000000000409D60:
 	Eq_n rax_n = malloc(rbx_n);
 	Eq_n rbp_n = rax_n;
@@ -4336,10 +4336,10 @@ Eq_n fn0000000000409E50(word32 rax_32_n, Eq_n rcx, Eq_n rdx, Eq_n rsi[], Eq_n rd
 				}
 				if (qwLoc50_n == ~0x00)
 				{
-					rbx_n = (word64) rbx_n + 1;
+					rbx_n = (word32) rbx_n + 1;
 					qwLoc50_n = rbx_n;
 					rbp_n += rcx;
-					r14_n = rsi[rbx_n];
+					r14_n = rsi[rbx_n * 2];
 					if (r14_n == 0x00)
 						break;
 					continue;
@@ -4349,7 +4349,7 @@ Eq_n fn0000000000409E50(word32 rax_32_n, Eq_n rcx, Eq_n rdx, Eq_n rsi[], Eq_n rd
 				{
 					Eq_n ecx_n = (word32) bLoc41_n;
 					rax_32_32_n = 0x00;
-					if (memcmp((word64) rdx + qwLoc50_n *s rcx, rbp_n, rcx) != 0x00)
+					if (memcmp((word32) rdx + qwLoc50_n *s rcx, rbp_n, rcx) != 0x00)
 						ecx_n.u1 = 0x01;
 					bLoc41_n = (byte) ecx_n;
 					ecx_n = ecx_n;
@@ -4359,7 +4359,7 @@ Eq_n fn0000000000409E50(word32 rax_32_n, Eq_n rcx, Eq_n rdx, Eq_n rsi[], Eq_n rd
 			}
 			rbx_n = (word64) rbx_n.u1 + 1;
 			rbp_n += rcx;
-			r14_n = rsi[rbx_n];
+			r14_n = rsi[rbx_n * 2];
 		} while (r14_n != 0x00);
 		rax_n.u0 = ~0x01;
 		if (bLoc41_n != 0x00)
@@ -4411,7 +4411,7 @@ byte * fn000000000040A000(Eq_n rdx, Eq_n rsi, Eq_n rdi[], struct Eq_n * fs, unio
 			rbp_n += rdx;
 			rdx_n.u0 = 0x00415E52;
 			rsi_n = (FILE *) 0x01;
-			r12_n = rdi[rbx_n];
+			r12_n = rdi[rbx_n * 2];
 			if (r12_n == 0x00)
 				break;
 			continue;
@@ -4425,7 +4425,7 @@ byte * fn000000000040A000(Eq_n rdx, Eq_n rsi, Eq_n rdi[], struct Eq_n * fs, unio
 		rdx_n.u0 = 0x00415E4A;
 		rsi_n = (FILE *) 0x01;
 		rbp_n += rdx;
-		r12_n = rdi[rbx_n];
+		r12_n = rdi[rbx_n * 2];
 	}
 	FILE * rdi_n = globals->ptr61A650;
 	byte * rax_n = *((char *) rdi_n + 40);
@@ -4512,7 +4512,7 @@ Eq_n fn000000000040A390(Eq_n rdi)
 	Eq_n rax_n = rdi;
 	while ((byte) edx_n == 0x2F)
 	{
-		rax_n = (word64) rax_n + 1;
+		rax_n = (word32) rax_n + 1;
 		edx_n = (word32) *rax_n;
 	}
 	Eq_n rdx_n = rax_n;
@@ -4520,7 +4520,7 @@ Eq_n fn000000000040A390(Eq_n rdi)
 		return rax_n;
 	uip64 rsi_n = 0x00;
 l000000000040A3C0:
-	rdx_n = (word64) rdx_n + 1;
+	rdx_n = (word32) rdx_n + 1;
 	byte cl_n = (byte) (word32) *rdx_n;
 	while (cl_n != 0x00)
 	{
@@ -4532,7 +4532,7 @@ l000000000040A3C0:
 		}
 		if (sil_n == 0x00)
 			goto l000000000040A3C0;
-		rdx_n = (word64) rdx_n + 1;
+		rdx_n = (word32) rdx_n + 1;
 		rax_n = rdx_n;
 		cl_n = (byte) (word32) *rdx_n;
 		rsi_n = 0x00;
@@ -4549,7 +4549,7 @@ Eq_n fn000000000040A400(word32 rax_32_n, Eq_n rdi)
 	do
 	{
 		Eq_n rdx_n = rax_n - 0x01;
-		if (*((word64) rax_n + (rdi - 0x01)) != 0x2F)
+		if (*((word32) rax_n + (rdi - 0x01)) != 0x2F)
 			return rax_n;
 		rax_n = rdx_n;
 	} while (rdx_n != 0x01);
@@ -4655,15 +4655,15 @@ Eq_n fn000000000040A630(ptr64 * rdx, Eq_n rsi, Eq_n rdi)
 	{
 		do
 		{
-			rbx_n = (word64) rbx_n + 1;
+			rbx_n = (word32) rbx_n + 1;
 			if (*rbx_n != 0x2F)
 				break;
-			rbx_n = (word64) rbx_n + 1;
-		} while (*((word64) rbx_n + 1) == 0x2F);
+			rbx_n = (word32) rbx_n + 1;
+		} while (*((word32) rbx_n + 1) == 0x2F);
 	}
 	Eq_n rax_n;
 	Eq_n rax_n = SEQ(rax_32_32_n, strlen(rbx_n));
-	Eq_n rax_n = malloc((word64) rax_n + ((word64) r14_n.u1 + ((word64) rsi_n + 1)));
+	Eq_n rax_n = malloc((word32) rax_n + ((word64) r14_n.u1 + ((word32) rsi_n + 1)));
 	if (rax_n != 0x00)
 	{
 		Eq_n rax_n = mempcpy(rax_n, rdi, rsi_n);
@@ -4755,8 +4755,8 @@ uint64 fn000000000040AB70(Eq_n rdi)
 	bool Z_n = SLICE(cond(*rax_n - 0x43), bool, 2);
 	if (*rax_n == 0x43)
 	{
-		Z_n = SLICE(cond(*((word64) rax_n + 1)), bool, 2);
-		if (*((word64) rax_n + 1) == 0x00)
+		Z_n = SLICE(cond(*((word32) rax_n + 1)), bool, 2);
+		if (*((word32) rax_n + 1) == 0x00)
 			return 0x00;
 	}
 	Eq_n rsi_n = rax_n;
@@ -4827,9 +4827,9 @@ l000000000040AC44:
 ui64 fn000000000040AC80(Eq_n rsi, Eq_n rdi)
 {
 	Eq_n rax_n;
-	(*((word64) rdi + 48))();
-	if (rax_n < *((word64) rdi + 16))
-		return (word64) *rdi + (rax_n << 0x04);
+	(*((word32) rdi + 48))();
+	if (rax_n < *((word32) rdi + 16))
+		return (word32) *rdi + (rax_n << 0x04);
 	abort();
 }
 
@@ -4851,15 +4851,15 @@ Eq_n fn000000000040ACB0(Eq_n ecx, union Eq_n * rdx, Eq_n rsi, Eq_n rdi, union Eq
 l000000000040ACE9:
 			if (r13b_n != 0x00)
 			{
-				Eq_n rax_n = *((word64) rax_n + 8);
+				Eq_n rax_n = *((word32) rax_n + 8);
 				if (rax_n != 0x00)
 				{
-					Eq_n r10_n = *((word64) rax_n + 8);
+					Eq_n r10_n = *((word32) rax_n + 8);
 					*rax_n = *rax_n;
-					*((word64) rax_n + 8) = r10_n;
+					*((word32) rax_n + 8) = r10_n;
 					rax_n->u0 = 0x00;
-					*((word64) rax_n + 8) = *((word64) rdi + 72);
-					*((word64) rdi + 72) = rax_n;
+					*((word32) rax_n + 8) = *((word32) rdi + 72);
+					*((word32) rdi + 72) = rax_n;
 				}
 				else
 					rax_n->u0 = 0x00;
@@ -4873,7 +4873,7 @@ l000000000040AD1C:
 		word64 r10_n;
 		word64 rdx_n;
 		word64 rcx_n;
-		(*((word64) rdi + 56))();
+		(*((word32) rdi + 56))();
 		word32 rcx_32_32_n = SLICE(rcx_n, word32, 32);
 		if ((byte) rax_n != 0x00)
 		{
@@ -4885,7 +4885,7 @@ l000000000040AD1C:
 			word32 ecx_n = (word32) rcx_n;
 			byte r13b_n = (byte) r13_n;
 			r13b_n = (byte) r13_n;
-			Eq_n rax_n = *((word64) rbx_n + 8);
+			Eq_n rax_n = *((word32) rbx_n + 8);
 			if (rax_n == 0x00)
 				break;
 			rsi_n = *rax_n;
@@ -4894,25 +4894,25 @@ l000000000040AD1C:
 l000000000040AD67:
 				if (r13b_n == 0x00)
 					goto l000000000040AD1C;
-				*((word64) rbx_n + 8) = *((word64) rax_n + 8);
+				*((word32) rbx_n + 8) = *((word32) rax_n + 8);
 				rax_n->u0 = 0x00;
-				*((word64) rax_n + 8) = *((word64) rdi + 72);
-				*((word64) rdi + 72) = rax_n;
+				*((word32) rax_n + 8) = *((word32) rdi + 72);
+				*((word32) rdi + 72) = rax_n;
 				rsiOut = rsi_n;
 				return rsi_n;
 			}
 			word64 rax_n;
 			word64 r9_n;
 			word64 r10_n;
-			(*((word64) rdi + 56))();
+			(*((word32) rdi + 56))();
 			word32 rcx_32_32_n = SLICE(rcx_n, word32, 32);
 			if ((byte) rax_n != 0x00)
 			{
-				rax_n = *((word64) rbx_n + 8);
+				rax_n = *((word32) rbx_n + 8);
 				rsi_n = *rax_n;
 				goto l000000000040AD67;
 			}
-			rbx_n = *((word64) rbx_n + 8);
+			rbx_n = *((word32) rbx_n + 8);
 		}
 	}
 	rsiOut.u0 = 0x00;
@@ -4967,51 +4967,51 @@ word32 fn000000000040AE40(Eq_n edx, Eq_n rsi, Eq_n rdi)
 	Eq_n edx = (word32) rdx;
 	byte r15b_n = (byte) (uint64) edx;
 	Eq_n r13_n = *rsi;
-	if (r13_n >= *((word64) rsi + 8))
+	if (r13_n >= *((word32) rsi + 8))
 		return 0x01;
 l000000000040AE68:
 	Eq_n rbp_n = *r13_n;
 	if (rbp_n == 0x00)
 	{
 l000000000040AEE1:
-		r13_n = (word64) r13_n + 16;
-		if (*((word64) rsi + 8) <= r13_n)
+		r13_n = (word32) r13_n + 16;
+		if (*((word32) rsi + 8) <= r13_n)
 			return 0x01;
 		goto l000000000040AE68;
 	}
-	Eq_n rbx_n = *((word64) r13_n + 8);
+	Eq_n rbx_n = *((word32) r13_n + 8);
 	if (rbx_n == 0x00)
 	{
 l000000000040AED4:
-		*((word64) r13_n + 8) = 0x00;
+		*((word32) r13_n + 8) = 0x00;
 		if (r15b_n != 0x00)
 			goto l000000000040AEE1;
 		Eq_n rax_n = fn000000000040AC80(rbp_n, rdi);
 		if (*rax_n != 0x00)
 		{
-			Eq_n rax_n = *((word64) rdi + 72);
+			Eq_n rax_n = *((word32) rdi + 72);
 			if (rax_n != 0x00)
-				*((word64) rdi + 72) = *((word64) rax_n + 8);
+				*((word32) rdi + 72) = *((word32) rax_n + 8);
 			else
 			{
 				rax_n = malloc(0x10);
 				if (rax_n == 0x00)
 					return 0x00;
 			}
-			Eq_n rdx_n = *((word64) rax_n + 8);
+			Eq_n rdx_n = *((word32) rax_n + 8);
 			*rax_n = rbp_n;
-			*((word64) rax_n + 8) = rdx_n;
-			*((word64) rax_n + 8) = rax_n;
+			*((word32) rax_n + 8) = rdx_n;
+			*((word32) rax_n + 8) = rax_n;
 		}
 		else
 		{
 			*rax_n = rbp_n;
-			*((word64) rdi + 24) = (word64) *((word64) rdi + 24) + 1;
+			*((word32) rdi + 24) = (word32) *((word32) rdi + 24) + 1;
 		}
 		*r13_n = 0x00;
-		--*((word64) rsi + 24);
-		r13_n = (word64) r13_n + 16;
-		if (*((word64) rsi + 8) <= r13_n)
+		--*((word32) rsi + 24);
+		r13_n = (word32) r13_n + 16;
+		if (*((word32) rsi + 8) <= r13_n)
 			return 0x01;
 		goto l000000000040AE68;
 	}
@@ -5019,14 +5019,14 @@ l000000000040AED4:
 	{
 		Eq_n rbp_n = *rbx_n;
 		Eq_n rax_n = fn000000000040AC80(rbp_n, rdi);
-		Eq_n rdx_n = *((word64) rbx_n + 8);
+		Eq_n rdx_n = *((word32) rbx_n + 8);
 		if (*rax_n == 0x00)
 		{
 			*rax_n = rbp_n;
-			*((word64) rdi + 24) = (word64) *((word64) rdi + 24) + 1;
+			*((word32) rdi + 24) = (word32) *((word32) rdi + 24) + 1;
 			rbx_n->u0 = 0x00;
-			*((word64) rbx_n + 8) = *((word64) rdi + 72);
-			*((word64) rdi + 72) = rbx_n;
+			*((word32) rbx_n + 8) = *((word32) rdi + 72);
+			*((word32) rdi + 72) = rbx_n;
 			if (rdx_n == 0x00)
 			{
 l000000000040AED0:
@@ -5036,8 +5036,8 @@ l000000000040AED0:
 		}
 		else
 		{
-			*((word64) rbx_n + 8) = *((word64) rax_n + 8);
-			*((word64) rax_n + 8) = rbx_n;
+			*((word32) rbx_n + 8) = *((word32) rax_n + 8);
+			*((word32) rax_n + 8) = rbx_n;
 			if (rdx_n == 0x00)
 				goto l000000000040AED0;
 		}
@@ -5048,7 +5048,7 @@ l000000000040AED0:
 // 000000000040AFB0: Register Eq_n fn000000000040AFB0(Register Eq_n rdi)
 Eq_n fn000000000040AFB0(Eq_n rdi)
 {
-	return *((word64) rdi + 32);
+	return *((word32) rdi + 32);
 }
 
 // 000000000040B400: Register Eq_n fn000000000040B400(Register (ptr64 code) rcx, Register (ptr64 code) rdx, Register (ptr64 Eq_n) rsi, Register Eq_n rdi, Register uint64 r8, Register Eq_n xmm0, Register Eq_n xmm1, Register Eq_n xmm2, Register out Eq_n xmm0Out, Register out Eq_n xmm1Out, Register out Eq_n xmm2Out)
@@ -5073,8 +5073,8 @@ Eq_n fn000000000040B400(<anonymous> * rcx, <anonymous> * rdx, struct Eq_n * rsi,
 	}
 	if (rsi == null)
 		rbp_n = &globals->t415EE0;
-	*((word64) rax_n + 40) = rbp_n;
-	if ((byte) (uint64) (uint8) fn000000000040ADB0((word64) rax_n + 40, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2) == 0x00)
+	*((word32) rax_n + 40) = rbp_n;
+	if ((byte) (uint64) (uint8) fn000000000040ADB0((word32) rax_n + 40, xmm0, xmm1, xmm2, out xmm0, out xmm1, out xmm2) == 0x00)
 	{
 l000000000040B548:
 		free(rax_n);
@@ -5101,7 +5101,7 @@ l000000000040B548:
 		if ((real32) xmm0 >= globals->t415F08)
 		{
 l000000000040B540:
-			((word64) rax_n + 16)->u0 = 0x00;
+			((word32) rax_n + 16)->u0 = 0x00;
 			goto l000000000040B548;
 		}
 		if ((real32) xmm0 >= globals->t415F0C)
@@ -5116,20 +5116,20 @@ l000000000040B540:
 	Eq_n rax_n = fn000000000040ABC0(r15_n, out r8_n);
 	if (rax_n <= 0xFFFFFFFF)
 	{
-		*((word64) rax_n + 16) = rax_n;
+		*((word32) rax_n + 16) = rax_n;
 		if (rax_n != 0x00)
 		{
 			Eq_n rax_n = calloc(rax_n, 0x10);
 			*rax_n = rax_n;
 			if (rax_n != 0x00)
 			{
-				*((word64) rax_n + 24) = 0x00;
-				*((word64) rax_n + 32) = 0x00;
-				*((word64) rax_n + 48) = r13_n;
-				*((word64) rax_n + 56) = r12_n;
-				*((word64) rax_n + 8) = (word64) rax_n + (rax_n << 0x04);
-				*((word64) rax_n + 64) = r8;
-				((word64) rax_n + 72)->u0 = 0x00;
+				*((word32) rax_n + 24) = 0x00;
+				*((word32) rax_n + 32) = 0x00;
+				*((word32) rax_n + 48) = r13_n;
+				*((word32) rax_n + 56) = r12_n;
+				*((word32) rax_n + 8) = (word32) rax_n + (rax_n << 0x04);
+				*((word32) rax_n + 64) = r8;
+				((word32) rax_n + 72)->u0 = 0x00;
 				rax_n = rax_n;
 l000000000040B52A:
 				xmm0Out = xmm0;
@@ -5147,10 +5147,10 @@ l000000000040B52A:
 void fn000000000040B640(Eq_n rdi)
 {
 	Eq_n rax_n;
-	if (*((word64) rdi + 64) != 0x00 && *((word64) rdi + 32) != 0x00)
+	if (*((word32) rdi + 64) != 0x00 && *((word32) rdi + 32) != 0x00)
 	{
 		Eq_n r12_n = *rdi;
-		if (r12_n >= *((word64) rdi + 8))
+		if (r12_n >= *((word32) rdi + 8))
 			goto l000000000040B693;
 		do
 		{
@@ -5161,20 +5161,20 @@ void fn000000000040B640(Eq_n rdi)
 				while (true)
 				{
 					word64 rax_n;
-					(*((word64) rdi + 64))();
+					(*((word32) rdi + 64))();
 					rbx_n = *((word64) rbx_n + 8);
 					if (rbx_n == 0x00)
 						break;
 					rdi_n = (word64) *rbx_n;
 				}
 			}
-			rax_n = *((word64) rdi + 8);
-			r12_n = (word64) r12_n + 16;
+			rax_n = *((word32) rdi + 8);
+			r12_n = (word32) r12_n + 16;
 		} while (rax_n > r12_n);
 	}
 	else
-		rax_n = *((word64) rdi + 8);
-	Eq_n r12_n = (word64) *rdi + 8;
+		rax_n = *((word32) rdi + 8);
+	Eq_n r12_n = (word32) *rdi + 8;
 	if (r12_n < rax_n)
 	{
 		do
@@ -5192,15 +5192,15 @@ void fn000000000040B640(Eq_n rdi)
 				}
 			}
 			r12_n = (word64) r12_n + 16;
-		} while (*((word64) rdi + 8) > r12_n);
+		} while (*((word32) rdi + 8) > r12_n);
 	}
 l000000000040B693:
-	Eq_n rdi_n = *((word64) rdi + 72);
+	Eq_n rdi_n = *((word32) rdi + 72);
 	if (rdi_n != 0x00)
 	{
 		while (true)
 		{
-			Eq_n rbx_n = *((word64) rdi_n + 8);
+			Eq_n rbx_n = *((word32) rdi_n + 8);
 			free(rdi_n);
 			if (rbx_n == 0x00)
 				break;
@@ -5215,7 +5215,7 @@ l000000000040B693:
 word32 fn000000000040B710(Eq_n rsi, Eq_n rdi, ptr64 & r8Out, union Eq_n & xmm0Out, union Eq_n & xmm1Out)
 {
 	ui32 esi_n = (word32) rsi;
-	struct Eq_n * rbp_n = *((word64) rdi + 40);
+	struct Eq_n * rbp_n = *((word32) rdi + 40);
 	if (rbp_n->b0010 == 0x00)
 	{
 		word128 xmm0_n;
@@ -5249,7 +5249,7 @@ l000000000040B870:
 	Eq_n rax_n = fn000000000040ABC0(rsi, out r8);
 	if (rax_n <= 0xFFFFFFFF)
 	{
-		if (*((word64) rdi + 16) == rax_n)
+		if (*((word32) rdi + 16) == rax_n)
 		{
 			r8Out = r8;
 			xmm0Out = xmm0;
@@ -5259,18 +5259,18 @@ l000000000040B870:
 		Eq_n rax_n = calloc(rax_n, 0x10);
 		if (rax_n != 0x00)
 		{
-			Eq_n rax_n = *((word64) rdi + 72);
+			Eq_n rax_n = *((word32) rdi + 72);
 			uint64 rax_n = (uint64) (uint32) fn000000000040AE40(0x00, rdi, fp - 0x68);
-			Eq_n rax_n = (word64) rax_n + (rax_n << 0x04);
+			Eq_n rax_n = (word32) rax_n + (rax_n << 0x04);
 			word32 ebp_n = (word32) (uint64) (word32) rax_n;
 			if ((byte) rax_n != 0x00)
 			{
 				free(*rdi);
 				*rdi = rax_n;
-				*((word64) rdi + 8) = rax_n;
-				*((word64) rdi + 16) = rax_n;
-				*((word64) rdi + 24) = 0x00;
-				*((word64) rdi + 72) = rax_n;
+				*((word32) rdi + 8) = rax_n;
+				*((word32) rdi + 16) = rax_n;
+				*((word32) rdi + 24) = 0x00;
+				*((word32) rdi + 72) = rax_n;
 				r8Out = r8;
 				xmm0Out = xmm0;
 				xmm1Out.u0 = <invalid>;
@@ -5278,7 +5278,7 @@ l000000000040B870:
 			}
 			else
 			{
-				*((word64) rdi + 72) = rax_n;
+				*((word32) rdi + 72) = rax_n;
 				if ((byte) (uint64) (uint32) fn000000000040AE40(0x01, fp - 0x68, rdi) == 0x00 || (byte) ((uint64) ((uint32) fn000000000040AE40(0x00, fp - 0x68, rdi))) == 0x00)
 					abort();
 				else
@@ -5323,7 +5323,7 @@ l000000000040B92A:
 			xmm2Out = xmm2;
 			return (word32) rax_n;
 		}
-		Eq_n rax_n = *((word64) rdi + 24);
+		Eq_n rax_n = *((word32) rdi + 24);
 		ui32 eax_n = (word32) rax_n;
 		if (rax_n >= 0x00)
 			xmm0 = DPB(xmm0, (real32) rax_n, 0);
@@ -5333,9 +5333,9 @@ l000000000040B92A:
 			xmm0 = SEQ(SLICE(DPB(xmm0, v28_n, 0), word96, 32), v28_n + v28_n);
 		}
 		word128 xmm1_n;
-		Eq_n rax_n = *((word64) rdi + 16);
+		Eq_n rax_n = *((word32) rdi + 16);
 		ui32 eax_n = (word32) rax_n;
-		struct Eq_n * rdx_n = *((word64) rdi + 40);
+		struct Eq_n * rdx_n = *((word32) rdi + 40);
 		if (rax_n >= 0x00)
 			xmm1_n = (word128) DPB(xmm1, (real32) rax_n, 0);
 		else
@@ -5350,21 +5350,21 @@ l000000000040B96A:
 			if (qwLoc20->t0000 == 0x00)
 			{
 				qwLoc20->t0000 = rsi;
-				*((word64) rdi + 32) = (word64) *((word64) rdi + 32) + 1;
-				*((word64) rdi + 24) = (word64) *((word64) rdi + 24) + 1;
+				*((word32) rdi + 32) = (word32) *((word32) rdi + 32) + 1;
+				*((word32) rdi + 24) = (word32) *((word32) rdi + 24) + 1;
 				rax_n = 0x01;
 				goto l000000000040B92A;
 			}
-			Eq_n rax_n = *((word64) rdi + 72);
+			Eq_n rax_n = *((word32) rdi + 72);
 			if (rax_n != 0x00)
 			{
-				*((word64) rdi + 72) = *((word64) rax_n + 8);
+				*((word32) rdi + 72) = *((word32) rax_n + 8);
 l000000000040B98F:
 				Eq_n rdx_n = qwLoc20->t0008;
 				*rax_n = rsi;
-				*((word64) rax_n + 8) = rdx_n;
+				*((word32) rax_n + 8) = rdx_n;
 				qwLoc20->t0008 = rax_n;
-				*((word64) rdi + 32) = (word64) *((word64) rdi + 32) + 1;
+				*((word32) rdi + 32) = (word32) *((word32) rdi + 32) + 1;
 				r8Out = r8;
 				xmm0Out = xmm0;
 				xmm1Out = xmm1;
@@ -5381,9 +5381,9 @@ l000000000040BB2E:
 		word128 xmm0_n;
 		word128 xmm1_n;
 		word128 xmm2_n;
-		fn000000000040ADB0((word64) rdi + 40, xmm0, xmm1, xmm2, out xmm0_n, out xmm1_n, out xmm2_n);
-		Eq_n rax_n = *((word64) rdi + 16);
-		struct Eq_n * rdx_n = *((word64) rdi + 40);
+		fn000000000040ADB0((word32) rdi + 40, xmm0, xmm1, xmm2, out xmm0_n, out xmm1_n, out xmm2_n);
+		Eq_n rax_n = *((word32) rdi + 16);
+		struct Eq_n * rdx_n = *((word32) rdi + 40);
 		ui32 eax_n = (word32) rax_n;
 		xmm2 = DPB(xmm2_n, rdx_n->r0008, 0);
 		if (rax_n >= 0x00)
@@ -5393,7 +5393,7 @@ l000000000040BB2E:
 			real32 v51_n = (real32) (rax_n >> 0x01 | (uint64) (eax_n & 0x01));
 			xmm0 = SEQ(SLICE(DPB(xmm0_n, v51_n, 0), word96, 32), v51_n + v51_n);
 		}
-		Eq_n rax_n = *((word64) rdi + 24);
+		Eq_n rax_n = *((word32) rdi + 24);
 		ui32 eax_n = (word32) rax_n;
 		if (rax_n >= 0x00)
 			xmm1 = DPB(xmm1_n, (real32) rax_n, 0);
@@ -5459,12 +5459,12 @@ uint64 fn000000000040BB90(Eq_n rsi, Eq_n rdi, Eq_n xmm0, Eq_n xmm1, Eq_n xmm2, i
 		rax_n = 0x00;
 		goto l000000000040BBC6;
 	}
-	--*((word64) rdi + 32);
+	--*((word32) rdi + 32);
 	if (*qwLoc20 == 0x00)
 	{
 		Eq_n xmm0_n;
-		Eq_n rax_n = *((word64) rdi + 24);
-		*((word64) rdi + 24) = rax_n - 0x01;
+		Eq_n rax_n = *((word32) rdi + 24);
+		*((word32) rdi + 24) = rax_n - 0x01;
 		ui32 eax_n = (word32) (rax_n - 0x01);
 		if (rax_n >= 0x01)
 			xmm0_n = DPB(xmm0, (real32) (rax_n - 0x01), 0);
@@ -5474,9 +5474,9 @@ uint64 fn000000000040BB90(Eq_n rsi, Eq_n rdi, Eq_n xmm0, Eq_n xmm1, Eq_n xmm2, i
 			xmm0_n = SEQ(SLICE(DPB(xmm0, v27_n, 0), word96, 32), v27_n + v27_n);
 		}
 		word128 xmm1_n;
-		Eq_n rax_n = *((word64) rdi + 16);
+		Eq_n rax_n = *((word32) rdi + 16);
 		ui32 eax_n = (word32) rax_n;
-		Eq_n rdx_n = *((word64) rdi + 40);
+		Eq_n rdx_n = *((word32) rdi + 40);
 		if (rax_n >= 0x00)
 			xmm1_n = (word128) DPB(xmm1, (real32) rax_n, 0);
 		else
@@ -5490,10 +5490,10 @@ uint64 fn000000000040BB90(Eq_n rsi, Eq_n rdi, Eq_n xmm0, Eq_n xmm1, Eq_n xmm2, i
 			word128 xmm0_n;
 			word128 xmm1_n;
 			word128 xmm2_n;
-			fn000000000040ADB0((word64) rdi + 40, xmm0_n, xmm1_n, xmm2, out xmm0_n, out xmm1_n, out xmm2_n);
-			Eq_n rdx_n = *((word64) rdi + 16);
+			fn000000000040ADB0((word32) rdi + 40, xmm0_n, xmm1_n, xmm2, out xmm0_n, out xmm1_n, out xmm2_n);
+			Eq_n rdx_n = *((word32) rdi + 16);
 			ui32 edx_n = (word32) rdx_n;
-			Eq_n rax_n = *((word64) rdi + 40);
+			Eq_n rax_n = *((word32) rdi + 40);
 			if (rdx_n >= 0x00)
 				xmm0_n = DPB(xmm0_n, (real32) rdx_n, 0);
 			else
@@ -5501,7 +5501,7 @@ uint64 fn000000000040BB90(Eq_n rsi, Eq_n rdi, Eq_n xmm0, Eq_n xmm1, Eq_n xmm2, i
 				real32 v43_n = (real32) (rdx_n >> 0x01 | (uint64) (edx_n & 0x01));
 				xmm0_n = SEQ(SLICE(DPB(xmm0_n, v43_n, 0), word96, 32), v43_n + v43_n);
 			}
-			Eq_n rdx_n = *((word64) rdi + 24);
+			Eq_n rdx_n = *((word32) rdi + 24);
 			ui32 edx_n = (word32) rdx_n;
 			if (rdx_n >= 0x00)
 				xmm1_n = DPB(xmm1_n, (real32) rdx_n, 0);
@@ -5514,9 +5514,9 @@ uint64 fn000000000040BB90(Eq_n rsi, Eq_n rdi, Eq_n xmm0, Eq_n xmm1, Eq_n xmm2, i
 			if ((real32) xmm2 > xmm1_n)
 			{
 				word96 v36_n = SLICE(xmm0_n, word96, 32);
-				word128 xmm0_n = SEQ(v36_n, (real32) xmm0_n * *((word64) rax_n + 4));
-				if (*((word64) rax_n + 16) == 0x00)
-					xmm0_n = SEQ(v36_n, (real32) xmm0_n * *((word64) rax_n + 8));
+				word128 xmm0_n = SEQ(v36_n, (real32) xmm0_n * *((word32) rax_n + 4));
+				if (*((word32) rax_n + 16) == 0x00)
+					xmm0_n = SEQ(v36_n, (real32) xmm0_n * *((word32) rax_n + 8));
 				Eq_n rsi_n;
 				if ((real32) xmm0_n < globals->t415F0C)
 					rsi_n = SEQ(rsi_32_32_n, (int32) xmm0_n);
@@ -5524,19 +5524,19 @@ uint64 fn000000000040BB90(Eq_n rsi, Eq_n rdi, Eq_n xmm0, Eq_n xmm1, Eq_n xmm2, i
 					rsi_n = SEQ(rsi_32_32_n, (int32) SEQ(SLICE(xmm0_n, word96, 32), (real32) xmm0_n - globals->t415F0C)) ^ 0x00;
 				if ((byte) (uint64) (word32) (uint64) (uint32) fn000000000040B710(rsi_n, rdi, out r8, out xmm0, out xmm1) == 0x00)
 				{
-					Eq_n rdi_n = *((word64) rdi + 72);
+					Eq_n rdi_n = *((word32) rdi + 72);
 					if (rdi_n != 0x00)
 					{
 						while (true)
 						{
-							Eq_n r12_n = *((word64) rdi_n + 8);
+							Eq_n r12_n = *((word32) rdi_n + 8);
 							free(rdi_n);
 							if (r12_n == 0x00)
 								break;
 							rdi_n = r12_n;
 						}
 					}
-					((word64) rdi + 72)->u0 = 0x00;
+					((word32) rdi + 72)->u0 = 0x00;
 				}
 				goto l000000000040BBC6;
 			}
@@ -5586,7 +5586,7 @@ Eq_n fn000000000040BD70(Eq_n rcx, word32 edx, Eq_n rsi, Eq_n rdi, Eq_n r8, struc
 	word32 ebx_n;
 	word32 rax_32_32_n;
 	Eq_n ecx_n;
-	byte * qwLocD0_n = (word64) rsi + 0x0288;
+	byte * qwLocD0_n = (word32) rsi + 0x0288;
 	if (r8 <= rcx)
 	{
 		uint128 rdx_rax_n = (uint128) (uint64) rcx;
@@ -5622,7 +5622,7 @@ Eq_n fn000000000040BD70(Eq_n rcx, word32 edx, Eq_n rsi, Eq_n rdi, Eq_n r8, struc
 l000000000040C12D:
 			uint64 r9_n = (uint64) ((word32) (uint64) edx & 0x10);
 			Eq_n edi_n = (word32) rdi_n;
-			r8_n = (word64) rsi + 0x0288;
+			r8_n = (word32) rsi + 0x0288;
 			ebx_n = ~0x00;
 			word32 r9d_n = (word32) r9_n;
 			if (r9d_n != 0x00)
@@ -5670,15 +5670,15 @@ l000000000040C12D:
 l000000000040C790:
 									if ((bLocC8_n & 0x08) != 0x00)
 									{
-										r8_n = (word64) rsi + 0x0288;
+										r8_n = (word32) rsi + 0x0288;
 										edi_n.u0 = 0x00;
 										goto l000000000040C530;
 									}
 									edi_n.u0 = 0x00;
 								}
 l000000000040C4DB:
-								((word64) rsi + 647)->u0 = (byte) (uint64) ((word32) edi_n + 48);
-								r8_n = memcpy((word64) rsi + 647 - r11_n, r15_n, r11_n);
+								((word32) rsi + 647)->u0 = (byte) (uint64) ((word32) edi_n + 48);
+								r8_n = memcpy((word32) rsi + 647 - r11_n, r15_n, r11_n);
 								r9_n = (uint64) r9d_n;
 								ecx_n.u0 = 0x00;
 								edi_n.u0 = 0x00;
@@ -5692,7 +5692,7 @@ l000000000040C4DB:
 								r10_n = (word64) rax_n.u1 + 1;
 								if (rax_n == 0x09)
 								{
-									r8_n = (word64) rsi + 0x0288;
+									r8_n = (word32) rsi + 0x0288;
 									ecx_n.u0 = 0x00;
 									edi_n.u0 = 0x00;
 									goto l000000000040C530;
@@ -5703,11 +5703,11 @@ l000000000040C4DB:
 						}
 						rdi_n = rdi_n;
 					} while (ebx_n != 0x08);
-					r8_n = (word64) rsi + 0x0288;
+					r8_n = (word32) rsi + 0x0288;
 				}
 				else
 				{
-					r8_n = (word64) rsi + 0x0288;
+					r8_n = (word32) rsi + 0x0288;
 					ebx_n = 0x00;
 				}
 			}
@@ -5724,7 +5724,7 @@ l000000000040C530:
 				al_n = (word32) (uint64) ((word32) edi_n.u0 + (word32) ((uint64) ((word32) r10_n & 0x01) + (int64) ecx_n != 0x00)) > 0x05;
 			if (al_n != 0x00)
 			{
-				r10_n = (word64) r10_n + 1;
+				r10_n = (word32) r10_n + 1;
 				if (r9d_n != 0x00 && ((uint64) v22_n == r10_n && ebx_n != 0x08))
 				{
 					ebx_n = (word32) (uint64) (ebx_n + 0x01);
@@ -5803,8 +5803,8 @@ l000000000040C237:
 				{
 					if ((bLocC8_n & 0x40) != 0x00)
 					{
-						((word64) rsi + 0x0288)->u0 = 0x20;
-						qwLocD0_n = (word64) rsi + 649;
+						((word32) rsi + 0x0288)->u0 = 0x20;
+						qwLocD0_n = (byte *) ((word32) rsi + 649);
 					}
 					byte * rdx_n;
 					if (ebx_n != 0x00)
@@ -6018,7 +6018,7 @@ l000000000040BE7D:
 		ebx_n = ~0x00;
 		r15_n = (uint64) (uint32) strlen(rsi);
 	}
-	r12_n = (word64) rsi + 0x0288 - r15_n;
+	r12_n = (word32) rsi + 0x0288 - r15_n;
 	rax_32_32_n = SLICE(memmove(r12_n, rsi, r15_n), word32, 32);
 	r8_n = r12_n + (r15_n - r14_n);
 	goto l000000000040C237;
@@ -6059,7 +6059,7 @@ word32 fn000000000040C810(word32 rax_32_n, union Eq_n * rdx, ui32 * rsi, Eq_n rd
 	ui32 ebp_n = 0x00;
 	if (*rbx_n == 0x27)
 	{
-		rbx_n = (word64) rbx_n + 1;
+		rbx_n = (word32) rbx_n + 1;
 		ebp_n = 0x04;
 	}
 	word32 ecx_n;
@@ -6099,10 +6099,10 @@ l000000000040C86A:
 	}
 	if ((byte) (uint64) ((word32) *rbx_n - 0x30) > 0x09)
 	{
-		Eq_n rdx_n = *((word128) rsp_n + 8);
+		Eq_n rdx_n = *((word32) rsp_n + 8);
 		while (rbx_n != rdx_n)
 		{
-			rbx_n = (word64) rbx_n + 1;
+			rbx_n = (word32) rbx_n + 1;
 			if ((byte) (uint64) ((word32) *rbx_n - 0x30) <= 0x09)
 				goto l000000000040C907;
 		}
@@ -6134,7 +6134,7 @@ Eq_n fn000000000040C9B0(Eq_n edi)
 	{
 		if (*rbx_n == ebp_n)
 			goto l000000000040C9D5;
-		rbx_n = *((word64) rbx_n + 8);
+		rbx_n = *((word32) rbx_n + 8);
 	}
 	struct passwd * rax_n = getpwuid((uint64) ebp_n);
 	Eq_n r12_n = 0x00416919;
@@ -6147,15 +6147,15 @@ Eq_n fn000000000040C9B0(Eq_n edi)
 	}
 	Eq_n rax_n = fn0000000000410C40(rdi_n);
 	*rax_n = ebp_n;
-	strcpy((word64) rax_n + 16, r12_n);
+	strcpy((word32) rax_n + 16, r12_n);
 	Eq_n rax_n = globals->t61B1F8;
 	globals->t61B1F8 = rax_n;
-	*((word64) rax_n + 8) = rax_n;
+	*((word32) rax_n + 8) = rax_n;
 	rbx_n = rax_n;
 l000000000040C9D5:
 	Eq_n rax_n = 0x00;
-	Eq_n rdx_n = (word64) rbx_n + 16;
-	if (*((word64) rbx_n + 16) != 0x00)
+	Eq_n rdx_n = (word32) rbx_n + 16;
+	if (*((word32) rbx_n + 16) != 0x00)
 		rax_n = rdx_n;
 	return rax_n;
 }
@@ -6170,7 +6170,7 @@ Eq_n fn000000000040CB40(Eq_n edi)
 	{
 		if (*rbx_n == ebp_n)
 			goto l000000000040CB65;
-		rbx_n = *((word64) rbx_n + 8);
+		rbx_n = *((word32) rbx_n + 8);
 	}
 	union Eq_n * rax_n = getgrgid((uint64) ebp_n);
 	Eq_n r12_n = 0x00416919;
@@ -6183,15 +6183,15 @@ Eq_n fn000000000040CB40(Eq_n edi)
 	}
 	Eq_n rax_n = fn0000000000410C40(rdi_n);
 	*rax_n = ebp_n;
-	strcpy((word64) rax_n + 16, r12_n);
+	strcpy((word32) rax_n + 16, r12_n);
 	Eq_n rax_n = globals->t61B1E8;
 	globals->t61B1E8 = rax_n;
-	*((word64) rax_n + 8) = rax_n;
+	*((word32) rax_n + 8) = rax_n;
 	rbx_n = rax_n;
 l000000000040CB65:
 	Eq_n rax_n = 0x00;
-	Eq_n rdx_n = (word64) rbx_n + 16;
-	if (*((word64) rbx_n + 16) != 0x00)
+	Eq_n rdx_n = (word32) rbx_n + 16;
+	if (*((word32) rbx_n + 16) != 0x00)
 		rax_n = rdx_n;
 	return rax_n;
 }
@@ -6199,8 +6199,8 @@ l000000000040CB65:
 // 000000000040CCD0: Register (ptr64 byte) fn000000000040CCD0(Register Eq_n rsi, Register int64 rdi)
 byte * fn000000000040CCD0(Eq_n rsi, int64 rdi)
 {
-	((word64) rsi + 20)->u0 = 0x00;
-	byte * rcx_n = (word64) rsi + 20;
+	((word32) rsi + 20)->u0 = 0x00;
+	byte * rcx_n = (word32) rsi + 20;
 	if (rdi < 0x00)
 	{
 		do
@@ -6229,8 +6229,8 @@ byte * fn000000000040CCD0(Eq_n rsi, int64 rdi)
 // 000000000040CD70: Register (ptr64 byte) fn000000000040CD70(Register Eq_n rsi, Register Eq_n rdi)
 byte * fn000000000040CD70(Eq_n rsi, Eq_n rdi)
 {
-	((word64) rsi + 20)->u0 = 0x00;
-	byte * rcx_n = (word64) rsi + 20;
+	((word32) rsi + 20)->u0 = 0x00;
+	byte * rcx_n = (word32) rsi + 20;
 	do
 	{
 		uint64 rdx_n = SLICE(rdi * 0xCCCCCCCD, word64, 64);
@@ -6378,7 +6378,7 @@ l000000000040CE3E:
 					uint64 rax_n = 0x00;
 					do
 					{
-						r13_n = (word64) r13_n + 1;
+						r13_n = (word32) r13_n + 1;
 						*(r13_n - 0x01) = 0x20;
 						if (rdx_n == rax_n)
 							break;
@@ -6397,7 +6397,7 @@ l000000000040CE3E:
 					uint64 rax_n = 0x00;
 					do
 					{
-						rdx_n = (word64) rdx_n + 1;
+						rdx_n = (word32) rdx_n + 1;
 						*(rdx_n - 0x01) = 0x20;
 						if (rsi_n == rax_n)
 							break;
@@ -6417,7 +6417,7 @@ l000000000040CF4C:
 		rcx_n.u1 = 0x00;
 		goto l000000000040CE3E;
 	}
-	qwLoc48_n = (word64) rax_n + 1;
+	qwLoc48_n = (word32) rax_n + 1;
 l000000000040D064:
 	Eq_n rax_n = malloc(qwLoc48_n);
 	rbp_n = rax_n;
@@ -6563,7 +6563,7 @@ l000000000040D2C3:
 				else
 				{
 l000000000040D29B:
-					rbp_n = (word64) rbp_n + 1;
+					rbp_n = (word32) rbp_n + 1;
 					r12d_n = (word32) (uint64) (r12d_n + 0x01);
 				}
 			} while (r13_n > rbp_n);
@@ -6579,7 +6579,7 @@ l000000000040D401:
 		uint64 rax_n = 0x00;
 		do
 		{
-			rbp_n = (word64) rbp_n + 1;
+			rbp_n = (word32) rbp_n + 1;
 			uint32 edx_n = (word32) rcx_n[SEQ(rdx_32_n, (word32) *(rbp_n - 0x01))];
 			word32 eax_n = (word32) rax_n;
 			uint64 rdx_n = SEQ(rdx_32_n, edx_n);
@@ -6634,14 +6634,14 @@ Eq_n fn000000000040D450(Eq_n rcx, Eq_n rdx, Eq_n rbx, Eq_n rsi, Eq_n rdi, union 
 	{
 		if (rsi == 0x02)
 		{
-			Eq_n r13_n = *((word64) rdi + 8);
+			Eq_n r13_n = *((word32) rdi + 8);
 			Eq_n r12_n = *rdi;
 			word64 rax_n;
 			rcx();
 			if ((word32) rax_n > 0x00)
 			{
 				*rdi = r13_n;
-				*((word64) rdi + 8) = r12_n;
+				*((word32) rdi + 8) = r12_n;
 				rdxOut = rdx;
 				rsiOut = rsi;
 				return rcx;
@@ -6650,13 +6650,13 @@ Eq_n fn000000000040D450(Eq_n rcx, Eq_n rdx, Eq_n rbx, Eq_n rsi, Eq_n rdi, union 
 		goto l000000000040D479;
 	}
 	Eq_n r12_n;
-	Eq_n rax_n = (word64) rdi + (rsi >> 0x01) * 0x08;
+	Eq_n rax_n = (word32) rdi + (rsi >> 0x01) * 0x08;
 	Eq_n qwLoc40_n = rax_n;
 	word64 rsi_n;
 	rcx = fn000000000040D450(rcx, rdx, rdi, rsi - (rsi >> 0x01), rax_n, out rdx, out rsi_n);
 	if (rsi >> 0x01 != 0x01)
 	{
-		Eq_n r13_n = (word64) rdi + (rsi >> 0x03) * 0x08;
+		Eq_n r13_n = (word32) rdi + (rsi >> 0x03) * 0x08;
 		word64 rdx_n;
 		word64 rsi_n;
 		fn000000000040D450(rcx, qwLoc48, rdi, qwLoc58 - (rsi >> 0x03), r13_n, out rdx_n, out rsi_n);
@@ -6678,7 +6678,7 @@ l000000000040D53B:
 			qwLoc40_n = v22_n;
 			if (rbx != v22_n)
 			{
-				r12_n = *((word64) rdi + v22_n * 0x08);
+				r12_n = *((word32) rdi + v22_n * 0x08);
 				goto l000000000040D537;
 			}
 			qwLoc40_n = r14_n;
@@ -6687,17 +6687,17 @@ l000000000040D53B:
 		else
 		{
 			*(r15_n - 0x08) = (union Eq_n *) r13_n;
-			r14_n = (word64) r14_n + 1;
+			r14_n = (word32) r14_n + 1;
 			if (qwLoc48 != r14_n)
 			{
-				r13_n = *((word64) rdi + r14_n * 0x08);
+				r13_n = *((word32) rdi + r14_n * 0x08);
 l000000000040D537:
-				r15_n = (word64) r15_n + 8;
+				r15_n = (word32) r15_n + 8;
 				goto l000000000040D53B;
 			}
 		}
 		ui64 rdx_n = qwLoc30_n - qwLoc40_n;
-		memcpy(r15_n, (word64) rdi + qwLoc40_n * 0x08, rdx_n << 0x03);
+		memcpy(r15_n, (word32) rdi + qwLoc40_n * 0x08, rdx_n << 0x03);
 		rdx = rdx_n << 0x03;
 		r12_n = *qwLoc38;
 	}
@@ -6715,7 +6715,7 @@ l000000000040D537:
 		rcx();
 		if ((word32) rax_n <= 0x00)
 		{
-			(rdi - 0x08)[r15_n] = r12_n;
+			(rdi - 0x08)[r15_n].t0000 = r12_n;
 			if (rsi >> 0x01 == qwLoc58 + 0x01)
 			{
 l000000000040D479:
@@ -6724,22 +6724,22 @@ l000000000040D479:
 				return rcx;
 			}
 			rcx = rdx;
-			r12_n = *((word64) rdx + (qwLoc58 + 0x01) * 0x08);
+			r12_n = *((word32) rdx + (qwLoc58 + 0x01) * 0x08);
 		}
 		else
 		{
-			(rdi - 0x08)[r15_n] = r13_n;
+			(rdi - 0x08)[r15_n].t0000 = r13_n;
 			r14_n = (word64) r14_n + 1;
 			if (rsi == r14_n)
 			{
 				uint64 r15_n = (rsi >> 0x01) - qwLoc58;
-				Eq_n rsi_n = (word64) rdx + qwLoc58 * 0x08;
-				memcpy((word64) rdi + r15_n * 0x08, rsi_n, r15_n * 0x08);
+				Eq_n rsi_n = (word32) rdx + qwLoc58 * 0x08;
+				memcpy((word32) rdi + r15_n * 0x08, rsi_n, r15_n * 0x08);
 				rdxOut = r15_n * 0x08;
 				rsiOut = rsi_n;
 				return rdx;
 			}
-			r13_n = *((word64) rdi + r14_n * 0x08);
+			r13_n = *((word32) rdi + r14_n * 0x08);
 		}
 		++r15_n;
 	}
@@ -6748,7 +6748,7 @@ l000000000040D479:
 // 000000000040D690: Register Eq_n fn000000000040D690(Register Eq_n rdx, Register Eq_n rbx, Register Eq_n rsi, Register Eq_n rdi)
 Eq_n fn000000000040D690(Eq_n rdx, Eq_n rbx, Eq_n rsi, Eq_n rdi)
 {
-	Eq_n rax_n = (word64) rdi + rsi * 0x08;
+	Eq_n rax_n = (word32) rdi + rsi * 0x08;
 	Eq_n rsi_n;
 	word64 rdx_n;
 	fn000000000040D450(rdx, rax_n, rbx, rsi, rdi, out rdx_n, out rsi_n);
@@ -6862,11 +6862,11 @@ Eq_n fn000000000040D7B0(word32 esi, Eq_n rdi, struct Eq_n * fs, ptr64 & rcxOut, 
 		byte dl_n = (byte) rdx_n;
 		if (dl_n == 0x55)
 		{
-			rdx_n.u0 = (uint64) ((word32) *((word64) rax_n + 1) & ~0x20);
+			rdx_n.u0 = (uint64) ((word32) *((word32) rax_n + 1) & ~0x20);
 			if ((byte) rdx_n == 0x54)
 			{
-				rdx_n.u0 = (uint64) ((word32) *((word64) rax_n + 2) & ~0x20);
-				if ((byte) rdx_n == 0x46 && (*((word64) rax_n + 3) == 0x2D && (*((word64) rax_n + 4) == 0x38 && *((word64) rax_n + 5) == 0x00)))
+				rdx_n.u0 = (uint64) ((word32) *((word32) rax_n + 2) & ~0x20);
+				if ((byte) rdx_n == 0x46 && (*((word32) rax_n + 3) == 0x2D && (*((word32) rax_n + 4) == 0x38 && *((word32) rax_n + 5) == 0x00)))
 				{
 					rbx_n.u0 = 4284388;
 					if (*rax_n == 0x60)
@@ -6880,8 +6880,8 @@ Eq_n fn000000000040D7B0(word32 esi, Eq_n rdi, struct Eq_n * fs, ptr64 & rcxOut, 
 			rdx_n = rdx_n;
 			if (dl_n == 0x47)
 			{
-				rdx_n.u0 = (uint64) ((word32) *((word64) rax_n + 1) & ~0x20);
-				if ((byte) rdx_n == 66 && (*((word64) rax_n + 2) == 0x31 && (*((word64) rax_n + 3) == 0x38 && (*((word64) rax_n + 4) == 0x30 && (*((word64) rax_n + 5) == 0x33 && (*((word64) rax_n + 6) == 0x30 && *((word64) rax_n + 7) == 0x00))))))
+				rdx_n.u0 = (uint64) ((word32) *((word32) rax_n + 1) & ~0x20);
+				if ((byte) rdx_n == 66 && (*((word32) rax_n + 2) == 0x31 && (*((word32) rax_n + 3) == 0x38 && (*((word32) rax_n + 4) == 0x30 && (*((word32) rax_n + 5) == 0x33 && (*((word32) rax_n + 6) == 0x30 && *((word32) rax_n + 7) == 0x00))))))
 				{
 					rbx_n.u0 = 4284397;
 					if (*rax_n != 0x60)
@@ -7340,7 +7340,7 @@ l000000000040E0A0:
 								goto l000000000040DC46;
 							}
 						}
-						rdx_n = (word64) rdx_n + 1;
+						rdx_n = (word32) rdx_n + 1;
 					} while (rdx_n != rax_n);
 				}
 				rdi_n = fp - 0x48;
@@ -7433,7 +7433,7 @@ l000000000040DED1:
 				rdi_n = rdi_n;
 				word32 r12_32_32_n = SLICE(SLICE(r12_n, word56, 8), word32, 32);
 				byte r12b_n = (byte) r12_n;
-				rbp_n = (word64) rbp_n + 1;
+				rbp_n = (word32) rbp_n + 1;
 				r12_n = r12_n;
 				rdx_n = SEQ(rdx_32_32_n, edx_n);
 				rcx_n = rdi;
@@ -7479,7 +7479,7 @@ l000000000040DB09:
 				r12_n = SEQ(r12_56_8_n, r12b_n);
 				rdx_n = SEQ(rdx_32_32_n, edx_n);
 				rdx_n = SEQ(rdx_32_32_n, edx_n);
-				if ((*((word64) qwArg08 + SEQ(rdx_32_32_n, edx_n) * 0x04) & (word32) rax_n) == 0x00)
+				if ((*((word32) qwArg08 + SEQ(rdx_32_32_n, edx_n) * 0x04) & (word32) rax_n) == 0x00)
 					goto l000000000040DB2E;
 				goto l000000000040DB33;
 			}
@@ -7514,7 +7514,7 @@ l000000000040DC46:
 				rcx_n = rcx_n;
 				rdx_n = rdx_n;
 			}
-			rbp_n = (word64) rbp_n + 1;
+			rbp_n = (word32) rbp_n + 1;
 			r12_n = r12_n;
 			rcx_n = rcx_n;
 			rdx_n = rdx_n;
@@ -7587,7 +7587,7 @@ struct Eq_n * fn000000000040E650(word32 edx, int32 esi, ui32 rsi_32_n, struct Eq
 	ui32 ecx_n = (word32) (uint64) esi;
 	if (rdi != null)
 		rax_n = rdi;
-	struct Eq_n * rsi_n = rax_n + (SEQ(rsi_32_n, (word32) (sil_n >> 0x05)) * 0x04) / 56;
+	struct Eq_n * rsi_n = rax_n + (SEQ(rsi_32_n, (word32) (sil_n >> 0x05)) * 0x04) / 52;
 	word32 edi_n = (word32) (uint64) rsi_n->dw0008;
 	byte cl_n = (byte) (uint64) (ecx_n & 0x1F);
 	rsi_n->dw0008 = (word32) (uint64) ((word32) (uint64) ((word32) (uint64) ((word32) (uint64) (edx ^ (word32) ((uint64) ((word32) ((uint64) edi_n) >> cl_n))) & 0x01) << cl_n) ^ edi_n);
@@ -7705,7 +7705,7 @@ void fn000000000040EC80(Eq_n rcx, Eq_n rdx, Eq_n esi, Eq_n rdi)
 		int32_t ** rax_n = __ctype_toupper_loc();
 		do
 		{
-			*((word64) rdi + rbx_n) = (byte) (uint64) *((char *) *rax_n + SEQ(rcx_32_n, (word32) (rsi + rbx_n)) * 0x04);
+			*((word32) rdi + rbx_n) = (byte) (uint64) *((char *) *rax_n + SEQ(rcx_32_n, (word32) (rsi + rbx_n)) * 0x04);
 			--rbx_n;
 		} while (rbx_n != ~0x00);
 	}
@@ -7718,7 +7718,7 @@ uint64 fn000000000040ECD0(Eq_n rcx, uint64 rdx, Eq_n rsi, Eq_n dil, Eq_n r8, str
 	Eq_n r12_n = rsi;
 	Eq_n rbx_n = rcx;
 	word64 rsi_n = fs->qw0028;
-	int32 esi_n = (word32) (uint64) *((word64) r8 + 8);
+	int32 esi_n = (word32) (uint64) *((word32) r8 + 8);
 	uint64 r9_n = r9;
 	Eq_n rdi_n = rdi;
 	uint64 rax_n;
@@ -7739,7 +7739,7 @@ uint64 fn000000000040ECD0(Eq_n rcx, uint64 rdx, Eq_n rsi, Eq_n dil, Eq_n r8, str
 				while (true)
 				{
 l000000000040ED94:
-					rbx_n = (word64) rbx_n + 1;
+					rbx_n = (word32) rbx_n + 1;
 					word32 edi_n = (word32) *rbx_n;
 					word32 r9d_n = (word32) r9_n;
 					byte dil_n = (byte) edi_n;
@@ -7804,7 +7804,7 @@ l000000000040EE0D:
 										goto l000000000040EE0D;
 									rbp_n = 0x7FFFFFFF;
 l000000000040EE15:
-									rbx_n = (word64) rbx_n + 1;
+									rbx_n = (word32) rbx_n + 1;
 									word32 edi_n = (word32) *rbx_n;
 									byte dil_n = (byte) edi_n;
 									uint64 rdx_n = (uint64) ((int32) dil_n - 0x30);
@@ -7829,7 +7829,7 @@ l000000000040EE15:
 								if (dil_n != 0x4F)
 									goto l000000000040EE52;
 							}
-							rbx_n = (word64) rbx_n + 1;
+							rbx_n = (word32) rbx_n + 1;
 							word32 edi_n = (word32) *rbx_n;
 							rcx_n = SEQ(rcx_32_32_n, (int32) dil_n);
 							rdi_n = SEQ(SEQ(rdi_32_32_n, SLICE(edi_n, word24, 8)), (byte) edi_n);
@@ -7855,7 +7855,7 @@ l000000000040EE52:
 										r15_n = rax_n;
 										--rax_n;
 										ecx_n = (word32) (uint64) (ecx_n + 0x01);
-									} while (*((word64) rax_n + 1) != 0x25);
+									} while (*((word32) rax_n + 1) != 0x25);
 									rcx_n = (int64) ecx_n;
 								}
 								int32 eax_n = 0x00;
@@ -7898,7 +7898,7 @@ l000000000040EE52:
 									r12_n += rcx_n;
 								}
 								r8 = rbx_n;
-								r13_n = (word64) rbx_n + r13_n;
+								r13_n = (uint64) ((word32) rbx_n + r13_n);
 								rcx = rcx_n;
 								goto l000000000040ED74;
 							}
@@ -7915,7 +7915,7 @@ l000000000040EE52:
 								return rax_n;
 							}
 						}
-						rbx_n = (word64) rbx_n + 1;
+						rbx_n = (word32) rbx_n + 1;
 						word32 edi_n = (word32) *rbx_n;
 						dil_n = (byte) edi_n;
 						SZO_n.u0 = SLICE(cond(dil_n - 0x30), bool, 4);
@@ -7933,13 +7933,13 @@ l000000000040EE98:
 			if (r12_n != 0x00)
 			{
 				r12_n->u0 = al_n;
-				r12_n = (word64) r12_n + 1;
+				r12_n = (word32) r12_n + 1;
 			}
 			++r13_n;
 			r8 = rbx_n;
 l000000000040ED74:
-			al_n = (byte) (word32) *((word64) r8 + 1);
-			rbx_n = (word64) r8 + 1;
+			al_n = (byte) (word32) *((word32) r8 + 1);
+			rbx_n = (word32) r8 + 1;
 		} while (al_n != 0x00);
 	}
 	if (r12_n != 0x00 && rdx != 0x00)
@@ -8087,7 +8087,7 @@ word32 fn0000000000410E90(Eq_n rcx, up32 edx, char ** rsi, Eq_n rdi, Eq_n r8, wo
 		Eq_n r9_n = SEQ(r9_32_n, (word32) bl_n);
 		if ((rdx_n->a0001[r9_n].b0000 & 0x20) == 0x00)
 			break;
-		rax_n = (word64) rax_n + 1;
+		rax_n = (word32) rax_n + 1;
 		bl_n = (byte) (word32) *rax_n;
 	}
 	uint64 rax_n;
@@ -8168,12 +8168,12 @@ l0000000000410FCB:
 		rcx_n = 0x01;
 		goto l0000000000410FD5;
 	}
-	byte al_n = (byte) (word32) *((word64) r14_n + 1);
+	byte al_n = (byte) (word32) *((word32) r14_n + 1);
 	if (al_n != 0x44)
 	{
 		if (al_n == 0x69)
 		{
-			uint64 rcx_n = (uint64) (uint8) (*((word64) r14_n + 2) == 66);
+			uint64 rcx_n = (uint64) (uint8) (*((word32) r14_n + 2) == 66);
 			rcx_n = (uint64) (uint32) (rcx_n + 0x01 + rcx_n);
 l0000000000410FD5:
 			uint64 rdx_n = (uint64) (edx_n - 66);
@@ -8248,7 +8248,7 @@ word32 fn0000000000411360(union Eq_n * rcx, up32 edx, char ** rsi, Eq_n rdi, Eq_
 		Eq_n r9_n = SEQ(r9_32_n, (word32) bl_n);
 		if ((rdx_n->a0001[r9_n].b0000 & 0x20) == 0x00)
 			break;
-		rax_n = (word64) rax_n + 1;
+		rax_n = (word32) rax_n + 1;
 		bl_n = (byte) (word32) *rax_n;
 	}
 	uint64 rax_n;
@@ -8336,12 +8336,12 @@ l00000000004114A3:
 		rcx_n = 0x01;
 		goto l00000000004114AD;
 	}
-	byte al_n = (byte) (word32) *((word64) r14_n + 1);
+	byte al_n = (byte) (word32) *((word32) r14_n + 1);
 	if (al_n != 0x44)
 	{
 		if (al_n == 0x69)
 		{
-			uint64 rcx_n = (uint64) (uint8) (*((word64) r14_n + 2) == 66);
+			uint64 rcx_n = (uint64) (uint8) (*((word32) r14_n + 2) == 66);
 			rcx_n = (uint64) (uint32) (rcx_n + 0x01 + rcx_n);
 l00000000004114AD:
 			uint64 rdx_n = (uint64) (edx_n - 66);
@@ -8470,13 +8470,13 @@ l000000000041196A:
 			byte bpl_n = (byte) (word32) *r14_n;
 			if (bpl_n == 0x00)
 				break;
-			if (strcmp(rbx_n, r14_n) == 0x00 || bpl_n == 0x2A && *((word64) r14_n + 1) == 0x00)
+			if (strcmp(rbx_n, r14_n) == 0x00 || bpl_n == 0x2A && *((word32) r14_n + 1) == 0x00)
 			{
-				rbx_n = (word64) r14_n + 1 + SEQ(rax_32_32_n, strlen(r14_n));
+				rbx_n = (word32) r14_n + 1 + SEQ(rax_32_32_n, strlen(r14_n));
 				break;
 			}
-			Eq_n rbp_n = (word64) r14_n + 1 + SEQ(rax_32_32_n, strlen(r14_n));
-			r14_n = (word64) rbp_n + 1 + SEQ(rax_32_32_n, strlen(rbp_n));
+			Eq_n rbp_n = (word32) r14_n + 1 + SEQ(rax_32_32_n, strlen(r14_n));
+			r14_n = (word32) rbp_n + 1 + SEQ(rax_32_32_n, strlen(rbp_n));
 		}
 		*rbx_n != 0x00;
 		ui64 rcx_n = rax_n ^ fs->qw0028;
@@ -8518,7 +8518,7 @@ l0000000000411A19:
 			memcpy(rax_n, r15_n, r12_n);
 			if ((word32) (uint64) dwLocD0_n != 0x00)
 				rax_n->u0 = 0x2F;
-			struct Eq_n * r13_n = (word64) rax_n + r13_n;
+			struct Eq_n * r13_n = (word32) rax_n + r13_n;
 			r13_n->qw0000 = 1918986339;
 			r13_n->dw0008 = 0x61696C61;
 			r13_n->w000C = 115;
@@ -8636,7 +8636,7 @@ l0000000000411AC9:
 							goto l0000000000411C2E;
 						}
 						int64 r14_n = qwLocD0_n - r10_n;
-						strcpy((word64) r13_n + ((~0x01 - rdx_n) + r14_n), fp - 0xB8);
+						strcpy((word32) r13_n + ((~0x01 - rdx_n) + r14_n), fp - 0xB8);
 						char * rdi_n = r13_n - 0x01 + r14_n;
 						strcpy(rdi_n, fp - 0x78);
 						rax_n = (byte *) *((char *) rax_n + 8);

--- a/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN.h
+++ b/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN.h
@@ -362,352 +362,19 @@ Eq_645: (fn void ())
 	T_658 (in fn000013AC : ptr32)
 	T_660 (in fn000013AC : ptr32)
 	T_662 (in fn000013AC : ptr32)
-Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((ptr32 Eq_8419) u4) ((ptr32 Eq_8426) u5) (Eq_1365 u6) (Eq_6422 u7) (Eq_7285 u8))
+Eq_664: (union "Eq_664" (byte u0) (word16 u1) ((ptr32 Eq_8467) u2) ((ptr32 Eq_8420) u3))
 	T_664 (in d0 : Eq_664)
-	T_665 (in a1_11 : Eq_664)
 	T_666 (in d1_13 : Eq_664)
 	T_673 (in d0 : Eq_664)
 	T_674 (in d1 : Eq_664)
-	T_675 (in a1 : Eq_664)
 	T_685 (in fn00003DE0(&globals->b142C, out d1_13, out a1_11) : word32)
 	T_707 (in fn00003DE0(&globals->b1468, out d1_85, out a1_86) : word32)
-	T_793 (in d5_256 : Eq_664)
-	T_794 (in -1<i32> : int32)
-	T_805 (in d2_1005 : Eq_664)
-	T_808 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
-	T_824 (in d2_1005 | d1_123 : word32)
-	T_834 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
-	T_950 (in 0<i32> : int32)
-	T_978 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-	T_984 (in Mem278[a7_275 + 0<32>:word32] : word32)
-	T_988 (in  : word32)
-	T_989 (in 10<i32> : int32)
-	T_990 (in __swap(10<i32>) : word32)
-	T_997 (in __swap(d5_256) : word32)
-	T_1002 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-	T_1003 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
-	T_1040 (in Mem278[a7_275 + 0<32>:word32] : word32)
-	T_1044 (in d1_303 - 0x30<32> + d0_293 : word32)
-	T_1089 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-	T_1097 (in 10<i32> : int32)
-	T_1098 (in __swap(10<i32>) : word32)
-	T_1105 (in __swap(d2_1005) : word32)
-	T_1110 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-	T_1111 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
-	T_1153 (in d1_196 - 0x30<32> + d0_186 : word32)
-	T_1161 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
-	T_1260 (in 0<32> : word32)
-	T_1339 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-	T_1388 (in 0<32> : word32)
-	T_1608 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
-	T_1745 (in dwArg04 : Eq_664)
-	T_1746 (in dwArg08 : Eq_664)
-	T_1747 (in dwArg0C : Eq_664)
-	T_1748 (in dwArg10 : Eq_664)
-	T_1752 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_1757 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1762 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_1767 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_1829 (in dwArg04 : Eq_664)
-	T_1830 (in dwArg08 : Eq_664)
-	T_1831 (in dwArg0C : Eq_664)
-	T_1832 (in dwArg10 : Eq_664)
-	T_1833 (in d1Out : Eq_664)
-	T_1834 (in a0Out : Eq_664)
-	T_1838 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_1843 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1848 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_1853 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_1854 (in out d1_1450 : ptr32)
-	T_1855 (in out a0_1447 : ptr32)
-	T_2419 (in 0<32> : word32)
-	T_2449 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-	T_2453 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-	T_2509 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
-	T_3393 (in d0 : Eq_664)
-	T_3394 (in d0_196 : Eq_664)
-	T_3395 (in d1_142 : Eq_664)
-	T_3396 (in a0_20 : Eq_664)
-	T_3397 (in d3_166 : Eq_664)
-	T_3398 (in 0<32> : word32)
-	T_3406 (in 0<32> : word32)
-	T_3412 (in d0 : Eq_664)
-	T_3413 (in d1 : Eq_664)
-	T_3414 (in d2 : Eq_664)
-	T_3415 (in d1Out : Eq_664)
-	T_3416 (in d2Out : Eq_664)
-	T_3417 (in out d1_318 : ptr32)
-	T_3418 (in out d2_319 : ptr32)
-	T_3419 (in fn00002534(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-	T_3420 (in 0<i32> : int32)
-	T_3423 (in d6_30 : Eq_664)
-	T_3426 (in  : word32)
-	T_3427 (in  : word32)
-	T_3428 (in 8<32> : word32)
-	T_3429 (in __rol(dwArg0C, 8<32>) : word32)
-	T_3455 (in 8<32> : word32)
-	T_3456 (in __rol(d6_30, 8<32>) : word32)
-	T_3462 (in 8<32> : word32)
-	T_3463 (in __rol(d6_30, 8<32>) : word32)
-	T_3470 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_3471 (in d1_175 : Eq_664)
-	T_3472 (in d2_176 : Eq_664)
-	T_3473 (in d0_174 : Eq_664)
-	T_3475 (in 0<i32> : int32)
-	T_3476 (in out d1_175 : ptr32)
-	T_3477 (in out d2_176 : ptr32)
-	T_3478 (in fn00002534(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-	T_3482 (in out d1_320 : ptr32)
-	T_3483 (in out d2_321 : ptr32)
-	T_3484 (in fn00002534(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-	T_3495 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_3498 (in d0_85 : Eq_664)
-	T_3500 (in dwArg04 >> d4_61 : word32)
-	T_3503 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-	T_3506 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-	T_3507 (in out d1_86 : ptr32)
-	T_3508 (in out d2_322 : ptr32)
-	T_3509 (in fn00002534(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-	T_3510 (in d3_72 : Eq_664)
-	T_3511 (in dwArg10 << d5_63 : word32)
-	T_3512 (in d5_101 : Eq_664)
-	T_3514 (in __swap(d0_85) : word32)
-	T_3515 (in d6_103 : Eq_664)
-	T_3517 (in __swap(d3_72) : word32)
-	T_3521 (in d2_107 : Eq_664)
-	T_3524 (in d0_85 * (word16) d3_72 : word32)
-	T_3525 (in __swap(d0_85 * (word16) d3_72) : word32)
-	T_3538 (in d6_82 : Eq_664)
-	T_3539 (in dwArg08 << d5_63 : word32)
-	T_3540 (in d2_124 : Eq_664)
-	T_3542 (in SEQ(v35_109, v39_116) : uipr32)
-	T_3543 (in __swap(SEQ(v35_109, v39_116)) : word32)
-	T_3551 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-	T_3552 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-	T_3556 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-	T_3557 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-	T_3579 (in d0_85 - 1<32> : word32)
-	T_3585 (in d7_13 : Eq_664)
-	T_3586 (in 0<32> : word32)
-	T_3590 (in d0 : Eq_664)
-	T_3591 (in d1 : Eq_664)
-	T_3592 (in d2 : Eq_664)
-	T_3593 (in d1Out : Eq_664)
-	T_3594 (in out d1 : ptr32)
-	T_3595 (in fn000026F2(d1, d2, d2, out d1) : word32)
-	T_3596 (in d6_17 : Eq_664)
-	T_3597 (in d5_19 : Eq_664)
-	T_3598 (in 0<32> : word32)
-	T_3600 (in d2_22 : Eq_664)
-	T_3602 (in __swap(d2) : word32)
-	T_3606 (in 0<32> : word32)
-	T_3615 (in 0<32> : word32)
-	T_3617 (in d0_281 : Eq_664)
-	T_3619 (in __swap(d0) : word32)
-	T_3620 (in d1_282 : Eq_664)
-	T_3622 (in __swap(d1) : word32)
-	T_3632 (in __swap(d1_282) : word32)
-	T_3639 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-	T_3640 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-	T_3645 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-	T_3651 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-	T_3652 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-	T_3656 (in d6_17 * 2<32> : word32)
-	T_3664 (in 0<32> : word32)
-	T_3666 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-	T_3668 (in d7_13 * 2<32> : word32)
-	T_3669 (in 0<32> : word32)
-	T_3673 (in d3_74 : Eq_664)
-	T_3680 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-	T_3681 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-	T_3684 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-	T_3685 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-	T_3686 (in d1_104 : Eq_664)
-	T_3687 (in 0xFFFF<32> : uipr32)
-	T_3688 (in d6_98 : Eq_664)
-	T_3692 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-	T_3693 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-	T_3694 (in d6_133 : Eq_664)
-	T_3696 (in __swap(d1_104) : word32)
-	T_3697 (in d3_140 : Eq_664)
-	T_3699 (in __swap(d6_133) : word32)
-	T_3700 (in d4_142 : Eq_664)
-	T_3702 (in __swap(d7_13) : word32)
-	T_3706 (in d6_146 : Eq_664)
-	T_3709 (in d6_133 * (word16) d7_13 : word32)
-	T_3710 (in __swap(d6_133 * (word16) d7_13) : word32)
-	T_3726 (in d6_178 : Eq_664)
-	T_3728 (in SEQ(v56_148, v59_155) : uipr32)
-	T_3729 (in __swap(SEQ(v56_148, v59_155)) : word32)
-	T_3730 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-	T_3731 (in d5_181 : word32)
-	T_3735 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-	T_3736 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-	T_3740 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-	T_3741 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-	T_3754 (in 0<32> : word32)
-	T_3756 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-	T_3757 (in 0<32> : word32)
-	T_3765 (in d1_104 - 1<32> : word32)
-	T_3766 (in d4_113 : Eq_664)
-	T_3769 (in __swap(d7_13) : word32)
-	T_3772 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-	T_3773 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-	T_3788 (in __swap(d7_13) : word32)
-	T_3792 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-	T_3794 (in d1_104 - 1<32> : word32)
-	T_3795 (in 0<32> : word32)
-	T_3801 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-	T_3802 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_3803 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_3804 (in d6_220 : Eq_664)
-	T_3808 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-	T_3809 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-	T_3812 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-	T_3813 (in d5_221 : Eq_664)
-	T_3815 (in __swap(d5_181) : word32)
-	T_3820 (in d5_266 : Eq_664)
-	T_3822 (in __swap(d5_181) : word32)
-	T_3823 (in d6_267 : Eq_664)
-	T_3825 (in __swap(d6_178) : word32)
-	T_3828 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-	T_3831 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-	T_3835 (in d2_73 : Eq_664)
-	T_3837 (in __swap(d5_19) : word32)
-	T_3839 (in __swap(d7_13) : word32)
-	T_3849 (in d5_221 >> 1<32> : word32)
-	T_3854 (in  : word32)
-	T_3860 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-	T_3867 (in d0 : Eq_664)
-	T_3868 (in d2 : Eq_664)
-	T_3869 (in dwArg04 : Eq_664)
-	T_3870 (in dwArg08 : Eq_664)
-	T_3871 (in 0<32> : word32)
-	T_3873 (in 0<32> : word32)
-	T_3875 (in d0_36 : Eq_664)
-	T_3876 (in -dwArg04 : word32)
-	T_3877 (in 0<32> : word32)
-	T_3881 (in out d1_43 : ptr32)
-	T_3882 (in fn000026F2(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_3883 (in -fn000026F2(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_3886 (in -dwArg08 : word32)
-	T_3887 (in out d1_55 : ptr32)
-	T_3888 (in fn000026F2(d0_36, -dwArg08, d2, out d1_55) : word32)
-	T_3891 (in out d1_88 : ptr32)
-	T_3892 (in fn000026F2(dwArg04, dwArg08, d2, out d1_88) : word32)
-	T_3895 (in -dwArg08 : word32)
-	T_3896 (in out d1_89 : ptr32)
-	T_3897 (in fn000026F2(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_3898 (in -fn000026F2(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_3899 (in d1_22 : Eq_664)
-	T_3901 (in __swap(d1) : word32)
-	T_3906 (in d2_11 : Eq_664)
-	T_3907 (in SEQ(v11_10, v10_9) : uipr32)
-	T_3910 (in d3_18 : Eq_664)
-	T_3911 (in 16<i32> : int32)
-	T_3915 (in d0_134 : Eq_664)
-	T_3917 (in __swap(d0) : word32)
-	T_3918 (in d1_135 : Eq_664)
-	T_3920 (in __swap(d1_22) : word32)
-	T_3925 (in __swap(d2_11) : word32)
-	T_3930 (in d0_150 : Eq_664)
-	T_3932 (in __swap(d0_134) : word32)
-	T_3946 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-	T_3947 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-	T_3949 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-	T_3951 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-	T_3961 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-	T_3966 (in 8<32> : word32)
-	T_3967 (in __rol(d1_22, 8<32>) : word32)
-	T_3968 (in 8<32> : uipr32)
-	T_3973 (in 4<32> : word32)
-	T_3974 (in __rol(d1_22, 4<32>) : word32)
-	T_3979 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-	T_3984 (in 2<32> : word32)
-	T_3985 (in __rol(d1_22, 2<32>) : word32)
-	T_3990 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-	T_3996 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-	T_3997 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-	T_4004 (in __swap(d3_18) : word32)
-	T_4010 (in d1_90 : Eq_664)
-	T_4012 (in __swap(d1_22) : word32)
-	T_4013 (in d3_102 : Eq_664)
-	T_4014 (in SEQ(v53_82, v51_79) : uipr32)
-	T_4015 (in d0_108 : Eq_664)
-	T_4025 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-	T_4026 (in 0<32> : word32)
-	T_4029 (in 1<32> : word32)
-	T_4030 (in __rol(d1_22, 1<32>) : word32)
-	T_4035 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-	T_4039 (in __swap(d3_102) : word32)
-	T_4040 (in __rol(d0_108, __swap(d3_102)) : word32)
-	T_4041 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-	T_4044 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-	T_4047 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-	T_4048 (in d0_108 + d1_90 : word32)
-	T_4049 (in 0<32> : word32)
-	T_4051 (in d1 : Eq_664)
-	T_4052 (in d1_171 : Eq_664)
-	T_4053 (in d3_202 : Eq_664)
-	T_4054 (in 0<32> : word32)
-	T_4062 (in 0<32> : word32)
-	T_4066 (in out d1_171 : ptr32)
-	T_4067 (in out d2_354 : ptr32)
-	T_4068 (in fn00002534(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-	T_4071 (in d6_33 : Eq_664)
-	T_4073 (in 8<32> : word32)
-	T_4074 (in __rol(dwArg0C, 8<32>) : word32)
-	T_4100 (in 8<32> : word32)
-	T_4101 (in __rol(d6_33, 8<32>) : word32)
-	T_4107 (in 8<32> : word32)
-	T_4108 (in __rol(d6_33, 8<32>) : word32)
-	T_4115 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_4118 (in d0_88 : Eq_664)
-	T_4120 (in dwArg04 >> d4_64 : word32)
-	T_4123 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-	T_4126 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-	T_4127 (in out d1_89 : ptr32)
-	T_4128 (in out d2_90 : ptr32)
-	T_4129 (in fn00002534(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-	T_4130 (in d3_75 : Eq_664)
-	T_4131 (in dwArg10 << d5_66 : word32)
-	T_4132 (in d7_104 : Eq_664)
-	T_4134 (in __swap(d0_88) : word32)
-	T_4135 (in d6_106 : Eq_664)
-	T_4137 (in __swap(d3_75) : word32)
-	T_4141 (in d2_110 : Eq_664)
-	T_4144 (in d0_88 * (word16) d3_75 : word32)
-	T_4145 (in __swap(d0_88 * (word16) d3_75) : word32)
-	T_4158 (in d2_127 : Eq_664)
-	T_4160 (in SEQ(v37_112, v40_119) : uipr32)
-	T_4161 (in __swap(SEQ(v37_112, v40_119)) : word32)
-	T_4171 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-	T_4172 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-	T_4176 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-	T_4177 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-	T_4196 (in dwArg08 - dwArg10 : word32)
-	T_4200 (in d1_211 : Eq_664)
-	T_4201 (in d2_212 : Eq_664)
-	T_4203 (in 0<i32> : int32)
-	T_4204 (in out d1_211 : ptr32)
-	T_4205 (in out d2_212 : ptr32)
-	T_4206 (in fn00002534(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-	T_4209 (in out d1_171 : ptr32)
-	T_4210 (in out d2_355 : ptr32)
-	T_4211 (in fn00002534(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-	T_4222 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_4227 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-	T_4240 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
 	T_4282 (in d0 : Eq_664)
 	T_4283 (in d1 : Eq_664)
-	T_4284 (in a1 : Eq_664)
 	T_4285 (in dwArg04 : Eq_664)
-	T_4287 (in dwArg0C : Eq_664)
 	T_4289 (in Mem10[0x00003FCC<p32>:word32] : word32)
-	T_4292 (in fp + 8<i32> : word32)
 	T_4293 (in fn00002C04(d0, d1, a1, *(union Eq_664 *) 0x3FCC<u32>, dwArg04, fp + 8<i32>) : word32)
 	T_4294 (in d0 : Eq_664)
-	T_4295 (in bArg07 : Eq_664)
 	T_4296 (in dwArg08 : Eq_664)
 	T_4297 (in d0_10 : Eq_664)
 	T_4298 (in 0<32> : word32)
@@ -717,28 +384,15 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_4320 (in *((word32) dwArg08 + 4<i32>) - 1<32> : word32)
 	T_4322 (in Mem25[dwArg08 + 4<i32>:word32] : word32)
 	T_4325 (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-	T_4328 (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-	T_4333 (in d2_1090 : Eq_664)
 	T_4335 (in a2_1014 : Eq_664)
 	T_4338 (in d5_1044 : Eq_664)
 	T_4339 (in 0<i32> : int32)
 	T_4345 (in d0_3698 : Eq_664)
 	T_4346 (in 0xFFFFFFFF<32> : word32)
 	T_4370 (in d0_63 & 8<32> : word32)
-	T_4396 (in d6_1133 : Eq_664)
-	T_4397 (in -1<i32> : int32)
 	T_4399 (in d0_289 & 4<32> : word32)
-	T_4419 (in 0<i32> : int32)
 	T_4421 (in d0_305 & 4<32> : word32)
-	T_4430 (in Mem316[a7_313 + 0<32>:word32] : word32)
-	T_4433 (in 10<i32> : int32)
-	T_4434 (in __swap(10<i32>) : word32)
-	T_4444 (in __swap(d6_1133) : word32)
-	T_4449 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-	T_4450 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-	T_4476 (in Mem316[a7_313 + 0<32>:word32] : word32)
 	T_4478 (in d1_340 - 0x30<32> : word32)
-	T_4480 (in d1_340 - 0x30<32> + d0_331 : word32)
 	T_4482 (in d0_354 & 4<32> : word32)
 	T_4496 (in SEQ(SLICE(d1, word24, 8), Mem361[a7_1330 + 72<i32>:byte]) : uip32)
 	T_4543 (in 0<32> : word32)
@@ -752,7 +406,6 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_4693 (in dwArg04 : Eq_664)
 	T_4699 (in Mem535[a7_533 + 0<32>:word32] : word32)
 	T_4703 (in fn00003CA8(*a7_533, out d1_5316, out a1, out a5_5317) : word32)
-	T_4705 (in a2_1014 + 4<i32> : word32)
 	T_4715 (in Mem554[a7_552 + 0<32>:word32] : word32)
 	T_4727 (in Mem558[a7_552 + 0<32>:word32] : word32)
 	T_4729 (in SEQ(SLICE(d0, word24, 8), v96_562) : uip32)
@@ -763,7 +416,6 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_4807 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_4813 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_4817 (in fn00003CA8(*a7_180, out d1_5318, out a1, out a5_5319) : word32)
-	T_4819 (in a2_1014 + 4<i32> : word32)
 	T_4829 (in Mem201[a7_199 + 0<32>:word32] : word32)
 	T_4841 (in Mem205[a7_199 + 0<32>:word32] : word32)
 	T_4843 (in SEQ(SLICE(d0, word24, 8), v109_209) : uip32)
@@ -772,14 +424,12 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_4865 (in 0xFFFFFFFF<32> : word32)
 	T_4875 (in Mem251[a7_248 + 0<32>:word32] : word32)
 	T_4880 (in Mem254[a7_248 - 4<i32> + 0<32>:word32] : word32)
-	T_4887 (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
 	T_4890 (in Mem254[a7_248 + 0<32>:word32] : word32)
 	T_4891 (in fn00002BD4(*(a7_248 - 1<i32>), *a7_248) : word32)
 	T_4899 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_4904 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_4908 (in fn00003CA8(a7_79->t0000, out d1, out a1, out a5_5320) : word32)
 	T_4911 (in Mem94[a7_79 + 48<i32>:word32] : word32)
-	T_4913 (in a2_1014 + 4<i32> : word32)
 	T_4923 (in Mem101[a7_99 + 0<32>:word32] : word32)
 	T_4935 (in Mem105[a7_99 + 0<32>:word32] : word32)
 	T_4938 (in Mem115[a7_99 + 0<32>:word32] : word32)
@@ -790,19 +440,16 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_4975 (in 0xFFFFFFFF<32> : word32)
 	T_4985 (in Mem151[a7_148 + 0<32>:word32] : word32)
 	T_4990 (in Mem154[a7_148 - 4<i32> + 0<32>:word32] : word32)
-	T_4996 (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
 	T_4999 (in Mem154[a7_148 + 0<32>:word32] : word32)
 	T_5000 (in fn00002BD4(*(a7_148 - 1<i32>), *a7_148) : word32)
 	T_5037 (in d1_1355 : Eq_664)
 	T_5040 (in SEQ(v147_608, v83_500 - 0x63<8>) : uip32)
-	T_5042 (in 0xFFFFFFFF<32> : word32)
 	T_5046 (in SEQ(v147_608, v83_500 - 0x6E<8>) : uip32)
 	T_5055 (in SEQ(v147_608, v83_500 - 0x73<8>) : uip32)
 	T_5082 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_5087 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_5091 (in fn00003CA8(a7_640->t0000, out d1, out a1, out a5_5321) : word32)
 	T_5094 (in Mem655[a7_640 + 48<i32>:word32] : word32)
-	T_5096 (in a2_1014 + 4<i32> : word32)
 	T_5106 (in Mem662[a7_660 + 0<32>:word32] : word32)
 	T_5118 (in Mem666[a7_660 + 0<32>:word32] : word32)
 	T_5121 (in Mem686[a7_660 + 0<32>:word32] : word32)
@@ -812,38 +459,29 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_5148 (in 0xFFFFFFFF<32> : word32)
 	T_5159 (in Mem738[a7_735 + 0<32>:word32] : word32)
 	T_5164 (in Mem741[a7_735 - 4<i32> + 0<32>:word32] : word32)
-	T_5170 (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
 	T_5173 (in Mem741[a7_735 + 0<32>:word32] : word32)
 	T_5174 (in fn00002BD4(*(a7_735 - 1<i32>), *a7_735) : word32)
 	T_5177 (in 0x2D<32> : word32)
 	T_5190 (in (word32) d2_1090 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_5192 (in d0 + 4<32> : word32)
 	T_5196 (in 0xFFFFFFFF<32> : word32)
 	T_5221 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5234 (in d0 + 4<32> : word32)
 	T_5235 (in 0xFFFFFFFF<32> : word32)
 	T_5249 (in d0_1765 & 8<32> : word32)
 	T_5302 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5310 (in d0 + 4<32> : word32)
 	T_5316 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_5321 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_5325 (in fn00003CA8(*a7_1807, out d1_5322, out a1, out a5_1727) : word32)
-	T_5327 (in a2_1014 + 4<i32> : word32)
 	T_5337 (in Mem1828[a7_1826 + 0<32>:word32] : word32)
 	T_5349 (in Mem1832[a7_1826 + 0<32>:word32] : word32)
 	T_5351 (in SEQ(SLICE(d0, word24, 8), v201_1836) : uip32)
 	T_5353 (in (uint32) (uint8) v201_1836 : uint32)
 	T_5358 (in 0xFFFFFFFF<32> : word32)
 	T_5370 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5379 (in d0 + 4<32> : word32)
 	T_5395 (in d0_1871 & 8<32> : word32)
 	T_5409 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5417 (in d0 + 4<32> : word32)
 	T_5423 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5432 (in d0 + 4<32> : word32)
 	T_5447 (in Mem1903[a7_1897 + 0<32>:word32] : word32)
 	T_5452 (in Mem1906[a7_1897 - 4<i32> + 0<32>:word32] : word32)
-	T_5458 (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
 	T_5461 (in Mem1906[a7_1897 + 0<32>:word32] : word32)
 	T_5462 (in fn00002BD4(*(a7_1897 - 1<i32>), *a7_1897) : word32)
 	T_5463 (in 0x2B<32> : word32)
@@ -852,7 +490,6 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_5512 (in Mem2009[a7_2007 + 0<32>:word32] : word32)
 	T_5516 (in fn00003CA8(a7_2007->t0000, out d1, out a1, out a5_5323) : word32)
 	T_5519 (in Mem2022[a7_2007 + 56<i32>:word32] : word32)
-	T_5521 (in a2_1014 + 4<i32> : word32)
 	T_5531 (in Mem2029[a7_2027 + 0<32>:word32] : word32)
 	T_5543 (in Mem2033[a7_2027 + 0<32>:word32] : word32)
 	T_5546 (in Mem2050[a7_2027 + 0<32>:word32] : word32)
@@ -866,24 +503,20 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_5639 (in Mem2150[a7_2148 + 0<32>:word32] : word32)
 	T_5643 (in fn00003CA8(a7_2148->t0000, out d1, out a1, out a5_5324) : word32)
 	T_5646 (in Mem2163[a7_2148 + 56<i32>:word32] : word32)
-	T_5648 (in a2_1014 + 4<i32> : word32)
 	T_5658 (in Mem2170[a7_2168 + 0<32>:word32] : word32)
 	T_5670 (in Mem2174[a7_2168 + 0<32>:word32] : word32)
 	T_5673 (in Mem2185[a7_2168 + 0<32>:word32] : word32)
 	T_5680 (in SEQ(SLICE(d0, word24, 8), v249_2178) : uip32)
 	T_5683 (in Mem2191[a7_2168 + 0<32>:word32] : word32)
 	T_5700 (in d0_2209 & 0xFF<32> : word32)
-	T_5719 (in 1<i32> : int32)
 	T_5720 (in 0x78<32> : word32)
 	T_5728 (in SEQ(SLICE(d0_2209 & 0xFF<32>, word24, 8), SLICE(d0_2209 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
 	T_5735 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5737 (in d0 + 4<32> : word32)
 	T_5775 (in d0_2253 : Eq_664)
 	T_5806 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_5811 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_5815 (in fn00003CA8(a7_2246->t0000, out d1, out a1, out a5_5325) : word32)
 	T_5818 (in Mem2261[a7_2246 + 56<i32>:word32] : word32)
-	T_5820 (in a2_1014 + 4<i32> : word32)
 	T_5830 (in Mem2268[a7_2266 + 0<32>:word32] : word32)
 	T_5842 (in Mem2272[a7_2266 + 0<32>:word32] : word32)
 	T_5845 (in Mem2283[a7_2266 + 0<32>:word32] : word32)
@@ -899,18 +532,14 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_5937 (in Mem1444[a7_1425 + 0<32>:word32] : word32)
 	T_5944 (in SEQ(SLICE(d0, word24, 8), v284_1435) : uip32)
 	T_5947 (in Mem1450[a7_1425 + 0<32>:word32] : word32)
-	T_5950 (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
 	T_5953 (in Mem1456[a7_1330 + 52<i32>:word32] : word32)
 	T_5976 (in 0xFFFFFFFF<32> : word32)
-	T_5980 (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
 	T_6029 (in Mem2338[a7_2334 + 0<32>:word32] : word32)
-	T_6043 (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
 	T_6046 (in Mem2342[a7_2334 + 0<32>:word32] : word32)
 	T_6047 (in fn00002BD4(*(a7_2334 - 1<i32>), a7_2334->t0000) : word32)
 	T_6053 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_6059 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_6063 (in fn00003CA8(*a7_1512, out d1_5328, out a1, out a5_5329) : word32)
-	T_6065 (in a2_1014 + 4<i32> : word32)
 	T_6075 (in Mem1533[a7_1531 + 0<32>:word32] : word32)
 	T_6087 (in Mem1537[a7_1531 + 0<32>:word32] : word32)
 	T_6089 (in SEQ(SLICE(d0, word24, 8), v314_1541) : uip32)
@@ -918,11 +547,9 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_6096 (in 0xFFFFFFFF<32> : word32)
 	T_6125 (in Mem1591[a7_1585 + 0<32>:word32] : word32)
 	T_6130 (in Mem1594[a7_1585 - 4<i32> + 0<32>:word32] : word32)
-	T_6136 (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
 	T_6139 (in Mem1594[a7_1585 + 0<32>:word32] : word32)
 	T_6140 (in fn00002BD4(*(a7_1585 - 1<i32>), *a7_1585) : word32)
 	T_6146 (in Mem2373[a7_2368 + 0<32>:word32] : word32)
-	T_6160 (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
 	T_6163 (in Mem2377[a7_2368 + 0<32>:word32] : word32)
 	T_6164 (in fn00002BD4(*(a7_2368 - 1<i32>), a7_2368->t0000) : word32)
 	T_6187 (in d0_2124 & 0x44<32> : word32)
@@ -932,7 +559,6 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_6239 (in Mem2445[a7_2443 + 0<32>:word32] : word32)
 	T_6243 (in fn00003CA8(a7_2443->t0000, out d1, out a1, out a5_5330) : word32)
 	T_6246 (in Mem2458[a7_2443 + 56<i32>:word32] : word32)
-	T_6248 (in a2_1014 + 4<i32> : word32)
 	T_6258 (in Mem2465[a7_2463 + 0<32>:word32] : word32)
 	T_6270 (in Mem2469[a7_2463 + 0<32>:word32] : word32)
 	T_6273 (in Mem2492[a7_2463 + 0<32>:word32] : word32)
@@ -946,35 +572,23 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_6366 (in Mem2554[a7_2552 + 0<32>:word32] : word32)
 	T_6370 (in fn00003CA8(a7_2552->t0000, out d1, out a1, out a5_5331) : word32)
 	T_6373 (in Mem2567[a7_2552 + 56<i32>:word32] : word32)
-	T_6375 (in a2_1014 + 4<i32> : word32)
 	T_6385 (in Mem2574[a7_2572 + 0<32>:word32] : word32)
 	T_6397 (in Mem2578[a7_2572 + 0<32>:word32] : word32)
 	T_6400 (in Mem2589[a7_2572 + 0<32>:word32] : word32)
 	T_6407 (in SEQ(SLICE(d0, word24, 8), v372_2582) : uip32)
 	T_6410 (in Mem2595[a7_2572 + 0<32>:word32] : word32)
 	T_6435 (in d0_2620 & 0x44<32> : word32)
-	T_6468 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
 	T_6477 (in d0_2760 & 0x44<32> : word32)
 	T_6490 (in Mem2671[a7_2667 + 0<32>:word32] : word32)
-	T_6504 (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
 	T_6507 (in Mem2675[a7_2667 + 0<32>:word32] : word32)
 	T_6508 (in fn00002BD4(*(a7_2667 - 1<i32>), a7_2667->t0000) : word32)
 	T_6520 (in Mem2603[a7_1330 + 74<i32>:word32] : word32)
-	T_6533 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-	T_6563 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
 	T_6572 (in d0_2818 & 4<32> : word32)
-	T_6578 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-	T_6584 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-	T_6594 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
 	T_6602 (in 0x37<32> : word32)
-	T_6615 (in v419_2893 : Eq_664)
-	T_6620 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6745 (in d0_3135 : Eq_664)
-	T_6795 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6821 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6828 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6832 (in fn00003CA8(*(a7_1330 - 4<i32>), out d1_5332, out a1, out a5_5333) : word32)
-	T_6834 (in a2_1014 + 4<i32> : word32)
 	T_6842 (in Mem3149[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6852 (in (uint32) (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint32)
 	T_6856 (in Mem3153[a7_1330 - 4<i32> + 0<32>:word32] : word32)
@@ -985,50 +599,29 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_6898 (in Mem3291[a7_1330 + 110<i32>:word32] : word32)
 	T_6904 (in Mem3272[a7_3259 + 0<32>:word32] : word32)
 	T_6909 (in Mem3275[a7_3259 - 4<i32> + 0<32>:word32] : word32)
-	T_6915 (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
 	T_6918 (in Mem3275[a7_3259 + 0<32>:word32] : word32)
 	T_6919 (in fn00002BD4(*(a7_3259 - 1<i32>), *a7_3259) : word32)
 	T_6925 (in Mem2639[a7_2635 + 0<32>:word32] : word32)
-	T_6939 (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
 	T_6942 (in Mem2643[a7_2635 + 0<32>:word32] : word32)
 	T_6943 (in fn00002BD4(*(a7_2635 - 1<i32>), a7_2635->t0000) : word32)
 	T_6961 (in d0_3206 & 4<32> : word32)
 	T_6969 (in 0x37<32> : word32)
-	T_6975 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_6978 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_6980 (in d7 >> 31<i32> : word32)
-	T_6983 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-	T_6993 (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
-	T_7025 (in dwArg04 : Eq_664)
-	T_7026 (in dwArg08 : Eq_664)
-	T_7027 (in dwArg0C : Eq_664)
-	T_7028 (in dwArg10 : Eq_664)
-	T_7033 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-	T_7038 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-	T_7043 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-	T_7048 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
 	T_7087 (in Mem3303[a7_3299 + 0<32>:word32] : word32)
 	T_7092 (in Mem3306[a7_3299 - 4<i32> + 0<32>:word32] : word32)
-	T_7098 (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
 	T_7101 (in Mem3306[a7_3299 + 0<32>:word32] : word32)
 	T_7102 (in fn00002BD4(*(a7_3299 - 1<i32>), *a7_3299) : word32)
 	T_7131 (in Mem3476[a7_3474 + 0<32>:word32] : word32)
-	T_7155 (in (d0_3495 << 2<32>) + 4<32> : word32)
 	T_7162 (in Mem3485[a7_3474 + 52<i32>:word32] : word32)
 	T_7165 (in Mem3503[a0_3501 + 4<i32>:word32] : word32)
 	T_7172 (in d0_3495 << 2<32> : word32)
-	T_7191 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7194 (in Mem3508[a7_3474 + 52<i32>:word32] : word32)
 	T_7195 (in SLICE(d0, byte, 0) : byte)
 	T_7201 (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_7220 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7223 (in Mem3525[a7_3474 + 52<i32>:word32] : word32)
 	T_7224 (in SLICE(d0, word16, 0) : word16)
 	T_7230 (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_7249 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7252 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_7258 (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7266 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7269 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_7275 (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
 	T_7301 (in -v528_3348->dw0004 : word32)
@@ -1037,46 +630,31 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_7317 (in Mem3375[a7_3364 + 0<32>:word32] : word32)
 	T_7342 (in d1_1027 : Eq_664)
 	T_7345 (in Mem773[a7_1330 + 52<i32>:word32] : word32)
-	T_7360 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_7367 (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
+	T_7370 (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
 	T_7377 (in d0_3398 << 2<32> : word32)
-	T_7396 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7399 (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
 	T_7400 (in SLICE(d0, byte, 0) : byte)
 	T_7406 (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_7425 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7428 (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
 	T_7429 (in SLICE(d0, word16, 0) : word16)
 	T_7435 (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_7454 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7457 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_7463 (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7471 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7474 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_7480 (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7484 (in SLICE(d5_785, byte, 0) : byte)
-	T_7488 (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
 	T_7490 (in d1_1027 + 1<32> : word32)
 	T_7491 (in 0x20<32> : word32)
-	T_7497 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-	T_7508 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
 	T_7523 (in SEQ(SLICE(d1_1027, word24, 8), v556_834) : uip32)
 	T_7549 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_7568 (in Mem889[a0_881 + 0<32>:byte] : byte)
 	T_7570 (in (uint32) (uint8) Mem889[a0_881 + 0<32>:byte] : uint32)
-	T_7576 (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-	T_7579 (in Mem895[a0_881 + 0<32>:byte] : byte)
-	T_7588 (in Mem889[a0_900 + 0<32>:byte] : byte)
 	T_7590 (in (uint32) (uint8) Mem889[a0_900 + 0<32>:byte] : uint32)
-	T_7597 (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-	T_7600 (in Mem914[a0_900 + 0<32>:byte] : byte)
 	T_7605 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_7618 (in (d0_957 << 2<32>) + 4<32> : word32)
 	T_7619 (in d0_957 << 2<32> : word32)
 	T_7658 (in Mem987[a7_985 + 0<32>:word32] : word32)
 	T_7663 (in Mem987[a7_985 + 0<32>:word32] : word32)
-	T_7667 (in fn00003CA8(*a7_985, out d1, out a1, out a5_5334) : word32)
+	T_7667 (in fn00003CA8(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
 	T_7670 (in Mem1000[a7_985 + 48<i32>:word32] : word32)
-	T_7672 (in a2_1014 + 4<i32> : word32)
 	T_7682 (in Mem1007[a7_1005 + 0<32>:word32] : word32)
 	T_7694 (in Mem1011[a7_1005 + 0<32>:word32] : word32)
 	T_7697 (in Mem1031[a7_1005 + 0<32>:word32] : word32)
@@ -1084,23 +662,13 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_7707 (in Mem1037[a7_1005 + 0<32>:word32] : word32)
 	T_7710 (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
 	T_7722 (in 0xFFFFFFFF<32> : word32)
-	T_7728 (in a7_1330 + 78<i32> : word32)
-	T_7731 (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-	T_7736 (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-	T_7737 (in 00000008 : ptr32)
-	T_7742 (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_7747 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_7750 (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-	T_7756 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_7761 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_7766 (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn000026C0(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)):byte] : uint32)
-	T_7771 (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
 	T_7776 (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
 	T_7777 (in 0<32> : word32)
 	T_7824 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_7830 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_7834 (in fn00003CA8(*a7_1182, out d1_5335, out a1, out a5_5336) : word32)
-	T_7836 (in a2_1014 + 4<i32> : word32)
 	T_7846 (in Mem1203[a7_1201 + 0<32>:word32] : word32)
 	T_7858 (in Mem1207[a7_1201 + 0<32>:word32] : word32)
 	T_7860 (in SEQ(SLICE(d0, word24, 8), v611_1211) : uip32)
@@ -1108,43 +676,12 @@ Eq_664: (union "Eq_664" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8471) u3) ((
 	T_7867 (in 0xFFFFFFFF<32> : word32)
 	T_7883 (in Mem1308[a7_1302 + 0<32>:word32] : word32)
 	T_7888 (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
-	T_7894 (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
 	T_7897 (in Mem1311[a7_1302 + 0<32>:word32] : word32)
 	T_7898 (in fn00002BD4(*(a7_1302 - 1<i32>), *a7_1302) : word32)
-	T_7906 (in a7_1330 + 78<i32> : word32)
-	T_7909 (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-	T_7914 (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-	T_7915 (in 00000008 : ptr32)
-	T_7920 (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_7925 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_7928 (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-	T_7933 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_7938 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_7943 (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn000026C0(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)):byte] : uint32)
-	T_7948 (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
 	T_7953 (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
 	T_7954 (in 0<32> : word32)
-	T_7975 (in d0_23 : Eq_664)
-	T_7977 (in __swap(dwArg08) : word32)
-	T_7978 (in d1_25 : Eq_664)
-	T_7980 (in __swap(dwArg10) : word32)
-	T_7990 (in d2_39 : Eq_664)
-	T_7998 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-	T_7999 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-	T_8003 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-	T_8004 (in 0<32> : word32)
-	T_8006 (in d2_45 : Eq_664)
-	T_8008 (in __swap(d2_39) : word32)
-	T_8011 (in __swap(dwArg0C) : word32)
-	T_8014 (in d3_71 : Eq_664)
-	T_8018 (in __swap(dwArg08) : word32)
-	T_8023 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-	T_8024 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-	T_8027 (in __swap(dwArg04) : word32)
-	T_8030 (in d3_89 : Eq_664)
-	T_8034 (in __swap(dwArg10) : word32)
-	T_8039 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-	T_8040 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
 	T_8077 (in 0<32> : word32)
 	T_8116 (in Mem86[dwArg04 + 8<i32>:word32] : word32)
 	T_8117 (in 0<32> : word32)
@@ -1198,7 +735,7 @@ Eq_669: (union "Eq_669" (int32 u0) (up32 u1))
 	T_2119 (in 0xFFFFFFFF<32> : word32)
 	T_2167 (in fn00001E10(*(a7_1854 - 4<i32>), *a7_1854, out a0_2921, out a5_1579) : word32)
 	T_2168 (in 0xFFFFFFFF<32> : word32)
-Eq_671: (fn Eq_669 (Eq_664, Eq_664, Eq_664, (ptr32 Eq_676)))
+Eq_671: (fn Eq_669 (Eq_664, Eq_664, (ptr32 (ptr32 byte)), (ptr32 Eq_676)))
 	T_671 (in fn00002BB8 : ptr32)
 	T_672 (in signature of fn00002BB8 : void)
 Eq_676: (struct "Eq_676" 0001 (0 uint8 b0000) (1 cu8 b0001))
@@ -1291,7 +828,7 @@ Eq_713: (union "Eq_713" (uint32 u0) (ptr32 u1))
 	T_1885 (in Mem1478[a7_1383 + 128<i32>:word32] : word32)
 	T_2359 (in ((word32) d3_1482 + 3<i32> >> 2<32> << 2<32>) + 4<32> : word32)
 	T_2605 (in ((word32) d3_1482 + 3<i32> >> 2<32> << 2<32>) + 4<32> : word32)
-Eq_720: (struct "Eq_720" 0004 (2C Eq_8427 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8428 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+Eq_720: (struct "Eq_720" 0004 (2C Eq_8421 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8422 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 	T_720 (in a7_1968 : (ptr32 Eq_720))
 	T_723 (in fp + -112<i32> : word32)
 	T_778 (in a7_51 + 4<i32> : word32)
@@ -1345,6 +882,416 @@ Eq_761: (fn Eq_669 (int32, (ptr32 Eq_711), (ptr32 ui32), ptr32))
 	T_2051 (in fn00001E10 : ptr32)
 	T_2108 (in fn00001E10 : ptr32)
 	T_2157 (in fn00001E10 : ptr32)
+Eq_793: (union "Eq_793" ((ptr32 Eq_1365) u0) ((ptr32 Eq_8423) u1) ((ptr32 Eq_8424) u2))
+	T_793 (in d5_256 : Eq_793)
+	T_794 (in -1<i32> : int32)
+	T_805 (in d2_1005 : Eq_793)
+	T_808 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
+	T_824 (in d2_1005 | d1_123 : word32)
+	T_834 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
+	T_950 (in 0<i32> : int32)
+	T_978 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
+	T_984 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_988 (in  : word32)
+	T_989 (in 10<i32> : int32)
+	T_990 (in __swap(10<i32>) : word32)
+	T_997 (in __swap(d5_256) : word32)
+	T_1002 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
+	T_1003 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
+	T_1040 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_1044 (in d1_303 - 0x30<32> + d0_293 : word32)
+	T_1089 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
+	T_1097 (in 10<i32> : int32)
+	T_1098 (in __swap(10<i32>) : word32)
+	T_1105 (in __swap(d2_1005) : word32)
+	T_1110 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
+	T_1111 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
+	T_1153 (in d1_196 - 0x30<32> + d0_186 : word32)
+	T_1161 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
+	T_1260 (in 0<32> : word32)
+	T_1339 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
+	T_1388 (in 0<32> : word32)
+	T_1608 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
+	T_1745 (in dwArg04 : Eq_793)
+	T_1746 (in dwArg08 : Eq_793)
+	T_1747 (in dwArg0C : Eq_793)
+	T_1748 (in dwArg10 : Eq_793)
+	T_1752 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_1757 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_1762 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_1767 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_1829 (in dwArg04 : Eq_793)
+	T_1830 (in dwArg08 : Eq_793)
+	T_1831 (in dwArg0C : Eq_793)
+	T_1832 (in dwArg10 : Eq_793)
+	T_1833 (in d1Out : Eq_793)
+	T_1834 (in a0Out : Eq_793)
+	T_1838 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_1843 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_1848 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_1853 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_1854 (in out d1_1450 : ptr32)
+	T_1855 (in out a0_1447 : ptr32)
+	T_2419 (in 0<32> : word32)
+	T_2449 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_2453 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_2509 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
+	T_3393 (in d0 : Eq_793)
+	T_3394 (in d0_196 : Eq_793)
+	T_3395 (in d1_142 : Eq_793)
+	T_3396 (in a0_20 : Eq_793)
+	T_3397 (in d3_166 : Eq_793)
+	T_3398 (in 0<32> : word32)
+	T_3406 (in 0<32> : word32)
+	T_3412 (in d0 : Eq_793)
+	T_3413 (in d1 : Eq_793)
+	T_3414 (in d2 : Eq_793)
+	T_3415 (in d1Out : Eq_793)
+	T_3416 (in d2Out : Eq_793)
+	T_3417 (in out d1_318 : ptr32)
+	T_3418 (in out d2_319 : ptr32)
+	T_3419 (in fn00002534(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
+	T_3420 (in 0<i32> : int32)
+	T_3423 (in d6_30 : Eq_793)
+	T_3426 (in  : word32)
+	T_3427 (in  : word32)
+	T_3428 (in 8<32> : word32)
+	T_3429 (in __rol(dwArg0C, 8<32>) : word32)
+	T_3455 (in 8<32> : word32)
+	T_3456 (in __rol(d6_30, 8<32>) : word32)
+	T_3462 (in 8<32> : word32)
+	T_3463 (in __rol(d6_30, 8<32>) : word32)
+	T_3470 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_3471 (in d1_175 : Eq_793)
+	T_3472 (in d2_176 : Eq_793)
+	T_3473 (in d0_174 : Eq_793)
+	T_3475 (in 0<i32> : int32)
+	T_3476 (in out d1_175 : ptr32)
+	T_3477 (in out d2_176 : ptr32)
+	T_3478 (in fn00002534(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
+	T_3482 (in out d1_320 : ptr32)
+	T_3483 (in out d2_321 : ptr32)
+	T_3484 (in fn00002534(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
+	T_3495 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_3498 (in d0_85 : Eq_793)
+	T_3500 (in dwArg04 >> d4_61 : word32)
+	T_3503 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
+	T_3506 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
+	T_3507 (in out d1_86 : ptr32)
+	T_3508 (in out d2_322 : ptr32)
+	T_3509 (in fn00002534(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
+	T_3510 (in d3_72 : Eq_793)
+	T_3511 (in dwArg10 << d5_63 : word32)
+	T_3512 (in d5_101 : Eq_793)
+	T_3514 (in __swap(d0_85) : word32)
+	T_3515 (in d6_103 : Eq_793)
+	T_3517 (in __swap(d3_72) : word32)
+	T_3521 (in d2_107 : Eq_793)
+	T_3524 (in d0_85 * (word16) d3_72 : word32)
+	T_3525 (in __swap(d0_85 * (word16) d3_72) : word32)
+	T_3538 (in d6_82 : Eq_793)
+	T_3539 (in dwArg08 << d5_63 : word32)
+	T_3540 (in d2_124 : Eq_793)
+	T_3542 (in SEQ(v35_109, v39_116) : uipr32)
+	T_3543 (in __swap(SEQ(v35_109, v39_116)) : word32)
+	T_3551 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
+	T_3552 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
+	T_3556 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
+	T_3557 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
+	T_3579 (in d0_85 - 1<32> : word32)
+	T_3585 (in d7_13 : Eq_793)
+	T_3586 (in 0<32> : word32)
+	T_3590 (in d0 : Eq_793)
+	T_3591 (in d1 : Eq_793)
+	T_3592 (in d2 : Eq_793)
+	T_3593 (in d1Out : Eq_793)
+	T_3594 (in out d1 : ptr32)
+	T_3595 (in fn000026F2(d1, d2, d2, out d1) : word32)
+	T_3596 (in d6_17 : Eq_793)
+	T_3597 (in d5_19 : Eq_793)
+	T_3598 (in 0<32> : word32)
+	T_3600 (in d2_22 : Eq_793)
+	T_3602 (in __swap(d2) : word32)
+	T_3606 (in 0<32> : word32)
+	T_3615 (in 0<32> : word32)
+	T_3617 (in d0_281 : Eq_793)
+	T_3619 (in __swap(d0) : word32)
+	T_3620 (in d1_282 : Eq_793)
+	T_3622 (in __swap(d1) : word32)
+	T_3632 (in __swap(d1_282) : word32)
+	T_3639 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
+	T_3640 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
+	T_3645 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
+	T_3651 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
+	T_3652 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
+	T_3656 (in d6_17 * 2<32> : word32)
+	T_3664 (in 0<32> : word32)
+	T_3666 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
+	T_3668 (in d7_13 * 2<32> : word32)
+	T_3669 (in 0<32> : word32)
+	T_3673 (in d3_74 : Eq_793)
+	T_3680 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
+	T_3681 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
+	T_3684 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
+	T_3685 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
+	T_3686 (in d1_104 : Eq_793)
+	T_3687 (in 0xFFFF<32> : uipr32)
+	T_3688 (in d6_98 : Eq_793)
+	T_3692 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
+	T_3693 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
+	T_3694 (in d6_133 : Eq_793)
+	T_3696 (in __swap(d1_104) : word32)
+	T_3697 (in d3_140 : Eq_793)
+	T_3699 (in __swap(d6_133) : word32)
+	T_3700 (in d4_142 : Eq_793)
+	T_3702 (in __swap(d7_13) : word32)
+	T_3706 (in d6_146 : Eq_793)
+	T_3709 (in d6_133 * (word16) d7_13 : word32)
+	T_3710 (in __swap(d6_133 * (word16) d7_13) : word32)
+	T_3726 (in d6_178 : Eq_793)
+	T_3728 (in SEQ(v56_148, v59_155) : uipr32)
+	T_3729 (in __swap(SEQ(v56_148, v59_155)) : word32)
+	T_3730 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
+	T_3731 (in d5_181 : word32)
+	T_3735 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
+	T_3736 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
+	T_3740 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
+	T_3741 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
+	T_3754 (in 0<32> : word32)
+	T_3756 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
+	T_3757 (in 0<32> : word32)
+	T_3765 (in d1_104 - 1<32> : word32)
+	T_3766 (in d4_113 : Eq_793)
+	T_3769 (in __swap(d7_13) : word32)
+	T_3772 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
+	T_3773 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
+	T_3788 (in __swap(d7_13) : word32)
+	T_3792 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
+	T_3794 (in d1_104 - 1<32> : word32)
+	T_3795 (in 0<32> : word32)
+	T_3801 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
+	T_3802 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_3803 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_3804 (in d6_220 : Eq_793)
+	T_3808 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
+	T_3809 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
+	T_3812 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
+	T_3813 (in d5_221 : Eq_793)
+	T_3815 (in __swap(d5_181) : word32)
+	T_3820 (in d5_266 : Eq_793)
+	T_3822 (in __swap(d5_181) : word32)
+	T_3823 (in d6_267 : Eq_793)
+	T_3825 (in __swap(d6_178) : word32)
+	T_3828 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
+	T_3831 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
+	T_3835 (in d2_73 : Eq_793)
+	T_3837 (in __swap(d5_19) : word32)
+	T_3839 (in __swap(d7_13) : word32)
+	T_3849 (in d5_221 >> 1<32> : word32)
+	T_3854 (in  : word32)
+	T_3860 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
+	T_3867 (in d0 : Eq_793)
+	T_3868 (in d2 : Eq_793)
+	T_3869 (in dwArg04 : Eq_793)
+	T_3870 (in dwArg08 : Eq_793)
+	T_3871 (in 0<32> : word32)
+	T_3873 (in 0<32> : word32)
+	T_3875 (in d0_36 : Eq_793)
+	T_3876 (in -dwArg04 : word32)
+	T_3877 (in 0<32> : word32)
+	T_3881 (in out d1_43 : ptr32)
+	T_3882 (in fn000026F2(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_3883 (in -fn000026F2(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_3886 (in -dwArg08 : word32)
+	T_3887 (in out d1_55 : ptr32)
+	T_3888 (in fn000026F2(d0_36, -dwArg08, d2, out d1_55) : word32)
+	T_3891 (in out d1_88 : ptr32)
+	T_3892 (in fn000026F2(dwArg04, dwArg08, d2, out d1_88) : word32)
+	T_3895 (in -dwArg08 : word32)
+	T_3896 (in out d1_89 : ptr32)
+	T_3897 (in fn000026F2(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_3898 (in -fn000026F2(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_3899 (in d1_22 : Eq_793)
+	T_3901 (in __swap(d1) : word32)
+	T_3906 (in d2_11 : Eq_793)
+	T_3907 (in SEQ(v11_10, v10_9) : uipr32)
+	T_3910 (in d3_18 : Eq_793)
+	T_3911 (in 16<i32> : int32)
+	T_3915 (in d0_134 : Eq_793)
+	T_3917 (in __swap(d0) : word32)
+	T_3918 (in d1_135 : Eq_793)
+	T_3920 (in __swap(d1_22) : word32)
+	T_3925 (in __swap(d2_11) : word32)
+	T_3930 (in d0_150 : Eq_793)
+	T_3932 (in __swap(d0_134) : word32)
+	T_3946 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
+	T_3947 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
+	T_3949 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
+	T_3951 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
+	T_3961 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
+	T_3966 (in 8<32> : word32)
+	T_3967 (in __rol(d1_22, 8<32>) : word32)
+	T_3968 (in 8<32> : uipr32)
+	T_3973 (in 4<32> : word32)
+	T_3974 (in __rol(d1_22, 4<32>) : word32)
+	T_3979 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
+	T_3984 (in 2<32> : word32)
+	T_3985 (in __rol(d1_22, 2<32>) : word32)
+	T_3990 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
+	T_3996 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
+	T_3997 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
+	T_4004 (in __swap(d3_18) : word32)
+	T_4010 (in d1_90 : Eq_793)
+	T_4012 (in __swap(d1_22) : word32)
+	T_4013 (in d3_102 : Eq_793)
+	T_4014 (in SEQ(v53_82, v51_79) : uipr32)
+	T_4015 (in d0_108 : Eq_793)
+	T_4025 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
+	T_4026 (in 0<32> : word32)
+	T_4029 (in 1<32> : word32)
+	T_4030 (in __rol(d1_22, 1<32>) : word32)
+	T_4035 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
+	T_4039 (in __swap(d3_102) : word32)
+	T_4040 (in __rol(d0_108, __swap(d3_102)) : word32)
+	T_4041 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
+	T_4044 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
+	T_4047 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
+	T_4048 (in d0_108 + d1_90 : word32)
+	T_4049 (in 0<32> : word32)
+	T_4051 (in d1 : Eq_793)
+	T_4052 (in d1_171 : Eq_793)
+	T_4053 (in d3_202 : Eq_793)
+	T_4054 (in 0<32> : word32)
+	T_4062 (in 0<32> : word32)
+	T_4066 (in out d1_171 : ptr32)
+	T_4067 (in out d2_354 : ptr32)
+	T_4068 (in fn00002534(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
+	T_4071 (in d6_33 : Eq_793)
+	T_4073 (in 8<32> : word32)
+	T_4074 (in __rol(dwArg0C, 8<32>) : word32)
+	T_4100 (in 8<32> : word32)
+	T_4101 (in __rol(d6_33, 8<32>) : word32)
+	T_4107 (in 8<32> : word32)
+	T_4108 (in __rol(d6_33, 8<32>) : word32)
+	T_4115 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_4118 (in d0_88 : Eq_793)
+	T_4120 (in dwArg04 >> d4_64 : word32)
+	T_4123 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
+	T_4126 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
+	T_4127 (in out d1_89 : ptr32)
+	T_4128 (in out d2_90 : ptr32)
+	T_4129 (in fn00002534(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
+	T_4130 (in d3_75 : Eq_793)
+	T_4131 (in dwArg10 << d5_66 : word32)
+	T_4132 (in d7_104 : Eq_793)
+	T_4134 (in __swap(d0_88) : word32)
+	T_4135 (in d6_106 : Eq_793)
+	T_4137 (in __swap(d3_75) : word32)
+	T_4141 (in d2_110 : Eq_793)
+	T_4144 (in d0_88 * (word16) d3_75 : word32)
+	T_4145 (in __swap(d0_88 * (word16) d3_75) : word32)
+	T_4158 (in d2_127 : Eq_793)
+	T_4160 (in SEQ(v37_112, v40_119) : uipr32)
+	T_4161 (in __swap(SEQ(v37_112, v40_119)) : word32)
+	T_4171 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
+	T_4172 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
+	T_4176 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
+	T_4177 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
+	T_4196 (in dwArg08 - dwArg10 : word32)
+	T_4200 (in d1_211 : Eq_793)
+	T_4201 (in d2_212 : Eq_793)
+	T_4203 (in 0<i32> : int32)
+	T_4204 (in out d1_211 : ptr32)
+	T_4205 (in out d2_212 : ptr32)
+	T_4206 (in fn00002534(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
+	T_4209 (in out d1_171 : ptr32)
+	T_4210 (in out d2_355 : ptr32)
+	T_4211 (in fn00002534(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
+	T_4222 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_4227 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
+	T_4240 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
+	T_4287 (in dwArg0C : Eq_793)
+	T_4292 (in fp + 8<i32> : word32)
+	T_4333 (in d2_1090 : Eq_793)
+	T_4396 (in d6_1133 : Eq_793)
+	T_4397 (in -1<i32> : int32)
+	T_4419 (in 0<i32> : int32)
+	T_4430 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_4433 (in 10<i32> : int32)
+	T_4434 (in __swap(10<i32>) : word32)
+	T_4444 (in __swap(d6_1133) : word32)
+	T_4449 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
+	T_4450 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
+	T_4476 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_4480 (in d1_340 - 0x30<32> + d0_331 : word32)
+	T_5042 (in 0xFFFFFFFF<32> : word32)
+	T_5192 (in d0 + 4<32> : word32)
+	T_5234 (in d0 + 4<32> : word32)
+	T_5310 (in d0 + 4<32> : word32)
+	T_5379 (in d0 + 4<32> : word32)
+	T_5417 (in d0 + 4<32> : word32)
+	T_5432 (in d0 + 4<32> : word32)
+	T_5719 (in 1<i32> : int32)
+	T_5737 (in d0 + 4<32> : word32)
+	T_6468 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
+	T_6533 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
+	T_6563 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
+	T_6578 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
+	T_6584 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
+	T_6594 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
+	T_6615 (in v419_2893 : Eq_793)
+	T_6620 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_6795 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_6975 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_6978 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_6980 (in d7 >> 31<i32> : word32)
+	T_6983 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
+	T_7025 (in dwArg04 : Eq_793)
+	T_7026 (in dwArg08 : Eq_793)
+	T_7027 (in dwArg0C : Eq_793)
+	T_7028 (in dwArg10 : Eq_793)
+	T_7033 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
+	T_7038 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
+	T_7043 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
+	T_7048 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
+	T_7155 (in (d0_3495 << 2<32>) + 4<32> : word32)
+	T_7191 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7220 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7249 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7266 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7360 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_7396 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7425 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7454 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7471 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7497 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
+	T_7508 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
+	T_7618 (in (d0_957 << 2<32>) + 4<32> : word32)
+	T_7756 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
+	T_7761 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
+	T_7933 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
+	T_7938 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
+	T_7975 (in d0_23 : Eq_793)
+	T_7977 (in __swap(dwArg08) : word32)
+	T_7978 (in d1_25 : Eq_793)
+	T_7980 (in __swap(dwArg10) : word32)
+	T_7990 (in d2_39 : Eq_793)
+	T_7998 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
+	T_7999 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
+	T_8003 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
+	T_8004 (in 0<32> : word32)
+	T_8006 (in d2_45 : Eq_793)
+	T_8008 (in __swap(d2_39) : word32)
+	T_8011 (in __swap(dwArg0C) : word32)
+	T_8014 (in d3_71 : Eq_793)
+	T_8018 (in __swap(dwArg08) : word32)
+	T_8023 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
+	T_8024 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
+	T_8027 (in __swap(dwArg04) : word32)
+	T_8030 (in d3_89 : Eq_793)
+	T_8034 (in __swap(dwArg10) : word32)
+	T_8039 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
+	T_8040 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
 Eq_800: (struct "Eq_800" (0 Eq_2365 t0000) (3C word32 dw003C) (40 up32 dw0040))
 	T_800 (in d7_1024 : (ptr32 Eq_800))
 	T_801 (in 0<i32> : int32)
@@ -1380,7 +1327,7 @@ Eq_956: (union "Eq_956" (uint32 u0) (ptr32 u1))
 	T_956 (in 3<32> : word32)
 Eq_957: (union "Eq_957" (uint32 u0) (ptr32 u1))
 	T_957 (in d3_1482 + 3<32> : word32)
-Eq_986: (fn Eq_664 (Eq_664))
+Eq_986: (fn Eq_793 (Eq_793))
 	T_986 (in __swap : ptr32)
 	T_987 (in signature of __swap : void)
 	T_994 (in __swap : ptr32)
@@ -1505,34 +1452,6 @@ Eq_1198: (struct "Eq_1198" (0 word32 dw0000) (4 word32 dw0004))
 	T_2436 (in Mem916[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_2458 (in Mem935[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_2496 (in Mem1000[a7_992 - 4<i32> + 0<32>:word32] : word32)
-Eq_1201: (union "Eq_1201" (ui24 u0) ((ptr32 Eq_8429) u1) (Eq_1365 u2))
-	T_1201 (in d0_1471 : Eq_1201)
-	T_1203 (in SEQ(SLICE(d0_159, word24, 8), v100_428) : uip32)
-	T_1248 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_1347 (in a2_1892 - a4_1925 : word32)
-	T_1350 (in Mem756[a7_1968 + 102<i32>:word32] : word32)
-	T_1372 (in Mem662[a7_1968 + 102<i32>:word32] : word32)
-	T_1383 (in Mem719[a7_1968 + 102<i32>:word32] : word32)
-	T_1385 (in d0_1471 + 1<32> : word32)
-	T_1496 (in Mem1516[a7_1508 + 0<32>:word32] : word32)
-	T_1506 (in Mem1531[a7_1508 + 0<32>:word32] : word32)
-	T_1509 (in Mem1537[a7_1508 + 0<32>:word32] : word32)
-	T_1510 (in d0_1541 : Eq_1201)
-	T_1513 (in Mem1537[a7_1508 + 0<32>:word32] : word32)
-	T_1542 (in Mem1546[a7_1508 + 0<32>:word32] : word32)
-	T_1622 (in d7_1371 : Eq_1201)
-	T_1625 (in Mem1367[v187_1368 + 4<i32>:word32] : word32)
-	T_1736 (in Mem1400[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1819 (in Mem1444[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1825 (in d1_1450 : Eq_1201)
-	T_1866 (in 0<32> : word32)
-	T_2344 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2406 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2474 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2553 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2565 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2578 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2590 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
 Eq_1234: (union "Eq_1234" (cu8 u0) (word32 u1))
 	T_1234 (in Mem535[a7_1968 + 44<i32>:byte] : byte)
 	T_1235 (in 0x70<8> : byte)
@@ -1562,20 +1481,8 @@ Eq_1316: (struct "Eq_1316" (0 (ptr32 Eq_1198) ptr0000) (30 byte b0030) (34 int32
 	T_1318 (in a7_1968 - 4<i32> : word32)
 Eq_1343: (union "Eq_1343" (bool u0) (int32 u1))
 	T_1343 (in d0_1181 < null : bool)
-Eq_1365: (union "Eq_1365" (ui24 u0) ((ptr32 Eq_8430) u1))
+Eq_1365: (struct "Eq_1365" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_1365 (in Mem662[a7_1968 + 102<i32>:word32] : word32)
-Eq_1366: (union "Eq_1366" (ui24 u0) ((ptr32 Eq_8431) u1) (Eq_1365 u2))
-	T_1366 (in d5_256 - a7_1968->t0066 : word32)
-	T_1367 (in 0<32> : word32)
-Eq_1371: (union "Eq_1371" (ui24 u0) ((ptr32 Eq_8432) u1) (Eq_1365 u2))
-	T_1371 (in a7_1968 + 102<i32> : word32)
-Eq_1378: (union "Eq_1378" (ui24 u0) ((ptr32 Eq_8433) u1) (Eq_1365 u2))
-	T_1378 (in d5_256 - d0_1471 : word32)
-	T_1379 (in 0<32> : word32)
-Eq_1382: (union "Eq_1382" (int32 u0) (uint32 u1) (Eq_1201 u2) (Eq_1365 u3))
-	T_1382 (in a7_1968 + 102<i32> : word32)
-Eq_1384: (union "Eq_1384" (ui24 u0) ((ptr32 Eq_8434) u1) (Eq_1365 u2))
-	T_1384 (in 1<32> : word32)
 Eq_1391: (union "Eq_1391" (uint32 u0) (ptr32 u1))
 	T_1391 (in 3<32> : word32)
 Eq_1392: (union "Eq_1392" (uint32 u0) (ptr32 u1))
@@ -1590,13 +1497,9 @@ Eq_1426: (union "Eq_1426" (uint32 u0) (ptr32 u1))
 Eq_1438: (struct "Eq_1438" (0 (ptr32 Eq_1198) ptr0000) (34 int32 dw0034))
 	T_1438 (in a7_1145 : (ptr32 Eq_1438))
 	T_1440 (in a7_1968 - 4<i32> : word32)
-Eq_1491: (struct "Eq_1491" (0 Eq_1201 t0000) (30 up32 dw0030) (34 up32 dw0034) (44 up32 dw0044))
+Eq_1491: (struct "Eq_1491" (0 (ptr32 Eq_1365) ptr0000) (30 up32 dw0030) (34 up32 dw0034) (44 up32 dw0044))
 	T_1491 (in a7_1508 : (ptr32 Eq_1491))
 	T_1493 (in a7_1465 - 4<i32> : word32)
-Eq_1508: (union "Eq_1508" (ui24 u0) ((ptr32 Eq_8435) u1) (Eq_1365 u2))
-	T_1508 (in a7_1508 + 0<32> : word32)
-Eq_1512: (union "Eq_1512" (ui24 u0) ((ptr32 Eq_8436) u1) (Eq_1365 u2))
-	T_1512 (in a7_1508 + 0<32> : word32)
 Eq_1523: (union "Eq_1523" (byte u0) (word32 u1))
 	T_1523 (in 0x10<32> : word32)
 	T_1526 (in Mem1293[a7_1020 + 44<i32>:word32] : word32)
@@ -1608,9 +1511,7 @@ Eq_1531: (union "Eq_1531" (byte u0) (ptr32 u1))
 Eq_1534: (union "Eq_1534" (byte u0) (word32 u1))
 	T_1534 (in Mem1296[a7_1020 + 44<i32>:word32] : word32)
 	T_1537 (in Mem1298[a7_1020 + 108<i32>:word32] : word32)
-Eq_1541: (union "Eq_1541" (ui24 u0) ((ptr32 Eq_8437) u1) (Eq_1365 u2))
-	T_1541 (in a7_1508 + 0<32> : word32)
-Eq_1615: (struct "Eq_1615" (0 word32 dw0000) (4 Eq_1201 t0004))
+Eq_1615: (struct "Eq_1615" (0 word32 dw0000) (4 (ptr32 Eq_1365) ptr0004))
 	T_1615 (in v187_1368 : (ptr32 Eq_1615))
 	T_1617 (in a7_1020 + 56<i32> : word32)
 Eq_1630: (union "Eq_1630" (byte u0) (word32 u1))
@@ -1634,14 +1535,14 @@ Eq_1696: (union "Eq_1696" (int32 u0) (up32 u1))
 Eq_1703: (struct "Eq_1703" (0 int32 dw0000) (34 Eq_727 t0034) (48 Eq_1190 t0048) (4C ui32 dw004C) (66 (ptr32 Eq_800) ptr0066) (6A word32 dw006A) (80 Eq_713 t0080))
 	T_1703 (in a7_1383 : (ptr32 Eq_1703))
 	T_1705 (in a7_1020 - 4<i32> : word32)
-Eq_1743: (fn int32 (Eq_664, Eq_664, Eq_664, Eq_664))
+Eq_1743: (fn int32 (Eq_793, Eq_793, Eq_793, Eq_793))
 	T_1743 (in fn00002778 : ptr32)
 	T_1744 (in signature of fn00002778 : void)
-Eq_1827: (fn word32 (Eq_664, Eq_664, Eq_664, Eq_664, Eq_664, Eq_664))
+Eq_1827: (fn word32 (Eq_793, Eq_793, Eq_793, Eq_793, Eq_793, Eq_793))
 	T_1827 (in fn00002430 : ptr32)
 	T_1828 (in signature of fn00002430 : void)
 Eq_1867: (union "Eq_1867" (bool u0) (word32 u1))
-	T_1867 (in d1_1450 < 0<32> : bool)
+	T_1867 (in d1_1450 < null : bool)
 Eq_1899: (union "Eq_1899" (int32 u0) (up32 u1))
 	T_1899 (in Mem1496[a7_1465 + 102<i32>:word32] : word32)
 Eq_1900: (union "Eq_1900" (int32 u0) (up32 u1))
@@ -1703,9 +1604,6 @@ Eq_2121: (union "Eq_2121" (int32 u0) (up32 u1))
 	T_2121 (in d2_1847 : Eq_2121)
 	T_2122 (in 0<i32> : int32)
 	T_2133 (in d2_1847 + 1<32> : word32)
-Eq_2212: (union "Eq_2212" (byte u0) (word32 u1))
-	T_2212 (in v248_1105 : Eq_2212)
-	T_2215 (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
 Eq_2216: (struct "Eq_2216" (0 (ptr32 Eq_1198) ptr0000) (34 int32 dw0034) (38 int32 dw0038))
 	T_2216 (in a7_1109 : (ptr32 Eq_2216))
 	T_2218 (in a7_1968 - 4<i32> : word32)
@@ -1716,9 +1614,6 @@ Eq_2253: (union "Eq_2253" (uint32 u0) (ptr32 u1))
 	T_2253 (in 3<32> : word32)
 Eq_2254: (union "Eq_2254" (uint32 u0) (ptr32 u1))
 	T_2254 (in d3_1482 + 3<32> : word32)
-Eq_2277: (union "Eq_2277" (word16 u0) (word32 u1))
-	T_2277 (in v262_844 : Eq_2277)
-	T_2280 (in Mem843[a7_1968 + 62<i32>:word16] : word16)
 Eq_2281: (struct "Eq_2281" (0 (ptr32 Eq_1198) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2281 (in a7_848 : (ptr32 Eq_2281))
 	T_2283 (in a7_1968 - 4<i32> : word32)
@@ -1734,8 +1629,6 @@ Eq_2339: (union "Eq_2339" (uint32 u0) (ptr32 u1))
 	T_2339 (in 3<32> : word32)
 Eq_2340: (union "Eq_2340" (uint32 u0) (ptr32 u1))
 	T_2340 (in d3_1482 + 3<32> : word32)
-Eq_2346: (union "Eq_2346" (ui24 u0) ((ptr32 Eq_8438) u1) (Eq_1365 u2))
-	T_2346 (in d0_1471 + 0<32> : word32)
 Eq_2355: (union "Eq_2355" (uint32 u0) (ptr32 u1))
 	T_2355 (in d3_1482 + 3<32> : word32)
 Eq_2365: (union "Eq_2365" (ui32 u0) (byte u1))
@@ -1752,9 +1645,6 @@ Eq_2371: (union "Eq_2371" (cu8 u0) (word32 u1) (Eq_1234 u2) (Eq_1237 u3) (Eq_131
 	T_2374 (in Mem894[a7_1968 + 44<i32>:byte] : byte)
 Eq_2373: (union "Eq_2373" (cu8 u0) (word32 u1) (Eq_1234 u2) (Eq_1237 u3) (Eq_1312 u4) (Eq_2371 u5))
 	T_2373 (in a7_1968 + 44<i32> : word32)
-Eq_2377: (union "Eq_2377" (byte u0) (word32 u1))
-	T_2377 (in v277_869 : Eq_2377)
-	T_2380 (in Mem868[a7_1968 + 63<i32>:byte] : byte)
 Eq_2381: (struct "Eq_2381" (0 (ptr32 Eq_1198) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2381 (in a7_873 : (ptr32 Eq_2381))
 	T_2383 (in a7_1968 - 4<i32> : word32)
@@ -1762,8 +1652,6 @@ Eq_2401: (union "Eq_2401" (uint32 u0) (ptr32 u1))
 	T_2401 (in 3<32> : word32)
 Eq_2402: (union "Eq_2402" (uint32 u0) (ptr32 u1))
 	T_2402 (in d3_1482 + 3<32> : word32)
-Eq_2408: (union "Eq_2408" (ui24 u0) ((ptr32 Eq_8439) u1) (Eq_1365 u2))
-	T_2408 (in d0_1471 + 0<32> : word32)
 Eq_2426: (struct "Eq_2426" (0 Eq_2365 t0000) (3C word32 dw003C) (40 up32 dw0040))
 	T_2426 (in a7_911 : (ptr32 Eq_2426))
 	T_2428 (in a7_1968 - 4<i32> : word32)
@@ -1773,8 +1661,6 @@ Eq_2469: (union "Eq_2469" (uint32 u0) (ptr32 u1))
 	T_2469 (in 3<32> : word32)
 Eq_2470: (union "Eq_2470" (uint32 u0) (ptr32 u1))
 	T_2470 (in d3_1482 + 3<32> : word32)
-Eq_2476: (union "Eq_2476" (ui24 u0) ((ptr32 Eq_8440) u1) (Eq_1365 u2))
-	T_2476 (in d0_1471 + 0<32> : word32)
 Eq_2482: (union "Eq_2482" (cu8 u0) (word32 u1) (Eq_1234 u2) (Eq_1237 u3) (Eq_1312 u4) (Eq_2371 u5))
 	T_2482 (in SLICE(d1_1068, byte, 0) : byte)
 	T_2485 (in Mem991[a7_1968 + 44<i32>:byte] : byte)
@@ -1811,34 +1697,26 @@ Eq_2548: (union "Eq_2548" (uint32 u0) (ptr32 u1))
 	T_2548 (in 3<32> : word32)
 Eq_2549: (union "Eq_2549" (uint32 u0) (ptr32 u1))
 	T_2549 (in d3_1482 + 3<32> : word32)
-Eq_2555: (union "Eq_2555" (ui24 u0) ((ptr32 Eq_8441) u1) (Eq_1365 u2))
-	T_2555 (in d0_1471 + 0<32> : word32)
 Eq_2560: (union "Eq_2560" (uint32 u0) (ptr32 u1))
 	T_2560 (in 3<32> : word32)
 Eq_2561: (union "Eq_2561" (uint32 u0) (ptr32 u1))
 	T_2561 (in d3_1482 + 3<32> : word32)
-Eq_2567: (union "Eq_2567" (ui24 u0) ((ptr32 Eq_8442) u1) (Eq_1365 u2))
-	T_2567 (in d0_1471 + 0<32> : word32)
 Eq_2573: (union "Eq_2573" (uint32 u0) (ptr32 u1))
 	T_2573 (in 3<32> : word32)
 Eq_2574: (union "Eq_2574" (uint32 u0) (ptr32 u1))
 	T_2574 (in d3_1482 + 3<32> : word32)
-Eq_2580: (union "Eq_2580" (ui24 u0) ((ptr32 Eq_8443) u1) (Eq_1365 u2))
-	T_2580 (in d0_1471 + 3<32> : word32)
 Eq_2585: (union "Eq_2585" (uint32 u0) (ptr32 u1))
 	T_2585 (in 3<32> : word32)
 Eq_2586: (union "Eq_2586" (uint32 u0) (ptr32 u1))
 	T_2586 (in d3_1482 + 3<32> : word32)
-Eq_2592: (union "Eq_2592" (ui24 u0) ((ptr32 Eq_8444) u1) (Eq_1365 u2))
-	T_2592 (in d0_1471 + 3<32> : word32)
 Eq_2597: (union "Eq_2597" (uint32 u0) (ptr32 u1))
 	T_2597 (in d3_1482 + 3<32> : word32)
 Eq_2602: (union "Eq_2602" (uint32 u0) (ptr32 u1))
 	T_2602 (in d3_1482 + 3<32> : word32)
-Eq_2606: (union "Eq_2606" (int32 u0) (uint32 u1) (Eq_1201 u2) (Eq_1365 u3) (Eq_1899 u4) (Eq_1961 u5) (Eq_1967 u6) (Eq_2035 u7) (Eq_2078 u8))
+Eq_2606: (union "Eq_2606" ((ptr32 Eq_1365) u0) ((ptr32 Eq_1365) u1) (Eq_1899 u2) (Eq_1961 u3) (Eq_1967 u4) (Eq_2035 u5) (Eq_2078 u6))
 	T_2606 (in 1<32> : word32)
 	T_2609 (in Mem525[a7_1968 + 102<i32>:word32] : word32)
-Eq_2608: (union "Eq_2608" (int32 u0) (uint32 u1) (Eq_1201 u2) (Eq_1365 u3) (Eq_1899 u4) (Eq_1961 u5) (Eq_1967 u6) (Eq_2035 u7) (Eq_2078 u8))
+Eq_2608: (union "Eq_2608" ((ptr32 Eq_1365) u0) (Eq_1899 u1) (Eq_1961 u2) (Eq_1967 u3) (Eq_2035 u4) (Eq_2078 u5))
 	T_2608 (in a7_1968 + 102<i32> : word32)
 Eq_2632: (fn Eq_680 (int32, (ptr32 Eq_711), (ptr32 ui32), ptr32, ptr32))
 	T_2632 (in fn00001E6C : ptr32)
@@ -1849,7 +1727,7 @@ Eq_2673: (fn Eq_2679 (ptr32, ptr32))
 	T_2674 (in signature of fn00002400 : void)
 	T_2849 (in fn00002400 : ptr32)
 	T_8073 (in fn00002400 : ptr32)
-Eq_2679: (union "Eq_2679" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1))
+Eq_2679: (union "Eq_2679" (byte u0) (word16 u1) ((ptr32 Eq_8467) u2) ((ptr32 Eq_8440) u3))
 	T_2679 (in fn00002400(out a1_125, out a5_127) : word32)
 	T_2852 (in fn00002400(out a1_21, out a5_23) : word32)
 	T_4694 (in d1Out : Eq_2679)
@@ -1956,7 +1834,7 @@ Eq_3350: (fn void ((ptr32 Eq_377)))
 Eq_3374: (fn void (int32, word32))
 	T_3374 (in SetSignal : ptr32)
 	T_3375 (in signature of SetSignal : void)
-Eq_3410: (fn Eq_664 (Eq_664, Eq_664, Eq_664, Eq_664, Eq_664))
+Eq_3410: (fn Eq_793 (Eq_793, Eq_793, Eq_793, Eq_793, Eq_793))
 	T_3410 (in fn00002534 : ptr32)
 	T_3411 (in signature of fn00002534 : void)
 	T_3474 (in fn00002534 : ptr32)
@@ -1966,7 +1844,7 @@ Eq_3410: (fn Eq_664 (Eq_664, Eq_664, Eq_664, Eq_664, Eq_664))
 	T_4119 (in fn00002534 : ptr32)
 	T_4202 (in fn00002534 : ptr32)
 	T_4208 (in fn00002534 : ptr32)
-Eq_3424: (fn Eq_664 (Eq_664, Eq_664))
+Eq_3424: (fn Eq_793 (Eq_793, Eq_793))
 	T_3424 (in __rol : ptr32)
 	T_3425 (in signature of __rol : void)
 	T_3454 (in __rol : ptr32)
@@ -1992,7 +1870,7 @@ Eq_3562: (union "Eq_3562" (bool u0) (word16 u1))
 	T_3562 (in v34_108 <u 0<16> : bool)
 Eq_3565: (union "Eq_3565" (bool u0) (word16 u1))
 	T_3565 (in v39_116 <u 0<16> : bool)
-Eq_3588: (fn Eq_664 (Eq_664, Eq_664, Eq_664, Eq_664))
+Eq_3588: (fn Eq_793 (Eq_793, Eq_793, Eq_793, Eq_793))
 	T_3588 (in fn000026F2 : ptr32)
 	T_3589 (in signature of fn000026F2 : void)
 	T_3880 (in fn000026F2 : ptr32)
@@ -2010,7 +1888,7 @@ Eq_3749: (union "Eq_3749" (bool u0) (word16 u1))
 	T_3749 (in v59_155 <u 0<16> : bool)
 Eq_3755: (union "Eq_3755" (bool u0) (uint32 u1))
 	T_3755 (in d6_178 <u 0<32> : bool)
-Eq_3852: (fn Eq_664 (Eq_664, word32, bool))
+Eq_3852: (fn Eq_793 (Eq_793, word32, bool))
 	T_3852 (in __rcr : ptr32)
 	T_3853 (in signature of __rcr : void)
 Eq_4182: (union "Eq_4182" (bool u0) (word16 u1))
@@ -2023,16 +1901,16 @@ Eq_4226: (union "Eq_4226" (bool u0) (word32 u1))
 	T_4226 (in d3_135 < 0<32> : bool)
 Eq_4234: (union "Eq_4234" (bool u0) (ui32 u1))
 	T_4234 (in d6_157 < 0<32> : bool)
-Eq_4280: (fn Eq_664 (Eq_664, Eq_664, Eq_664, Eq_664, (ptr32 Eq_676), Eq_664))
+Eq_4280: (fn Eq_664 (Eq_664, Eq_664, (ptr32 (ptr32 byte)), Eq_664, (ptr32 Eq_676), Eq_793))
 	T_4280 (in fn00002C04 : ptr32)
 	T_4281 (in signature of fn00002C04 : void)
-Eq_4329: (union "Eq_4329" (uint8 u0) ((ptr32 Eq_8450) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_4329 (in a7_1330 : Eq_4329)
+Eq_4329: (struct "Eq_4329" 0004 (2C int32 dw002C) (30 Eq_8441 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8442 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+	T_4329 (in a7_1330 : (ptr32 Eq_4329))
 	T_4332 (in fp + -120<i32> : word32)
 	T_7141 (in a7_3474 + 4<i32> : word32)
 	T_7311 (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
 	T_7327 (in a7_3364 + 4<i32> : word32)
-Eq_4336: (union "Eq_4336" (byte u0) (word16 u1) ((ptr32 Eq_8471) u2) ((ptr32 Eq_8452) u3))
+Eq_4336: (union "Eq_4336" (byte u0) (word16 u1) ((ptr32 Eq_8467) u2) ((ptr32 Eq_8444) u3))
 	T_4336 (in d4_132 : Eq_4336)
 	T_4337 (in 0<i32> : int32)
 	T_4744 (in d4_132 + 1<32> : word32)
@@ -2061,7 +1939,7 @@ Eq_4336: (union "Eq_4336" (byte u0) (word16 u1) ((ptr32 Eq_8471) u2) ((ptr32 Eq_
 	T_6581 (in Mem2854[a7_1330 + 52<i32>:word32] : word32)
 	T_6597 (in Mem2840[a7_1330 + 52<i32>:word32] : word32)
 	T_6611 (in 0<i32> : int32)
-	T_6613 (in d5_1044 - 0x30<32> : word32)
+	T_6613 (in d5_1044 - (struct Eq_8457 *) 0x30<32> : word32)
 	T_7024 (in d4 : Eq_4336)
 	T_7076 (in d4_3243 - 1<32> : word32)
 	T_7872 (in d4_1070 - 1<32> : word32)
@@ -2185,7 +2063,7 @@ Eq_4691: (fn Eq_664 (Eq_664, Eq_2679, (ptr32 word32), (ptr32 byte)))
 	T_6824 (in fn00003CA8 : ptr32)
 	T_7660 (in fn00003CA8 : ptr32)
 	T_7827 (in fn00003CA8 : ptr32)
-Eq_4881: (fn Eq_664 (Eq_664, Eq_664))
+Eq_4881: (fn Eq_664 (byte, Eq_664))
 	T_4881 (in fn00002BD4 : ptr32)
 	T_4882 (in signature of fn00002BD4 : void)
 	T_4991 (in fn00002BD4 : ptr32)
@@ -2328,8 +2206,6 @@ Eq_6356: (struct "Eq_6356" (0 Eq_664 t0000) (38 Eq_664 t0038))
 Eq_6380: (struct "Eq_6380" (0 Eq_664 t0000) (38 uint32 dw0038))
 	T_6380 (in a7_2572 : (ptr32 Eq_6380))
 	T_6382 (in a7_1330 - 4<i32> : word32)
-Eq_6422: (union "Eq_6422" (uint8 u0) (word32 u1))
-	T_6422 (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
 Eq_6430: (union "Eq_6430" (int32 u0) (uint32 u1))
 	T_6430 (in 1<32> : word32)
 Eq_6472: (union "Eq_6472" (byte u0) (word32 u1))
@@ -2361,67 +2237,29 @@ Eq_6589: (union "Eq_6589" (int32 u0) (uint32 u1))
 Eq_6598: (union "Eq_6598" (byte u0) (word32 u1))
 	T_6598 (in SLICE(d7, byte, 0) : byte)
 	T_6601 (in Mem2843[a7_1330 + 74<i32>:byte] : byte)
-Eq_6612: (union "Eq_6612" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1))
-	T_6612 (in 0x30<32> : word32)
-Eq_6614: (union "Eq_6614" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1))
-	T_6614 (in d6_3015 : Eq_6614)
-	T_6680 (in 0<i32> : int32)
-	T_6682 (in d5_1044 - 0x37<32> : word32)
-Eq_6629: (union "Eq_6629" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1))
-	T_6629 (in d2_2977 : word32)
-	T_6633 (in d4_2510 + Mem2975[a7_1330 + 68<i32>:word32] : word32)
-	T_6636 (in Mem2980[a7_1330 + 48<i32>:word32] : word32)
-	T_6649 (in 0<32> : word32)
-Eq_6632: (union "Eq_6632" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1))
-	T_6632 (in Mem2975[a7_1330 + 68<i32>:word32] : word32)
 Eq_6650: (union "Eq_6650" (bool u0) (word32 u1))
-	T_6650 (in d2_2977 < 0<32> : bool)
-Eq_6681: (union "Eq_6681" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1))
-	T_6681 (in 0x37<32> : word32)
-Eq_6683: (union "Eq_6683" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1))
-	T_6683 (in d2_3074 : Eq_6683)
-	T_6742 (in 0<i32> : int32)
-	T_6744 (in d5_1044 - 0x57<32> : word32)
-	T_6749 (in Mem3085[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-Eq_6696: (union "Eq_6696" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1) (Eq_6632 u2))
-	T_6696 (in d2_3037 : word32)
-	T_6700 (in d6_3015 + Mem3035[a7_1330 + 48<i32>:word32] : word32)
-	T_6703 (in Mem3040[a7_1330 + 68<i32>:word32] : word32)
-	T_6716 (in 0<32> : word32)
-Eq_6702: (union "Eq_6702" ((ptr32 (ptr32 Eq_4336)) u0) (Eq_6632 u1))
+	T_6650 (in d2_2977 < null : bool)
+Eq_6702: (union "Eq_6702" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8461) u1))
 	T_6702 (in a7_1330 + 68<i32> : word32)
-Eq_6743: (union "Eq_6743" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1))
-	T_6743 (in 0x57<32> : word32)
-Eq_6758: (union "Eq_6758" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1))
-	T_6758 (in d2_3095 : word32)
-	T_6762 (in d2_3074 + Mem3093[a7_1330 + 68<i32>:word32] : word32)
-	T_6765 (in Mem3098[a7_1330 + 48<i32>:word32] : word32)
-	T_6777 (in 0<32> : word32)
-Eq_6760: (union "Eq_6760" ((ptr32 (ptr32 Eq_4336)) u0) (Eq_6632 u1) (Eq_6696 u2))
+Eq_6760: (union "Eq_6760" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8461) u1))
 	T_6760 (in a7_1330 + 68<i32> : word32)
-Eq_6761: (union "Eq_6761" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1) (Eq_6632 u2) (Eq_6696 u3))
+Eq_6761: (union "Eq_6761" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8461) u1) ((ptr32 Eq_8467) u2))
 	T_6761 (in Mem3093[a7_1330 + 68<i32>:word32] : word32)
-Eq_6764: (union "Eq_6764" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1))
+Eq_6764: (union "Eq_6764" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8467) u1))
 	T_6764 (in a7_1330 + 48<i32> : word32)
 Eq_6778: (union "Eq_6778" (bool u0) (word32 u1))
-	T_6778 (in d2_3095 < 0<32> : bool)
+	T_6778 (in d2_3095 < null : bool)
 Eq_6892: (union "Eq_6892" (int32 u0) (uint32 u1))
 	T_6892 (in 1<32> : word32)
 Eq_6920: (struct "Eq_6920" (0 Eq_664 t0000) (4E word32 dw004E))
 	T_6920 (in a7_2635 : (ptr32 Eq_6920))
 	T_6922 (in a7_1330 - 4<i32> : word32)
-Eq_6971: (struct "Eq_6971" (0 Eq_664 t0000) (1 Eq_7060 t0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
+Eq_6971: (struct "Eq_6971" (0 Eq_793 t0000) (1 ui24 n0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
 	T_6971 (in a7_2886 : (ptr32 Eq_6971))
 	T_6972 (in a7_1330 - 4<i32> : word32)
-Eq_6982: (union "Eq_6982" (ui24 u0) ((ptr32 Eq_8474) u1) (Eq_1365 u2))
-	T_6982 (in a7_2886 + 0<32> : word32)
-Eq_7022: (fn word32 (Eq_4336, Eq_664, Eq_664, Eq_664, Eq_664, ptr32))
+Eq_7022: (fn word32 (Eq_4336, Eq_793, Eq_793, Eq_793, Eq_793, ptr32))
 	T_7022 (in fn00003C28 : ptr32)
 	T_7023 (in signature of fn00003C28 : void)
-Eq_7059: (union "Eq_7059" (ui24 u0) ((ptr32 Eq_8475) u1) (Eq_1365 u2))
-	T_7059 (in a7_2886 + 1<32> : word32)
-Eq_7060: (union "Eq_7060" (ui24 u0) ((ptr32 Eq_8476) u1) (Eq_1365 u2))
-	T_7060 (in Mem2934[a7_2886 + 1<32>:word24] : word24)
 Eq_7073: (union "Eq_7073" (int32 u0) (uint32 u1))
 	T_7073 (in 1<32> : word32)
 Eq_7126: (struct "Eq_7126" (0 Eq_664 t0000) (30 word32 dw0030) (34 Eq_664 t0034) (38 byte b0038) (4C byte b004C))
@@ -2430,303 +2268,67 @@ Eq_7126: (struct "Eq_7126" (0 Eq_664 t0000) (30 word32 dw0030) (34 Eq_664 t0034)
 Eq_7156: (struct "Eq_7156" (0 word32 dw0000) (4 Eq_664 t0004))
 	T_7156 (in a0_3501 : (ptr32 Eq_7156))
 	T_7159 (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
-Eq_7284: (union "Eq_7284" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1) (Eq_6758 u2))
+Eq_7284: (union "Eq_7284" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8467) u1))
 	T_7284 (in a7_1330 + 48<i32> : word32)
-Eq_7285: (union "Eq_7285" (uint8 u0) ((ptr32 (ptr32 Eq_4336)) u1) ((ptr32 Eq_8471) u2) (Eq_6422 u3) (Eq_6758 u4))
+Eq_7285: (union "Eq_7285" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8467) u1) ((ptr32 Eq_8467) u2))
 	T_7285 (in Mem3324[a7_1330 + 48<i32>:word32] : word32)
 	T_7288 (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
-Eq_7287: (union "Eq_7287" (uint8 u0) (word32 u1) (Eq_6422 u2))
-	T_7287 (in a7_1330 + 56<i32> : word32)
 Eq_7295: (struct "Eq_7295" (0 int32 dw0000) (4 word32 dw0004))
 	T_7295 (in v528_3348 : (ptr32 Eq_7295))
 	T_7297 (in a7_1330 + 44<i32> : word32)
 Eq_7307: (union "Eq_7307" (bool u0) (int32 u1))
 	T_7307 (in d1 < 0<32> : bool)
-Eq_7310: (union "Eq_7310" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7310 (in a7_1330 + 0x38<32> : word32)
-Eq_7312: (union "Eq_7312" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7312 (in a7_3364 : Eq_7312)
+Eq_7312: (struct "Eq_7312" (0 Eq_664 t0000) (30 byte b0030) (38 word32 dw0038) (3C Eq_664 t003C) (4C byte b004C))
+	T_7312 (in a7_3364 : (ptr32 Eq_7312))
 	T_7314 (in a7_1330 - 4<i32> : word32)
-Eq_7313: (union "Eq_7313" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7313 (in 4<i32> : int32)
-Eq_7316: (union "Eq_7316" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7316 (in a7_3364 + 0<32> : word32)
-Eq_7319: (union "Eq_7319" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7319 (in a7_3364 + 76<i32> : word32)
-Eq_7324: (union "Eq_7324" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7324 (in a7_3364 + 48<i32> : word32)
-Eq_7326: (union "Eq_7326" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7326 (in 4<i32> : int32)
-Eq_7329: (union "Eq_7329" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7329 (in a7_3364 + 48<i32> : word32)
-Eq_7335: (union "Eq_7335" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7335 (in a7_1330 + 52<i32> : word32)
-Eq_7339: (union "Eq_7339" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7339 (in a7_1330 + 44<i32> : word32)
-Eq_7344: (union "Eq_7344" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7344 (in a7_1330 + 52<i32> : word32)
-Eq_7348: (union "Eq_7348" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7348 (in a7_1330 + 44<i32> : word32)
-Eq_7361: (struct "Eq_7361" (0 word32 dw0000) (4 word32 dw0004))
+Eq_7337: (union "Eq_7337" (int32 u0) (byte u1))
+	T_7337 (in v544_774 : Eq_7337)
+	T_7340 (in Mem773[a7_1330 + 44<i32>:byte] : byte)
+	T_7493 (in 0<8> : byte)
+	T_7500 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+Eq_7346: (union "Eq_7346" (int32 u0) (byte u1))
+	T_7346 (in 1<8> : byte)
+	T_7349 (in Mem769[a7_1330 + 44<i32>:byte] : byte)
+Eq_7361: (struct "Eq_7361" (0 word32 dw0000) (4 Eq_664 t0004))
 	T_7361 (in a0_3404 : (ptr32 Eq_7361))
 	T_7364 (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
-Eq_7366: (union "Eq_7366" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7366 (in a7_3364 + 60<i32> : word32)
-Eq_7372: (union "Eq_7372" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7372 (in a7_3364 + 56<i32> : word32)
-Eq_7380: (union "Eq_7380" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7380 (in a7_3364 + 48<i32> : word32)
-Eq_7385: (union "Eq_7385" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7385 (in a7_3364 + 48<i32> : word32)
-Eq_7398: (union "Eq_7398" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7398 (in a7_3364 + 60<i32> : word32)
-Eq_7409: (union "Eq_7409" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7409 (in a7_3364 + 48<i32> : word32)
-Eq_7414: (union "Eq_7414" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7414 (in a7_3364 + 48<i32> : word32)
-Eq_7427: (union "Eq_7427" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7427 (in a7_3364 + 60<i32> : word32)
-Eq_7438: (union "Eq_7438" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7438 (in a7_3364 + 48<i32> : word32)
-Eq_7443: (union "Eq_7443" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7443 (in a7_3364 + 48<i32> : word32)
-Eq_7456: (union "Eq_7456" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7456 (in a7_3364 + 60<i32> : word32)
-Eq_7473: (union "Eq_7473" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7473 (in a7_3364 + 60<i32> : word32)
-Eq_7485: (union "Eq_7485" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7485 (in 78<i32> : int32)
-Eq_7486: (union "Eq_7486" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7486 (in a7_1330 + 78<i32> : word32)
-Eq_7487: (union "Eq_7487" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7487 (in a7_1330 + 78<i32> + d1_1027 : word32)
-Eq_7489: (union "Eq_7489" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7489 (in 1<32> : word32)
-Eq_7496: (union "Eq_7496" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7496 (in a7_1330 + 132<i32> : word32)
-Eq_7499: (union "Eq_7499" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7499 (in a7_1330 + 44<i32> : word32)
-Eq_7503: (union "Eq_7503" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7503 (in a7_1330 + 44<i32> : word32)
-Eq_7507: (union "Eq_7507" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7507 (in a7_1330 + 132<i32> : word32)
-Eq_7512: (union "Eq_7512" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7512 (in a7_1330 + 73<i32> : word32)
-Eq_7560: (union "Eq_7560" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7560 (in a0_881 : Eq_7560)
-	T_7565 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_7561: (union "Eq_7561" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7561 (in 78<i32> : int32)
-Eq_7562: (union "Eq_7562" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7562 (in a7_1330 + 78<i32> : word32)
-Eq_7564: (union "Eq_7564" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
+Eq_7501: (union "Eq_7501" (int32 u0) (byte u1))
+	T_7501 (in v554_824 : Eq_7501)
+	T_7504 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+	T_7558 (in 0<8> : byte)
+Eq_7564: (union "Eq_7564" (int32 u0) (uint32 u1))
 	T_7564 (in d5_862 >> 3<32> : word32)
-Eq_7567: (union "Eq_7567" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7567 (in a0_881 + 0<32> : word32)
-Eq_7578: (union "Eq_7578" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7578 (in a0_881 + 0<32> : word32)
-Eq_7580: (union "Eq_7580" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7580 (in a0_900 : Eq_7580)
-	T_7585 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_7581: (union "Eq_7581" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7581 (in 78<i32> : int32)
-Eq_7582: (union "Eq_7582" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7582 (in a7_1330 + 78<i32> : word32)
-Eq_7584: (union "Eq_7584" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
+Eq_7584: (union "Eq_7584" (int32 u0) (uint32 u1))
 	T_7584 (in d5_862 >> 3<32> : word32)
-Eq_7587: (union "Eq_7587" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7587 (in a0_900 + 0<32> : word32)
-Eq_7599: (union "Eq_7599" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7599 (in a0_900 + 0<32> : word32)
-Eq_7653: (union "Eq_7653" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7653 (in a7_985 : Eq_7653)
+Eq_7653: (struct "Eq_7653" (0 Eq_664 t0000) (30 Eq_664 t0030))
+	T_7653 (in a7_985 : (ptr32 Eq_7653))
 	T_7655 (in a7_1330 - 4<i32> : word32)
-Eq_7654: (union "Eq_7654" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7654 (in 4<i32> : int32)
-Eq_7657: (union "Eq_7657" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7657 (in a7_985 + 0<32> : word32)
-Eq_7662: (union "Eq_7662" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7662 (in a7_985 + 0<32> : word32)
-Eq_7669: (union "Eq_7669" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7669 (in a7_985 + 48<i32> : word32)
-Eq_7677: (union "Eq_7677" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7677 (in a7_1005 : Eq_7677)
+Eq_7677: (struct "Eq_7677" (0 Eq_664 t0000) (30 uint32 dw0030))
+	T_7677 (in a7_1005 : (ptr32 Eq_7677))
 	T_7679 (in a7_1330 - 4<i32> : word32)
-Eq_7678: (union "Eq_7678" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7678 (in 4<i32> : int32)
-Eq_7681: (union "Eq_7681" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7681 (in a7_1005 + 0<32> : word32)
-Eq_7693: (union "Eq_7693" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7693 (in a7_1005 + 0<32> : word32)
-Eq_7696: (union "Eq_7696" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7696 (in a7_1005 + 0<32> : word32)
-Eq_7701: (union "Eq_7701" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7701 (in a7_1005 + 48<i32> : word32)
-Eq_7706: (union "Eq_7706" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7706 (in a7_1005 + 0<32> : word32)
-Eq_7709: (union "Eq_7709" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7709 (in a7_1330 + 44<i32> : word32)
 Eq_7711: (union "Eq_7711" (int32 u0) (uint32 u1))
 	T_7711 (in d3_1057 : Eq_7711)
 	T_7713 (in d3_1850 + 1<32> : word32)
 	T_7864 (in d3_1057 + 1<32> : word32)
 Eq_7712: (union "Eq_7712" (int32 u0) (uint32 u1))
 	T_7712 (in 1<32> : word32)
-Eq_7718: (union "Eq_7718" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7718 (in a7_1330 + 44<i32> : word32)
-Eq_7724: (union "Eq_7724" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7724 (in a7_1076 : Eq_7724)
+Eq_7724: (struct "Eq_7724" (0 ptr32 ptr0000) (4D byte b004D))
+	T_7724 (in a7_1076 : (ptr32 Eq_7724))
 	T_7726 (in a7_1330 - 4<i32> : word32)
-Eq_7725: (union "Eq_7725" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7725 (in 4<i32> : int32)
-Eq_7727: (union "Eq_7727" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7727 (in 78<i32> : int32)
-Eq_7730: (union "Eq_7730" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7730 (in a7_1076 + 0<32> : word32)
-Eq_7732: (union "Eq_7732" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7732 (in 4<i32> : int32)
-Eq_7733: (union "Eq_7733" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7733 (in a7_1076 - 4<i32> : word32)
-Eq_7735: (union "Eq_7735" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7735 (in a7_1076 - 4<i32> + 0<32> : word32)
-Eq_7738: (union "Eq_7738" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7738 (in 8<i32> : int32)
-Eq_7739: (union "Eq_7739" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7739 (in a7_1076 - 8<i32> : word32)
-Eq_7741: (union "Eq_7741" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7741 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_7743: (union "Eq_7743" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7743 (in 12<i32> : int32)
-Eq_7744: (union "Eq_7744" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7744 (in a7_1076 - 12<i32> : word32)
-Eq_7746: (union "Eq_7746" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7746 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_7749: (union "Eq_7749" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7749 (in a7_1076 + 0<32> : word32)
-Eq_7751: (fn int32 (Eq_664, Eq_664, Eq_664))
+Eq_7751: (fn int32 (Eq_793, Eq_793, Eq_793))
 	T_7751 (in fn000026C0 : ptr32)
 	T_7752 (in signature of fn000026C0 : void)
 	T_7929 (in fn000026C0 : ptr32)
-Eq_7753: (union "Eq_7753" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7753 (in a7_1076 - 12<i32> : word32)
-Eq_7755: (union "Eq_7755" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7755 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_7757: (union "Eq_7757" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7757 (in 8<i32> : int32)
-Eq_7758: (union "Eq_7758" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7758 (in a7_1076 - 8<i32> : word32)
-Eq_7760: (union "Eq_7760" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7760 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_7767: (union "Eq_7767" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7767 (in 4<i32> : int32)
-Eq_7768: (union "Eq_7768" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7768 (in a7_1076 - 4<i32> : word32)
-Eq_7770: (union "Eq_7770" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7770 (in a7_1076 - 4<i32> + 0<32> : word32)
 Eq_7779: (union "Eq_7779" (int32 u0) (uint32 u1))
 	T_7779 (in d6_1133 - d3_1057 : word32)
 	T_7780 (in 0<32> : word32)
-Eq_7784: (union "Eq_7784" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7784 (in a7_1076 + 77<i32> : word32)
-Eq_7819: (union "Eq_7819" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7819 (in a7_1182 : Eq_7819)
-	T_7821 (in a7_1330 - 4<i32> : word32)
-Eq_7820: (union "Eq_7820" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7820 (in 4<i32> : int32)
-Eq_7823: (union "Eq_7823" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7823 (in a7_1182 + 0<32> : word32)
-Eq_7829: (union "Eq_7829" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7829 (in a7_1182 + 0<32> : word32)
-Eq_7841: (union "Eq_7841" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7841 (in a7_1201 : Eq_7841)
-	T_7843 (in a7_1330 - 4<i32> : word32)
-Eq_7842: (union "Eq_7842" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7842 (in 4<i32> : int32)
-Eq_7845: (union "Eq_7845" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7845 (in a7_1201 + 0<32> : word32)
-Eq_7857: (union "Eq_7857" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7857 (in a7_1201 + 0<32> : word32)
 Eq_7863: (union "Eq_7863" (int32 u0) (uint32 u1))
 	T_7863 (in 1<32> : word32)
 Eq_7869: (union "Eq_7869" (int32 u0) (uint32 u1))
 	T_7869 (in 1<32> : word32)
-Eq_7874: (union "Eq_7874" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7874 (in a7_1330 + 73<i32> : word32)
-Eq_7878: (union "Eq_7878" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7878 (in a7_1302 : Eq_7878)
-	T_7880 (in a7_1330 - 4<i32> : word32)
-Eq_7879: (union "Eq_7879" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7879 (in 4<i32> : int32)
-Eq_7882: (union "Eq_7882" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7882 (in a7_1302 + 0<32> : word32)
-Eq_7884: (union "Eq_7884" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7884 (in 4<i32> : int32)
-Eq_7885: (union "Eq_7885" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7885 (in a7_1302 - 4<i32> : word32)
-Eq_7887: (union "Eq_7887" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7887 (in a7_1302 - 4<i32> + 0<32> : word32)
-Eq_7890: (union "Eq_7890" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7890 (in 1<i32> : int32)
-Eq_7891: (union "Eq_7891" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7891 (in a7_1302 - 1<i32> : word32)
-Eq_7893: (union "Eq_7893" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7893 (in a7_1302 - 1<i32> + 0<32> : word32)
-Eq_7896: (union "Eq_7896" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7896 (in a7_1302 + 0<32> : word32)
-Eq_7900: (union "Eq_7900" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7900 (in a7_1330 + 73<i32> : word32)
-Eq_7902: (union "Eq_7902" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7902 (in a7_1237 : Eq_7902)
-	T_7904 (in a7_1330 - 4<i32> : word32)
-Eq_7903: (union "Eq_7903" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7903 (in 4<i32> : int32)
-Eq_7905: (union "Eq_7905" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7905 (in 78<i32> : int32)
-Eq_7908: (union "Eq_7908" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7908 (in a7_1237 + 0<32> : word32)
-Eq_7910: (union "Eq_7910" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7910 (in 4<i32> : int32)
-Eq_7911: (union "Eq_7911" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7911 (in a7_1237 - 4<i32> : word32)
-Eq_7913: (union "Eq_7913" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7913 (in a7_1237 - 4<i32> + 0<32> : word32)
-Eq_7916: (union "Eq_7916" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7916 (in 8<i32> : int32)
-Eq_7917: (union "Eq_7917" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7917 (in a7_1237 - 8<i32> : word32)
-Eq_7919: (union "Eq_7919" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7919 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_7921: (union "Eq_7921" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7921 (in 12<i32> : int32)
-Eq_7922: (union "Eq_7922" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7922 (in a7_1237 - 12<i32> : word32)
-Eq_7924: (union "Eq_7924" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7924 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_7927: (union "Eq_7927" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7927 (in a7_1237 + 0<32> : word32)
-Eq_7930: (union "Eq_7930" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7930 (in a7_1237 - 12<i32> : word32)
-Eq_7932: (union "Eq_7932" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7932 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_7934: (union "Eq_7934" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7934 (in 8<i32> : int32)
-Eq_7935: (union "Eq_7935" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7935 (in a7_1237 - 8<i32> : word32)
-Eq_7937: (union "Eq_7937" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7937 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_7944: (union "Eq_7944" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7944 (in 4<i32> : int32)
-Eq_7945: (union "Eq_7945" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7945 (in a7_1237 - 4<i32> : word32)
-Eq_7947: (union "Eq_7947" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7947 (in a7_1237 - 4<i32> + 0<32> : word32)
 Eq_7956: (union "Eq_7956" (int32 u0) (uint32 u1))
 	T_7956 (in d6_1133 - d3_1057 : word32)
 	T_7957 (in 0<32> : word32)
-Eq_7968: (union "Eq_7968" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7968 (in a7_1330 + 60<i32> : word32)
-Eq_7972: (union "Eq_7972" (uint8 u0) ((ptr32 Eq_8497) u1) (Eq_6422 u2) (Eq_7285 u3))
-	T_7972 (in a7_1330 + 60<i32> : word32)
 Eq_8107: (fn int32 (ptr32, ptr32))
 	T_8107 (in fn00003DA4 : ptr32)
 	T_8108 (in signature of fn00003DA4 : void)
@@ -2735,25 +2337,25 @@ Eq_8144: (fn void ())
 	T_8145 (in signature of execPrivate2 : void)
 Eq_8362: (struct "Eq_8362" 0004 (0 byte b0000))
 	T_8362
-Eq_8419: (struct "Eq_8419" 0001 (0 word32 dw0000) (3 byte b0003) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
+Eq_8419: (struct "Eq_8419" (0 Eq_4336 t0000))
 	T_8419
-Eq_8420: (struct "Eq_8420" (0 Eq_664 t0000))
+Eq_8420: (struct "Eq_8420" 0004 (0 (ptr32 Eq_8419) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8420
-Eq_8421: (union "Eq_8421" (int32 u0) (byte u1) (Eq_664 u2))
+Eq_8421: (union "Eq_8421" (cu8 u0) (word32 u1) (Eq_1234 u2) (Eq_1237 u3) (Eq_1312 u4) (Eq_2371 u5) (Eq_2482 u6) (Eq_2523 u7))
 	T_8421
-Eq_8422: (union "Eq_8422" (byte u0) ((ptr32 (ptr32 Eq_4336)) u1) ((ptr32 Eq_8471) u2) (Eq_664 u3) (Eq_6758 u4) (Eq_7285 u5))
+Eq_8422: (union "Eq_8422" ((ptr32 Eq_1365) u0) (Eq_1899 u1) (Eq_1961 u2) (Eq_1967 u3) (Eq_2035 u4) (Eq_2078 u5) (Eq_2606 u6))
 	T_8422
-Eq_8423: (union "Eq_8423" (uint8 u0) (word32 u1) (Eq_6422 u2))
+Eq_8423: (struct "Eq_8423" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8423
-Eq_8424: (union "Eq_8424" (uint8 u0) (word32 u1) (Eq_4329 u2) (Eq_6422 u3) (Eq_7285 u4))
+Eq_8424: (struct "Eq_8424" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8424
-Eq_8425: (union "Eq_8425" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1) (Eq_6632 u2) (Eq_6696 u3) (Eq_6761 u4))
+Eq_8425: (struct "Eq_8425" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8425
-Eq_8426: (struct "Eq_8426" 0004 (FFFFFFFC (ptr32 Eq_8420) ptrFFFFFFFC) (0 (ptr32 Eq_4336) ptr0000) (2C Eq_8421 t002C) (30 Eq_8422 t0030) (34 word32 dw0034) (37 Eq_8423 t0037) (38 Eq_8424 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8425 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8426: (struct "Eq_8426" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8426
-Eq_8427: (union "Eq_8427" (cu8 u0) (word32 u1) (Eq_1234 u2) (Eq_1237 u3) (Eq_1312 u4) (Eq_2371 u5) (Eq_2482 u6) (Eq_2523 u7))
+Eq_8427: (struct "Eq_8427" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8427
-Eq_8428: (union "Eq_8428" (int32 u0) (uint32 u1) (Eq_1201 u2) (Eq_1365 u3) (Eq_1899 u4) (Eq_1961 u5) (Eq_1967 u6) (Eq_2035 u7) (Eq_2078 u8) (Eq_2606 u9))
+Eq_8428: (struct "Eq_8428" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8428
 Eq_8429: (struct "Eq_8429" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8429
@@ -2777,31 +2379,31 @@ Eq_8438: (struct "Eq_8438" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8438
 Eq_8439: (struct "Eq_8439" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8439
-Eq_8440: (struct "Eq_8440" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8440: (struct "Eq_8440" 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8440
-Eq_8441: (struct "Eq_8441" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8441: (union "Eq_8441" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8467) u1) (Eq_7285 u2))
 	T_8441
-Eq_8442: (struct "Eq_8442" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8442: (union "Eq_8442" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8461) u1) ((ptr32 Eq_8467) u2) (Eq_6761 u3))
 	T_8442
-Eq_8443: (struct "Eq_8443" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8443: (struct "Eq_8443" (0 Eq_4336 t0000))
 	T_8443
-Eq_8444: (struct "Eq_8444" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8444: (struct "Eq_8444" 0004 (0 (ptr32 Eq_8443) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8444
-Eq_8445: (union "Eq_8445" (int32 u0) (byte u1) (Eq_664 u2))
+Eq_8445: (struct "Eq_8445" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8445
-Eq_8446: (union "Eq_8446" (byte u0) ((ptr32 (ptr32 Eq_4336)) u1) ((ptr32 Eq_8471) u2) (Eq_664 u3) (Eq_6758 u4) (Eq_7285 u5))
+Eq_8446: (struct "Eq_8446" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8446
-Eq_8447: (union "Eq_8447" (uint8 u0) (word32 u1) (Eq_6422 u2))
+Eq_8447: (struct "Eq_8447" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8447
-Eq_8448: (union "Eq_8448" (uint8 u0) (word32 u1) (Eq_4329 u2) (Eq_6422 u3) (Eq_7285 u4))
+Eq_8448: (struct "Eq_8448" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8448
-Eq_8449: (union "Eq_8449" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1) (Eq_6632 u2) (Eq_6696 u3) (Eq_6761 u4))
+Eq_8449: (struct "Eq_8449" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8449
-Eq_8450: (struct "Eq_8450" 0004 (0 Eq_664 t0000) (2C Eq_8445 t002C) (30 Eq_8446 t0030) (34 word32 dw0034) (37 Eq_8447 t0037) (38 Eq_8448 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8449 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8450: (struct "Eq_8450" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8450
-Eq_8451: (struct "Eq_8451" (0 Eq_4336 t0000))
+Eq_8451: (struct "Eq_8451" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8451
-Eq_8452: (struct "Eq_8452" 0004 (0 (ptr32 Eq_8451) ptr0000))
+Eq_8452: (struct "Eq_8452" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8452
 Eq_8453: (struct "Eq_8453" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8453
@@ -2809,31 +2411,39 @@ Eq_8454: (struct "Eq_8454" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8454
 Eq_8455: (struct "Eq_8455" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8455
-Eq_8456: (struct "Eq_8456" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
-	T_8456
-Eq_8457: (struct "Eq_8457" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8457: (struct "Eq_8457" 0004 (0 (ptr32 Eq_8505) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8457
-Eq_8458: (struct "Eq_8458" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8458: (struct "Eq_8458" 0004 (0 (ptr32 Eq_8506) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8458
-Eq_8459: (struct "Eq_8459" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8459: (struct "Eq_8459" 0004 (0 (ptr32 Eq_8507) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8459
-Eq_8460: (struct "Eq_8460" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
-	T_8460
-Eq_8461: (struct "Eq_8461" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8461: (struct "Eq_8461" 0004 (0 (ptr32 Eq_8512) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8461
-Eq_8462: (struct "Eq_8462" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
-	T_8462
-Eq_8463: (struct "Eq_8463" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8463: (struct "Eq_8463" 0004 (0 (ptr32 Eq_8509) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8463
-Eq_8470: (struct "Eq_8470" (0 Eq_4336 t0000))
+Eq_8464: (struct "Eq_8464" 0004 (0 (ptr32 Eq_8510) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
+	T_8464
+Eq_8465: (struct "Eq_8465" 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
+	T_8465
+Eq_8466: (struct "Eq_8466" (0 Eq_4336 t0000))
+	T_8466
+Eq_8467: (struct "Eq_8467" 0004 (0 (ptr32 Eq_8511) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
+	T_8467
+Eq_8469: (struct "Eq_8469" 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
+	T_8469
+Eq_8470: (struct "Eq_8470" 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8470
-Eq_8471: (struct "Eq_8471" 0004 (0 (ptr32 Eq_8470) ptr0000))
+Eq_8471: (struct "Eq_8471" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8471
-Eq_8474: (struct "Eq_8474" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8472: (struct "Eq_8472" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+	T_8472
+Eq_8473: (struct "Eq_8473" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+	T_8473
+Eq_8474: (struct "Eq_8474" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8474
-Eq_8475: (struct "Eq_8475" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8475: (struct "Eq_8475" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8475
-Eq_8476: (struct "Eq_8476" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8476: (struct "Eq_8476" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8476
 Eq_8477: (struct "Eq_8477" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8477
@@ -2865,17 +2475,17 @@ Eq_8490: (struct "Eq_8490" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8490
 Eq_8491: (struct "Eq_8491" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8491
-Eq_8492: (union "Eq_8492" (int32 u0) (byte u1) (Eq_664 u2))
+Eq_8492: (struct "Eq_8492" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8492
-Eq_8493: (union "Eq_8493" (byte u0) ((ptr32 (ptr32 Eq_4336)) u1) ((ptr32 Eq_8471) u2) (Eq_664 u3) (Eq_6758 u4) (Eq_7285 u5))
+Eq_8493: (struct "Eq_8493" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8493
-Eq_8494: (union "Eq_8494" (uint8 u0) (word32 u1) (Eq_6422 u2))
+Eq_8494: (struct "Eq_8494" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8494
-Eq_8495: (union "Eq_8495" (uint8 u0) (word32 u1) (Eq_4329 u2) (Eq_6422 u3) (Eq_7285 u4))
+Eq_8495: (struct "Eq_8495" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8495
-Eq_8496: (union "Eq_8496" ((ptr32 (ptr32 Eq_4336)) u0) ((ptr32 Eq_8471) u1) (Eq_6632 u2) (Eq_6696 u3) (Eq_6761 u4))
+Eq_8496: (struct "Eq_8496" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8496
-Eq_8497: (struct "Eq_8497" 0004 (0 Eq_664 t0000) (2C Eq_8492 t002C) (30 Eq_8493 t0030) (34 word32 dw0034) (37 Eq_8494 t0037) (38 Eq_8495 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8496 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8497: (struct "Eq_8497" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8497
 Eq_8498: (struct "Eq_8498" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8498
@@ -2891,28 +2501,22 @@ Eq_8503: (struct "Eq_8503" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8503
 Eq_8504: (struct "Eq_8504" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
 	T_8504
-Eq_8505: (struct "Eq_8505" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8505: (union "Eq_8505" (Eq_4336 u0) (Eq_8466 u1))
 	T_8505
-Eq_8506: (struct "Eq_8506" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8506: (union "Eq_8506" (Eq_4336 u0) (Eq_8466 u1))
 	T_8506
-Eq_8507: (struct "Eq_8507" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8507: (union "Eq_8507" (Eq_4336 u0) (Eq_8466 u1))
 	T_8507
-Eq_8508: (struct "Eq_8508" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8508: (union "Eq_8508" (Eq_4336 u0) (Eq_8466 u1))
 	T_8508
-Eq_8509: (struct "Eq_8509" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8509: (union "Eq_8509" (Eq_4336 u0) (Eq_8466 u1))
 	T_8509
-Eq_8510: (struct "Eq_8510" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8510: (union "Eq_8510" (Eq_4336 u0) (Eq_8466 u1))
 	T_8510
-Eq_8511: (struct "Eq_8511" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8511: (union "Eq_8511" (Eq_4336 u0) (Eq_8466 u1))
 	T_8511
-Eq_8512: (struct "Eq_8512" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
+Eq_8512: (union "Eq_8512" (Eq_4336 u0) (Eq_8508 u1) (Eq_8511 u2))
 	T_8512
-Eq_8513: (struct "Eq_8513" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
-	T_8513
-Eq_8514: (struct "Eq_8514" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
-	T_8514
-Eq_8515: (struct "Eq_8515" 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))
-	T_8515
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -5570,9 +5174,9 @@ T_664: (in d0 : Eq_664)
   Class: Eq_664
   DataType: Eq_664
   OrigDataType: word32
-T_665: (in a1_11 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_665: (in a1_11 : (ptr32 (ptr32 byte)))
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_666: (in d1_13 : Eq_664)
   Class: Eq_664
@@ -5610,9 +5214,9 @@ T_674: (in d1 : Eq_664)
   Class: Eq_664
   DataType: Eq_664
   OrigDataType: word32
-T_675: (in a1 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_675: (in a1 : (ptr32 (ptr32 byte)))
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_676: (in dwArg04 : (ptr32 Eq_676))
   Class: Eq_676
@@ -5793,7 +5397,7 @@ T_719: (in fn00001490(d0, *(struct Eq_711 **) 0x3FD0<u32>, dwArg04, fp + 8<i32>)
 T_720: (in a7_1968 : (ptr32 Eq_720))
   Class: Eq_720
   DataType: (ptr32 Eq_720)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1234 u2) (T_1240 u3) (T_1315 u4) (T_2374 u5) (T_2485 u6) (T_2526 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1365 u2) (T_1372 u3) (T_1383 u4) (T_1899 u5) (T_1964 u6) (T_1967 u7) (T_2035 u8) (T_2081 u9) (T_2609 u10)) u0066) (6A byte b006A)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1234 u2) (T_1240 u3) (T_1315 u4) (T_2374 u5) (T_2485 u6) (T_2526 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1365 u2) (T_1372 u3) (T_1383 u4) (T_1899 u5) (T_1964 u6) (T_1967 u7) (T_2035 u8) (T_2081 u9) (T_2609 u10)) u0066) (6A byte b006A)))
 T_721: (in fp : ptr32)
   Class: Eq_721
   DataType: ptr32
@@ -5809,7 +5413,7 @@ T_723: (in fp + -112<i32> : word32)
 T_724: (in d3_1482 : Eq_713)
   Class: Eq_713
   DataType: Eq_713
-  OrigDataType: word32
+  OrigDataType: (ptr32 Eq_1365)
 T_725: (in a5_1579 : (ptr32 Eq_711))
   Class: Eq_711
   DataType: (ptr32 Eq_711)
@@ -6080,15 +5684,15 @@ T_791: (in a7_1968 + 102<i32> : word32)
   OrigDataType: ptr32
 T_792: (in Mem91[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_789
-  DataType: Eq_8428
+  DataType: Eq_8422
   OrigDataType: word32
-T_793: (in d5_256 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: (struct "Eq_720" 0004 (2C Eq_8427 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8428 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+T_793: (in d5_256 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: (struct "Eq_720" 0004 (2C Eq_8421 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8422 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 T_794: (in -1<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_795: (in d4_376 : int32)
   Class: Eq_795
@@ -6130,10 +5734,10 @@ T_804: (in a4_1925 + 1<i32> : word32)
   Class: Eq_802
   DataType: (ptr32 uint8)
   OrigDataType: ptr32
-T_805: (in d2_1005 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: (ptr32 Eq_664)
+T_805: (in d2_1005 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: (ptr32 Eq_793)
 T_806: (in 72<i32> : int32)
   Class: Eq_806
   DataType: int32
@@ -6143,8 +5747,8 @@ T_807: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_808: (in Mem91[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_809: (in d1_103 : Eq_669)
   Class: Eq_669
@@ -6207,8 +5811,8 @@ T_823: (in Mem121[a7_99 + 0<32>:word32] : word32)
   DataType: Eq_669
   OrigDataType: word32
 T_824: (in d2_1005 | d1_123 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_825: (in 1<i32> : int32)
   Class: Eq_825
@@ -6247,8 +5851,8 @@ T_833: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_834: (in Mem143[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_835: (in 0<32> : word32)
   Class: Eq_835
@@ -6711,8 +6315,8 @@ T_949: (in (uint32) (uint8) Mem248[a0_1447 + 0<32>:byte] : uint32)
   DataType: uint32
   OrigDataType: uint32
 T_950: (in 0<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_951: (in 4<32> : word32)
   Class: Eq_951
@@ -6823,12 +6427,12 @@ T_977: (in a7_1968 + 44<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_978: (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_979: (in a7_275 : (ptr32 Eq_664))
+T_979: (in a7_275 : (ptr32 Eq_793))
   Class: Eq_979
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_793 t0000)))
 T_980: (in 4<i32> : int32)
   Class: Eq_980
@@ -6836,7 +6440,7 @@ T_980: (in 4<i32> : int32)
   OrigDataType: int32
 T_981: (in a7_1968 - 4<i32> : word32)
   Class: Eq_979
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: ptr32
 T_982: (in 0<32> : word32)
   Class: Eq_982
@@ -6847,8 +6451,8 @@ T_983: (in a7_275 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_984: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_985: (in d1_284 : uint32)
   Class: Eq_985
@@ -6863,16 +6467,16 @@ T_987: (in signature of __swap : void)
   DataType: (ptr32 Eq_986)
   OrigDataType: 
 T_988: (in  : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: 
 T_989: (in 10<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_990: (in __swap(10<i32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_991: (in SLICE(d5_256, word16, 0) : word16)
   Class: Eq_991
@@ -6899,8 +6503,8 @@ T_996: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_997 (T_793)))
 T_997: (in __swap(d5_256) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_998: (in 0xA<16> : word16)
   Class: Eq_998
@@ -6919,12 +6523,12 @@ T_1001: (in SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_1002: (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_1003: (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1004: (in SLICE(__swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_1004
@@ -7071,8 +6675,8 @@ T_1039: (in a7_275 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1040: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1041: (in 0x30<32> : word32)
   Class: Eq_1041
@@ -7087,8 +6691,8 @@ T_1043: (in d1_303 - 0x30<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1044: (in d1_303 - 0x30<32> + d0_293 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_1045: (in 4<32> : word32)
   Class: Eq_1045
@@ -7267,8 +6871,8 @@ T_1088: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1089: (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1090: (in 4<i32> : int32)
   Class: Eq_1090
@@ -7299,12 +6903,12 @@ T_1096: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_1098 (T_1097)))
 T_1097: (in 10<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_1098: (in __swap(10<i32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_1099: (in SLICE(d2_1005, word16, 0) : word16)
   Class: Eq_1099
@@ -7331,8 +6935,8 @@ T_1104: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_1105 (T_805)))
 T_1105: (in __swap(d2_1005) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_1106: (in 0xA<16> : word16)
   Class: Eq_1106
@@ -7351,12 +6955,12 @@ T_1109: (in SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_1110: (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_1111: (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1112: (in SLICE(__swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_1112
@@ -7523,8 +7127,8 @@ T_1152: (in d1_196 - 0x30<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1153: (in d1_196 - 0x30<32> + d0_186 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_1154: (in 4<32> : word32)
   Class: Eq_1154
@@ -7555,8 +7159,8 @@ T_1160: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1161: (in Mem217[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1162: (in 0x6C<32> : word32)
   Class: Eq_795
@@ -7714,17 +7318,17 @@ T_1200: (in SEQ(SLICE(d1_103, word24, 8), v100_428) : uip32)
   Class: Eq_1198
   DataType: (ptr32 Eq_1198)
   OrigDataType: uip32
-T_1201: (in d0_1471 : Eq_1201)
+T_1201: (in d0_1471 : (ptr32 Eq_1365))
   Class: Eq_1201
-  DataType: Eq_1201
-  OrigDataType: word32
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_1202: (in SLICE(d0_159, word24, 8) : word24)
   Class: Eq_1202
   DataType: word24
   OrigDataType: word24
 T_1203: (in SEQ(SLICE(d0_159, word24, 8), v100_428) : uip32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: uip32
 T_1204: (in 0x25<8> : byte)
   Class: Eq_1191
@@ -7752,7 +7356,7 @@ T_1209: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1210: (in Mem465[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1207
-  DataType: Eq_8428
+  DataType: Eq_8422
   OrigDataType: word32
 T_1211: (in 00001DE4 : ptr32)
   Class: Eq_670
@@ -7904,7 +7508,7 @@ T_1247: (in 2<32> : word32)
   OrigDataType: word32
 T_1248: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: ui32
 T_1249: (in 0<32> : word32)
   Class: Eq_1249
@@ -7932,7 +7536,7 @@ T_1254: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1255: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1252
-  DataType: Eq_8428
+  DataType: Eq_8422
   OrigDataType: word32
 T_1256: (in 4<32> : word32)
   Class: Eq_1256
@@ -7951,8 +7555,8 @@ T_1259: (in a1_661 : (ptr32 byte))
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct 0001 (0 byte b0000)))
 T_1260: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_1261: (in d5_256 == 0<32> : bool)
   Class: Eq_1261
@@ -7989,7 +7593,7 @@ T_1268: (in d3_1050 : ptr32)
 T_1269: (in a7_1020 : (ptr32 Eq_720))
   Class: Eq_720
   DataType: (ptr32 Eq_720)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1234 u2) (T_1240 u3) (T_1315 u4) (T_2374 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1365 u2) (T_1372 u3) (T_1383 u4) (T_1899 u5) (T_1964 u6) (T_1967 u7) (T_2035 u8) (T_2081 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1234 u2) (T_1240 u3) (T_1315 u4) (T_2374 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1365 u2) (T_1372 u3) (T_1383 u4) (T_1899 u5) (T_1964 u6) (T_1967 u7) (T_2035 u8) (T_2081 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
 T_1270: (in SLICE(d1_1068, byte, 0) : byte)
   Class: Eq_1270
   DataType: byte
@@ -8256,7 +7860,7 @@ T_1335: (in 8<i32> : int32)
   OrigDataType: int32
 T_1336: (in a7_1174 - 8<i32> : word32)
   Class: Eq_1336
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_1339 t0000)))
 T_1337: (in 0<32> : word32)
   Class: Eq_1337
@@ -8267,8 +7871,8 @@ T_1338: (in a7_1174 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1339: (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1340: (in 4<i32> : int32)
   Class: Eq_1340
@@ -8300,7 +7904,7 @@ T_1346: (in d1_1182 - (d0_1181 < null) >= 0<32> : bool)
   OrigDataType: bool
 T_1347: (in a2_1892 - a4_1925 : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_1348: (in 102<i32> : int32)
   Class: Eq_1348
@@ -8312,8 +7916,8 @@ T_1349: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1350: (in Mem756[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1201
-  DataType: Eq_8428
-  OrigDataType: Eq_1201
+  DataType: Eq_8422
+  OrigDataType: (ptr32 Eq_1365)
 T_1351: (in 0<32> : word32)
   Class: Eq_1351
   DataType: word32
@@ -8372,17 +7976,17 @@ T_1364: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1365: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1365
-  DataType: Eq_1365
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_1366: (in d5_256 - a7_1968->t0066 : word32)
   Class: Eq_1366
-  DataType: Eq_1366
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_1367: (in 0<32> : word32)
   Class: Eq_1366
-  DataType: ui24
+  DataType: (ptr32 Eq_1365)
   OrigDataType: up32
-T_1368: (in d5_256 - a7_1968->t0066 <= 0<32> : bool)
+T_1368: (in d5_256 - a7_1968->t0066 <= null : bool)
   Class: Eq_1368
   DataType: bool
   OrigDataType: bool
@@ -8396,12 +8000,12 @@ T_1370: (in 102<i32> : int32)
   OrigDataType: int32
 T_1371: (in a7_1968 + 102<i32> : word32)
   Class: Eq_1371
-  DataType: (ptr32 Eq_1371)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2)))
+  DataType: (ptr32 (ptr32 Eq_1365))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2)))
 T_1372: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1201
-  DataType: Eq_1201
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_1373: (in 0<32> : word32)
   Class: Eq_1373
   DataType: word32
@@ -8424,13 +8028,13 @@ T_1377: (in *a1_661 != 0<8> : bool)
   OrigDataType: bool
 T_1378: (in d5_256 - d0_1471 : word32)
   Class: Eq_1378
-  DataType: Eq_1378
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_1379: (in 0<32> : word32)
   Class: Eq_1378
-  DataType: ui24
+  DataType: (ptr32 Eq_1365)
   OrigDataType: up32
-T_1380: (in d5_256 - d0_1471 <= 0<32> : bool)
+T_1380: (in d5_256 - d0_1471 <= null : bool)
   Class: Eq_1380
   DataType: bool
   OrigDataType: bool
@@ -8440,20 +8044,20 @@ T_1381: (in 102<i32> : int32)
   OrigDataType: int32
 T_1382: (in a7_1968 + 102<i32> : word32)
   Class: Eq_1382
-  DataType: (ptr32 Eq_1382)
+  DataType: (ptr32 (ptr32 Eq_1365))
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (T_1365 u2) (T_1372 u3)))
 T_1383: (in Mem719[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1201
-  DataType: Eq_8428
-  OrigDataType: Eq_1201
+  DataType: Eq_8422
+  OrigDataType: (ptr32 Eq_1365)
 T_1384: (in 1<32> : word32)
   Class: Eq_1384
-  DataType: ui24
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_1385: (in d0_1471 + 1<32> : word32)
   Class: Eq_1201
-  DataType: Eq_1201
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_1386: (in 1<i32> : int32)
   Class: Eq_1386
   DataType: int32
@@ -8463,8 +8067,8 @@ T_1387: (in a1_661 + 1<i32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_1388: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: up32
 T_1389: (in d5_256 <= 0<32> : bool)
   Class: Eq_1389
@@ -8896,7 +8500,7 @@ T_1495: (in a7_1508 + 0<32> : word32)
   OrigDataType: ptr32
 T_1496: (in Mem1516[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_1497: (in 48<i32> : int32)
   Class: Eq_1497
@@ -8936,7 +8540,7 @@ T_1505: (in a7_1508 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_1506: (in Mem1531[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_1507: (in 0<32> : word32)
   Class: Eq_1507
@@ -8944,28 +8548,28 @@ T_1507: (in 0<32> : word32)
   OrigDataType: word32
 T_1508: (in a7_1508 + 0<32> : word32)
   Class: Eq_1508
-  DataType: (ptr32 Eq_1508)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2)))
+  DataType: (ptr32 (ptr32 Eq_1365))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2)))
 T_1509: (in Mem1537[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1201
-  DataType: Eq_1201
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
-T_1510: (in d0_1541 : Eq_1201)
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
+T_1510: (in d0_1541 : (ptr32 Eq_1365))
   Class: Eq_1201
-  DataType: Eq_1201
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_1511: (in 0<32> : word32)
   Class: Eq_1511
   DataType: word32
   OrigDataType: word32
 T_1512: (in a7_1508 + 0<32> : word32)
   Class: Eq_1512
-  DataType: (ptr32 Eq_1512)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2)))
+  DataType: (ptr32 (ptr32 Eq_1365))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2)))
 T_1513: (in Mem1537[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1201
-  DataType: Eq_1201
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_1514: (in 52<i32> : int32)
   Class: Eq_1514
   DataType: int32
@@ -9076,12 +8680,12 @@ T_1540: (in 0<32> : word32)
   OrigDataType: word32
 T_1541: (in a7_1508 + 0<32> : word32)
   Class: Eq_1541
-  DataType: (ptr32 Eq_1541)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2)))
+  DataType: (ptr32 (ptr32 Eq_1365))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2)))
 T_1542: (in Mem1546[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1201
-  DataType: Eq_1201
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_1543: (in 68<i32> : int32)
   Class: Eq_1543
   DataType: int32
@@ -9343,8 +8947,8 @@ T_1607: (in a7_1020 + 68<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1608: (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1609: (in 48<i32> : int32)
   Class: Eq_1609
@@ -9398,9 +9002,9 @@ T_1621: (in Mem1367[v187_1368 + 0<32>:word32] : word32)
   Class: Eq_1618
   DataType: word32
   OrigDataType: word32
-T_1622: (in d7_1371 : Eq_1201)
+T_1622: (in d7_1371 : (ptr32 Eq_1365))
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_1623: (in 4<i32> : int32)
   Class: Eq_1623
@@ -9412,7 +9016,7 @@ T_1624: (in v187_1368 + 4<i32> : word32)
   OrigDataType: ptr32
 T_1625: (in Mem1367[v187_1368 + 4<i32>:word32] : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_1626: (in d3_1373 : word32)
   Class: Eq_1626
@@ -9844,7 +9448,7 @@ T_1732: (in 20<i32> : int32)
   OrigDataType: int32
 T_1733: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1733
-  DataType: (ptr32 Eq_1201)
+  DataType: (ptr32 (ptr32 Eq_1365))
   OrigDataType: (ptr32 (struct (0 T_1736 t0000)))
 T_1734: (in 0<32> : word32)
   Class: Eq_1734
@@ -9856,7 +9460,7 @@ T_1735: (in a7_1383 - 20<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_1736: (in Mem1400[a7_1383 - 20<i32> + 0<32>:word32] : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_1737: (in 24<i32> : int32)
   Class: Eq_1737
@@ -9890,25 +9494,25 @@ T_1744: (in signature of fn00002778 : void)
   Class: Eq_1743
   DataType: (ptr32 Eq_1743)
   OrigDataType: 
-T_1745: (in dwArg04 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_1745: (in dwArg04 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_1746: (in dwArg08 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_1746: (in dwArg08 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_1747: (in dwArg0C : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_1747: (in dwArg0C : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_1748: (in dwArg10 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_1748: (in dwArg10 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_1749: (in a7_1383 - 24<i32> : word32)
   Class: Eq_1749
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_1752 t0000)))
 T_1750: (in 0<32> : word32)
   Class: Eq_1750
@@ -9919,8 +9523,8 @@ T_1751: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1752: (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1753: (in 20<i32> : int32)
   Class: Eq_1753
@@ -9928,7 +9532,7 @@ T_1753: (in 20<i32> : int32)
   OrigDataType: int32
 T_1754: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1754
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_1757 t0000)))
 T_1755: (in 0<32> : word32)
   Class: Eq_1755
@@ -9939,8 +9543,8 @@ T_1756: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1757: (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1758: (in 16<i32> : int32)
   Class: Eq_1758
@@ -9948,7 +9552,7 @@ T_1758: (in 16<i32> : int32)
   OrigDataType: int32
 T_1759: (in a7_1383 - 16<i32> : word32)
   Class: Eq_1759
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_1762 t0000)))
 T_1760: (in 0<32> : word32)
   Class: Eq_1760
@@ -9959,8 +9563,8 @@ T_1761: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1762: (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1763: (in 12<i32> : int32)
   Class: Eq_1763
@@ -9968,7 +9572,7 @@ T_1763: (in 12<i32> : int32)
   OrigDataType: int32
 T_1764: (in a7_1383 - 12<i32> : word32)
   Class: Eq_1764
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_1767 t0000)))
 T_1765: (in 0<32> : word32)
   Class: Eq_1765
@@ -9979,8 +9583,8 @@ T_1766: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1767: (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1768: (in fn00002778(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>)) : word32)
   Class: Eq_1742
@@ -10176,7 +9780,7 @@ T_1815: (in 20<i32> : int32)
   OrigDataType: int32
 T_1816: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1816
-  DataType: (ptr32 Eq_1201)
+  DataType: (ptr32 (ptr32 Eq_1365))
   OrigDataType: (ptr32 (struct (0 T_1819 t0000)))
 T_1817: (in 0<32> : word32)
   Class: Eq_1817
@@ -10188,7 +9792,7 @@ T_1818: (in a7_1383 - 20<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_1819: (in Mem1444[a7_1383 - 20<i32> + 0<32>:word32] : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_1820: (in 24<i32> : int32)
   Class: Eq_1820
@@ -10210,9 +9814,9 @@ T_1824: (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
   Class: Eq_1618
   DataType: word32
   OrigDataType: word32
-T_1825: (in d1_1450 : Eq_1201)
+T_1825: (in d1_1450 : (ptr32 Eq_1365))
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: up32
 T_1826: (in d0_1449 : word32)
   Class: Eq_1618
@@ -10226,33 +9830,33 @@ T_1828: (in signature of fn00002430 : void)
   Class: Eq_1827
   DataType: (ptr32 Eq_1827)
   OrigDataType: 
-T_1829: (in dwArg04 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_1829: (in dwArg04 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_1830: (in dwArg08 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_1830: (in dwArg08 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_1831: (in dwArg0C : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_1831: (in dwArg0C : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_1832: (in dwArg10 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_1832: (in dwArg10 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_1833: (in d1Out : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_1833: (in d1Out : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
-T_1834: (in a0Out : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_1834: (in a0Out : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_1835: (in a7_1383 - 24<i32> : word32)
   Class: Eq_1835
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_1838 t0000)))
 T_1836: (in 0<32> : word32)
   Class: Eq_1836
@@ -10263,8 +9867,8 @@ T_1837: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1838: (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1839: (in 20<i32> : int32)
   Class: Eq_1839
@@ -10272,7 +9876,7 @@ T_1839: (in 20<i32> : int32)
   OrigDataType: int32
 T_1840: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1840
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_1843 t0000)))
 T_1841: (in 0<32> : word32)
   Class: Eq_1841
@@ -10283,8 +9887,8 @@ T_1842: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1843: (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1844: (in 16<i32> : int32)
   Class: Eq_1844
@@ -10292,7 +9896,7 @@ T_1844: (in 16<i32> : int32)
   OrigDataType: int32
 T_1845: (in a7_1383 - 16<i32> : word32)
   Class: Eq_1845
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_1848 t0000)))
 T_1846: (in 0<32> : word32)
   Class: Eq_1846
@@ -10303,8 +9907,8 @@ T_1847: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1848: (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1849: (in 12<i32> : int32)
   Class: Eq_1849
@@ -10312,7 +9916,7 @@ T_1849: (in 12<i32> : int32)
   OrigDataType: int32
 T_1850: (in a7_1383 - 12<i32> : word32)
   Class: Eq_1850
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_1853 t0000)))
 T_1851: (in 0<32> : word32)
   Class: Eq_1851
@@ -10323,16 +9927,16 @@ T_1852: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1853: (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_1854: (in out d1_1450 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_1855: (in out a0_1447 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: (ptr32 (struct (0 T_852 t0000)))
 T_1856: (in fn00002430(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>), out d1_1450, out a0_1447) : word32)
   Class: Eq_1618
@@ -10376,13 +9980,13 @@ T_1865: (in d3_1373 + 1<32> : word32)
   OrigDataType: word32
 T_1866: (in 0<32> : word32)
   Class: Eq_1201
-  DataType: ui24
+  DataType: (ptr32 Eq_1365)
   OrigDataType: up32
-T_1867: (in d1_1450 < 0<32> : bool)
+T_1867: (in d1_1450 < null : bool)
   Class: Eq_1867
   DataType: Eq_1867
   OrigDataType: (union (bool u0) (word32 u1))
-T_1868: (in d0_1449 - (d1_1450 < 0<32>) : word32)
+T_1868: (in d0_1449 - (d1_1450 < null) : word32)
   Class: Eq_1868
   DataType: word32
   OrigDataType: word32
@@ -10390,7 +9994,7 @@ T_1869: (in 0<32> : word32)
   Class: Eq_1868
   DataType: word32
   OrigDataType: word32
-T_1870: (in d0_1449 - (d1_1450 < 0<32>) != 0<32> : bool)
+T_1870: (in d0_1449 - (d1_1450 < null) != 0<32> : bool)
   Class: Eq_1870
   DataType: bool
   OrigDataType: bool
@@ -11758,22 +11362,22 @@ T_2211: (in Mem1091[a7_1057 + 0<32>:word32] : word32)
   Class: Eq_1198
   DataType: (ptr32 Eq_1198)
   OrigDataType: int32
-T_2212: (in v248_1105 : Eq_2212)
+T_2212: (in v248_1105 : byte)
   Class: Eq_2212
-  DataType: Eq_2212
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2213: (in 55<i32> : int32)
   Class: Eq_2213
   DataType: int32
   OrigDataType: int32
 T_2214: (in a7_1968 + 55<i32> : word32)
   Class: Eq_2214
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2215: (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
   Class: Eq_2212
-  DataType: Eq_2212
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2216: (in a7_1109 : (ptr32 Eq_2216))
   Class: Eq_2216
   DataType: (ptr32 Eq_2216)
@@ -11988,8 +11592,8 @@ T_2268: (in 56<i32> : int32)
   OrigDataType: int32
 T_2269: (in a7_1968 + 56<i32> : word32)
   Class: Eq_2269
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2270: (in Mem836[a7_1968 + 56<i32>:word32] : word32)
   Class: Eq_2267
   DataType: word32
@@ -12018,22 +11622,22 @@ T_2276: (in d4_376 != 2<32> : bool)
   Class: Eq_2276
   DataType: bool
   OrigDataType: bool
-T_2277: (in v262_844 : Eq_2277)
+T_2277: (in v262_844 : word16)
   Class: Eq_2277
-  DataType: Eq_2277
-  OrigDataType: (union (word16 u0) (word32 u1))
+  DataType: word16
+  OrigDataType: word16
 T_2278: (in 62<i32> : int32)
   Class: Eq_2278
   DataType: int32
   OrigDataType: int32
 T_2279: (in a7_1968 + 62<i32> : word32)
   Class: Eq_2279
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2280: (in Mem843[a7_1968 + 62<i32>:word16] : word16)
   Class: Eq_2277
-  DataType: Eq_2277
-  OrigDataType: word32
+  DataType: word16
+  OrigDataType: word16
 T_2281: (in a7_848 : (ptr32 Eq_2281))
   Class: Eq_2281
   DataType: (ptr32 Eq_2281)
@@ -12288,7 +11892,7 @@ T_2343: (in 2<32> : word32)
   OrigDataType: word32
 T_2344: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: ui32
 T_2345: (in 0<32> : word32)
   Class: Eq_2345
@@ -12296,8 +11900,8 @@ T_2345: (in 0<32> : word32)
   OrigDataType: word32
 T_2346: (in d0_1471 + 0<32> : word32)
   Class: Eq_2346
-  DataType: Eq_2346
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_2347: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_830
   DataType: (ptr32 Eq_830)
@@ -12418,22 +12022,22 @@ T_2376: (in d0_891 == 0<32> : bool)
   Class: Eq_2376
   DataType: bool
   OrigDataType: bool
-T_2377: (in v277_869 : Eq_2377)
+T_2377: (in v277_869 : byte)
   Class: Eq_2377
-  DataType: Eq_2377
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2378: (in 63<i32> : int32)
   Class: Eq_2378
   DataType: int32
   OrigDataType: int32
 T_2379: (in a7_1968 + 63<i32> : word32)
   Class: Eq_2379
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2380: (in Mem868[a7_1968 + 63<i32>:byte] : byte)
   Class: Eq_2377
-  DataType: Eq_2377
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2381: (in a7_873 : (ptr32 Eq_2381))
   Class: Eq_2381
   DataType: (ptr32 Eq_2381)
@@ -12536,7 +12140,7 @@ T_2405: (in 2<32> : word32)
   OrigDataType: word32
 T_2406: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: ui32
 T_2407: (in 0<32> : word32)
   Class: Eq_2407
@@ -12544,8 +12148,8 @@ T_2407: (in 0<32> : word32)
   OrigDataType: word32
 T_2408: (in d0_1471 + 0<32> : word32)
   Class: Eq_2408
-  DataType: Eq_2408
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_2409: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_830
   DataType: (ptr32 Eq_830)
@@ -12587,8 +12191,8 @@ T_2418: (in (byte) d1_1068 == 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_2419: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_2420: (in d5_256 != 0<32> : bool)
   Class: Eq_2420
@@ -12696,7 +12300,7 @@ T_2445: (in 8<i32> : int32)
   OrigDataType: int32
 T_2446: (in a7_911 - 8<i32> : word32)
   Class: Eq_2446
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_2449 t0000)))
 T_2447: (in 0<32> : word32)
   Class: Eq_2447
@@ -12707,12 +12311,12 @@ T_2448: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2449: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_2450: (in a7_911 - 8<i32> : word32)
   Class: Eq_2450
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_2453 t0000)))
 T_2451: (in 0<32> : word32)
   Class: Eq_2451
@@ -12723,8 +12327,8 @@ T_2452: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2453: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_2454: (in 4<i32> : int32)
   Class: Eq_2454
@@ -12808,7 +12412,7 @@ T_2473: (in 2<32> : word32)
   OrigDataType: word32
 T_2474: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: ui32
 T_2475: (in 0<32> : word32)
   Class: Eq_2475
@@ -12816,8 +12420,8 @@ T_2475: (in 0<32> : word32)
   OrigDataType: word32
 T_2476: (in d0_1471 + 0<32> : word32)
   Class: Eq_2476
-  DataType: Eq_2476
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_2477: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_830
   DataType: (ptr32 Eq_830)
@@ -12936,7 +12540,7 @@ T_2505: (in 8<i32> : int32)
   OrigDataType: int32
 T_2506: (in a7_992 - 8<i32> : word32)
   Class: Eq_2506
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_2509 t0000)))
 T_2507: (in 0<32> : word32)
   Class: Eq_2507
@@ -12947,8 +12551,8 @@ T_2508: (in a7_992 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2509: (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_2510: (in d1_1017 : word32)
   Class: Eq_2510
@@ -13124,7 +12728,7 @@ T_2552: (in 2<32> : word32)
   OrigDataType: word32
 T_2553: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: ui32
 T_2554: (in 0<32> : word32)
   Class: Eq_2554
@@ -13132,8 +12736,8 @@ T_2554: (in 0<32> : word32)
   OrigDataType: word32
 T_2555: (in d0_1471 + 0<32> : word32)
   Class: Eq_2555
-  DataType: Eq_2555
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_2556: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_830
   DataType: (ptr32 Eq_830)
@@ -13172,7 +12776,7 @@ T_2564: (in 2<32> : word32)
   OrigDataType: word32
 T_2565: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: ui32
 T_2566: (in 0<32> : word32)
   Class: Eq_2566
@@ -13180,8 +12784,8 @@ T_2566: (in 0<32> : word32)
   OrigDataType: word32
 T_2567: (in d0_1471 + 0<32> : word32)
   Class: Eq_2567
-  DataType: Eq_2567
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_2568: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_830
   DataType: (ptr32 Eq_830)
@@ -13224,7 +12828,7 @@ T_2577: (in 2<32> : word32)
   OrigDataType: word32
 T_2578: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: ui32
 T_2579: (in 3<32> : word32)
   Class: Eq_2579
@@ -13232,8 +12836,8 @@ T_2579: (in 3<32> : word32)
   OrigDataType: word32
 T_2580: (in d0_1471 + 3<32> : word32)
   Class: Eq_2580
-  DataType: Eq_2580
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_2581: (in Mem341[d0_1471 + 3<32>:byte] : byte)
   Class: Eq_2581
   DataType: byte
@@ -13272,7 +12876,7 @@ T_2589: (in 2<32> : word32)
   OrigDataType: word32
 T_2590: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1201
-  DataType: Eq_1201
+  DataType: (ptr32 Eq_1365)
   OrigDataType: ui32
 T_2591: (in 3<32> : word32)
   Class: Eq_2591
@@ -13280,8 +12884,8 @@ T_2591: (in 3<32> : word32)
   OrigDataType: word32
 T_2592: (in d0_1471 + 3<32> : word32)
   Class: Eq_2592
-  DataType: Eq_2592
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: (ptr32 Eq_1365)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_2593: (in Mem341[d0_1471 + 3<32>:byte] : byte)
   Class: Eq_2593
   DataType: byte
@@ -13336,7 +12940,7 @@ T_2605: (in ((word32) d3_1482 + 3<i32> >> 2<32> << 2<32>) + 4<32> : word32)
   OrigDataType: ui32
 T_2606: (in 1<32> : word32)
   Class: Eq_2606
-  DataType: int32
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_2607: (in 102<i32> : int32)
   Class: Eq_2607
@@ -13348,8 +12952,8 @@ T_2608: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (Eq_1365 u2) (Eq_1201 u3) (Eq_1201 u4) (Eq_1899 u5) (Eq_1961 u6) (Eq_1967 u7) (Eq_2035 u8) (Eq_2078 u9)))
 T_2609: (in Mem525[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_2606
-  DataType: Eq_8428
-  OrigDataType: int32
+  DataType: Eq_8422
+  OrigDataType: (ptr32 Eq_1365)
 T_2610: (in 0<i32> : int32)
   Class: Eq_1190
   DataType: int32
@@ -16482,29 +16086,29 @@ T_3392: (in fn0000131C(0x14<u32>, out a1, out a5) : word32)
   Class: Eq_588
   DataType: word32
   OrigDataType: word32
-T_3393: (in d0 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3393: (in d0 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3394: (in d0_196 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: uint8
-T_3395: (in d1_142 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3394: (in d0_196 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: (ptr32 Eq_1365)
+T_3395: (in d1_142 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_3396: (in a0_20 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3396: (in a0_20 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
-T_3397: (in d3_166 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3397: (in d3_166 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
 T_3398: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_3399: (in dwArg0C != 0<32> : bool)
   Class: Eq_3399
@@ -16535,8 +16139,8 @@ T_3405: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_3406: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_3407: (in dwArg10 != 0<32> : bool)
   Class: Eq_3407
@@ -16558,41 +16162,41 @@ T_3411: (in signature of fn00002534 : void)
   Class: Eq_3410
   DataType: (ptr32 Eq_3410)
   OrigDataType: 
-T_3412: (in d0 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3412: (in d0 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: (union (int32 u1) (up32 u0))
-T_3413: (in d1 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3413: (in d1 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: up32
-T_3414: (in d2 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3414: (in d2 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: (union (int32 u0) (up32 u1))
-T_3415: (in d1Out : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3415: (in d1Out : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
-T_3416: (in d2Out : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3416: (in d2Out : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3417: (in out d1_318 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3418: (in out d2_319 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3419: (in fn00002534(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3420: (in 0<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_3421: (in d4_29 : int32)
   Class: Eq_3421
@@ -16602,9 +16206,9 @@ T_3422: (in 24<i32> : int32)
   Class: Eq_3421
   DataType: int32
   OrigDataType: int32
-T_3423: (in d6_30 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3423: (in d6_30 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uip32
 T_3424: (in __rol : ptr32)
   Class: Eq_3424
@@ -16615,20 +16219,20 @@ T_3425: (in signature of __rol : void)
   DataType: (ptr32 Eq_3424)
   OrigDataType: 
 T_3426: (in  : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: 
 T_3427: (in  : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: 
 T_3428: (in 8<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_3429: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3430: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3430
@@ -16731,12 +16335,12 @@ T_3454: (in __rol : ptr32)
   DataType: (ptr32 Eq_3424)
   OrigDataType: (ptr32 (fn T_3456 (T_3423, T_3455)))
 T_3455: (in 8<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_3456: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3457: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3457
@@ -16759,12 +16363,12 @@ T_3461: (in __rol : ptr32)
   DataType: (ptr32 Eq_3424)
   OrigDataType: (ptr32 (fn T_3463 (T_3423, T_3462)))
 T_3462: (in 8<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_3463: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3464: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3464
@@ -16791,40 +16395,40 @@ T_3469: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_3470: (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uip32
-T_3471: (in d1_175 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3471: (in d1_175 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3472: (in d2_176 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3472: (in d2_176 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3473: (in d0_174 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3473: (in d0_174 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3474: (in fn00002534 : ptr32)
   Class: Eq_3410
   DataType: (ptr32 Eq_3410)
   OrigDataType: (ptr32 (fn T_3478 (T_3475, T_1829, T_3397, T_3476, T_3477)))
 T_3475: (in 0<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_3476: (in out d1_175 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3477: (in out d2_176 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3478: (in fn00002534(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3479: (in d2_321 : word32)
   Class: Eq_3479
@@ -16839,16 +16443,16 @@ T_3481: (in fn00002534 : ptr32)
   DataType: (ptr32 Eq_3410)
   OrigDataType: (ptr32 (fn T_3484 (T_3471, T_1830, T_3472, T_3482, T_3483)))
 T_3482: (in out d1_320 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3483: (in out d2_321 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3484: (in fn00002534(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3485: (in 1<i32> : int32)
   Class: Eq_3485
@@ -16891,8 +16495,8 @@ T_3494: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_3495: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
 T_3496: (in d1_86 : word32)
   Class: Eq_3496
@@ -16902,17 +16506,17 @@ T_3497: (in d2_322 : word32)
   Class: Eq_3497
   DataType: word32
   OrigDataType: word32
-T_3498: (in d0_85 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3498: (in d0_85 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3499: (in fn00002534 : ptr32)
   Class: Eq_3410
   DataType: (ptr32 Eq_3410)
   OrigDataType: (ptr32 (fn T_3509 (T_3500, T_3503, T_3506, T_3507, T_3508)))
 T_3500: (in dwArg04 >> d4_61 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3501: (in dwArg04 << d5_63 : word32)
   Class: Eq_3501
@@ -16923,8 +16527,8 @@ T_3502: (in dwArg08 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3503: (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_3504: (in dwArg0C << d5_63 : word32)
   Class: Eq_3504
@@ -16935,52 +16539,52 @@ T_3505: (in dwArg10 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3506: (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_3507: (in out d1_86 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3508: (in out d2_322 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3509: (in fn00002534(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3510: (in d3_72 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3510: (in d3_72 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3511: (in dwArg10 << d5_63 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
-T_3512: (in d5_101 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3512: (in d5_101 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3513: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3514 (T_3498)))
 T_3514: (in __swap(d0_85) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3515: (in d6_103 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3515: (in d6_103 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3516: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3517 (T_3510)))
 T_3517: (in __swap(d3_72) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3518: (in d3_102 : uint32)
   Class: Eq_3518
@@ -16994,9 +16598,9 @@ T_3520: (in d3_72 * (word16) d5_101 : word32)
   Class: Eq_3518
   DataType: uint32
   OrigDataType: uint32
-T_3521: (in d2_107 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3521: (in d2_107 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3522: (in __swap : ptr32)
   Class: Eq_986
@@ -17007,12 +16611,12 @@ T_3523: (in SLICE(d3_72, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3524: (in d0_85 * (word16) d3_72 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3525: (in __swap(d0_85 * (word16) d3_72) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3526: (in v34_108 : cup16)
   Class: Eq_3526
@@ -17062,29 +16666,29 @@ T_3537: (in SLICE(SEQ(v35_109, v34_108) + d4_104, word16, 0) : word16)
   Class: Eq_3534
   DataType: cup16
   OrigDataType: word16
-T_3538: (in d6_82 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3538: (in d6_82 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3539: (in dwArg08 << d5_63 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
-T_3540: (in d2_124 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3540: (in d2_124 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3541: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3543 (T_3542)))
 T_3542: (in SEQ(v35_109, v39_116) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3543: (in __swap(SEQ(v35_109, v39_116)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3544: (in d5_105 : uint32)
   Class: Eq_3544
@@ -17115,12 +16719,12 @@ T_3550: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3551: (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3552: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3553: (in __swap : ptr32)
   Class: Eq_986
@@ -17135,12 +16739,12 @@ T_3555: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3556: (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3557: (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3558: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
   Class: Eq_3558
@@ -17227,8 +16831,8 @@ T_3578: (in 1<32> : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3579: (in d0_85 - 1<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3580: (in 0<32> : word32)
   Class: Eq_3547
@@ -17250,13 +16854,13 @@ T_3584: (in d6_82 - d2_124 >= 0<32> : bool)
   Class: Eq_3584
   DataType: bool
   OrigDataType: bool
-T_3585: (in d7_13 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3585: (in d7_13 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: (union (int32 u0) (uint32 u1))
 T_3586: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_3587: (in d2 == 0<32> : bool)
   Class: Eq_3587
@@ -17270,57 +16874,57 @@ T_3589: (in signature of fn000026F2 : void)
   Class: Eq_3588
   DataType: (ptr32 Eq_3588)
   OrigDataType: 
-T_3590: (in d0 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3590: (in d0 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_3591: (in d1 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3591: (in d1 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3592: (in d2 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3592: (in d2 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3593: (in d1Out : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3593: (in d1Out : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3594: (in out d1 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3595: (in fn000026F2(d1, d2, d2, out d1) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3596: (in d6_17 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3596: (in d6_17 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_3597: (in d5_19 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3597: (in d5_19 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3598: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_3599: (in d0 != 0<32> : bool)
   Class: Eq_3599
   DataType: bool
   OrigDataType: bool
-T_3600: (in d2_22 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3600: (in d2_22 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3601: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3602 (T_3414)))
 T_3602: (in __swap(d2) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3603: (in SLICE(d2_22, word16, 0) : word16)
   Class: Eq_3603
@@ -17335,8 +16939,8 @@ T_3605: (in (word16) d2_22 != 0<16> : bool)
   DataType: bool
   OrigDataType: bool
 T_3606: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_3607: (in d1 == 0<32> : bool)
   Class: Eq_3607
@@ -17371,36 +16975,36 @@ T_3614: (in 0<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_3615: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_3616: (in d2 < 0<32> : bool)
   Class: Eq_3616
   DataType: bool
   OrigDataType: bool
-T_3617: (in d0_281 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3617: (in d0_281 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3618: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3619 (T_3412)))
 T_3619: (in __swap(d0) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3620: (in d1_282 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3620: (in d1_282 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3621: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3622 (T_3413)))
 T_3622: (in __swap(d1) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3623: (in d0_285 : uint32)
   Class: Eq_3623
@@ -17439,8 +17043,8 @@ T_3631: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3632 (T_3620)))
 T_3632: (in __swap(d1_282) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3633: (in SLICE(__swap(d1_282), word16, 0) : word16)
   Class: Eq_3633
@@ -17467,12 +17071,12 @@ T_3638: (in (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3639: (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3640: (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3641: (in SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16) : word16)
   Class: Eq_3641
@@ -17491,8 +17095,8 @@ T_3644: (in (uint16) (d0_295 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3645: (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3646: (in __swap : ptr32)
   Class: Eq_986
@@ -17515,12 +17119,12 @@ T_3650: (in 0<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3651: (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3652: (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3653: (in v41_64 : word16)
   Class: Eq_3653
@@ -17535,8 +17139,8 @@ T_3655: (in 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3656: (in d6_17 * 2<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_3657: (in SLICE(d0_44, word16, 16) : word16)
   Class: Eq_3657
@@ -17567,28 +17171,28 @@ T_3663: (in d5_19 * 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3664: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: up32
 T_3665: (in d6_17 < 0<32> : bool)
   Class: Eq_3665
   DataType: bool
   OrigDataType: bool
 T_3666: (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_3667: (in 2<32> : word32)
   Class: Eq_3667
   DataType: ui32
   OrigDataType: ui32
 T_3668: (in d7_13 * 2<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_3669: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_3670: (in d7_13 > 0<32> : bool)
   Class: Eq_3670
@@ -17602,9 +17206,9 @@ T_3672: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3681 (T_3680)))
-T_3673: (in d3_74 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3673: (in d3_74 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3674: (in SLICE(d3_74, uint16, 0) : uint16)
   Class: Eq_3674
@@ -17631,12 +17235,12 @@ T_3679: (in (uint16) (d5_19 /u SLICE(d3_74, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3680: (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3681: (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3682: (in SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16) : word16)
   Class: Eq_3682
@@ -17647,24 +17251,24 @@ T_3683: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3684: (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3685: (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3686: (in d1_104 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: uint8
+T_3686: (in d1_104 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: (ptr32 Eq_1365)
 T_3687: (in 0xFFFF<32> : uipr32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: uipr32
-T_3688: (in d6_98 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3688: (in d6_98 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3689: (in __swap : ptr32)
   Class: Eq_986
@@ -17679,48 +17283,48 @@ T_3691: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3692: (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3693: (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3694: (in d6_133 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3694: (in d6_133 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3695: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3696 (T_3686)))
 T_3696: (in __swap(d1_104) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3697: (in d3_140 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3697: (in d3_140 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3698: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3699 (T_3694)))
 T_3699: (in __swap(d6_133) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3700: (in d4_142 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3700: (in d4_142 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3701: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3702 (T_3585)))
 T_3702: (in __swap(d7_13) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3703: (in d5_141 : uint32)
   Class: Eq_3703
@@ -17734,9 +17338,9 @@ T_3705: (in d7_13 * (word16) d3_140 : word32)
   Class: Eq_3703
   DataType: uint32
   OrigDataType: uint32
-T_3706: (in d6_146 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3706: (in d6_146 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3707: (in __swap : ptr32)
   Class: Eq_986
@@ -17747,12 +17351,12 @@ T_3708: (in SLICE(d7_13, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3709: (in d6_133 * (word16) d7_13 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3710: (in __swap(d6_133 * (word16) d7_13) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3711: (in v55_147 : cup16)
   Class: Eq_3711
@@ -17814,29 +17418,29 @@ T_3725: (in d3_140 * (word16) d4_142 : word32)
   Class: Eq_3723
   DataType: uint32
   OrigDataType: uint32
-T_3726: (in d6_178 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3726: (in d6_178 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3727: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3729 (T_3728)))
 T_3728: (in SEQ(v56_148, v59_155) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3729: (in __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3730: (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3731: (in d5_181 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3732: (in __swap : ptr32)
   Class: Eq_986
@@ -17851,12 +17455,12 @@ T_3734: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3735: (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3736: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3737: (in __swap : ptr32)
   Class: Eq_986
@@ -17871,12 +17475,12 @@ T_3739: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3740: (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3741: (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3742: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
   Class: Eq_3742
@@ -17927,20 +17531,20 @@ T_3753: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ
   DataType: uint32
   OrigDataType: uint32
 T_3754: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: up32
 T_3755: (in d6_178 <u 0<32> : bool)
   Class: Eq_3755
   DataType: Eq_3755
   OrigDataType: (union (bool u0) (uint32 u1))
 T_3756: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3757: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: up32
 T_3758: (in d5_181 >= 0<32> : bool)
   Class: Eq_3758
@@ -17971,12 +17575,12 @@ T_3764: (in 1<32> : word32)
   DataType: uipr32
   OrigDataType: uipr32
 T_3765: (in d1_104 - 1<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
-T_3766: (in d4_113 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3766: (in d4_113 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3767: (in __swap : ptr32)
   Class: Eq_986
@@ -17987,8 +17591,8 @@ T_3768: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3769 (T_3585)))
 T_3769: (in __swap(d7_13) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3770: (in SLICE(d1_104, word16, 0) : word16)
   Class: Eq_3770
@@ -17999,12 +17603,12 @@ T_3771: (in __swap(d7_13) * (word16) d1_104 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3772: (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3773: (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3774: (in wLoc22_442 : word16)
   Class: Eq_3774
@@ -18063,8 +17667,8 @@ T_3787: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3788 (T_3585)))
 T_3788: (in __swap(d7_13) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3789: (in SLICE(__swap(d7_13), word16, 16) : word16)
   Class: Eq_3789
@@ -18079,20 +17683,20 @@ T_3791: (in SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : uipr32)
   DataType: uipr32
   OrigDataType: uipr32
 T_3792: (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3793: (in 1<32> : word32)
   Class: Eq_3793
   DataType: uint32
   OrigDataType: uint32
 T_3794: (in d1_104 - 1<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3795: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: up32
 T_3796: (in d6_178 < 0<32> : bool)
   Class: Eq_3796
@@ -18115,20 +17719,20 @@ T_3800: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3801: (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3802: (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3803: (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_3804: (in d6_220 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3804: (in d6_220 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3805: (in __swap : ptr32)
   Class: Eq_986
@@ -18143,12 +17747,12 @@ T_3807: (in SLICE(d5_181, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3808: (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3809: (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3810: (in SLICE(dwLoc24, word16, 16) : word16)
   Class: Eq_3810
@@ -18159,20 +17763,20 @@ T_3811: (in SLICE(d1_104, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3812: (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
-T_3813: (in d5_221 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3813: (in d5_221 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3814: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3815 (T_3731)))
 T_3815: (in __swap(d5_181) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3816: (in v82_224 : word16)
   Class: Eq_3816
@@ -18190,29 +17794,29 @@ T_3819: (in v41_64 == 0<16> : bool)
   Class: Eq_3819
   DataType: bool
   OrigDataType: bool
-T_3820: (in d5_266 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3820: (in d5_266 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3821: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3822 (T_3731)))
 T_3822: (in __swap(d5_181) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3823: (in d6_267 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3823: (in d6_267 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3824: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3825 (T_3726)))
 T_3825: (in __swap(d6_178) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3826: (in SLICE(d5_266, word16, 16) : word16)
   Class: Eq_3826
@@ -18223,8 +17827,8 @@ T_3827: (in SLICE(d6_267, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3828: (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3829: (in SLICE(d6_267, word16, 16) : word16)
   Class: Eq_3829
@@ -18235,8 +17839,8 @@ T_3830: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3831: (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3832: (in true : bool)
   Class: Eq_3611
@@ -18250,25 +17854,25 @@ T_3834: (in SEQ(SLICE(d1_104, word16, 0), wLoc22_442) : word32)
   Class: Eq_3775
   DataType: word32
   OrigDataType: word32
-T_3835: (in d2_73 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3835: (in d2_73 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3836: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3837 (T_3597)))
 T_3837: (in __swap(d5_19) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3838: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3839 (T_3585)))
 T_3839: (in __swap(d7_13) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3840: (in d2_73 - d3_74 : word32)
   Class: Eq_3840
@@ -18307,8 +17911,8 @@ T_3848: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3849: (in d5_221 >> 1<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3850: (in v86_241 : word16)
   Class: Eq_3850
@@ -18327,8 +17931,8 @@ T_3853: (in signature of __rcr : void)
   DataType: (ptr32 Eq_3852)
   OrigDataType: 
 T_3854: (in  : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: 
 T_3855: (in  : word32)
   Class: Eq_3855
@@ -18351,8 +17955,8 @@ T_3859: (in SLICE(cond(d5_221), bool, 4) : bool)
   DataType: bool
   OrigDataType: bool
 T_3860: (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3861: (in SLICE(d7_230, word16, 16) : word16)
   Class: Eq_3861
@@ -18378,49 +17982,49 @@ T_3866: (in v86_241 != 0<16> : bool)
   Class: Eq_3866
   DataType: bool
   OrigDataType: bool
-T_3867: (in d0 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3867: (in d0 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3868: (in d2 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3868: (in d2 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3869: (in dwArg04 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3869: (in dwArg04 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
-T_3870: (in dwArg08 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3870: (in dwArg08 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
 T_3871: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_3872: (in dwArg04 > 0<32> : bool)
   Class: Eq_3872
   DataType: bool
   OrigDataType: bool
 T_3873: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_3874: (in dwArg08 > 0<32> : bool)
   Class: Eq_3874
   DataType: bool
   OrigDataType: bool
-T_3875: (in d0_36 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3875: (in d0_36 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
 T_3876: (in -dwArg04 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
 T_3877: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_3878: (in dwArg08 > 0<32> : bool)
   Class: Eq_3878
@@ -18435,16 +18039,16 @@ T_3880: (in fn000026F2 : ptr32)
   DataType: (ptr32 Eq_3588)
   OrigDataType: (ptr32 (fn T_3882 (T_3875, T_3870, T_3868, T_3881)))
 T_3881: (in out d1_43 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3882: (in fn000026F2(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3883: (in -fn000026F2(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3884: (in d1_55 : word32)
   Class: Eq_3884
@@ -18455,16 +18059,16 @@ T_3885: (in fn000026F2 : ptr32)
   DataType: (ptr32 Eq_3588)
   OrigDataType: (ptr32 (fn T_3888 (T_3875, T_3886, T_3868, T_3887)))
 T_3886: (in -dwArg08 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
 T_3887: (in out d1_55 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3888: (in fn000026F2(d0_36, -dwArg08, d2, out d1_55) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3889: (in d1_88 : word32)
   Class: Eq_3889
@@ -18475,12 +18079,12 @@ T_3890: (in fn000026F2 : ptr32)
   DataType: (ptr32 Eq_3588)
   OrigDataType: (ptr32 (fn T_3892 (T_3869, T_3870, T_3868, T_3891)))
 T_3891: (in out d1_88 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3892: (in fn000026F2(dwArg04, dwArg08, d2, out d1_88) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3893: (in d1_89 : word32)
   Class: Eq_3893
@@ -18491,32 +18095,32 @@ T_3894: (in fn000026F2 : ptr32)
   DataType: (ptr32 Eq_3588)
   OrigDataType: (ptr32 (fn T_3897 (T_3869, T_3895, T_3868, T_3896)))
 T_3895: (in -dwArg08 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
 T_3896: (in out d1_89 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_3897: (in fn000026F2(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3898: (in -fn000026F2(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3899: (in d1_22 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3899: (in d1_22 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3900: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3901 (T_3591)))
 T_3901: (in __swap(d1) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3902: (in v10_9 : word16)
   Class: Eq_3902
@@ -18534,13 +18138,13 @@ T_3905: (in SLICE(d2, word16, 16) : word16)
   Class: Eq_3904
   DataType: word16
   OrigDataType: word16
-T_3906: (in d2_11 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3906: (in d2_11 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3907: (in SEQ(v11_10, v10_9) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3908: (in 0<16> : word16)
   Class: Eq_3902
@@ -18550,13 +18154,13 @@ T_3909: (in v10_9 != 0<16> : bool)
   Class: Eq_3909
   DataType: bool
   OrigDataType: bool
-T_3910: (in d3_18 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: uint8
+T_3910: (in d3_18 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: (ptr32 Eq_1365)
 T_3911: (in 16<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_3912: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3912
@@ -18570,29 +18174,29 @@ T_3914: (in (word16) d1_22 >= 0x80<16> : bool)
   Class: Eq_3914
   DataType: bool
   OrigDataType: bool
-T_3915: (in d0_134 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3915: (in d0_134 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3916: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3917 (T_3590)))
 T_3917: (in __swap(d0) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_3918: (in d1_135 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3918: (in d1_135 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3919: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3920 (T_3899)))
 T_3920: (in __swap(d1_22) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3921: (in v14_137 : word16)
   Class: Eq_3921
@@ -18611,8 +18215,8 @@ T_3924: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3925 (T_3906)))
 T_3925: (in __swap(d2_11) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3926: (in SLICE(__swap(d2_11), word16, 16) : word16)
   Class: Eq_3926
@@ -18630,17 +18234,17 @@ T_3929: (in v14_137 == 0<16> : bool)
   Class: Eq_3929
   DataType: bool
   OrigDataType: bool
-T_3930: (in d0_150 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_3930: (in d0_150 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3931: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_3932 (T_3915)))
 T_3932: (in __swap(d0_134) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3933: (in d2_154 : uint32)
   Class: Eq_3933
@@ -18695,28 +18299,28 @@ T_3945: (in (uint16) (d2_154 % SLICE(d1_135, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3946: (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_3947: (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3948: (in SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0) : word16)
   Class: Eq_3948
   DataType: word16
   OrigDataType: word16
 T_3949: (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3950: (in SLICE(d0_150, word16, 16) : word16)
   Class: Eq_3950
   DataType: word16
   OrigDataType: word16
 T_3951: (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3952: (in v17_143 : uint16)
   Class: Eq_3952
@@ -18755,8 +18359,8 @@ T_3960: (in SLICE(d0_134, word16, 16) : word16)
   DataType: word16
   OrigDataType: word16
 T_3961: (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3962: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3962
@@ -18775,16 +18379,16 @@ T_3965: (in __rol : ptr32)
   DataType: (ptr32 Eq_3424)
   OrigDataType: (ptr32 (fn T_3967 (T_3899, T_3966)))
 T_3966: (in 8<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_3967: (in __rol(d1_22, 8<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3968: (in 8<32> : uipr32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: uipr32
 T_3969: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3969
@@ -18803,12 +18407,12 @@ T_3972: (in __rol : ptr32)
   DataType: (ptr32 Eq_3424)
   OrigDataType: (ptr32 (fn T_3974 (T_3899, T_3973)))
 T_3973: (in 4<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_3974: (in __rol(d1_22, 4<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3975: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_3975
@@ -18827,8 +18431,8 @@ T_3978: (in (word16) d3_18 - 4<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3979: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3980: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3980
@@ -18847,12 +18451,12 @@ T_3983: (in __rol : ptr32)
   DataType: (ptr32 Eq_3424)
   OrigDataType: (ptr32 (fn T_3985 (T_3899, T_3984)))
 T_3984: (in 2<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_3985: (in __rol(d1_22, 2<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3986: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_3986
@@ -18871,8 +18475,8 @@ T_3989: (in (word16) d3_18 - 2<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3990: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3991: (in d0_71 : uint32)
   Class: Eq_3991
@@ -18895,12 +18499,12 @@ T_3995: (in SLICE(d0, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3996: (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_3997: (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_3998: (in SLICE(__swap(SEQ(v11_10, (word16) d0)), word16, 16) : word16)
   Class: Eq_3998
@@ -18927,8 +18531,8 @@ T_4003: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_4004 (T_3910)))
 T_4004: (in __swap(d3_18) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4005: (in SLICE(__swap(d3_18), word16, 16) : word16)
   Class: Eq_4002
@@ -18950,29 +18554,29 @@ T_4009: (in (uint16) (d0_71 /u SLICE(d1_22, uint16, 0)) : uint16)
   Class: Eq_4006
   DataType: uint16
   OrigDataType: uint16
-T_4010: (in d1_90 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4010: (in d1_90 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4011: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_4012 (T_3899)))
 T_4012: (in __swap(d1_22) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_4013: (in d3_102 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4013: (in d3_102 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_4014: (in SEQ(v53_82, v51_79) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
-T_4015: (in d0_108 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4015: (in d0_108 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4016: (in SLICE(d1_22, uint16, 0) : uint16)
   Class: Eq_4016
@@ -19011,12 +18615,12 @@ T_4024: (in SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4025: (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4026: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: up32
 T_4027: (in d0_108 >= 0<32> : bool)
   Class: Eq_4027
@@ -19027,12 +18631,12 @@ T_4028: (in __rol : ptr32)
   DataType: (ptr32 Eq_3424)
   OrigDataType: (ptr32 (fn T_4030 (T_3899, T_4029)))
 T_4029: (in 1<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_4030: (in __rol(d1_22, 1<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4031: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_4031
@@ -19051,8 +18655,8 @@ T_4034: (in (word16) d3_18 - 1<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4035: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_4036: (in __swap : ptr32)
   Class: Eq_986
@@ -19067,16 +18671,16 @@ T_4038: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_4039 (T_4013)))
 T_4039: (in __swap(d3_102) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4040: (in __rol(d0_108, __swap(d3_102)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4041: (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4042: (in SLICE(d3_102, word16, 0) : word16)
   Class: Eq_4042
@@ -19087,8 +18691,8 @@ T_4043: (in (uint16) SLICE(d3_102, word16, 0) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_4044: (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4045: (in 1<16> : word16)
   Class: Eq_4045
@@ -19099,36 +18703,36 @@ T_4046: (in v51_79 - 1<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4047: (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_4048: (in d0_108 + d1_90 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4049: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: up32
 T_4050: (in d0_108 >= 0<32> : bool)
   Class: Eq_4050
   DataType: bool
   OrigDataType: bool
-T_4051: (in d1 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4051: (in d1 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_4052: (in d1_171 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4052: (in d1_171 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_4053: (in d3_202 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4053: (in d3_202 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
 T_4054: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_4055: (in dwArg0C != 0<32> : bool)
   Class: Eq_4055
@@ -19159,8 +18763,8 @@ T_4061: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_4062: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_4063: (in dwArg10 != 0<32> : bool)
   Class: Eq_4063
@@ -19175,16 +18779,16 @@ T_4065: (in fn00002534 : ptr32)
   DataType: (ptr32 Eq_3410)
   OrigDataType: (ptr32 (fn T_4068 (T_1745, T_1746, T_1748, T_4066, T_4067)))
 T_4066: (in out d1_171 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_4067: (in out d2_354 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_4068: (in fn00002534(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4069: (in d4_32 : int32)
   Class: Eq_4069
@@ -19194,21 +18798,21 @@ T_4070: (in 24<i32> : int32)
   Class: Eq_4069
   DataType: int32
   OrigDataType: int32
-T_4071: (in d6_33 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4071: (in d6_33 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uip32
 T_4072: (in __rol : ptr32)
   Class: Eq_3424
   DataType: (ptr32 Eq_3424)
   OrigDataType: (ptr32 (fn T_4074 (T_1747, T_4073)))
 T_4073: (in 8<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_4074: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4075: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4075
@@ -19311,12 +18915,12 @@ T_4099: (in __rol : ptr32)
   DataType: (ptr32 Eq_3424)
   OrigDataType: (ptr32 (fn T_4101 (T_4071, T_4100)))
 T_4100: (in 8<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_4101: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4102: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4102
@@ -19339,12 +18943,12 @@ T_4106: (in __rol : ptr32)
   DataType: (ptr32 Eq_3424)
   OrigDataType: (ptr32 (fn T_4108 (T_4071, T_4107)))
 T_4107: (in 8<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_4108: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4109: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4109
@@ -19371,8 +18975,8 @@ T_4114: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_4115: (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uip32
 T_4116: (in d1_89 : ui32)
   Class: Eq_4116
@@ -19382,17 +18986,17 @@ T_4117: (in d2_90 : word32)
   Class: Eq_4117
   DataType: word32
   OrigDataType: word32
-T_4118: (in d0_88 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4118: (in d0_88 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4119: (in fn00002534 : ptr32)
   Class: Eq_3410
   DataType: (ptr32 Eq_3410)
   OrigDataType: (ptr32 (fn T_4129 (T_4120, T_4123, T_4126, T_4127, T_4128)))
 T_4120: (in dwArg04 >> d4_64 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4121: (in dwArg04 << d5_66 : word32)
   Class: Eq_4121
@@ -19403,8 +19007,8 @@ T_4122: (in dwArg08 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4123: (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_4124: (in dwArg0C << d5_66 : word32)
   Class: Eq_4124
@@ -19415,52 +19019,52 @@ T_4125: (in dwArg10 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4126: (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_4127: (in out d1_89 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_4128: (in out d2_90 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_4129: (in fn00002534(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_4130: (in d3_75 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4130: (in d3_75 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4131: (in dwArg10 << d5_66 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
-T_4132: (in d7_104 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4132: (in d7_104 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4133: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_4134 (T_4118)))
 T_4134: (in __swap(d0_88) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_4135: (in d6_106 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4135: (in d6_106 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4136: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_4137 (T_4130)))
 T_4137: (in __swap(d3_75) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4138: (in d3_105 : uint32)
   Class: Eq_4138
@@ -19474,9 +19078,9 @@ T_4140: (in d3_75 * (word16) d7_104 : word32)
   Class: Eq_4138
   DataType: uint32
   OrigDataType: uint32
-T_4141: (in d2_110 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4141: (in d2_110 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4142: (in __swap : ptr32)
   Class: Eq_986
@@ -19487,12 +19091,12 @@ T_4143: (in SLICE(d3_75, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4144: (in d0_88 * (word16) d3_75 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4145: (in __swap(d0_88 * (word16) d3_75) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4146: (in v36_111 : cup16)
   Class: Eq_4146
@@ -19542,21 +19146,21 @@ T_4157: (in SLICE(SEQ(v37_112, v36_111) + d4_107, word16, 0) : word16)
   Class: Eq_4154
   DataType: cup16
   OrigDataType: word16
-T_4158: (in d2_127 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4158: (in d2_127 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_4159: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_4161 (T_4160)))
 T_4160: (in SEQ(v37_112, v40_119) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_4161: (in __swap(SEQ(v37_112, v40_119)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4162: (in d7_108 : uint32)
   Class: Eq_4162
@@ -19595,12 +19199,12 @@ T_4170: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4171: (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_4172: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4173: (in __swap : ptr32)
   Class: Eq_986
@@ -19615,12 +19219,12 @@ T_4175: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4176: (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_4177: (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4178: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
   Class: Eq_4178
@@ -19695,8 +19299,8 @@ T_4195: (in dwArg0C - dwArg04 < 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_4196: (in dwArg08 - dwArg10 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4197: (in dwArg10 - dwArg08 : word32)
   Class: Eq_4197
@@ -19710,33 +19314,33 @@ T_4199: (in dwArg10 - dwArg08 > 0<32> : bool)
   Class: Eq_4199
   DataType: bool
   OrigDataType: bool
-T_4200: (in d1_211 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4200: (in d1_211 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_4201: (in d2_212 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4201: (in d2_212 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4202: (in fn00002534 : ptr32)
   Class: Eq_3410
   DataType: (ptr32 Eq_3410)
   OrigDataType: (ptr32 (fn T_4206 (T_4203, T_1745, T_4053, T_4204, T_4205)))
 T_4203: (in 0<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_4204: (in out d1_211 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_4205: (in out d2_212 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_4206: (in fn00002534(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4207: (in d2_355 : word32)
   Class: Eq_4207
@@ -19747,16 +19351,16 @@ T_4208: (in fn00002534 : ptr32)
   DataType: (ptr32 Eq_3410)
   OrigDataType: (ptr32 (fn T_4211 (T_4200, T_1746, T_4201, T_4209, T_4210)))
 T_4209: (in out d1_171 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: (union (uint32 u0) (ptr32 u1))
 T_4210: (in out d2_355 : ptr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_4211: (in fn00002534(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4212: (in 1<i32> : int32)
   Class: Eq_4212
@@ -19799,8 +19403,8 @@ T_4221: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_4222: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
 T_4223: (in d3_135 - d3_75 : word32)
   Class: Eq_4167
@@ -19819,8 +19423,8 @@ T_4226: (in d3_135 < 0<32> : bool)
   DataType: Eq_4226
   OrigDataType: (union (bool u0) (word32 u1))
 T_4227: (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4228: (in 0<32> : word32)
   Class: Eq_4189
@@ -19871,8 +19475,8 @@ T_4239: (in d6_157 >> d5_66 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4240: (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_4241: (in d6_85 - d3_135 : word32)
   Class: Eq_4241
@@ -20046,10 +19650,10 @@ T_4283: (in d1 : Eq_664)
   Class: Eq_664
   DataType: Eq_664
   OrigDataType: uint32
-T_4284: (in a1 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: Eq_7945
+T_4284: (in a1 : (ptr32 (ptr32 byte)))
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: (ptr32 (struct (0 T_4706 t0000)))
 T_4285: (in dwArg04 : Eq_664)
   Class: Eq_664
   DataType: Eq_664
@@ -20058,9 +19662,9 @@ T_4286: (in dwArg08 : (ptr32 Eq_676))
   Class: Eq_676
   DataType: (ptr32 Eq_676)
   OrigDataType: (ptr32 (struct (0 T_4342 t0000)))
-T_4287: (in dwArg0C : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4287: (in dwArg0C : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4288: (in 00003FCC : ptr32)
   Class: Eq_4288
@@ -20079,8 +19683,8 @@ T_4291: (in 8<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4292: (in fp + 8<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_4293: (in fn00002C04(d0, d1, a1, *(union Eq_664 *) 0x3FCC<u32>, dwArg04, fp + 8<i32>) : word32)
   Class: Eq_664
@@ -20090,9 +19694,9 @@ T_4294: (in d0 : Eq_664)
   Class: Eq_664
   DataType: Eq_664
   OrigDataType: word32
-T_4295: (in bArg07 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_4295: (in bArg07 : byte)
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_4296: (in dwArg08 : Eq_664)
   Class: Eq_664
@@ -20104,7 +19708,7 @@ T_4297: (in d0_10 : Eq_664)
   OrigDataType: up32
 T_4298: (in 0<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4299: (in dwArg08 == 0<32> : bool)
   Class: Eq_4299
@@ -20223,13 +19827,13 @@ T_4327: (in Mem5[dwArg08 + 4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_4328: (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_664
+  Class: Eq_4295
   DataType: Eq_664
   OrigDataType: byte
-T_4329: (in a7_1330 : Eq_4329)
+T_4329: (in a7_1330 : (ptr32 Eq_4329))
   Class: Eq_4329
-  DataType: Eq_4329
-  OrigDataType: word32
+  DataType: (ptr32 Eq_4329)
+  OrigDataType: (ptr32 (struct 0004 (2C int32 dw002C) (30 (union ((ptr32 (ptr32 Eq_4336)) u0) (T_6699 u1) (T_6765 u2) (T_7285 u3)) u0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 (union ((ptr32 (ptr32 Eq_4336)) u0) (T_6632 u1) (T_6699 u2) (T_6703 u3) (T_6761 u4)) u0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084)))
 T_4330: (in fp : ptr32)
   Class: Eq_4330
   DataType: ptr32
@@ -20240,12 +19844,12 @@ T_4331: (in -120<i32> : int32)
   OrigDataType: int32
 T_4332: (in fp + -120<i32> : word32)
   Class: Eq_4329
-  DataType: Eq_4329
+  DataType: (ptr32 Eq_4329)
   OrigDataType: ptr32
-T_4333: (in d2_1090 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: Eq_4329
+T_4333: (in d2_1090 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: (struct "Eq_4329" 0004 (2C int32 dw002C) (30 Eq_8441 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8442 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_4334: (in a4_274 : (ptr32 Eq_676))
   Class: Eq_676
   DataType: (ptr32 Eq_676)
@@ -20253,7 +19857,7 @@ T_4334: (in a4_274 : (ptr32 Eq_676))
 T_4335: (in a2_1014 : Eq_664)
   Class: Eq_664
   DataType: Eq_664
-  OrigDataType: Eq_7841
+  OrigDataType: (ptr32 Eq_664)
 T_4336: (in d4_132 : Eq_4336)
   Class: Eq_4336
   DataType: Eq_4336
@@ -20265,10 +19869,10 @@ T_4337: (in 0<i32> : int32)
 T_4338: (in d5_1044 : Eq_664)
   Class: Eq_664
   DataType: Eq_664
-  OrigDataType: Eq_4329
+  OrigDataType: (struct "Eq_4329" 0004 (2C int32 dw002C) (30 Eq_8441 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8442 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_4339: (in 0<i32> : int32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_4340: (in 0<32> : word32)
   Class: Eq_4340
@@ -20293,10 +19897,10 @@ T_4344: (in dwArg08->b0000 == 0<8> : bool)
 T_4345: (in d0_3698 : Eq_664)
   Class: Eq_664
   DataType: Eq_664
-  OrigDataType: uint8
+  OrigDataType: byte
 T_4346: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4347: (in d5_1044 != 0xFFFFFFFF<32> : bool)
   Class: Eq_4347
@@ -20420,7 +20024,7 @@ T_4376: (in a7_1330 + 72<i32> : word32)
   OrigDataType: ptr32
 T_4377: (in Mem277[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4374
-  DataType: Eq_4329
+  DataType: byte
   OrigDataType: byte
 T_4378: (in 0<8> : byte)
   Class: Eq_4378
@@ -20436,7 +20040,7 @@ T_4380: (in a7_1330 + 73<i32> : word32)
   OrigDataType: ptr32
 T_4381: (in Mem278[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_4378
-  DataType: Eq_4329
+  DataType: byte
   OrigDataType: byte
 T_4382: (in a3_279 : (ptr32 byte))
   Class: Eq_4382
@@ -20494,13 +20098,13 @@ T_4395: (in (uint32) (uint8) Mem278[0x0000288D<p32> + (uint32) ((uint8) Mem278[a
   Class: Eq_4385
   DataType: uint32
   OrigDataType: uint32
-T_4396: (in d6_1133 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: uint8
+T_4396: (in d6_1133 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: (ptr32 Eq_1365)
 T_4397: (in -1<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_4398: (in 4<32> : word32)
   Class: Eq_4398
@@ -20587,8 +20191,8 @@ T_4418: (in (uint32) (uint8) Mem278[0x0000288D<p32> + (uint32) ((uint8) Mem278[a
   DataType: uint32
   OrigDataType: uint32
 T_4419: (in 0<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_4420: (in 4<32> : word32)
   Class: Eq_4420
@@ -20610,9 +20214,9 @@ T_4424: (in (d0_305 & 4<32>) == 0<32> : bool)
   Class: Eq_4424
   DataType: bool
   OrigDataType: bool
-T_4425: (in a7_313 : (ptr32 Eq_664))
+T_4425: (in a7_313 : (ptr32 Eq_793))
   Class: Eq_4425
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_793 t0000)))
 T_4426: (in 4<i32> : int32)
   Class: Eq_4426
@@ -20620,7 +20224,7 @@ T_4426: (in 4<i32> : int32)
   OrigDataType: int32
 T_4427: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4425
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: ptr32
 T_4428: (in 0<32> : word32)
   Class: Eq_4428
@@ -20631,8 +20235,8 @@ T_4429: (in a7_313 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4430: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4431: (in d1_322 : uint32)
   Class: Eq_4431
@@ -20643,12 +20247,12 @@ T_4432: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_4434 (T_4433)))
 T_4433: (in 10<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_4434: (in __swap(10<i32>) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4435: (in SLICE(d6_1133, word16, 0) : word16)
   Class: Eq_4435
@@ -20687,8 +20291,8 @@ T_4443: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_4444 (T_4396)))
 T_4444: (in __swap(d6_1133) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4445: (in 0xA<16> : word16)
   Class: Eq_4445
@@ -20707,12 +20311,12 @@ T_4448: (in SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4449: (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_4450: (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4451: (in SLICE(__swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_4451
@@ -20815,8 +20419,8 @@ T_4475: (in a7_313 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4476: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_4477: (in 0x30<32> : word32)
   Class: Eq_4477
@@ -20831,8 +20435,8 @@ T_4479: (in d1_340 - 0x30<32> : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4480: (in d1_340 - 0x30<32> + d0_331 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_4481: (in 4<32> : word32)
   Class: Eq_4481
@@ -21034,7 +20638,7 @@ T_4530: (in 0x6A<8> : byte)
   Class: Eq_4529
   DataType: byte
   OrigDataType: byte
-T_4531: (in *((word32) a7_1330 + 72<i32>) != 0x6A<8> : bool)
+T_4531: (in a7_1330[18<i32>] != 0x6A<8> : bool)
   Class: Eq_4531
   DataType: bool
   OrigDataType: bool
@@ -21084,7 +20688,7 @@ T_4542: (in *a3_279 == 0x68<8> : bool)
   OrigDataType: bool
 T_4543: (in 0<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4544: (in false : bool)
   Class: Eq_4544
@@ -21124,7 +20728,7 @@ T_4552: (in *a3_279 != 0x68<8> : bool)
   OrigDataType: bool
 T_4553: (in 2<i32> : int32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_4554: (in 0<32> : word32)
   Class: Eq_4554
@@ -21280,7 +20884,7 @@ T_4591: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4592: (in Mem463[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4589
-  DataType: Eq_4329
+  DataType: byte
   OrigDataType: byte
 T_4593: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_4593
@@ -21296,7 +20900,7 @@ T_4595: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4596: (in Mem469[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_4593
-  DataType: Eq_4329
+  DataType: byte
   OrigDataType: byte
 T_4597: (in SLICE(d1, word24, 8) : word24)
   Class: Eq_4597
@@ -21340,7 +20944,7 @@ T_4606: (in *a3_279 != 0x6C<8> : bool)
   OrigDataType: bool
 T_4607: (in 1<i32> : int32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_4608: (in 72<i32> : int32)
   Class: Eq_4608
@@ -21358,7 +20962,7 @@ T_4611: (in 0x74<8> : byte)
   Class: Eq_4610
   DataType: byte
   OrigDataType: byte
-T_4612: (in *((word32) a7_1330 + 72<i32>) != 0x74<8> : bool)
+T_4612: (in a7_1330[18<i32>] != 0x74<8> : bool)
   Class: Eq_4612
   DataType: bool
   OrigDataType: bool
@@ -21376,7 +20980,7 @@ T_4615: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4616: (in Mem477[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4613
-  DataType: Eq_4329
+  DataType: byte
   OrigDataType: byte
 T_4617: (in 72<i32> : int32)
   Class: Eq_4617
@@ -21394,7 +20998,7 @@ T_4620: (in 0x7A<8> : byte)
   Class: Eq_4619
   DataType: byte
   OrigDataType: byte
-T_4621: (in *((word32) a7_1330 + 72<i32>) != 0x7A<8> : bool)
+T_4621: (in a7_1330[18<i32>] != 0x7A<8> : bool)
   Class: Eq_4621
   DataType: bool
   OrigDataType: bool
@@ -21412,7 +21016,7 @@ T_4624: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4625: (in Mem485[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4622
-  DataType: Eq_4329
+  DataType: byte
   OrigDataType: byte
 T_4626: (in v83_500 : byte)
   Class: Eq_4626
@@ -21476,7 +21080,7 @@ T_4640: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4641: (in Mem493[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4638
-  DataType: Eq_4329
+  DataType: byte
   OrigDataType: byte
 T_4642: (in v147_608 : word24)
   Class: Eq_4642
@@ -21731,8 +21335,8 @@ T_4704: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4705: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_4706: (in a0_551 : (ptr32 byte))
   Class: Eq_4706
@@ -21792,8 +21396,8 @@ T_4719: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_4720: (in Mem558[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: word32
 T_4721: (in v96_562 : byte)
   Class: Eq_4721
   DataType: byte
@@ -22187,8 +21791,8 @@ T_4818: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4819: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_4820: (in a0_198 : (ptr32 byte))
   Class: Eq_4706
@@ -22248,8 +21852,8 @@ T_4833: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_4834: (in Mem205[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_4835: (in v109_209 : byte)
   Class: Eq_4721
   DataType: byte
@@ -22372,7 +21976,7 @@ T_4864: (in 1<i32> : int32)
   OrigDataType: int32
 T_4865: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4866: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_4866
@@ -22448,7 +22052,7 @@ T_4883: (in 1<i32> : int32)
   OrigDataType: int32
 T_4884: (in a7_248 - 1<i32> : word32)
   Class: Eq_4884
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4887 t0000)))
 T_4885: (in 0<32> : word32)
   Class: Eq_4885
@@ -22459,8 +22063,8 @@ T_4886: (in a7_248 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4887: (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_4888: (in 0<32> : word32)
   Class: Eq_4888
@@ -22533,7 +22137,7 @@ T_4904: (in Mem81[a7_79 + 0<32>:word32] : word32)
 T_4905: (in out d1 : ptr32)
   Class: Eq_2679
   DataType: Eq_2679
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_4906: (in out a1 : ptr32)
   Class: Eq_4695
   DataType: (ptr32 word32)
@@ -22563,8 +22167,8 @@ T_4912: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4913: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_4914: (in a0_98 : (ptr32 byte))
   Class: Eq_4706
@@ -22624,8 +22228,8 @@ T_4927: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_4928: (in Mem105[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_4929: (in v130_109 : byte)
   Class: Eq_4721
   DataType: byte
@@ -22778,7 +22382,7 @@ T_4966: (in Mem127[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_4966
   DataType: int32
   OrigDataType: int32
-T_4967: (in d0 - *((word32) a7_1330 + 44<i32>) : word32)
+T_4967: (in d0 - a7_1330[11<i32>] : word32)
   Class: Eq_4967
   DataType: int32
   OrigDataType: int32
@@ -22786,7 +22390,7 @@ T_4968: (in 0<32> : word32)
   Class: Eq_4967
   DataType: int32
   OrigDataType: word32
-T_4969: (in d0 - *((word32) a7_1330 + 44<i32>) == 0<32> : bool)
+T_4969: (in d0 - a7_1330[11<i32>] == 0<32> : bool)
   Class: Eq_4969
   DataType: bool
   OrigDataType: bool
@@ -22812,7 +22416,7 @@ T_4974: (in a4_274->b0000 != 0<8> : bool)
   OrigDataType: bool
 T_4975: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4976: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_4976
@@ -22884,7 +22488,7 @@ T_4992: (in 1<i32> : int32)
   OrigDataType: int32
 T_4993: (in a7_148 - 1<i32> : word32)
   Class: Eq_4993
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4996 t0000)))
 T_4994: (in 0<32> : word32)
   Class: Eq_4994
@@ -22895,8 +22499,8 @@ T_4995: (in a7_148 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4996: (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_4997: (in 0<32> : word32)
   Class: Eq_4997
@@ -23036,8 +22640,8 @@ T_5030: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5031: (in Mem761[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_5028
-  DataType: Eq_4329
-  OrigDataType: byte
+  DataType: Eq_5028
+  OrigDataType: int32
 T_5032: (in 0<32> : word32)
   Class: Eq_5032
   DataType: word32
@@ -23079,8 +22683,8 @@ T_5041: (in v83_500 == 0x63<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_5042: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: word32
 T_5043: (in d6_1133 != 0xFFFFFFFF<32> : bool)
   Class: Eq_5043
@@ -23118,7 +22722,7 @@ T_5051: (in 0<8> : byte)
   Class: Eq_5050
   DataType: byte
   OrigDataType: byte
-T_5052: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5052: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5052
   DataType: bool
   OrigDataType: bool
@@ -23158,7 +22762,7 @@ T_5061: (in 0<8> : byte)
   Class: Eq_5060
   DataType: byte
   OrigDataType: byte
-T_5062: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5062: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5062
   DataType: bool
   OrigDataType: bool
@@ -23176,7 +22780,7 @@ T_5065: (in a7_1330 + 48<i32> : word32)
   OrigDataType: ptr32
 T_5066: (in Mem1948[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_5063
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
 T_5067: (in 0<32> : word32)
   Class: Eq_5067
@@ -23192,7 +22796,7 @@ T_5069: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5070: (in Mem1949[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_5067
-  DataType: Eq_4329
+  DataType: int32
   OrigDataType: int32
 T_5071: (in 0<32> : word32)
   Class: Eq_5071
@@ -23208,7 +22812,7 @@ T_5073: (in a7_1330 + 110<i32> : word32)
   OrigDataType: ptr32
 T_5074: (in Mem1950[a7_1330 + 110<i32>:word32] : word32)
   Class: Eq_5071
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
 T_5075: (in 0<8> : byte)
   Class: Eq_4626
@@ -23265,7 +22869,7 @@ T_5087: (in Mem642[a7_640 + 0<32>:word32] : word32)
 T_5088: (in out d1 : ptr32)
   Class: Eq_2679
   DataType: Eq_2679
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_5089: (in out a1 : ptr32)
   Class: Eq_4695
   DataType: (ptr32 word32)
@@ -23295,8 +22899,8 @@ T_5095: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5096: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5097: (in a0_659 : (ptr32 byte))
   Class: Eq_4706
@@ -23356,8 +22960,8 @@ T_5110: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_5111: (in Mem666[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_5112: (in v163_670 : byte)
   Class: Eq_4721
   DataType: byte
@@ -23482,7 +23086,7 @@ T_5142: (in 0x25<32> : word32)
   Class: Eq_5141
   DataType: int32
   OrigDataType: word32
-T_5143: (in *((word32) a7_1330 + 44<i32>) == 0x25<32> : bool)
+T_5143: (in a7_1330[11<i32>] == 0x25<32> : bool)
   Class: Eq_5143
   DataType: bool
   OrigDataType: bool
@@ -23504,7 +23108,7 @@ T_5147: (in a3_1955 - 1<i32> : word32)
   OrigDataType: ptr32
 T_5148: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5149: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5149
@@ -23580,7 +23184,7 @@ T_5166: (in 1<i32> : int32)
   OrigDataType: int32
 T_5167: (in a7_735 - 1<i32> : word32)
   Class: Eq_5167
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5170 t0000)))
 T_5168: (in 0<32> : word32)
   Class: Eq_5168
@@ -23591,8 +23195,8 @@ T_5169: (in a7_735 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5170: (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_5171: (in 0<32> : word32)
   Class: Eq_5171
@@ -23620,7 +23224,7 @@ T_5176: (in d3_130 == 0<32> : bool)
   OrigDataType: bool
 T_5177: (in 0x2D<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5178: (in d5_1044 != 0x2D<32> : bool)
   Class: Eq_5178
@@ -23640,7 +23244,7 @@ T_5181: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5182: (in Mem1962[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_5179
-  DataType: Eq_4329
+  DataType: byte
   OrigDataType: byte
 T_5183: (in 120<i32> : int32)
   Class: Eq_4486
@@ -23679,8 +23283,8 @@ T_5191: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5192: (in d0 + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
 T_5193: (in 0<32> : word32)
   Class: Eq_5193
@@ -23696,7 +23300,7 @@ T_5195: (in Mem629[d0 + 0<32>:word32] : word32)
   OrigDataType: word32
 T_5196: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5197: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5197
@@ -23728,7 +23332,7 @@ T_5203: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5204: (in Mem1716[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_5202
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
 T_5205: (in 1<i32> : int32)
   Class: Eq_4348
@@ -23750,7 +23354,7 @@ T_5209: (in 1<8> : byte)
   Class: Eq_5208
   DataType: byte
   OrigDataType: byte
-T_5210: (in *((word32) a7_1330 + 72<i32>) != 1<8> : bool)
+T_5210: (in a7_1330[18<i32>] != 1<8> : bool)
   Class: Eq_5210
   DataType: bool
   OrigDataType: bool
@@ -23770,13 +23374,13 @@ T_5214: (in 0x6C<8> : byte)
   Class: Eq_5213
   DataType: byte
   OrigDataType: byte
-T_5215: (in *((word32) a7_1330 + 72<i32>) != 0x6C<8> : bool)
+T_5215: (in a7_1330[18<i32>] != 0x6C<8> : bool)
   Class: Eq_5215
   DataType: bool
   OrigDataType: bool
 T_5216: (in 3<32> : word32)
   Class: Eq_5216
-  DataType: (ptr32 Eq_8453)
+  DataType: (ptr32 Eq_8445)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5217: (in d2_1090 + 3<32> : word32)
   Class: Eq_5217
@@ -23847,12 +23451,12 @@ T_5233: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5234: (in d0 + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_5235: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5236: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5236
@@ -24094,17 +23698,17 @@ T_5295: (in 0x68<8> : byte)
   Class: Eq_5294
   DataType: byte
   OrigDataType: byte
-T_5296: (in *((word32) a7_1330 + 72<i32>) != 0x68<8> : bool)
+T_5296: (in a7_1330[18<i32>] != 0x68<8> : bool)
   Class: Eq_5296
   DataType: bool
   OrigDataType: bool
 T_5297: (in 3<32> : word32)
   Class: Eq_5297
-  DataType: (ptr32 Eq_8454)
+  DataType: (ptr32 Eq_8446)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5298: (in d2_1090 + 3<32> : word32)
   Class: Eq_5298
-  DataType: (ptr32 Eq_8455)
+  DataType: (ptr32 Eq_8447)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5299: (in 2<32> : word32)
   Class: Eq_5299
@@ -24151,8 +23755,8 @@ T_5309: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5310: (in d0 + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_5311: (in a7_1807 : (ptr32 Eq_664))
   Class: Eq_5311
@@ -24219,8 +23823,8 @@ T_5326: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5327: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5328: (in a0_1825 : (ptr32 byte))
   Class: Eq_4706
@@ -24280,8 +23884,8 @@ T_5341: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_5342: (in Mem1832[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_5343: (in v201_1836 : byte)
   Class: Eq_4721
   DataType: byte
@@ -24344,7 +23948,7 @@ T_5357: (in d4_132 + 1<32> : word32)
   OrigDataType: int32
 T_5358: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5359: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5359
@@ -24366,17 +23970,17 @@ T_5363: (in 2<8> : byte)
   Class: Eq_5362
   DataType: byte
   OrigDataType: byte
-T_5364: (in *((word32) a7_1330 + 72<i32>) != 2<8> : bool)
+T_5364: (in a7_1330[18<i32>] != 2<8> : bool)
   Class: Eq_5364
   DataType: bool
   OrigDataType: bool
 T_5365: (in 3<32> : word32)
   Class: Eq_5365
-  DataType: (ptr32 Eq_8456)
+  DataType: (ptr32 Eq_8448)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5366: (in d2_1090 + 3<32> : word32)
   Class: Eq_5366
-  DataType: (ptr32 Eq_8457)
+  DataType: (ptr32 Eq_8449)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5367: (in 2<32> : word32)
   Class: Eq_5367
@@ -24427,8 +24031,8 @@ T_5378: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5379: (in d0 + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_5380: (in 73<i32> : int32)
   Class: Eq_5380
@@ -24440,7 +24044,7 @@ T_5381: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5382: (in Mem1889[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_5256
-  DataType: Eq_4329
+  DataType: byte
   OrigDataType: byte
 T_5383: (in d0_1871 : uint32)
   Class: Eq_5383
@@ -24528,11 +24132,11 @@ T_5403: (in v190_1777 != 0<8> : bool)
   OrigDataType: bool
 T_5404: (in 3<32> : word32)
   Class: Eq_5404
-  DataType: (ptr32 Eq_8458)
+  DataType: (ptr32 Eq_8450)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5405: (in d2_1090 + 3<32> : word32)
   Class: Eq_5405
-  DataType: (ptr32 Eq_8459)
+  DataType: (ptr32 Eq_8451)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5406: (in 2<32> : word32)
   Class: Eq_5406
@@ -24579,16 +24183,16 @@ T_5416: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5417: (in d0 + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_5418: (in 3<32> : word32)
   Class: Eq_5418
-  DataType: (ptr32 Eq_8460)
+  DataType: (ptr32 Eq_8452)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5419: (in d2_1090 + 3<32> : word32)
   Class: Eq_5419
-  DataType: (ptr32 Eq_8461)
+  DataType: (ptr32 Eq_8453)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5420: (in 2<32> : word32)
   Class: Eq_5420
@@ -24639,8 +24243,8 @@ T_5431: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5432: (in d0 + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_5433: (in 1<32> : word32)
   Class: Eq_5433
@@ -24674,7 +24278,7 @@ T_5440: (in 0<8> : byte)
   Class: Eq_5439
   DataType: byte
   OrigDataType: byte
-T_5441: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5441: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5441
   DataType: bool
   OrigDataType: bool
@@ -24732,7 +24336,7 @@ T_5454: (in 1<i32> : int32)
   OrigDataType: int32
 T_5455: (in a7_1897 - 1<i32> : word32)
   Class: Eq_5455
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5458 t0000)))
 T_5456: (in 0<32> : word32)
   Class: Eq_5456
@@ -24743,8 +24347,8 @@ T_5457: (in a7_1897 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5458: (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_5459: (in 0<32> : word32)
   Class: Eq_5459
@@ -24764,7 +24368,7 @@ T_5462: (in fn00002BD4(*(a7_1897 - 1<i32>), *a7_1897) : word32)
   OrigDataType: word32
 T_5463: (in 0x2B<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5464: (in d5_1044 != 0x2B<32> : bool)
   Class: Eq_5464
@@ -24816,8 +24420,8 @@ T_5475: (in a7_1330 + 110<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5476: (in Mem1994[a7_1330 + 110<i32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_4329
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_5477: (in a0_1999 : (ptr32 ui32))
   Class: Eq_5477
   DataType: (ptr32 ui32)
@@ -24965,7 +24569,7 @@ T_5512: (in Mem2009[a7_2007 + 0<32>:word32] : word32)
 T_5513: (in out d1 : ptr32)
   Class: Eq_2679
   DataType: Eq_2679
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_5514: (in out a1 : ptr32)
   Class: Eq_4695
   DataType: (ptr32 word32)
@@ -24995,8 +24599,8 @@ T_5520: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5521: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5522: (in a0_2026 : (ptr32 byte))
   Class: Eq_4706
@@ -25056,8 +24660,8 @@ T_5535: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_5536: (in Mem2033[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_5537: (in v231_2037 : byte)
   Class: Eq_4721
   DataType: byte
@@ -25216,7 +24820,7 @@ T_5575: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5576: (in Mem1946[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_5574
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
 T_5577: (in d4_2510 : Eq_4336)
   Class: Eq_4336
@@ -25240,7 +24844,7 @@ T_5581: (in (byte) d7 != 0x78<8> : bool)
   OrigDataType: bool
 T_5582: (in 0x30<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5583: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_5583
@@ -25473,7 +25077,7 @@ T_5639: (in Mem2150[a7_2148 + 0<32>:word32] : word32)
 T_5640: (in out d1 : ptr32)
   Class: Eq_2679
   DataType: Eq_2679
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_5641: (in out a1 : ptr32)
   Class: Eq_4695
   DataType: (ptr32 word32)
@@ -25503,8 +25107,8 @@ T_5647: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5648: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5649: (in a0_2167 : (ptr32 byte))
   Class: Eq_4706
@@ -25564,8 +25168,8 @@ T_5662: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_5663: (in Mem2174[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_5664: (in v249_2178 : byte)
   Class: Eq_4721
   DataType: byte
@@ -25684,12 +25288,12 @@ T_5692: (in 55<i32> : int32)
   OrigDataType: int32
 T_5693: (in a7_1330 + 55<i32> : word32)
   Class: Eq_5693
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_5694: (in Mem2199[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_5694
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_5695: (in SEQ(SLICE(d0_2155, word24, 8), Mem2199[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_5690
   DataType: ui32
@@ -25782,17 +25386,17 @@ T_5717: (in 0<8> : byte)
   Class: Eq_5716
   DataType: byte
   OrigDataType: byte
-T_5718: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5718: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5718
   DataType: bool
   OrigDataType: bool
 T_5719: (in 1<i32> : int32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: int32
 T_5720: (in 0x78<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5721: (in d0 != 0x78<32> : bool)
   Class: Eq_5721
@@ -25832,11 +25436,11 @@ T_5729: (in 0<32> : word32)
   OrigDataType: word32
 T_5730: (in 3<32> : word32)
   Class: Eq_5730
-  DataType: (ptr32 Eq_8462)
+  DataType: (ptr32 Eq_8454)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5731: (in d2_1090 + 3<32> : word32)
   Class: Eq_5731
-  DataType: (ptr32 Eq_8463)
+  DataType: (ptr32 Eq_8455)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5732: (in 2<32> : word32)
   Class: Eq_5732
@@ -25859,8 +25463,8 @@ T_5736: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5737: (in d0 + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ptr32
 T_5738: (in 0<32> : word32)
   Class: Eq_5738
@@ -25972,8 +25576,8 @@ T_5764: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5765: (in Mem1393[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_5713
-  DataType: Eq_4329
-  OrigDataType: (ptr32 Eq_4336)
+  DataType: (ptr32 Eq_4336)
+  OrigDataType: int32
 T_5766: (in 0<32> : word32)
   Class: Eq_5766
   DataType: word32
@@ -26161,7 +25765,7 @@ T_5811: (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 T_5812: (in out d1 : ptr32)
   Class: Eq_2679
   DataType: Eq_2679
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_5813: (in out a1 : ptr32)
   Class: Eq_4695
   DataType: (ptr32 word32)
@@ -26191,8 +25795,8 @@ T_5819: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5820: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5821: (in a0_2265 : (ptr32 byte))
   Class: Eq_4706
@@ -26252,8 +25856,8 @@ T_5834: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_5835: (in Mem2272[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_5836: (in v271_2276 : byte)
   Class: Eq_4721
   DataType: byte
@@ -26501,7 +26105,7 @@ T_5896: (in Mem1404[a7_1400 + 0<32>:word32] : word32)
 T_5897: (in out d1 : ptr32)
   Class: Eq_2679
   DataType: Eq_2679
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_5898: (in out a1_5326 : ptr32)
   Class: Eq_4695
   DataType: (ptr32 word32)
@@ -26711,8 +26315,8 @@ T_5949: (in a7_1330 + 44<i32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_5950: (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: int32
 T_5951: (in 52<i32> : int32)
   Class: Eq_5951
@@ -26766,7 +26370,7 @@ T_5963: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_5962
   DataType: word32
   OrigDataType: word32
-T_5964: (in *((word32) a7_1330 + 52<i32>) == 0xFFFFFFFF<32> : bool)
+T_5964: (in a7_1330[13<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_5964
   DataType: bool
   OrigDataType: bool
@@ -26786,7 +26390,7 @@ T_5968: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_5967
   DataType: word32
   OrigDataType: word32
-T_5969: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_5969: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_5969
   DataType: bool
   OrigDataType: bool
@@ -26816,7 +26420,7 @@ T_5975: (in 120<i32> : int32)
   OrigDataType: int32
 T_5976: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5977: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5977
@@ -26831,9 +26435,9 @@ T_5979: (in a7_1330 + 44<i32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_5980: (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_4329
-  OrigDataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: int32
 T_5981: (in d6_1133 - d3_1462 : word32)
   Class: Eq_5981
   DataType: Eq_5981
@@ -27072,7 +26676,7 @@ T_6039: (in 1<i32> : int32)
   OrigDataType: int32
 T_6040: (in a7_2334 - 1<i32> : word32)
   Class: Eq_6040
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6043 t0000)))
 T_6041: (in 0<32> : word32)
   Class: Eq_6041
@@ -27083,8 +26687,8 @@ T_6042: (in a7_2334 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6043: (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_6044: (in 0<32> : word32)
   Class: Eq_6044
@@ -27171,8 +26775,8 @@ T_6064: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_6065: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6066: (in a0_1530 : (ptr32 byte))
   Class: Eq_4706
@@ -27232,8 +26836,8 @@ T_6079: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_6080: (in Mem1537[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_6081: (in v314_1541 : byte)
   Class: Eq_4721
   DataType: byte
@@ -27296,7 +26900,7 @@ T_6095: (in d4_1466 + 1<32> : word32)
   OrigDataType: int32
 T_6096: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6097: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6097
@@ -27312,7 +26916,7 @@ T_6099: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_6100: (in Mem1577[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_5984
-  DataType: Eq_4329
+  DataType: byte
   OrigDataType: byte
 T_6101: (in d6_1133 - d3_1462 : word32)
   Class: Eq_6101
@@ -27350,7 +26954,7 @@ T_6109: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6108
   DataType: word32
   OrigDataType: word32
-T_6110: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_6110: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6110
   DataType: bool
   OrigDataType: bool
@@ -27386,7 +26990,7 @@ T_6118: (in 0<8> : byte)
   Class: Eq_6117
   DataType: byte
   OrigDataType: byte
-T_6119: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_6119: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_6119
   DataType: bool
   OrigDataType: bool
@@ -27444,7 +27048,7 @@ T_6132: (in 1<i32> : int32)
   OrigDataType: int32
 T_6133: (in a7_1585 - 1<i32> : word32)
   Class: Eq_6133
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6136 t0000)))
 T_6134: (in 0<32> : word32)
   Class: Eq_6134
@@ -27455,8 +27059,8 @@ T_6135: (in a7_1585 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6136: (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_6137: (in 0<32> : word32)
   Class: Eq_6137
@@ -27540,7 +27144,7 @@ T_6156: (in 1<i32> : int32)
   OrigDataType: int32
 T_6157: (in a7_2368 - 1<i32> : word32)
   Class: Eq_6157
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6160 t0000)))
 T_6158: (in 0<32> : word32)
   Class: Eq_6158
@@ -27551,8 +27155,8 @@ T_6159: (in a7_2368 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6160: (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_6161: (in 0<32> : word32)
   Class: Eq_6161
@@ -27604,7 +27208,7 @@ T_6172: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6173: (in Mem1625[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_6171
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
 T_6174: (in d0_2124 : uint32)
   Class: Eq_6174
@@ -27704,7 +27308,7 @@ T_6197: (in (byte) d7 == 0x78<8> : bool)
   OrigDataType: bool
 T_6198: (in 0x30<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6199: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_6199
@@ -27873,7 +27477,7 @@ T_6239: (in Mem2445[a7_2443 + 0<32>:word32] : word32)
 T_6240: (in out d1 : ptr32)
   Class: Eq_2679
   DataType: Eq_2679
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6241: (in out a1 : ptr32)
   Class: Eq_4695
   DataType: (ptr32 word32)
@@ -27903,8 +27507,8 @@ T_6247: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_6248: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6249: (in a0_2462 : (ptr32 byte))
   Class: Eq_4706
@@ -27964,8 +27568,8 @@ T_6262: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_6263: (in Mem2469[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_6264: (in v351_2473 : byte)
   Class: Eq_4721
   DataType: byte
@@ -28084,12 +27688,12 @@ T_6292: (in 55<i32> : int32)
   OrigDataType: int32
 T_6293: (in a7_1330 + 55<i32> : word32)
   Class: Eq_6293
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_6294: (in Mem2506[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_6294
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_6295: (in SEQ(SLICE(d0_2450, word24, 8), Mem2506[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_6290
   DataType: ui32
@@ -28164,7 +27768,7 @@ T_6312: (in __btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[(int3
   OrigDataType: bool
 T_6313: (in 0x78<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6314: (in d0 != 0x78<32> : bool)
   Class: Eq_6314
@@ -28214,7 +27818,7 @@ T_6325: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6324
   DataType: word32
   OrigDataType: word32
-T_6326: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_6326: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6326
   DataType: bool
   OrigDataType: bool
@@ -28381,7 +27985,7 @@ T_6366: (in Mem2554[a7_2552 + 0<32>:word32] : word32)
 T_6367: (in out d1 : ptr32)
   Class: Eq_2679
   DataType: Eq_2679
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6368: (in out a1 : ptr32)
   Class: Eq_4695
   DataType: (ptr32 word32)
@@ -28411,8 +28015,8 @@ T_6374: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_6375: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6376: (in a0_2571 : (ptr32 byte))
   Class: Eq_4706
@@ -28472,8 +28076,8 @@ T_6389: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_6390: (in Mem2578[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_6391: (in v372_2582 : byte)
   Class: Eq_4721
   DataType: byte
@@ -28596,12 +28200,12 @@ T_6420: (in 55<i32> : int32)
   OrigDataType: int32
 T_6421: (in a7_1330 + 55<i32> : word32)
   Class: Eq_6421
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_6422: (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_6422
-  DataType: Eq_6422
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_6422 u2))
+  DataType: uint8
+  OrigDataType: uint8
 T_6423: (in SEQ(SLICE(d0_2559, word24, 8), Mem2603[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_6423
   DataType: ui32
@@ -28610,7 +28214,7 @@ T_6424: (in 0xFF<32> : word32)
   Class: Eq_6424
   DataType: ui32
   OrigDataType: ui32
-T_6425: (in SEQ(SLICE(d0_2559, word24, 8), *((word32) a7_1330 + 55<i32>)) & 0xFF<32> : word32)
+T_6425: (in SEQ(SLICE(d0_2559, word24, 8), a7_1330->b0037) & 0xFF<32> : word32)
   Class: Eq_6425
   DataType: int32
   OrigDataType: int32
@@ -28680,7 +28284,7 @@ T_6441: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6442: (in Mem2726[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_6439
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
 T_6443: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6443
@@ -28783,9 +28387,9 @@ T_6467: (in a7_1330 + 132<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6468: (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_4329
-  OrigDataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: word32
 T_6469: (in 52<i32> : int32)
   Class: Eq_6469
   DataType: int32
@@ -28796,8 +28400,8 @@ T_6470: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6471: (in Mem2796[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4336
-  DataType: Eq_4329
-  OrigDataType: Eq_4336
+  DataType: Eq_4336
+  OrigDataType: word32
 T_6472: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6472
   DataType: Eq_6472
@@ -28812,8 +28416,8 @@ T_6474: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6475: (in Mem2801[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6472
-  DataType: Eq_4329
-  OrigDataType: Eq_6472
+  DataType: Eq_6472
+  OrigDataType: word32
 T_6476: (in 0x44<32> : word32)
   Class: Eq_6476
   DataType: ui32
@@ -28916,7 +28520,7 @@ T_6500: (in 1<i32> : int32)
   OrigDataType: int32
 T_6501: (in a7_2667 - 1<i32> : word32)
   Class: Eq_6501
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6504 t0000)))
 T_6502: (in 0<32> : word32)
   Class: Eq_6502
@@ -28927,8 +28531,8 @@ T_6503: (in a7_2667 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6504: (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_6505: (in 0<32> : word32)
   Class: Eq_6505
@@ -28962,7 +28566,7 @@ T_6512: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6511
   DataType: word32
   OrigDataType: word32
-T_6513: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_6513: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_6513
   DataType: bool
   OrigDataType: bool
@@ -29043,8 +28647,8 @@ T_6532: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6533: (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_6534: (in 110<i32> : int32)
   Class: Eq_6534
@@ -29062,7 +28666,7 @@ T_6537: (in 0<32> : word32)
   Class: Eq_6536
   DataType: word32
   OrigDataType: word32
-T_6538: (in *((word32) a7_1330 + 110<i32>) == 0<32> : bool)
+T_6538: (in a7_1330->dw006E == 0<32> : bool)
   Class: Eq_6538
   DataType: bool
   OrigDataType: bool
@@ -29082,7 +28686,7 @@ T_6542: (in 0xA<32> : word32)
   Class: Eq_6541
   DataType: word32
   OrigDataType: word32
-T_6543: (in *((word32) a7_1330 + 114<i32>) != 0xA<32> : bool)
+T_6543: (in a7_1330->dw0072 != 0xA<32> : bool)
   Class: Eq_6543
   DataType: bool
   OrigDataType: bool
@@ -29102,7 +28706,7 @@ T_6547: (in 8<32> : word32)
   Class: Eq_6546
   DataType: word32
   OrigDataType: word32
-T_6548: (in *((word32) a7_1330 + 114<i32>) != 8<32> : bool)
+T_6548: (in a7_1330->dw0072 != 8<32> : bool)
   Class: Eq_6548
   DataType: bool
   OrigDataType: bool
@@ -29163,9 +28767,9 @@ T_6562: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6563: (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_4329
-  OrigDataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: word32
 T_6564: (in 52<i32> : int32)
   Class: Eq_6564
   DataType: int32
@@ -29176,8 +28780,8 @@ T_6565: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6566: (in Mem2823[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4336
-  DataType: Eq_4329
-  OrigDataType: Eq_4336
+  DataType: Eq_4336
+  OrigDataType: word32
 T_6567: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6567
   DataType: Eq_6567
@@ -29192,8 +28796,8 @@ T_6569: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6570: (in Mem2825[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6567
-  DataType: Eq_4329
-  OrigDataType: Eq_6567
+  DataType: Eq_6567
+  OrigDataType: word32
 T_6571: (in 4<32> : word32)
   Class: Eq_6571
   DataType: ui32
@@ -29223,9 +28827,9 @@ T_6577: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6578: (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_4329
-  OrigDataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: word32
 T_6579: (in 52<i32> : int32)
   Class: Eq_6579
   DataType: int32
@@ -29236,8 +28840,8 @@ T_6580: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6581: (in Mem2854[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4336
-  DataType: Eq_4329
-  OrigDataType: Eq_4336
+  DataType: Eq_4336
+  OrigDataType: word32
 T_6582: (in 64<i32> : int32)
   Class: Eq_6582
   DataType: int32
@@ -29247,9 +28851,9 @@ T_6583: (in a7_1330 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6584: (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_4329
-  OrigDataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: word32
 T_6585: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6585
   DataType: Eq_6585
@@ -29264,8 +28868,8 @@ T_6587: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6588: (in Mem2869[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6585
-  DataType: Eq_4329
-  OrigDataType: Eq_6585
+  DataType: Eq_6585
+  OrigDataType: word32
 T_6589: (in d6_1133 - d3_2423 : word32)
   Class: Eq_6589
   DataType: Eq_6589
@@ -29287,9 +28891,9 @@ T_6593: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6594: (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_4329
-  OrigDataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: word32
 T_6595: (in 52<i32> : int32)
   Class: Eq_6595
   DataType: int32
@@ -29300,8 +28904,8 @@ T_6596: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6597: (in Mem2840[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4336
-  DataType: Eq_4329
-  OrigDataType: Eq_4336
+  DataType: Eq_4336
+  OrigDataType: word32
 T_6598: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6598
   DataType: Eq_6598
@@ -29316,11 +28920,11 @@ T_6600: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6601: (in Mem2843[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6598
-  DataType: Eq_4329
-  OrigDataType: Eq_6598
+  DataType: Eq_6598
+  OrigDataType: word32
 T_6602: (in 0x37<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_6603: (in d5_1044 > 0x37<32> : bool)
   Class: Eq_6603
@@ -29360,19 +28964,19 @@ T_6611: (in 0<i32> : int32)
   OrigDataType: int32
 T_6612: (in 0x30<32> : word32)
   Class: Eq_6612
-  DataType: (ptr32 (ptr32 Eq_4336))
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
-T_6613: (in d5_1044 - 0x30<32> : word32)
+  DataType: (ptr32 Eq_8457)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
+T_6613: (in d5_1044 - (struct Eq_8457 *) 0x30<32> : word32)
   Class: Eq_4336
   DataType: Eq_4336
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
-T_6614: (in d6_3015 : Eq_6614)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
+T_6614: (in d6_3015 : (ptr32 Eq_8458))
   Class: Eq_6614
-  DataType: Eq_6614
-  OrigDataType: (ptr32 (ptr32 Eq_4336))
-T_6615: (in v419_2893 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+  DataType: (ptr32 Eq_8458)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
+T_6615: (in v419_2893 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_6616: (in 4<i32> : int32)
   Class: Eq_6616
@@ -29380,7 +28984,7 @@ T_6616: (in 4<i32> : int32)
   OrigDataType: int32
 T_6617: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6617
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_6620 t0000)))
 T_6618: (in 0<32> : word32)
   Class: Eq_6618
@@ -29391,8 +28995,8 @@ T_6619: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6620: (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_6621: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6621
@@ -29428,8 +29032,8 @@ T_6628: (in Mem2975[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_6629: (in d2_2977 : word32)
   Class: Eq_6629
-  DataType: Eq_6629
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  DataType: (ptr32 Eq_8459)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6630: (in 68<i32> : int32)
   Class: Eq_6630
   DataType: int32
@@ -29440,12 +29044,12 @@ T_6631: (in a7_1330 + 68<i32> : word32)
   OrigDataType: ptr32
 T_6632: (in Mem2975[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_6632
-  DataType: Eq_6632
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  DataType: (ptr32 Eq_8461)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6633: (in d4_2510 + Mem2975[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_6629
-  DataType: Eq_6629
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  DataType: (ptr32 Eq_8459)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6634: (in 48<i32> : int32)
   Class: Eq_6634
   DataType: int32
@@ -29456,8 +29060,8 @@ T_6635: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6636: (in Mem2980[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6629
-  DataType: Eq_4329
-  OrigDataType: Eq_6629
+  DataType: (ptr32 Eq_8459)
+  OrigDataType: word32
 T_6637: (in 8<i32> : int32)
   Class: Eq_6637
   DataType: int32
@@ -29508,9 +29112,9 @@ T_6648: (in Mem2986[a7_1330 + 64<i32>:word32] + d0_2969 : word32)
   OrigDataType: word32
 T_6649: (in 0<32> : word32)
   Class: Eq_6629
-  DataType: (ptr32 (ptr32 Eq_4336))
+  DataType: (ptr32 Eq_8459)
   OrigDataType: up32
-T_6650: (in d2_2977 < 0<32> : bool)
+T_6650: (in d2_2977 < null : bool)
   Class: Eq_6650
   DataType: Eq_6650
   OrigDataType: (union (bool u0) (word32 u1))
@@ -29528,8 +29132,8 @@ T_6653: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_6654: (in Mem2992[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_6651
-  DataType: Eq_4329
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_6655: (in v441_2993 : word32)
   Class: Eq_6655
   DataType: word32
@@ -29632,20 +29236,20 @@ T_6679: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t
   OrigDataType: bool
 T_6680: (in 0<i32> : int32)
   Class: Eq_6614
-  DataType: (ptr32 (ptr32 Eq_4336))
+  DataType: (ptr32 Eq_8458)
   OrigDataType: int32
 T_6681: (in 0x37<32> : word32)
   Class: Eq_6681
-  DataType: (ptr32 (ptr32 Eq_4336))
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
-T_6682: (in d5_1044 - 0x37<32> : word32)
+  DataType: (ptr32 Eq_8463)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
+T_6682: (in d5_1044 - (struct Eq_8463 *) 0x37<32> : word32)
   Class: Eq_6614
-  DataType: Eq_6614
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
-T_6683: (in d2_3074 : Eq_6683)
+  DataType: (ptr32 Eq_8458)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
+T_6683: (in d2_3074 : (ptr32 Eq_8464))
   Class: Eq_6683
-  DataType: Eq_6683
-  OrigDataType: (ptr32 (ptr32 Eq_4336))
+  DataType: (ptr32 Eq_8464)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6684: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6684
   DataType: (ptr32 word32)
@@ -29696,8 +29300,8 @@ T_6695: (in Mem3035[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_6696: (in d2_3037 : word32)
   Class: Eq_6696
-  DataType: Eq_6696
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  DataType: (ptr32 Eq_8461)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6697: (in 48<i32> : int32)
   Class: Eq_6697
   DataType: int32
@@ -29708,12 +29312,12 @@ T_6698: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6699: (in Mem3035[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6699
-  DataType: (ptr32 Eq_8471)
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  DataType: (ptr32 Eq_8467)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6700: (in d6_3015 + Mem3035[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6696
-  DataType: Eq_6696
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  DataType: (ptr32 Eq_8461)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6701: (in 68<i32> : int32)
   Class: Eq_6701
   DataType: int32
@@ -29724,8 +29328,8 @@ T_6702: (in a7_1330 + 68<i32> : word32)
   OrigDataType: (ptr32 (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4336)) u1) (T_6632 u3)))
 T_6703: (in Mem3040[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_6696
-  DataType: Eq_4329
-  OrigDataType: Eq_6696
+  DataType: (ptr32 Eq_8461)
+  OrigDataType: (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4336)) u1) (T_6632 u3))
 T_6704: (in 8<i32> : int32)
   Class: Eq_6704
   DataType: int32
@@ -29776,13 +29380,13 @@ T_6715: (in Mem3045[a7_1330 + 44<i32>:word32] + d0_3029 : word32)
   OrigDataType: int32
 T_6716: (in 0<32> : word32)
   Class: Eq_6696
-  DataType: (ptr32 (ptr32 Eq_4336))
+  DataType: (ptr32 Eq_8461)
   OrigDataType: up32
-T_6717: (in d2_3037 < 0<32> : bool)
+T_6717: (in d2_3037 < null : bool)
   Class: Eq_6717
   DataType: bool
   OrigDataType: bool
-T_6718: (in (word32) *((word32) a7_1330 + 44<i32>) + d0_3029 + (d2_3037 < 0<32>) : word32)
+T_6718: (in (word32) a7_1330[11<i32>] + d0_3029 + (d2_3037 < null) : word32)
   Class: Eq_6718
   DataType: int32
   OrigDataType: int32
@@ -29796,8 +29400,8 @@ T_6720: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6721: (in Mem3051[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_6718
-  DataType: Eq_4329
-  OrigDataType: int32
+  DataType: int32
+  OrigDataType: word32
 T_6722: (in v453_3052 : word32)
   Class: Eq_6722
   DataType: word32
@@ -29880,23 +29484,23 @@ T_6741: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t
   OrigDataType: bool
 T_6742: (in 0<i32> : int32)
   Class: Eq_6683
-  DataType: (ptr32 (ptr32 Eq_4336))
+  DataType: (ptr32 Eq_8464)
   OrigDataType: int32
 T_6743: (in 0x57<32> : word32)
   Class: Eq_6743
-  DataType: (ptr32 (ptr32 Eq_4336))
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
-T_6744: (in d5_1044 - 0x57<32> : word32)
+  DataType: (ptr32 Eq_8467)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
+T_6744: (in d5_1044 - (struct Eq_8467 *) 0x57<32> : word32)
   Class: Eq_6683
-  DataType: Eq_6683
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  DataType: (ptr32 Eq_8464)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6745: (in d0_3135 : Eq_664)
   Class: Eq_664
   DataType: Eq_664
   OrigDataType: uint32
 T_6746: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6746
-  DataType: (ptr32 Eq_6683)
+  DataType: (ptr32 (ptr32 Eq_8464))
   OrigDataType: (ptr32 (struct (0 T_6749 t0000)))
 T_6747: (in 0<32> : word32)
   Class: Eq_6747
@@ -29908,7 +29512,7 @@ T_6748: (in a7_1330 - 4<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_6749: (in Mem3085[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_6683
-  DataType: Eq_6683
+  DataType: (ptr32 Eq_8464)
   OrigDataType: word32
 T_6750: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6750
@@ -29944,8 +29548,8 @@ T_6757: (in Mem3093[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_6758: (in d2_3095 : word32)
   Class: Eq_6758
-  DataType: Eq_6758
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  DataType: (ptr32 Eq_8467)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6759: (in 68<i32> : int32)
   Class: Eq_6759
   DataType: int32
@@ -29960,8 +29564,8 @@ T_6761: (in Mem3093[a7_1330 + 68<i32>:word32] : word32)
   OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u0) (T_6632 u1) (T_6699 u2) (T_6703 u3))
 T_6762: (in d2_3074 + Mem3093[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_6758
-  DataType: Eq_6758
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  DataType: (ptr32 Eq_8467)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_6763: (in 48<i32> : int32)
   Class: Eq_6763
   DataType: int32
@@ -29972,8 +29576,8 @@ T_6764: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4336)) u1) (T_6699 u3)))
 T_6765: (in Mem3098[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6758
-  DataType: Eq_4329
-  OrigDataType: Eq_6758
+  DataType: (ptr32 Eq_8467)
+  OrigDataType: (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4336)) u1) (T_6699 u3))
 T_6766: (in 8<i32> : int32)
   Class: Eq_6766
   DataType: int32
@@ -30020,9 +29624,9 @@ T_6776: (in Mem3103[a7_1330 + 64<i32>:word32] + (d2_3074 >> 31<i32>) : word32)
   OrigDataType: word32
 T_6777: (in 0<32> : word32)
   Class: Eq_6758
-  DataType: (ptr32 (ptr32 Eq_4336))
+  DataType: (ptr32 Eq_8467)
   OrigDataType: up32
-T_6778: (in d2_3095 < 0<32> : bool)
+T_6778: (in d2_3095 < null : bool)
   Class: Eq_6778
   DataType: Eq_6778
   OrigDataType: (union (bool u0) (word32 u1))
@@ -30040,8 +29644,8 @@ T_6781: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_6782: (in Mem3108[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_6779
-  DataType: Eq_4329
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_6783: (in a0_3119 : (ptr32 ui32))
   Class: Eq_6783
   DataType: (ptr32 ui32)
@@ -30080,7 +29684,7 @@ T_6791: (in Mem3108[a7_1330 - 8<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_6792: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6792
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_6795 t0000)))
 T_6793: (in 0<32> : word32)
   Class: Eq_6793
@@ -30091,8 +29695,8 @@ T_6794: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6795: (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_6796: (in 0<32> : word32)
   Class: Eq_6796
@@ -30247,8 +29851,8 @@ T_6833: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_6834: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6835: (in a0_3146 : (ptr32 byte))
   Class: Eq_4706
@@ -30300,8 +29904,8 @@ T_6846: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_6847: (in Mem3153[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_6848: (in 0<32> : word32)
   Class: Eq_6848
   DataType: word32
@@ -30380,7 +29984,7 @@ T_6866: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6867: (in Mem3172[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_6864
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
 T_6868: (in d0_3184 : uint32)
   Class: Eq_6868
@@ -30456,7 +30060,7 @@ T_6885: (in (d0_3184 & 0x44<32>) == 0<32> : bool)
   OrigDataType: bool
 T_6886: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6887: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6887
@@ -30472,7 +30076,7 @@ T_6889: (in d3_2423 != 2<32> : bool)
   OrigDataType: bool
 T_6890: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6891: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6891
@@ -30560,7 +30164,7 @@ T_6911: (in 1<i32> : int32)
   OrigDataType: int32
 T_6912: (in a7_3259 - 1<i32> : word32)
   Class: Eq_6912
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6915 t0000)))
 T_6913: (in 0<32> : word32)
   Class: Eq_6913
@@ -30571,8 +30175,8 @@ T_6914: (in a7_3259 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6915: (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_6916: (in 0<32> : word32)
   Class: Eq_6916
@@ -30656,7 +30260,7 @@ T_6935: (in 1<i32> : int32)
   OrigDataType: int32
 T_6936: (in a7_2635 - 1<i32> : word32)
   Class: Eq_6936
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6939 t0000)))
 T_6937: (in 0<32> : word32)
   Class: Eq_6937
@@ -30667,8 +30271,8 @@ T_6938: (in a7_2635 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6939: (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_6940: (in 0<32> : word32)
   Class: Eq_6940
@@ -30788,7 +30392,7 @@ T_6968: (in a4_2881 - (v465_3109 + 1<32>) >= 0<32> : bool)
   OrigDataType: bool
 T_6969: (in 0x37<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_6970: (in d1 > 0x37<32> : bool)
   Class: Eq_6970
@@ -30811,8 +30415,8 @@ T_6974: (in a7_2886 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6975: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_6976: (in 0<32> : word32)
   Class: Eq_6976
@@ -30823,16 +30427,16 @@ T_6977: (in a7_2886 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6978: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_6979: (in 31<i32> : int32)
   Class: Eq_6979
   DataType: int32
   OrigDataType: int32
 T_6980: (in d7 >> 31<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: int32
 T_6981: (in 0<32> : word32)
   Class: Eq_6981
@@ -30840,12 +30444,12 @@ T_6981: (in 0<32> : word32)
   OrigDataType: word32
 T_6982: (in a7_2886 + 0<32> : word32)
   Class: Eq_6982
-  DataType: (ptr32 Eq_6982)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2)))
+  DataType: (ptr32 (ptr32 Eq_1365))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2)))
 T_6983: (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1365 u2))
 T_6984: (in 4<i32> : int32)
   Class: Eq_6984
   DataType: int32
@@ -30872,7 +30476,7 @@ T_6989: (in 8<i32> : int32)
   OrigDataType: int32
 T_6990: (in a7_2886 - 8<i32> : word32)
   Class: Eq_6990
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
   OrigDataType: (ptr32 (struct (0 T_6993 t0000)))
 T_6991: (in 0<32> : word32)
   Class: Eq_6991
@@ -30883,8 +30487,8 @@ T_6992: (in a7_2886 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6993: (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6994: (in 52<i32> : int32)
   Class: Eq_6994
@@ -31010,21 +30614,21 @@ T_7024: (in d4 : Eq_4336)
   Class: Eq_4336
   DataType: Eq_4336
   OrigDataType: word32
-T_7025: (in dwArg04 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_7025: (in dwArg04 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_7026: (in dwArg08 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_7026: (in dwArg08 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_7027: (in dwArg0C : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_7027: (in dwArg0C : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
-T_7028: (in dwArg10 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_7028: (in dwArg10 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_7029: (in d1Out : ptr32)
   Class: Eq_7029
@@ -31032,7 +30636,7 @@ T_7029: (in d1Out : ptr32)
   OrigDataType: ptr32
 T_7030: (in a7_2886 - 24<i32> : word32)
   Class: Eq_7030
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_7033 t0000)))
 T_7031: (in 0<32> : word32)
   Class: Eq_7031
@@ -31043,8 +30647,8 @@ T_7032: (in a7_2886 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7033: (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_7034: (in 20<i32> : int32)
   Class: Eq_7034
@@ -31052,7 +30656,7 @@ T_7034: (in 20<i32> : int32)
   OrigDataType: int32
 T_7035: (in a7_2886 - 20<i32> : word32)
   Class: Eq_7035
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_7038 t0000)))
 T_7036: (in 0<32> : word32)
   Class: Eq_7036
@@ -31063,8 +30667,8 @@ T_7037: (in a7_2886 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7038: (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_7039: (in 16<i32> : int32)
   Class: Eq_7039
@@ -31072,7 +30676,7 @@ T_7039: (in 16<i32> : int32)
   OrigDataType: int32
 T_7040: (in a7_2886 - 16<i32> : word32)
   Class: Eq_7040
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_7043 t0000)))
 T_7041: (in 0<32> : word32)
   Class: Eq_7041
@@ -31083,8 +30687,8 @@ T_7042: (in a7_2886 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7043: (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_7044: (in 12<i32> : int32)
   Class: Eq_7044
@@ -31092,7 +30696,7 @@ T_7044: (in 12<i32> : int32)
   OrigDataType: int32
 T_7045: (in a7_2886 - 12<i32> : word32)
   Class: Eq_7045
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 Eq_793)
   OrigDataType: (ptr32 (struct (0 T_7048 t0000)))
 T_7046: (in 0<32> : word32)
   Class: Eq_7046
@@ -31103,8 +30707,8 @@ T_7047: (in a7_2886 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7048: (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_7049: (in out d1_2921 : ptr32)
   Class: Eq_7029
@@ -31148,12 +30752,12 @@ T_7058: (in 1<32> : word32)
   OrigDataType: word32
 T_7059: (in a7_2886 + 1<32> : word32)
   Class: Eq_7059
-  DataType: (ptr32 Eq_7059)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2)))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7060: (in Mem2934[a7_2886 + 1<32>:word24] : word24)
   Class: Eq_7060
-  DataType: Eq_7060
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1365 u2))
+  DataType: ui24
+  OrigDataType: ui24
 T_7061: (in SLICE(d5_1044, byte, 0) : byte)
   Class: Eq_7061
   DataType: uint8
@@ -31166,7 +30770,7 @@ T_7063: (in 0xFF<32> : word32)
   Class: Eq_7063
   DataType: ui32
   OrigDataType: ui32
-T_7064: (in SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32> : word32)
+T_7064: (in SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32> : word32)
   Class: Eq_7064
   DataType: int32
   OrigDataType: int32
@@ -31190,7 +30794,7 @@ T_7069: (in 4<32> : word32)
   Class: Eq_7069
   DataType: ui32
   OrigDataType: ui32
-T_7070: (in (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32> : word32)
+T_7070: (in (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32> : word32)
   Class: Eq_7070
   DataType: ui32
   OrigDataType: ui32
@@ -31198,7 +30802,7 @@ T_7071: (in 0<32> : word32)
   Class: Eq_7070
   DataType: ui32
   OrigDataType: word32
-T_7072: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32>) == 0<32> : bool)
+T_7072: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32>) == 0<32> : bool)
   Class: Eq_7072
   DataType: bool
   OrigDataType: bool
@@ -31234,7 +30838,7 @@ T_7080: (in 0<8> : byte)
   Class: Eq_7079
   DataType: byte
   OrigDataType: byte
-T_7081: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7081: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7081
   DataType: bool
   OrigDataType: bool
@@ -31292,7 +30896,7 @@ T_7094: (in 1<i32> : int32)
   OrigDataType: int32
 T_7095: (in a7_3299 - 1<i32> : word32)
   Class: Eq_7095
-  DataType: (ptr32 Eq_664)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7098 t0000)))
 T_7096: (in 0<32> : word32)
   Class: Eq_7096
@@ -31303,8 +30907,8 @@ T_7097: (in a7_3299 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7098: (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_7099: (in 0<32> : word32)
   Class: Eq_7099
@@ -31336,7 +30940,7 @@ T_7105: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7106: (in Mem2714[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7103
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
 T_7107: (in 8<32> : word32)
   Class: Eq_7107
@@ -31352,7 +30956,7 @@ T_7109: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7110: (in Mem2717[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7107
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
 T_7111: (in 52<i32> : int32)
   Class: Eq_7111
@@ -31410,7 +31014,7 @@ T_7124: (in 0x2D<32> : word32)
   Class: Eq_7123
   DataType: word32
   OrigDataType: word32
-T_7125: (in *((word32) a7_1330 + 110<i32>) != 0x2D<32> : bool)
+T_7125: (in a7_1330->dw006E != 0x2D<32> : bool)
   Class: Eq_7125
   DataType: bool
   OrigDataType: bool
@@ -31476,7 +31080,7 @@ T_7140: (in 4<i32> : int32)
   OrigDataType: int32
 T_7141: (in a7_3474 + 4<i32> : word32)
   Class: Eq_4329
-  DataType: Eq_4329
+  DataType: (ptr32 Eq_4329)
   OrigDataType: ptr32
 T_7142: (in 56<i32> : int32)
   Class: Eq_7142
@@ -31504,11 +31108,11 @@ T_7147: (in d0_3495 : word32)
   OrigDataType: uint32
 T_7148: (in 3<32> : word32)
   Class: Eq_7148
-  DataType: (ptr32 Eq_8477)
+  DataType: (ptr32 Eq_8472)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7149: (in d2_1090 + 3<32> : word32)
   Class: Eq_7149
-  DataType: (ptr32 Eq_8478)
+  DataType: (ptr32 Eq_8473)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7150: (in 2<32> : word32)
   Class: Eq_7150
@@ -31531,8 +31135,8 @@ T_7154: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7155: (in (d0_3495 << 2<32>) + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_7156: (in a0_3501 : (ptr32 Eq_7156))
   Class: Eq_7156
@@ -31544,7 +31148,7 @@ T_7157: (in -4<i32> : int32)
   OrigDataType: int32
 T_7158: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7158
-  DataType: (ptr32 Eq_8479)
+  DataType: (ptr32 Eq_8474)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7159: (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7156
@@ -31648,11 +31252,11 @@ T_7183: (in v517_3507 == 0<8> : bool)
   OrigDataType: bool
 T_7184: (in 3<32> : word32)
   Class: Eq_7184
-  DataType: (ptr32 Eq_8480)
+  DataType: (ptr32 Eq_8475)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7185: (in d2_1090 + 3<32> : word32)
   Class: Eq_7185
-  DataType: (ptr32 Eq_8481)
+  DataType: (ptr32 Eq_8476)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7186: (in 2<32> : word32)
   Class: Eq_7186
@@ -31675,8 +31279,8 @@ T_7190: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7191: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_7192: (in 52<i32> : int32)
   Class: Eq_7192
@@ -31700,7 +31304,7 @@ T_7196: (in -4<i32> : int32)
   OrigDataType: int32
 T_7197: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7197
-  DataType: (ptr32 Eq_8482)
+  DataType: (ptr32 Eq_8477)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7198: (in Mem3508[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7198
@@ -31716,8 +31320,8 @@ T_7200: (in Mem3508[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7201: (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
   Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: byte
+  DataType: Eq_793
+  OrigDataType: Eq_664
 T_7202: (in v518_3524 : byte)
   Class: Eq_7136
   DataType: byte
@@ -31764,11 +31368,11 @@ T_7212: (in v518_3524 == 0<8> : bool)
   OrigDataType: bool
 T_7213: (in 3<32> : word32)
   Class: Eq_7213
-  DataType: (ptr32 Eq_8483)
+  DataType: (ptr32 Eq_8478)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7214: (in d2_1090 + 3<32> : word32)
   Class: Eq_7214
-  DataType: (ptr32 Eq_8484)
+  DataType: (ptr32 Eq_8479)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7215: (in 2<32> : word32)
   Class: Eq_7215
@@ -31791,8 +31395,8 @@ T_7219: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7220: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_7221: (in 52<i32> : int32)
   Class: Eq_7221
@@ -31816,7 +31420,7 @@ T_7225: (in -4<i32> : int32)
   OrigDataType: int32
 T_7226: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7226
-  DataType: (ptr32 Eq_8485)
+  DataType: (ptr32 Eq_8480)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7227: (in Mem3525[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7227
@@ -31832,8 +31436,8 @@ T_7229: (in Mem3525[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7230: (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
   Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: word16
+  DataType: Eq_793
+  OrigDataType: Eq_664
 T_7231: (in v519_3541 : byte)
   Class: Eq_7136
   DataType: byte
@@ -31880,11 +31484,11 @@ T_7241: (in v519_3541 == 0<8> : bool)
   OrigDataType: bool
 T_7242: (in 3<32> : word32)
   Class: Eq_7242
-  DataType: (ptr32 Eq_8486)
+  DataType: (ptr32 Eq_8481)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7243: (in d2_1090 + 3<32> : word32)
   Class: Eq_7243
-  DataType: (ptr32 Eq_8487)
+  DataType: (ptr32 Eq_8482)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7244: (in 2<32> : word32)
   Class: Eq_7244
@@ -31907,8 +31511,8 @@ T_7248: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7249: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_7250: (in 52<i32> : int32)
   Class: Eq_7250
@@ -31928,7 +31532,7 @@ T_7253: (in -4<i32> : int32)
   OrigDataType: int32
 T_7254: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7254
-  DataType: (ptr32 Eq_8488)
+  DataType: (ptr32 Eq_8483)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7255: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7255
@@ -31944,15 +31548,15 @@ T_7257: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7258: (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: word32
+  DataType: Eq_793
+  OrigDataType: Eq_664
 T_7259: (in 3<32> : word32)
   Class: Eq_7259
-  DataType: (ptr32 Eq_8489)
+  DataType: (ptr32 Eq_8484)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7260: (in d2_1090 + 3<32> : word32)
   Class: Eq_7260
-  DataType: (ptr32 Eq_8490)
+  DataType: (ptr32 Eq_8485)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7261: (in 2<32> : word32)
   Class: Eq_7261
@@ -31975,8 +31579,8 @@ T_7265: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7266: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_7267: (in 52<i32> : int32)
   Class: Eq_7267
@@ -31996,7 +31600,7 @@ T_7270: (in -4<i32> : int32)
   OrigDataType: int32
 T_7271: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7271
-  DataType: (ptr32 Eq_8491)
+  DataType: (ptr32 Eq_8486)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7272: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7272
@@ -32012,8 +31616,8 @@ T_7274: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7275: (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: word32
+  DataType: Eq_793
+  OrigDataType: Eq_664
 T_7276: (in 60<i32> : int32)
   Class: Eq_7276
   DataType: int32
@@ -32040,7 +31644,7 @@ T_7281: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7282: (in Mem3574[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_7280
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
 T_7283: (in 48<i32> : int32)
   Class: Eq_7283
@@ -32060,12 +31664,12 @@ T_7286: (in 56<i32> : int32)
   OrigDataType: int32
 T_7287: (in a7_1330 + 56<i32> : word32)
   Class: Eq_7287
-  DataType: (ptr32 Eq_7287)
-  OrigDataType: (ptr32 (union (uint8 u0) (word32 u1) (T_6422 u2)))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7288: (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
   Class: Eq_7285
   DataType: Eq_7285
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_6422 u2))
+  OrigDataType: word32
 T_7289: (in 44<i32> : int32)
   Class: Eq_7289
   DataType: int32
@@ -32136,7 +31740,7 @@ T_7305: (in -v528_3348->dw0000 : word32)
   OrigDataType: int32
 T_7306: (in 0<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: up32
 T_7307: (in d1 < 0<32> : bool)
   Class: Eq_7307
@@ -32152,44 +31756,44 @@ T_7309: (in 0x38<32> : word32)
   OrigDataType: word32
 T_7310: (in a7_1330 + 0x38<32> : word32)
   Class: Eq_7310
-  DataType: (ptr32 Eq_7310)
-  OrigDataType: (ptr32 (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3)))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7311: (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
   Class: Eq_4329
-  DataType: Eq_4329
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
-T_7312: (in a7_3364 : Eq_7312)
+  DataType: (ptr32 Eq_4329)
+  OrigDataType: word32
+T_7312: (in a7_3364 : (ptr32 Eq_7312))
   Class: Eq_7312
-  DataType: Eq_7312
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_7312)
+  OrigDataType: (ptr32 (struct (0 T_7317 t0000) (30 T_7322 t0030) (38 T_7373 t0038) (3C T_666 t003C) (4C T_7320 t004C)))
 T_7313: (in 4<i32> : int32)
   Class: Eq_7313
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7314: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7312
-  DataType: Eq_7312
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_7312)
+  OrigDataType: ptr32
 T_7315: (in 0<32> : word32)
   Class: Eq_7315
   DataType: word32
   OrigDataType: word32
 T_7316: (in a7_3364 + 0<32> : word32)
   Class: Eq_7316
-  DataType: Eq_7316
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7317: (in Mem3375[a7_3364 + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_7312
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_7318: (in 76<i32> : int32)
   Class: Eq_7318
   DataType: int32
   OrigDataType: int32
 T_7319: (in a7_3364 + 76<i32> : word32)
   Class: Eq_7319
-  DataType: Eq_7319
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7320: (in Mem3375[a7_3364 + 76<i32>:byte] : byte)
   Class: Eq_7320
   DataType: byte
@@ -32198,7 +31802,7 @@ T_7321: (in 1<8> : byte)
   Class: Eq_7321
   DataType: byte
   OrigDataType: byte
-T_7322: (in *((word32) a7_3364 + 76<i32>) - 1<8> : byte)
+T_7322: (in a7_3364->b004C - 1<8> : byte)
   Class: Eq_7322
   DataType: byte
   OrigDataType: byte
@@ -32208,37 +31812,37 @@ T_7323: (in 48<i32> : int32)
   OrigDataType: int32
 T_7324: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7324
-  DataType: Eq_7324
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7325: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
   Class: Eq_7322
-  DataType: Eq_7312
+  DataType: byte
   OrigDataType: byte
 T_7326: (in 4<i32> : int32)
   Class: Eq_7326
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7327: (in a7_3364 + 4<i32> : word32)
   Class: Eq_4329
-  DataType: Eq_4329
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_4329)
+  OrigDataType: ptr32
 T_7328: (in 48<i32> : int32)
   Class: Eq_7328
   DataType: int32
   OrigDataType: int32
 T_7329: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7329
-  DataType: Eq_7329
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7330: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7330
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7331: (in 0<8> : byte)
-  Class: Eq_7330
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
-T_7332: (in *((word32) a7_3364 + 48<i32>) == 0<8> : bool)
+T_7332: (in a7_3364->b0030 == 0<8> : bool)
   Class: Eq_7332
   DataType: bool
   OrigDataType: bool
@@ -32252,28 +31856,28 @@ T_7334: (in 52<i32> : int32)
   OrigDataType: int32
 T_7335: (in a7_1330 + 52<i32> : word32)
   Class: Eq_7335
-  DataType: Eq_7335
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7336: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7333
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
-T_7337: (in v544_774 : byte)
+T_7337: (in v544_774 : Eq_7337)
   Class: Eq_7337
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7337
+  OrigDataType: (union (int32 u0) (byte u1))
 T_7338: (in 44<i32> : int32)
   Class: Eq_7338
   DataType: int32
   OrigDataType: int32
 T_7339: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7339
-  DataType: Eq_7339
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7340: (in Mem773[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7337
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7337
+  OrigDataType: int32
 T_7341: (in SEQ(v84_506, v544_774) : uip32)
   Class: Eq_4486
   DataType: int32
@@ -32288,8 +31892,8 @@ T_7343: (in 52<i32> : int32)
   OrigDataType: int32
 T_7344: (in a7_1330 + 52<i32> : word32)
   Class: Eq_7344
-  DataType: Eq_7344
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7345: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
@@ -32304,12 +31908,12 @@ T_7347: (in 44<i32> : int32)
   OrigDataType: int32
 T_7348: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7348
-  DataType: Eq_7348
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7349: (in Mem769[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7346
-  DataType: Eq_4329
-  OrigDataType: byte
+  DataType: Eq_7346
+  OrigDataType: int32
 T_7350: (in 1<i32> : int32)
   Class: Eq_7350
   DataType: int32
@@ -32324,11 +31928,11 @@ T_7352: (in d0_3398 : word32)
   OrigDataType: uint32
 T_7353: (in 3<32> : word32)
   Class: Eq_7353
-  DataType: (ptr32 Eq_8498)
+  DataType: (ptr32 Eq_8487)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7354: (in d2_1090 + 3<32> : word32)
   Class: Eq_7354
-  DataType: (ptr32 Eq_8499)
+  DataType: (ptr32 Eq_8488)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7355: (in 2<32> : word32)
   Class: Eq_7355
@@ -32351,8 +31955,8 @@ T_7359: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7360: (in (d0_3398 << 2<32>) + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_7361: (in a0_3404 : (ptr32 Eq_7361))
   Class: Eq_7361
@@ -32364,7 +31968,7 @@ T_7362: (in -4<i32> : int32)
   OrigDataType: int32
 T_7363: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7363
-  DataType: (ptr32 Eq_8500)
+  DataType: (ptr32 Eq_8489)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7364: (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7361
@@ -32376,11 +31980,11 @@ T_7365: (in 60<i32> : int32)
   OrigDataType: int32
 T_7366: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7366
-  DataType: Eq_7366
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7367: (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_7367
-  DataType: word32
+  Class: Eq_664
+  DataType: Eq_664
   OrigDataType: word32
 T_7368: (in 4<i32> : int32)
   Class: Eq_7368
@@ -32391,8 +31995,8 @@ T_7369: (in a0_3404 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7370: (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
-  Class: Eq_7367
-  DataType: word32
+  Class: Eq_664
+  DataType: Eq_664
   OrigDataType: word32
 T_7371: (in 56<i32> : int32)
   Class: Eq_7371
@@ -32400,8 +32004,8 @@ T_7371: (in 56<i32> : int32)
   OrigDataType: int32
 T_7372: (in a7_3364 + 56<i32> : word32)
   Class: Eq_7372
-  DataType: Eq_7372
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7373: (in Mem3406[a7_3364 + 56<i32>:word32] : word32)
   Class: Eq_7373
   DataType: word32
@@ -32423,7 +32027,7 @@ T_7377: (in d0_3398 << 2<32> : word32)
   DataType: Eq_664
   OrigDataType: ui32
 T_7378: (in v540_3410 : byte)
-  Class: Eq_7378
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7379: (in 48<i32> : int32)
@@ -32432,18 +32036,18 @@ T_7379: (in 48<i32> : int32)
   OrigDataType: int32
 T_7380: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7380
-  DataType: Eq_7380
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7381: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7381
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7382: (in 1<8> : byte)
   Class: Eq_7382
   DataType: byte
   OrigDataType: byte
-T_7383: (in *((word32) a7_3364 + 48<i32>) - 1<8> : byte)
-  Class: Eq_7378
+T_7383: (in a7_3364->b0030 - 1<8> : byte)
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7384: (in 48<i32> : int32)
@@ -32452,14 +32056,14 @@ T_7384: (in 48<i32> : int32)
   OrigDataType: int32
 T_7385: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7385
-  DataType: Eq_7385
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7386: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7378
-  DataType: Eq_7312
+  Class: Eq_7322
+  DataType: byte
   OrigDataType: byte
 T_7387: (in 0<8> : byte)
-  Class: Eq_7378
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7388: (in v540_3410 == 0<8> : bool)
@@ -32468,11 +32072,11 @@ T_7388: (in v540_3410 == 0<8> : bool)
   OrigDataType: bool
 T_7389: (in 3<32> : word32)
   Class: Eq_7389
-  DataType: (ptr32 Eq_8501)
+  DataType: (ptr32 Eq_8490)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7390: (in d2_1090 + 3<32> : word32)
   Class: Eq_7390
-  DataType: (ptr32 Eq_8502)
+  DataType: (ptr32 Eq_8491)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7391: (in 2<32> : word32)
   Class: Eq_7391
@@ -32495,8 +32099,8 @@ T_7395: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7396: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_7397: (in 60<i32> : int32)
   Class: Eq_7397
@@ -32504,8 +32108,8 @@ T_7397: (in 60<i32> : int32)
   OrigDataType: int32
 T_7398: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7398
-  DataType: Eq_7398
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7399: (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
@@ -32520,7 +32124,7 @@ T_7401: (in -4<i32> : int32)
   OrigDataType: int32
 T_7402: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7402
-  DataType: (ptr32 Eq_8503)
+  DataType: (ptr32 Eq_8492)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7403: (in Mem3411[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7403
@@ -32536,10 +32140,10 @@ T_7405: (in Mem3411[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7406: (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
   Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: byte
+  DataType: Eq_793
+  OrigDataType: Eq_664
 T_7407: (in v541_3427 : byte)
-  Class: Eq_7407
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7408: (in 48<i32> : int32)
@@ -32548,18 +32152,18 @@ T_7408: (in 48<i32> : int32)
   OrigDataType: int32
 T_7409: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7409
-  DataType: Eq_7409
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7410: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7410
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7411: (in 0x66<8> : byte)
   Class: Eq_7411
   DataType: byte
   OrigDataType: byte
-T_7412: (in *((word32) a7_3364 + 48<i32>) - 0x66<8> : byte)
-  Class: Eq_7407
+T_7412: (in a7_3364->b0030 - 0x66<8> : byte)
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7413: (in 48<i32> : int32)
@@ -32568,14 +32172,14 @@ T_7413: (in 48<i32> : int32)
   OrigDataType: int32
 T_7414: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7414
-  DataType: Eq_7414
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7415: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7407
-  DataType: Eq_7312
+  Class: Eq_7322
+  DataType: byte
   OrigDataType: byte
 T_7416: (in 0<8> : byte)
-  Class: Eq_7407
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7417: (in v541_3427 == 0<8> : bool)
@@ -32584,11 +32188,11 @@ T_7417: (in v541_3427 == 0<8> : bool)
   OrigDataType: bool
 T_7418: (in 3<32> : word32)
   Class: Eq_7418
-  DataType: (ptr32 Eq_8504)
+  DataType: (ptr32 Eq_8493)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7419: (in d2_1090 + 3<32> : word32)
   Class: Eq_7419
-  DataType: (ptr32 Eq_8505)
+  DataType: (ptr32 Eq_8494)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7420: (in 2<32> : word32)
   Class: Eq_7420
@@ -32611,8 +32215,8 @@ T_7424: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7425: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_7426: (in 60<i32> : int32)
   Class: Eq_7426
@@ -32620,8 +32224,8 @@ T_7426: (in 60<i32> : int32)
   OrigDataType: int32
 T_7427: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7427
-  DataType: Eq_7427
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7428: (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
@@ -32636,7 +32240,7 @@ T_7430: (in -4<i32> : int32)
   OrigDataType: int32
 T_7431: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7431
-  DataType: (ptr32 Eq_8506)
+  DataType: (ptr32 Eq_8495)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7432: (in Mem3428[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7432
@@ -32652,10 +32256,10 @@ T_7434: (in Mem3428[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7435: (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
   Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: word16
+  DataType: Eq_793
+  OrigDataType: Eq_664
 T_7436: (in v542_3444 : byte)
-  Class: Eq_7436
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7437: (in 48<i32> : int32)
@@ -32664,18 +32268,18 @@ T_7437: (in 48<i32> : int32)
   OrigDataType: int32
 T_7438: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7438
-  DataType: Eq_7438
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7439: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7439
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7440: (in 4<8> : byte)
   Class: Eq_7440
   DataType: byte
   OrigDataType: byte
-T_7441: (in *((word32) a7_3364 + 48<i32>) - 4<8> : byte)
-  Class: Eq_7436
+T_7441: (in a7_3364->b0030 - 4<8> : byte)
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7442: (in 48<i32> : int32)
@@ -32684,14 +32288,14 @@ T_7442: (in 48<i32> : int32)
   OrigDataType: int32
 T_7443: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7443
-  DataType: Eq_7443
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7444: (in Mem3445[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7436
-  DataType: Eq_7312
+  Class: Eq_7322
+  DataType: byte
   OrigDataType: byte
 T_7445: (in 0<8> : byte)
-  Class: Eq_7436
+  Class: Eq_7322
   DataType: byte
   OrigDataType: byte
 T_7446: (in v542_3444 == 0<8> : bool)
@@ -32700,11 +32304,11 @@ T_7446: (in v542_3444 == 0<8> : bool)
   OrigDataType: bool
 T_7447: (in 3<32> : word32)
   Class: Eq_7447
-  DataType: (ptr32 Eq_8507)
+  DataType: (ptr32 Eq_8496)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7448: (in d2_1090 + 3<32> : word32)
   Class: Eq_7448
-  DataType: (ptr32 Eq_8508)
+  DataType: (ptr32 Eq_8497)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7449: (in 2<32> : word32)
   Class: Eq_7449
@@ -32727,8 +32331,8 @@ T_7453: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7454: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_7455: (in 60<i32> : int32)
   Class: Eq_7455
@@ -32736,8 +32340,8 @@ T_7455: (in 60<i32> : int32)
   OrigDataType: int32
 T_7456: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7456
-  DataType: Eq_7456
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7457: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
@@ -32748,7 +32352,7 @@ T_7458: (in -4<i32> : int32)
   OrigDataType: int32
 T_7459: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7459
-  DataType: (ptr32 Eq_8509)
+  DataType: (ptr32 Eq_8498)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7460: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7460
@@ -32764,15 +32368,15 @@ T_7462: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7463: (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: word32
+  DataType: Eq_793
+  OrigDataType: Eq_664
 T_7464: (in 3<32> : word32)
   Class: Eq_7464
-  DataType: (ptr32 Eq_8510)
+  DataType: (ptr32 Eq_8499)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7465: (in d2_1090 + 3<32> : word32)
   Class: Eq_7465
-  DataType: (ptr32 Eq_8511)
+  DataType: (ptr32 Eq_8500)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7466: (in 2<32> : word32)
   Class: Eq_7466
@@ -32795,8 +32399,8 @@ T_7470: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7471: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_7472: (in 60<i32> : int32)
   Class: Eq_7472
@@ -32804,8 +32408,8 @@ T_7472: (in 60<i32> : int32)
   OrigDataType: int32
 T_7473: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7473
-  DataType: Eq_7473
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7474: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
@@ -32816,7 +32420,7 @@ T_7475: (in -4<i32> : int32)
   OrigDataType: int32
 T_7476: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7476
-  DataType: (ptr32 Eq_8512)
+  DataType: (ptr32 Eq_8501)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7477: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7477
@@ -32832,8 +32436,8 @@ T_7479: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7480: (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: word32
+  DataType: Eq_793
+  OrigDataType: Eq_664
 T_7481: (in 0<i32> : int32)
   Class: Eq_7481
   DataType: int32
@@ -32847,36 +32451,36 @@ T_7483: (in 0xFF<32> : word32)
   DataType: int32
   OrigDataType: word32
 T_7484: (in SLICE(d5_785, byte, 0) : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_7484
+  DataType: byte
   OrigDataType: byte
 T_7485: (in 78<i32> : int32)
   Class: Eq_7485
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7486: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7486
-  DataType: Eq_7486
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7487: (in a7_1330 + 78<i32> + d1_1027 : word32)
   Class: Eq_7487
-  DataType: Eq_7487
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7488 t0000)))
 T_7488: (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_7484
+  DataType: byte
   OrigDataType: byte
 T_7489: (in 1<32> : word32)
   Class: Eq_7489
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: word32
+  OrigDataType: word32
 T_7490: (in d1_1027 + 1<32> : word32)
   Class: Eq_664
   DataType: Eq_664
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  OrigDataType: int32
 T_7491: (in 0x20<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: up32
 T_7492: (in d1_1027 < 0x20<32> : bool)
   Class: Eq_7492
@@ -32896,40 +32500,40 @@ T_7495: (in 132<i32> : int32)
   OrigDataType: int32
 T_7496: (in a7_1330 + 132<i32> : word32)
   Class: Eq_7496
-  DataType: Eq_7496
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7497: (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_4329
-  OrigDataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
+  OrigDataType: word32
 T_7498: (in 44<i32> : int32)
   Class: Eq_7498
   DataType: int32
   OrigDataType: int32
 T_7499: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7499
-  DataType: Eq_7499
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7500: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7337
-  DataType: Eq_4329
-  OrigDataType: byte
-T_7501: (in v554_824 : byte)
+  DataType: Eq_7337
+  OrigDataType: int32
+T_7501: (in v554_824 : Eq_7501)
   Class: Eq_7501
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7501
+  OrigDataType: (union (int32 u1) (byte u0))
 T_7502: (in 44<i32> : int32)
   Class: Eq_7502
   DataType: int32
   OrigDataType: int32
 T_7503: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7503
-  DataType: Eq_7503
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7504: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7501
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7501
+  OrigDataType: int32
 T_7505: (in a6_1164 : (ptr32 byte))
   Class: Eq_7505
   DataType: (ptr32 byte)
@@ -32940,11 +32544,11 @@ T_7506: (in 132<i32> : int32)
   OrigDataType: int32
 T_7507: (in a7_1330 + 132<i32> : word32)
   Class: Eq_7507
-  DataType: Eq_7507
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7508: (in Mem946[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_7509: (in 1<i32> : int32)
   Class: Eq_7509
@@ -32960,8 +32564,8 @@ T_7511: (in 73<i32> : int32)
   OrigDataType: int32
 T_7512: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7512
-  DataType: Eq_7512
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7513: (in Mem946[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7513
   DataType: byte
@@ -32970,7 +32574,7 @@ T_7514: (in 0<8> : byte)
   Class: Eq_7513
   DataType: byte
   OrigDataType: byte
-T_7515: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7515: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7515
   DataType: bool
   OrigDataType: bool
@@ -33150,18 +32754,18 @@ T_7559: (in v554_824 == 0<8> : bool)
   Class: Eq_7559
   DataType: bool
   OrigDataType: bool
-T_7560: (in a0_881 : Eq_7560)
+T_7560: (in a0_881 : word32)
   Class: Eq_7560
-  DataType: Eq_7560
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7568 t0000)))
 T_7561: (in 78<i32> : int32)
   Class: Eq_7561
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7562: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7562
-  DataType: Eq_7562
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7563: (in 3<32> : word32)
   Class: Eq_7563
   DataType: word32
@@ -33169,22 +32773,22 @@ T_7563: (in 3<32> : word32)
 T_7564: (in d5_862 >> 3<32> : word32)
   Class: Eq_7564
   DataType: Eq_7564
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_7565: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_7560
-  DataType: Eq_7560
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_7566: (in 0<32> : word32)
   Class: Eq_7566
   DataType: word32
   OrigDataType: word32
 T_7567: (in a0_881 + 0<32> : word32)
   Class: Eq_7567
-  DataType: Eq_7567
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7568: (in Mem889[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_7568
+  DataType: byte
   OrigDataType: byte
 T_7569: (in (uint8) Mem889[a0_881 + 0<32>:byte] : uint8)
   Class: Eq_7569
@@ -33215,8 +32819,8 @@ T_7575: (in 1<i32> << (d5_862 & 7<i32>) | d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7576: (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_7568
+  DataType: byte
   OrigDataType: byte
 T_7577: (in 0<32> : word32)
   Class: Eq_7577
@@ -33224,24 +32828,24 @@ T_7577: (in 0<32> : word32)
   OrigDataType: word32
 T_7578: (in a0_881 + 0<32> : word32)
   Class: Eq_7578
-  DataType: Eq_7578
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7579: (in Mem895[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_7560
-  OrigDataType: Eq_664
-T_7580: (in a0_900 : Eq_7580)
+  Class: Eq_7568
+  DataType: byte
+  OrigDataType: byte
+T_7580: (in a0_900 : word32)
   Class: Eq_7580
-  DataType: Eq_7580
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7588 t0000)))
 T_7581: (in 78<i32> : int32)
   Class: Eq_7581
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7582: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7582
-  DataType: Eq_7582
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7583: (in 3<32> : word32)
   Class: Eq_7583
   DataType: word32
@@ -33249,22 +32853,22 @@ T_7583: (in 3<32> : word32)
 T_7584: (in d5_862 >> 3<32> : word32)
   Class: Eq_7584
   DataType: Eq_7584
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_7585: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_7580
-  DataType: Eq_7580
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_7586: (in 0<32> : word32)
   Class: Eq_7586
   DataType: word32
   OrigDataType: word32
 T_7587: (in a0_900 + 0<32> : word32)
   Class: Eq_7587
-  DataType: Eq_7587
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7588: (in Mem889[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_7588
+  DataType: byte
   OrigDataType: byte
 T_7589: (in (uint8) Mem889[a0_900 + 0<32>:byte] : uint8)
   Class: Eq_7589
@@ -33299,8 +32903,8 @@ T_7596: (in ~(1<i32> << (d5_862 & 7<i32>)) & d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7597: (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_7588
+  DataType: byte
   OrigDataType: byte
 T_7598: (in 0<32> : word32)
   Class: Eq_7598
@@ -33308,12 +32912,12 @@ T_7598: (in 0<32> : word32)
   OrigDataType: word32
 T_7599: (in a0_900 + 0<32> : word32)
   Class: Eq_7599
-  DataType: Eq_7599
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7600: (in Mem914[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_7580
-  OrigDataType: Eq_664
+  Class: Eq_7588
+  DataType: byte
+  OrigDataType: byte
 T_7601: (in 1<32> : word32)
   Class: Eq_7601
   DataType: word32
@@ -33356,11 +32960,11 @@ T_7610: (in d0_957 : word32)
   OrigDataType: uint32
 T_7611: (in 3<32> : word32)
   Class: Eq_7611
-  DataType: (ptr32 Eq_8513)
+  DataType: (ptr32 Eq_8502)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7612: (in d2_1090 + 3<32> : word32)
   Class: Eq_7612
-  DataType: (ptr32 Eq_8514)
+  DataType: (ptr32 Eq_8503)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7613: (in 2<32> : word32)
   Class: Eq_7613
@@ -33383,8 +32987,8 @@ T_7617: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7618: (in (d0_957 << 2<32>) + 4<32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: ui32
 T_7619: (in d0_957 << 2<32> : word32)
   Class: Eq_664
@@ -33396,7 +33000,7 @@ T_7620: (in -4<i32> : int32)
   OrigDataType: int32
 T_7621: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7621
-  DataType: (ptr32 Eq_8515)
+  DataType: (ptr32 Eq_8504)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_664) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7622: (in Mem946[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7505
@@ -33522,30 +33126,30 @@ T_7652: (in a3_1955->b0000 == 0<8> : bool)
   Class: Eq_7652
   DataType: bool
   OrigDataType: bool
-T_7653: (in a7_985 : Eq_7653)
+T_7653: (in a7_985 : (ptr32 Eq_7653))
   Class: Eq_7653
-  DataType: Eq_7653
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_7653)
+  OrigDataType: (ptr32 (struct (0 T_666 t0000) (30 T_7670 t0030)))
 T_7654: (in 4<i32> : int32)
   Class: Eq_7654
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7655: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7653
-  DataType: Eq_7653
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_7653)
+  OrigDataType: ptr32
 T_7656: (in 0<32> : word32)
   Class: Eq_7656
   DataType: word32
   OrigDataType: word32
 T_7657: (in a7_985 + 0<32> : word32)
   Class: Eq_7657
-  DataType: Eq_7657
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7658: (in Mem987[a7_985 + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_7653
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_7659: (in a5_5334 : word32)
   Class: Eq_7659
   DataType: word32
@@ -33560,8 +33164,8 @@ T_7661: (in 0<32> : word32)
   OrigDataType: word32
 T_7662: (in a7_985 + 0<32> : word32)
   Class: Eq_7662
-  DataType: Eq_7662
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7663: (in Mem987[a7_985 + 0<32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
@@ -33569,7 +33173,7 @@ T_7663: (in Mem987[a7_985 + 0<32>:word32] : word32)
 T_7664: (in out d1 : ptr32)
   Class: Eq_2679
   DataType: Eq_2679
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4336)) u1) (uint32 u0) (ptr32 u2) (Eq_6699 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4336) ptr0000) (4 Eq_664 t0004) (8 Eq_664 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6699 u3))
 T_7665: (in out a1 : ptr32)
   Class: Eq_4695
   DataType: (ptr32 word32)
@@ -33578,7 +33182,7 @@ T_7666: (in out a5_5334 : ptr32)
   Class: Eq_4696
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_7667: (in fn00003CA8(*a7_985, out d1, out a1, out a5_5334) : word32)
+T_7667: (in fn00003CA8(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
   Class: Eq_664
   DataType: Eq_664
   OrigDataType: word32
@@ -33588,19 +33192,19 @@ T_7668: (in 48<i32> : int32)
   OrigDataType: int32
 T_7669: (in a7_985 + 48<i32> : word32)
   Class: Eq_7669
-  DataType: Eq_7669
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7670: (in Mem1000[a7_985 + 48<i32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_7653
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_7671: (in 4<i32> : int32)
   Class: Eq_7671
   DataType: int32
   OrigDataType: int32
 T_7672: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_7673: (in a0_1004 : (ptr32 byte))
   Class: Eq_4706
@@ -33618,30 +33222,30 @@ T_7676: (in Mem981[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
-T_7677: (in a7_1005 : Eq_7677)
+T_7677: (in a7_1005 : (ptr32 Eq_7677))
   Class: Eq_7677
-  DataType: Eq_7677
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_7677)
+  OrigDataType: (ptr32 (struct (0 T_666 t0000) (30 T_7702 t0030)))
 T_7678: (in 4<i32> : int32)
   Class: Eq_7678
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7679: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7677
-  DataType: Eq_7677
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_7677)
+  OrigDataType: ptr32
 T_7680: (in 0<32> : word32)
   Class: Eq_7680
   DataType: word32
   OrigDataType: word32
 T_7681: (in a7_1005 + 0<32> : word32)
   Class: Eq_7681
-  DataType: Eq_7681
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7682: (in Mem1007[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_7677
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_7683: (in 1<i32> : int32)
   Class: Eq_7683
   DataType: int32
@@ -33660,8 +33264,8 @@ T_7686: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_7687: (in Mem1011[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_7688: (in v585_1015 : byte)
   Class: Eq_4721
   DataType: byte
@@ -33684,8 +33288,8 @@ T_7692: (in 0<32> : word32)
   OrigDataType: word32
 T_7693: (in a7_1005 + 0<32> : word32)
   Class: Eq_7693
-  DataType: Eq_7693
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7694: (in Mem1011[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
@@ -33696,12 +33300,12 @@ T_7695: (in 0<32> : word32)
   OrigDataType: word32
 T_7696: (in a7_1005 + 0<32> : word32)
   Class: Eq_7696
-  DataType: Eq_7696
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7697: (in Mem1031[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_7677
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_7698: (in (uint8) v585_1015 : uint8)
   Class: Eq_7698
   DataType: uint8
@@ -33716,12 +33320,12 @@ T_7700: (in 48<i32> : int32)
   OrigDataType: int32
 T_7701: (in a7_1005 + 48<i32> : word32)
   Class: Eq_7701
-  DataType: Eq_7701
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7702: (in Mem1037[a7_1005 + 48<i32>:word32] : word32)
   Class: Eq_7699
-  DataType: Eq_7677
-  OrigDataType: uint32
+  DataType: uint32
+  OrigDataType: word32
 T_7703: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_7703
   DataType: word24
@@ -33736,8 +33340,8 @@ T_7705: (in 0<32> : word32)
   OrigDataType: word32
 T_7706: (in a7_1005 + 0<32> : word32)
   Class: Eq_7706
-  DataType: Eq_7706
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7707: (in Mem1037[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
@@ -33748,12 +33352,12 @@ T_7708: (in 44<i32> : int32)
   OrigDataType: int32
 T_7709: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7709
-  DataType: Eq_7709
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7710: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
-  OrigDataType: word32
+  OrigDataType: int32
 T_7711: (in d3_1057 : Eq_7711)
   Class: Eq_7711
   DataType: Eq_7711
@@ -33784,135 +33388,135 @@ T_7717: (in 44<i32> : int32)
   OrigDataType: int32
 T_7718: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7718
-  DataType: Eq_7718
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7719: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_7719
-  DataType: word32
-  OrigDataType: word32
+  DataType: int32
+  OrigDataType: int32
 T_7720: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_7719
-  DataType: word32
+  DataType: int32
   OrigDataType: word32
-T_7721: (in *((word32) a7_1330 + 44<i32>) == 0xFFFFFFFF<32> : bool)
+T_7721: (in a7_1330[11<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_7721
   DataType: bool
   OrigDataType: bool
 T_7722: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_7723: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_7723
   DataType: bool
   OrigDataType: bool
-T_7724: (in a7_1076 : Eq_7724)
+T_7724: (in a7_1076 : (ptr32 Eq_7724))
   Class: Eq_7724
-  DataType: Eq_7724
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_7724)
+  OrigDataType: (ptr32 (struct (0 T_7728 t0000) (4D T_7785 t004D)))
 T_7725: (in 4<i32> : int32)
   Class: Eq_7725
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7726: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7724
-  DataType: Eq_7724
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_7724)
+  OrigDataType: ptr32
 T_7727: (in 78<i32> : int32)
   Class: Eq_7727
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7728: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  Class: Eq_7728
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7729: (in 0<32> : word32)
   Class: Eq_7729
   DataType: word32
   OrigDataType: word32
 T_7730: (in a7_1076 + 0<32> : word32)
   Class: Eq_7730
-  DataType: Eq_7730
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7731: (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_7724
+  Class: Eq_7728
+  DataType: ptr32
   OrigDataType: word32
 T_7732: (in 4<i32> : int32)
   Class: Eq_7732
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7733: (in a7_1076 - 4<i32> : word32)
   Class: Eq_7733
-  DataType: Eq_7733
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_7736 t0000)))
 T_7734: (in 0<32> : word32)
   Class: Eq_7734
   DataType: word32
   OrigDataType: word32
 T_7735: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_7735
-  DataType: Eq_7735
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7736: (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_7733
-  OrigDataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: word32
 T_7737: (in 00000008 : ptr32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_7737
+  DataType: ptr32
   OrigDataType: ptr32
 T_7738: (in 8<i32> : int32)
   Class: Eq_7738
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7739: (in a7_1076 - 8<i32> : word32)
   Class: Eq_7739
-  DataType: Eq_7739
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7742 t0000)))
 T_7740: (in 0<32> : word32)
   Class: Eq_7740
   DataType: word32
   OrigDataType: word32
 T_7741: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_7741
-  DataType: Eq_7741
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7742: (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_7739
-  OrigDataType: uint8
+  Class: Eq_7737
+  DataType: ptr32
+  OrigDataType: word32
 T_7743: (in 12<i32> : int32)
   Class: Eq_7743
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7744: (in a7_1076 - 12<i32> : word32)
   Class: Eq_7744
-  DataType: Eq_7744
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_664)
+  OrigDataType: (ptr32 (struct (0 T_7747 t0000)))
 T_7745: (in 0<32> : word32)
   Class: Eq_7745
   DataType: word32
   OrigDataType: word32
 T_7746: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_7746
-  DataType: Eq_7746
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7747: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_7744
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_7748: (in 0<32> : word32)
   Class: Eq_7748
   DataType: word32
   OrigDataType: word32
 T_7749: (in a7_1076 + 0<32> : word32)
   Class: Eq_7749
-  DataType: Eq_7749
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7750: (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_7728
+  DataType: ptr32
   OrigDataType: ptr32
 T_7751: (in fn000026C0 : ptr32)
   Class: Eq_7751
@@ -33924,45 +33528,45 @@ T_7752: (in signature of fn000026C0 : void)
   OrigDataType: 
 T_7753: (in a7_1076 - 12<i32> : word32)
   Class: Eq_7753
-  DataType: Eq_7753
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_793)
+  OrigDataType: (ptr32 (struct (0 T_7756 t0000)))
 T_7754: (in 0<32> : word32)
   Class: Eq_7754
   DataType: word32
   OrigDataType: word32
 T_7755: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_7755
-  DataType: Eq_7755
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7756: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_7757: (in 8<i32> : int32)
   Class: Eq_7757
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7758: (in a7_1076 - 8<i32> : word32)
   Class: Eq_7758
-  DataType: Eq_7758
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_793)
+  OrigDataType: (ptr32 (struct (0 T_7761 t0000)))
 T_7759: (in 0<32> : word32)
   Class: Eq_7759
   DataType: word32
   OrigDataType: word32
 T_7760: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_7760
-  DataType: Eq_7760
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7761: (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_7762: (in fn000026C0(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_7762
   DataType: int32
   OrigDataType: int32
-T_7763: (in Mem1087[a7_1076 + 0<32>:word32] + fn000026C0(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
+T_7763: (in a7_1076->ptr0000 + fn000026C0(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_7763
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7764 t0000)))
@@ -33980,23 +33584,23 @@ T_7766: (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn000026C
   OrigDataType: uint32
 T_7767: (in 4<i32> : int32)
   Class: Eq_7767
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7768: (in a7_1076 - 4<i32> : word32)
   Class: Eq_7768
-  DataType: Eq_7768
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_7771 t0000)))
 T_7769: (in 0<32> : word32)
   Class: Eq_7769
   DataType: word32
   OrigDataType: word32
 T_7770: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_7770
-  DataType: Eq_7770
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7771: (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_7772: (in 1<i32> : int32)
   Class: Eq_7772
@@ -34020,7 +33624,7 @@ T_7776: (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
   OrigDataType: ui32
 T_7777: (in 0<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_7778: (in d0 == 0<32> : bool)
   Class: Eq_7778
@@ -34048,8 +33652,8 @@ T_7783: (in 77<i32> : int32)
   OrigDataType: int32
 T_7784: (in a7_1076 + 77<i32> : word32)
   Class: Eq_7784
-  DataType: Eq_7784
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7785: (in Mem1087[a7_1076 + 77<i32>:byte] : byte)
   Class: Eq_7782
   DataType: byte
@@ -34186,30 +33790,30 @@ T_7818: (in a6_1164 + 1<i32> : word32)
   Class: Eq_7505
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_7819: (in a7_1182 : Eq_7819)
+T_7819: (in a7_1182 : (ptr32 Eq_664))
   Class: Eq_7819
-  DataType: Eq_7819
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_664)
+  OrigDataType: (ptr32 (struct (0 T_666 t0000)))
 T_7820: (in 4<i32> : int32)
   Class: Eq_7820
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7821: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7819
-  DataType: Eq_7819
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_664)
+  OrigDataType: ptr32
 T_7822: (in 0<32> : word32)
   Class: Eq_7822
   DataType: word32
   OrigDataType: word32
 T_7823: (in a7_1182 + 0<32> : word32)
   Class: Eq_7823
-  DataType: Eq_7823
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7824: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_7819
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_7825: (in d1_5335 : word32)
   Class: Eq_7825
   DataType: word32
@@ -34228,8 +33832,8 @@ T_7828: (in 0<32> : word32)
   OrigDataType: word32
 T_7829: (in a7_1182 + 0<32> : word32)
   Class: Eq_7829
-  DataType: Eq_7829
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7830: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
@@ -34255,8 +33859,8 @@ T_7835: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_7836: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_7837: (in a0_1200 : (ptr32 byte))
   Class: Eq_4706
@@ -34274,30 +33878,30 @@ T_7840: (in Mem1177[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
-T_7841: (in a7_1201 : Eq_7841)
+T_7841: (in a7_1201 : (ptr32 Eq_664))
   Class: Eq_7841
-  DataType: Eq_7841
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_664)
+  OrigDataType: (ptr32 (struct (0 T_666 t0000)))
 T_7842: (in 4<i32> : int32)
   Class: Eq_7842
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7843: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7841
-  DataType: Eq_7841
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_664)
+  OrigDataType: ptr32
 T_7844: (in 0<32> : word32)
   Class: Eq_7844
   DataType: word32
   OrigDataType: word32
 T_7845: (in a7_1201 + 0<32> : word32)
   Class: Eq_7845
-  DataType: Eq_7845
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7846: (in Mem1203[a7_1201 + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_7841
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_7847: (in 1<i32> : int32)
   Class: Eq_7847
   DataType: int32
@@ -34316,8 +33920,8 @@ T_7850: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4724 t0000))))
 T_7851: (in Mem1207[a1 + 0<32>:word32] : word32)
   Class: Eq_4706
-  DataType: Eq_664
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4724 t0000)))
 T_7852: (in v611_1211 : byte)
   Class: Eq_4721
   DataType: byte
@@ -34340,8 +33944,8 @@ T_7856: (in 0<32> : word32)
   OrigDataType: word32
 T_7857: (in a7_1201 + 0<32> : word32)
   Class: Eq_7857
-  DataType: Eq_7857
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7858: (in Mem1207[a7_1201 + 0<32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
@@ -34380,7 +33984,7 @@ T_7866: (in d4_1070 + 1<32> : word32)
   OrigDataType: int32
 T_7867: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_7868: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_7868
@@ -34408,8 +34012,8 @@ T_7873: (in 73<i32> : int32)
   OrigDataType: int32
 T_7874: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7874
-  DataType: Eq_7874
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7875: (in Mem1331[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7875
   DataType: byte
@@ -34418,77 +34022,77 @@ T_7876: (in 0<8> : byte)
   Class: Eq_7875
   DataType: byte
   OrigDataType: byte
-T_7877: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7877: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7877
   DataType: bool
   OrigDataType: bool
-T_7878: (in a7_1302 : Eq_7878)
+T_7878: (in a7_1302 : (ptr32 Eq_664))
   Class: Eq_7878
-  DataType: Eq_7878
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_664)
+  OrigDataType: (ptr32 (struct (0 T_666 t0000)))
 T_7879: (in 4<i32> : int32)
   Class: Eq_7879
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7880: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7878
-  DataType: Eq_7878
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_664)
+  OrigDataType: ptr32
 T_7881: (in 0<32> : word32)
   Class: Eq_7881
   DataType: word32
   OrigDataType: word32
 T_7882: (in a7_1302 + 0<32> : word32)
   Class: Eq_7882
-  DataType: Eq_7882
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7883: (in Mem1308[a7_1302 + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_7878
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_7884: (in 4<i32> : int32)
   Class: Eq_7884
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7885: (in a7_1302 - 4<i32> : word32)
   Class: Eq_7885
-  DataType: Eq_7885
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_664)
+  OrigDataType: (ptr32 (struct (0 T_7888 t0000)))
 T_7886: (in 0<32> : word32)
   Class: Eq_7886
   DataType: word32
   OrigDataType: word32
 T_7887: (in a7_1302 - 4<i32> + 0<32> : word32)
   Class: Eq_7887
-  DataType: Eq_7887
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7888: (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_7885
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_7889: (in fn00002BD4 : ptr32)
   Class: Eq_4881
   DataType: (ptr32 Eq_4881)
   OrigDataType: (ptr32 (fn T_7898 (T_7894, T_7897)))
 T_7890: (in 1<i32> : int32)
   Class: Eq_7890
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7891: (in a7_1302 - 1<i32> : word32)
   Class: Eq_7891
-  DataType: Eq_7891
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7894 t0000)))
 T_7892: (in 0<32> : word32)
   Class: Eq_7892
   DataType: word32
   OrigDataType: word32
 T_7893: (in a7_1302 - 1<i32> + 0<32> : word32)
   Class: Eq_7893
-  DataType: Eq_7893
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7894: (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_4295
+  DataType: byte
   OrigDataType: byte
 T_7895: (in 0<32> : word32)
   Class: Eq_7895
@@ -34496,8 +34100,8 @@ T_7895: (in 0<32> : word32)
   OrigDataType: word32
 T_7896: (in a7_1302 + 0<32> : word32)
   Class: Eq_7896
-  DataType: Eq_7896
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7897: (in Mem1311[a7_1302 + 0<32>:word32] : word32)
   Class: Eq_664
   DataType: Eq_664
@@ -34512,119 +34116,119 @@ T_7899: (in 73<i32> : int32)
   OrigDataType: int32
 T_7900: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7900
-  DataType: Eq_7900
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7901: (in Mem1294[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7782
-  DataType: Eq_4329
+  DataType: byte
   OrigDataType: byte
-T_7902: (in a7_1237 : Eq_7902)
+T_7902: (in a7_1237 : (ptr32 ptr32))
   Class: Eq_7902
-  DataType: Eq_7902
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7906 t0000)))
 T_7903: (in 4<i32> : int32)
   Class: Eq_7903
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7904: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7902
-  DataType: Eq_7902
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
 T_7905: (in 78<i32> : int32)
   Class: Eq_7905
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7906: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_664
-  DataType: Eq_664
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  Class: Eq_7906
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7907: (in 0<32> : word32)
   Class: Eq_7907
   DataType: word32
   OrigDataType: word32
 T_7908: (in a7_1237 + 0<32> : word32)
   Class: Eq_7908
-  DataType: Eq_7908
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7909: (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_7902
+  Class: Eq_7906
+  DataType: ptr32
   OrigDataType: word32
 T_7910: (in 4<i32> : int32)
   Class: Eq_7910
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7911: (in a7_1237 - 4<i32> : word32)
   Class: Eq_7911
-  DataType: Eq_7911
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_7914 t0000)))
 T_7912: (in 0<32> : word32)
   Class: Eq_7912
   DataType: word32
   OrigDataType: word32
 T_7913: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_7913
-  DataType: Eq_7913
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7914: (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_7911
-  OrigDataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: word32
 T_7915: (in 00000008 : ptr32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_7915
+  DataType: ptr32
   OrigDataType: ptr32
 T_7916: (in 8<i32> : int32)
   Class: Eq_7916
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7917: (in a7_1237 - 8<i32> : word32)
   Class: Eq_7917
-  DataType: Eq_7917
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7920 t0000)))
 T_7918: (in 0<32> : word32)
   Class: Eq_7918
   DataType: word32
   OrigDataType: word32
 T_7919: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_7919
-  DataType: Eq_7919
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7920: (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_7917
-  OrigDataType: uint8
+  Class: Eq_7915
+  DataType: ptr32
+  OrigDataType: word32
 T_7921: (in 12<i32> : int32)
   Class: Eq_7921
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7922: (in a7_1237 - 12<i32> : word32)
   Class: Eq_7922
-  DataType: Eq_7922
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_664)
+  OrigDataType: (ptr32 (struct (0 T_7925 t0000)))
 T_7923: (in 0<32> : word32)
   Class: Eq_7923
   DataType: word32
   OrigDataType: word32
 T_7924: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_7924
-  DataType: Eq_7924
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7925: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
   Class: Eq_664
-  DataType: Eq_7922
-  OrigDataType: Eq_664
+  DataType: Eq_664
+  OrigDataType: word32
 T_7926: (in 0<32> : word32)
   Class: Eq_7926
   DataType: word32
   OrigDataType: word32
 T_7927: (in a7_1237 + 0<32> : word32)
   Class: Eq_7927
-  DataType: Eq_7927
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7928: (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_7906
+  DataType: ptr32
   OrigDataType: ptr32
 T_7929: (in fn000026C0 : ptr32)
   Class: Eq_7751
@@ -34632,45 +34236,45 @@ T_7929: (in fn000026C0 : ptr32)
   OrigDataType: (ptr32 (fn T_7939 (T_4333, T_7933, T_7938)))
 T_7930: (in a7_1237 - 12<i32> : word32)
   Class: Eq_7930
-  DataType: Eq_7930
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_793)
+  OrigDataType: (ptr32 (struct (0 T_7933 t0000)))
 T_7931: (in 0<32> : word32)
   Class: Eq_7931
   DataType: word32
   OrigDataType: word32
 T_7932: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_7932
-  DataType: Eq_7932
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7933: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_7934: (in 8<i32> : int32)
   Class: Eq_7934
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7935: (in a7_1237 - 8<i32> : word32)
   Class: Eq_7935
-  DataType: Eq_7935
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 Eq_793)
+  OrigDataType: (ptr32 (struct (0 T_7938 t0000)))
 T_7936: (in 0<32> : word32)
   Class: Eq_7936
   DataType: word32
   OrigDataType: word32
 T_7937: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_7937
-  DataType: Eq_7937
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7938: (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_7939: (in fn000026C0(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_7762
   DataType: int32
   OrigDataType: int32
-T_7940: (in Mem1248[a7_1237 + 0<32>:word32] + fn000026C0(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
+T_7940: (in *a7_1237 + fn000026C0(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_7940
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7941 t0000)))
@@ -34688,23 +34292,23 @@ T_7943: (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn000026C
   OrigDataType: uint32
 T_7944: (in 4<i32> : int32)
   Class: Eq_7944
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7945: (in a7_1237 - 4<i32> : word32)
   Class: Eq_7945
-  DataType: Eq_7945
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_7948 t0000)))
 T_7946: (in 0<32> : word32)
   Class: Eq_7946
   DataType: word32
   OrigDataType: word32
 T_7947: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_7947
-  DataType: Eq_7947
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7948: (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_665
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_7949: (in 1<i32> : int32)
   Class: Eq_7949
@@ -34728,7 +34332,7 @@ T_7953: (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
   OrigDataType: ui32
 T_7954: (in 0<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_7955: (in d0 == 0<32> : bool)
   Class: Eq_7955
@@ -34784,8 +34388,8 @@ T_7967: (in 60<i32> : int32)
   OrigDataType: int32
 T_7968: (in a7_1330 + 60<i32> : word32)
   Class: Eq_7968
-  DataType: Eq_7968
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7969: (in Mem1348[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_7969
   DataType: word32
@@ -34800,39 +34404,39 @@ T_7971: (in Mem1348[a7_1330 + 60<i32>:word32] + 1<32> : word32)
   OrigDataType: word32
 T_7972: (in a7_1330 + 60<i32> : word32)
   Class: Eq_7972
-  DataType: Eq_7972
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8497) u1) (T_6422 u2) (T_7288 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7973: (in Mem1351[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_7971
-  DataType: Eq_4329
+  DataType: word32
   OrigDataType: word32
 T_7974: (in d0 : uint32)
   Class: Eq_7974
   DataType: uint32
   OrigDataType: word32
-T_7975: (in d0_23 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_7975: (in d0_23 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_7976: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_7977 (T_7026)))
 T_7977: (in __swap(dwArg08) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
-T_7978: (in d1_25 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_7978: (in d1_25 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_7979: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_7980 (T_7028)))
 T_7980: (in __swap(dwArg10) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_7981: (in d4_29 : uint32)
   Class: Eq_7981
@@ -34870,9 +34474,9 @@ T_7989: (in d1_25 * (word16) d0_23 : word32)
   Class: Eq_7987
   DataType: uint32
   OrigDataType: uint32
-T_7990: (in d2_39 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_7990: (in d2_39 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_7991: (in SLICE(d1_25, word16, 0) : word16)
   Class: Eq_7991
@@ -34903,12 +34507,12 @@ T_7997: (in (word16) d4_29 ^ (word16) d4_29 : word16)
   DataType: ui16
   OrigDataType: ui16
 T_7998: (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_7999: (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_8000: (in dwArg08 *u SLICE(d1_25, word16, 0) + __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
   Class: Eq_8000
@@ -34923,28 +34527,28 @@ T_8002: (in dwArg10 * (word16) d0_23 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_8003: (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_8004: (in 0<32> : word32)
-  Class: Eq_664
-  DataType: uint8
+  Class: Eq_793
+  DataType: (ptr32 Eq_1365)
   OrigDataType: up32
 T_8005: (in d2_39 >= 0<32> : bool)
   Class: Eq_8005
   DataType: bool
   OrigDataType: bool
-T_8006: (in d2_45 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_8006: (in d2_45 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_8007: (in __swap : ptr32)
   Class: Eq_986
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_8008 (T_7990)))
 T_8008: (in __swap(d2_39) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_8009: (in d3_65 : uint32)
   Class: Eq_8009
@@ -34955,8 +34559,8 @@ T_8010: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_8011 (T_7027)))
 T_8011: (in __swap(dwArg0C) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_8012: (in SLICE(dwArg08, word16, 0) : word16)
   Class: Eq_8012
@@ -34966,9 +34570,9 @@ T_8013: (in __swap(dwArg0C) * (word16) dwArg08 : word32)
   Class: Eq_8009
   DataType: uint32
   OrigDataType: uint32
-T_8014: (in d3_71 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_8014: (in d3_71 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_8015: (in __swap : ptr32)
   Class: Eq_986
@@ -34983,8 +34587,8 @@ T_8017: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_8018 (T_7026)))
 T_8018: (in __swap(dwArg08) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_8019: (in SLICE(dwArg0C, word16, 0) : word16)
   Class: Eq_8019
@@ -35003,12 +34607,12 @@ T_8022: (in SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_8023: (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_8024: (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_8025: (in d3_83 : uint32)
   Class: Eq_8025
@@ -35019,8 +34623,8 @@ T_8026: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_8027 (T_7025)))
 T_8027: (in __swap(dwArg04) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_8028: (in SLICE(dwArg10, word16, 0) : word16)
   Class: Eq_8028
@@ -35030,9 +34634,9 @@ T_8029: (in __swap(dwArg04) * (word16) dwArg10 : word32)
   Class: Eq_8025
   DataType: uint32
   OrigDataType: uint32
-T_8030: (in d3_89 : Eq_664)
-  Class: Eq_664
-  DataType: Eq_664
+T_8030: (in d3_89 : Eq_793)
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_8031: (in __swap : ptr32)
   Class: Eq_986
@@ -35047,8 +34651,8 @@ T_8033: (in __swap : ptr32)
   DataType: (ptr32 Eq_986)
   OrigDataType: (ptr32 (fn T_8034 (T_7028)))
 T_8034: (in __swap(dwArg10) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uint32
 T_8035: (in SLICE(dwArg04, word16, 0) : word16)
   Class: Eq_8035
@@ -35067,12 +34671,12 @@ T_8038: (in SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_8039: (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: uipr32
 T_8040: (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
-  Class: Eq_664
-  DataType: Eq_664
+  Class: Eq_793
+  DataType: Eq_793
   OrigDataType: word32
 T_8041: (in SLICE(d2_45, word16, 16) : word16)
   Class: Eq_8041
@@ -35220,7 +34824,7 @@ T_8076: (in fn00002400(out a1_116, out a5_279) : word32)
   OrigDataType: word32
 T_8077: (in 0<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_8078: (in dwArg04 != 0<32> : bool)
   Class: Eq_8078
@@ -35380,7 +34984,7 @@ T_8116: (in Mem86[dwArg04 + 8<i32>:word32] : word32)
   OrigDataType: word32
 T_8117: (in 0<32> : word32)
   Class: Eq_664
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_8118: (in *((word32) dwArg04 + 8<i32>) != 0<32> : bool)
   Class: Eq_8118
@@ -36736,7 +36340,7 @@ T_8455:
   OrigDataType: 
 T_8456:
   Class: Eq_8456
-  DataType: Eq_8456
+  DataType: Eq_4336
   OrigDataType: 
 T_8457:
   Class: Eq_8457
@@ -36752,7 +36356,7 @@ T_8459:
   OrigDataType: 
 T_8460:
   Class: Eq_8460
-  DataType: Eq_8460
+  DataType: Eq_4336
   OrigDataType: 
 T_8461:
   Class: Eq_8461
@@ -36760,7 +36364,7 @@ T_8461:
   OrigDataType: 
 T_8462:
   Class: Eq_8462
-  DataType: Eq_8462
+  DataType: Eq_4336
   OrigDataType: 
 T_8463:
   Class: Eq_8463
@@ -36768,19 +36372,19 @@ T_8463:
   OrigDataType: 
 T_8464:
   Class: Eq_8464
-  DataType: Eq_4336
+  DataType: Eq_8464
   OrigDataType: 
 T_8465:
   Class: Eq_8465
-  DataType: (ptr32 Eq_4336)
+  DataType: Eq_8465
   OrigDataType: 
 T_8466:
   Class: Eq_8466
-  DataType: Eq_4336
+  DataType: Eq_8466
   OrigDataType: 
 T_8467:
   Class: Eq_8467
-  DataType: (ptr32 Eq_4336)
+  DataType: Eq_8467
   OrigDataType: 
 T_8468:
   Class: Eq_8468
@@ -36788,7 +36392,7 @@ T_8468:
   OrigDataType: 
 T_8469:
   Class: Eq_8469
-  DataType: (ptr32 Eq_4336)
+  DataType: Eq_8469
   OrigDataType: 
 T_8470:
   Class: Eq_8470
@@ -36800,11 +36404,11 @@ T_8471:
   OrigDataType: 
 T_8472:
   Class: Eq_8472
-  DataType: Eq_4336
+  DataType: Eq_8472
   OrigDataType: 
 T_8473:
   Class: Eq_8473
-  DataType: (ptr32 Eq_4336)
+  DataType: Eq_8473
   OrigDataType: 
 T_8474:
   Class: Eq_8474
@@ -36961,18 +36565,6 @@ T_8511:
 T_8512:
   Class: Eq_8512
   DataType: Eq_8512
-  OrigDataType: 
-T_8513:
-  Class: Eq_8513
-  DataType: Eq_8513
-  OrigDataType: 
-T_8514:
-  Class: Eq_8514
-  DataType: Eq_8514
-  OrigDataType: 
-T_8515:
-  Class: Eq_8515
-  DataType: Eq_8515
   OrigDataType: 
 */
 typedef struct Eq_676;
@@ -37159,15 +36751,10 @@ typedef void (Eq_624)();
 typedef void (Eq_645)();
 
 typedef union Eq_664 {
-	uint8 u0;
-	ui24 u1;
-	word16 u2;
-	struct Eq_8471 * u3;
-	struct Eq_8419 * u4;
-	struct Eq_8426 * u5;
-	Eq_1365 u6;
-	Eq_6422 u7;
-	Eq_7285 u8;
+	byte u0;
+	word16 u1;
+	struct Eq_8467 * u2;
+	struct Eq_8420 * u3;
 } Eq_664;
 
 typedef void (Eq_667)(Eq_669, byte *);
@@ -37177,7 +36764,7 @@ typedef union Eq_669 {
 	up32 u1;
 } Eq_669;
 
-typedef Eq_669 (Eq_671)(Eq_664, Eq_664, Eq_664, Eq_676 *);
+typedef Eq_669 (Eq_671)(Eq_664, Eq_664, byte * *, Eq_676 *);
 
 typedef struct Eq_676 {	// size: 1 1
 	uint8 b0000;	// 0
@@ -37212,19 +36799,19 @@ typedef union Eq_713 {
 } Eq_713;
 
 typedef struct Eq_720 {	// size: 4 4
-	Eq_8427 t002C;	// 2C
+	Eq_8421 t002C;	// 2C
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
-	word32 dw0037;	// 37
+	byte b0037;	// 37
 	word32 dw0038;	// 38
 	word32 dw003C;	// 3C
-	word32 dw003E;	// 3E
-	word32 dw003F;	// 3F
+	word16 w003E;	// 3E
+	byte b003F;	// 3F
 	word32 dw0040;	// 40
 	word32 dw0044;	// 44
 	ui32 dw0048;	// 48
 	word32 dw0062;	// 62
-	Eq_8428 t0066;	// 66
+	Eq_8422 t0066;	// 66
 	byte b006A;	// 6A
 	word32 dw006C;	// 6C
 	word32 dw007C;	// 7C
@@ -37237,6 +36824,12 @@ typedef union Eq_727 {
 } Eq_727;
 
 typedef Eq_669 (Eq_761)(int32, Eq_711 *, ui32 *, ptr32);
+
+typedef union Eq_793 {
+	struct Eq_1365 * u0;
+	struct Eq_8423 * u1;
+	struct Eq_8424 * u2;
+} Eq_793;
 
 typedef struct Eq_800 {
 	Eq_2365 t0000;	// 0
@@ -37269,7 +36862,7 @@ typedef union Eq_957 {
 	ptr32 u1;
 } Eq_957;
 
-typedef Eq_664 (Eq_986)(Eq_664);
+typedef Eq_793 (Eq_986)(Eq_793);
 
 typedef union Eq_1009 {
 	int32 u0;
@@ -37296,12 +36889,6 @@ typedef struct Eq_1198 {
 	word32 dw0000;	// 0
 	word32 dw0004;	// 4
 } Eq_1198;
-
-typedef union Eq_1201 {
-	ui24 u0;
-	struct Eq_8429 * u1;
-	Eq_1365 u2;
-} Eq_1201;
 
 typedef union Eq_1234 {
 	cu8 u0;
@@ -37372,41 +36959,10 @@ typedef union Eq_1343 {
 	int32 u1;
 } Eq_1343;
 
-typedef union Eq_1365 {
-	ui24 u0;
-	struct Eq_8430 * u1;
+typedef struct Eq_1365 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_1365;
-
-typedef union Eq_1366 {
-	ui24 u0;
-	struct Eq_8431 * u1;
-	Eq_1365 u2;
-} Eq_1366;
-
-typedef union Eq_1371 {
-	ui24 u0;
-	struct Eq_8432 * u1;
-	Eq_1365 u2;
-} Eq_1371;
-
-typedef union Eq_1378 {
-	ui24 u0;
-	struct Eq_8433 * u1;
-	Eq_1365 u2;
-} Eq_1378;
-
-typedef union Eq_1382 {
-	int32 u0;
-	uint32 u1;
-	Eq_1201 u2;
-	Eq_1365 u3;
-} Eq_1382;
-
-typedef union Eq_1384 {
-	ui24 u0;
-	struct Eq_8434 * u1;
-	Eq_1365 u2;
-} Eq_1384;
 
 typedef union Eq_1391 {
 	uint32 u0;
@@ -37441,23 +36997,11 @@ typedef struct Eq_1438 {
 } Eq_1438;
 
 typedef struct Eq_1491 {
-	Eq_1201 t0000;	// 0
+	struct Eq_1365 * ptr0000;	// 0
 	up32 dw0030;	// 30
 	up32 dw0034;	// 34
 	up32 dw0044;	// 44
 } Eq_1491;
-
-typedef union Eq_1508 {
-	ui24 u0;
-	struct Eq_8435 * u1;
-	Eq_1365 u2;
-} Eq_1508;
-
-typedef union Eq_1512 {
-	ui24 u0;
-	struct Eq_8436 * u1;
-	Eq_1365 u2;
-} Eq_1512;
 
 typedef union Eq_1523 {
 	byte u0;
@@ -37474,15 +37018,9 @@ typedef union Eq_1534 {
 	word32 u1;
 } Eq_1534;
 
-typedef union Eq_1541 {
-	ui24 u0;
-	struct Eq_8437 * u1;
-	Eq_1365 u2;
-} Eq_1541;
-
 typedef struct Eq_1615 {
 	word32 dw0000;	// 0
-	Eq_1201 t0004;	// 4
+	struct Eq_1365 * ptr0004;	// 4
 } Eq_1615;
 
 typedef union Eq_1630 {
@@ -37520,9 +37058,9 @@ typedef struct Eq_1703 {
 	Eq_713 t0080;	// 80
 } Eq_1703;
 
-typedef int32 (Eq_1743)(Eq_664, Eq_664, Eq_664, Eq_664);
+typedef int32 (Eq_1743)(Eq_793, Eq_793, Eq_793, Eq_793);
 
-typedef word32 (Eq_1827)(Eq_664, Eq_664, Eq_664, Eq_664, Eq_664, Eq_664);
+typedef word32 (Eq_1827)(Eq_793, Eq_793, Eq_793, Eq_793, Eq_793, Eq_793);
 
 typedef union Eq_1867 {
 	bool u0;
@@ -37665,11 +37203,6 @@ typedef union Eq_2121 {
 	up32 u1;
 } Eq_2121;
 
-typedef union Eq_2212 {
-	byte u0;
-	word32 u1;
-} Eq_2212;
-
 typedef struct Eq_2216 {
 	struct Eq_1198 * ptr0000;	// 0
 	int32 dw0034;	// 34
@@ -37690,11 +37223,6 @@ typedef union Eq_2254 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2254;
-
-typedef union Eq_2277 {
-	word16 u0;
-	word32 u1;
-} Eq_2277;
 
 typedef struct Eq_2281 {
 	struct Eq_1198 * ptr0000;	// 0
@@ -37732,12 +37260,6 @@ typedef union Eq_2340 {
 	ptr32 u1;
 } Eq_2340;
 
-typedef union Eq_2346 {
-	ui24 u0;
-	struct Eq_8438 * u1;
-	Eq_1365 u2;
-} Eq_2346;
-
 typedef union Eq_2355 {
 	uint32 u0;
 	ptr32 u1;
@@ -37765,11 +37287,6 @@ typedef union Eq_2373 {
 	Eq_2371 u5;
 } Eq_2373;
 
-typedef union Eq_2377 {
-	byte u0;
-	word32 u1;
-} Eq_2377;
-
 typedef struct Eq_2381 {
 	struct Eq_1198 * ptr0000;	// 0
 	word32 dw003C;	// 3C
@@ -37785,12 +37302,6 @@ typedef union Eq_2402 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2402;
-
-typedef union Eq_2408 {
-	ui24 u0;
-	struct Eq_8439 * u1;
-	Eq_1365 u2;
-} Eq_2408;
 
 typedef struct Eq_2426 {
 	Eq_2365 t0000;	// 0
@@ -37812,12 +37323,6 @@ typedef union Eq_2470 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2470;
-
-typedef union Eq_2476 {
-	ui24 u0;
-	struct Eq_8440 * u1;
-	Eq_1365 u2;
-} Eq_2476;
 
 typedef union Eq_2482 {
 	cu8 u0;
@@ -37931,12 +37436,6 @@ typedef union Eq_2549 {
 	ptr32 u1;
 } Eq_2549;
 
-typedef union Eq_2555 {
-	ui24 u0;
-	struct Eq_8441 * u1;
-	Eq_1365 u2;
-} Eq_2555;
-
 typedef union Eq_2560 {
 	uint32 u0;
 	ptr32 u1;
@@ -37946,12 +37445,6 @@ typedef union Eq_2561 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2561;
-
-typedef union Eq_2567 {
-	ui24 u0;
-	struct Eq_8442 * u1;
-	Eq_1365 u2;
-} Eq_2567;
 
 typedef union Eq_2573 {
 	uint32 u0;
@@ -37963,12 +37456,6 @@ typedef union Eq_2574 {
 	ptr32 u1;
 } Eq_2574;
 
-typedef union Eq_2580 {
-	ui24 u0;
-	struct Eq_8443 * u1;
-	Eq_1365 u2;
-} Eq_2580;
-
 typedef union Eq_2585 {
 	uint32 u0;
 	ptr32 u1;
@@ -37978,12 +37465,6 @@ typedef union Eq_2586 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2586;
-
-typedef union Eq_2592 {
-	ui24 u0;
-	struct Eq_8444 * u1;
-	Eq_1365 u2;
-} Eq_2592;
 
 typedef union Eq_2597 {
 	uint32 u0;
@@ -37996,27 +37477,22 @@ typedef union Eq_2602 {
 } Eq_2602;
 
 typedef union Eq_2606 {
-	int32 u0;
-	uint32 u1;
-	Eq_1201 u2;
-	Eq_1365 u3;
-	Eq_1899 u4;
-	Eq_1961 u5;
-	Eq_1967 u6;
-	Eq_2035 u7;
-	Eq_2078 u8;
+	struct Eq_1365 * u0;
+	struct Eq_1365 * u1;
+	Eq_1899 u2;
+	Eq_1961 u3;
+	Eq_1967 u4;
+	Eq_2035 u5;
+	Eq_2078 u6;
 } Eq_2606;
 
 typedef union Eq_2608 {
-	int32 u0;
-	uint32 u1;
-	Eq_1201 u2;
-	Eq_1365 u3;
-	Eq_1899 u4;
-	Eq_1961 u5;
-	Eq_1967 u6;
-	Eq_2035 u7;
-	Eq_2078 u8;
+	struct Eq_1365 * u0;
+	Eq_1899 u1;
+	Eq_1961 u2;
+	Eq_1967 u3;
+	Eq_2035 u4;
+	Eq_2078 u5;
 } Eq_2608;
 
 typedef Eq_680 (Eq_2632)(int32, Eq_711 *, ui32 *, ptr32, ptr32);
@@ -38024,8 +37500,10 @@ typedef Eq_680 (Eq_2632)(int32, Eq_711 *, ui32 *, ptr32, ptr32);
 typedef Eq_2679 (Eq_2673)(ptr32, ptr32);
 
 typedef union Eq_2679 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
+	byte u0;
+	word16 u1;
+	struct Eq_8467 * u2;
+	struct Eq_8440 * u3;
 } Eq_2679;
 
 typedef int32 (Eq_2734)(int32, ptr32, ptr32, int32 *);
@@ -38077,9 +37555,9 @@ typedef void (Eq_3350)(Eq_377 *);
 
 typedef void (Eq_3374)(int32, word32);
 
-typedef Eq_664 (Eq_3410)(Eq_664, Eq_664, Eq_664, Eq_664, Eq_664);
+typedef Eq_793 (Eq_3410)(Eq_793, Eq_793, Eq_793, Eq_793, Eq_793);
 
-typedef Eq_664 (Eq_3424)(Eq_664, Eq_664);
+typedef Eq_793 (Eq_3424)(Eq_793, Eq_793);
 
 typedef struct Eq_3445 {	// size: 1 1
 	Eq_3445 a0000[];	// 0
@@ -38100,7 +37578,7 @@ typedef union Eq_3565 {
 	word16 u1;
 } Eq_3565;
 
-typedef Eq_664 (Eq_3588)(Eq_664, Eq_664, Eq_664, Eq_664);
+typedef Eq_793 (Eq_3588)(Eq_793, Eq_793, Eq_793, Eq_793);
 
 typedef union Eq_3611 {
 	bool u0;
@@ -38122,7 +37600,7 @@ typedef union Eq_3755 {
 	uint32 u1;
 } Eq_3755;
 
-typedef Eq_664 (Eq_3852)(Eq_664, word32, bool);
+typedef Eq_793 (Eq_3852)(Eq_793, word32, bool);
 
 typedef union Eq_4182 {
 	bool u0;
@@ -38149,20 +37627,30 @@ typedef union Eq_4234 {
 	ui32 u1;
 } Eq_4234;
 
-typedef Eq_664 (Eq_4280)(Eq_664, Eq_664, Eq_664, Eq_664, Eq_676 *, Eq_664);
+typedef Eq_664 (Eq_4280)(Eq_664, Eq_664, byte * *, Eq_664, Eq_676 *, Eq_793);
 
-typedef union Eq_4329 {
-	uint8 u0;
-	struct Eq_8450 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
+typedef struct Eq_4329 {	// size: 4 4
+	int32 dw002C;	// 2C
+	Eq_8441 t0030;	// 30
+	word32 dw0034;	// 34
+	uint8 b0037;	// 37
+	word32 dw0038;	// 38
+	word32 dw003C;	// 3C
+	word32 dw0040;	// 40
+	Eq_8442 t0044;	// 44
+	byte b0048;	// 48
+	byte b0049;	// 49
+	word32 dw004A;	// 4A
+	word32 dw006E;	// 6E
+	word32 dw0072;	// 72
+	word32 dw0084;	// 84
 } Eq_4329;
 
 typedef union Eq_4336 {
 	byte u0;
 	word16 u1;
-	struct Eq_8471 * u2;
-	struct Eq_8452 * u3;
+	struct Eq_8467 * u2;
+	struct Eq_8444 * u3;
 } Eq_4336;
 
 typedef union Eq_4348 {
@@ -38201,7 +37689,7 @@ typedef union Eq_4469 {
 
 typedef Eq_664 (Eq_4691)(Eq_664, Eq_2679, word32 *, byte *);
 
-typedef Eq_664 (Eq_4881)(Eq_664, Eq_664);
+typedef Eq_664 (Eq_4881)(byte, Eq_664);
 
 typedef struct Eq_4894 {
 	Eq_664 t0000;	// 0
@@ -38431,11 +37919,6 @@ typedef struct Eq_6380 {
 	uint32 dw0038;	// 38
 } Eq_6380;
 
-typedef union Eq_6422 {
-	uint8 u0;
-	word32 u1;
-} Eq_6422;
-
 typedef union Eq_6430 {
 	int32 u0;
 	uint32 u1;
@@ -38491,78 +37974,30 @@ typedef union Eq_6598 {
 	word32 u1;
 } Eq_6598;
 
-typedef union Eq_6612 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-} Eq_6612;
-
-typedef union Eq_6614 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-} Eq_6614;
-
-typedef union Eq_6629 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-} Eq_6629;
-
-typedef union Eq_6632 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-} Eq_6632;
-
 typedef union Eq_6650 {
 	bool u0;
 	word32 u1;
 } Eq_6650;
 
-typedef union Eq_6681 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-} Eq_6681;
-
-typedef union Eq_6683 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-} Eq_6683;
-
-typedef union Eq_6696 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-	Eq_6632 u2;
-} Eq_6696;
-
 typedef union Eq_6702 {
 	union Eq_4336 ** u0;
-	Eq_6632 u1;
+	struct Eq_8461 * u1;
 } Eq_6702;
-
-typedef union Eq_6743 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-} Eq_6743;
-
-typedef union Eq_6758 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-} Eq_6758;
 
 typedef union Eq_6760 {
 	union Eq_4336 ** u0;
-	Eq_6632 u1;
-	Eq_6696 u2;
+	struct Eq_8461 * u1;
 } Eq_6760;
 
 typedef union Eq_6761 {
 	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-	Eq_6632 u2;
-	Eq_6696 u3;
+	struct Eq_8461 * u1;
+	struct Eq_8467 * u2;
 } Eq_6761;
 
 typedef union Eq_6764 {
 	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
+	struct Eq_8467 * u1;
 } Eq_6764;
 
 typedef union Eq_6778 {
@@ -38581,33 +38016,15 @@ typedef struct Eq_6920 {
 } Eq_6920;
 
 typedef struct Eq_6971 {
-	Eq_664 t0000;	// 0
-	Eq_7060 t0001;	// 1
+	Eq_793 t0000;	// 0
+	ui24 n0001;	// 1
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
 	word32 dw0044;	// 44
 	word32 dw0048;	// 48
 } Eq_6971;
 
-typedef union Eq_6982 {
-	ui24 u0;
-	struct Eq_8474 * u1;
-	Eq_1365 u2;
-} Eq_6982;
-
-typedef word32 (Eq_7022)(Eq_4336, Eq_664, Eq_664, Eq_664, Eq_664, ptr32);
-
-typedef union Eq_7059 {
-	ui24 u0;
-	struct Eq_8475 * u1;
-	Eq_1365 u2;
-} Eq_7059;
-
-typedef union Eq_7060 {
-	ui24 u0;
-	struct Eq_8476 * u1;
-	Eq_1365 u2;
-} Eq_7060;
+typedef word32 (Eq_7022)(Eq_4336, Eq_793, Eq_793, Eq_793, Eq_793, ptr32);
 
 typedef union Eq_7073 {
 	int32 u0;
@@ -38629,23 +38046,14 @@ typedef struct Eq_7156 {
 
 typedef union Eq_7284 {
 	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-	Eq_6758 u2;
+	struct Eq_8467 * u1;
 } Eq_7284;
 
 typedef union Eq_7285 {
-	uint8 u0;
-	union Eq_4336 ** u1;
-	struct Eq_8471 * u2;
-	Eq_6422 u3;
-	Eq_6758 u4;
+	union Eq_4336 ** u0;
+	struct Eq_8467 * u1;
+	struct Eq_8467 * u2;
 } Eq_7285;
-
-typedef union Eq_7287 {
-	uint8 u0;
-	word32 u1;
-	Eq_6422 u2;
-} Eq_7287;
 
 typedef struct Eq_7295 {
 	int32 dw0000;	// 0
@@ -38657,416 +38065,53 @@ typedef union Eq_7307 {
 	int32 u1;
 } Eq_7307;
 
-typedef union Eq_7310 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7310;
-
-typedef union Eq_7312 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
+typedef struct Eq_7312 {
+	Eq_664 t0000;	// 0
+	byte b0030;	// 30
+	word32 dw0038;	// 38
+	Eq_664 t003C;	// 3C
+	byte b004C;	// 4C
 } Eq_7312;
 
-typedef union Eq_7313 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7313;
+typedef union Eq_7337 {
+	int32 u0;
+	byte u1;
+} Eq_7337;
 
-typedef union Eq_7316 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7316;
-
-typedef union Eq_7319 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7319;
-
-typedef union Eq_7324 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7324;
-
-typedef union Eq_7326 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7326;
-
-typedef union Eq_7329 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7329;
-
-typedef union Eq_7335 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7335;
-
-typedef union Eq_7339 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7339;
-
-typedef union Eq_7344 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7344;
-
-typedef union Eq_7348 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7348;
+typedef union Eq_7346 {
+	int32 u0;
+	byte u1;
+} Eq_7346;
 
 typedef struct Eq_7361 {
 	word32 dw0000;	// 0
-	word32 dw0004;	// 4
+	Eq_664 t0004;	// 4
 } Eq_7361;
 
-typedef union Eq_7366 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7366;
-
-typedef union Eq_7372 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7372;
-
-typedef union Eq_7380 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7380;
-
-typedef union Eq_7385 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7385;
-
-typedef union Eq_7398 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7398;
-
-typedef union Eq_7409 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7409;
-
-typedef union Eq_7414 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7414;
-
-typedef union Eq_7427 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7427;
-
-typedef union Eq_7438 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7438;
-
-typedef union Eq_7443 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7443;
-
-typedef union Eq_7456 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7456;
-
-typedef union Eq_7473 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7473;
-
-typedef union Eq_7485 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7485;
-
-typedef union Eq_7486 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7486;
-
-typedef union Eq_7487 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7487;
-
-typedef union Eq_7489 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7489;
-
-typedef union Eq_7496 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7496;
-
-typedef union Eq_7499 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7499;
-
-typedef union Eq_7503 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7503;
-
-typedef union Eq_7507 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7507;
-
-typedef union Eq_7512 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7512;
-
-typedef union Eq_7560 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7560;
-
-typedef union Eq_7561 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7561;
-
-typedef union Eq_7562 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7562;
+typedef union Eq_7501 {
+	int32 u0;
+	byte u1;
+} Eq_7501;
 
 typedef union Eq_7564 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_7564;
 
-typedef union Eq_7567 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7567;
-
-typedef union Eq_7578 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7578;
-
-typedef union Eq_7580 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7580;
-
-typedef union Eq_7581 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7581;
-
-typedef union Eq_7582 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7582;
-
 typedef union Eq_7584 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_7584;
 
-typedef union Eq_7587 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7587;
-
-typedef union Eq_7599 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7599;
-
-typedef union Eq_7653 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
+typedef struct Eq_7653 {
+	Eq_664 t0000;	// 0
+	Eq_664 t0030;	// 30
 } Eq_7653;
 
-typedef union Eq_7654 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7654;
-
-typedef union Eq_7657 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7657;
-
-typedef union Eq_7662 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7662;
-
-typedef union Eq_7669 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7669;
-
-typedef union Eq_7677 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
+typedef struct Eq_7677 {
+	Eq_664 t0000;	// 0
+	uint32 dw0030;	// 30
 } Eq_7677;
-
-typedef union Eq_7678 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7678;
-
-typedef union Eq_7681 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7681;
-
-typedef union Eq_7693 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7693;
-
-typedef union Eq_7696 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7696;
-
-typedef union Eq_7701 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7701;
-
-typedef union Eq_7706 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7706;
-
-typedef union Eq_7709 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7709;
 
 typedef union Eq_7711 {
 	int32 u0;
@@ -39078,236 +38123,17 @@ typedef union Eq_7712 {
 	uint32 u1;
 } Eq_7712;
 
-typedef union Eq_7718 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7718;
-
-typedef union Eq_7724 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
+typedef struct Eq_7724 {
+	ptr32 ptr0000;	// 0
+	byte b004D;	// 4D
 } Eq_7724;
 
-typedef union Eq_7725 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7725;
-
-typedef union Eq_7727 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7727;
-
-typedef union Eq_7730 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7730;
-
-typedef union Eq_7732 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7732;
-
-typedef union Eq_7733 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7733;
-
-typedef union Eq_7735 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7735;
-
-typedef union Eq_7738 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7738;
-
-typedef union Eq_7739 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7739;
-
-typedef union Eq_7741 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7741;
-
-typedef union Eq_7743 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7743;
-
-typedef union Eq_7744 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7744;
-
-typedef union Eq_7746 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7746;
-
-typedef union Eq_7749 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7749;
-
-typedef int32 (Eq_7751)(Eq_664, Eq_664, Eq_664);
-
-typedef union Eq_7753 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7753;
-
-typedef union Eq_7755 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7755;
-
-typedef union Eq_7757 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7757;
-
-typedef union Eq_7758 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7758;
-
-typedef union Eq_7760 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7760;
-
-typedef union Eq_7767 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7767;
-
-typedef union Eq_7768 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7768;
-
-typedef union Eq_7770 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7770;
+typedef int32 (Eq_7751)(Eq_793, Eq_793, Eq_793);
 
 typedef union Eq_7779 {
 	int32 u0;
 	uint32 u1;
 } Eq_7779;
-
-typedef union Eq_7784 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7784;
-
-typedef union Eq_7819 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7819;
-
-typedef union Eq_7820 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7820;
-
-typedef union Eq_7823 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7823;
-
-typedef union Eq_7829 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7829;
-
-typedef union Eq_7841 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7841;
-
-typedef union Eq_7842 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7842;
-
-typedef union Eq_7845 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7845;
-
-typedef union Eq_7857 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7857;
 
 typedef union Eq_7863 {
 	int32 u0;
@@ -39319,262 +38145,10 @@ typedef union Eq_7869 {
 	uint32 u1;
 } Eq_7869;
 
-typedef union Eq_7874 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7874;
-
-typedef union Eq_7878 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7878;
-
-typedef union Eq_7879 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7879;
-
-typedef union Eq_7882 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7882;
-
-typedef union Eq_7884 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7884;
-
-typedef union Eq_7885 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7885;
-
-typedef union Eq_7887 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7887;
-
-typedef union Eq_7890 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7890;
-
-typedef union Eq_7891 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7891;
-
-typedef union Eq_7893 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7893;
-
-typedef union Eq_7896 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7896;
-
-typedef union Eq_7900 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7900;
-
-typedef union Eq_7902 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7902;
-
-typedef union Eq_7903 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7903;
-
-typedef union Eq_7905 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7905;
-
-typedef union Eq_7908 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7908;
-
-typedef union Eq_7910 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7910;
-
-typedef union Eq_7911 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7911;
-
-typedef union Eq_7913 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7913;
-
-typedef union Eq_7916 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7916;
-
-typedef union Eq_7917 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7917;
-
-typedef union Eq_7919 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7919;
-
-typedef union Eq_7921 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7921;
-
-typedef union Eq_7922 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7922;
-
-typedef union Eq_7924 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7924;
-
-typedef union Eq_7927 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7927;
-
-typedef union Eq_7930 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7930;
-
-typedef union Eq_7932 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7932;
-
-typedef union Eq_7934 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7934;
-
-typedef union Eq_7935 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7935;
-
-typedef union Eq_7937 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7937;
-
-typedef union Eq_7944 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7944;
-
-typedef union Eq_7945 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7945;
-
-typedef union Eq_7947 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7947;
-
 typedef union Eq_7956 {
 	int32 u0;
 	uint32 u1;
 } Eq_7956;
-
-typedef union Eq_7968 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7968;
-
-typedef union Eq_7972 {
-	uint8 u0;
-	struct Eq_8497 * u1;
-	Eq_6422 u2;
-	Eq_7285 u3;
-} Eq_7972;
 
 typedef int32 (Eq_8107)(ptr32, ptr32);
 
@@ -39584,79 +38158,20 @@ typedef struct Eq_8362 {	// size: 4 4
 	byte b0000;	// 0
 } Eq_8362;
 
-typedef struct Eq_8419 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8419 {
+	Eq_4336 t0000;	// 0
+} Eq_8419;
+
+typedef struct Eq_8420 {	// size: 4 4
+	struct Eq_8419 * ptr0000;	// 0
 	Eq_664 t0004;	// 4
 	Eq_664 t0008;	// 8
 	int32 dw0014;	// 14
 	ui32 dw0018;	// 18
 	int32 dw001C;	// 1C
-} Eq_8419;
-
-typedef struct Eq_8420 {
-	Eq_664 t0000;	// 0
 } Eq_8420;
 
 typedef union Eq_8421 {
-	int32 u0;
-	byte u1;
-	Eq_664 u2;
-} Eq_8421;
-
-typedef union Eq_8422 {
-	byte u0;
-	union Eq_4336 ** u1;
-	struct Eq_8471 * u2;
-	Eq_664 u3;
-	Eq_6758 u4;
-	Eq_7285 u5;
-} Eq_8422;
-
-typedef union Eq_8423 {
-	uint8 u0;
-	word32 u1;
-	Eq_6422 u2;
-} Eq_8423;
-
-typedef union Eq_8424 {
-	uint8 u0;
-	word32 u1;
-	Eq_4329 u2;
-	Eq_6422 u3;
-	Eq_7285 u4;
-} Eq_8424;
-
-typedef union Eq_8425 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-	Eq_6632 u2;
-	Eq_6696 u3;
-	Eq_6761 u4;
-} Eq_8425;
-
-typedef struct Eq_8426 {	// size: 4 4
-	struct Eq_8420 * ptrFFFFFFFC;	// FFFFFFFC
-	union Eq_4336 * ptr0000;	// 0
-	Eq_8421 t002C;	// 2C
-	Eq_8422 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8423 t0037;	// 37
-	Eq_8424 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8425 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
-} Eq_8426;
-
-typedef union Eq_8427 {
 	cu8 u0;
 	word32 u1;
 	Eq_1234 u2;
@@ -39665,19 +38180,45 @@ typedef union Eq_8427 {
 	Eq_2371 u5;
 	Eq_2482 u6;
 	Eq_2523 u7;
+} Eq_8421;
+
+typedef union Eq_8422 {
+	struct Eq_1365 * u0;
+	Eq_1899 u1;
+	Eq_1961 u2;
+	Eq_1967 u3;
+	Eq_2035 u4;
+	Eq_2078 u5;
+	Eq_2606 u6;
+} Eq_8422;
+
+typedef struct Eq_8423 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8423;
+
+typedef struct Eq_8424 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8424;
+
+typedef struct Eq_8425 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8425;
+
+typedef struct Eq_8426 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8426;
+
+typedef struct Eq_8427 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_8427;
 
-typedef union Eq_8428 {
-	int32 u0;
-	uint32 u1;
-	Eq_1201 u2;
-	Eq_1365 u3;
-	Eq_1899 u4;
-	Eq_1961 u5;
-	Eq_1967 u6;
-	Eq_2035 u7;
-	Eq_2078 u8;
-	Eq_2606 u9;
+typedef struct Eq_8428 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_8428;
 
 typedef struct Eq_8429 {	// size: 1 1
@@ -39735,94 +38276,71 @@ typedef struct Eq_8439 {	// size: 1 1
 	byte b0003;	// 3
 } Eq_8439;
 
-typedef struct Eq_8440 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8440 {	// size: 4 4
+	union Eq_4336 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8440;
 
-typedef struct Eq_8441 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef union Eq_8441 {
+	union Eq_4336 ** u0;
+	struct Eq_8467 * u1;
+	Eq_7285 u2;
 } Eq_8441;
 
-typedef struct Eq_8442 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef union Eq_8442 {
+	union Eq_4336 ** u0;
+	struct Eq_8461 * u1;
+	struct Eq_8467 * u2;
+	Eq_6761 u3;
 } Eq_8442;
 
-typedef struct Eq_8443 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8443 {
+	Eq_4336 t0000;	// 0
 } Eq_8443;
 
-typedef struct Eq_8444 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8444 {	// size: 4 4
+	struct Eq_8443 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8444;
 
-typedef union Eq_8445 {
-	int32 u0;
-	byte u1;
-	Eq_664 u2;
+typedef struct Eq_8445 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8445;
 
-typedef union Eq_8446 {
-	byte u0;
-	union Eq_4336 ** u1;
-	struct Eq_8471 * u2;
-	Eq_664 u3;
-	Eq_6758 u4;
-	Eq_7285 u5;
+typedef struct Eq_8446 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8446;
 
-typedef union Eq_8447 {
-	uint8 u0;
-	word32 u1;
-	Eq_6422 u2;
+typedef struct Eq_8447 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8447;
 
-typedef union Eq_8448 {
-	uint8 u0;
-	word32 u1;
-	Eq_4329 u2;
-	Eq_6422 u3;
-	Eq_7285 u4;
+typedef struct Eq_8448 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8448;
 
-typedef union Eq_8449 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-	Eq_6632 u2;
-	Eq_6696 u3;
-	Eq_6761 u4;
+typedef struct Eq_8449 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8449;
 
 typedef struct Eq_8450 {	// size: 4 4
-	Eq_664 t0000;	// 0
-	Eq_8445 t002C;	// 2C
-	Eq_8446 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8447 t0037;	// 37
-	Eq_8448 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8449 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8450;
 
-typedef struct Eq_8451 {
-	Eq_4336 t0000;	// 0
+typedef struct Eq_8451 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8451;
 
 typedef struct Eq_8452 {	// size: 4 4
-	struct Eq_8451 * ptr0000;	// 0
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8452;
 
 typedef struct Eq_8453 {	// size: 4 4
@@ -39837,59 +38355,123 @@ typedef struct Eq_8455 {	// size: 4 4
 	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8455;
 
-typedef struct Eq_8456 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8456;
-
 typedef struct Eq_8457 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8505 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8457;
 
 typedef struct Eq_8458 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8506 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8458;
 
 typedef struct Eq_8459 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8507 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8459;
 
-typedef struct Eq_8460 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8460;
-
 typedef struct Eq_8461 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8512 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8461;
 
-typedef struct Eq_8462 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8462;
-
 typedef struct Eq_8463 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8509 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8463;
 
-typedef struct Eq_8470 {
+typedef struct Eq_8464 {	// size: 4 4
+	union Eq_8510 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
+} Eq_8464;
+
+typedef struct Eq_8465 {	// size: 4 4
+	union Eq_4336 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
+} Eq_8465;
+
+typedef struct Eq_8466 {
 	Eq_4336 t0000;	// 0
+} Eq_8466;
+
+typedef struct Eq_8467 {	// size: 4 4
+	union Eq_8511 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
+} Eq_8467;
+
+typedef struct Eq_8469 {	// size: 4 4
+	union Eq_4336 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
+} Eq_8469;
+
+typedef struct Eq_8470 {	// size: 4 4
+	union Eq_4336 * ptr0000;	// 0
+	Eq_664 t0004;	// 4
+	Eq_664 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8470;
 
-typedef struct Eq_8471 {	// size: 4 4
-	struct Eq_8470 * ptr0000;	// 0
+typedef struct Eq_8471 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_8471;
 
-typedef struct Eq_8474 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8472 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8472;
+
+typedef struct Eq_8473 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8473;
+
+typedef struct Eq_8474 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8474;
 
-typedef struct Eq_8475 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8475 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8475;
 
-typedef struct Eq_8476 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8476 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8476;
 
 typedef struct Eq_8477 {	// size: 4 4
@@ -39952,61 +38534,28 @@ typedef struct Eq_8491 {	// size: 4 4
 	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8491;
 
-typedef union Eq_8492 {
-	int32 u0;
-	byte u1;
-	Eq_664 u2;
+typedef struct Eq_8492 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8492;
 
-typedef union Eq_8493 {
-	byte u0;
-	union Eq_4336 ** u1;
-	struct Eq_8471 * u2;
-	Eq_664 u3;
-	Eq_6758 u4;
-	Eq_7285 u5;
+typedef struct Eq_8493 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8493;
 
-typedef union Eq_8494 {
-	uint8 u0;
-	word32 u1;
-	Eq_6422 u2;
+typedef struct Eq_8494 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8494;
 
-typedef union Eq_8495 {
-	uint8 u0;
-	word32 u1;
-	Eq_4329 u2;
-	Eq_6422 u3;
-	Eq_7285 u4;
+typedef struct Eq_8495 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8495;
 
-typedef union Eq_8496 {
-	union Eq_4336 ** u0;
-	struct Eq_8471 * u1;
-	Eq_6632 u2;
-	Eq_6696 u3;
-	Eq_6761 u4;
+typedef struct Eq_8496 {	// size: 4 4
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8496;
 
 typedef struct Eq_8497 {	// size: 4 4
-	Eq_664 t0000;	// 0
-	Eq_8492 t002C;	// 2C
-	Eq_8493 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8494 t0037;	// 37
-	Eq_8495 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8496 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
+	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8497;
 
 typedef struct Eq_8498 {	// size: 4 4
@@ -40037,47 +38586,44 @@ typedef struct Eq_8504 {	// size: 4 4
 	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8504;
 
-typedef struct Eq_8505 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8505 {
+	Eq_4336 u0;
+	Eq_8466 u1;
 } Eq_8505;
 
-typedef struct Eq_8506 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8506 {
+	Eq_4336 u0;
+	Eq_8466 u1;
 } Eq_8506;
 
-typedef struct Eq_8507 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8507 {
+	Eq_4336 u0;
+	Eq_8466 u1;
 } Eq_8507;
 
-typedef struct Eq_8508 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8508 {
+	Eq_4336 u0;
+	Eq_8466 u1;
 } Eq_8508;
 
-typedef struct Eq_8509 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8509 {
+	Eq_4336 u0;
+	Eq_8466 u1;
 } Eq_8509;
 
-typedef struct Eq_8510 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8510 {
+	Eq_4336 u0;
+	Eq_8466 u1;
 } Eq_8510;
 
-typedef struct Eq_8511 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8511 {
+	Eq_4336 u0;
+	Eq_8466 u1;
 } Eq_8511;
 
-typedef struct Eq_8512 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8512 {
+	Eq_4336 u0;
+	Eq_8508 u1;
+	Eq_8511 u2;
 } Eq_8512;
-
-typedef struct Eq_8513 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8513;
-
-typedef struct Eq_8514 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8514;
-
-typedef struct Eq_8515 {	// size: 4 4
-	union Eq_664 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8515;
 

--- a/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN_code.c
+++ b/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN_code.c
@@ -372,7 +372,7 @@ void fn000013C4()
 // 000013D8: Register Eq_n fn000013D8()
 Eq_n fn000013D8()
 {
-	Eq_n a1_n;
+	byte ** a1_n;
 	Eq_n d1_n;
 	fn00001474(fn00002BB8(fn00003DE0(&globals->b142C, out d1_n, out a1_n), d1_n, a1_n, &globals->t1448), &globals->b144C);
 	int32 d2_n = 1;
@@ -500,7 +500,7 @@ void fn00001490(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 					{
 						a0_n = 0x288D + (SEQ(SLICE(d0_n, word24, 8), *a2_n) & 0xFF);
 						uint32 d0_n = (uint32) (uint8) a0_n->t0000;
-						d5_n.u0 = 0;
+						&d5_n.u0->dw0000 = 0;
 						d0_n = d0_n & 0x04;
 						if ((d0_n & 0x04) != 0x00)
 						{
@@ -549,7 +549,7 @@ void fn00001490(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 				Eq_n v100_n = *a2_n;
 				byte * a2_n = a2_n + 1;
 				struct Eq_n * d1_n = SEQ(SLICE(d1_n, word24, 8), v100_n);
-				Eq_n d0_n = SEQ(SLICE(d0_n, word24, 8), v100_n);
+				struct Eq_n * d0_n = SEQ(SLICE(d0_n, word24, 8), v100_n);
 				if (v100_n != 0x25)
 				{
 					if (v100_n != 88)
@@ -571,7 +571,7 @@ void fn00001490(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 									if (v100_n == 0x00)
 										a2_n -= (byte *) 1;
 									d0_n = a2_n - a4_n;
-									a7_n->t0066.u2 = d0_n;
+									a7_n->t0066 = d0_n;
 									a7_n[16] = (struct Eq_n) 0x00;
 									a3_n = a4_n;
 									d5_n.u0 = 0;
@@ -579,20 +579,20 @@ void fn00001490(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 								else
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a3_n = (byte *) *d0_n;
+									a3_n = d0_n->dw0000;
 									a7_n->t0066 = 0x00;
-									d3_n = (word32) d0_n + 4;
-									a0_n = (word32) d0_n + 4;
+									d3_n = d0_n + 4;
+									a0_n = (struct Eq_n *) (d0_n + 4);
 									byte * a1_n = a3_n;
-									if ((d5_n == 0x00 || d5_n - a7_n->t0066 > 0x00) && *a3_n != 0x00)
+									if ((d5_n == 0x00 || d5_n - a7_n->t0066 > null) && *a3_n != 0x00)
 									{
-										d0_n = a7_n->t0066;
+										d0_n = (struct Eq_n *) a7_n->t0066;
 										do
 										{
-											d0_n = (word32) d0_n + 1;
+											++d0_n;
 											++a1_n;
-										} while ((d5_n <= 0x00 || d5_n - d0_n > 0x00) && *a1_n != 0x00);
-										a7_n->t0066.u2 = d0_n;
+										} while ((d5_n <= 0x00 || d5_n - d0_n > null) && *a1_n != 0x00);
+										a7_n->t0066 = d0_n;
 									}
 									d5_n.u0 = 0;
 								}
@@ -602,32 +602,32 @@ void fn00001490(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 								if (d4_n == 0x01)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0004 = d6_n;
 									a0_n->t0000.u0 = 0x00;
 								}
 								else if (d4_n == 0x6C)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = d6_n;
 								}
 								else if (d4_n == 0x68)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = (word16) d6_n;
 								}
 								else if (d4_n == 0x02)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = (byte) d6_n;
 								}
 								else
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = d6_n;
 								}
 								d3_n = ((word32) d3_n + 3 >> 0x02 << 0x02) + 0x04;
@@ -640,16 +640,16 @@ void fn00001490(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 							if (d4_n == 0x6C)
 							{
 								d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-								*a3_n = (byte) *((word32) d0_n + 3);
+								*a3_n = (byte) d0_n[3];
 							}
 							else
 							{
 								d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-								*a3_n = (byte) *((word32) d0_n + 3);
+								*a3_n = (byte) d0_n[3];
 							}
 							a0_n = ((word32) d3_n + 3 >> 0x02 << 0x02) + 0x04;
 							d3_n = ((word32) d3_n + 3 >> 0x02 << 0x02) + 0x04;
-							a7_n->t0066.u0 = 0x01;
+							a7_n->t0066 = 0x01;
 							d5_n.u0 = 0;
 						}
 						goto l00001BFC;
@@ -688,7 +688,7 @@ l0000170E:
 						}
 						if (d4_n == 0x68)
 						{
-							Eq_n v262_n = a7_n->dw003E;
+							word16 v262_n = a7_n->w003E;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1_n;
 							a7_n->dw0040 = (uint32) (uint16) v262_n;
@@ -697,7 +697,7 @@ l0000170E:
 						}
 						if (d4_n == 0x02)
 						{
-							Eq_n v277_n = a7_n->dw003F;
+							byte v277_n = a7_n->b003F;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1_n;
 							a7_n->dw0040 = (uint32) (uint8) v277_n;
@@ -808,7 +808,7 @@ l0000196A:
 							}
 							if (d4_n == 0x02)
 							{
-								Eq_n v248_n = a7_n->dw0037;
+								byte v248_n = a7_n->b0037;
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->ptr0000 = d1_n;
 								int32 d1_n = (int32) (int16) (int8) SEQ(SLICE(d1_n, word24, 8), v248_n);
@@ -877,7 +877,7 @@ l000019AC:
 					a7_n->dw0062 = d7_n;
 					struct Eq_n * v187_n = a7_n + 0x0E;
 					word32 d6_n = v187_n->dw0000;
-					Eq_n d7_n = v187_n->t0004;
+					struct Eq_n * d7_n = v187_n->ptr0004;
 					word32 d3_n = a7_n->t0066;
 					Eq_n a1_n = a7_n[11];
 					do
@@ -889,7 +889,7 @@ l000019AC:
 						*(a7_n - 8) = (union Eq_n *) a1_n;
 						*(a7_n - 0x0C) = d1_n;
 						*(a7_n - 16) = d1_n >> 31;
-						*(a7_n - 20) = (union Eq_n *) d7_n;
+						*(a7_n - 20) = (struct Eq_n **) d7_n;
 						*(a7_n - 24) = d6_n;
 						int32 d1_n = fn00002778(*(a7_n - 24), *(a7_n - 20), *(a7_n - 16), *(a7_n - 0x0C));
 						ptr32 v191_n = *(a7_n - 8);
@@ -902,9 +902,9 @@ l000019AC:
 						*(a7_n - 8) = v191_n;
 						*(a7_n - 0x0C) = d1_n;
 						*(a7_n - 16) = d0_n;
-						*(a7_n - 20) = (union Eq_n *) d7_n;
+						*(a7_n - 20) = (struct Eq_n **) d7_n;
 						*(a7_n - 24) = d6_n;
-						Eq_n d1_n;
+						struct Eq_n * d1_n;
 						word32 d0_n = fn00002430(*(a7_n - 24), *(a7_n - 20), *(a7_n - 16), *(a7_n - 0x0C), out d1_n, out a0_n);
 						a1_n = *(a7_n - 8);
 						d6_n = d0_n;
@@ -912,7 +912,7 @@ l000019AC:
 						a7_n = (struct Eq_n *) (&a7_n->dw0000 + 1);
 						++d3_n;
 						d0_n = d1_n;
-					} while (d0_n - (d1_n < 0x00) != 0x00);
+					} while (d0_n - (d1_n < null) != 0x00);
 					a7_n->dw006A = d3_n;
 					d7_n = a7_n->ptr0066;
 					d6_n = a7_n->t0034;
@@ -935,15 +935,15 @@ l00001BFC:
 				else
 					a7_n[11] = (struct Eq_n) d5_n;
 				struct Eq_n * a7_n = a7_n - 4;
-				a7_n->t0000 = d0_n;
+				a7_n->ptr0000 = d0_n;
 				a7_n->dw0034 = d7_n + a7_n->dw0030 / 0x0044;
-				a7_n->t0000 = a7_n->t0000;
-				Eq_n d0_n = a7_n->t0000;
+				a7_n->ptr0000 = a7_n->ptr0000;
+				struct Eq_n * d0_n = a7_n->ptr0000;
 				if (a7_n->dw0034 - a7_n->dw0044 >= 0x00)
 					a7_n->dw0030 = 0x00;
 				else
 				{
-					a7_n->t0000 = d0_n;
+					a7_n->ptr0000 = d0_n;
 					a7_n->dw0030 = a7_n->dw0044 - a7_n->dw0034;
 				}
 				a7_n[0x0C] = a7_n[11];
@@ -1563,7 +1563,7 @@ l0000252E:
 		word32 d1_n;
 		d1_n = fn00002534(dwArg04, dwArg08, dwArg10, out d1_n, out d2_n);
 l0000252C:
-		d0_n.u0 = 0;
+		&d0_n.u0->dw0000 = 0;
 		goto l0000252E;
 	}
 }
@@ -1621,7 +1621,7 @@ l0000254E:
 					Eq_n d2_n = __swap(d5_n);
 					Eq_n d3_n = __swap(d7_n);
 					if ((word16) (d2_n - d3_n) == 0x00)
-						d1_n.u0 = 0xFFFF;
+						&d1_n.u0->dw0000 = 0xFFFF;
 					else
 						d1_n = __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_n % (uint16) d3_n), (uint16) (d5_n /u (uint16) d3_n))), word16, 16), 0x00));
 					Eq_n d6_n = __swap(SEQ(SLICE(d6_n, word16, 16), 0x00));
@@ -1733,7 +1733,7 @@ Eq_n fn000026F2(Eq_n d0, Eq_n d1, Eq_n d2, union Eq_n & d1Out)
 		if ((word16) d1_n < 0x80)
 		{
 			d1_n = __rol(d1_n, 0x08);
-			d3_n.u0 = 0x08;
+			&d3_n.u0->dw0000 = 0x08;
 		}
 		if ((word16) d1_n < 0x0800)
 		{
@@ -1894,31 +1894,31 @@ void fn00002B74(struct Eq_n * dwArg04)
 	}
 }
 
-// 00002BB8: Register Eq_n fn00002BB8(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack (ptr32 Eq_n) dwArg04)
-Eq_n fn00002BB8(Eq_n d0, Eq_n d1, Eq_n a1, struct Eq_n * dwArg04)
+// 00002BB8: Register Eq_n fn00002BB8(Register Eq_n d0, Register Eq_n d1, Register (ptr32 (ptr32 byte)) a1, Stack (ptr32 Eq_n) dwArg04)
+Eq_n fn00002BB8(Eq_n d0, Eq_n d1, byte ** a1, struct Eq_n * dwArg04)
 {
 	return fn00002C04(d0, d1, a1, *(union Eq_n *) 0x3FCC, dwArg04, fp + 8);
 }
 
-// 00002BD4: Register Eq_n fn00002BD4(Stack Eq_n bArg07, Stack Eq_n dwArg08)
-Eq_n fn00002BD4(Eq_n bArg07, Eq_n dwArg08)
+// 00002BD4: Register Eq_n fn00002BD4(Stack byte bArg07, Stack Eq_n dwArg08)
+Eq_n fn00002BD4(byte bArg07, Eq_n dwArg08)
 {
 	Eq_n d0_n = dwArg08;
 	if (dwArg08 != 0x00)
 	{
 		d0_n = *((word32) dwArg08 + 4);
 		if (d0_n - *((word32) dwArg08 + 8) < 0x00)
-			**((word32) dwArg08 + 4) = bArg07;
+			(*((word32) dwArg08 + 4))->u0 = bArg07;
 		*((word32) dwArg08 + 20) = (word32) *((word32) dwArg08 + 20) + 1;
 		--*((word32) dwArg08 + 4);
 	}
 	return d0_n;
 }
 
-// 00002C04: Register Eq_n fn00002C04(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
-Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
+// 00002C04: Register Eq_n fn00002C04(Register Eq_n d0, Register Eq_n d1, Register (ptr32 (ptr32 byte)) a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
+Eq_n fn00002C04(Eq_n d0, Eq_n d1, byte ** a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
 {
-	Eq_n a7_n = fp + -0x0078;
+	struct Eq_n * a7_n = fp + -0x0078;
 	Eq_n d2_n = dwArg0C;
 	struct Eq_n * a4_n = dwArg08;
 	Eq_n a2_n = dwArg04;
@@ -1932,8 +1932,8 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 			Eq_n d3_n = 0;
 			if (a4_n->b0000 == 0x25)
 			{
-				*((word32) a7_n + 72) = 0x69;
-				*((word32) a7_n + 73) = 0x00;
+				a7_n[18] = (struct Eq_n) 0x69;
+				a7_n->b0049 = 0x00;
 				byte * a3_n = a4_n + 1;
 				uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 				Eq_n d6_n = -1;
@@ -1941,7 +1941,7 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				if ((d0_n & 0x04) != 0x00)
 				{
 					uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-					d6_n.u0 = 0;
+					&d6_n.u0->dw0000 = 0;
 					d0 = d0_n & 0x04;
 					if ((d0_n & 0x04) != 0x00)
 					{
@@ -1963,8 +1963,8 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				}
 				if (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))))
 				{
-					d7 = SEQ(SLICE(d7, word24, 8), *((word32) a7_n + 73));
-					d1 = SEQ(SLICE(d1, word24, 8), *((word32) a7_n + 72));
+					d7 = SEQ(SLICE(d7, word24, 8), a7_n->b0049);
+					d1 = SEQ(SLICE(d1, word24, 8), a7_n[18]);
 					do
 					{
 						if (*a3_n == 0x2A)
@@ -1977,15 +1977,15 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 							d1 = SEQ(SLICE(d1, word24, 8), *a3_n);
 						++a3_n;
 					} while (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))));
-					*((word32) a7_n + 72) = (byte) d1;
-					*((word32) a7_n + 73) = (byte) d7;
+					a7_n[18] = (struct Eq_n) (byte) d1;
+					a7_n->b0049 = (byte) d7;
 				}
-				if (*((word32) a7_n + 72) == 0x6A)
-					*((word32) a7_n + 72) = 0x01;
-				if (*((word32) a7_n + 72) == 116)
-					*((word32) a7_n + 72) = 0x69;
-				if (*((word32) a7_n + 72) == 122)
-					*((word32) a7_n + 72) = 0x6C;
+				if (a7_n[18] == 0x6A)
+					a7_n[18] = (struct Eq_n) 0x01;
+				if (a7_n[18] == 116)
+					a7_n[18] = (struct Eq_n) 0x69;
+				if (a7_n[18] == 122)
+					a7_n[18] = (struct Eq_n) 0x6C;
 				byte v83_n = *a3_n;
 				word24 v84_n = SLICE(d7, word24, 8);
 				struct Eq_n * a3_n = a3_n + 1;
@@ -2006,7 +2006,7 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 							byte * a0_n = *a1;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							*a1 = (byte **) (a0_n + 1);
 							byte v96_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v96_n);
@@ -2043,19 +2043,19 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 								d1 = SEQ(v147_n, v83_n - 115);
 								if (v83_n != 115)
 								{
-									*((word32) a7_n + 48) = 0x00;
-									*((word32) a7_n + 44) = 0x00;
-									*((word32) a7_n + 110) = 0x00;
+									a7_n[0x0C] = (struct Eq_n) 0x00;
+									a7_n[11] = (struct Eq_n) 0x00;
+									a7_n->dw006E = 0x00;
 									if (v83_n == 0x00)
 										--a3_n;
 									if (v83_n == 0x70)
 									{
-										*((word32) a7_n + 72) = 0x6C;
+										a7_n[18] = (struct Eq_n) 0x6C;
 										d7 = 0x0078;
 									}
 									if ((d5_n == 0x2D && (byte) d7 != 117 || d5_n == 0x2B) && d6_n - d3_n >= 0x00)
 									{
-										*((word32) a7_n + 110) = d5_n;
+										a7_n->dw006E = (word32) d5_n;
 										ui32 * a0_n = (word32) a2_n + 24;
 										*a0_n |= 0x01;
 										int32 * a0_n = (word32) a2_n + 20;
@@ -2067,7 +2067,7 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											byte * a0_n = *a1;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v231_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -2083,7 +2083,7 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0 = fn00003CA8(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0;
 										}
-										d5_n = *((word32) a7_n + 52);
+										d5_n = a7_n[0x0D];
 										d3_n = (word32) d3_n + 1;
 										d4_n = (word32) d4_n + 1;
 									}
@@ -2103,7 +2103,7 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												byte * a0_n = *a1;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												*a1 = (byte **) (a0_n + 1);
 												byte v249_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -2119,8 +2119,8 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00003CA8(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 64) = *((word32) a7_n + 52);
-											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+											a7_n[16] = a7_n[0x0D];
+											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 											Eq_n d3_n = (word32) d3_n + 1;
 											d0 = d0_n & 0xFF;
 											if (!__btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[(int32) (int16) (d0_n & 0xFF)].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0], 0x00))
@@ -2139,7 +2139,7 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 													byte * a0_n = *a1;
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
-													*a1 = a0_n + 1;
+													*a1 = (byte **) (a0_n + 1);
 													byte v271_n = *a0_n;
 													a2_n = a7_n->t0000;
 													a7_n->t0000 = d1;
@@ -2155,12 +2155,12 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 													d0_n = fn00003CA8(a7_n->t0000, out d1, out a1, out a5_n);
 													a7_n->t0038 = d0_n;
 												}
-												*((word32) a7_n + 74) = *((word32) a7_n + 52);
+												a7_n->dw004A = (word32) a7_n[0x0D];
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x44;
 												if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 													d7 = 0x0078;
-												if (*((word32) a7_n + 74) != ~0x00)
+												if (a7_n->dw004A != ~0x00)
 												{
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
@@ -2170,7 +2170,7 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											}
 											else
 												d7 = 111;
-											if (*((word32) a7_n + 64) != ~0x00)
+											if (a7_n[16] != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -2207,7 +2207,7 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											byte * a0_n = *a1;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v351_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -2223,8 +2223,8 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0_n = fn00003CA8(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0_n;
 										}
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
-										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+										a7_n[16] = a7_n[0x0D];
+										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 										Eq_n d3_n = (word32) d3_n + 1;
 										int32 d4_n = (word32) d4_n + 1;
 										d0 = d0_n & 0xFF;
@@ -2244,7 +2244,7 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												byte * a0_n = *a1;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												*a1 = (byte **) (a0_n + 1);
 												byte v372_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -2260,17 +2260,17 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00003CA8(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 74) = *((word32) a7_n + 52);
-											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55)) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
+											a7_n->dw004A = (word32) a7_n[0x0D];
+											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(SLICE(d0_n, word24, 8), a7_n->b0037) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 											d3_n = (word32) d3_n + 1;
 											d4_n = d4_n + 0x01;
 											d0 = d0_n & 0x44;
 											if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 											{
-												d5_n = *((word32) a7_n + 74);
+												d5_n = a7_n->dw004A;
 												goto l0000366E;
 											}
-											if (*((word32) a7_n + 74) != ~0x00)
+											if (a7_n->dw004A != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -2278,7 +2278,7 @@ Eq_n fn00002C04(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0 = fn00002BD4(*(a7_n - 1), a7_n->t0000);
 											}
 										}
-										if (*((word32) a7_n + 64) != ~0x00)
+										if (a7_n[16] != ~0x00)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
@@ -2292,52 +2292,52 @@ l0000366E:
 									if ((byte) d7 != 0x78 && (byte) d7 != 88)
 									{
 										if ((byte) d7 == 111)
-											*((word32) a7_n + 52) = 0x08;
+											a7_n[0x0D] = (struct Eq_n) 0x08;
 										else
-											*((word32) a7_n + 52) = 0x0A;
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
+											a7_n[0x0D] = (struct Eq_n) 0x0A;
+										a7_n[16] = a7_n[0x0D];
 									}
 									else
-										*((word32) a7_n + 64) = 0x10;
-									*((word32) a7_n + 114) = *((word32) a7_n + 64);
+										a7_n[16] = (struct Eq_n) 0x10;
+									a7_n->dw0072 = (word32) a7_n[16];
 									uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(SLICE(d0, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-									*((word32) a7_n + 0x0084) = d2_n;
-									*((word32) a7_n + 52) = d4_n;
-									*((word32) a7_n + 74) = (byte) d7;
+									a7_n[33] = (struct Eq_n) d2_n;
+									a7_n[0x0D] = (struct Eq_n) d4_n;
+									a7_n->dw004A = (word32) (byte) d7;
 									d0 = d0_n & 0x44;
 									if ((d0_n & 0x44) != 0x00)
 									{
-										if (*((word32) a7_n + 114) == 0x0A)
+										if (a7_n->dw0072 == 0x0A)
 										{
 											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(SLICE(d0_n & 0x44, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											d0 = d0_n & 0x04;
 											if ((d0_n & 0x04) != 0x00)
 												goto l0000370A;
 											goto l0000390A;
 										}
 l0000370A:
-										if (*((word32) a7_n + 114) == 0x08)
+										if (a7_n->dw0072 == 0x08)
 										{
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d5_n <= 55)
 												goto l0000372A;
 										}
 										else
 										{
 l0000372A:
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 64) = d6_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n[16] = (struct Eq_n) d6_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d6_n - d3_n >= 0x00)
 											{
-												d7 = (int32) *((word32) a7_n + 114);
-												up32 a4_n = *((word32) a7_n + 64);
+												d7 = a7_n->dw0072;
+												up32 a4_n = a7_n[16];
 												do
 												{
 													struct Eq_n * a7_n = a7_n - 4;
@@ -2345,7 +2345,7 @@ l0000372A:
 													Eq_n v419_n = a7_n->t0000;
 													a7_n->t0000 = d7 >> 31;
 													*(a7_n - 4) = d7;
-													*(a7_n - 8) = (union Eq_n *) a1;
+													*(a7_n - 8) = (byte ***) a1;
 													*(a7_n - 0x0C) = a7_n->dw0034;
 													*(a7_n - 16) = a7_n->dw0030;
 													*(a7_n - 20) = d7;
@@ -2353,44 +2353,44 @@ l0000372A:
 													word32 d1_n;
 													a7_n->dw0044 = fn00003C28(d4_n, *(a7_n - 24), *(a7_n - 20), *(a7_n - 16), *(a7_n - 0x0C), out d1_n);
 													a7_n->dw0048 = d1_n;
-													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(a7_n->t0001, (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x04) != 0x00)
-														d4_n = d5_n - 0x30;
+													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(a7_n->n0001, (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x04) != 0x00)
+														d4_n = d5_n - (struct Eq_n *) 0x30;
 													else
 														d4_n.u0 = 0;
-													Eq_n d6_n;
+													struct Eq_n * d6_n;
 													*(a7_n - 4) = (union Eq_n *) v419_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d4_n + Mem2975[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = (union Eq_n *) d3_n;
 													int32 d0_n = d4_n >> 31;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + d0_n);
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < null) + ((word32) a7_n[16] + d0_n));
 													word32 v441_n = *(a7_n - 8);
 													word32 v442_n = *(a7_n - 4);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x01) != 0x00)
-														d6_n = d5_n - 55;
+														d6_n = d5_n - (struct Eq_n *) 55;
 													else
-														d6_n.u0 = 0;
-													Eq_n d2_n;
+														d6_n = null;
+													struct Eq_n * d2_n;
 													*(a7_n - 4) = v442_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d6_n + Mem3035[a7_n + 48:word32];
-													*((word32) a7_n + 0x0044) = d2_n;
+													a7_n[0x0011] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v441_n;
 													int32 d0_n = d6_n >> 31;
-													*((word32) a7_n + 64) = (word32) *((word32) a7_n + 44) + d0_n + (d2_n < 0x00);
+													a7_n[16] = (struct Eq_n) ((word32) a7_n[11] + d0_n + (d2_n < null));
 													word32 v453_n = *(a7_n - 8);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x02) != 0x00)
-														d2_n = d5_n - 0x57;
+														d2_n = d5_n - (struct Eq_n *) 0x57;
 													else
-														d2_n.u0 = 0;
+														d2_n = null;
 													Eq_n d0_n;
-													*(a7_n - 4) = (union Eq_n *) d2_n;
+													*(a7_n - 4) = (struct Eq_n **) d2_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d2_n + Mem3093[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v453_n;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + (d2_n >> 31));
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < null) + ((word32) a7_n[16] + (d2_n >> 31)));
 													ui32 * a0_n = (word32) a2_n + 24;
 													up32 v465_n = *(a7_n - 8);
 													d2_n = *(a7_n - 4);
@@ -2403,7 +2403,7 @@ l0000372A:
 														a1 = (word32) a2_n + 4;
 														byte * a0_n = *a1;
 														*(a7_n - 4) = (union Eq_n *) a2_n;
-														*a1 = a0_n + 1;
+														*a1 = (byte **) (a0_n + 1);
 														d0_n = (uint32) (uint8) *a0_n;
 														a2_n = *(a7_n - 4);
 														d1 = (uint32) (uint8) (byte) d0_n;
@@ -2416,7 +2416,7 @@ l0000372A:
 														d0_n = fn00003CA8(*(a7_n - 4), out d1_n, out a1, out a5_n);
 														d1 = d0_n;
 													}
-													*((word32) a7_n + 52) = (word32) *((word32) a7_n + 52) + 1;
+													a7_n[0x0D] = (struct Eq_n) ((word32) a7_n[0x0D] + 1);
 													uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(SLICE(d0_n, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 													d5_n = d1;
 													d3_n = v465_n + 0x01;
@@ -2435,11 +2435,11 @@ l0000372A:
 										}
 									}
 l0000390A:
-									Eq_n v476_n = *((word32) a7_n + 74);
+									Eq_n v476_n = a7_n->dw004A;
 									d7 = SEQ(SLICE(d7, word24, 8), v476_n);
-									word32 d4_n = *((word32) a7_n + 52);
-									d2_n = *((word32) a7_n + 0x0084);
-									if (*((word32) a7_n + 110) != 0x00 && d3_n == 0x02)
+									word32 d4_n = a7_n[0x0D];
+									d2_n = a7_n[33];
+									if (a7_n->dw006E != 0x00 && d3_n == 0x02)
 									{
 										if (d5_n != ~0x00)
 										{
@@ -2450,7 +2450,7 @@ l0000390A:
 										}
 										--d3_n;
 										--d4_n;
-										d5_n = *((word32) a7_n + 110);
+										d5_n = a7_n->dw006E;
 									}
 									if (d5_n != ~0x00)
 									{
@@ -2461,14 +2461,14 @@ l0000390A:
 									}
 									d3_n = d3_n - 0x01;
 									d4_n = d4_n - 0x01;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										if (v476_n == 117)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = d0;
 											a7_n->b0038 = a7_n->b004C - 0x01;
-											a7_n = (char *) &a7_n->t0000 + 4;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
 											if (a7_n->b0038 != 0x00)
 											{
 												byte v517_n = a7_n->b0038 - 0x01;
@@ -2520,58 +2520,58 @@ l0000390A:
 										}
 										else
 										{
-											if (*((word32) a7_n + 110) == 0x2D)
+											if (a7_n->dw006E == 0x2D)
 											{
-												struct Eq_n * v528_n = (word32) a7_n + 44;
+												struct Eq_n * v528_n = a7_n + 11;
 												d1 = -v528_n->dw0004;
 												d0 = -v528_n->dw0000 - (d1 < 0x00);
-												a7_n = *((word32) a7_n + 56);
+												a7_n = (struct Eq_n *) a7_n[0x0E];
 											}
 											else
 											{
-												*((word32) a7_n + 56) = *((word32) a7_n + 48);
-												*((word32) a7_n + 52) = *((word32) a7_n + 44);
+												a7_n[0x0E] = a7_n[0x0C];
+												a7_n[0x0D] = a7_n[11];
 											}
-											Eq_n a7_n = a7_n - 4;
-											*a7_n = d0;
-											*((word32) a7_n + 48) = *((word32) a7_n + 76) - 0x01;
-											a7_n = (word32) a7_n + 4;
-											if (*((word32) a7_n + 48) != 0x00)
+											struct Eq_n * a7_n = a7_n - 4;
+											a7_n->t0000 = d0;
+											a7_n->b0030 = a7_n->b004C - 0x01;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
+											if (a7_n->b0030 != 0x00)
 											{
-												byte v540_n = *((word32) a7_n + 48) - 0x01;
-												*((word32) a7_n + 48) = v540_n;
+												byte v540_n = a7_n->b0030 - 0x01;
+												a7_n->b0030 = v540_n;
 												if (v540_n != 0x00)
 												{
-													byte v541_n = *((word32) a7_n + 48) - 0x66;
-													*((word32) a7_n + 48) = v541_n;
+													byte v541_n = a7_n->b0030 - 0x66;
+													a7_n->b0030 = v541_n;
 													if (v541_n != 0x00)
 													{
-														byte v542_n = *((word32) a7_n + 48) - 0x04;
-														*((word32) a7_n + 48) = v542_n;
+														byte v542_n = a7_n->b0030 - 0x04;
+														a7_n->b0030 = v542_n;
 														if (v542_n != 0x00)
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 														else
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 													}
 													else
 													{
 														d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-														d0 = *((word32) a7_n + 60);
+														d0 = a7_n->t003C;
 														**((word32) d2_n - 4) = (word16) d0;
 													}
 												}
 												else
 												{
 													d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-													d0 = *((word32) a7_n + 60);
+													d0 = a7_n->t003C;
 													**((word32) d2_n - 4) = (byte) d0;
 												}
 											}
@@ -2580,18 +2580,18 @@ l0000390A:
 												word32 d0_n = d2_n + 0x03 >>u 0x02;
 												d2_n = (d0_n << 0x02) + 0x04;
 												struct Eq_n * a0_n = *((word32) d2_n - 4);
-												a0_n->dw0004 = (word32) *((word32) a7_n + 60);
-												a0_n->dw0000 = (word32) *((word32) a7_n + 56);
+												a0_n->t0004 = a7_n->t003C;
+												a0_n->dw0000 = a7_n->dw0038;
 												d0 = d0_n << 0x02;
 											}
 										}
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 								else
 								{
 									byte * a5_n;
-									if (*((word32) a7_n + 73) == 0x00)
+									if (a7_n->b0049 == 0x00)
 									{
 										d0 = (word32) d2_n + 3 >> 0x02 << 0x02;
 										d2_n = (word32) d0 + 4;
@@ -2605,7 +2605,7 @@ l0000390A:
 										d0 = d0_n & 0x08;
 										if ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00)
 										{
-											byte v190_n = *((word32) a7_n + 73);
+											byte v190_n = a7_n->b0049;
 											d7 = SEQ(v84_n, v190_n);
 											do
 											{
@@ -2625,7 +2625,7 @@ l0000390A:
 													byte * a0_n = *a1;
 													union Eq_n * a7_n = a7_n - 4;
 													*a7_n = (union Eq_n *) a2_n;
-													*a1 = a0_n + 1;
+													*a1 = (byte **) (a0_n + 1);
 													byte v201_n = *a0_n;
 													a2_n = *a7_n;
 													d0 = SEQ(SLICE(d0, word24, 8), v201_n);
@@ -2647,7 +2647,7 @@ l0000390A:
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t288D)[SEQ(SLICE(d0, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x08;
 											} while ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00);
-											*((word32) a7_n + 73) = v190_n;
+											a7_n->b0049 = v190_n;
 										}
 									}
 									if (d5_n != ~0x00)
@@ -2659,18 +2659,18 @@ l0000390A:
 									}
 									d3_n = d3_n - 0x01;
 									--d4_n;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										*a5_n = 0x00;
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 							}
 							else
 							{
-								if (*((word32) a7_n + 73) == 0x00)
+								if (a7_n->b0049 == 0x00)
 								{
-									if (*((word32) a7_n + 72) == 0x01)
+									if (a7_n[18] == 0x01)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										struct Eq_n * a0_n = *d0;
@@ -2678,19 +2678,19 @@ l0000390A:
 										a0_n->dw0000 = 0x00;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x6C)
+									else if (a7_n[18] == 0x6C)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x68)
+									else if (a7_n[18] == 0x68)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (word16) d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x02)
+									else if (a7_n[18] == 0x02)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (byte) d4_n;
@@ -2703,16 +2703,16 @@ l0000390A:
 										d2_n = (word32) d0 + 4;
 									}
 								}
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 								d3_n.u0 = 1;
 							}
 						}
 						else
 						{
 							if (d6_n == ~0x00)
-								d6_n.u0 = 1;
+								&d6_n.u0->dw0000 = 1;
 							union Eq_n * a1_n;
-							if (*((word32) a7_n + 73) == 0x00)
+							if (a7_n->b0049 == 0x00)
 							{
 								d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 								d2_n = (word32) d0 + 4;
@@ -2724,7 +2724,7 @@ l0000390A:
 							*a0_n |= 0x01;
 							int32 * a0_n = (word32) a2_n + 20;
 							--*a0_n;
-							*((word32) a7_n + 44) = a1_n;
+							a7_n[11] = (struct Eq_n) a1_n;
 							if (*a0_n >= 0x00)
 							{
 								byte ** a1_n = (word32) a2_n + 4;
@@ -2741,7 +2741,7 @@ l0000390A:
 							}
 							else
 							{
-								int32 a1_n = *((word32) a7_n + 44);
+								int32 a1_n = a7_n[11];
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->t0000 = a2_n;
 								a7_n->dw0030 = a1_n;
@@ -2751,18 +2751,18 @@ l0000390A:
 								a7_n->t0038 = d0;
 								a7_n->dw0030 = a7_n->dw0030;
 							}
-							a1 = *((word32) a7_n + 44);
-							d5_n = *((word32) a7_n + 52);
+							a1 = (byte **) a7_n[11];
+							d5_n = a7_n[0x0D];
 							Eq_n d3_n = (word32) d3_n + 1;
 							int32 d4_n = (word32) d4_n + 1;
-							if (*((word32) a7_n + 52) != ~0x00)
+							if (a7_n[0x0D] != ~0x00)
 							{
-								*((word32) a7_n + 44) = a1;
+								a7_n[11] = (struct Eq_n) a1;
 								if (d6_n - d3_n >= 0x00)
 								{
-									byte v302_n = *((word32) a7_n + 73);
+									byte v302_n = a7_n->b0049;
 									d7 = SEQ(v84_n, v302_n);
-									byte * a4_n = *((word32) a7_n + 44);
+									byte * a4_n = a7_n[11];
 									do
 									{
 										if (v302_n == 0x00)
@@ -2781,7 +2781,7 @@ l0000390A:
 											byte * a0_n = *a1;
 											union Eq_n * a7_n = a7_n - 4;
 											*a7_n = (union Eq_n *) a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v314_n = *a0_n;
 											a2_n = *a7_n;
 											d0 = SEQ(SLICE(d0, word24, 8), v314_n);
@@ -2800,7 +2800,7 @@ l0000390A:
 										d3_n = (word32) d3_n + 1;
 										++d4_n;
 									} while (d1 != ~0x00 && d6_n - d3_n >= 0x00);
-									*((word32) a7_n + 73) = v302_n;
+									a7_n->b0049 = v302_n;
 								}
 							}
 							if (d5_n != ~0x00)
@@ -2812,22 +2812,22 @@ l0000390A:
 							}
 							d3_n = d3_n - 0x01;
 							d4_n = d4_n - 0x01;
-							if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							if (a7_n->b0049 == 0x00 && d3_n != 0x00)
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 					else
 					{
-						*((word32) a7_n + 44) = 0x00;
+						a7_n[11] = (struct Eq_n) 0x00;
 						if (a3_n->b0000 == 0x5E)
 						{
-							*((word32) a7_n + 44) = 0x01;
+							a7_n[11] = (struct Eq_n) 0x01;
 							++a3_n;
 						}
-						*((word32) a7_n + 52) = 0x00;
-						byte v544_n = *((word32) a7_n + 44);
+						a7_n[0x0D] = (struct Eq_n) 0x00;
+						Eq_n v544_n = a7_n[11];
 						d7 = SEQ(v84_n, v544_n);
-						Eq_n d1_n = *((word32) a7_n + 52);
+						Eq_n d1_n = a7_n[0x0D];
 						do
 						{
 							int32 d5_n;
@@ -2835,12 +2835,12 @@ l0000390A:
 								d5_n = 0xFF;
 							else
 								d5_n = 0;
-							*((word32) d1_n + ((word32) a7_n + 78)) = (byte) d5_n;
+							Mem796[a7_n + 78 + d1_n:byte] = SLICE(d5_n, byte, 0);
 							d1_n = (word32) d1_n + 1;
 						} while (d1_n < 0x20);
-						*((word32) a7_n + 0x0084) = d2_n;
-						*((word32) a7_n + 44) = v544_n;
-						byte v554_n = *((word32) a7_n + 44);
+						a7_n[33] = (struct Eq_n) d2_n;
+						a7_n[11] = (struct Eq_n) v544_n;
+						Eq_n v554_n = a7_n[11];
 						while (a3_n->b0000 != 0x00)
 						{
 							cu8 v556_n = a3_n->b0000;
@@ -2859,13 +2859,13 @@ l0000390A:
 							{
 								if (v554_n != 0x00)
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (~(1 << (d5_n & 7)) & d1_n);
 								}
 								else
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (1 << (d5_n & 7) | d1_n);
 								}
@@ -2876,9 +2876,9 @@ l0000390A:
 								break;
 						}
 						byte * a6_n;
-						d2_n = *((word32) a7_n + 0x0084);
+						d2_n = a7_n[33];
 						++a3_n;
-						if (*((word32) a7_n + 73) == 0x00)
+						if (a7_n->b0049 == 0x00)
 						{
 							word32 d0_n = d2_n + 0x03 >>u 0x02;
 							d2_n = (d0_n << 0x02) + 0x04;
@@ -2896,40 +2896,40 @@ l0000390A:
 						{
 							a1 = (word32) a2_n + 4;
 							byte * a0_n = *a1;
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*a1 = a0_n + 1;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
+							*a1 = (byte **) (a0_n + 1);
 							byte v585_n = *a0_n;
-							a2_n = *a7_n;
-							*a7_n = d1_n;
-							*((word32) a7_n + 48) = (uint32) (uint8) v585_n;
+							a2_n = a7_n->t0000;
+							a7_n->t0000 = d1_n;
+							a7_n->dw0030 = (uint32) (uint8) v585_n;
 							d0 = SEQ(SLICE(d0, word24, 8), v585_n);
-							d1 = *a7_n;
+							d1 = a7_n->t0000;
 						}
 						else
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
 							word32 a5_n;
-							d0 = fn00003CA8(*a7_n, out d1, out a1, out a5_n);
-							*((word32) a7_n + 48) = d0;
+							d0 = fn00003CA8(a7_n->t0000, out d1, out a1, out a5_n);
+							a7_n->t0030 = d0;
 						}
-						d5_n = *((word32) a7_n + 44);
+						d5_n = a7_n[11];
 						Eq_n d3_n = (word32) d3_n + 1;
 						int32 d4_n = (word32) d4_n + 1;
-						if (*((word32) a7_n + 44) != ~0x00)
+						if (a7_n[11] != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = (word32) a7_n + 78;
-							*(a7_n - 4) = a1;
-							(a7_n - 8)->u0 = 0x08;
-							*(a7_n - 0x0C) = d5_n;
-							d1 = (uint32) (uint8) *((word32) *a7_n + fn000026C0(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-							a1 = *(a7_n - 4);
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->ptr0000 = &a7_n->dw004A + 1;
+							*(a7_n - 4) = (byte ***) a1;
+							*(a7_n - 8) = 0x08;
+							*(a7_n - 0x0C) = (union Eq_n *) d5_n;
+							d1 = (uint32) (uint8) (a7_n->ptr0000 + fn000026C0(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+							a1 = (byte **) *(a7_n - 4);
 							d0 = 1 << (d5_n & 7) & d1;
 							if (d0 != 0x00 && d6_n - d3_n >= 0x00)
 							{
-								byte v601_n = *((word32) a7_n + 77);
+								byte v601_n = a7_n->b004D;
 								d7 = SEQ(SLICE(d7, word24, 8), v601_n);
 								do
 								{
@@ -2947,9 +2947,9 @@ l0000390A:
 									{
 										a1 = (word32) a2_n + 4;
 										byte * a0_n = *a1;
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
-										*a1 = a0_n + 1;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
+										*a1 = (byte **) (a0_n + 1);
 										byte v611_n = *a0_n;
 										a2_n = *a7_n;
 										d0 = SEQ(SLICE(d0, word24, 8), v611_n);
@@ -2957,8 +2957,8 @@ l0000390A:
 									}
 									else
 									{
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
 										word32 d1_n;
 										word32 a5_n;
 										d0 = fn00003CA8(*a7_n, out d1_n, out a1, out a5_n);
@@ -2969,31 +2969,31 @@ l0000390A:
 									++d4_n;
 									if (d1 == ~0x00)
 										break;
-									Eq_n a7_n = a7_n - 4;
-									*a7_n = (word32) a7_n + 78;
-									*(a7_n - 4) = a1;
-									(a7_n - 8)->u0 = 0x08;
-									*(a7_n - 0x0C) = d1;
-									d1 = (uint32) (uint8) *((word32) *a7_n + fn000026C0(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-									a1 = *(a7_n - 4);
+									ptr32 * a7_n = a7_n - 4;
+									*a7_n = &a7_n->dw004A + 1;
+									*(a7_n - 4) = (byte ***) a1;
+									*(a7_n - 8) = 0x08;
+									*(a7_n - 0x0C) = (union Eq_n *) d1;
+									d1 = (uint32) (uint8) (*a7_n + fn000026C0(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+									a1 = (byte **) *(a7_n - 4);
 									d0 = 1 << (d1 & 7) & d1;
 								} while (d0 != 0x00 && d6_n - d3_n >= 0x00);
-								*((word32) a7_n + 73) = v601_n;
+								a7_n->b0049 = v601_n;
 							}
 						}
 						if (d5_n != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*(a7_n - 4) = d5_n;
+							union Eq_n * a7_n = a7_n - 4;
+							*a7_n = (union Eq_n *) a2_n;
+							*(a7_n - 4) = (union Eq_n *) d5_n;
 							d0 = fn00002BD4(*(a7_n - 1), *a7_n);
 						}
 						d3_n = d3_n - 0x01;
 						d4_n = d4_n - 0x01;
-						if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+						if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 						{
 							*a6_n = 0x00;
-							*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 				}
@@ -3010,7 +3010,7 @@ l0000390A:
 						byte * a0_n = *a1;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						*a1 = (byte **) (a0_n + 1);
 						byte v163_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1_n;
@@ -3026,10 +3026,10 @@ l0000390A:
 						d0 = fn00003CA8(a7_n->t0000, out d1, out a1, out a5_n);
 						a7_n->t0030 = d0;
 					}
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n = (word32) d3_n.u0 + 1;
 					d4_n = (word32) d4_n + 1;
-					if (*((word32) a7_n + 44) != 0x25)
+					if (a7_n[11] != 0x25)
 					{
 						if (d5_n != ~0x00)
 						{
@@ -3064,7 +3064,7 @@ l0000390A:
 							byte * a0_n = *a1;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							*a1 = (byte **) (a0_n + 1);
 							byte v109_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v109_n);
@@ -3108,7 +3108,7 @@ l0000390A:
 						byte * a0_n = *a1;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						*a1 = (byte **) (a0_n + 1);
 						byte v130_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1;
@@ -3125,10 +3125,10 @@ l0000390A:
 						a7_n->t0030 = d0_n;
 					}
 					d0 = (int32) (int16) (int8) SEQ(SLICE(d0_n, word24, 8), a4_n->b0000);
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n.u0 = 0x01;
 					d4_n = (word32) d4_n + 1;
-					if (d0 - *((word32) a7_n + 44) != 0x00)
+					if (d0 - a7_n[11] != 0x00)
 					{
 						if (d5_n != ~0x00)
 						{

--- a/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG.globals.c
+++ b/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG.globals.c
@@ -9,6 +9,24 @@ Eq_n g_t0001;
 struct Eq_n * g_ptr0004;
 word32 g_a0008[];
 ui32 g_a0010[];
+struct Eq_n g_t12BC = 
+	{
+		1685025582,
+		
+		{
+			1818845810
+		},
+		&g_t61727900,
+		
+		{
+			0x4E494C3A
+		},
+		null,
+		&g_t48E72030,
+		0x47F90000,
+		0x3F68203C,
+		16232,
+	};
 struct Eq_n g_t147C = 
 	{
 		0x25,
@@ -32,23 +50,20 @@ Eq_n g_t28C5 =
 	};
 ptr32 g_ptr3E20 = 0x00;
 struct Eq_n * g_ptr3E24 = &g_t4000;
-Eq_n g_t3E28 = 
-	{
-		0x00
-	};
+struct Eq_n * g_ptr3E28 = null;
 struct Eq_n * g_ptr3E2C = &g_t10202;
 struct Eq_n * g_ptr3E30 = &g_t3030303;
 Eq_n g_t3E34 = 
 	{
-		0x04
+		0x04040404
 	};
 Eq_n g_t3E38 = 
 	{
-		0x04
+		0x04040404
 	};
 Eq_n g_t3E3C = 
 	{
-		0x05
+		0x05050505
 	};
 word32 g_dw3E48 = 0x05050505;
 ptr32 g_ptr3E4C = 0x06060606;
@@ -72,4 +87,6 @@ Eq_n g_t4000;
 Eq_n g_t10202;
 Eq_n g_t3030303;
 Eq_n g_t6060606;
+Eq_n g_t48E72030;
+Eq_n g_t61727900;
 

--- a/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG.h
+++ b/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG.h
@@ -4,7 +4,7 @@
 
 /*
 // Equivalence classes ////////////
-Eq_1: (struct "Globals" (0 (ptr32 Eq_116) ptr0000) (1 Eq_1022 t0001) (4 (ptr32 Eq_4) ptr0004) (8 (arr word32) a0008) (10 (arr ui32) a0010) (147C (struct "Eq_620" 0001 (0 uint8 b0000) (1 cu8 b0001)) t147C) (149C (struct "Eq_620" 0001) t149C) (14A0 (struct "Eq_620" 0001) t14A0) (28C5 Eq_4404 t28C5) (3E20 ptr32 ptr3E20) (3E24 (ptr32 Eq_4) ptr3E24) (3E28 Eq_25 t3E28) (3E2C (ptr32 Eq_61) ptr3E2C) (3E30 (ptr32 Eq_61) ptr3E30) (3E34 Eq_25 t3E34) (3E38 Eq_25 t3E38) (3E3C Eq_25 t3E3C) (3E48 word32 dw3E48) (3E4C ptr32 ptr3E4C) (3E50 int32 dw3E50) (3E54 (ptr32 Eq_2963) ptr3E54) (3E58 (ptr32 Eq_4) ptr3E58) (3E5C Eq_3672 t3E5C) (3F60 word32 dw3F60) (3F68 Eq_542 t3F68) (3F6C word32 dw3F6C) (3F78 (ptr32 Eq_557) ptr3F78) (3F7C Eq_25 t3F7C) (3F80 (ptr32 Eq_922) ptr3F80) (3F88 (ptr32 Eq_922) ptr3F88) (4000 Eq_4 t4000) (10202 Eq_61 t10202) (3030303 Eq_61 t3030303) (6060606 Eq_2963 t6060606))
+Eq_1: (struct "Globals" (0 (ptr32 Eq_116) ptr0000) (1 Eq_1022 t0001) (4 (ptr32 Eq_4) ptr0004) (8 (arr word32) a0008) (10 (arr ui32) a0010) (12BC (struct "Eq_25" 0004 (0 word32 dw0000) (4 Eq_134 t0004) (8 (ptr32 Eq_25) ptr0008) (C Eq_106 t000C) (10 (ptr32 (arr Eq_160)) ptr0010) (14 (ptr32 Eq_3186) ptr0014) (18 ptr32 ptr0018) (1C word32 dw001C) (20 word32 dw0020)) t12BC) (147C (struct "Eq_620" 0001 (0 uint8 b0000) (1 cu8 b0001)) t147C) (149C (struct "Eq_620" 0001) t149C) (14A0 (struct "Eq_620" 0001) t14A0) (28C5 Eq_4404 t28C5) (3E20 ptr32 ptr3E20) (3E24 (ptr32 Eq_4) ptr3E24) (3E28 (ptr32 Eq_25) ptr3E28) (3E2C (ptr32 Eq_61) ptr3E2C) (3E30 (ptr32 Eq_61) ptr3E30) (3E34 Eq_134 t3E34) (3E38 Eq_134 t3E38) (3E3C Eq_134 t3E3C) (3E48 word32 dw3E48) (3E4C ptr32 ptr3E4C) (3E50 int32 dw3E50) (3E54 (ptr32 Eq_3186) ptr3E54) (3E58 (ptr32 Eq_4) ptr3E58) (3E5C Eq_3672 t3E5C) (3F60 word32 dw3F60) (3F68 Eq_542 t3F68) (3F6C word32 dw3F6C) (3F78 (ptr32 Eq_557) ptr3F78) (3F7C Eq_73 t3F7C) (3F80 (ptr32 Eq_922) ptr3F80) (3F88 (ptr32 Eq_922) ptr3F88) (4000 Eq_4 t4000) (10202 Eq_61 t10202) (3030303 Eq_61 t3030303) (6060606 Eq_3186 t6060606) (48E72030 Eq_3186 t48E72030) (61727900 Eq_25 t61727900))
 	globals_t (in globals : (ptr32 (struct "Globals")))
 Eq_4: (struct "Eq_4" (0 word32 dw0000) (8 byte b0008) (C Eq_78 t000C) (10 word32 dw0010) (14 Eq_11 t0014) (18 up32 dw0018) (1C word32 dw001C))
 	T_4 (in a6_9 : (ptr32 Eq_4))
@@ -72,269 +72,175 @@ Eq_11: (union "Eq_11" (up32 u0) (cup16 u1))
 	T_3518 (in 0x27<16> : word16)
 	T_3571 (in Mem11[Mem11[0x00003E24<p32>:word32] + 20<i32>:word16] : word16)
 	T_3572 (in 0x27<16> : word16)
-Eq_19: (struct "Eq_19" (8 byte b0008) (3A word32 dw003A) (9C Eq_25 t009C) (A0 Eq_25 t00A0) (A4 word32 dw00A4) (AC (ptr32 Eq_61) ptr00AC) (B0 (ptr32 word32) ptr00B0) (E0 Eq_25 t00E0))
+Eq_19: (struct "Eq_19" (8 byte b0008) (3A word32 dw003A) (9C Eq_134 t009C) (A0 Eq_134 t00A0) (A4 word32 dw00A4) (AC (ptr32 Eq_61) ptr00AC) (B0 (ptr32 word32) ptr00B0) (E0 Eq_134 t00E0))
 	T_19 (in d0_36 : (ptr32 Eq_19))
 	T_24 (in FindTask(0<32>) : word32)
 	T_126 (in a3 : (ptr32 Eq_19))
 Eq_20: (fn (ptr32 Eq_19) (word32))
 	T_20 (in FindTask : ptr32)
 	T_21 (in signature of FindTask : void)
-Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (Eq_7323 u4))
-	T_25 (in a1_255 : Eq_25)
+Eq_25: (struct "Eq_25" 0004 (0 word32 dw0000) (4 Eq_134 t0004) (8 (ptr32 Eq_25) ptr0008) (C Eq_106 t000C) (10 (ptr32 (arr Eq_160)) ptr0010) (14 (ptr32 Eq_3186) ptr0014) (18 ptr32 ptr0018) (1C word32 dw001C) (20 word32 dw0020))
+	T_25 (in a1_255 : (ptr32 Eq_25))
 	T_26 (in 000012BC : ptr32)
-	T_27 (in d0_112 : Eq_25)
+	T_27 (in d0_112 : (ptr32 Eq_25))
 	T_34 (in OpenLibrary(0x12BC<u32>, 0<i32>) : word32)
 	T_35 (in 0<32> : word32)
 	T_58 (in Mem67[0x00003E28<p32>:word32] : word32)
-	T_73 (in d1_111 : Eq_25)
-	T_74 (in 0x10001<32> : word32)
 	T_82 (in AllocMem(d0_107 + 0x11<32>, 0x10001<32>) : word32)
 	T_83 (in 0<32> : word32)
 	T_92 (in library : word32)
 	T_94 (in Mem67[0x00003E28<p32>:word32] : word32)
-	T_112 (in (word32) d0_112 + 16<i32> + d0_100 : word32)
+	T_112 (in d0_112 + 16<i32> + d0_100 : word32)
 	T_115 (in Mem177[d0_112 + 8<i32>:word32] : word32)
-	T_134 (in d0_197 : Eq_25)
-	T_137 (in Mem194[d0_180 + 36<i32>:word32] : word32)
-	T_138 (in 0<32> : word32)
 	T_147 (in Mem179[d0_112 + 8<i32>:word32] : word32)
-	T_153 (in d0_262 : Eq_25)
-	T_159 (in (uint32) (uint8) 0<32>[d0_252 * 4<32>] : uint32)
-	T_204 (in Mem416[0x00003E34<p32>:word32] : word32)
-	T_209 (in Mem418[0x00003E38<p32>:word32] : word32)
-	T_229 (in SEQ(SLICE(d1_111, word24, 8), v40_292) : uip32)
 	T_242 (in Mem313[a6_266 + 0<32>:word32] : word32)
-	T_260 (in SEQ(v72_327, v71_324) : uip32)
 	T_267 (in a1_255 + 1<i32> : word32)
 	T_276 (in a1_255 + 1<i32> : word32)
 	T_281 (in a1_255 + 1<i32> : word32)
-	T_288 (in SEQ(SLICE(d1_111, word24, 8), v50_371) : uip32)
-	T_308 (in a2 : Eq_25)
+	T_308 (in a2 : (ptr32 Eq_25))
 	T_312 (in userFunction : word32)
-	T_316 (in Mem209[d0_112 + 4<i32>:word32] : word32)
-	T_317 (in 000012C8 : ptr32)
-	T_318 (in 0<32> : word32)
-	T_324 (in Mem214[0x00003E34<p32>:word32] : word32)
-	T_326 (in Mem216[0x00003E38<p32>:word32] : word32)
-	T_328 (in Mem218[0x00003E3C<p32>:word32] : word32)
-	T_331 (in Mem221[d0_36 + 156<i32>:word32] : word32)
-	T_334 (in Mem223[d0_36 + 160<i32>:word32] : word32)
 	T_359 (in a1_255 + 1<i32> : word32)
-	T_366 (in SEQ(v72_327, v75_337) : uip32)
-	T_374 (in 10<i32> : int32)
-	T_390 (in 27<i32> : int32)
-	T_392 (in Mem435[0x00003E3C<p32>:word32] : word32)
-	T_393 (in v92_428 : Eq_25)
-	T_396 (in Mem418[d0_36 + 224<i32>:word32] : word32)
-	T_398 (in Mem429[0x00003E3C<p32>:word32] : word32)
-	T_399 (in 0<32> : word32)
-	T_427 (in d1 : Eq_25)
-	T_428 (in a1 : Eq_25)
+	T_428 (in a1 : (ptr32 Eq_25))
 	T_449 (in message : word32)
-	T_472 (in v5_8 : Eq_25)
+	T_472 (in v5_8 : (ptr32 Eq_25))
 	T_477 (in Mem0[a7_6 - 8<i32> + 0<32>:word32] : word32)
 	T_489 (in Mem0[0x00003E28<p32>:word32] : word32)
 	T_491 (in 0<32> : word32)
-	T_580 (in d0_10 : Eq_25)
+	T_593 (in a1 : (ptr32 Eq_25))
+	T_612 (in a1_34 : (ptr32 Eq_25))
+	T_619 (in a1 : (ptr32 Eq_25))
+	T_3198 (in a1Out : (ptr32 Eq_25))
+	T_3202 (in out a1 : ptr32)
+	T_3331 (in d0 : (ptr32 Eq_25))
+	T_3332 (in d0_158 : (ptr32 Eq_25))
+	T_3341 (in a3_120 : (ptr32 Eq_25))
+	T_3342 (in 0<32> : word32)
+	T_3349 (in AllocPooled(dwArg08, dwArg04) : word32)
+	T_3362 (in d0_50 : (ptr32 Eq_25))
+	T_3366 (in AllocMem(dwArg08 + 16<i32>, d1) : word32)
+	T_3367 (in 0<32> : word32)
+	T_3382 (in d0_82 : (ptr32 Eq_25))
+	T_3384 (in AllocMem(d3_77, d1) : word32)
+	T_3385 (in 0<32> : word32)
+	T_3395 (in d0_128 : (ptr32 Eq_25))
+	T_3400 (in Allocate(a5_162, dwArg08) : word32)
+	T_3401 (in 0<32> : word32)
+	T_3469 (in Allocate(d0_82 + 1<i32>, dwArg08) : word32)
+	T_3470 (in a2_142 : (ptr32 Eq_25))
+	T_3488 (in a2_149 + 4<i32> : word32)
+	T_3509 (in d0_50 + 16<i32> : word32)
+	T_3510 (in d0 : (ptr32 Eq_25))
+	T_3511 (in d0_51 : (ptr32 Eq_25))
+	T_3520 (in 0<32> : word32)
+	T_3521 (in a1 : word32)
+	T_3531 (in CreatePrivatePool(dwArg04, dwArg08, dwArg0C) : word32)
+	T_3532 (in d0_30 : (ptr32 Eq_25))
+	T_3536 (in AllocMem(24<i32>, 0<i32>) : word32)
+	T_3538 (in 0<32> : word32)
+	T_3550 (in Mem40[d0_30 + 8<i32>:word32] : word32)
+	T_4322 (in a1 : (ptr32 Eq_25))
+	T_4743 (in a2_1014 + 4<i32> : word32)
+	T_4857 (in a2_1014 + 4<i32> : word32)
+	T_4951 (in a2_1014 + 4<i32> : word32)
+	T_5134 (in a2_1014 + 4<i32> : word32)
+	T_5365 (in a2_1014 + 4<i32> : word32)
+	T_5559 (in a2_1014 + 4<i32> : word32)
+	T_5686 (in a2_1014 + 4<i32> : word32)
+	T_5858 (in a2_1014 + 4<i32> : word32)
+	T_5988 (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
+	T_6018 (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
+	T_6103 (in a2_1014 + 4<i32> : word32)
+	T_6286 (in a2_1014 + 4<i32> : word32)
+	T_6413 (in a2_1014 + 4<i32> : word32)
+	T_6872 (in a2_1014 + 4<i32> : word32)
+	T_7031 (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
+	T_7710 (in a2_1014 + 4<i32> : word32)
+	T_7774 (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
+	T_7809 (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
+	T_7874 (in a2_1014 + 4<i32> : word32)
+	T_7952 (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
+	T_7986 (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
+Eq_28: (fn (ptr32 Eq_25) (ptr32, int32))
+	T_28 (in OpenLibrary : ptr32)
+	T_29 (in signature of OpenLibrary : void)
+Eq_51: (fn void (word32))
+	T_51 (in Alert : ptr32)
+	T_52 (in signature of Alert : void)
+	T_96 (in Alert : ptr32)
+Eq_61: (struct "Eq_61" (0 word32 dw0000) (24 Eq_134 t0024))
+	T_61 (in Mem67[d0_36 + 172<i32>:word32] : word32)
+	T_62 (in 0<32> : word32)
+	T_87 (in Mem153[d0_36 + 172<i32>:word32] : word32)
+	T_88 (in 0<32> : word32)
+	T_99 (in dwLoc0C_569 : (ptr32 Eq_61))
+	T_118 (in d0_180 : (ptr32 Eq_61))
+	T_121 (in Mem179[d0_36 + 172<i32>:word32] : word32)
+	T_122 (in 0<32> : word32)
+	T_129 (in Mem187[0x00003E2C<p32>:word32] : word32)
+	T_131 (in Mem189[0x00003E30<p32>:word32] : word32)
+	T_211 (in d0_112 + 16<i32> : word32)
+	T_430 (in dwArg08 : (ptr32 Eq_61))
+Eq_73: (union "Eq_73" (byte u0) (word16 u1) ((ptr32 Eq_8357) u2))
+	T_73 (in d1_111 : Eq_73)
+	T_74 (in 0x10001<32> : word32)
+	T_229 (in SEQ(SLICE(d1_111, word24, 8), v40_292) : uip32)
+	T_260 (in SEQ(v72_327, v71_324) : uip32)
+	T_288 (in SEQ(SLICE(d1_111, word24, 8), v50_371) : uip32)
+	T_317 (in 000012C8 : ptr32)
+	T_366 (in SEQ(v72_327, v75_337) : uip32)
+	T_374 (in 10<i32> : int32)
+	T_390 (in 27<i32> : int32)
+	T_427 (in d1 : Eq_73)
+	T_580 (in d0_10 : Eq_73)
 	T_581 (in 0x3F5C<32> : word32)
-	T_591 (in d0 : Eq_25)
-	T_592 (in d1 : Eq_25)
-	T_593 (in a1 : Eq_25)
-	T_612 (in a1_34 : Eq_25)
-	T_613 (in d1_36 : Eq_25)
-	T_614 (in d0_173 : Eq_25)
-	T_617 (in d0 : Eq_25)
-	T_618 (in d1 : Eq_25)
-	T_619 (in a1 : Eq_25)
-	T_624 (in d0 : Eq_25)
+	T_591 (in d0 : Eq_73)
+	T_592 (in d1 : Eq_73)
+	T_613 (in d1_36 : Eq_73)
+	T_614 (in d0_173 : Eq_73)
+	T_617 (in d0 : Eq_73)
+	T_618 (in d1 : Eq_73)
+	T_624 (in d0 : Eq_73)
 	T_630 (in fn00002BF0(d0, d1, a1, &globals->t147C) : word32)
 	T_634 (in fn000015A4(fn00002BF0(d0, d1, a1, &globals->t147C), 0x1480<u32>, out d1_36, out a1_34) : word32)
 	T_636 (in fn00002BF0(fn000015A4(fn00002BF0(d0, d1, a1, &globals->t147C), 0x1480<u32>, out d1_36, out a1_34), d1_36, a1_34, &globals->t149C) : word32)
 	T_638 (in fn00002BF0(fn00002BF0(fn000015A4(fn00002BF0(d0, d1, a1, &globals->t147C), 0x1480<u32>, out d1_36, out a1_34), d1_36, a1_34, &globals->t149C), d1_36, a1_34, &globals->t14A0) : word32)
-	T_645 (in d2_158 : Eq_25)
-	T_646 (in 1<i32> : int32)
 	T_653 (in fn000015A4(d0_173, 0x14A4<u32>, out d1_234, out a1_235) : word32)
 	T_654 (in 40<i32> : int32)
-	T_655 (in 40<i32> : int32)
-	T_665 (in d2 : Eq_25)
-	T_666 (in dwArg04 : Eq_25)
-	T_667 (in dwArg08 : Eq_25)
-	T_669 (in d1_89 >> 1<32> : word32)
-	T_670 (in 0000000A : ptr32)
-	T_695 (in d2_158 + 1<32> : word32)
-	T_696 (in 0<32> : word32)
-	T_698 (in d1_13 : Eq_25)
-	T_699 (in -dwArg08 : word32)
-	T_700 (in 0<32> : word32)
-	T_702 (in 0<32> : word32)
-	T_707 (in d0 : Eq_25)
-	T_708 (in d1 : Eq_25)
-	T_709 (in d2 : Eq_25)
-	T_710 (in d1Out : Eq_25)
-	T_711 (in -dwArg04 : word32)
-	T_712 (in out d1_49 : ptr32)
-	T_713 (in fn0000151E(-dwArg04, dwArg08, d2, out d1_49) : word32)
-	T_716 (in out d1_60 : ptr32)
-	T_717 (in fn0000151E(dwArg04, dwArg08, d2, out d1_60) : word32)
-	T_720 (in -dwArg04 : word32)
-	T_721 (in out d1_23 : ptr32)
-	T_722 (in fn0000151E(-dwArg04, d1_13, d2, out d1_23) : word32)
-	T_725 (in out d1_34 : ptr32)
-	T_726 (in fn0000151E(dwArg04, d1_13, d2, out d1_34) : word32)
-	T_727 (in d0 : Eq_25)
-	T_728 (in d2 : Eq_25)
-	T_729 (in dwArg04 : Eq_25)
-	T_730 (in dwArg08 : Eq_25)
-	T_731 (in 0<32> : word32)
-	T_733 (in 0<32> : word32)
-	T_735 (in d0_36 : Eq_25)
-	T_736 (in -dwArg04 : word32)
-	T_737 (in 0<32> : word32)
-	T_741 (in out d1_43 : ptr32)
-	T_742 (in fn0000151E(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_743 (in -fn0000151E(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_746 (in -dwArg08 : word32)
-	T_747 (in out d1_55 : ptr32)
-	T_748 (in fn0000151E(d0_36, -dwArg08, d2, out d1_55) : word32)
-	T_751 (in out d1_88 : ptr32)
-	T_752 (in fn0000151E(dwArg04, dwArg08, d2, out d1_88) : word32)
-	T_755 (in -dwArg08 : word32)
-	T_756 (in out d1_89 : ptr32)
-	T_757 (in fn0000151E(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_758 (in -fn0000151E(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_759 (in d1_22 : Eq_25)
-	T_762 (in  : word32)
-	T_763 (in __swap(d1) : word32)
-	T_768 (in d2_11 : Eq_25)
-	T_769 (in SEQ(v11_10, v10_9) : uipr32)
-	T_772 (in d3_18 : Eq_25)
-	T_773 (in 16<i32> : int32)
-	T_777 (in d0_134 : Eq_25)
-	T_779 (in __swap(d0) : word32)
-	T_780 (in d1_135 : Eq_25)
-	T_782 (in __swap(d1_22) : word32)
-	T_787 (in __swap(d2_11) : word32)
-	T_792 (in d0_150 : Eq_25)
-	T_794 (in __swap(d0_134) : word32)
-	T_808 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-	T_809 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-	T_811 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-	T_813 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-	T_823 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-	T_829 (in  : word32)
-	T_830 (in  : word32)
-	T_831 (in 8<32> : word32)
-	T_832 (in __rol(d1_22, 8<32>) : word32)
-	T_833 (in 8<32> : uipr32)
-	T_838 (in 4<32> : word32)
-	T_839 (in __rol(d1_22, 4<32>) : word32)
-	T_844 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-	T_849 (in 2<32> : word32)
-	T_850 (in __rol(d1_22, 2<32>) : word32)
-	T_855 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-	T_861 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-	T_862 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-	T_869 (in __swap(d3_18) : word32)
-	T_875 (in d1_90 : Eq_25)
-	T_877 (in __swap(d1_22) : word32)
-	T_878 (in d3_102 : Eq_25)
-	T_879 (in SEQ(v53_82, v51_79) : uipr32)
-	T_880 (in d0_108 : Eq_25)
-	T_890 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-	T_891 (in 0<32> : word32)
-	T_894 (in 1<32> : word32)
-	T_895 (in __rol(d1_22, 1<32>) : word32)
-	T_900 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-	T_904 (in __swap(d3_102) : word32)
-	T_905 (in __rol(d0_108, __swap(d3_102)) : word32)
-	T_906 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-	T_909 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-	T_912 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-	T_913 (in d0_108 + d1_90 : word32)
-	T_914 (in 0<32> : word32)
-	T_918 (in d0_17 : Eq_25)
-	T_921 (in d0 : Eq_25)
+	T_918 (in d0_17 : Eq_73)
+	T_921 (in d0 : Eq_73)
 	T_934 (in fn000015C0(d0, *(struct Eq_922 **) 0x3F80<u32>, dwArg04, fp + 8<i32>, out d1_20, out a1_19) : word32)
-	T_935 (in d0_1952 : Eq_25)
-	T_943 (in d6_1480 : Eq_25)
+	T_935 (in d0_1952 : Eq_73)
+	T_943 (in d6_1480 : Eq_73)
 	T_944 (in 0<i32> : int32)
 	T_998 (in fn00001F40(*(a7_51 - 4<i32>), *a7_51, out d1, out a0_66, out a1, out a5_1579) : word32)
 	T_1001 (in 0xFFFFFFFF<32> : word32)
-	T_1015 (in d5_256 : Eq_25)
-	T_1016 (in -1<i32> : int32)
-	T_1027 (in d2_1005 : Eq_25)
-	T_1030 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
-	T_1031 (in d1_103 : Eq_25)
+	T_1031 (in d1_103 : Eq_73)
 	T_1033 (in d1_103 + 1<32> : word32)
 	T_1034 (in 5<32> : word32)
 	T_1039 (in Mem121[a7_99 + 0<32>:word32] : word32)
-	T_1040 (in d1_123 : Eq_25)
+	T_1040 (in d1_123 : Eq_73)
 	T_1042 (in 1<i32> << d1_103 : word32)
 	T_1045 (in Mem121[a7_99 + 0<32>:word32] : word32)
-	T_1046 (in d2_1005 | d1_123 : word32)
 	T_1049 (in 5<32> : word32)
 	T_1051 (in 0<i32> : int32)
-	T_1056 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
 	T_1074 (in Mem143[a0_1447 + 0<32>:byte] : byte)
 	T_1131 (in Mem102[a7_99 + 0<32>:word32] : word32)
 	T_1134 (in Mem102[a7_99 + 0<32>:word32] : word32)
 	T_1169 (in Mem248[a0_1447 + 0<32>:byte] : byte)
-	T_1172 (in 0<i32> : int32)
-	T_1200 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-	T_1206 (in Mem278[a7_275 + 0<32>:word32] : word32)
-	T_1209 (in 10<i32> : int32)
-	T_1210 (in __swap(10<i32>) : word32)
-	T_1217 (in __swap(d5_256) : word32)
-	T_1222 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-	T_1223 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
 	T_1255 (in Mem278[a0_1447 + 0<32>:byte] : byte)
-	T_1260 (in Mem278[a7_275 + 0<32>:word32] : word32)
 	T_1262 (in d1_303 - 0x30<32> : word32)
-	T_1264 (in d1_303 - 0x30<32> + d0_293 : word32)
-	T_1309 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-	T_1317 (in 10<i32> : int32)
-	T_1318 (in __swap(10<i32>) : word32)
-	T_1325 (in __swap(d2_1005) : word32)
-	T_1330 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-	T_1331 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
 	T_1363 (in Mem171[a0_1447 + 0<32>:byte] : byte)
 	T_1371 (in d1_196 - 0x30<32> : word32)
-	T_1373 (in d1_196 - 0x30<32> + d0_186 : word32)
-	T_1381 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
 	T_1409 (in d6_1480 + 1<32> : word32)
-	T_1478 (in 0<32> : word32)
-	T_1557 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-	T_1606 (in 0<32> : word32)
-	T_1781 (in d0_1566 : Eq_25)
+	T_1781 (in d0_1566 : Eq_73)
 	T_1786 (in a7_1465[18<i32>] & 2<i32> : word32)
 	T_1787 (in 0<32> : word32)
-	T_1826 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
 	T_1829 (in Mem1359[a7_1020 + 48<i32>:word32] : word32)
 	T_1908 (in fn00001F40(*(a7_1578 - 4<i32>), a7_1578->ptr0000, out d1, out a0_1447, out a1, out a5_1579) : word32)
 	T_1909 (in 0xFFFFFFFF<32> : word32)
 	T_1914 (in d6_1480 + 1<32> : word32)
-	T_1964 (in dwArg04 : Eq_25)
-	T_1965 (in dwArg08 : Eq_25)
-	T_1966 (in dwArg0C : Eq_25)
-	T_1967 (in dwArg10 : Eq_25)
-	T_1971 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_1976 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1981 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_1986 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_2048 (in dwArg04 : Eq_25)
-	T_2049 (in dwArg08 : Eq_25)
-	T_2050 (in dwArg0C : Eq_25)
-	T_2051 (in dwArg10 : Eq_25)
-	T_2052 (in d1Out : Eq_25)
-	T_2053 (in a0Out : Eq_25)
-	T_2057 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_2062 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_2067 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_2072 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_2073 (in out d1_1450 : ptr32)
-	T_2074 (in out a0_1447 : ptr32)
 	T_2098 (in Mem1478[a7_1383 + 52<i32>:word32] : word32)
-	T_2122 (in d0_1691 : Eq_25)
+	T_2122 (in d0_1691 : Eq_73)
 	T_2127 (in a7_1465[18<i32>] & 2<i32> : word32)
 	T_2128 (in 0<32> : word32)
 	T_2172 (in fn00001F40(*(a7_1465 - 8<i32>), *(a7_1465 - 4<i32>), out d1, out a0_1447, out a1, out a5_1579) : word32)
@@ -358,12 +264,8 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_2580 (in 0<32> : word32)
 	T_2583 (in Mem624[a0_1447 + 0<32>:word32] : word32)
 	T_2641 (in Mem611[a0_1447 + 0<32>:word32] : word32)
-	T_2648 (in 0<32> : word32)
-	T_2678 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-	T_2682 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
 	T_2707 (in SLICE(d6_1480, word16, 0) : word16)
 	T_2710 (in Mem599[a0_1447 + 0<32>:word16] : word16)
-	T_2738 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
 	T_2788 (in Mem575[a0_1447 + 0<32>:word32] : word32)
 	T_2798 (in SLICE(d6_1480, byte, 0) : byte)
 	T_2801 (in Mem587[a0_1447 + 0<32>:byte] : byte)
@@ -372,249 +274,14 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_2889 (in Mem66[a0_104 + 0<32>:byte] : byte)
 	T_3014 (in SLICE(dwArg04, byte, 0) : byte)
 	T_3017 (in Mem118[a0_112 + 0<32>:byte] : byte)
-	T_3198 (in a1Out : Eq_25)
-	T_3202 (in out a1 : ptr32)
-	T_3331 (in d0 : Eq_25)
-	T_3332 (in d0_158 : Eq_25)
-	T_3341 (in a3_120 : Eq_25)
-	T_3342 (in 0<32> : word32)
-	T_3349 (in AllocPooled(dwArg08, dwArg04) : word32)
-	T_3362 (in d0_50 : Eq_25)
-	T_3366 (in AllocMem(dwArg08 + 16<i32>, d1) : word32)
-	T_3367 (in 0<32> : word32)
-	T_3382 (in d0_82 : Eq_25)
-	T_3384 (in AllocMem(d3_77, d1) : word32)
-	T_3385 (in 0<32> : word32)
-	T_3395 (in d0_128 : Eq_25)
-	T_3400 (in Allocate(a5_162, dwArg08) : word32)
-	T_3401 (in 0<32> : word32)
-	T_3469 (in Allocate((word32) d0_82 + 4<i32>, dwArg08) : word32)
-	T_3470 (in a2_142 : Eq_25)
-	T_3488 (in a2_149 + 4<i32> : word32)
-	T_3509 (in d0_50 + 16<i32> : word32)
-	T_3510 (in d0 : Eq_25)
-	T_3511 (in d0_51 : Eq_25)
-	T_3520 (in 0<32> : word32)
-	T_3521 (in a1 : word32)
-	T_3531 (in CreatePrivatePool(dwArg04, dwArg08, dwArg0C) : word32)
-	T_3532 (in d0_30 : Eq_25)
-	T_3536 (in AllocMem(24<i32>, 0<i32>) : word32)
-	T_3538 (in 0<32> : word32)
-	T_3545 (in 0<32> : word32)
-	T_3547 (in Mem38[d0_30 + 4<i32>:word32] : word32)
-	T_3550 (in Mem40[d0_30 + 8<i32>:word32] : word32)
-	T_3623 (in d0 : Eq_25)
-	T_3624 (in d0_196 : Eq_25)
-	T_3625 (in d1_142 : Eq_25)
-	T_3626 (in a0_20 : Eq_25)
-	T_3627 (in d3_166 : Eq_25)
-	T_3628 (in 0<32> : word32)
-	T_3636 (in 0<32> : word32)
-	T_3642 (in d0 : Eq_25)
-	T_3643 (in d1 : Eq_25)
-	T_3644 (in d2 : Eq_25)
-	T_3645 (in d1Out : Eq_25)
-	T_3646 (in d2Out : Eq_25)
-	T_3647 (in out d1_318 : ptr32)
-	T_3648 (in out d2_319 : ptr32)
-	T_3649 (in fn00002664(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-	T_3650 (in 0<i32> : int32)
-	T_3653 (in d6_30 : Eq_25)
-	T_3655 (in 8<32> : word32)
-	T_3656 (in __rol(dwArg0C, 8<32>) : word32)
-	T_3682 (in 8<32> : word32)
-	T_3683 (in __rol(d6_30, 8<32>) : word32)
-	T_3689 (in 8<32> : word32)
-	T_3690 (in __rol(d6_30, 8<32>) : word32)
-	T_3697 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_3698 (in d1_175 : Eq_25)
-	T_3699 (in d2_176 : Eq_25)
-	T_3700 (in d0_174 : Eq_25)
-	T_3702 (in 0<i32> : int32)
-	T_3703 (in out d1_175 : ptr32)
-	T_3704 (in out d2_176 : ptr32)
-	T_3705 (in fn00002664(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-	T_3709 (in out d1_320 : ptr32)
-	T_3710 (in out d2_321 : ptr32)
-	T_3711 (in fn00002664(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-	T_3722 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_3725 (in d0_85 : Eq_25)
-	T_3727 (in dwArg04 >> d4_61 : word32)
-	T_3730 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-	T_3733 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-	T_3734 (in out d1_86 : ptr32)
-	T_3735 (in out d2_322 : ptr32)
-	T_3736 (in fn00002664(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-	T_3737 (in d3_72 : Eq_25)
-	T_3738 (in dwArg10 << d5_63 : word32)
-	T_3739 (in d5_101 : Eq_25)
-	T_3741 (in __swap(d0_85) : word32)
-	T_3742 (in d6_103 : Eq_25)
-	T_3744 (in __swap(d3_72) : word32)
-	T_3748 (in d2_107 : Eq_25)
-	T_3751 (in d0_85 * (word16) d3_72 : word32)
-	T_3752 (in __swap(d0_85 * (word16) d3_72) : word32)
-	T_3765 (in d6_82 : Eq_25)
-	T_3766 (in dwArg08 << d5_63 : word32)
-	T_3767 (in d2_124 : Eq_25)
-	T_3769 (in SEQ(v35_109, v39_116) : uipr32)
-	T_3770 (in __swap(SEQ(v35_109, v39_116)) : word32)
-	T_3778 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-	T_3779 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-	T_3783 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-	T_3784 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-	T_3806 (in d0_85 - 1<32> : word32)
-	T_3812 (in d7_13 : Eq_25)
-	T_3813 (in 0<32> : word32)
-	T_3816 (in out d1 : ptr32)
-	T_3817 (in fn0000151E(d1, d2, d2, out d1) : word32)
-	T_3818 (in d6_17 : Eq_25)
-	T_3819 (in d5_19 : Eq_25)
-	T_3820 (in 0<32> : word32)
-	T_3822 (in d2_22 : Eq_25)
-	T_3824 (in __swap(d2) : word32)
-	T_3828 (in 0<32> : word32)
-	T_3837 (in 0<32> : word32)
-	T_3839 (in d0_281 : Eq_25)
-	T_3841 (in __swap(d0) : word32)
-	T_3842 (in d1_282 : Eq_25)
-	T_3844 (in __swap(d1) : word32)
-	T_3854 (in __swap(d1_282) : word32)
-	T_3861 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-	T_3862 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-	T_3867 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-	T_3873 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-	T_3874 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-	T_3878 (in d6_17 * 2<32> : word32)
-	T_3886 (in 0<32> : word32)
-	T_3888 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-	T_3890 (in d7_13 * 2<32> : word32)
-	T_3891 (in 0<32> : word32)
-	T_3895 (in d3_74 : Eq_25)
-	T_3902 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-	T_3903 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-	T_3906 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-	T_3907 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-	T_3908 (in d1_104 : Eq_25)
-	T_3909 (in 0xFFFF<32> : uipr32)
-	T_3910 (in d6_98 : Eq_25)
-	T_3914 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-	T_3915 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-	T_3916 (in d6_133 : Eq_25)
-	T_3918 (in __swap(d1_104) : word32)
-	T_3919 (in d3_140 : Eq_25)
-	T_3921 (in __swap(d6_133) : word32)
-	T_3922 (in d4_142 : Eq_25)
-	T_3924 (in __swap(d7_13) : word32)
-	T_3928 (in d6_146 : Eq_25)
-	T_3931 (in d6_133 * (word16) d7_13 : word32)
-	T_3932 (in __swap(d6_133 * (word16) d7_13) : word32)
-	T_3948 (in d6_178 : Eq_25)
-	T_3950 (in SEQ(v56_148, v59_155) : uipr32)
-	T_3951 (in __swap(SEQ(v56_148, v59_155)) : word32)
-	T_3952 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-	T_3953 (in d5_181 : word32)
-	T_3957 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-	T_3958 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-	T_3962 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-	T_3963 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-	T_3976 (in 0<32> : word32)
-	T_3978 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-	T_3979 (in 0<32> : word32)
-	T_3987 (in d1_104 - 1<32> : word32)
-	T_3988 (in d4_113 : Eq_25)
-	T_3991 (in __swap(d7_13) : word32)
-	T_3994 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-	T_3995 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-	T_4010 (in __swap(d7_13) : word32)
-	T_4014 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-	T_4016 (in d1_104 - 1<32> : word32)
-	T_4017 (in 0<32> : word32)
-	T_4023 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-	T_4024 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_4025 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_4026 (in d6_220 : Eq_25)
-	T_4030 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-	T_4031 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-	T_4034 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-	T_4035 (in d5_221 : Eq_25)
-	T_4037 (in __swap(d5_181) : word32)
-	T_4042 (in d5_266 : Eq_25)
-	T_4044 (in __swap(d5_181) : word32)
-	T_4045 (in d6_267 : Eq_25)
-	T_4047 (in __swap(d6_178) : word32)
-	T_4050 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-	T_4053 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-	T_4057 (in d2_73 : Eq_25)
-	T_4059 (in __swap(d5_19) : word32)
-	T_4061 (in __swap(d7_13) : word32)
-	T_4071 (in d5_221 >> 1<32> : word32)
-	T_4076 (in  : word32)
-	T_4082 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-	T_4089 (in d1 : Eq_25)
-	T_4090 (in d1_171 : Eq_25)
-	T_4091 (in d3_202 : Eq_25)
-	T_4092 (in 0<32> : word32)
-	T_4100 (in 0<32> : word32)
-	T_4104 (in out d1_171 : ptr32)
-	T_4105 (in out d2_354 : ptr32)
-	T_4106 (in fn00002664(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-	T_4109 (in d6_33 : Eq_25)
-	T_4111 (in 8<32> : word32)
-	T_4112 (in __rol(dwArg0C, 8<32>) : word32)
-	T_4138 (in 8<32> : word32)
-	T_4139 (in __rol(d6_33, 8<32>) : word32)
-	T_4145 (in 8<32> : word32)
-	T_4146 (in __rol(d6_33, 8<32>) : word32)
-	T_4153 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_4156 (in d0_88 : Eq_25)
-	T_4158 (in dwArg04 >> d4_64 : word32)
-	T_4161 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-	T_4164 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-	T_4165 (in out d1_89 : ptr32)
-	T_4166 (in out d2_90 : ptr32)
-	T_4167 (in fn00002664(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-	T_4168 (in d3_75 : Eq_25)
-	T_4169 (in dwArg10 << d5_66 : word32)
-	T_4170 (in d7_104 : Eq_25)
-	T_4172 (in __swap(d0_88) : word32)
-	T_4173 (in d6_106 : Eq_25)
-	T_4175 (in __swap(d3_75) : word32)
-	T_4179 (in d2_110 : Eq_25)
-	T_4182 (in d0_88 * (word16) d3_75 : word32)
-	T_4183 (in __swap(d0_88 * (word16) d3_75) : word32)
-	T_4196 (in d2_127 : Eq_25)
-	T_4198 (in SEQ(v37_112, v40_119) : uipr32)
-	T_4199 (in __swap(SEQ(v37_112, v40_119)) : word32)
-	T_4209 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-	T_4210 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-	T_4214 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-	T_4215 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-	T_4234 (in dwArg08 - dwArg10 : word32)
-	T_4238 (in d1_211 : Eq_25)
-	T_4239 (in d2_212 : Eq_25)
-	T_4241 (in 0<i32> : int32)
-	T_4242 (in out d1_211 : ptr32)
-	T_4243 (in out d2_212 : ptr32)
-	T_4244 (in fn00002664(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-	T_4247 (in out d1_171 : ptr32)
-	T_4248 (in out d2_355 : ptr32)
-	T_4249 (in fn00002664(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-	T_4260 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_4265 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-	T_4278 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
-	T_4320 (in d0 : Eq_25)
-	T_4321 (in d1 : Eq_25)
-	T_4322 (in a1 : Eq_25)
-	T_4323 (in dwArg04 : Eq_25)
-	T_4325 (in dwArg0C : Eq_25)
+	T_4320 (in d0 : Eq_73)
+	T_4321 (in d1 : Eq_73)
+	T_4323 (in dwArg04 : Eq_73)
 	T_4327 (in Mem10[0x00003F7C<p32>:word32] : word32)
-	T_4330 (in fp + 8<i32> : word32)
-	T_4331 (in fn00002C3C(d0, d1, a1, *(union Eq_25 *) 0x3F7C<u32>, dwArg04, fp + 8<i32>) : word32)
-	T_4332 (in d0 : Eq_25)
-	T_4333 (in bArg07 : Eq_25)
-	T_4334 (in dwArg08 : Eq_25)
-	T_4335 (in d0_10 : Eq_25)
+	T_4331 (in fn00002C3C(d0, d1, a1, *(union Eq_73 *) 0x3F7C<u32>, dwArg04, fp + 8<i32>) : word32)
+	T_4332 (in d0 : Eq_73)
+	T_4334 (in dwArg08 : Eq_73)
+	T_4335 (in d0_10 : Eq_73)
 	T_4336 (in 0<32> : word32)
 	T_4340 (in Mem5[dwArg08 + 4<i32>:word32] : word32)
 	T_4343 (in Mem5[dwArg08 + 8<i32>:word32] : word32)
@@ -622,53 +289,38 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_4358 (in *((word32) dwArg08 + 4<i32>) - 1<32> : word32)
 	T_4360 (in Mem25[dwArg08 + 4<i32>:word32] : word32)
 	T_4363 (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-	T_4366 (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-	T_4371 (in d2_1090 : Eq_25)
-	T_4373 (in a2_1014 : Eq_25)
-	T_4376 (in d5_1044 : Eq_25)
+	T_4373 (in a2_1014 : Eq_73)
+	T_4376 (in d5_1044 : Eq_73)
 	T_4377 (in 0<i32> : int32)
-	T_4383 (in d0_3698 : Eq_25)
+	T_4383 (in d0_3698 : Eq_73)
 	T_4384 (in 0xFFFFFFFF<32> : word32)
 	T_4408 (in d0_63 & 8<32> : word32)
-	T_4434 (in d6_1133 : Eq_25)
-	T_4435 (in -1<i32> : int32)
 	T_4437 (in d0_289 & 4<32> : word32)
-	T_4457 (in 0<i32> : int32)
 	T_4459 (in d0_305 & 4<32> : word32)
-	T_4468 (in Mem316[a7_313 + 0<32>:word32] : word32)
-	T_4471 (in 10<i32> : int32)
-	T_4472 (in __swap(10<i32>) : word32)
-	T_4482 (in __swap(d6_1133) : word32)
-	T_4487 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-	T_4488 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-	T_4514 (in Mem316[a7_313 + 0<32>:word32] : word32)
 	T_4516 (in d1_340 - 0x30<32> : word32)
-	T_4518 (in d1_340 - 0x30<32> + d0_331 : word32)
 	T_4520 (in d0_354 & 4<32> : word32)
 	T_4534 (in SEQ(SLICE(d1, word24, 8), Mem361[a7_1330 + 72<i32>:byte]) : uip32)
 	T_4581 (in 0<32> : word32)
 	T_4591 (in 2<i32> : int32)
 	T_4639 (in SEQ(SLICE(d1, word24, 8), Mem361[a3_279 + 0<32>:byte]) : uip32)
 	T_4645 (in 1<i32> : int32)
-	T_4682 (in d1_612 : Eq_25)
+	T_4682 (in d1_612 : Eq_73)
 	T_4685 (in SEQ(v147_608, v83_500 - 0x25<8>) : uip32)
-	T_4695 (in d0_540 : Eq_25)
+	T_4695 (in d0_540 : Eq_73)
 	T_4726 (in Mem535[a7_533 + 0<32>:word32] : word32)
-	T_4731 (in dwArg04 : Eq_25)
+	T_4731 (in dwArg04 : Eq_73)
 	T_4737 (in Mem535[a7_533 + 0<32>:word32] : word32)
 	T_4741 (in fn00003CE0(*a7_533, out d1_5316, out a1, out a5_5317) : word32)
-	T_4743 (in a2_1014 + 4<i32> : word32)
 	T_4753 (in Mem554[a7_552 + 0<32>:word32] : word32)
 	T_4765 (in Mem558[a7_552 + 0<32>:word32] : word32)
 	T_4767 (in SEQ(SLICE(d0, word24, 8), v96_562) : uip32)
 	T_4769 (in (uint32) (uint8) v96_562 : uint32)
 	T_4784 (in d0_591 & 8<32> : word32)
-	T_4788 (in d0_111 : Eq_25)
-	T_4814 (in d0_187 : Eq_25)
+	T_4788 (in d0_111 : Eq_73)
+	T_4814 (in d0_187 : Eq_73)
 	T_4845 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_4851 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_4855 (in fn00003CE0(*a7_180, out d1_5318, out a1, out a5_5319) : word32)
-	T_4857 (in a2_1014 + 4<i32> : word32)
 	T_4867 (in Mem201[a7_199 + 0<32>:word32] : word32)
 	T_4879 (in Mem205[a7_199 + 0<32>:word32] : word32)
 	T_4881 (in SEQ(SLICE(d0, word24, 8), v109_209) : uip32)
@@ -677,14 +329,12 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_4903 (in 0xFFFFFFFF<32> : word32)
 	T_4913 (in Mem251[a7_248 + 0<32>:word32] : word32)
 	T_4918 (in Mem254[a7_248 - 4<i32> + 0<32>:word32] : word32)
-	T_4925 (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
 	T_4928 (in Mem254[a7_248 + 0<32>:word32] : word32)
 	T_4929 (in fn00002C0C(*(a7_248 - 1<i32>), *a7_248) : word32)
 	T_4937 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_4942 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_4946 (in fn00003CE0(a7_79->t0000, out d1, out a1, out a5_5320) : word32)
 	T_4949 (in Mem94[a7_79 + 48<i32>:word32] : word32)
-	T_4951 (in a2_1014 + 4<i32> : word32)
 	T_4961 (in Mem101[a7_99 + 0<32>:word32] : word32)
 	T_4973 (in Mem105[a7_99 + 0<32>:word32] : word32)
 	T_4976 (in Mem115[a7_99 + 0<32>:word32] : word32)
@@ -695,19 +345,16 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_5013 (in 0xFFFFFFFF<32> : word32)
 	T_5023 (in Mem151[a7_148 + 0<32>:word32] : word32)
 	T_5028 (in Mem154[a7_148 - 4<i32> + 0<32>:word32] : word32)
-	T_5034 (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
 	T_5037 (in Mem154[a7_148 + 0<32>:word32] : word32)
 	T_5038 (in fn00002C0C(*(a7_148 - 1<i32>), *a7_148) : word32)
-	T_5075 (in d1_1355 : Eq_25)
+	T_5075 (in d1_1355 : Eq_73)
 	T_5078 (in SEQ(v147_608, v83_500 - 0x63<8>) : uip32)
-	T_5080 (in 0xFFFFFFFF<32> : word32)
 	T_5084 (in SEQ(v147_608, v83_500 - 0x6E<8>) : uip32)
 	T_5093 (in SEQ(v147_608, v83_500 - 0x73<8>) : uip32)
 	T_5120 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_5125 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_5129 (in fn00003CE0(a7_640->t0000, out d1, out a1, out a5_5321) : word32)
 	T_5132 (in Mem655[a7_640 + 48<i32>:word32] : word32)
-	T_5134 (in a2_1014 + 4<i32> : word32)
 	T_5144 (in Mem662[a7_660 + 0<32>:word32] : word32)
 	T_5156 (in Mem666[a7_660 + 0<32>:word32] : word32)
 	T_5159 (in Mem686[a7_660 + 0<32>:word32] : word32)
@@ -717,38 +364,29 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_5186 (in 0xFFFFFFFF<32> : word32)
 	T_5197 (in Mem738[a7_735 + 0<32>:word32] : word32)
 	T_5202 (in Mem741[a7_735 - 4<i32> + 0<32>:word32] : word32)
-	T_5208 (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
 	T_5211 (in Mem741[a7_735 + 0<32>:word32] : word32)
 	T_5212 (in fn00002C0C(*(a7_735 - 1<i32>), *a7_735) : word32)
 	T_5215 (in 0x2D<32> : word32)
 	T_5228 (in (word32) d2_1090 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_5230 (in d0 + 4<32> : word32)
 	T_5234 (in 0xFFFFFFFF<32> : word32)
 	T_5259 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5272 (in d0 + 4<32> : word32)
 	T_5273 (in 0xFFFFFFFF<32> : word32)
 	T_5287 (in d0_1765 & 8<32> : word32)
 	T_5340 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5348 (in d0 + 4<32> : word32)
 	T_5354 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_5359 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_5363 (in fn00003CE0(*a7_1807, out d1_5322, out a1, out a5_1727) : word32)
-	T_5365 (in a2_1014 + 4<i32> : word32)
 	T_5375 (in Mem1828[a7_1826 + 0<32>:word32] : word32)
 	T_5387 (in Mem1832[a7_1826 + 0<32>:word32] : word32)
 	T_5389 (in SEQ(SLICE(d0, word24, 8), v201_1836) : uip32)
 	T_5391 (in (uint32) (uint8) v201_1836 : uint32)
 	T_5396 (in 0xFFFFFFFF<32> : word32)
 	T_5408 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5417 (in d0 + 4<32> : word32)
 	T_5433 (in d0_1871 & 8<32> : word32)
 	T_5447 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5455 (in d0 + 4<32> : word32)
 	T_5461 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5470 (in d0 + 4<32> : word32)
 	T_5485 (in Mem1903[a7_1897 + 0<32>:word32] : word32)
 	T_5490 (in Mem1906[a7_1897 - 4<i32> + 0<32>:word32] : word32)
-	T_5496 (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
 	T_5499 (in Mem1906[a7_1897 + 0<32>:word32] : word32)
 	T_5500 (in fn00002C0C(*(a7_1897 - 1<i32>), *a7_1897) : word32)
 	T_5501 (in 0x2B<32> : word32)
@@ -757,7 +395,6 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_5550 (in Mem2009[a7_2007 + 0<32>:word32] : word32)
 	T_5554 (in fn00003CE0(a7_2007->t0000, out d1, out a1, out a5_5323) : word32)
 	T_5557 (in Mem2022[a7_2007 + 56<i32>:word32] : word32)
-	T_5559 (in a2_1014 + 4<i32> : word32)
 	T_5569 (in Mem2029[a7_2027 + 0<32>:word32] : word32)
 	T_5581 (in Mem2033[a7_2027 + 0<32>:word32] : word32)
 	T_5584 (in Mem2050[a7_2027 + 0<32>:word32] : word32)
@@ -766,29 +403,25 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_5597 (in Mem2062[a7_1330 + 52<i32>:word32] : word32)
 	T_5620 (in 0x30<32> : word32)
 	T_5634 (in d0_2109 & 4<32> : word32)
-	T_5641 (in d0_2155 : Eq_25)
+	T_5641 (in d0_2155 : Eq_73)
 	T_5672 (in Mem2150[a7_2148 + 0<32>:word32] : word32)
 	T_5677 (in Mem2150[a7_2148 + 0<32>:word32] : word32)
 	T_5681 (in fn00003CE0(a7_2148->t0000, out d1, out a1, out a5_5324) : word32)
 	T_5684 (in Mem2163[a7_2148 + 56<i32>:word32] : word32)
-	T_5686 (in a2_1014 + 4<i32> : word32)
 	T_5696 (in Mem2170[a7_2168 + 0<32>:word32] : word32)
 	T_5708 (in Mem2174[a7_2168 + 0<32>:word32] : word32)
 	T_5711 (in Mem2185[a7_2168 + 0<32>:word32] : word32)
 	T_5718 (in SEQ(SLICE(d0, word24, 8), v249_2178) : uip32)
 	T_5721 (in Mem2191[a7_2168 + 0<32>:word32] : word32)
 	T_5738 (in d0_2209 & 0xFF<32> : word32)
-	T_5757 (in 1<i32> : int32)
 	T_5758 (in 0x78<32> : word32)
 	T_5766 (in SEQ(SLICE(d0_2209 & 0xFF<32>, word24, 8), SLICE(d0_2209 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
 	T_5773 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5775 (in d0 + 4<32> : word32)
-	T_5813 (in d0_2253 : Eq_25)
+	T_5813 (in d0_2253 : Eq_73)
 	T_5844 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_5849 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_5853 (in fn00003CE0(a7_2246->t0000, out d1, out a1, out a5_5325) : word32)
 	T_5856 (in Mem2261[a7_2246 + 56<i32>:word32] : word32)
-	T_5858 (in a2_1014 + 4<i32> : word32)
 	T_5868 (in Mem2268[a7_2266 + 0<32>:word32] : word32)
 	T_5880 (in Mem2272[a7_2266 + 0<32>:word32] : word32)
 	T_5883 (in Mem2283[a7_2266 + 0<32>:word32] : word32)
@@ -804,18 +437,14 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_5975 (in Mem1444[a7_1425 + 0<32>:word32] : word32)
 	T_5982 (in SEQ(SLICE(d0, word24, 8), v284_1435) : uip32)
 	T_5985 (in Mem1450[a7_1425 + 0<32>:word32] : word32)
-	T_5988 (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
 	T_5991 (in Mem1456[a7_1330 + 52<i32>:word32] : word32)
 	T_6014 (in 0xFFFFFFFF<32> : word32)
-	T_6018 (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
 	T_6067 (in Mem2338[a7_2334 + 0<32>:word32] : word32)
-	T_6081 (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
 	T_6084 (in Mem2342[a7_2334 + 0<32>:word32] : word32)
 	T_6085 (in fn00002C0C(*(a7_2334 - 1<i32>), a7_2334->t0000) : word32)
 	T_6091 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_6097 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_6101 (in fn00003CE0(*a7_1512, out d1_5328, out a1, out a5_5329) : word32)
-	T_6103 (in a2_1014 + 4<i32> : word32)
 	T_6113 (in Mem1533[a7_1531 + 0<32>:word32] : word32)
 	T_6125 (in Mem1537[a7_1531 + 0<32>:word32] : word32)
 	T_6127 (in SEQ(SLICE(d0, word24, 8), v314_1541) : uip32)
@@ -823,21 +452,18 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_6134 (in 0xFFFFFFFF<32> : word32)
 	T_6163 (in Mem1591[a7_1585 + 0<32>:word32] : word32)
 	T_6168 (in Mem1594[a7_1585 - 4<i32> + 0<32>:word32] : word32)
-	T_6174 (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
 	T_6177 (in Mem1594[a7_1585 + 0<32>:word32] : word32)
 	T_6178 (in fn00002C0C(*(a7_1585 - 1<i32>), *a7_1585) : word32)
 	T_6184 (in Mem2373[a7_2368 + 0<32>:word32] : word32)
-	T_6198 (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
 	T_6201 (in Mem2377[a7_2368 + 0<32>:word32] : word32)
 	T_6202 (in fn00002C0C(*(a7_2368 - 1<i32>), a7_2368->t0000) : word32)
 	T_6225 (in d0_2124 & 0x44<32> : word32)
 	T_6236 (in 0x30<32> : word32)
-	T_6241 (in d0_2450 : Eq_25)
+	T_6241 (in d0_2450 : Eq_73)
 	T_6272 (in Mem2445[a7_2443 + 0<32>:word32] : word32)
 	T_6277 (in Mem2445[a7_2443 + 0<32>:word32] : word32)
 	T_6281 (in fn00003CE0(a7_2443->t0000, out d1, out a1, out a5_5330) : word32)
 	T_6284 (in Mem2458[a7_2443 + 56<i32>:word32] : word32)
-	T_6286 (in a2_1014 + 4<i32> : word32)
 	T_6296 (in Mem2465[a7_2463 + 0<32>:word32] : word32)
 	T_6308 (in Mem2469[a7_2463 + 0<32>:word32] : word32)
 	T_6311 (in Mem2492[a7_2463 + 0<32>:word32] : word32)
@@ -846,40 +472,28 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_6341 (in d0_2517 & 0xFF<32> : word32)
 	T_6351 (in 0x78<32> : word32)
 	T_6359 (in SEQ(SLICE(d0_2517 & 0xFF<32>, word24, 8), SLICE(d0_2517 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
-	T_6368 (in d0_2559 : Eq_25)
+	T_6368 (in d0_2559 : Eq_73)
 	T_6399 (in Mem2554[a7_2552 + 0<32>:word32] : word32)
 	T_6404 (in Mem2554[a7_2552 + 0<32>:word32] : word32)
 	T_6408 (in fn00003CE0(a7_2552->t0000, out d1, out a1, out a5_5331) : word32)
 	T_6411 (in Mem2567[a7_2552 + 56<i32>:word32] : word32)
-	T_6413 (in a2_1014 + 4<i32> : word32)
 	T_6423 (in Mem2574[a7_2572 + 0<32>:word32] : word32)
 	T_6435 (in Mem2578[a7_2572 + 0<32>:word32] : word32)
 	T_6438 (in Mem2589[a7_2572 + 0<32>:word32] : word32)
 	T_6445 (in SEQ(SLICE(d0, word24, 8), v372_2582) : uip32)
 	T_6448 (in Mem2595[a7_2572 + 0<32>:word32] : word32)
 	T_6473 (in d0_2620 & 0x44<32> : word32)
-	T_6506 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
 	T_6515 (in d0_2760 & 0x44<32> : word32)
 	T_6528 (in Mem2671[a7_2667 + 0<32>:word32] : word32)
-	T_6542 (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
 	T_6545 (in Mem2675[a7_2667 + 0<32>:word32] : word32)
 	T_6546 (in fn00002C0C(*(a7_2667 - 1<i32>), a7_2667->t0000) : word32)
 	T_6558 (in Mem2603[a7_1330 + 74<i32>:word32] : word32)
-	T_6571 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-	T_6601 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
 	T_6610 (in d0_2818 & 4<32> : word32)
-	T_6616 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-	T_6622 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-	T_6632 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
 	T_6640 (in 0x37<32> : word32)
-	T_6653 (in v419_2893 : Eq_25)
-	T_6658 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-	T_6783 (in d0_3135 : Eq_25)
-	T_6833 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_6783 (in d0_3135 : Eq_73)
 	T_6859 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6866 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6870 (in fn00003CE0(*(a7_1330 - 4<i32>), out d1_5332, out a1, out a5_5333) : word32)
-	T_6872 (in a2_1014 + 4<i32> : word32)
 	T_6880 (in Mem3149[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6890 (in (uint32) (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint32)
 	T_6894 (in Mem3153[a7_1330 - 4<i32> + 0<32>:word32] : word32)
@@ -890,98 +504,62 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_6936 (in Mem3291[a7_1330 + 110<i32>:word32] : word32)
 	T_6942 (in Mem3272[a7_3259 + 0<32>:word32] : word32)
 	T_6947 (in Mem3275[a7_3259 - 4<i32> + 0<32>:word32] : word32)
-	T_6953 (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
 	T_6956 (in Mem3275[a7_3259 + 0<32>:word32] : word32)
 	T_6957 (in fn00002C0C(*(a7_3259 - 1<i32>), *a7_3259) : word32)
 	T_6963 (in Mem2639[a7_2635 + 0<32>:word32] : word32)
-	T_6977 (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
 	T_6980 (in Mem2643[a7_2635 + 0<32>:word32] : word32)
 	T_6981 (in fn00002C0C(*(a7_2635 - 1<i32>), a7_2635->t0000) : word32)
 	T_6999 (in d0_3206 & 4<32> : word32)
 	T_7007 (in 0x37<32> : word32)
-	T_7013 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_7016 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_7018 (in d7 >> 31<i32> : word32)
-	T_7021 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-	T_7031 (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
-	T_7063 (in dwArg04 : Eq_25)
-	T_7064 (in dwArg08 : Eq_25)
-	T_7065 (in dwArg0C : Eq_25)
-	T_7066 (in dwArg10 : Eq_25)
-	T_7071 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-	T_7076 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-	T_7081 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-	T_7086 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
 	T_7125 (in Mem3303[a7_3299 + 0<32>:word32] : word32)
 	T_7130 (in Mem3306[a7_3299 - 4<i32> + 0<32>:word32] : word32)
-	T_7136 (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
 	T_7139 (in Mem3306[a7_3299 + 0<32>:word32] : word32)
 	T_7140 (in fn00002C0C(*(a7_3299 - 1<i32>), *a7_3299) : word32)
 	T_7169 (in Mem3476[a7_3474 + 0<32>:word32] : word32)
-	T_7193 (in (d0_3495 << 2<32>) + 4<32> : word32)
 	T_7200 (in Mem3485[a7_3474 + 52<i32>:word32] : word32)
 	T_7203 (in Mem3503[a0_3501 + 4<i32>:word32] : word32)
 	T_7210 (in d0_3495 << 2<32> : word32)
-	T_7229 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7232 (in Mem3508[a7_3474 + 52<i32>:word32] : word32)
 	T_7233 (in SLICE(d0, byte, 0) : byte)
 	T_7239 (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_7258 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7261 (in Mem3525[a7_3474 + 52<i32>:word32] : word32)
 	T_7262 (in SLICE(d0, word16, 0) : word16)
 	T_7268 (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_7287 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7290 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_7296 (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7304 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7307 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_7313 (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
 	T_7339 (in -v528_3348->dw0004 : word32)
 	T_7344 (in 0<32> : word32)
 	T_7346 (in -v528_3348->dw0000 - (d1 < 0<32>) : word32)
 	T_7355 (in Mem3375[a7_3364 + 0<32>:word32] : word32)
-	T_7380 (in d1_1027 : Eq_25)
+	T_7380 (in d1_1027 : Eq_73)
 	T_7383 (in Mem773[a7_1330 + 52<i32>:word32] : word32)
-	T_7398 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_7405 (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
+	T_7408 (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
 	T_7415 (in d0_3398 << 2<32> : word32)
-	T_7434 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7437 (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
 	T_7438 (in SLICE(d0, byte, 0) : byte)
 	T_7444 (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_7463 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7466 (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
 	T_7467 (in SLICE(d0, word16, 0) : word16)
 	T_7473 (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_7492 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7495 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_7501 (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7509 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7512 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_7518 (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7522 (in SLICE(d5_785, byte, 0) : byte)
-	T_7526 (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
 	T_7528 (in d1_1027 + 1<32> : word32)
 	T_7529 (in 0x20<32> : word32)
-	T_7535 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-	T_7546 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
 	T_7561 (in SEQ(SLICE(d1_1027, word24, 8), v556_834) : uip32)
 	T_7587 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_7606 (in Mem889[a0_881 + 0<32>:byte] : byte)
 	T_7608 (in (uint32) (uint8) Mem889[a0_881 + 0<32>:byte] : uint32)
-	T_7614 (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-	T_7617 (in Mem895[a0_881 + 0<32>:byte] : byte)
-	T_7626 (in Mem889[a0_900 + 0<32>:byte] : byte)
 	T_7628 (in (uint32) (uint8) Mem889[a0_900 + 0<32>:byte] : uint32)
-	T_7635 (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-	T_7638 (in Mem914[a0_900 + 0<32>:byte] : byte)
 	T_7643 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_7656 (in (d0_957 << 2<32>) + 4<32> : word32)
 	T_7657 (in d0_957 << 2<32> : word32)
 	T_7696 (in Mem987[a7_985 + 0<32>:word32] : word32)
 	T_7701 (in Mem987[a7_985 + 0<32>:word32] : word32)
-	T_7705 (in fn00003CE0(*a7_985, out d1, out a1, out a5_5334) : word32)
+	T_7705 (in fn00003CE0(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
 	T_7708 (in Mem1000[a7_985 + 48<i32>:word32] : word32)
-	T_7710 (in a2_1014 + 4<i32> : word32)
 	T_7720 (in Mem1007[a7_1005 + 0<32>:word32] : word32)
 	T_7732 (in Mem1011[a7_1005 + 0<32>:word32] : word32)
 	T_7735 (in Mem1031[a7_1005 + 0<32>:word32] : word32)
@@ -989,23 +567,13 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_7745 (in Mem1037[a7_1005 + 0<32>:word32] : word32)
 	T_7748 (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
 	T_7760 (in 0xFFFFFFFF<32> : word32)
-	T_7766 (in a7_1330 + 78<i32> : word32)
-	T_7769 (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-	T_7774 (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-	T_7775 (in 00000008 : ptr32)
-	T_7780 (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_7785 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_7788 (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-	T_7794 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_7799 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_7804 (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn000014EC(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)):byte] : uint32)
-	T_7809 (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
 	T_7814 (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
 	T_7815 (in 0<32> : word32)
 	T_7862 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_7868 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_7872 (in fn00003CE0(*a7_1182, out d1_5335, out a1, out a5_5336) : word32)
-	T_7874 (in a2_1014 + 4<i32> : word32)
 	T_7884 (in Mem1203[a7_1201 + 0<32>:word32] : word32)
 	T_7896 (in Mem1207[a7_1201 + 0<32>:word32] : word32)
 	T_7898 (in SEQ(SLICE(d0, word24, 8), v611_1211) : uip32)
@@ -1013,75 +581,24 @@ Eq_25: (union "Eq_25" (uint8 u0) (word16 u1) ((ptr32 Eq_8363) u2) (Eq_6460 u3) (
 	T_7905 (in 0xFFFFFFFF<32> : word32)
 	T_7921 (in Mem1308[a7_1302 + 0<32>:word32] : word32)
 	T_7926 (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
-	T_7932 (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
 	T_7935 (in Mem1311[a7_1302 + 0<32>:word32] : word32)
 	T_7936 (in fn00002C0C(*(a7_1302 - 1<i32>), *a7_1302) : word32)
-	T_7944 (in a7_1330 + 78<i32> : word32)
-	T_7947 (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-	T_7952 (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-	T_7953 (in 00000008 : ptr32)
-	T_7958 (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_7963 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_7966 (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-	T_7971 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_7976 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_7981 (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn000014EC(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)):byte] : uint32)
-	T_7986 (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
 	T_7991 (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
 	T_7992 (in 0<32> : word32)
-	T_8013 (in d0_23 : Eq_25)
-	T_8015 (in __swap(dwArg08) : word32)
-	T_8016 (in d1_25 : Eq_25)
-	T_8018 (in __swap(dwArg10) : word32)
-	T_8028 (in d2_39 : Eq_25)
-	T_8036 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-	T_8037 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-	T_8041 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-	T_8042 (in 0<32> : word32)
-	T_8044 (in d2_45 : Eq_25)
-	T_8046 (in __swap(d2_39) : word32)
-	T_8049 (in __swap(dwArg0C) : word32)
-	T_8052 (in d3_71 : Eq_25)
-	T_8056 (in __swap(dwArg08) : word32)
-	T_8061 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-	T_8062 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-	T_8065 (in __swap(dwArg04) : word32)
-	T_8068 (in d3_89 : Eq_25)
-	T_8072 (in __swap(dwArg10) : word32)
-	T_8077 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-	T_8078 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
 	T_8115 (in 0<32> : word32)
 	T_8154 (in Mem86[dwArg04 + 8<i32>:word32] : word32)
 	T_8155 (in 0<32> : word32)
 	T_8175 (in Mem135[dwArg04 + 8<i32>:word32] : word32)
 	T_8178 (in Mem137[dwArg04 + 4<i32>:word32] : word32)
-	T_8220 (in a0_153 : Eq_25)
+	T_8220 (in a0_153 : Eq_73)
 	T_8223 (in Mem149[dwArg04 + 4<i32>:word32] : word32)
 	T_8225 (in a0_153 + 1<i32> : word32)
 	T_8227 (in Mem157[dwArg04 + 4<i32>:word32] : word32)
 	T_8261 (in d0_117 + 1<i32> : word32)
 	T_8264 (in Mem131[dwArg04 + 8<i32>:word32] : word32)
-Eq_28: (fn Eq_25 (ptr32, int32))
-	T_28 (in OpenLibrary : ptr32)
-	T_29 (in signature of OpenLibrary : void)
-Eq_51: (fn void (word32))
-	T_51 (in Alert : ptr32)
-	T_52 (in signature of Alert : void)
-	T_96 (in Alert : ptr32)
-Eq_61: (struct "Eq_61" (0 word32 dw0000) (24 Eq_25 t0024))
-	T_61 (in Mem67[d0_36 + 172<i32>:word32] : word32)
-	T_62 (in 0<32> : word32)
-	T_87 (in Mem153[d0_36 + 172<i32>:word32] : word32)
-	T_88 (in 0<32> : word32)
-	T_99 (in dwLoc0C_569 : (ptr32 Eq_61))
-	T_118 (in d0_180 : (ptr32 Eq_61))
-	T_121 (in Mem179[d0_36 + 172<i32>:word32] : word32)
-	T_122 (in 0<32> : word32)
-	T_129 (in Mem187[0x00003E2C<p32>:word32] : word32)
-	T_131 (in Mem189[0x00003E30<p32>:word32] : word32)
-	T_211 (in d0_112 + 16<i32> : word32)
-	T_430 (in dwArg08 : (ptr32 Eq_61))
-Eq_75: (fn Eq_25 (Eq_77, Eq_78))
+Eq_75: (fn (ptr32 Eq_25) (Eq_77, Eq_78))
 	T_75 (in AllocMem : ptr32)
 	T_76 (in signature of AllocMem : void)
 	T_3363 (in AllocMem : ptr32)
@@ -1109,7 +626,7 @@ Eq_78: (union "Eq_78" (int32 u0) (ptr32 u1))
 	T_3381 (in Mem26[dwArg04 + 12<i32>:word32] : word32)
 	T_3405 (in Mem135[dwArg04 + 12<i32>:word32] : word32)
 	T_3535 (in 0<i32> : int32)
-Eq_90: (fn void (Eq_25))
+Eq_90: (fn void ((ptr32 Eq_25)))
 	T_90 (in CloseLibrary : ptr32)
 	T_91 (in signature of CloseLibrary : void)
 	T_487 (in CloseLibrary : ptr32)
@@ -1136,6 +653,28 @@ Eq_124: (fn void ((ptr32 Eq_19)))
 	T_124 (in fn00001214 : ptr32)
 	T_125 (in signature of fn00001214 : void)
 	T_304 (in fn00001214 : ptr32)
+Eq_134: (union "Eq_134" (int32 u0) (uint32 u1))
+	T_134 (in d0_197 : Eq_134)
+	T_137 (in Mem194[d0_180 + 36<i32>:word32] : word32)
+	T_138 (in 0<32> : word32)
+	T_153 (in d0_262 : Eq_134)
+	T_159 (in (uint32) (uint8) 0<32>[d0_252 * 4<32>] : uint32)
+	T_204 (in Mem416[0x00003E34<p32>:word32] : word32)
+	T_209 (in Mem418[0x00003E38<p32>:word32] : word32)
+	T_316 (in Mem209[d0_112 + 4<i32>:word32] : word32)
+	T_318 (in 0<32> : word32)
+	T_324 (in Mem214[0x00003E34<p32>:word32] : word32)
+	T_326 (in Mem216[0x00003E38<p32>:word32] : word32)
+	T_328 (in Mem218[0x00003E3C<p32>:word32] : word32)
+	T_331 (in Mem221[d0_36 + 156<i32>:word32] : word32)
+	T_334 (in Mem223[d0_36 + 160<i32>:word32] : word32)
+	T_392 (in Mem435[0x00003E3C<p32>:word32] : word32)
+	T_393 (in v92_428 : Eq_134)
+	T_396 (in Mem418[d0_36 + 224<i32>:word32] : word32)
+	T_398 (in Mem429[0x00003E3C<p32>:word32] : word32)
+	T_399 (in 0<32> : word32)
+	T_3545 (in 0<32> : word32)
+	T_3547 (in Mem38[d0_30 + 4<i32>:word32] : word32)
 Eq_160: (struct "Eq_160" 0001 (0 (arr Eq_160) a0000))
 	T_160 (in 0<8> : byte)
 	T_162 (in Mem263[a0_260 + d0_262:byte] : byte)
@@ -1151,11 +690,11 @@ Eq_200: (fn void ())
 Eq_205: (fn void ())
 	T_205 (in execPrivate5 : ptr32)
 	T_206 (in signature of execPrivate5 : void)
-Eq_306: (fn void (Eq_25))
+Eq_306: (fn void ((ptr32 Eq_25)))
 	T_306 (in fn0000126C : ptr32)
 	T_307 (in signature of fn0000126C : void)
 	T_493 (in fn0000126C : ptr32)
-Eq_310: (fn void (Eq_25))
+Eq_310: (fn void ((ptr32 Eq_25)))
 	T_310 (in Supervisor : ptr32)
 	T_311 (in signature of Supervisor : void)
 Eq_320: (fn void ())
@@ -1186,7 +725,7 @@ Eq_379: (struct "Eq_379" (0 int32 dw0000) (4 word32 dw0004))
 	T_3582 (in list : word32)
 	T_3590 (in a2_29 : (ptr32 Eq_379))
 	T_3592 (in a2_24 - 4<i32> : word32)
-Eq_425: (fn void (Eq_25, Eq_25, int32, (ptr32 Eq_61)))
+Eq_425: (fn void (Eq_73, (ptr32 Eq_25), int32, (ptr32 Eq_61)))
 	T_425 (in fn00001354 : ptr32)
 	T_426 (in signature of fn00001354 : void)
 Eq_432: (fn void (word32))
@@ -1198,7 +737,7 @@ Eq_438: (fn void (word32))
 Eq_444: (fn void ())
 	T_444 (in Forbid : ptr32)
 	T_445 (in signature of Forbid : void)
-Eq_447: (fn void (Eq_25))
+Eq_447: (fn void ((ptr32 Eq_25)))
 	T_447 (in ReplyMsg : ptr32)
 	T_448 (in signature of ReplyMsg : void)
 Eq_484: (fn void ())
@@ -1230,10 +769,10 @@ Eq_587: (fn word32 (ptr32, ptr32, ptr32))
 	T_587 (in fn0000131C : ptr32)
 	T_588 (in signature of fn0000131C : void)
 	T_3618 (in fn0000131C : ptr32)
-Eq_589: (fn ptr32 (Eq_25, Eq_25, Eq_25))
+Eq_589: (fn ptr32 (Eq_73, Eq_73, (ptr32 Eq_25)))
 	T_589 (in fn00001390 : ptr32)
 	T_590 (in signature of fn00001390 : void)
-Eq_615: (fn Eq_25 (Eq_25, Eq_25, Eq_25, (ptr32 Eq_620)))
+Eq_615: (fn Eq_73 (Eq_73, Eq_73, (ptr32 Eq_25), (ptr32 Eq_620)))
 	T_615 (in fn00002BF0 : ptr32)
 	T_616 (in signature of fn00002BF0 : void)
 	T_621 (in fn00002BF0 : ptr32)
@@ -1253,7 +792,7 @@ Eq_620: (struct "Eq_620" 0001 (0 uint8 b0000) (1 cu8 b0001))
 	T_7548 (in a3_1955 + 1<i32> : word32)
 	T_7559 (in a3_1955 + 1<i32> : word32)
 	T_7576 (in a3_1955 + 2<i32> : word32)
-Eq_622: (fn Eq_25 (Eq_25, Eq_625, ptr32, ptr32))
+Eq_622: (fn Eq_73 (Eq_73, Eq_625, ptr32, ptr32))
 	T_622 (in fn000015A4 : ptr32)
 	T_623 (in signature of fn000015A4 : void)
 	T_649 (in fn000015A4 : ptr32)
@@ -1280,10 +819,444 @@ Eq_625: (union "Eq_625" (byte u0) ((ptr32 byte) u1))
 	T_1939 (in Mem1392[a7_1383 - 8<i32> + 0<32>:word32] : word32)
 	T_2005 (in a3_1270 - (byte *) 1<i32> : word32)
 	T_2080 (in Mem1446[a7_1383 - 8<i32> + 0<32>:word32] : word32)
-Eq_663: (fn void (Eq_25, Eq_25, Eq_25))
+Eq_645: (union "Eq_645" ((ptr32 Eq_1583) u0) ((ptr32 Eq_8358) u1) ((ptr32 Eq_8359) u2))
+	T_645 (in d2_158 : Eq_645)
+	T_646 (in 1<i32> : int32)
+	T_655 (in 40<i32> : int32)
+	T_665 (in d2 : Eq_645)
+	T_666 (in dwArg04 : Eq_645)
+	T_667 (in dwArg08 : Eq_645)
+	T_669 (in d1_89 >> 1<32> : word32)
+	T_670 (in 0000000A : ptr32)
+	T_695 (in d2_158 + 1<32> : word32)
+	T_696 (in 0<32> : word32)
+	T_698 (in d1_13 : Eq_645)
+	T_699 (in -dwArg08 : word32)
+	T_700 (in 0<32> : word32)
+	T_702 (in 0<32> : word32)
+	T_707 (in d0 : Eq_645)
+	T_708 (in d1 : Eq_645)
+	T_709 (in d2 : Eq_645)
+	T_710 (in d1Out : Eq_645)
+	T_711 (in -dwArg04 : word32)
+	T_712 (in out d1_49 : ptr32)
+	T_713 (in fn0000151E(-dwArg04, dwArg08, d2, out d1_49) : word32)
+	T_716 (in out d1_60 : ptr32)
+	T_717 (in fn0000151E(dwArg04, dwArg08, d2, out d1_60) : word32)
+	T_720 (in -dwArg04 : word32)
+	T_721 (in out d1_23 : ptr32)
+	T_722 (in fn0000151E(-dwArg04, d1_13, d2, out d1_23) : word32)
+	T_725 (in out d1_34 : ptr32)
+	T_726 (in fn0000151E(dwArg04, d1_13, d2, out d1_34) : word32)
+	T_727 (in d0 : Eq_645)
+	T_728 (in d2 : Eq_645)
+	T_729 (in dwArg04 : Eq_645)
+	T_730 (in dwArg08 : Eq_645)
+	T_731 (in 0<32> : word32)
+	T_733 (in 0<32> : word32)
+	T_735 (in d0_36 : Eq_645)
+	T_736 (in -dwArg04 : word32)
+	T_737 (in 0<32> : word32)
+	T_741 (in out d1_43 : ptr32)
+	T_742 (in fn0000151E(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_743 (in -fn0000151E(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_746 (in -dwArg08 : word32)
+	T_747 (in out d1_55 : ptr32)
+	T_748 (in fn0000151E(d0_36, -dwArg08, d2, out d1_55) : word32)
+	T_751 (in out d1_88 : ptr32)
+	T_752 (in fn0000151E(dwArg04, dwArg08, d2, out d1_88) : word32)
+	T_755 (in -dwArg08 : word32)
+	T_756 (in out d1_89 : ptr32)
+	T_757 (in fn0000151E(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_758 (in -fn0000151E(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_759 (in d1_22 : Eq_645)
+	T_762 (in  : word32)
+	T_763 (in __swap(d1) : word32)
+	T_768 (in d2_11 : Eq_645)
+	T_769 (in SEQ(v11_10, v10_9) : uipr32)
+	T_772 (in d3_18 : Eq_645)
+	T_773 (in 16<i32> : int32)
+	T_777 (in d0_134 : Eq_645)
+	T_779 (in __swap(d0) : word32)
+	T_780 (in d1_135 : Eq_645)
+	T_782 (in __swap(d1_22) : word32)
+	T_787 (in __swap(d2_11) : word32)
+	T_792 (in d0_150 : Eq_645)
+	T_794 (in __swap(d0_134) : word32)
+	T_808 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
+	T_809 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
+	T_811 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
+	T_813 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
+	T_823 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
+	T_829 (in  : word32)
+	T_830 (in  : word32)
+	T_831 (in 8<32> : word32)
+	T_832 (in __rol(d1_22, 8<32>) : word32)
+	T_833 (in 8<32> : uipr32)
+	T_838 (in 4<32> : word32)
+	T_839 (in __rol(d1_22, 4<32>) : word32)
+	T_844 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
+	T_849 (in 2<32> : word32)
+	T_850 (in __rol(d1_22, 2<32>) : word32)
+	T_855 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
+	T_861 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
+	T_862 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
+	T_869 (in __swap(d3_18) : word32)
+	T_875 (in d1_90 : Eq_645)
+	T_877 (in __swap(d1_22) : word32)
+	T_878 (in d3_102 : Eq_645)
+	T_879 (in SEQ(v53_82, v51_79) : uipr32)
+	T_880 (in d0_108 : Eq_645)
+	T_890 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
+	T_891 (in 0<32> : word32)
+	T_894 (in 1<32> : word32)
+	T_895 (in __rol(d1_22, 1<32>) : word32)
+	T_900 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
+	T_904 (in __swap(d3_102) : word32)
+	T_905 (in __rol(d0_108, __swap(d3_102)) : word32)
+	T_906 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
+	T_909 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
+	T_912 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
+	T_913 (in d0_108 + d1_90 : word32)
+	T_914 (in 0<32> : word32)
+	T_1015 (in d5_256 : Eq_645)
+	T_1016 (in -1<i32> : int32)
+	T_1027 (in d2_1005 : Eq_645)
+	T_1030 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
+	T_1046 (in d2_1005 | d1_123 : word32)
+	T_1056 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
+	T_1172 (in 0<i32> : int32)
+	T_1200 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
+	T_1206 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_1209 (in 10<i32> : int32)
+	T_1210 (in __swap(10<i32>) : word32)
+	T_1217 (in __swap(d5_256) : word32)
+	T_1222 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
+	T_1223 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
+	T_1260 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_1264 (in d1_303 - 0x30<32> + d0_293 : word32)
+	T_1309 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
+	T_1317 (in 10<i32> : int32)
+	T_1318 (in __swap(10<i32>) : word32)
+	T_1325 (in __swap(d2_1005) : word32)
+	T_1330 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
+	T_1331 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
+	T_1373 (in d1_196 - 0x30<32> + d0_186 : word32)
+	T_1381 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
+	T_1478 (in 0<32> : word32)
+	T_1557 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
+	T_1606 (in 0<32> : word32)
+	T_1826 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
+	T_1964 (in dwArg04 : Eq_645)
+	T_1965 (in dwArg08 : Eq_645)
+	T_1966 (in dwArg0C : Eq_645)
+	T_1967 (in dwArg10 : Eq_645)
+	T_1971 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_1976 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_1981 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_1986 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_2048 (in dwArg04 : Eq_645)
+	T_2049 (in dwArg08 : Eq_645)
+	T_2050 (in dwArg0C : Eq_645)
+	T_2051 (in dwArg10 : Eq_645)
+	T_2052 (in d1Out : Eq_645)
+	T_2053 (in a0Out : Eq_645)
+	T_2057 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_2062 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_2067 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_2072 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_2073 (in out d1_1450 : ptr32)
+	T_2074 (in out a0_1447 : ptr32)
+	T_2648 (in 0<32> : word32)
+	T_2678 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_2682 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_2738 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
+	T_3623 (in d0 : Eq_645)
+	T_3624 (in d0_196 : Eq_645)
+	T_3625 (in d1_142 : Eq_645)
+	T_3626 (in a0_20 : Eq_645)
+	T_3627 (in d3_166 : Eq_645)
+	T_3628 (in 0<32> : word32)
+	T_3636 (in 0<32> : word32)
+	T_3642 (in d0 : Eq_645)
+	T_3643 (in d1 : Eq_645)
+	T_3644 (in d2 : Eq_645)
+	T_3645 (in d1Out : Eq_645)
+	T_3646 (in d2Out : Eq_645)
+	T_3647 (in out d1_318 : ptr32)
+	T_3648 (in out d2_319 : ptr32)
+	T_3649 (in fn00002664(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
+	T_3650 (in 0<i32> : int32)
+	T_3653 (in d6_30 : Eq_645)
+	T_3655 (in 8<32> : word32)
+	T_3656 (in __rol(dwArg0C, 8<32>) : word32)
+	T_3682 (in 8<32> : word32)
+	T_3683 (in __rol(d6_30, 8<32>) : word32)
+	T_3689 (in 8<32> : word32)
+	T_3690 (in __rol(d6_30, 8<32>) : word32)
+	T_3697 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_3698 (in d1_175 : Eq_645)
+	T_3699 (in d2_176 : Eq_645)
+	T_3700 (in d0_174 : Eq_645)
+	T_3702 (in 0<i32> : int32)
+	T_3703 (in out d1_175 : ptr32)
+	T_3704 (in out d2_176 : ptr32)
+	T_3705 (in fn00002664(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
+	T_3709 (in out d1_320 : ptr32)
+	T_3710 (in out d2_321 : ptr32)
+	T_3711 (in fn00002664(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
+	T_3722 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_3725 (in d0_85 : Eq_645)
+	T_3727 (in dwArg04 >> d4_61 : word32)
+	T_3730 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
+	T_3733 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
+	T_3734 (in out d1_86 : ptr32)
+	T_3735 (in out d2_322 : ptr32)
+	T_3736 (in fn00002664(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
+	T_3737 (in d3_72 : Eq_645)
+	T_3738 (in dwArg10 << d5_63 : word32)
+	T_3739 (in d5_101 : Eq_645)
+	T_3741 (in __swap(d0_85) : word32)
+	T_3742 (in d6_103 : Eq_645)
+	T_3744 (in __swap(d3_72) : word32)
+	T_3748 (in d2_107 : Eq_645)
+	T_3751 (in d0_85 * (word16) d3_72 : word32)
+	T_3752 (in __swap(d0_85 * (word16) d3_72) : word32)
+	T_3765 (in d6_82 : Eq_645)
+	T_3766 (in dwArg08 << d5_63 : word32)
+	T_3767 (in d2_124 : Eq_645)
+	T_3769 (in SEQ(v35_109, v39_116) : uipr32)
+	T_3770 (in __swap(SEQ(v35_109, v39_116)) : word32)
+	T_3778 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
+	T_3779 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
+	T_3783 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
+	T_3784 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
+	T_3806 (in d0_85 - 1<32> : word32)
+	T_3812 (in d7_13 : Eq_645)
+	T_3813 (in 0<32> : word32)
+	T_3816 (in out d1 : ptr32)
+	T_3817 (in fn0000151E(d1, d2, d2, out d1) : word32)
+	T_3818 (in d6_17 : Eq_645)
+	T_3819 (in d5_19 : Eq_645)
+	T_3820 (in 0<32> : word32)
+	T_3822 (in d2_22 : Eq_645)
+	T_3824 (in __swap(d2) : word32)
+	T_3828 (in 0<32> : word32)
+	T_3837 (in 0<32> : word32)
+	T_3839 (in d0_281 : Eq_645)
+	T_3841 (in __swap(d0) : word32)
+	T_3842 (in d1_282 : Eq_645)
+	T_3844 (in __swap(d1) : word32)
+	T_3854 (in __swap(d1_282) : word32)
+	T_3861 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
+	T_3862 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
+	T_3867 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
+	T_3873 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
+	T_3874 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
+	T_3878 (in d6_17 * 2<32> : word32)
+	T_3886 (in 0<32> : word32)
+	T_3888 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
+	T_3890 (in d7_13 * 2<32> : word32)
+	T_3891 (in 0<32> : word32)
+	T_3895 (in d3_74 : Eq_645)
+	T_3902 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
+	T_3903 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
+	T_3906 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
+	T_3907 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
+	T_3908 (in d1_104 : Eq_645)
+	T_3909 (in 0xFFFF<32> : uipr32)
+	T_3910 (in d6_98 : Eq_645)
+	T_3914 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
+	T_3915 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
+	T_3916 (in d6_133 : Eq_645)
+	T_3918 (in __swap(d1_104) : word32)
+	T_3919 (in d3_140 : Eq_645)
+	T_3921 (in __swap(d6_133) : word32)
+	T_3922 (in d4_142 : Eq_645)
+	T_3924 (in __swap(d7_13) : word32)
+	T_3928 (in d6_146 : Eq_645)
+	T_3931 (in d6_133 * (word16) d7_13 : word32)
+	T_3932 (in __swap(d6_133 * (word16) d7_13) : word32)
+	T_3948 (in d6_178 : Eq_645)
+	T_3950 (in SEQ(v56_148, v59_155) : uipr32)
+	T_3951 (in __swap(SEQ(v56_148, v59_155)) : word32)
+	T_3952 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
+	T_3953 (in d5_181 : word32)
+	T_3957 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
+	T_3958 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
+	T_3962 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
+	T_3963 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
+	T_3976 (in 0<32> : word32)
+	T_3978 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
+	T_3979 (in 0<32> : word32)
+	T_3987 (in d1_104 - 1<32> : word32)
+	T_3988 (in d4_113 : Eq_645)
+	T_3991 (in __swap(d7_13) : word32)
+	T_3994 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
+	T_3995 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
+	T_4010 (in __swap(d7_13) : word32)
+	T_4014 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
+	T_4016 (in d1_104 - 1<32> : word32)
+	T_4017 (in 0<32> : word32)
+	T_4023 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
+	T_4024 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_4025 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_4026 (in d6_220 : Eq_645)
+	T_4030 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
+	T_4031 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
+	T_4034 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
+	T_4035 (in d5_221 : Eq_645)
+	T_4037 (in __swap(d5_181) : word32)
+	T_4042 (in d5_266 : Eq_645)
+	T_4044 (in __swap(d5_181) : word32)
+	T_4045 (in d6_267 : Eq_645)
+	T_4047 (in __swap(d6_178) : word32)
+	T_4050 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
+	T_4053 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
+	T_4057 (in d2_73 : Eq_645)
+	T_4059 (in __swap(d5_19) : word32)
+	T_4061 (in __swap(d7_13) : word32)
+	T_4071 (in d5_221 >> 1<32> : word32)
+	T_4076 (in  : word32)
+	T_4082 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
+	T_4089 (in d1 : Eq_645)
+	T_4090 (in d1_171 : Eq_645)
+	T_4091 (in d3_202 : Eq_645)
+	T_4092 (in 0<32> : word32)
+	T_4100 (in 0<32> : word32)
+	T_4104 (in out d1_171 : ptr32)
+	T_4105 (in out d2_354 : ptr32)
+	T_4106 (in fn00002664(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
+	T_4109 (in d6_33 : Eq_645)
+	T_4111 (in 8<32> : word32)
+	T_4112 (in __rol(dwArg0C, 8<32>) : word32)
+	T_4138 (in 8<32> : word32)
+	T_4139 (in __rol(d6_33, 8<32>) : word32)
+	T_4145 (in 8<32> : word32)
+	T_4146 (in __rol(d6_33, 8<32>) : word32)
+	T_4153 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_4156 (in d0_88 : Eq_645)
+	T_4158 (in dwArg04 >> d4_64 : word32)
+	T_4161 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
+	T_4164 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
+	T_4165 (in out d1_89 : ptr32)
+	T_4166 (in out d2_90 : ptr32)
+	T_4167 (in fn00002664(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
+	T_4168 (in d3_75 : Eq_645)
+	T_4169 (in dwArg10 << d5_66 : word32)
+	T_4170 (in d7_104 : Eq_645)
+	T_4172 (in __swap(d0_88) : word32)
+	T_4173 (in d6_106 : Eq_645)
+	T_4175 (in __swap(d3_75) : word32)
+	T_4179 (in d2_110 : Eq_645)
+	T_4182 (in d0_88 * (word16) d3_75 : word32)
+	T_4183 (in __swap(d0_88 * (word16) d3_75) : word32)
+	T_4196 (in d2_127 : Eq_645)
+	T_4198 (in SEQ(v37_112, v40_119) : uipr32)
+	T_4199 (in __swap(SEQ(v37_112, v40_119)) : word32)
+	T_4209 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
+	T_4210 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
+	T_4214 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
+	T_4215 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
+	T_4234 (in dwArg08 - dwArg10 : word32)
+	T_4238 (in d1_211 : Eq_645)
+	T_4239 (in d2_212 : Eq_645)
+	T_4241 (in 0<i32> : int32)
+	T_4242 (in out d1_211 : ptr32)
+	T_4243 (in out d2_212 : ptr32)
+	T_4244 (in fn00002664(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
+	T_4247 (in out d1_171 : ptr32)
+	T_4248 (in out d2_355 : ptr32)
+	T_4249 (in fn00002664(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
+	T_4260 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_4265 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
+	T_4278 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
+	T_4325 (in dwArg0C : Eq_645)
+	T_4330 (in fp + 8<i32> : word32)
+	T_4371 (in d2_1090 : Eq_645)
+	T_4434 (in d6_1133 : Eq_645)
+	T_4435 (in -1<i32> : int32)
+	T_4457 (in 0<i32> : int32)
+	T_4468 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_4471 (in 10<i32> : int32)
+	T_4472 (in __swap(10<i32>) : word32)
+	T_4482 (in __swap(d6_1133) : word32)
+	T_4487 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
+	T_4488 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
+	T_4514 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_4518 (in d1_340 - 0x30<32> + d0_331 : word32)
+	T_5080 (in 0xFFFFFFFF<32> : word32)
+	T_5230 (in d0 + 4<32> : word32)
+	T_5272 (in d0 + 4<32> : word32)
+	T_5348 (in d0 + 4<32> : word32)
+	T_5417 (in d0 + 4<32> : word32)
+	T_5455 (in d0 + 4<32> : word32)
+	T_5470 (in d0 + 4<32> : word32)
+	T_5757 (in 1<i32> : int32)
+	T_5775 (in d0 + 4<32> : word32)
+	T_6506 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
+	T_6571 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
+	T_6601 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
+	T_6616 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
+	T_6622 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
+	T_6632 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
+	T_6653 (in v419_2893 : Eq_645)
+	T_6658 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_6833 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_7013 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_7016 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_7018 (in d7 >> 31<i32> : word32)
+	T_7021 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
+	T_7063 (in dwArg04 : Eq_645)
+	T_7064 (in dwArg08 : Eq_645)
+	T_7065 (in dwArg0C : Eq_645)
+	T_7066 (in dwArg10 : Eq_645)
+	T_7071 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
+	T_7076 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
+	T_7081 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
+	T_7086 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
+	T_7193 (in (d0_3495 << 2<32>) + 4<32> : word32)
+	T_7229 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7258 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7287 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7304 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7398 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_7434 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7463 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7492 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7509 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7535 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
+	T_7546 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
+	T_7656 (in (d0_957 << 2<32>) + 4<32> : word32)
+	T_7794 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
+	T_7799 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
+	T_7971 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
+	T_7976 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
+	T_8013 (in d0_23 : Eq_645)
+	T_8015 (in __swap(dwArg08) : word32)
+	T_8016 (in d1_25 : Eq_645)
+	T_8018 (in __swap(dwArg10) : word32)
+	T_8028 (in d2_39 : Eq_645)
+	T_8036 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
+	T_8037 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
+	T_8041 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
+	T_8042 (in 0<32> : word32)
+	T_8044 (in d2_45 : Eq_645)
+	T_8046 (in __swap(d2_39) : word32)
+	T_8049 (in __swap(dwArg0C) : word32)
+	T_8052 (in d3_71 : Eq_645)
+	T_8056 (in __swap(dwArg08) : word32)
+	T_8061 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
+	T_8062 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
+	T_8065 (in __swap(dwArg04) : word32)
+	T_8068 (in d3_89 : Eq_645)
+	T_8072 (in __swap(dwArg10) : word32)
+	T_8077 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
+	T_8078 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
+Eq_663: (fn void (Eq_645, Eq_645, Eq_645))
 	T_663 (in fn000014AC : ptr32)
 	T_664 (in signature of fn000014AC : void)
-Eq_705: (fn Eq_25 (Eq_25, Eq_25, Eq_25, Eq_25))
+Eq_705: (fn Eq_645 (Eq_645, Eq_645, Eq_645, Eq_645))
 	T_705 (in fn0000151E : ptr32)
 	T_706 (in signature of fn0000151E : void)
 	T_715 (in fn0000151E : ptr32)
@@ -1294,7 +1267,7 @@ Eq_705: (fn Eq_25 (Eq_25, Eq_25, Eq_25, Eq_25))
 	T_750 (in fn0000151E : ptr32)
 	T_754 (in fn0000151E : ptr32)
 	T_3815 (in fn0000151E : ptr32)
-Eq_760: (fn Eq_25 (Eq_25))
+Eq_760: (fn Eq_645 (Eq_645))
 	T_760 (in __swap : ptr32)
 	T_761 (in signature of __swap : void)
 	T_778 (in __swap : ptr32)
@@ -1364,7 +1337,7 @@ Eq_760: (fn Eq_25 (Eq_25))
 	T_8064 (in __swap : ptr32)
 	T_8069 (in __swap : ptr32)
 	T_8071 (in __swap : ptr32)
-Eq_827: (fn Eq_25 (Eq_25, Eq_25))
+Eq_827: (fn Eq_645 (Eq_645, Eq_645))
 	T_827 (in __rol : ptr32)
 	T_828 (in signature of __rol : void)
 	T_837 (in __rol : ptr32)
@@ -1377,7 +1350,7 @@ Eq_827: (fn Eq_25 (Eq_25, Eq_25))
 	T_4110 (in __rol : ptr32)
 	T_4137 (in __rol : ptr32)
 	T_4144 (in __rol : ptr32)
-Eq_919: (fn Eq_25 (Eq_25, (ptr32 Eq_922), Eq_625, Eq_924, (ptr32 Eq_925), Eq_625))
+Eq_919: (fn Eq_73 (Eq_73, (ptr32 Eq_922), Eq_625, Eq_924, (ptr32 Eq_925), Eq_625))
 	T_919 (in fn000015C0 : ptr32)
 	T_920 (in signature of fn000015C0 : void)
 Eq_922: (struct "Eq_922" (0 word32 dw0000) (4 (ptr32 ui32) ptr0004) (8 (ptr32 ui32) ptr0008) (C (ptr32 Eq_922) ptr000C) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
@@ -1461,7 +1434,7 @@ Eq_925: (struct "Eq_925" (0 word32 dw0000) (4 word32 dw0004))
 	T_2665 (in Mem916[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_2687 (in Mem935[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_2725 (in Mem1000[a7_992 - 4<i32> + 0<32>:word32] : word32)
-Eq_936: (struct "Eq_936" 0004 (2C Eq_8364 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8365 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+Eq_936: (struct "Eq_936" 0004 (2C Eq_8360 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8361 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 	T_936 (in a7_1968 : (ptr32 Eq_936))
 	T_939 (in fp + -112<i32> : word32)
 	T_1000 (in a7_51 + 4<i32> : word32)
@@ -1476,7 +1449,7 @@ Eq_936: (struct "Eq_936" 0004 (2C Eq_8364 t002C) (30 word32 dw0030) (34 word32 d
 	T_1806 (in Mem1237[a7_1174 + 64<i32>:word32] : word32)
 	T_2082 (in a7_1383 + 4<i32> : word32)
 	T_2746 (in a7_992 + 4<i32> : word32)
-Eq_977: (fn Eq_25 (int32, (ptr32 Eq_922), Eq_981, (ptr32 ui32), Eq_983, ptr32))
+Eq_977: (fn Eq_73 (int32, (ptr32 Eq_922), Eq_981, (ptr32 ui32), Eq_983, ptr32))
 	T_977 (in fn00001F40 : ptr32)
 	T_978 (in signature of fn00001F40 : void)
 	T_1896 (in fn00001F40 : ptr32)
@@ -1521,7 +1494,7 @@ Eq_1022: (struct "Eq_1022" (0 Eq_2594 t0000) (3C word32 dw003C) (40 up32 dw0040)
 	T_2370 (in 1<32> : word32)
 	T_2654 (in 1<32> : word32)
 	T_2776 (in d7_1026 + 1<32> : word32)
-Eq_1052: (struct "Eq_1052" (0 Eq_25 t0000) (4 Eq_25 t0004))
+Eq_1052: (struct "Eq_1052" (0 Eq_73 t0000) (4 Eq_73 t0004))
 	T_1052 (in a0_1447 : (ptr32 Eq_1052))
 	T_1070 (in 0x28C5<u32> + (SEQ(SLICE(d0, word24, 8), *a2_135) & 0xFF<32>) : word32)
 	T_1099 (in d0_159 + 4<32> : word32)
@@ -1646,13 +1619,13 @@ Eq_1876: (struct "Eq_1876" (0 (ptr32 Eq_922) ptr0000) (6E (arr byte) a006E))
 Eq_1915: (union "Eq_1915" (int32 u0) (up32 u1))
 	T_1915 (in d7_1024 - d2_1571 : word32)
 	T_1916 (in 0<32> : word32)
-Eq_1922: (struct "Eq_1922" (0 int32 dw0000) (34 Eq_25 t0034) (48 Eq_1410 t0048) (4C ui32 dw004C) (66 (ptr32 Eq_1022) ptr0066) (6A word32 dw006A) (80 Eq_924 t0080))
+Eq_1922: (struct "Eq_1922" (0 int32 dw0000) (34 Eq_73 t0034) (48 Eq_1410 t0048) (4C ui32 dw004C) (66 (ptr32 Eq_1022) ptr0066) (6A word32 dw006A) (80 Eq_924 t0080))
 	T_1922 (in a7_1383 : (ptr32 Eq_1922))
 	T_1924 (in a7_1020 - 4<i32> : word32)
-Eq_1962: (fn int32 (Eq_25, Eq_25, Eq_25, Eq_25))
+Eq_1962: (fn int32 (Eq_645, Eq_645, Eq_645, Eq_645))
 	T_1962 (in fn000027B0 : ptr32)
 	T_1963 (in signature of fn000027B0 : void)
-Eq_2046: (fn word32 (Eq_25, Eq_25, Eq_25, Eq_25, Eq_25, Eq_25))
+Eq_2046: (fn word32 (Eq_645, Eq_645, Eq_645, Eq_645, Eq_645, Eq_645))
 	T_2046 (in fn00002560 : ptr32)
 	T_2047 (in signature of fn00002560 : void)
 Eq_2086: (union "Eq_2086" (bool u0) (word32 u1))
@@ -1718,9 +1691,6 @@ Eq_2348: (union "Eq_2348" (int32 u0) (up32 u1))
 	T_2348 (in d2_1847 : Eq_2348)
 	T_2349 (in 0<i32> : int32)
 	T_2360 (in d2_1847 + 1<32> : word32)
-Eq_2441: (union "Eq_2441" (byte u0) (word32 u1))
-	T_2441 (in v248_1105 : Eq_2441)
-	T_2444 (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
 Eq_2445: (struct "Eq_2445" (0 (ptr32 Eq_925) ptr0000) (34 int32 dw0034) (38 int32 dw0038))
 	T_2445 (in a7_1109 : (ptr32 Eq_2445))
 	T_2447 (in a7_1968 - 4<i32> : word32)
@@ -1731,9 +1701,6 @@ Eq_2482: (union "Eq_2482" (uint32 u0) (ptr32 u1))
 	T_2482 (in 3<32> : word32)
 Eq_2483: (union "Eq_2483" (uint32 u0) (ptr32 u1))
 	T_2483 (in d3_1482 + 3<32> : word32)
-Eq_2506: (union "Eq_2506" (word16 u0) (word32 u1))
-	T_2506 (in v262_844 : Eq_2506)
-	T_2509 (in Mem843[a7_1968 + 62<i32>:word16] : word16)
 Eq_2510: (struct "Eq_2510" (0 (ptr32 Eq_925) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2510 (in a7_848 : (ptr32 Eq_2510))
 	T_2512 (in a7_1968 - 4<i32> : word32)
@@ -1765,9 +1732,6 @@ Eq_2600: (union "Eq_2600" (cu8 u0) (word32 u1) (Eq_1453 u2) (Eq_1456 u3) (Eq_153
 	T_2603 (in Mem894[a7_1968 + 44<i32>:byte] : byte)
 Eq_2602: (union "Eq_2602" (cu8 u0) (word32 u1) (Eq_1453 u2) (Eq_1456 u3) (Eq_1530 u4) (Eq_2600 u5))
 	T_2602 (in a7_1968 + 44<i32> : word32)
-Eq_2606: (union "Eq_2606" (byte u0) (word32 u1))
-	T_2606 (in v277_869 : Eq_2606)
-	T_2609 (in Mem868[a7_1968 + 63<i32>:byte] : byte)
 Eq_2610: (struct "Eq_2610" (0 (ptr32 Eq_925) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2610 (in a7_873 : (ptr32 Eq_2610))
 	T_2612 (in a7_1968 - 4<i32> : word32)
@@ -1844,78 +1808,12 @@ Eq_2837: (union "Eq_2837" ((ptr32 Eq_1583) u0) (Eq_2118 u1) (Eq_2182 u2) (Eq_218
 Eq_2861: (fn Eq_981 (int32, (ptr32 Eq_922), (ptr32 ui32), ptr32, ptr32))
 	T_2861 (in fn00001F9C : ptr32)
 	T_2862 (in signature of fn00001F9C : void)
-Eq_2903: (fn Eq_2909 (ptr32, ptr32))
+Eq_2903: (fn (ptr32 (ptr32 Eq_4374)) (ptr32, ptr32))
 	T_2903 (in fn00002530 : ptr32)
 	T_2904 (in signature of fn00002530 : void)
 	T_3079 (in fn00002530 : ptr32)
 	T_8111 (in fn00002530 : ptr32)
-Eq_2909: (union "Eq_2909" (byte u0) ((ptr32 Eq_8381) u1))
-	T_2909 (in fn00002530(out a1_125, out a5_127) : word32)
-	T_3082 (in fn00002530(out a1_21, out a5_23) : word32)
-	T_4732 (in d1Out : Eq_2909)
-	T_4738 (in out d1_5316 : ptr32)
-	T_4852 (in out d1_5318 : ptr32)
-	T_4943 (in out d1 : ptr32)
-	T_5126 (in out d1 : ptr32)
-	T_5360 (in out d1_5322 : ptr32)
-	T_5551 (in out d1 : ptr32)
-	T_5678 (in out d1 : ptr32)
-	T_5850 (in out d1 : ptr32)
-	T_5935 (in out d1 : ptr32)
-	T_6098 (in out d1_5328 : ptr32)
-	T_6278 (in out d1 : ptr32)
-	T_6405 (in out d1 : ptr32)
-	T_6867 (in out d1_5332 : ptr32)
-	T_7702 (in out d1 : ptr32)
-	T_7869 (in out d1_5335 : ptr32)
-	T_8110 (in d1_118 : Eq_2909)
-	T_8114 (in fn00002530(out a1_116, out a5_279) : word32)
-	T_8181 (in Mem137[dwArg04 + 0<32>:word32] : word32)
-Eq_2963: (struct "Eq_2963" (0 word32 dw0000) (4 word32 dw0004))
-	T_2963 (in d0_160 : (ptr32 Eq_2963))
-	T_2977 (in fn0000215C(d4_143 + dwArg08->dw001C, out d1_161, out a0, out a1_125) : word32)
-	T_2978 (in 0<32> : word32)
-	T_3186 (in a0_13 : (ptr32 Eq_2963))
-	T_3188 (in Mem5[0x00003E54<p32>:word32] : word32)
-	T_3194 (in dwArg08 : (ptr32 Eq_2963))
-	T_3195 (in dwArg0C : (ptr32 Eq_2963))
-	T_3196 (in d1Out : (ptr32 Eq_2963))
-	T_3200 (in out d1 : ptr32)
-	T_3423 (in d0_82 + 40<i32> : word32)
-	T_3426 (in Mem95[d0_82 + 20<i32>:word32] : word32)
-	T_3433 (in Mem97[d0_82 + 20<i32>:word32] : word32)
-	T_3437 (in a2_100 : (ptr32 Eq_2963))
-	T_3439 (in Mem99[d0_82 + 20<i32>:word32] : word32)
-	T_3454 (in Mem106[d0_82 + 20<i32>:word32] : word32)
-	T_3525 (in d1 : word32)
-	T_3529 (in puddleSize : word32)
-	T_3530 (in puddleThresh : word32)
-	T_3537 (in 0<i32> : int32)
-	T_3563 (in Mem48[d0_30 + 20<i32>:word32] : word32)
-	T_4349 (in Mem20[dwArg08 + 20<i32>:word32] : word32)
-	T_4351 (in Mem20[dwArg08 + 20<i32>:word32] + 1<32> : word32)
-	T_4353 (in Mem22[dwArg08 + 20<i32>:word32] : word32)
-	T_8132 (in d0_125 : (ptr32 Eq_2963))
-	T_8136 (in *((word32) dwArg04 + 24<i32>) & 0x200<32> : word32)
-	T_8137 (in 0<32> : word32)
-	T_8151 (in fn00003DDC(out a1_116, out a5_279) : word32)
-	T_8161 (in *((word32) dwArg04 + 24<i32>) & 4<i32> : word32)
-	T_8162 (in 0<32> : word32)
-	T_8172 (in 1<i32> : int32)
-	T_8187 (in Mem147[dwArg04 + 20<i32>:word32] : word32)
-	T_8188 (in v26_148 : (ptr32 Eq_2963))
-	T_8190 (in Mem147[dwArg04 + 20<i32>:word32] : word32)
-	T_8192 (in *((word32) dwArg04 + 20<i32>) - 1<32> : word32)
-	T_8194 (in Mem149[dwArg04 + 20<i32>:word32] : word32)
-	T_8195 (in 0<32> : word32)
-	T_8208 (in d0_117 : (ptr32 Eq_2963))
-	T_8217 (in fn0000215C((word32) *((word32) dwArg04 + 28<i32>) + d4_100, out d1_118, out a0_318, out a1_116) : word32)
-	T_8218 (in 0<32> : word32)
-	T_8238 (in Mem149[dwArg04 + 20<i32>:word32] : word32)
-	T_8239 (in -1<i32> : int32)
-	T_8255 (in 0<32> : word32)
-	T_8258 (in Mem184[dwArg04 + 20<i32>:word32] : word32)
-Eq_2964: (fn (ptr32 Eq_2963) (int32, ptr32, ptr32, (ptr32 int32)))
+Eq_2964: (fn int32 (int32, ptr32, ptr32, (ptr32 int32)))
 	T_2964 (in fn0000215C : ptr32)
 	T_2965 (in signature of fn0000215C : void)
 	T_8209 (in fn0000215C : ptr32)
@@ -1936,7 +1834,25 @@ Eq_3170: (union "Eq_3170" (int32 u0) (ptr32 u1))
 	T_3222 (in 0<i32> : int32)
 	T_3228 (in d0_58 + 4<i32> : word32)
 	T_3229 (in 0<i32> : int32)
-Eq_3191: (fn (ptr32 Eq_4) (Eq_106, (ptr32 Eq_2963), (ptr32 Eq_2963), (ptr32 Eq_2963), (ptr32 Eq_4), Eq_25))
+Eq_3186: (struct "Eq_3186" (0 word32 dw0000) (4 word32 dw0004))
+	T_3186 (in a0_13 : (ptr32 Eq_3186))
+	T_3188 (in Mem5[0x00003E54<p32>:word32] : word32)
+	T_3194 (in dwArg08 : (ptr32 Eq_3186))
+	T_3195 (in dwArg0C : (ptr32 Eq_3186))
+	T_3196 (in d1Out : (ptr32 Eq_3186))
+	T_3200 (in out d1 : ptr32)
+	T_3423 (in d0_82 + 40<i32> : word32)
+	T_3426 (in Mem95[d0_82 + 20<i32>:word32] : word32)
+	T_3433 (in Mem97[d0_82 + 20<i32>:word32] : word32)
+	T_3437 (in a2_100 : (ptr32 Eq_3186))
+	T_3439 (in Mem99[d0_82 + 20<i32>:word32] : word32)
+	T_3454 (in Mem106[d0_82 + 20<i32>:word32] : word32)
+	T_3525 (in d1 : word32)
+	T_3529 (in puddleSize : word32)
+	T_3530 (in puddleThresh : word32)
+	T_3537 (in 0<i32> : int32)
+	T_3563 (in Mem48[d0_30 + 20<i32>:word32] : word32)
+Eq_3191: (fn (ptr32 Eq_4) (Eq_106, (ptr32 Eq_3186), (ptr32 Eq_3186), (ptr32 Eq_3186), (ptr32 Eq_4), (ptr32 Eq_25)))
 	T_3191 (in fn00002450 : ptr32)
 	T_3192 (in signature of fn00002450 : void)
 Eq_3207: (fn (ptr32 int32) ((ptr32 Eq_4), up32, Eq_78, (ptr32 Eq_4)))
@@ -1954,38 +1870,22 @@ Eq_3278: (fn void ((ptr32 Eq_4)))
 Eq_3316: (fn void ((ptr32 Eq_4), up32, up32))
 	T_3316 (in Deallocate : ptr32)
 	T_3317 (in signature of Deallocate : void)
-Eq_3345: (fn Eq_25 (up32, (ptr32 Eq_4)))
+Eq_3345: (fn (ptr32 Eq_25) (up32, (ptr32 Eq_4)))
 	T_3345 (in AllocPooled : ptr32)
 	T_3346 (in signature of AllocPooled : void)
 Eq_3364: (union "Eq_3364" (int32 u0) (up32 u1))
 	T_3364 (in 16<i32> : int32)
-Eq_3396: (fn Eq_25 ((ptr32 Eq_4), up32))
+Eq_3396: (fn (ptr32 Eq_25) ((ptr32 Eq_4), up32))
 	T_3396 (in Allocate : ptr32)
 	T_3397 (in signature of Allocate : void)
 	T_3467 (in Allocate : ptr32)
-Eq_3427: (union "Eq_3427" (ui32 u0) (ptr32 u1))
-	T_3427 (in d0_82 + 40<i32> : word32)
-	T_3430 (in Mem97[d0_82 + 24<i32>:word32] : word32)
-	T_8119 (in Mem26[dwArg04 + 24<i32>:word32] : word32)
-	T_8127 (in Mem26[dwArg04 + 24<i32>:word32] : word32)
-	T_8129 (in *((word32) dwArg04 + 24<i32>) | 1<i32> : word32)
-	T_8131 (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-	T_8134 (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-	T_8159 (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-	T_8200 (in Mem86[dwArg04 + 24<i32>:word32] : word32)
-	T_8243 (in Mem149[dwArg04 + 24<i32>:word32] : word32)
-	T_8245 (in *((word32) dwArg04 + 24<i32>) | 16<i32> : word32)
-	T_8247 (in Mem172[dwArg04 + 24<i32>:word32] : word32)
-	T_8250 (in Mem149[dwArg04 + 24<i32>:word32] : word32)
-	T_8252 (in *((word32) dwArg04 + 24<i32>) | 8<i32> : word32)
-	T_8254 (in Mem179[dwArg04 + 24<i32>:word32] : word32)
 Eq_3459: (fn void ((ptr32 Eq_4), ptr32))
 	T_3459 (in AddHead : ptr32)
 	T_3460 (in signature of AddHead : void)
 Eq_3497: (fn void ((ptr32 Eq_4), ptr32))
 	T_3497 (in AddTail : ptr32)
 	T_3498 (in signature of AddTail : void)
-Eq_3526: (fn Eq_25 (Eq_106, (ptr32 Eq_2963), (ptr32 Eq_2963)))
+Eq_3526: (fn (ptr32 Eq_25) (Eq_106, (ptr32 Eq_3186), (ptr32 Eq_3186)))
 	T_3526 (in CreatePrivatePool : ptr32)
 	T_3527 (in signature of CreatePrivatePool : void)
 Eq_3576: (fn void ((ptr32 Eq_379)))
@@ -1998,7 +1898,7 @@ Eq_3580: (fn void ((ptr32 Eq_379)))
 Eq_3604: (fn void (int32, word32))
 	T_3604 (in SetSignal : ptr32)
 	T_3605 (in signature of SetSignal : void)
-Eq_3640: (fn Eq_25 (Eq_25, Eq_25, Eq_25, Eq_25, Eq_25))
+Eq_3640: (fn Eq_645 (Eq_645, Eq_645, Eq_645, Eq_645, Eq_645))
 	T_3640 (in fn00002664 : ptr32)
 	T_3641 (in signature of fn00002664 : void)
 	T_3701 (in fn00002664 : ptr32)
@@ -2032,7 +1932,7 @@ Eq_3971: (union "Eq_3971" (bool u0) (word16 u1))
 	T_3971 (in v59_155 <u 0<16> : bool)
 Eq_3977: (union "Eq_3977" (bool u0) (uint32 u1))
 	T_3977 (in d6_178 <u 0<32> : bool)
-Eq_4074: (fn Eq_25 (Eq_25, word32, bool))
+Eq_4074: (fn Eq_645 (Eq_645, word32, bool))
 	T_4074 (in __rcr : ptr32)
 	T_4075 (in signature of __rcr : void)
 Eq_4220: (union "Eq_4220" (bool u0) (word16 u1))
@@ -2045,11 +1945,11 @@ Eq_4264: (union "Eq_4264" (bool u0) (word32 u1))
 	T_4264 (in d3_135 < 0<32> : bool)
 Eq_4272: (union "Eq_4272" (bool u0) (ui32 u1))
 	T_4272 (in d6_157 < 0<32> : bool)
-Eq_4318: (fn Eq_25 (Eq_25, Eq_25, Eq_25, Eq_25, (ptr32 Eq_620), Eq_25))
+Eq_4318: (fn Eq_73 (Eq_73, Eq_73, (ptr32 Eq_25), Eq_73, (ptr32 Eq_620), Eq_645))
 	T_4318 (in fn00002C3C : ptr32)
 	T_4319 (in signature of fn00002C3C : void)
-Eq_4367: (union "Eq_4367" (uint8 u0) ((ptr32 Eq_8387) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_4367 (in a7_1330 : Eq_4367)
+Eq_4367: (struct "Eq_4367" 0004 (2C int32 dw002C) (30 Eq_8377 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8378 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+	T_4367 (in a7_1330 : (ptr32 Eq_4367))
 	T_4370 (in fp + -120<i32> : word32)
 	T_7179 (in a7_3474 + 4<i32> : word32)
 	T_7349 (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
@@ -2190,7 +2090,7 @@ Eq_4477: (union "Eq_4477" (int32 u0) (uint32 u1))
 	T_4477 (in 10<i32> : int32)
 Eq_4507: (union "Eq_4507" (int32 u0) (uint32 u1))
 	T_4507 (in (uint32) (uint8) Mem316[a3_279 + 0<32>:byte] : uint32)
-Eq_4729: (fn Eq_25 (Eq_25, Eq_2909, (ptr32 word32), (ptr32 byte)))
+Eq_4729: (fn Eq_73 (Eq_73, (ptr32 (ptr32 Eq_4374)), (ptr32 word32), (ptr32 byte)))
 	T_4729 (in fn00003CE0 : ptr32)
 	T_4730 (in signature of fn00003CE0 : void)
 	T_4848 (in fn00003CE0 : ptr32)
@@ -2207,7 +2107,7 @@ Eq_4729: (fn Eq_25 (Eq_25, Eq_2909, (ptr32 word32), (ptr32 byte)))
 	T_6862 (in fn00003CE0 : ptr32)
 	T_7698 (in fn00003CE0 : ptr32)
 	T_7865 (in fn00003CE0 : ptr32)
-Eq_4919: (fn Eq_25 (Eq_25, Eq_25))
+Eq_4919: (fn Eq_73 (byte, Eq_73))
 	T_4919 (in fn00002C0C : ptr32)
 	T_4920 (in signature of fn00002C0C : void)
 	T_5029 (in fn00002C0C : ptr32)
@@ -2221,27 +2121,21 @@ Eq_4919: (fn Eq_25 (Eq_25, Eq_25))
 	T_6972 (in fn00002C0C : ptr32)
 	T_7131 (in fn00002C0C : ptr32)
 	T_7927 (in fn00002C0C : ptr32)
-Eq_4932: (struct "Eq_4932" (0 Eq_25 t0000) (30 Eq_25 t0030))
+Eq_4932: (struct "Eq_4932" (0 Eq_73 t0000) (30 Eq_73 t0030))
 	T_4932 (in a7_79 : (ptr32 Eq_4932))
 	T_4934 (in a7_1330 - 4<i32> : word32)
-Eq_4956: (struct "Eq_4956" (0 Eq_25 t0000) (30 uint32 dw0030))
+Eq_4956: (struct "Eq_4956" (0 Eq_73 t0000) (30 uint32 dw0030))
 	T_4956 (in a7_99 : (ptr32 Eq_4956))
 	T_4958 (in a7_1330 - 4<i32> : word32)
-Eq_4986: (union "Eq_4986" (byte u0) ((ptr32 Eq_8388) u1))
-	T_4986 (in a7_99 + 0<32> : word32)
 Eq_5066: (union "Eq_5066" (int32 u0) (byte u1))
 	T_5066 (in 0<8> : byte)
 	T_5069 (in Mem761[a7_1330 + 44<i32>:byte] : byte)
-Eq_5115: (struct "Eq_5115" (0 Eq_25 t0000) (30 Eq_25 t0030))
+Eq_5115: (struct "Eq_5115" (0 Eq_73 t0000) (30 Eq_73 t0030))
 	T_5115 (in a7_640 : (ptr32 Eq_5115))
 	T_5117 (in a7_1330 - 4<i32> : word32)
-Eq_5139: (struct "Eq_5139" (0 Eq_25 t0000) (30 uint32 dw0030))
+Eq_5139: (struct "Eq_5139" (0 Eq_73 t0000) (30 uint32 dw0030))
 	T_5139 (in a7_660 : (ptr32 Eq_5139))
 	T_5141 (in a7_1330 - 4<i32> : word32)
-Eq_5158: (union "Eq_5158" (byte u0) ((ptr32 Eq_8389) u1))
-	T_5158 (in a7_660 + 0<32> : word32)
-Eq_5168: (union "Eq_5168" (byte u0) ((ptr32 Eq_8390) u1))
-	T_5168 (in a7_660 + 0<32> : word32)
 Eq_5255: (union "Eq_5255" (int32 u0) (uint32 u1))
 	T_5255 (in d2_1090 + 3<32> : word32)
 Eq_5260: (struct "Eq_5260" (0 word32 dw0000) (4 Eq_4374 t0004))
@@ -2260,31 +2154,23 @@ Eq_5471: (union "Eq_5471" (int32 u0) (uint32 u1))
 Eq_5506: (union "Eq_5506" (int32 u0) (uint32 u1))
 	T_5506 (in d6_1133 - d3_1850 : word32)
 	T_5507 (in 0<32> : word32)
-Eq_5540: (struct "Eq_5540" (0 Eq_25 t0000) (38 Eq_25 t0038))
+Eq_5540: (struct "Eq_5540" (0 Eq_73 t0000) (38 Eq_73 t0038))
 	T_5540 (in a7_2007 : (ptr32 Eq_5540))
 	T_5542 (in a7_1330 - 4<i32> : word32)
-Eq_5564: (struct "Eq_5564" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_5564: (struct "Eq_5564" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_5564 (in a7_2027 : (ptr32 Eq_5564))
 	T_5566 (in a7_1330 - 4<i32> : word32)
-Eq_5583: (union "Eq_5583" (byte u0) ((ptr32 Eq_8400) u1))
-	T_5583 (in a7_2027 + 0<32> : word32)
-Eq_5593: (union "Eq_5593" (byte u0) ((ptr32 Eq_8401) u1))
-	T_5593 (in a7_2027 + 0<32> : word32)
 Eq_5598: (union "Eq_5598" (int32 u0) (uint32 u1))
 	T_5598 (in 1<32> : word32)
 Eq_5638: (union "Eq_5638" (int32 u0) (uint32 u1))
 	T_5638 (in d6_1133 - d3_1850 : word32)
 	T_5639 (in 0<32> : word32)
-Eq_5667: (struct "Eq_5667" (0 Eq_25 t0000) (38 Eq_25 t0038))
+Eq_5667: (struct "Eq_5667" (0 Eq_73 t0000) (38 Eq_73 t0038))
 	T_5667 (in a7_2148 : (ptr32 Eq_5667))
 	T_5669 (in a7_1330 - 4<i32> : word32)
-Eq_5691: (struct "Eq_5691" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_5691: (struct "Eq_5691" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_5691 (in a7_2168 : (ptr32 Eq_5691))
 	T_5693 (in a7_1330 - 4<i32> : word32)
-Eq_5710: (union "Eq_5710" (byte u0) ((ptr32 Eq_8402) u1))
-	T_5710 (in a7_2168 + 0<32> : word32)
-Eq_5720: (union "Eq_5720" (byte u0) ((ptr32 Eq_8403) u1))
-	T_5720 (in a7_2168 + 0<32> : word32)
 Eq_5734: (union "Eq_5734" (int32 u0) (uint32 u1))
 	T_5734 (in d3_2201 : Eq_5734)
 	T_5736 (in d3_1850 + 1<32> : word32)
@@ -2297,26 +2183,18 @@ Eq_5739: (fn bool (Eq_4404, word16))
 Eq_5810: (union "Eq_5810" (int32 u0) (uint32 u1))
 	T_5810 (in d6_1133 - d3_2201 : word32)
 	T_5811 (in 0<32> : word32)
-Eq_5839: (struct "Eq_5839" (0 Eq_25 t0000) (38 Eq_25 t0038))
+Eq_5839: (struct "Eq_5839" (0 Eq_73 t0000) (38 Eq_73 t0038))
 	T_5839 (in a7_2246 : (ptr32 Eq_5839))
 	T_5841 (in a7_1330 - 4<i32> : word32)
-Eq_5863: (struct "Eq_5863" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_5863: (struct "Eq_5863" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_5863 (in a7_2266 : (ptr32 Eq_5863))
 	T_5865 (in a7_1330 - 4<i32> : word32)
-Eq_5882: (union "Eq_5882" (byte u0) ((ptr32 Eq_8406) u1))
-	T_5882 (in a7_2266 + 0<32> : word32)
-Eq_5892: (union "Eq_5892" (byte u0) ((ptr32 Eq_8407) u1))
-	T_5892 (in a7_2266 + 0<32> : word32)
-Eq_5920: (struct "Eq_5920" (0 Eq_25 t0000) (30 int32 dw0030) (38 Eq_25 t0038))
+Eq_5920: (struct "Eq_5920" (0 Eq_73 t0000) (30 int32 dw0030) (38 Eq_73 t0038))
 	T_5920 (in a7_1400 : (ptr32 Eq_5920))
 	T_5922 (in a7_1330 - 4<i32> : word32)
-Eq_5955: (struct "Eq_5955" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_5955: (struct "Eq_5955" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_5955 (in a7_1425 : (ptr32 Eq_5955))
 	T_5957 (in a7_1330 - 4<i32> : word32)
-Eq_5974: (union "Eq_5974" (byte u0) ((ptr32 Eq_8408) u1))
-	T_5974 (in a7_1425 + 0<32> : word32)
-Eq_5984: (union "Eq_5984" (byte u0) ((ptr32 Eq_8409) u1))
-	T_5984 (in a7_1425 + 0<32> : word32)
 Eq_5992: (union "Eq_5992" (int32 u0) (uint32 u1))
 	T_5992 (in d3_1462 : Eq_5992)
 	T_5994 (in d3_1850 + 1<32> : word32)
@@ -2333,7 +2211,7 @@ Eq_6010: (union "Eq_6010" (int32 u0) (uint32 u1))
 Eq_6019: (union "Eq_6019" (int32 u0) (uint32 u1))
 	T_6019 (in d6_1133 - d3_1462 : word32)
 	T_6020 (in 0<32> : word32)
-Eq_6062: (struct "Eq_6062" (0 Eq_25 t0000) (4E word32 dw004E))
+Eq_6062: (struct "Eq_6062" (0 Eq_73 t0000) (4E word32 dw004E))
 	T_6062 (in a7_2334 : (ptr32 Eq_6062))
 	T_6064 (in a7_1330 - 4<i32> : word32)
 Eq_6130: (union "Eq_6130" (int32 u0) (uint32 u1))
@@ -2343,7 +2221,7 @@ Eq_6139: (union "Eq_6139" (int32 u0) (uint32 u1))
 	T_6140 (in 0<32> : word32)
 Eq_6149: (union "Eq_6149" (int32 u0) (uint32 u1))
 	T_6149 (in 1<32> : word32)
-Eq_6179: (struct "Eq_6179" (0 Eq_25 t0000) (44 word32 dw0044))
+Eq_6179: (struct "Eq_6179" (0 Eq_73 t0000) (44 word32 dw0044))
 	T_6179 (in a7_2368 : (ptr32 Eq_6179))
 	T_6181 (in a7_1330 - 4<i32> : word32)
 Eq_6229: (union "Eq_6229" (int32 u0) (uint32 u1))
@@ -2352,16 +2230,12 @@ Eq_6229: (union "Eq_6229" (int32 u0) (uint32 u1))
 Eq_6238: (union "Eq_6238" (int32 u0) (uint32 u1))
 	T_6238 (in d6_1133 - d3_1850 : word32)
 	T_6239 (in 0<32> : word32)
-Eq_6267: (struct "Eq_6267" (0 Eq_25 t0000) (38 Eq_25 t0038))
+Eq_6267: (struct "Eq_6267" (0 Eq_73 t0000) (38 Eq_73 t0038))
 	T_6267 (in a7_2443 : (ptr32 Eq_6267))
 	T_6269 (in a7_1330 - 4<i32> : word32)
-Eq_6291: (struct "Eq_6291" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_6291: (struct "Eq_6291" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_6291 (in a7_2463 : (ptr32 Eq_6291))
 	T_6293 (in a7_1330 - 4<i32> : word32)
-Eq_6310: (union "Eq_6310" (byte u0) ((ptr32 Eq_8410) u1))
-	T_6310 (in a7_2463 + 0<32> : word32)
-Eq_6320: (union "Eq_6320" (byte u0) ((ptr32 Eq_8411) u1))
-	T_6320 (in a7_2463 + 0<32> : word32)
 Eq_6334: (union "Eq_6334" (int32 u0) (uint32 u1))
 	T_6334 (in d3_2508 : Eq_6334)
 	T_6336 (in d3_1850 + 1<32> : word32)
@@ -2370,18 +2244,12 @@ Eq_6335: (union "Eq_6335" (int32 u0) (uint32 u1))
 Eq_6365: (union "Eq_6365" (int32 u0) (uint32 u1))
 	T_6365 (in d6_1133 - d3_2508 : word32)
 	T_6366 (in 0<32> : word32)
-Eq_6394: (struct "Eq_6394" (0 Eq_25 t0000) (38 Eq_25 t0038))
+Eq_6394: (struct "Eq_6394" (0 Eq_73 t0000) (38 Eq_73 t0038))
 	T_6394 (in a7_2552 : (ptr32 Eq_6394))
 	T_6396 (in a7_1330 - 4<i32> : word32)
-Eq_6418: (struct "Eq_6418" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_6418: (struct "Eq_6418" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_6418 (in a7_2572 : (ptr32 Eq_6418))
 	T_6420 (in a7_1330 - 4<i32> : word32)
-Eq_6437: (union "Eq_6437" (byte u0) ((ptr32 Eq_8412) u1))
-	T_6437 (in a7_2572 + 0<32> : word32)
-Eq_6447: (union "Eq_6447" (byte u0) ((ptr32 Eq_8413) u1))
-	T_6447 (in a7_2572 + 0<32> : word32)
-Eq_6460: (union "Eq_6460" (uint8 u0) (word32 u1))
-	T_6460 (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
 Eq_6468: (union "Eq_6468" (int32 u0) (uint32 u1))
 	T_6468 (in 1<32> : word32)
 Eq_6510: (union "Eq_6510" (byte u0) (word32 u1))
@@ -2389,7 +2257,7 @@ Eq_6510: (union "Eq_6510" (byte u0) (word32 u1))
 	T_6513 (in Mem2801[a7_1330 + 74<i32>:byte] : byte)
 Eq_6519: (union "Eq_6519" (int32 u0) (uint32 u1))
 	T_6519 (in 1<32> : word32)
-Eq_6523: (struct "Eq_6523" (0 Eq_25 t0000) (44 word32 dw0044))
+Eq_6523: (struct "Eq_6523" (0 Eq_73 t0000) (44 word32 dw0044))
 	T_6523 (in a7_2667 : (ptr32 Eq_6523))
 	T_6525 (in a7_1330 - 4<i32> : word32)
 Eq_6552: (union "Eq_6552" (int32 u0) (uint32 u1))
@@ -2455,341 +2323,85 @@ Eq_6816: (union "Eq_6816" (bool u0) (word32 u1))
 	T_6816 (in d2_3095 < 0<32> : bool)
 Eq_6930: (union "Eq_6930" (int32 u0) (uint32 u1))
 	T_6930 (in 1<32> : word32)
-Eq_6958: (struct "Eq_6958" (0 Eq_25 t0000) (4E word32 dw004E))
+Eq_6958: (struct "Eq_6958" (0 Eq_73 t0000) (4E word32 dw004E))
 	T_6958 (in a7_2635 : (ptr32 Eq_6958))
 	T_6960 (in a7_1330 - 4<i32> : word32)
-Eq_7009: (struct "Eq_7009" (0 Eq_25 t0000) (1 Eq_7098 t0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
+Eq_7009: (struct "Eq_7009" (0 Eq_645 t0000) (1 ui24 n0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
 	T_7009 (in a7_2886 : (ptr32 Eq_7009))
 	T_7010 (in a7_1330 - 4<i32> : word32)
-Eq_7060: (fn word32 (Eq_4374, Eq_25, Eq_25, Eq_25, Eq_25, ptr32))
+Eq_7060: (fn word32 (Eq_4374, Eq_645, Eq_645, Eq_645, Eq_645, ptr32))
 	T_7060 (in fn00003C60 : ptr32)
 	T_7061 (in signature of fn00003C60 : void)
-Eq_7098: (union "Eq_7098" (int24 u0) (int32 u1))
-	T_7098 (in Mem2934[a7_2886 + 1<32>:word24] : word24)
 Eq_7111: (union "Eq_7111" (int32 u0) (uint32 u1))
 	T_7111 (in 1<32> : word32)
-Eq_7164: (struct "Eq_7164" (0 Eq_25 t0000) (30 word32 dw0030) (34 Eq_25 t0034) (38 byte b0038) (4C byte b004C))
+Eq_7164: (struct "Eq_7164" (0 Eq_73 t0000) (30 word32 dw0030) (34 Eq_73 t0034) (38 byte b0038) (4C byte b004C))
 	T_7164 (in a7_3474 : (ptr32 Eq_7164))
 	T_7166 (in a7_1330 - 4<i32> : word32)
-Eq_7194: (struct "Eq_7194" (0 word32 dw0000) (4 Eq_25 t0004))
+Eq_7194: (struct "Eq_7194" (0 word32 dw0000) (4 Eq_73 t0004))
 	T_7194 (in a0_3501 : (ptr32 Eq_7194))
 	T_7197 (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
-Eq_7260: (union "Eq_7260" (byte u0) ((ptr32 Eq_8422) u1))
-	T_7260 (in a7_3474 + 52<i32> : word32)
-Eq_7289: (union "Eq_7289" (byte u0) ((ptr32 Eq_8426) u1))
-	T_7289 (in a7_3474 + 52<i32> : word32)
-Eq_7306: (union "Eq_7306" (byte u0) ((ptr32 Eq_8430) u1))
-	T_7306 (in a7_3474 + 52<i32> : word32)
 Eq_7322: (union "Eq_7322" (int32 u0) (ptr32 u1) (Eq_6737 u2) (Eq_6796 u3))
 	T_7322 (in a7_1330 + 48<i32> : word32)
-Eq_7323: (union "Eq_7323" (int32 u0) (uint8 u1) (ptr32 u2) (Eq_6460 u3) (Eq_6737 u4) (Eq_6796 u5))
+Eq_7323: (union "Eq_7323" (int32 u0) (ptr32 u1) (Eq_6737 u2) (Eq_6796 u3))
 	T_7323 (in Mem3324[a7_1330 + 48<i32>:word32] : word32)
 	T_7326 (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
-Eq_7325: (union "Eq_7325" (uint8 u0) (word32 u1) (Eq_6460 u2))
-	T_7325 (in a7_1330 + 56<i32> : word32)
 Eq_7333: (struct "Eq_7333" (0 int32 dw0000) (4 word32 dw0004))
 	T_7333 (in v528_3348 : (ptr32 Eq_7333))
 	T_7335 (in a7_1330 + 44<i32> : word32)
 Eq_7345: (union "Eq_7345" (bool u0) (int32 u1))
 	T_7345 (in d1 < 0<32> : bool)
-Eq_7348: (union "Eq_7348" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7348 (in a7_1330 + 0x38<32> : word32)
-Eq_7350: (union "Eq_7350" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7350 (in a7_3364 : Eq_7350)
+Eq_7350: (struct "Eq_7350" (0 Eq_73 t0000) (30 byte b0030) (38 word32 dw0038) (3C Eq_73 t003C) (4C byte b004C))
+	T_7350 (in a7_3364 : (ptr32 Eq_7350))
 	T_7352 (in a7_1330 - 4<i32> : word32)
-Eq_7351: (union "Eq_7351" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7351 (in 4<i32> : int32)
-Eq_7354: (union "Eq_7354" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7354 (in a7_3364 + 0<32> : word32)
-Eq_7357: (union "Eq_7357" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7357 (in a7_3364 + 76<i32> : word32)
-Eq_7362: (union "Eq_7362" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7362 (in a7_3364 + 48<i32> : word32)
-Eq_7364: (union "Eq_7364" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7364 (in 4<i32> : int32)
-Eq_7367: (union "Eq_7367" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7367 (in a7_3364 + 48<i32> : word32)
-Eq_7373: (union "Eq_7373" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7373 (in a7_1330 + 52<i32> : word32)
-Eq_7377: (union "Eq_7377" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7377 (in a7_1330 + 44<i32> : word32)
-Eq_7382: (union "Eq_7382" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7382 (in a7_1330 + 52<i32> : word32)
-Eq_7386: (union "Eq_7386" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7386 (in a7_1330 + 44<i32> : word32)
-Eq_7399: (struct "Eq_7399" (0 word32 dw0000) (4 word32 dw0004))
+Eq_7375: (union "Eq_7375" (int32 u0) (byte u1))
+	T_7375 (in v544_774 : Eq_7375)
+	T_7378 (in Mem773[a7_1330 + 44<i32>:byte] : byte)
+	T_7531 (in 0<8> : byte)
+	T_7538 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+Eq_7384: (union "Eq_7384" (int32 u0) (byte u1))
+	T_7384 (in 1<8> : byte)
+	T_7387 (in Mem769[a7_1330 + 44<i32>:byte] : byte)
+Eq_7399: (struct "Eq_7399" (0 word32 dw0000) (4 Eq_73 t0004))
 	T_7399 (in a0_3404 : (ptr32 Eq_7399))
 	T_7402 (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
-Eq_7404: (union "Eq_7404" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7404 (in a7_3364 + 60<i32> : word32)
-Eq_7410: (union "Eq_7410" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7410 (in a7_3364 + 56<i32> : word32)
-Eq_7418: (union "Eq_7418" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7418 (in a7_3364 + 48<i32> : word32)
-Eq_7423: (union "Eq_7423" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7423 (in a7_3364 + 48<i32> : word32)
-Eq_7436: (union "Eq_7436" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7436 (in a7_3364 + 60<i32> : word32)
-Eq_7447: (union "Eq_7447" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7447 (in a7_3364 + 48<i32> : word32)
-Eq_7452: (union "Eq_7452" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7452 (in a7_3364 + 48<i32> : word32)
-Eq_7465: (union "Eq_7465" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7465 (in a7_3364 + 60<i32> : word32)
-Eq_7476: (union "Eq_7476" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7476 (in a7_3364 + 48<i32> : word32)
-Eq_7481: (union "Eq_7481" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7481 (in a7_3364 + 48<i32> : word32)
-Eq_7494: (union "Eq_7494" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7494 (in a7_3364 + 60<i32> : word32)
-Eq_7511: (union "Eq_7511" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7511 (in a7_3364 + 60<i32> : word32)
-Eq_7523: (union "Eq_7523" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7523 (in 78<i32> : int32)
-Eq_7524: (union "Eq_7524" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7524 (in a7_1330 + 78<i32> : word32)
-Eq_7525: (union "Eq_7525" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7525 (in a7_1330 + 78<i32> + d1_1027 : word32)
-Eq_7527: (union "Eq_7527" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7527 (in 1<32> : word32)
-Eq_7534: (union "Eq_7534" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7534 (in a7_1330 + 132<i32> : word32)
-Eq_7537: (union "Eq_7537" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7537 (in a7_1330 + 44<i32> : word32)
-Eq_7541: (union "Eq_7541" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7541 (in a7_1330 + 44<i32> : word32)
-Eq_7545: (union "Eq_7545" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7545 (in a7_1330 + 132<i32> : word32)
-Eq_7550: (union "Eq_7550" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7550 (in a7_1330 + 73<i32> : word32)
-Eq_7582: (union "Eq_7582" (byte u0) ((ptr32 Eq_8453) u1))
-	T_7582 (in d5_862 : Eq_7582)
-	T_7584 (in (uint32) (uint8) v556_834 : uint32)
-	T_7640 (in d5_862 + 1<32> : word32)
-Eq_7588: (union "Eq_7588" (byte u0) ((ptr32 Eq_8454) u1))
-	T_7588 (in d0 - d5_862 : word32)
-	T_7589 (in 0<32> : word32)
-Eq_7598: (union "Eq_7598" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7598 (in a0_881 : Eq_7598)
-	T_7603 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_7599: (union "Eq_7599" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7599 (in 78<i32> : int32)
-Eq_7600: (union "Eq_7600" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7600 (in a7_1330 + 78<i32> : word32)
-Eq_7602: (union "Eq_7602" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
+Eq_7539: (union "Eq_7539" (int32 u0) (byte u1))
+	T_7539 (in v554_824 : Eq_7539)
+	T_7542 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+	T_7596 (in 0<8> : byte)
+Eq_7602: (union "Eq_7602" (int32 u0) (uint32 u1))
 	T_7602 (in d5_862 >> 3<32> : word32)
-Eq_7605: (union "Eq_7605" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7605 (in a0_881 + 0<32> : word32)
-Eq_7616: (union "Eq_7616" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7616 (in a0_881 + 0<32> : word32)
-Eq_7618: (union "Eq_7618" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7618 (in a0_900 : Eq_7618)
-	T_7623 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_7619: (union "Eq_7619" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7619 (in 78<i32> : int32)
-Eq_7620: (union "Eq_7620" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7620 (in a7_1330 + 78<i32> : word32)
-Eq_7622: (union "Eq_7622" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
+Eq_7622: (union "Eq_7622" (int32 u0) (uint32 u1))
 	T_7622 (in d5_862 >> 3<32> : word32)
-Eq_7625: (union "Eq_7625" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7625 (in a0_900 + 0<32> : word32)
-Eq_7637: (union "Eq_7637" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7637 (in a0_900 + 0<32> : word32)
-Eq_7639: (union "Eq_7639" (byte u0) ((ptr32 Eq_8455) u1))
-	T_7639 (in 1<32> : word32)
-Eq_7644: (union "Eq_7644" (byte u0) ((ptr32 Eq_8456) u1))
-	T_7644 (in d0 - d5_862 : word32)
-	T_7645 (in 0<32> : word32)
-Eq_7691: (union "Eq_7691" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7691 (in a7_985 : Eq_7691)
+Eq_7691: (struct "Eq_7691" (0 Eq_73 t0000) (30 Eq_73 t0030))
+	T_7691 (in a7_985 : (ptr32 Eq_7691))
 	T_7693 (in a7_1330 - 4<i32> : word32)
-Eq_7692: (union "Eq_7692" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7692 (in 4<i32> : int32)
-Eq_7695: (union "Eq_7695" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7695 (in a7_985 + 0<32> : word32)
-Eq_7700: (union "Eq_7700" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7700 (in a7_985 + 0<32> : word32)
-Eq_7707: (union "Eq_7707" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7707 (in a7_985 + 48<i32> : word32)
-Eq_7715: (union "Eq_7715" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7715 (in a7_1005 : Eq_7715)
+Eq_7715: (struct "Eq_7715" (0 Eq_73 t0000) (30 uint32 dw0030))
+	T_7715 (in a7_1005 : (ptr32 Eq_7715))
 	T_7717 (in a7_1330 - 4<i32> : word32)
-Eq_7716: (union "Eq_7716" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7716 (in 4<i32> : int32)
-Eq_7719: (union "Eq_7719" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7719 (in a7_1005 + 0<32> : word32)
-Eq_7731: (union "Eq_7731" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7731 (in a7_1005 + 0<32> : word32)
-Eq_7734: (union "Eq_7734" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7734 (in a7_1005 + 0<32> : word32)
-Eq_7739: (union "Eq_7739" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7739 (in a7_1005 + 48<i32> : word32)
-Eq_7744: (union "Eq_7744" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7744 (in a7_1005 + 0<32> : word32)
-Eq_7747: (union "Eq_7747" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7747 (in a7_1330 + 44<i32> : word32)
 Eq_7749: (union "Eq_7749" (int32 u0) (uint32 u1))
 	T_7749 (in d3_1057 : Eq_7749)
 	T_7751 (in d3_1850 + 1<32> : word32)
 	T_7902 (in d3_1057 + 1<32> : word32)
 Eq_7750: (union "Eq_7750" (int32 u0) (uint32 u1))
 	T_7750 (in 1<32> : word32)
-Eq_7756: (union "Eq_7756" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7756 (in a7_1330 + 44<i32> : word32)
-Eq_7762: (union "Eq_7762" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7762 (in a7_1076 : Eq_7762)
+Eq_7762: (struct "Eq_7762" (0 ptr32 ptr0000) (4D byte b004D))
+	T_7762 (in a7_1076 : (ptr32 Eq_7762))
 	T_7764 (in a7_1330 - 4<i32> : word32)
-Eq_7763: (union "Eq_7763" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7763 (in 4<i32> : int32)
-Eq_7765: (union "Eq_7765" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7765 (in 78<i32> : int32)
-Eq_7768: (union "Eq_7768" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7768 (in a7_1076 + 0<32> : word32)
-Eq_7770: (union "Eq_7770" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7770 (in 4<i32> : int32)
-Eq_7771: (union "Eq_7771" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7771 (in a7_1076 - 4<i32> : word32)
-Eq_7773: (union "Eq_7773" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7773 (in a7_1076 - 4<i32> + 0<32> : word32)
-Eq_7776: (union "Eq_7776" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7776 (in 8<i32> : int32)
-Eq_7777: (union "Eq_7777" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7777 (in a7_1076 - 8<i32> : word32)
-Eq_7779: (union "Eq_7779" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7779 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_7781: (union "Eq_7781" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7781 (in 12<i32> : int32)
-Eq_7782: (union "Eq_7782" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7782 (in a7_1076 - 12<i32> : word32)
-Eq_7784: (union "Eq_7784" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7784 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_7787: (union "Eq_7787" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7787 (in a7_1076 + 0<32> : word32)
-Eq_7789: (fn int32 (Eq_25, Eq_25, Eq_25))
+Eq_7789: (fn int32 (Eq_645, Eq_645, Eq_645))
 	T_7789 (in fn000014EC : ptr32)
 	T_7790 (in signature of fn000014EC : void)
 	T_7967 (in fn000014EC : ptr32)
-Eq_7791: (union "Eq_7791" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7791 (in a7_1076 - 12<i32> : word32)
-Eq_7793: (union "Eq_7793" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7793 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_7795: (union "Eq_7795" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7795 (in 8<i32> : int32)
-Eq_7796: (union "Eq_7796" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7796 (in a7_1076 - 8<i32> : word32)
-Eq_7798: (union "Eq_7798" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7798 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_7805: (union "Eq_7805" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7805 (in 4<i32> : int32)
-Eq_7806: (union "Eq_7806" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7806 (in a7_1076 - 4<i32> : word32)
-Eq_7808: (union "Eq_7808" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7808 (in a7_1076 - 4<i32> + 0<32> : word32)
 Eq_7817: (union "Eq_7817" (int32 u0) (uint32 u1))
 	T_7817 (in d6_1133 - d3_1057 : word32)
 	T_7818 (in 0<32> : word32)
-Eq_7822: (union "Eq_7822" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7822 (in a7_1076 + 77<i32> : word32)
-Eq_7857: (union "Eq_7857" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7857 (in a7_1182 : Eq_7857)
-	T_7859 (in a7_1330 - 4<i32> : word32)
-Eq_7858: (union "Eq_7858" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7858 (in 4<i32> : int32)
-Eq_7861: (union "Eq_7861" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7861 (in a7_1182 + 0<32> : word32)
-Eq_7867: (union "Eq_7867" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7867 (in a7_1182 + 0<32> : word32)
-Eq_7879: (union "Eq_7879" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7879 (in a7_1201 : Eq_7879)
-	T_7881 (in a7_1330 - 4<i32> : word32)
-Eq_7880: (union "Eq_7880" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7880 (in 4<i32> : int32)
-Eq_7883: (union "Eq_7883" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7883 (in a7_1201 + 0<32> : word32)
-Eq_7895: (union "Eq_7895" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7895 (in a7_1201 + 0<32> : word32)
 Eq_7901: (union "Eq_7901" (int32 u0) (uint32 u1))
 	T_7901 (in 1<32> : word32)
 Eq_7907: (union "Eq_7907" (int32 u0) (uint32 u1))
 	T_7907 (in 1<32> : word32)
-Eq_7912: (union "Eq_7912" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7912 (in a7_1330 + 73<i32> : word32)
-Eq_7916: (union "Eq_7916" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7916 (in a7_1302 : Eq_7916)
-	T_7918 (in a7_1330 - 4<i32> : word32)
-Eq_7917: (union "Eq_7917" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7917 (in 4<i32> : int32)
-Eq_7920: (union "Eq_7920" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7920 (in a7_1302 + 0<32> : word32)
-Eq_7922: (union "Eq_7922" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7922 (in 4<i32> : int32)
-Eq_7923: (union "Eq_7923" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7923 (in a7_1302 - 4<i32> : word32)
-Eq_7925: (union "Eq_7925" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7925 (in a7_1302 - 4<i32> + 0<32> : word32)
-Eq_7928: (union "Eq_7928" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7928 (in 1<i32> : int32)
-Eq_7929: (union "Eq_7929" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7929 (in a7_1302 - 1<i32> : word32)
-Eq_7931: (union "Eq_7931" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7931 (in a7_1302 - 1<i32> + 0<32> : word32)
-Eq_7934: (union "Eq_7934" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7934 (in a7_1302 + 0<32> : word32)
-Eq_7938: (union "Eq_7938" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7938 (in a7_1330 + 73<i32> : word32)
-Eq_7940: (union "Eq_7940" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7940 (in a7_1237 : Eq_7940)
-	T_7942 (in a7_1330 - 4<i32> : word32)
-Eq_7941: (union "Eq_7941" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7941 (in 4<i32> : int32)
-Eq_7943: (union "Eq_7943" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7943 (in 78<i32> : int32)
-Eq_7946: (union "Eq_7946" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7946 (in a7_1237 + 0<32> : word32)
-Eq_7948: (union "Eq_7948" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7948 (in 4<i32> : int32)
-Eq_7949: (union "Eq_7949" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7949 (in a7_1237 - 4<i32> : word32)
-Eq_7951: (union "Eq_7951" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7951 (in a7_1237 - 4<i32> + 0<32> : word32)
-Eq_7954: (union "Eq_7954" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7954 (in 8<i32> : int32)
-Eq_7955: (union "Eq_7955" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7955 (in a7_1237 - 8<i32> : word32)
-Eq_7957: (union "Eq_7957" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7957 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_7959: (union "Eq_7959" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7959 (in 12<i32> : int32)
-Eq_7960: (union "Eq_7960" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7960 (in a7_1237 - 12<i32> : word32)
-Eq_7962: (union "Eq_7962" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7962 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_7965: (union "Eq_7965" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7965 (in a7_1237 + 0<32> : word32)
-Eq_7968: (union "Eq_7968" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7968 (in a7_1237 - 12<i32> : word32)
-Eq_7970: (union "Eq_7970" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7970 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_7972: (union "Eq_7972" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7972 (in 8<i32> : int32)
-Eq_7973: (union "Eq_7973" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7973 (in a7_1237 - 8<i32> : word32)
-Eq_7975: (union "Eq_7975" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7975 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_7982: (union "Eq_7982" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7982 (in 4<i32> : int32)
-Eq_7983: (union "Eq_7983" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7983 (in a7_1237 - 4<i32> : word32)
-Eq_7985: (union "Eq_7985" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_7985 (in a7_1237 - 4<i32> + 0<32> : word32)
 Eq_7994: (union "Eq_7994" (int32 u0) (uint32 u1))
 	T_7994 (in d6_1133 - d3_1057 : word32)
 	T_7995 (in 0<32> : word32)
-Eq_8006: (union "Eq_8006" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_8006 (in a7_1330 + 60<i32> : word32)
-Eq_8010: (union "Eq_8010" (uint8 u0) ((ptr32 Eq_8437) u1) (Eq_6460 u2) (Eq_7323 u3))
-	T_8010 (in a7_1330 + 60<i32> : word32)
-Eq_8145: (fn (ptr32 Eq_2963) (ptr32, ptr32))
+Eq_8145: (fn int32 (ptr32, ptr32))
 	T_8145 (in fn00003DDC : ptr32)
 	T_8146 (in signature of fn00003DDC : void)
 Eq_8182: (fn void ())
@@ -2797,23 +2409,23 @@ Eq_8182: (fn void ())
 	T_8183 (in signature of execPrivate2 : void)
 Eq_8300: (struct "Eq_8300" 0004 (0 byte b0000))
 	T_8300
-Eq_8357: (struct "Eq_8357" (0 Eq_25 t0000))
+Eq_8357: (struct "Eq_8357" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_73 t0004) (8 Eq_73 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8357
-Eq_8358: (union "Eq_8358" (int32 u0) (byte u1) (Eq_25 u2))
+Eq_8358: (struct "Eq_8358" 0001 (0 word32 dw0000))
 	T_8358
-Eq_8359: (union "Eq_8359" (int32 u0) (uint32 u1) (byte u2) (ptr32 u3) (Eq_25 u4) (Eq_6737 u5) (Eq_6796 u6) (Eq_7323 u7))
+Eq_8359: (struct "Eq_8359" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8359
-Eq_8360: (union "Eq_8360" (uint8 u0) (word32 u1) (Eq_6460 u2))
+Eq_8360: (union "Eq_8360" (cu8 u0) (word32 u1) (Eq_1453 u2) (Eq_1456 u3) (Eq_1530 u4) (Eq_2600 u5) (Eq_2711 u6) (Eq_2752 u7))
 	T_8360
-Eq_8361: (union "Eq_8361" (uint8 u0) (word32 u1) (Eq_4367 u2) (Eq_6460 u3) (Eq_7323 u4))
+Eq_8361: (union "Eq_8361" ((ptr32 Eq_1583) u0) (Eq_2118 u1) (Eq_2182 u2) (Eq_2188 u3) (Eq_2258 u4) (Eq_2303 u5) (Eq_2835 u6))
 	T_8361
-Eq_8362: (union "Eq_8362" (int32 u0) (ptr32 u1) (Eq_6670 u2) (Eq_6734 u3) (Eq_6799 u4))
+Eq_8362: (struct "Eq_8362" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8362
-Eq_8363: (struct "Eq_8363" 0004 (FFFFFFFC (ptr32 Eq_8357) ptrFFFFFFFC) (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (arr Eq_160)) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020) (2C Eq_8358 t002C) (30 Eq_8359 t0030) (34 word32 dw0034) (37 Eq_8360 t0037) (38 Eq_8361 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8362 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8363: (struct "Eq_8363" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8363
-Eq_8364: (union "Eq_8364" (cu8 u0) (word32 u1) (Eq_1453 u2) (Eq_1456 u3) (Eq_1530 u4) (Eq_2600 u5) (Eq_2711 u6) (Eq_2752 u7))
+Eq_8364: (struct "Eq_8364" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8364
-Eq_8365: (union "Eq_8365" ((ptr32 Eq_1583) u0) (Eq_2118 u1) (Eq_2182 u2) (Eq_2188 u3) (Eq_2258 u4) (Eq_2303 u5) (Eq_2835 u6))
+Eq_8365: (struct "Eq_8365" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8365
 Eq_8366: (struct "Eq_8366" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8366
@@ -2837,172 +2449,98 @@ Eq_8375: (struct "Eq_8375" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8375
 Eq_8376: (struct "Eq_8376" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8376
-Eq_8377: (struct "Eq_8377" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8377: (union "Eq_8377" (int32 u0) (ptr32 u1) (Eq_6737 u2) (Eq_6796 u3) (Eq_7323 u4))
 	T_8377
-Eq_8378: (struct "Eq_8378" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8378: (union "Eq_8378" (int32 u0) (ptr32 u1) (Eq_6670 u2) (Eq_6734 u3) (Eq_6799 u4))
 	T_8378
-Eq_8379: (struct "Eq_8379" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8379: (struct "Eq_8379" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8379
-Eq_8380: (struct "Eq_8380" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8380: (struct "Eq_8380" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8380
-Eq_8381: (struct "Eq_8381" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (arr Eq_160)) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8381: (struct "Eq_8381" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8381
-Eq_8382: (union "Eq_8382" (int32 u0) (byte u1) (Eq_25 u2))
+Eq_8382: (struct "Eq_8382" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8382
-Eq_8383: (union "Eq_8383" (int32 u0) (uint32 u1) (byte u2) (ptr32 u3) (Eq_25 u4) (Eq_6737 u5) (Eq_6796 u6) (Eq_7323 u7))
+Eq_8383: (struct "Eq_8383" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8383
-Eq_8384: (union "Eq_8384" (uint8 u0) (word32 u1) (Eq_6460 u2))
+Eq_8384: (struct "Eq_8384" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8384
-Eq_8385: (union "Eq_8385" (uint8 u0) (word32 u1) (Eq_4367 u2) (Eq_6460 u3) (Eq_7323 u4))
+Eq_8385: (struct "Eq_8385" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8385
-Eq_8386: (union "Eq_8386" (int32 u0) (ptr32 u1) (Eq_6670 u2) (Eq_6734 u3) (Eq_6799 u4))
+Eq_8386: (struct "Eq_8386" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8386
-Eq_8387: (struct "Eq_8387" 0004 (0 Eq_25 t0000) (2C Eq_8382 t002C) (30 Eq_8383 t0030) (34 word32 dw0034) (37 Eq_8384 t0037) (38 Eq_8385 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8386 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8387: (struct "Eq_8387" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8387
-Eq_8388: (struct "Eq_8388" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8388: (struct "Eq_8388" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8388
-Eq_8389: (struct "Eq_8389" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8389: (struct "Eq_8389" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8389
-Eq_8390: (struct "Eq_8390" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8390: (struct "Eq_8390" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8390
-Eq_8391: (struct "Eq_8391" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8391: (struct "Eq_8391" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8391
-Eq_8392: (struct "Eq_8392" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8392: (struct "Eq_8392" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8392
-Eq_8393: (struct "Eq_8393" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8393: (struct "Eq_8393" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8393
-Eq_8394: (struct "Eq_8394" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8394: (struct "Eq_8394" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8394
-Eq_8395: (struct "Eq_8395" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8395: (struct "Eq_8395" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8395
-Eq_8396: (struct "Eq_8396" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8396: (struct "Eq_8396" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8396
-Eq_8397: (struct "Eq_8397" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8397: (struct "Eq_8397" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8397
-Eq_8398: (struct "Eq_8398" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8398: (struct "Eq_8398" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8398
-Eq_8399: (struct "Eq_8399" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8399: (struct "Eq_8399" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8399
-Eq_8400: (struct "Eq_8400" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8400: (struct "Eq_8400" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8400
-Eq_8401: (struct "Eq_8401" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8401: (struct "Eq_8401" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8401
-Eq_8402: (struct "Eq_8402" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8402: (struct "Eq_8402" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8402
-Eq_8403: (struct "Eq_8403" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8403: (struct "Eq_8403" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8403
-Eq_8404: (struct "Eq_8404" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8404: (struct "Eq_8404" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8404
-Eq_8405: (struct "Eq_8405" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8405: (struct "Eq_8405" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8405
-Eq_8406: (struct "Eq_8406" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8406: (struct "Eq_8406" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8406
-Eq_8407: (struct "Eq_8407" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8407: (struct "Eq_8407" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8407
-Eq_8408: (struct "Eq_8408" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8408: (struct "Eq_8408" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8408
-Eq_8409: (struct "Eq_8409" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8409: (struct "Eq_8409" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8409
-Eq_8410: (struct "Eq_8410" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8410: (struct "Eq_8410" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8410
-Eq_8411: (struct "Eq_8411" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8411: (struct "Eq_8411" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8411
-Eq_8412: (struct "Eq_8412" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8412: (struct "Eq_8412" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8412
-Eq_8413: (struct "Eq_8413" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8413: (struct "Eq_8413" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8413
-Eq_8414: (struct "Eq_8414" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8414: (struct "Eq_8414" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8414
-Eq_8415: (struct "Eq_8415" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8415: (struct "Eq_8415" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8415
-Eq_8416: (struct "Eq_8416" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8416: (struct "Eq_8416" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8416
-Eq_8417: (struct "Eq_8417" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8417: (struct "Eq_8417" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8417
-Eq_8418: (struct "Eq_8418" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8418: (struct "Eq_8418" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8418
-Eq_8419: (struct "Eq_8419" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8419: (struct "Eq_8419" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8419
-Eq_8420: (struct "Eq_8420" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8420: (struct "Eq_8420" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8420
-Eq_8421: (struct "Eq_8421" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8421: (struct "Eq_8421" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8421
-Eq_8422: (struct "Eq_8422" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8422: (struct "Eq_8422" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8422
-Eq_8423: (struct "Eq_8423" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8423
-Eq_8424: (struct "Eq_8424" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8424
-Eq_8425: (struct "Eq_8425" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8425
-Eq_8426: (struct "Eq_8426" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8426
-Eq_8427: (struct "Eq_8427" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8427
-Eq_8428: (struct "Eq_8428" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8428
-Eq_8429: (struct "Eq_8429" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8429
-Eq_8430: (struct "Eq_8430" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8430
-Eq_8431: (struct "Eq_8431" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8431
-Eq_8432: (union "Eq_8432" (int32 u0) (byte u1) (Eq_25 u2))
-	T_8432
-Eq_8433: (union "Eq_8433" (int32 u0) (uint32 u1) (byte u2) (ptr32 u3) (Eq_25 u4) (Eq_6737 u5) (Eq_6796 u6) (Eq_7323 u7))
-	T_8433
-Eq_8434: (union "Eq_8434" (uint8 u0) (word32 u1) (Eq_6460 u2))
-	T_8434
-Eq_8435: (union "Eq_8435" (uint8 u0) (word32 u1) (Eq_4367 u2) (Eq_6460 u3) (Eq_7323 u4))
-	T_8435
-Eq_8436: (union "Eq_8436" (int32 u0) (ptr32 u1) (Eq_6670 u2) (Eq_6734 u3) (Eq_6799 u4))
-	T_8436
-Eq_8437: (struct "Eq_8437" 0004 (0 Eq_25 t0000) (2C Eq_8432 t002C) (30 Eq_8433 t0030) (34 word32 dw0034) (37 Eq_8434 t0037) (38 Eq_8435 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8436 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
-	T_8437
-Eq_8438: (struct "Eq_8438" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8438
-Eq_8439: (struct "Eq_8439" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8439
-Eq_8440: (struct "Eq_8440" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8440
-Eq_8441: (struct "Eq_8441" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8441
-Eq_8442: (struct "Eq_8442" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8442
-Eq_8443: (struct "Eq_8443" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8443
-Eq_8444: (struct "Eq_8444" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8444
-Eq_8445: (struct "Eq_8445" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8445
-Eq_8446: (struct "Eq_8446" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8446
-Eq_8447: (struct "Eq_8447" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8447
-Eq_8448: (struct "Eq_8448" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8448
-Eq_8449: (struct "Eq_8449" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8449
-Eq_8450: (struct "Eq_8450" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8450
-Eq_8451: (struct "Eq_8451" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8451
-Eq_8452: (struct "Eq_8452" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8452
-Eq_8453: (struct "Eq_8453" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (arr Eq_160)) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8453
-Eq_8454: (struct "Eq_8454" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8454
-Eq_8455: (struct "Eq_8455" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8455
-Eq_8456: (struct "Eq_8456" 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2963) ptr0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8456
-Eq_8457: (struct "Eq_8457" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8457
-Eq_8458: (struct "Eq_8458" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8458
-Eq_8459: (struct "Eq_8459" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8459
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -3100,17 +2638,17 @@ T_24: (in FindTask(0<32>) : word32)
   Class: Eq_19
   DataType: (ptr32 Eq_19)
   OrigDataType: word32
-T_25: (in a1_255 : Eq_25)
+T_25: (in a1_255 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  DataType: (ptr32 Eq_25)
+  OrigDataType: (ptr32 (struct 0001 (0 byte b0000)))
 T_26: (in 000012BC : ptr32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
-T_27: (in d0_112 : Eq_25)
+T_27: (in d0_112 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: (ptr32 (struct (0 T_104 t0000) (4 T_316 t0004) (8 T_25 t0008) (C T_106 t000C) (10 T_165 t0010)))
 T_28: (in OpenLibrary : ptr32)
   Class: Eq_28
@@ -3138,13 +2676,13 @@ T_33: (in 0<i32> : int32)
   OrigDataType: int32
 T_34: (in OpenLibrary(0x12BC<u32>, 0<i32>) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_35: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_36: (in d0_112 == 0<32> : bool)
+T_36: (in d0_112 == null : bool)
   Class: Eq_36
   DataType: bool
   OrigDataType: bool
@@ -3230,11 +2768,11 @@ T_56: (in d4_74 : int32)
   OrigDataType: int32
 T_57: (in 00003E28 : ptr32)
   Class: Eq_57
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 (ptr32 Eq_25))
   OrigDataType: (ptr32 (struct (0 T_58 t0000)))
 T_58: (in Mem67[0x00003E28<p32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_59: (in 172<i32> : int32)
   Class: Eq_59
@@ -3292,13 +2830,13 @@ T_72: (in d0_100 + d2_102 : word32)
   Class: Eq_71
   DataType: ui32
   OrigDataType: ui32
-T_73: (in d1_111 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+T_73: (in d1_111 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: byte
 T_74: (in 0x10001<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_75: (in AllocMem : ptr32)
   Class: Eq_75
@@ -3330,13 +2868,13 @@ T_81: (in 0x10001<32> : word32)
   OrigDataType: word32
 T_82: (in AllocMem(d0_107 + 0x11<32>, 0x10001<32>) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_83: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_84: (in d0_112 == 0<32> : bool)
+T_84: (in d0_112 == null : bool)
   Class: Eq_84
   DataType: bool
   OrigDataType: bool
@@ -3370,17 +2908,17 @@ T_91: (in signature of CloseLibrary : void)
   OrigDataType: 
 T_92: (in library : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: 
 T_93: (in 00003E28 : ptr32)
   Class: Eq_93
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 (ptr32 Eq_25))
   OrigDataType: (ptr32 (struct (0 T_94 t0000)))
 T_94: (in Mem67[0x00003E28<p32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_95: (in CloseLibrary(globals->t3E28) : void)
+T_95: (in CloseLibrary(globals->ptr3E28) : void)
   Class: Eq_95
   DataType: void
   OrigDataType: void
@@ -3418,8 +2956,8 @@ T_103: (in d0_112 + 0<32> : word32)
   OrigDataType: word32
 T_104: (in Mem169[d0_112 + 0<32>:word32] : word32)
   Class: Eq_77
-  DataType: Eq_25
-  OrigDataType: Eq_77
+  DataType: Eq_77
+  OrigDataType: word32
 T_105: (in 1<32> : word32)
   Class: Eq_105
   DataType: int32
@@ -3438,8 +2976,8 @@ T_108: (in d0_112 + 12<i32> : word32)
   OrigDataType: ptr32
 T_109: (in Mem173[d0_112 + 12<i32>:word32] : word32)
   Class: Eq_106
-  DataType: Eq_25
-  OrigDataType: Eq_106
+  DataType: Eq_106
+  OrigDataType: word32
 T_110: (in 16<i32> : int32)
   Class: Eq_110
   DataType: int32
@@ -3448,9 +2986,9 @@ T_111: (in d0_112 + 16<i32> : word32)
   Class: Eq_111
   DataType: ptr32
   OrigDataType: ptr32
-T_112: (in (word32) d0_112 + 16<i32> + d0_100 : word32)
+T_112: (in d0_112 + 16<i32> + d0_100 : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_113: (in 8<i32> : int32)
   Class: Eq_113
@@ -3462,7 +3000,7 @@ T_114: (in d0_112 + 8<i32> : word32)
   OrigDataType: ptr32
 T_115: (in Mem177[d0_112 + 8<i32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_116: (in 0<32> : word32)
   Class: Eq_116
@@ -3536,9 +3074,9 @@ T_133: (in Mem194[0<32>:word32] : word32)
   Class: Eq_116
   DataType: (ptr32 Eq_116)
   OrigDataType: word32
-T_134: (in d0_197 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_134: (in d0_197 : Eq_134)
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: ui32
 T_135: (in 36<i32> : int32)
   Class: Eq_135
@@ -3549,12 +3087,12 @@ T_136: (in d0_180 + 36<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_137: (in Mem194[d0_180 + 36<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_138: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_134
+  DataType: int32
   OrigDataType: word32
 T_139: (in d0_197 == 0<32> : bool)
   Class: Eq_139
@@ -3590,7 +3128,7 @@ T_146: (in d0_112 + 8<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_147: (in Mem179[d0_112 + 8<i32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_148: (in a0_260 : (ptr32 (arr Eq_160)))
   Class: Eq_148
@@ -3612,9 +3150,9 @@ T_152: (in (d0_252 << 2<32>) + 1<i32> : word32)
   Class: Eq_148
   DataType: (ptr32 (arr Eq_160))
   OrigDataType: ui32
-T_153: (in d0_262 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_153: (in d0_262 : Eq_134)
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: (union (int32 u0) (uint32 u1))
 T_154: (in 0<32> : word32)
   Class: Eq_154
@@ -3637,8 +3175,8 @@ T_158: (in (uint8) 0<32>[d0_252 * 4<32>] : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_159: (in (uint32) (uint8) 0<32>[d0_252 * 4<32>] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: uint32
 T_160: (in 0<8> : byte)
   Class: Eq_160
@@ -3662,8 +3200,8 @@ T_164: (in d0_112 + 16<i32> : word32)
   OrigDataType: ptr32
 T_165: (in Mem265[d0_112 + 16<i32>:word32] : word32)
   Class: Eq_148
-  DataType: Eq_25
-  OrigDataType: (ptr32 (arr Eq_160))
+  DataType: (ptr32 (arr Eq_160))
+  OrigDataType: word32
 T_166: (in a6_266 : (ptr32 word32))
   Class: Eq_166
   DataType: (ptr32 word32)
@@ -3782,7 +3320,7 @@ T_194: (in a1_255 + 0<32> : word32)
   OrigDataType: ptr32
 T_195: (in Mem380[a1_255 + 0<32>:byte] : byte)
   Class: Eq_192
-  DataType: Eq_25
+  DataType: byte
   OrigDataType: byte
 T_196: (in 0<32> : word32)
   Class: Eq_196
@@ -3814,11 +3352,11 @@ T_202: (in execPrivate4() : void)
   OrigDataType: void
 T_203: (in 00003E34 : ptr32)
   Class: Eq_203
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_204 t0000)))
 T_204: (in Mem416[0x00003E34<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_205: (in execPrivate5 : ptr32)
   Class: Eq_205
@@ -3834,11 +3372,11 @@ T_207: (in execPrivate5() : void)
   OrigDataType: void
 T_208: (in 00003E38 : ptr32)
   Class: Eq_208
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_209 t0000)))
 T_209: (in Mem418[0x00003E38<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_210: (in 16<i32> : int32)
   Class: Eq_210
@@ -3917,8 +3455,8 @@ T_228: (in SLICE(d1_111, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_229: (in SEQ(SLICE(d1_111, word24, 8), v40_292) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_230: (in 0<8> : byte)
   Class: Eq_220
@@ -3948,7 +3486,7 @@ T_236: (in Mem291[d0_112 + 12<i32>:word32] : word32)
   Class: Eq_106
   DataType: Eq_106
   OrigDataType: int32
-T_237: (in d3_267 - *((word32) d0_112 + 12<i32>) : word32)
+T_237: (in d3_267 - d0_112[3<i32>] : word32)
   Class: Eq_237
   DataType: int32
   OrigDataType: int32
@@ -3956,7 +3494,7 @@ T_238: (in 0<32> : word32)
   Class: Eq_237
   DataType: int32
   OrigDataType: word32
-T_239: (in d3_267 - *((word32) d0_112 + 12<i32>) == 0<32> : bool)
+T_239: (in d3_267 - d0_112[3<i32>] == 0<32> : bool)
   Class: Eq_239
   DataType: bool
   OrigDataType: bool
@@ -3970,7 +3508,7 @@ T_241: (in a6_266 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_242: (in Mem313[a6_266 + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_243: (in 4<i32> : int32)
   Class: Eq_243
@@ -4041,8 +3579,8 @@ T_259: (in a2_290 + 1<i32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_260: (in SEQ(v72_327, v71_324) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_261: (in 0<8> : byte)
   Class: Eq_252
@@ -4062,7 +3600,7 @@ T_264: (in a1_255 + 0<32> : word32)
   OrigDataType: (ptr32 byte)
 T_265: (in Mem366[a1_255 + 0<32>:byte] : byte)
   Class: Eq_220
-  DataType: Eq_25
+  DataType: byte
   OrigDataType: byte
 T_266: (in 1<i32> : int32)
   Class: Eq_266
@@ -4070,7 +3608,7 @@ T_266: (in 1<i32> : int32)
   OrigDataType: int32
 T_267: (in a1_255 + 1<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_268: (in v50_371 : byte)
   Class: Eq_268
@@ -4098,7 +3636,7 @@ T_273: (in a1_255 + 0<32> : word32)
   OrigDataType: (ptr32 byte)
 T_274: (in Mem516[a1_255 + 0<32>:byte] : byte)
   Class: Eq_271
-  DataType: Eq_25
+  DataType: byte
   OrigDataType: byte
 T_275: (in 1<i32> : int32)
   Class: Eq_275
@@ -4106,7 +3644,7 @@ T_275: (in 1<i32> : int32)
   OrigDataType: int32
 T_276: (in a1_255 + 1<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_277: (in 0<32> : word32)
   Class: Eq_277
@@ -4118,7 +3656,7 @@ T_278: (in a1_255 + 0<32> : word32)
   OrigDataType: (ptr32 byte)
 T_279: (in Mem523[a1_255 + 0<32>:byte] : byte)
   Class: Eq_268
-  DataType: Eq_25
+  DataType: byte
   OrigDataType: byte
 T_280: (in 1<i32> : int32)
   Class: Eq_280
@@ -4126,7 +3664,7 @@ T_280: (in 1<i32> : int32)
   OrigDataType: int32
 T_281: (in a1_255 + 1<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_282: (in 0<32> : word32)
   Class: Eq_282
@@ -4153,8 +3691,8 @@ T_287: (in SLICE(d1_111, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_288: (in SEQ(SLICE(d1_111, word24, 8), v50_371) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_289: (in 0<8> : byte)
   Class: Eq_268
@@ -4232,9 +3770,9 @@ T_307: (in signature of fn0000126C : void)
   Class: Eq_306
   DataType: (ptr32 Eq_306)
   OrigDataType: 
-T_308: (in a2 : Eq_25)
+T_308: (in a2 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_309: (in fn0000126C(d0_112) : void)
   Class: Eq_309
@@ -4250,7 +3788,7 @@ T_311: (in signature of Supervisor : void)
   OrigDataType: 
 T_312: (in userFunction : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: 
 T_313: (in Supervisor(d0_112) : void)
   Class: Eq_313
@@ -4265,16 +3803,16 @@ T_315: (in d0_112 + 4<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_316: (in Mem209[d0_112 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_317: (in 000012C8 : ptr32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: ptr32
 T_318: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_134
+  DataType: int32
   OrigDataType: word32
 T_319: (in d0_197 != 0<32> : bool)
   Class: Eq_319
@@ -4294,27 +3832,27 @@ T_322: (in Enable() : void)
   OrigDataType: void
 T_323: (in 00003E34 : ptr32)
   Class: Eq_323
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_324 t0000)))
 T_324: (in Mem214[0x00003E34<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_325: (in 00003E38 : ptr32)
   Class: Eq_325
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_326 t0000)))
 T_326: (in Mem216[0x00003E38<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_327: (in 00003E3C : ptr32)
   Class: Eq_327
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_328 t0000)))
 T_328: (in Mem218[0x00003E3C<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_329: (in 156<i32> : int32)
   Class: Eq_329
@@ -4325,8 +3863,8 @@ T_330: (in d0_36 + 156<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_331: (in Mem221[d0_36 + 156<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_332: (in 160<i32> : int32)
   Class: Eq_332
@@ -4337,8 +3875,8 @@ T_333: (in d0_36 + 160<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_334: (in Mem223[d0_36 + 160<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_335: (in d0_227 : word32)
   Class: Eq_335
@@ -4430,7 +3968,7 @@ T_356: (in a1_255 + 0<32> : word32)
   OrigDataType: (ptr32 byte)
 T_357: (in Mem362[a1_255 + 0<32>:byte] : byte)
   Class: Eq_354
-  DataType: Eq_25
+  DataType: byte
   OrigDataType: byte
 T_358: (in 1<i32> : int32)
   Class: Eq_358
@@ -4438,7 +3976,7 @@ T_358: (in 1<i32> : int32)
   OrigDataType: int32
 T_359: (in a1_255 + 1<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_360: (in v75_337 : byte)
   Class: Eq_360
@@ -4465,8 +4003,8 @@ T_365: (in a2_290 + 1<i32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_366: (in SEQ(v72_327, v75_337) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_367: (in 0xDF<8> : byte)
   Class: Eq_367
@@ -4497,8 +4035,8 @@ T_373: (in (v75_337 & 0xDF<8>) != 0x45<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_374: (in 10<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_375: (in a5_713 : word32)
   Class: Eq_375
@@ -4561,20 +4099,20 @@ T_389: (in fn0000127C(out a1_714, out a5_715) : word32)
   DataType: word32
   OrigDataType: word32
 T_390: (in 27<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_391: (in 00003E3C : ptr32)
   Class: Eq_391
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_392 t0000)))
 T_392: (in Mem435[0x00003E3C<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
-T_393: (in v92_428 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_393: (in v92_428 : Eq_134)
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_394: (in 224<i32> : int32)
   Class: Eq_394
@@ -4585,20 +4123,20 @@ T_395: (in d0_36 + 224<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_396: (in Mem418[d0_36 + 224<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_397: (in 00003E3C : ptr32)
   Class: Eq_397
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_398 t0000)))
 T_398: (in Mem429[0x00003E3C<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_399: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_134
+  DataType: int32
   OrigDataType: word32
 T_400: (in v92_428 != 0<32> : bool)
   Class: Eq_400
@@ -4708,13 +4246,13 @@ T_426: (in signature of fn00001354 : void)
   Class: Eq_425
   DataType: (ptr32 Eq_425)
   OrigDataType: 
-T_427: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_427: (in d1 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_428: (in a1 : Eq_25)
+T_428: (in a1 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_429: (in dwArg04 : int32)
   Class: Eq_169
@@ -4798,7 +4336,7 @@ T_448: (in signature of ReplyMsg : void)
   OrigDataType: 
 T_449: (in message : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: 
 T_450: (in ReplyMsg(a2) : void)
   Class: Eq_450
@@ -4888,9 +4426,9 @@ T_471: (in Mem0[a7_6 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_379
   DataType: (ptr32 Eq_379)
   OrigDataType: word32
-T_472: (in v5_8 : Eq_25)
+T_472: (in v5_8 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_473: (in 8<i32> : int32)
   Class: Eq_473
@@ -4898,7 +4436,7 @@ T_473: (in 8<i32> : int32)
   OrigDataType: int32
 T_474: (in a7_6 - 8<i32> : word32)
   Class: Eq_474
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 (ptr32 Eq_25))
   OrigDataType: (ptr32 (struct (0 T_477 t0000)))
 T_475: (in 0<32> : word32)
   Class: Eq_475
@@ -4910,7 +4448,7 @@ T_476: (in a7_6 - 8<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_477: (in Mem0[a7_6 - 8<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_478: (in d1_14 : word32)
   Class: Eq_462
@@ -4954,21 +4492,21 @@ T_487: (in CloseLibrary : ptr32)
   OrigDataType: (ptr32 (fn T_490 (T_489)))
 T_488: (in 00003E28 : ptr32)
   Class: Eq_488
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 (ptr32 Eq_25))
   OrigDataType: (ptr32 (struct (0 T_489 t0000)))
 T_489: (in Mem0[0x00003E28<p32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_490: (in CloseLibrary(globals->t3E28) : void)
+T_490: (in CloseLibrary(globals->ptr3E28) : void)
   Class: Eq_95
   DataType: void
   OrigDataType: void
 T_491: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_492: (in v5_8 == 0<32> : bool)
+T_492: (in v5_8 == null : bool)
   Class: Eq_492
   DataType: bool
   OrigDataType: bool
@@ -5320,13 +4858,13 @@ T_579: (in 00003F60 : ptr32)
   Class: Eq_578
   DataType: (ptr32 (ptr32 code))
   OrigDataType: ptr32
-T_580: (in d0_10 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_580: (in d0_10 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_581: (in 0x3F5C<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_582: (in 0x3F5C<32> : word32)
   Class: Eq_582
@@ -5364,17 +4902,17 @@ T_590: (in signature of fn00001390 : void)
   Class: Eq_589
   DataType: (ptr32 Eq_589)
   OrigDataType: 
-T_591: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_591: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_592: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_592: (in d1 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_593: (in a1 : Eq_25)
+T_593: (in a1 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_594: (in fn00001390(d0_10, d1, a1) : word32)
   Class: Eq_452
@@ -5448,18 +4986,18 @@ T_611: (in *a3_17 != null : bool)
   Class: Eq_611
   DataType: bool
   OrigDataType: bool
-T_612: (in a1_34 : Eq_25)
+T_612: (in a1_34 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_613: (in d1_36 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_613: (in d1_36 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_614: (in d0_173 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+T_614: (in d0_173 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: byte
 T_615: (in fn00002BF0 : ptr32)
   Class: Eq_615
   DataType: (ptr32 Eq_615)
@@ -5468,17 +5006,17 @@ T_616: (in signature of fn00002BF0 : void)
   Class: Eq_615
   DataType: (ptr32 Eq_615)
   OrigDataType: 
-T_617: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_617: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_618: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_618: (in d1 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_619: (in a1 : Eq_25)
+T_619: (in a1 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_620: (in dwArg04 : (ptr32 Eq_620))
   Class: Eq_620
@@ -5496,9 +5034,9 @@ T_623: (in signature of fn000015A4 : void)
   Class: Eq_622
   DataType: (ptr32 Eq_622)
   OrigDataType: 
-T_624: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_624: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_625: (in dwArg04 : Eq_625)
   Class: Eq_625
@@ -5521,8 +5059,8 @@ T_629: (in 0000147C : ptr32)
   DataType: (ptr32 Eq_620)
   OrigDataType: ptr32
 T_630: (in fn00002BF0(d0, d1, a1, &globals->t147C) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_631: (in 00001480 : ptr32)
   Class: Eq_625
@@ -5537,24 +5075,24 @@ T_633: (in out a1_34 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_634: (in fn000015A4(fn00002BF0(d0, d1, a1, &globals->t147C), 0x1480<u32>, out d1_36, out a1_34) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_635: (in 0000149C : ptr32)
   Class: Eq_620
   DataType: (ptr32 Eq_620)
   OrigDataType: ptr32
 T_636: (in fn00002BF0(fn000015A4(fn00002BF0(d0, d1, a1, &globals->t147C), 0x1480<u32>, out d1_36, out a1_34), d1_36, a1_34, &globals->t149C) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_637: (in 000014A0 : ptr32)
   Class: Eq_620
   DataType: (ptr32 Eq_620)
   OrigDataType: ptr32
 T_638: (in fn00002BF0(fn00002BF0(fn000015A4(fn00002BF0(d0, d1, a1, &globals->t147C), 0x1480<u32>, out d1_36, out a1_34), d1_36, a1_34, &globals->t149C), d1_36, a1_34, &globals->t14A0) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_639: (in d3_164 : int32)
   Class: Eq_639
@@ -5580,13 +5118,13 @@ T_644: (in d3_164 - dwLoc04 <= 0<32> : bool)
   Class: Eq_644
   DataType: bool
   OrigDataType: bool
-T_645: (in d2_158 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_645: (in d2_158 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_646: (in 1<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_647: (in a1_235 : word32)
   Class: Eq_647
@@ -5613,16 +5151,16 @@ T_652: (in out a1_235 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_653: (in fn000015A4(d0_173, 0x14A4<u32>, out d1_234, out a1_235) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_654: (in 40<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_655: (in 40<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_656: (in d2_158 <= 40<i32> : bool)
   Class: Eq_656
@@ -5660,29 +5198,29 @@ T_664: (in signature of fn000014AC : void)
   Class: Eq_663
   DataType: (ptr32 Eq_663)
   OrigDataType: 
-T_665: (in d2 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_665: (in d2 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_666: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_666: (in dwArg04 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
-T_667: (in dwArg08 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_667: (in dwArg08 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_668: (in 1<32> : word32)
   Class: Eq_668
   DataType: word32
   OrigDataType: word32
 T_669: (in d1_89 >> 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_670: (in 0000000A : ptr32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: ptr32
 T_671: (in fn000014AC(d2_158, d1_89 >> 1<32>, 0xA<u32>) : void)
   Class: Eq_671
@@ -5781,36 +5319,36 @@ T_694: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_695: (in d2_158 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_696: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_697: (in dwArg08 < 0<32> : bool)
   Class: Eq_697
   DataType: bool
   OrigDataType: bool
-T_698: (in d1_13 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_698: (in d1_13 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_699: (in -dwArg08 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_700: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_701: (in dwArg04 < 0<32> : bool)
   Class: Eq_701
   DataType: bool
   OrigDataType: bool
 T_702: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_703: (in dwArg04 < 0<32> : bool)
   Class: Eq_703
@@ -5828,33 +5366,33 @@ T_706: (in signature of fn0000151E : void)
   Class: Eq_705
   DataType: (ptr32 Eq_705)
   OrigDataType: 
-T_707: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_707: (in d0 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_708: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_708: (in d1 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_709: (in d2 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_709: (in d2 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_710: (in d1Out : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_710: (in d1Out : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_711: (in -dwArg04 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_712: (in out d1_49 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_713: (in fn0000151E(-dwArg04, dwArg08, d2, out d1_49) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_714: (in d1_60 : word32)
   Class: Eq_714
@@ -5865,12 +5403,12 @@ T_715: (in fn0000151E : ptr32)
   DataType: (ptr32 Eq_705)
   OrigDataType: (ptr32 (fn T_717 (T_666, T_667, T_665, T_716)))
 T_716: (in out d1_60 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_717: (in fn0000151E(dwArg04, dwArg08, d2, out d1_60) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_718: (in d1_23 : word32)
   Class: Eq_718
@@ -5881,16 +5419,16 @@ T_719: (in fn0000151E : ptr32)
   DataType: (ptr32 Eq_705)
   OrigDataType: (ptr32 (fn T_722 (T_720, T_698, T_665, T_721)))
 T_720: (in -dwArg04 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_721: (in out d1_23 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_722: (in fn0000151E(-dwArg04, d1_13, d2, out d1_23) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_723: (in d1_34 : word32)
   Class: Eq_723
@@ -5901,56 +5439,56 @@ T_724: (in fn0000151E : ptr32)
   DataType: (ptr32 Eq_705)
   OrigDataType: (ptr32 (fn T_726 (T_666, T_698, T_665, T_725)))
 T_725: (in out d1_34 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_726: (in fn0000151E(dwArg04, d1_13, d2, out d1_34) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_727: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_727: (in d0 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_728: (in d2 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_728: (in d2 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_729: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_729: (in dwArg04 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
-T_730: (in dwArg08 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_730: (in dwArg08 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_731: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_732: (in dwArg04 > 0<32> : bool)
   Class: Eq_732
   DataType: bool
   OrigDataType: bool
 T_733: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_734: (in dwArg08 > 0<32> : bool)
   Class: Eq_734
   DataType: bool
   OrigDataType: bool
-T_735: (in d0_36 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_735: (in d0_36 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_736: (in -dwArg04 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_737: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_738: (in dwArg08 > 0<32> : bool)
   Class: Eq_738
@@ -5965,16 +5503,16 @@ T_740: (in fn0000151E : ptr32)
   DataType: (ptr32 Eq_705)
   OrigDataType: (ptr32 (fn T_742 (T_735, T_730, T_728, T_741)))
 T_741: (in out d1_43 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_742: (in fn0000151E(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_743: (in -fn0000151E(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_744: (in d1_55 : word32)
   Class: Eq_744
@@ -5985,16 +5523,16 @@ T_745: (in fn0000151E : ptr32)
   DataType: (ptr32 Eq_705)
   OrigDataType: (ptr32 (fn T_748 (T_735, T_746, T_728, T_747)))
 T_746: (in -dwArg08 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_747: (in out d1_55 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_748: (in fn0000151E(d0_36, -dwArg08, d2, out d1_55) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_749: (in d1_88 : word32)
   Class: Eq_749
@@ -6005,12 +5543,12 @@ T_750: (in fn0000151E : ptr32)
   DataType: (ptr32 Eq_705)
   OrigDataType: (ptr32 (fn T_752 (T_729, T_730, T_728, T_751)))
 T_751: (in out d1_88 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_752: (in fn0000151E(dwArg04, dwArg08, d2, out d1_88) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_753: (in d1_89 : word32)
   Class: Eq_753
@@ -6021,24 +5559,24 @@ T_754: (in fn0000151E : ptr32)
   DataType: (ptr32 Eq_705)
   OrigDataType: (ptr32 (fn T_757 (T_729, T_755, T_728, T_756)))
 T_755: (in -dwArg08 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_756: (in out d1_89 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_757: (in fn0000151E(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_758: (in -fn0000151E(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_759: (in d1_22 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_759: (in d1_22 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_760: (in __swap : ptr32)
   Class: Eq_760
@@ -6049,12 +5587,12 @@ T_761: (in signature of __swap : void)
   DataType: (ptr32 Eq_760)
   OrigDataType: 
 T_762: (in  : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: 
 T_763: (in __swap(d1) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_764: (in v10_9 : word16)
   Class: Eq_764
@@ -6072,13 +5610,13 @@ T_767: (in SLICE(d2, word16, 16) : word16)
   Class: Eq_766
   DataType: word16
   OrigDataType: word16
-T_768: (in d2_11 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_768: (in d2_11 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_769: (in SEQ(v11_10, v10_9) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_770: (in 0<16> : word16)
   Class: Eq_764
@@ -6088,13 +5626,13 @@ T_771: (in v10_9 != 0<16> : bool)
   Class: Eq_771
   DataType: bool
   OrigDataType: bool
-T_772: (in d3_18 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+T_772: (in d3_18 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: (ptr32 Eq_1583)
 T_773: (in 16<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_774: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_774
@@ -6108,29 +5646,29 @@ T_776: (in (word16) d1_22 >= 0x80<16> : bool)
   Class: Eq_776
   DataType: bool
   OrigDataType: bool
-T_777: (in d0_134 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_777: (in d0_134 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_778: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_779 (T_707)))
 T_779: (in __swap(d0) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_780: (in d1_135 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_780: (in d1_135 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_781: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_782 (T_759)))
 T_782: (in __swap(d1_22) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_783: (in v14_137 : word16)
   Class: Eq_783
@@ -6149,8 +5687,8 @@ T_786: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_787 (T_768)))
 T_787: (in __swap(d2_11) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_788: (in SLICE(__swap(d2_11), word16, 16) : word16)
   Class: Eq_788
@@ -6168,17 +5706,17 @@ T_791: (in v14_137 == 0<16> : bool)
   Class: Eq_791
   DataType: bool
   OrigDataType: bool
-T_792: (in d0_150 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_792: (in d0_150 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_793: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_794 (T_777)))
 T_794: (in __swap(d0_134) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_795: (in d2_154 : uint32)
   Class: Eq_795
@@ -6233,28 +5771,28 @@ T_807: (in (uint16) (d2_154 % SLICE(d1_135, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_808: (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_809: (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_810: (in SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0) : word16)
   Class: Eq_810
   DataType: word16
   OrigDataType: word16
 T_811: (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_812: (in SLICE(d0_150, word16, 16) : word16)
   Class: Eq_812
   DataType: word16
   OrigDataType: word16
 T_813: (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_814: (in v17_143 : uint16)
   Class: Eq_814
@@ -6293,8 +5831,8 @@ T_822: (in SLICE(d0_134, word16, 16) : word16)
   DataType: word16
   OrigDataType: word16
 T_823: (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_824: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_824
@@ -6317,24 +5855,24 @@ T_828: (in signature of __rol : void)
   DataType: (ptr32 Eq_827)
   OrigDataType: 
 T_829: (in  : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: 
 T_830: (in  : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: 
 T_831: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_832: (in __rol(d1_22, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_833: (in 8<32> : uipr32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: uipr32
 T_834: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_834
@@ -6353,12 +5891,12 @@ T_837: (in __rol : ptr32)
   DataType: (ptr32 Eq_827)
   OrigDataType: (ptr32 (fn T_839 (T_759, T_838)))
 T_838: (in 4<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_839: (in __rol(d1_22, 4<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_840: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_840
@@ -6377,8 +5915,8 @@ T_843: (in (word16) d3_18 - 4<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_844: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_845: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_845
@@ -6397,12 +5935,12 @@ T_848: (in __rol : ptr32)
   DataType: (ptr32 Eq_827)
   OrigDataType: (ptr32 (fn T_850 (T_759, T_849)))
 T_849: (in 2<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_850: (in __rol(d1_22, 2<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_851: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_851
@@ -6421,8 +5959,8 @@ T_854: (in (word16) d3_18 - 2<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_855: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_856: (in d0_71 : uint32)
   Class: Eq_856
@@ -6445,12 +5983,12 @@ T_860: (in SLICE(d0, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_861: (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_862: (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_863: (in SLICE(__swap(SEQ(v11_10, (word16) d0)), word16, 16) : word16)
   Class: Eq_863
@@ -6477,8 +6015,8 @@ T_868: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_869 (T_772)))
 T_869: (in __swap(d3_18) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_870: (in SLICE(__swap(d3_18), word16, 16) : word16)
   Class: Eq_867
@@ -6500,29 +6038,29 @@ T_874: (in (uint16) (d0_71 /u SLICE(d1_22, uint16, 0)) : uint16)
   Class: Eq_871
   DataType: uint16
   OrigDataType: uint16
-T_875: (in d1_90 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_875: (in d1_90 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_876: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_877 (T_759)))
 T_877: (in __swap(d1_22) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_878: (in d3_102 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_878: (in d3_102 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_879: (in SEQ(v53_82, v51_79) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
-T_880: (in d0_108 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_880: (in d0_108 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_881: (in SLICE(d1_22, uint16, 0) : uint16)
   Class: Eq_881
@@ -6561,12 +6099,12 @@ T_889: (in SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_890: (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_891: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: up32
 T_892: (in d0_108 >= 0<32> : bool)
   Class: Eq_892
@@ -6577,12 +6115,12 @@ T_893: (in __rol : ptr32)
   DataType: (ptr32 Eq_827)
   OrigDataType: (ptr32 (fn T_895 (T_759, T_894)))
 T_894: (in 1<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_895: (in __rol(d1_22, 1<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_896: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_896
@@ -6601,8 +6139,8 @@ T_899: (in (word16) d3_18 - 1<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_900: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_901: (in __swap : ptr32)
   Class: Eq_760
@@ -6617,16 +6155,16 @@ T_903: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_904 (T_878)))
 T_904: (in __swap(d3_102) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_905: (in __rol(d0_108, __swap(d3_102)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_906: (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_907: (in SLICE(d3_102, word16, 0) : word16)
   Class: Eq_907
@@ -6637,8 +6175,8 @@ T_908: (in (uint16) SLICE(d3_102, word16, 0) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_909: (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_910: (in 1<16> : word16)
   Class: Eq_910
@@ -6649,16 +6187,16 @@ T_911: (in v51_79 - 1<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_912: (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_913: (in d0_108 + d1_90 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_914: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: up32
 T_915: (in d0_108 >= 0<32> : bool)
   Class: Eq_915
@@ -6672,9 +6210,9 @@ T_917: (in d1_20 : ptr32)
   Class: Eq_626
   DataType: ptr32
   OrigDataType: word32
-T_918: (in d0_17 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_918: (in d0_17 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_919: (in fn000015C0 : ptr32)
   Class: Eq_919
@@ -6684,10 +6222,10 @@ T_920: (in signature of fn000015C0 : void)
   Class: Eq_919
   DataType: (ptr32 Eq_919)
   OrigDataType: 
-T_921: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_25)
+T_921: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (ptr32 Eq_73)
 T_922: (in dwArg04 : (ptr32 Eq_922))
   Class: Eq_922
   DataType: (ptr32 Eq_922)
@@ -6737,17 +6275,17 @@ T_933: (in out a1_19 : ptr32)
   DataType: Eq_625
   OrigDataType: ptr32
 T_934: (in fn000015C0(d0, *(struct Eq_922 **) 0x3F80<u32>, dwArg04, fp + 8<i32>, out d1_20, out a1_19) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_935: (in d0_1952 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_935: (in d0_1952 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_936: (in a7_1968 : (ptr32 Eq_936))
   Class: Eq_936
   DataType: (ptr32 Eq_936)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1453 u2) (T_1459 u3) (T_1533 u4) (T_2603 u5) (T_2714 u6) (T_2755 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1583 u2) (T_1590 u3) (T_1601 u4) (T_2118 u5) (T_2185 u6) (T_2188 u7) (T_2258 u8) (T_2306 u9) (T_2838 u10)) u0066) (6A byte b006A)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1453 u2) (T_1459 u3) (T_1533 u4) (T_2603 u5) (T_2714 u6) (T_2755 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1583 u2) (T_1590 u3) (T_1601 u4) (T_2118 u5) (T_2185 u6) (T_2188 u7) (T_2258 u8) (T_2306 u9) (T_2838 u10)) u0066) (6A byte b006A)))
 T_937: (in fp : ptr32)
   Class: Eq_937
   DataType: ptr32
@@ -6772,13 +6310,13 @@ T_942: (in a4_1925 : Eq_625)
   Class: Eq_625
   DataType: Eq_625
   OrigDataType: word32
-T_943: (in d6_1480 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_943: (in d6_1480 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_944: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_945: (in 0<32> : word32)
   Class: Eq_945
@@ -6993,8 +6531,8 @@ T_997: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_998: (in fn00001F40(*(a7_51 - 4<i32>), *a7_51, out d1, out a0_66, out a1, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_999: (in 4<i32> : int32)
   Class: Eq_999
@@ -7005,8 +6543,8 @@ T_1000: (in a7_51 + 4<i32> : word32)
   DataType: (ptr32 Eq_936)
   OrigDataType: ptr32
 T_1001: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_1002: (in d0 != 0xFFFFFFFF<32> : bool)
   Class: Eq_1002
@@ -7058,15 +6596,15 @@ T_1013: (in a7_1968 + 102<i32> : word32)
   OrigDataType: ptr32
 T_1014: (in Mem91[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1011
-  DataType: Eq_8365
+  DataType: Eq_8361
   OrigDataType: word32
-T_1015: (in d5_256 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (struct "Eq_936" 0004 (2C Eq_8364 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8365 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+T_1015: (in d5_256 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: (struct "Eq_936" 0004 (2C Eq_8360 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8361 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 T_1016: (in -1<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_1017: (in d4_376 : int32)
   Class: Eq_1017
@@ -7108,10 +6646,10 @@ T_1026: (in a4_1925 + 1<i32> : word32)
   Class: Eq_1024
   DataType: (ptr32 uint8)
   OrigDataType: ptr32
-T_1027: (in d2_1005 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_25)
+T_1027: (in d2_1005 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: (ptr32 Eq_645)
 T_1028: (in 72<i32> : int32)
   Class: Eq_1028
   DataType: int32
@@ -7121,32 +6659,32 @@ T_1029: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1030: (in Mem91[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_1031: (in d1_103 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_25)
+T_1031: (in d1_103 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (ptr32 Eq_73)
 T_1032: (in 1<32> : word32)
   Class: Eq_1032
   DataType: word32
   OrigDataType: word32
 T_1033: (in d1_103 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_1034: (in 5<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: up32
 T_1035: (in d1_103 < 5<32> : bool)
   Class: Eq_1035
   DataType: bool
   OrigDataType: bool
-T_1036: (in a7_99 : (ptr32 Eq_25))
+T_1036: (in a7_99 : (ptr32 Eq_73))
   Class: Eq_1036
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_614 t0000)))
 T_1037: (in 0<32> : word32)
   Class: Eq_1037
@@ -7157,20 +6695,20 @@ T_1038: (in a7_99 + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_1039: (in Mem121[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_1040: (in d1_123 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1040: (in d1_123 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_1041: (in 1<i32> : int32)
   Class: Eq_1041
   DataType: int32
   OrigDataType: int32
 T_1042: (in 1<i32> << d1_103 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_1043: (in 0<32> : word32)
   Class: Eq_1043
@@ -7181,12 +6719,12 @@ T_1044: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1045: (in Mem121[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_1046: (in d2_1005 | d1_123 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_1047: (in 1<i32> : int32)
   Class: Eq_1047
@@ -7197,16 +6735,16 @@ T_1048: (in a2_135 + 1<i32> : word32)
   DataType: (ptr32 uint8)
   OrigDataType: ptr32
 T_1049: (in 5<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: up32
 T_1050: (in d1_103 < 5<32> : bool)
   Class: Eq_1050
   DataType: bool
   OrigDataType: bool
 T_1051: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_1052: (in a0_1447 : (ptr32 Eq_1052))
   Class: Eq_1052
@@ -7225,8 +6763,8 @@ T_1055: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1056: (in Mem143[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1057: (in 0<32> : word32)
   Class: Eq_1057
@@ -7297,8 +6835,8 @@ T_1073: (in a0_1447 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1074: (in Mem143[a0_1447 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_1075: (in (uint8) Mem143[a0_1447 + 0<32>:byte] : uint8)
   Class: Eq_1075
@@ -7514,7 +7052,7 @@ T_1127: (in 4<i32> : int32)
   OrigDataType: int32
 T_1128: (in a7_1968 - 4<i32> : word32)
   Class: Eq_1036
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_1129: (in 0<32> : word32)
   Class: Eq_1129
@@ -7525,8 +7063,8 @@ T_1130: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 Eq_1130)
   OrigDataType: (ptr32 (union (int32 u1) (up32 u0)))
 T_1131: (in Mem102[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: (union (int32 u1) (up32 u0))
 T_1132: (in 0<32> : word32)
   Class: Eq_1132
@@ -7537,8 +7075,8 @@ T_1133: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_1134: (in Mem102[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_1135: (in 00001F18 : ptr32)
   Class: Eq_1135
@@ -7677,8 +7215,8 @@ T_1168: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_1169: (in Mem248[a0_1447 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_1170: (in (uint8) Mem248[a0_1447 + 0<32>:byte] : uint8)
   Class: Eq_1170
@@ -7689,8 +7227,8 @@ T_1171: (in (uint32) (uint8) Mem248[a0_1447 + 0<32>:byte] : uint32)
   DataType: uint32
   OrigDataType: uint32
 T_1172: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_1173: (in 4<32> : word32)
   Class: Eq_1173
@@ -7801,12 +7339,12 @@ T_1199: (in a7_1968 + 44<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1200: (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_1201: (in a7_275 : (ptr32 Eq_25))
+T_1201: (in a7_275 : (ptr32 Eq_645))
   Class: Eq_1201
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_645 t0000)))
 T_1202: (in 4<i32> : int32)
   Class: Eq_1202
@@ -7814,7 +7352,7 @@ T_1202: (in 4<i32> : int32)
   OrigDataType: int32
 T_1203: (in a7_1968 - 4<i32> : word32)
   Class: Eq_1201
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: ptr32
 T_1204: (in 0<32> : word32)
   Class: Eq_1204
@@ -7825,8 +7363,8 @@ T_1205: (in a7_275 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1206: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1207: (in d1_284 : uint32)
   Class: Eq_1207
@@ -7837,12 +7375,12 @@ T_1208: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_1210 (T_1209)))
 T_1209: (in 10<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_1210: (in __swap(10<i32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_1211: (in SLICE(d5_256, word16, 0) : word16)
   Class: Eq_1211
@@ -7869,8 +7407,8 @@ T_1216: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_1217 (T_1015)))
 T_1217: (in __swap(d5_256) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_1218: (in 0xA<16> : word16)
   Class: Eq_1218
@@ -7889,12 +7427,12 @@ T_1221: (in SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_1222: (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_1223: (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1224: (in SLICE(__swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_1224
@@ -8021,8 +7559,8 @@ T_1254: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_1255: (in Mem278[a0_1447 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_1256: (in (uint8) Mem278[a0_1447 + 0<32>:byte] : uint8)
   Class: Eq_1256
@@ -8041,24 +7579,24 @@ T_1259: (in a7_275 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1260: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1261: (in 0x30<32> : word32)
   Class: Eq_1261
   DataType: int32
   OrigDataType: int32
 T_1262: (in d1_303 - 0x30<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_1263: (in d1_303 - 0x30<32> : word32)
   Class: Eq_1263
   DataType: int32
   OrigDataType: int32
 T_1264: (in d1_303 - 0x30<32> + d0_293 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_1265: (in 4<32> : word32)
   Class: Eq_1265
@@ -8237,8 +7775,8 @@ T_1308: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1309: (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1310: (in 4<i32> : int32)
   Class: Eq_1310
@@ -8269,12 +7807,12 @@ T_1316: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_1318 (T_1317)))
 T_1317: (in 10<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_1318: (in __swap(10<i32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_1319: (in SLICE(d2_1005, word16, 0) : word16)
   Class: Eq_1319
@@ -8301,8 +7839,8 @@ T_1324: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_1325 (T_1027)))
 T_1325: (in __swap(d2_1005) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_1326: (in 0xA<16> : word16)
   Class: Eq_1326
@@ -8321,12 +7859,12 @@ T_1329: (in SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_1330: (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_1331: (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1332: (in SLICE(__swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_1332
@@ -8453,8 +7991,8 @@ T_1362: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_1363: (in Mem171[a0_1447 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_1364: (in (uint8) Mem171[a0_1447 + 0<32>:byte] : uint8)
   Class: Eq_1364
@@ -8485,16 +8023,16 @@ T_1370: (in 0x30<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1371: (in d1_196 - 0x30<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_1372: (in d1_196 - 0x30<32> : word32)
   Class: Eq_1372
   DataType: int32
   OrigDataType: int32
 T_1373: (in d1_196 - 0x30<32> + d0_186 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_1374: (in 4<32> : word32)
   Class: Eq_1374
@@ -8525,8 +8063,8 @@ T_1380: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1381: (in Mem217[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1382: (in 0x6C<32> : word32)
   Class: Eq_1017
@@ -8637,8 +8175,8 @@ T_1408: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_1409: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_1410: (in d5_1481 : Eq_1410)
   Class: Eq_1410
@@ -8718,7 +8256,7 @@ T_1428: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1429: (in Mem465[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1426
-  DataType: Eq_8365
+  DataType: Eq_8361
   OrigDataType: word32
 T_1430: (in 00001F14 : ptr32)
   Class: Eq_625
@@ -8898,7 +8436,7 @@ T_1473: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1474: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1471
-  DataType: Eq_8365
+  DataType: Eq_8361
   OrigDataType: word32
 T_1475: (in 4<32> : word32)
   Class: Eq_1475
@@ -8913,8 +8451,8 @@ T_1477: (in d0_1471 + 4<32> : word32)
   DataType: (ptr32 Eq_1052)
   OrigDataType: ptr32
 T_1478: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_1479: (in d5_256 == 0<32> : bool)
   Class: Eq_1479
@@ -8951,7 +8489,7 @@ T_1486: (in d3_1050 : ptr32)
 T_1487: (in a7_1020 : (ptr32 Eq_936))
   Class: Eq_936
   DataType: (ptr32 Eq_936)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1453 u2) (T_1459 u3) (T_1533 u4) (T_2603 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1583 u2) (T_1590 u3) (T_1601 u4) (T_2118 u5) (T_2185 u6) (T_2188 u7) (T_2258 u8) (T_2306 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1453 u2) (T_1459 u3) (T_1533 u4) (T_2603 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1583 u2) (T_1590 u3) (T_1601 u4) (T_2118 u5) (T_2185 u6) (T_2188 u7) (T_2258 u8) (T_2306 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
 T_1488: (in SLICE(d1, byte, 0) : byte)
   Class: Eq_1488
   DataType: byte
@@ -9218,7 +8756,7 @@ T_1553: (in 8<i32> : int32)
   OrigDataType: int32
 T_1554: (in a7_1174 - 8<i32> : word32)
   Class: Eq_1554
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_1557 t0000)))
 T_1555: (in 0<32> : word32)
   Class: Eq_1555
@@ -9229,8 +8767,8 @@ T_1556: (in a7_1174 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1557: (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1558: (in 4<i32> : int32)
   Class: Eq_1558
@@ -9274,7 +8812,7 @@ T_1567: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1568: (in Mem756[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1420
-  DataType: Eq_8365
+  DataType: Eq_8361
   OrigDataType: (ptr32 Eq_1583)
 T_1569: (in 0<32> : word32)
   Class: Eq_1569
@@ -9406,7 +8944,7 @@ T_1600: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (T_1583 u2) (T_1590 u3)))
 T_1601: (in Mem719[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1420
-  DataType: Eq_8365
+  DataType: Eq_8361
   OrigDataType: (ptr32 Eq_1583)
 T_1602: (in 1<32> : word32)
   Class: Eq_1602
@@ -9425,8 +8963,8 @@ T_1605: (in a1 + 1<i32> : word32)
   DataType: Eq_625
   OrigDataType: ptr32
 T_1606: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: up32
 T_1607: (in d5_256 <= 0<32> : bool)
   Class: Eq_1607
@@ -10124,9 +9662,9 @@ T_1780: (in Mem1564[a7_1465 + 48<i32>:word32] : word32)
   Class: Eq_1777
   DataType: word32
   OrigDataType: word32
-T_1781: (in d0_1566 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1781: (in d0_1566 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_1782: (in 72<i32> : int32)
   Class: Eq_1782
@@ -10145,12 +9683,12 @@ T_1785: (in 2<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_1786: (in a7_1465[18<i32>] & 2<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_1787: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_1788: (in d0_1566 == 0<32> : bool)
   Class: Eq_1788
@@ -10305,8 +9843,8 @@ T_1825: (in a7_1020 + 68<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1826: (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1827: (in 48<i32> : int32)
   Class: Eq_1827
@@ -10317,8 +9855,8 @@ T_1828: (in a7_1020 + 48<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1829: (in Mem1359[a7_1020 + 48<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_1830: (in 98<i32> : int32)
   Class: Eq_1830
@@ -10633,12 +10171,12 @@ T_1907: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1908: (in fn00001F40(*(a7_1578 - 4<i32>), a7_1578->ptr0000, out d1, out a0_1447, out a1, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_1909: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_1910: (in d0_1566 != 0xFFFFFFFF<32> : bool)
   Class: Eq_1910
@@ -10657,8 +10195,8 @@ T_1913: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_1914: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_1915: (in d7_1024 - d2_1571 : word32)
   Class: Eq_1915
@@ -10856,25 +10394,25 @@ T_1963: (in signature of fn000027B0 : void)
   Class: Eq_1962
   DataType: (ptr32 Eq_1962)
   OrigDataType: 
-T_1964: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1964: (in dwArg04 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_1965: (in dwArg08 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1965: (in dwArg08 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_1966: (in dwArg0C : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1966: (in dwArg0C : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_1967: (in dwArg10 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1967: (in dwArg10 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_1968: (in a7_1383 - 24<i32> : word32)
   Class: Eq_1968
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_1971 t0000)))
 T_1969: (in 0<32> : word32)
   Class: Eq_1969
@@ -10885,8 +10423,8 @@ T_1970: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1971: (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1972: (in 20<i32> : int32)
   Class: Eq_1972
@@ -10894,7 +10432,7 @@ T_1972: (in 20<i32> : int32)
   OrigDataType: int32
 T_1973: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1973
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_1976 t0000)))
 T_1974: (in 0<32> : word32)
   Class: Eq_1974
@@ -10905,8 +10443,8 @@ T_1975: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1976: (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1977: (in 16<i32> : int32)
   Class: Eq_1977
@@ -10914,7 +10452,7 @@ T_1977: (in 16<i32> : int32)
   OrigDataType: int32
 T_1978: (in a7_1383 - 16<i32> : word32)
   Class: Eq_1978
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_1981 t0000)))
 T_1979: (in 0<32> : word32)
   Class: Eq_1979
@@ -10925,8 +10463,8 @@ T_1980: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1981: (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1982: (in 12<i32> : int32)
   Class: Eq_1982
@@ -10934,7 +10472,7 @@ T_1982: (in 12<i32> : int32)
   OrigDataType: int32
 T_1983: (in a7_1383 - 12<i32> : word32)
   Class: Eq_1983
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_1986 t0000)))
 T_1984: (in 0<32> : word32)
   Class: Eq_1984
@@ -10945,8 +10483,8 @@ T_1985: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1986: (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_1987: (in fn000027B0(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>)) : word32)
   Class: Eq_1961
@@ -11192,33 +10730,33 @@ T_2047: (in signature of fn00002560 : void)
   Class: Eq_2046
   DataType: (ptr32 Eq_2046)
   OrigDataType: 
-T_2048: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_2048: (in dwArg04 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_2049: (in dwArg08 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_2049: (in dwArg08 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_2050: (in dwArg0C : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_2050: (in dwArg0C : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_2051: (in dwArg10 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_2051: (in dwArg10 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_2052: (in d1Out : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_2052: (in d1Out : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
-T_2053: (in a0Out : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_2053: (in a0Out : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_2054: (in a7_1383 - 24<i32> : word32)
   Class: Eq_2054
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_2057 t0000)))
 T_2055: (in 0<32> : word32)
   Class: Eq_2055
@@ -11229,8 +10767,8 @@ T_2056: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2057: (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_2058: (in 20<i32> : int32)
   Class: Eq_2058
@@ -11238,7 +10776,7 @@ T_2058: (in 20<i32> : int32)
   OrigDataType: int32
 T_2059: (in a7_1383 - 20<i32> : word32)
   Class: Eq_2059
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_2062 t0000)))
 T_2060: (in 0<32> : word32)
   Class: Eq_2060
@@ -11249,8 +10787,8 @@ T_2061: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2062: (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_2063: (in 16<i32> : int32)
   Class: Eq_2063
@@ -11258,7 +10796,7 @@ T_2063: (in 16<i32> : int32)
   OrigDataType: int32
 T_2064: (in a7_1383 - 16<i32> : word32)
   Class: Eq_2064
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_2067 t0000)))
 T_2065: (in 0<32> : word32)
   Class: Eq_2065
@@ -11269,8 +10807,8 @@ T_2066: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2067: (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_2068: (in 12<i32> : int32)
   Class: Eq_2068
@@ -11278,7 +10816,7 @@ T_2068: (in 12<i32> : int32)
   OrigDataType: int32
 T_2069: (in a7_1383 - 12<i32> : word32)
   Class: Eq_2069
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_2072 t0000)))
 T_2070: (in 0<32> : word32)
   Class: Eq_2070
@@ -11289,16 +10827,16 @@ T_2071: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2072: (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_2073: (in out d1_1450 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_2074: (in out a0_1447 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: (ptr32 (struct (0 T_1074 t0000)))
 T_2075: (in fn00002560(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>), out d1_1450, out a0_1447) : word32)
   Class: Eq_1836
@@ -11393,8 +10931,8 @@ T_2097: (in a7_1383 + 52<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2098: (in Mem1478[a7_1383 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2099: (in 72<i32> : int32)
   Class: Eq_2099
@@ -11488,9 +11026,9 @@ T_2121: (in d5_1481 - a7_1465->t0066 > 0<32> : bool)
   Class: Eq_2121
   DataType: bool
   OrigDataType: bool
-T_2122: (in d0_1691 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_2122: (in d0_1691 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_2123: (in 72<i32> : int32)
   Class: Eq_2123
@@ -11509,12 +11047,12 @@ T_2126: (in 2<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_2127: (in a7_1465[18<i32>] & 2<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_2128: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2129: (in d0_1691 != 0<32> : bool)
   Class: Eq_2129
@@ -11689,12 +11227,12 @@ T_2171: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2172: (in fn00001F40(*(a7_1465 - 8<i32>), *(a7_1465 - 4<i32>), out d1, out a0_1447, out a1, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2173: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2174: (in fn00001F40(*(a7_1465 - 8<i32>), *(a7_1465 - 4<i32>), out d1, out a0_1447, out a1, out a5_1579) != 0xFFFFFFFF<32> : bool)
   Class: Eq_2174
@@ -11713,8 +11251,8 @@ T_2177: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_2178: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_2179: (in a4_1632 - d2_1625 : word32)
   Class: Eq_2179
@@ -11917,12 +11455,12 @@ T_2228: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2229: (in fn00001F40(*(a7_1706 - 4<i32>), a7_1706->ptr0000, out d1, out a0_2920, out a1, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2230: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2231: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_2231
@@ -11941,8 +11479,8 @@ T_2234: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_2235: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_2236: (in d7_1024 - d2_1696 : word32)
   Class: Eq_2236
@@ -12145,12 +11683,12 @@ T_2285: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2286: (in fn00001F40(*(a7_1761 - 4<i32>), *a7_1761, out d1, out a0_2921, out a1, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2287: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2288: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_2288
@@ -12169,8 +11707,8 @@ T_2291: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_2292: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_2293: (in d5_1481 - d2_1747 : word32)
   Class: Eq_2293
@@ -12201,12 +11739,12 @@ T_2299: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_2300: (in a7_1465[18<i32>] & 4<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_2301: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2302: (in d0 == 0<32> : bool)
   Class: Eq_2302
@@ -12241,8 +11779,8 @@ T_2309: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_2310: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_2311: (in a4_1798 - d2_1791 : word32)
   Class: Eq_2311
@@ -12381,12 +11919,12 @@ T_2344: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2345: (in fn00001F40(*(a7_1800 - 4<i32>), *a7_1800, out d1, out a0_2922, out a1, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2346: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2347: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_2347
@@ -12449,8 +11987,8 @@ T_2361: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_2362: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_2363: (in a3_1852 - d2_1847 : word32)
   Class: Eq_2363
@@ -12585,12 +12123,12 @@ T_2395: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2396: (in fn00001F40(*(a7_1854 - 4<i32>), *a7_1854, out d1, out a0_2923, out a1, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2397: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2398: (in d0 != 0xFFFFFFFF<32> : bool)
   Class: Eq_2398
@@ -12764,22 +12302,22 @@ T_2440: (in Mem1091[a7_1057 + 0<32>:word32] : word32)
   Class: Eq_925
   DataType: (ptr32 Eq_925)
   OrigDataType: ptr32
-T_2441: (in v248_1105 : Eq_2441)
+T_2441: (in v248_1105 : byte)
   Class: Eq_2441
-  DataType: Eq_2441
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2442: (in 55<i32> : int32)
   Class: Eq_2442
   DataType: int32
   OrigDataType: int32
 T_2443: (in a7_1968 + 55<i32> : word32)
   Class: Eq_2443
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2444: (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
   Class: Eq_2441
-  DataType: Eq_2441
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2445: (in a7_1109 : (ptr32 Eq_2445))
   Class: Eq_2445
   DataType: (ptr32 Eq_2445)
@@ -12994,8 +12532,8 @@ T_2497: (in 56<i32> : int32)
   OrigDataType: int32
 T_2498: (in a7_1968 + 56<i32> : word32)
   Class: Eq_2498
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2499: (in Mem836[a7_1968 + 56<i32>:word32] : word32)
   Class: Eq_2496
   DataType: word32
@@ -13024,22 +12562,22 @@ T_2505: (in d4_376 != 2<32> : bool)
   Class: Eq_2505
   DataType: bool
   OrigDataType: bool
-T_2506: (in v262_844 : Eq_2506)
+T_2506: (in v262_844 : word16)
   Class: Eq_2506
-  DataType: Eq_2506
-  OrigDataType: (union (word16 u0) (word32 u1))
+  DataType: word16
+  OrigDataType: word16
 T_2507: (in 62<i32> : int32)
   Class: Eq_2507
   DataType: int32
   OrigDataType: int32
 T_2508: (in a7_1968 + 62<i32> : word32)
   Class: Eq_2508
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2509: (in Mem843[a7_1968 + 62<i32>:word16] : word16)
   Class: Eq_2506
-  DataType: Eq_2506
-  OrigDataType: word32
+  DataType: word16
+  OrigDataType: word16
 T_2510: (in a7_848 : (ptr32 Eq_2510))
   Class: Eq_2510
   DataType: (ptr32 Eq_2510)
@@ -13317,12 +12855,12 @@ T_2578: (in a0_1447 + 4<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2579: (in Mem623[a0_1447 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2580: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2581: (in 0<32> : word32)
   Class: Eq_2581
@@ -13333,9 +12871,9 @@ T_2582: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_2583: (in Mem624[a0_1447 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: byte
 T_2584: (in d3_1482 + 3<32> : word32)
   Class: Eq_2584
   DataType: Eq_2584
@@ -13424,22 +12962,22 @@ T_2605: (in d0_891 == 0<32> : bool)
   Class: Eq_2605
   DataType: bool
   OrigDataType: bool
-T_2606: (in v277_869 : Eq_2606)
+T_2606: (in v277_869 : byte)
   Class: Eq_2606
-  DataType: Eq_2606
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2607: (in 63<i32> : int32)
   Class: Eq_2607
   DataType: int32
   OrigDataType: int32
 T_2608: (in a7_1968 + 63<i32> : word32)
   Class: Eq_2608
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2609: (in Mem868[a7_1968 + 63<i32>:byte] : byte)
   Class: Eq_2606
-  DataType: Eq_2606
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2610: (in a7_873 : (ptr32 Eq_2610))
   Class: Eq_2610
   DataType: (ptr32 Eq_2610)
@@ -13565,8 +13103,8 @@ T_2640: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_2641: (in Mem611[a0_1447 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2642: (in SLICE(d1, byte, 0) : byte)
   Class: Eq_2642
@@ -13593,8 +13131,8 @@ T_2647: (in (byte) d1 == 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_2648: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_2649: (in d5_256 != 0<32> : bool)
   Class: Eq_2649
@@ -13702,7 +13240,7 @@ T_2674: (in 8<i32> : int32)
   OrigDataType: int32
 T_2675: (in a7_911 - 8<i32> : word32)
   Class: Eq_2675
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_2678 t0000)))
 T_2676: (in 0<32> : word32)
   Class: Eq_2676
@@ -13713,12 +13251,12 @@ T_2677: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2678: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_2679: (in a7_911 - 8<i32> : word32)
   Class: Eq_2679
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_2682 t0000)))
 T_2680: (in 0<32> : word32)
   Class: Eq_2680
@@ -13729,8 +13267,8 @@ T_2681: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2682: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_2683: (in 4<i32> : int32)
   Class: Eq_2683
@@ -13829,8 +13367,8 @@ T_2706: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   DataType: (ptr32 Eq_1052)
   OrigDataType: word32
 T_2707: (in SLICE(d6_1480, word16, 0) : word16)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word16
 T_2708: (in 0<32> : word32)
   Class: Eq_2708
@@ -13841,8 +13379,8 @@ T_2709: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_2710: (in Mem599[a0_1447 + 0<32>:word16] : word16)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_2711: (in SLICE(d1, byte, 0) : byte)
   Class: Eq_2711
@@ -13942,7 +13480,7 @@ T_2734: (in 8<i32> : int32)
   OrigDataType: int32
 T_2735: (in a7_992 - 8<i32> : word32)
   Class: Eq_2735
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_2738 t0000)))
 T_2736: (in 0<32> : word32)
   Class: Eq_2736
@@ -13953,8 +13491,8 @@ T_2737: (in a7_992 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2738: (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_2739: (in d1_1017 : word32)
   Class: Eq_2739
@@ -14153,8 +13691,8 @@ T_2787: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_2788: (in Mem575[a0_1447 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_2789: (in 3<32> : word32)
   Class: Eq_2789
@@ -14193,8 +13731,8 @@ T_2797: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   DataType: (ptr32 Eq_1052)
   OrigDataType: word32
 T_2798: (in SLICE(d6_1480, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2799: (in 0<32> : word32)
   Class: Eq_2799
@@ -14205,8 +13743,8 @@ T_2800: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_2801: (in Mem587[a0_1447 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_2802: (in 3<32> : word32)
   Class: Eq_2802
@@ -14354,7 +13892,7 @@ T_2837: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (Eq_1583 u2) (Eq_1420 u3) (Eq_1420 u4) (Eq_2118 u5) (Eq_2182 u6) (Eq_2188 u7) (Eq_2258 u8) (Eq_2303 u9)))
 T_2838: (in Mem525[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_2835
-  DataType: Eq_8365
+  DataType: Eq_8361
   OrigDataType: (ptr32 Eq_1583)
 T_2839: (in 0<i32> : int32)
   Class: Eq_1410
@@ -14529,8 +14067,8 @@ T_2881: (in Mem63[dwArg08 + 4<i32>:word32] : word32)
   DataType: (ptr32 ui32)
   OrigDataType: word32
 T_2882: (in SLICE(dwArg04, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2883: (in 0<32> : word32)
   Class: Eq_2883
@@ -14541,8 +14079,8 @@ T_2884: (in a0_104 + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_2885: (in Mem66[a0_104 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2886: (in dwArg08 + 4<i32> : word32)
   Class: Eq_983
@@ -14557,8 +14095,8 @@ T_2888: (in a0_104 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_2889: (in Mem66[a0_104 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2890: (in (uint8) Mem66[a0_104 + 0<32>:byte] : uint8)
   Class: Eq_2890
@@ -14638,7 +14176,7 @@ T_2908: (in out a5_127 : ptr32)
   OrigDataType: ptr32
 T_2909: (in fn00002530(out a1_125, out a5_127) : word32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: word32
 T_2910: (in 0<32> : word32)
   Class: Eq_922
@@ -14852,9 +14390,9 @@ T_2962: (in d1_161 : word32)
   Class: Eq_2962
   DataType: word32
   OrigDataType: word32
-T_2963: (in d0_160 : (ptr32 Eq_2963))
+T_2963: (in d0_160 : int32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
 T_2964: (in fn0000215C : ptr32)
   Class: Eq_2964
@@ -14910,13 +14448,13 @@ T_2976: (in out a1_125 : ptr32)
   OrigDataType: ptr32
 T_2977: (in fn0000215C(d4_143 + dwArg08->dw001C, out d1_161, out a0, out a1_125) : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
 T_2978: (in 0<32> : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
-T_2979: (in d0_160 != null : bool)
+T_2979: (in d0_160 != 0<32> : bool)
   Class: Eq_2979
   DataType: bool
   OrigDataType: bool
@@ -15057,8 +14595,8 @@ T_3013: (in Mem116[dwArg08 + 4<i32>:word32] : word32)
   DataType: (ptr32 ui32)
   OrigDataType: word32
 T_3014: (in SLICE(dwArg04, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_3015: (in 0<32> : word32)
   Class: Eq_3015
@@ -15069,8 +14607,8 @@ T_3016: (in a0_112 + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3017: (in Mem118[a0_112 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_3018: (in fn000020B0 : ptr32)
   Class: Eq_3018
@@ -15330,7 +14868,7 @@ T_3081: (in out a5_23 : ptr32)
   OrigDataType: ptr32
 T_3082: (in fn00002530(out a1_21, out a5_23) : word32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: word32
 T_3083: (in 0<32> : word32)
   Class: Eq_922
@@ -15744,17 +15282,17 @@ T_3185: (in globals->ptr3E58 != null : bool)
   Class: Eq_3185
   DataType: bool
   OrigDataType: bool
-T_3186: (in a0_13 : (ptr32 Eq_2963))
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+T_3186: (in a0_13 : (ptr32 Eq_3186))
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: word32
 T_3187: (in 00003E54 : ptr32)
   Class: Eq_3187
-  DataType: (ptr32 (ptr32 Eq_2963))
+  DataType: (ptr32 (ptr32 Eq_3186))
   OrigDataType: (ptr32 (struct (0 T_3188 t0000)))
 T_3188: (in Mem5[0x00003E54<p32>:word32] : word32)
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: word32
 T_3189: (in 0<32> : word32)
   Class: Eq_116
@@ -15776,33 +15314,33 @@ T_3193: (in dwArg04 : Eq_106)
   Class: Eq_106
   DataType: Eq_106
   OrigDataType: word32
-T_3194: (in dwArg08 : (ptr32 Eq_2963))
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+T_3194: (in dwArg08 : (ptr32 Eq_3186))
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: up32
-T_3195: (in dwArg0C : (ptr32 Eq_2963))
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+T_3195: (in dwArg0C : (ptr32 Eq_3186))
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: up32
-T_3196: (in d1Out : (ptr32 Eq_2963))
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+T_3196: (in d1Out : (ptr32 Eq_3186))
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: ptr32
 T_3197: (in a0Out : (ptr32 Eq_4))
   Class: Eq_4
   DataType: (ptr32 Eq_4)
   OrigDataType: ptr32
-T_3198: (in a1Out : Eq_25)
+T_3198: (in a1Out : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_3199: (in dwLoc10 : word32)
   Class: Eq_106
   DataType: Eq_106
   OrigDataType: word32
 T_3200: (in out d1 : ptr32)
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: ptr32
 T_3201: (in out a0 : ptr32)
   Class: Eq_4
@@ -15810,7 +15348,7 @@ T_3201: (in out a0 : ptr32)
   OrigDataType: ptr32
 T_3202: (in out a1 : ptr32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_3203: (in fn00002450(dwLoc10, a0_13, a0_13, out d1, out a0, out a1) : word32)
   Class: Eq_4
@@ -16324,13 +15862,13 @@ T_3330: (in a2_40->dw001C - dwArg04->dw0010 != 0<32> : bool)
   Class: Eq_3330
   DataType: bool
   OrigDataType: bool
-T_3331: (in d0 : Eq_25)
+T_3331: (in d0 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3332: (in d0_158 : Eq_25)
+T_3332: (in d0_158 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3333: (in a0_115 : (ptr32 Eq_4))
   Class: Eq_4
@@ -16364,13 +15902,13 @@ T_3340: (in a0_115->t0014 < 0x27<16> : bool)
   Class: Eq_3340
   DataType: bool
   OrigDataType: bool
-T_3341: (in a3_120 : Eq_25)
+T_3341: (in a3_120 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  DataType: (ptr32 Eq_25)
+  OrigDataType: ptr32
 T_3342: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3343: (in 0<32> : word32)
   Class: Eq_4
@@ -16398,7 +15936,7 @@ T_3348: (in poolHeader : word32)
   OrigDataType: 
 T_3349: (in AllocPooled(dwArg08, dwArg04) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3350: (in d1 : word32)
   Class: Eq_78
@@ -16448,9 +15986,9 @@ T_3361: (in Mem26[dwArg04 + 12<i32>:word32] : word32)
   Class: Eq_78
   DataType: Eq_78
   OrigDataType: word32
-T_3362: (in d0_50 : Eq_25)
+T_3362: (in d0_50 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: (ptr32 (struct (0 T_3496 t0000) (C T_3507 t000C)))
 T_3363: (in AllocMem : ptr32)
   Class: Eq_75
@@ -16466,13 +16004,13 @@ T_3365: (in dwArg08 + 16<i32> : word32)
   OrigDataType: up32
 T_3366: (in AllocMem(dwArg08 + 16<i32>, d1) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3367: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3368: (in d0_50 == 0<32> : bool)
+T_3368: (in d0_50 == null : bool)
   Class: Eq_3368
   DataType: bool
   OrigDataType: bool
@@ -16528,9 +16066,9 @@ T_3381: (in Mem26[dwArg04 + 12<i32>:word32] : word32)
   Class: Eq_78
   DataType: Eq_78
   OrigDataType: word32
-T_3382: (in d0_82 : Eq_25)
+T_3382: (in d0_82 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: (ptr32 (struct (0 T_3417 t0000) (C T_3421 t000C) (14 T_3423 t0014) (18 T_3430 t0018) (1C T_3458 t001C) (20 T_3376 t0020)))
 T_3383: (in AllocMem : ptr32)
   Class: Eq_75
@@ -16538,13 +16076,13 @@ T_3383: (in AllocMem : ptr32)
   OrigDataType: (ptr32 (fn T_3384 (T_3373, T_3350)))
 T_3384: (in AllocMem(d3_77, d1) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3385: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3386: (in d0_82 == 0<32> : bool)
+T_3386: (in d0_82 == null : bool)
   Class: Eq_3386
   DataType: bool
   OrigDataType: bool
@@ -16580,9 +16118,9 @@ T_3394: (in Mem26[a5_162 + 0<32>:word32] : word32)
   Class: Eq_4
   DataType: (ptr32 Eq_4)
   OrigDataType: word32
-T_3395: (in d0_128 : Eq_25)
+T_3395: (in d0_128 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3396: (in Allocate : ptr32)
   Class: Eq_3396
@@ -16602,13 +16140,13 @@ T_3399: (in byteSize : word32)
   OrigDataType: 
 T_3400: (in Allocate(a5_162, dwArg08) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3401: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3402: (in d0_128 != 0<32> : bool)
+T_3402: (in d0_128 != null : bool)
   Class: Eq_3402
   DataType: bool
   OrigDataType: bool
@@ -16670,8 +16208,8 @@ T_3416: (in d0_82 + 0<32> : word32)
   OrigDataType: word32
 T_3417: (in Mem88[d0_82 + 0<32>:word32] : word32)
   Class: Eq_77
-  DataType: Eq_25
-  OrigDataType: Eq_77
+  DataType: Eq_77
+  OrigDataType: word32
 T_3418: (in 0xA<8> : byte)
   Class: Eq_106
   DataType: byte
@@ -16686,15 +16224,15 @@ T_3420: (in d0_82 + 12<i32> : word32)
   OrigDataType: ptr32
 T_3421: (in Mem91[d0_82 + 12<i32>:byte] : byte)
   Class: Eq_106
-  DataType: Eq_25
+  DataType: Eq_106
   OrigDataType: byte
 T_3422: (in 40<i32> : int32)
   Class: Eq_3422
   DataType: int32
   OrigDataType: int32
 T_3423: (in d0_82 + 40<i32> : word32)
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: ptr32
 T_3424: (in 20<i32> : int32)
   Class: Eq_3424
@@ -16705,12 +16243,12 @@ T_3425: (in d0_82 + 20<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3426: (in Mem95[d0_82 + 20<i32>:word32] : word32)
-  Class: Eq_2963
-  DataType: Eq_25
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: word32
 T_3427: (in d0_82 + 40<i32> : word32)
   Class: Eq_3427
-  DataType: Eq_3427
+  DataType: ptr32
   OrigDataType: ptr32
 T_3428: (in 24<i32> : int32)
   Class: Eq_3428
@@ -16722,7 +16260,7 @@ T_3429: (in d0_82 + 24<i32> : word32)
   OrigDataType: ptr32
 T_3430: (in Mem97[d0_82 + 24<i32>:word32] : word32)
   Class: Eq_3427
-  DataType: Eq_25
+  DataType: ptr32
   OrigDataType: word32
 T_3431: (in 0<32> : word32)
   Class: Eq_3431
@@ -16733,8 +16271,8 @@ T_3432: (in d0_82 + 20<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_3433: (in Mem97[d0_82 + 20<i32>:word32] : word32)
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: (ptr32 (struct (0 T_3436 t0000)))
 T_3434: (in 0<32> : word32)
   Class: Eq_3434
@@ -16746,19 +16284,19 @@ T_3435: (in Mem97[d0_82 + 20<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_3436: (in Mem99[Mem97[d0_82 + 20<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_3431
-  DataType: Eq_25
+  DataType: word32
   OrigDataType: word32
-T_3437: (in a2_100 : (ptr32 Eq_2963))
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+T_3437: (in a2_100 : (ptr32 Eq_3186))
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: (ptr32 (struct (4 T_3376 t0004)))
 T_3438: (in d0_82 + 20<i32> : word32)
   Class: Eq_3438
   DataType: (ptr32 ptr32)
   OrigDataType: (ptr32 ptr32)
 T_3439: (in Mem99[d0_82 + 20<i32>:word32] : word32)
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: ptr32
 T_3440: (in 16<i32> : int32)
   Class: Eq_3440
@@ -16802,7 +16340,7 @@ T_3449: (in d0_82 + 32<i32> : word32)
   OrigDataType: ptr32
 T_3450: (in Mem106[d0_82 + 32<i32>:word32] : word32)
   Class: Eq_3327
-  DataType: Eq_25
+  DataType: word32
   OrigDataType: word32
 T_3451: (in d0_82 + 32<i32> : word32)
   Class: Eq_3451
@@ -16817,12 +16355,12 @@ T_3453: (in d0_82 + 20<i32> : word32)
   DataType: (ptr32 ptr32)
   OrigDataType: (ptr32 ptr32)
 T_3454: (in Mem106[d0_82 + 20<i32>:word32] : word32)
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: ptr32
 T_3455: (in Mem106[d0_82 + 32<i32>:word32] + Mem106[d0_82 + 20<i32>:word32] : word32)
   Class: Eq_3455
-  DataType: int32
+  DataType: word32
   OrigDataType: word32
 T_3456: (in 28<i32> : int32)
   Class: Eq_3456
@@ -16834,7 +16372,7 @@ T_3457: (in d0_82 + 28<i32> : word32)
   OrigDataType: ptr32
 T_3458: (in Mem110[d0_82 + 28<i32>:word32] : word32)
   Class: Eq_3455
-  DataType: int32
+  DataType: word32
   OrigDataType: word32
 T_3459: (in AddHead : ptr32)
   Class: Eq_3459
@@ -16860,7 +16398,7 @@ T_3464: (in d0_82 + 4<i32> : word32)
   Class: Eq_3462
   DataType: ptr32
   OrigDataType: ptr32
-T_3465: (in AddHead(dwArg04, (word32) d0_82 + 4<i32>) : void)
+T_3465: (in AddHead(dwArg04, d0_82 + 1<i32>) : void)
   Class: Eq_3465
   DataType: void
   OrigDataType: void
@@ -16876,14 +16414,14 @@ T_3468: (in d0_82 + 4<i32> : word32)
   Class: Eq_4
   DataType: (ptr32 Eq_4)
   OrigDataType: ptr32
-T_3469: (in Allocate((word32) d0_82 + 4<i32>, dwArg08) : word32)
+T_3469: (in Allocate(d0_82 + 1<i32>, dwArg08) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3470: (in a2_142 : Eq_25)
+T_3470: (in a2_142 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 Eq_25)
+  OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
 T_3471: (in d2_145 : uint32)
   Class: Eq_3471
   DataType: uint32
@@ -16918,7 +16456,7 @@ T_3478: (in a2_142 + 0<32> : word32)
   OrigDataType: word32
 T_3479: (in Mem148[a2_142 + 0<32>:word32] : word32)
   Class: Eq_3476
-  DataType: Eq_25
+  DataType: word32
   OrigDataType: word32
 T_3480: (in a2_149 : (ptr32 word32))
   Class: Eq_3480
@@ -16954,7 +16492,7 @@ T_3487: (in 4<i32> : int32)
   OrigDataType: int32
 T_3488: (in a2_149 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_3489: (in 1<32> : word32)
   Class: Eq_3489
@@ -16986,8 +16524,8 @@ T_3495: (in d0_50 + 0<32> : word32)
   OrigDataType: word32
 T_3496: (in Mem56[d0_50 + 0<32>:word32] : word32)
   Class: Eq_77
-  DataType: Eq_25
-  OrigDataType: Eq_77
+  DataType: Eq_77
+  OrigDataType: word32
 T_3497: (in AddTail : ptr32)
   Class: Eq_3497
   DataType: (ptr32 Eq_3497)
@@ -17012,7 +16550,7 @@ T_3502: (in d0_50 + 4<i32> : word32)
   Class: Eq_3500
   DataType: ptr32
   OrigDataType: ptr32
-T_3503: (in AddTail(dwArg04, (word32) d0_50 + 4<i32>) : void)
+T_3503: (in AddTail(dwArg04, d0_50 + 1<i32>) : void)
   Class: Eq_3503
   DataType: void
   OrigDataType: void
@@ -17030,23 +16568,23 @@ T_3506: (in d0_50 + 12<i32> : word32)
   OrigDataType: ptr32
 T_3507: (in Mem62[d0_50 + 12<i32>:word32] : word32)
   Class: Eq_106
-  DataType: Eq_25
-  OrigDataType: int32
+  DataType: Eq_106
+  OrigDataType: word32
 T_3508: (in 16<i32> : int32)
   Class: Eq_3508
   DataType: int32
   OrigDataType: int32
 T_3509: (in d0_50 + 16<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
-T_3510: (in d0 : Eq_25)
+T_3510: (in d0 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3511: (in d0_51 : Eq_25)
+T_3511: (in d0_51 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3512: (in a0_17 : (ptr32 Eq_4))
   Class: Eq_4
@@ -17082,12 +16620,12 @@ T_3519: (in a0_17->t0014 < 0x27<16> : bool)
   OrigDataType: bool
 T_3520: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3521: (in a1 : word32)
   Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+  DataType: (ptr32 Eq_25)
+  OrigDataType: word32
 T_3522: (in dwArg08 - dwArg0C : word32)
   Class: Eq_3522
   DataType: up32
@@ -17101,8 +16639,8 @@ T_3524: (in dwArg08 - dwArg0C < 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_3525: (in d1 : word32)
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: (union ((ptr32 (struct (0 word32 dw0000) (4 word32 dw0004))) u1) (ptr32 u0))
 T_3526: (in CreatePrivatePool : ptr32)
   Class: Eq_3526
@@ -17117,20 +16655,20 @@ T_3528: (in requirements : word32)
   DataType: Eq_106
   OrigDataType: 
 T_3529: (in puddleSize : word32)
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: 
 T_3530: (in puddleThresh : word32)
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: 
 T_3531: (in CreatePrivatePool(dwArg04, dwArg08, dwArg0C) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3532: (in d0_30 : Eq_25)
+T_3532: (in d0_30 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: (ptr32 (struct (0 T_3544 t0000) (4 T_3547 t0004) (8 T_3550 t0008) (C T_3553 t000C) (10 T_3560 t0010) (14 T_3563 t0014)))
 T_3533: (in AllocMem : ptr32)
   Class: Eq_75
@@ -17146,17 +16684,17 @@ T_3535: (in 0<i32> : int32)
   OrigDataType: int32
 T_3536: (in AllocMem(24<i32>, 0<i32>) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3537: (in 0<i32> : int32)
-  Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
   OrigDataType: int32
 T_3538: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3539: (in d0_30 == 0<32> : bool)
+T_3539: (in d0_30 == null : bool)
   Class: Eq_3539
   DataType: bool
   OrigDataType: bool
@@ -17178,20 +16716,20 @@ T_3543: (in d0_30 + 0<32> : word32)
   OrigDataType: word32
 T_3544: (in Mem37[d0_30 + 0<32>:word32] : word32)
   Class: Eq_3541
-  DataType: Eq_25
+  DataType: word32
   OrigDataType: word32
 T_3545: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_134
+  DataType: int32
   OrigDataType: word32
 T_3546: (in d0_30 + 4<i32> : word32)
   Class: Eq_3546
   DataType: ptr32
   OrigDataType: ptr32
 T_3547: (in Mem38[d0_30 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+  Class: Eq_134
+  DataType: Eq_134
+  OrigDataType: word32
 T_3548: (in 8<i32> : int32)
   Class: Eq_3548
   DataType: int32
@@ -17202,7 +16740,7 @@ T_3549: (in d0_30 + 8<i32> : word32)
   OrigDataType: ptr32
 T_3550: (in Mem40[d0_30 + 8<i32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3551: (in 12<i32> : int32)
   Class: Eq_3551
@@ -17214,8 +16752,8 @@ T_3552: (in d0_30 + 12<i32> : word32)
   OrigDataType: ptr32
 T_3553: (in Mem42[d0_30 + 12<i32>:word32] : word32)
   Class: Eq_106
-  DataType: Eq_25
-  OrigDataType: Eq_106
+  DataType: Eq_106
+  OrigDataType: word32
 T_3554: (in 7<32> : word32)
   Class: Eq_3554
   DataType: word32
@@ -17242,8 +16780,8 @@ T_3559: (in d0_30 + 16<i32> : word32)
   OrigDataType: ptr32
 T_3560: (in Mem46[d0_30 + 16<i32>:word32] : word32)
   Class: Eq_148
-  DataType: Eq_25
-  OrigDataType: (ptr32 (arr Eq_160))
+  DataType: (ptr32 (arr Eq_160))
+  OrigDataType: word32
 T_3561: (in 20<i32> : int32)
   Class: Eq_3561
   DataType: int32
@@ -17253,9 +16791,9 @@ T_3562: (in d0_30 + 20<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3563: (in Mem48[d0_30 + 20<i32>:word32] : word32)
-  Class: Eq_2963
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_2963)
+  Class: Eq_3186
+  DataType: (ptr32 Eq_3186)
+  OrigDataType: word32
 T_3564: (in d0_30 + 4<i32> : word32)
   Class: Eq_4
   DataType: (ptr32 Eq_4)
@@ -17492,29 +17030,29 @@ T_3622: (in fn0000131C(0x14<u32>, out a1, out a5) : word32)
   Class: Eq_597
   DataType: word32
   OrigDataType: word32
-T_3623: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3623: (in d0 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_3624: (in d0_196 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
-T_3625: (in d1_142 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3624: (in d0_196 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: (ptr32 Eq_1583)
+T_3625: (in d1_142 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_3626: (in a0_20 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3626: (in a0_20 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
-T_3627: (in d3_166 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3627: (in d3_166 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_3628: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_3629: (in dwArg0C != 0<32> : bool)
   Class: Eq_3629
@@ -17545,8 +17083,8 @@ T_3635: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_3636: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_3637: (in dwArg10 != 0<32> : bool)
   Class: Eq_3637
@@ -17568,41 +17106,41 @@ T_3641: (in signature of fn00002664 : void)
   Class: Eq_3640
   DataType: (ptr32 Eq_3640)
   OrigDataType: 
-T_3642: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 word32 dw0000) (4 T_134 t0004) (8 T_25 t0008) (C T_106 t000C) (10 T_148 t0010) (14 T_3186 t0014) (18 T_3430 t0018) (1C T_3458 t001C) (20 T_3376 t0020))) u1) (up32 u0))
-T_3643: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3642: (in d0 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: (union (int32 u1) (up32 u0))
+T_3643: (in d1 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: up32
-T_3644: (in d2 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3644: (in d2 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: (union (int32 u0) (up32 u1))
-T_3645: (in d1Out : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3645: (in d1Out : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
-T_3646: (in d2Out : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3646: (in d2Out : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_3647: (in out d1_318 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_3648: (in out d2_319 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_3649: (in fn00002664(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3650: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_3651: (in d4_29 : int32)
   Class: Eq_3651
@@ -17612,21 +17150,21 @@ T_3652: (in 24<i32> : int32)
   Class: Eq_3651
   DataType: int32
   OrigDataType: int32
-T_3653: (in d6_30 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3653: (in d6_30 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uip32
 T_3654: (in __rol : ptr32)
   Class: Eq_827
   DataType: (ptr32 Eq_827)
   OrigDataType: (ptr32 (fn T_3656 (T_2050, T_3655)))
 T_3655: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_3656: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3657: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3657
@@ -17729,12 +17267,12 @@ T_3681: (in __rol : ptr32)
   DataType: (ptr32 Eq_827)
   OrigDataType: (ptr32 (fn T_3683 (T_3653, T_3682)))
 T_3682: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_3683: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3684: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3684
@@ -17757,12 +17295,12 @@ T_3688: (in __rol : ptr32)
   DataType: (ptr32 Eq_827)
   OrigDataType: (ptr32 (fn T_3690 (T_3653, T_3689)))
 T_3689: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_3690: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3691: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3691
@@ -17789,40 +17327,40 @@ T_3696: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_3697: (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uip32
-T_3698: (in d1_175 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3698: (in d1_175 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_3699: (in d2_176 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3699: (in d2_176 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_3700: (in d0_174 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3700: (in d0_174 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3701: (in fn00002664 : ptr32)
   Class: Eq_3640
   DataType: (ptr32 Eq_3640)
   OrigDataType: (ptr32 (fn T_3705 (T_3702, T_2048, T_3627, T_3703, T_3704)))
 T_3702: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_3703: (in out d1_175 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_3704: (in out d2_176 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_3705: (in fn00002664(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3706: (in d2_321 : word32)
   Class: Eq_3706
@@ -17837,16 +17375,16 @@ T_3708: (in fn00002664 : ptr32)
   DataType: (ptr32 Eq_3640)
   OrigDataType: (ptr32 (fn T_3711 (T_3698, T_2049, T_3699, T_3709, T_3710)))
 T_3709: (in out d1_320 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_3710: (in out d2_321 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_3711: (in fn00002664(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3712: (in 1<i32> : int32)
   Class: Eq_3712
@@ -17889,8 +17427,8 @@ T_3721: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_3722: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_3723: (in d1_86 : word32)
   Class: Eq_3723
@@ -17900,17 +17438,17 @@ T_3724: (in d2_322 : word32)
   Class: Eq_3724
   DataType: word32
   OrigDataType: word32
-T_3725: (in d0_85 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3725: (in d0_85 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3726: (in fn00002664 : ptr32)
   Class: Eq_3640
   DataType: (ptr32 Eq_3640)
   OrigDataType: (ptr32 (fn T_3736 (T_3727, T_3730, T_3733, T_3734, T_3735)))
 T_3727: (in dwArg04 >> d4_61 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3728: (in dwArg04 << d5_63 : word32)
   Class: Eq_3728
@@ -17921,8 +17459,8 @@ T_3729: (in dwArg08 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3730: (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_3731: (in dwArg0C << d5_63 : word32)
   Class: Eq_3731
@@ -17933,52 +17471,52 @@ T_3732: (in dwArg10 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3733: (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_3734: (in out d1_86 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_3735: (in out d2_322 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_3736: (in fn00002664(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_3737: (in d3_72 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3737: (in d3_72 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3738: (in dwArg10 << d5_63 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
-T_3739: (in d5_101 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3739: (in d5_101 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3740: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3741 (T_3725)))
 T_3741: (in __swap(d0_85) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_3742: (in d6_103 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3742: (in d6_103 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3743: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3744 (T_3737)))
 T_3744: (in __swap(d3_72) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3745: (in d3_102 : uint32)
   Class: Eq_3745
@@ -17992,9 +17530,9 @@ T_3747: (in d3_72 * (word16) d5_101 : word32)
   Class: Eq_3745
   DataType: uint32
   OrigDataType: uint32
-T_3748: (in d2_107 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3748: (in d2_107 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3749: (in __swap : ptr32)
   Class: Eq_760
@@ -18005,12 +17543,12 @@ T_3750: (in SLICE(d3_72, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3751: (in d0_85 * (word16) d3_72 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3752: (in __swap(d0_85 * (word16) d3_72) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3753: (in v34_108 : cup16)
   Class: Eq_3753
@@ -18060,29 +17598,29 @@ T_3764: (in SLICE(SEQ(v35_109, v34_108) + d4_104, word16, 0) : word16)
   Class: Eq_3761
   DataType: cup16
   OrigDataType: word16
-T_3765: (in d6_82 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3765: (in d6_82 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3766: (in dwArg08 << d5_63 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
-T_3767: (in d2_124 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3767: (in d2_124 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3768: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3770 (T_3769)))
 T_3769: (in SEQ(v35_109, v39_116) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_3770: (in __swap(SEQ(v35_109, v39_116)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3771: (in d5_105 : uint32)
   Class: Eq_3771
@@ -18113,12 +17651,12 @@ T_3777: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3778: (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_3779: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3780: (in __swap : ptr32)
   Class: Eq_760
@@ -18133,12 +17671,12 @@ T_3782: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3783: (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_3784: (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3785: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
   Class: Eq_3785
@@ -18225,8 +17763,8 @@ T_3805: (in 1<32> : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3806: (in d0_85 - 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3807: (in 0<32> : word32)
   Class: Eq_3774
@@ -18248,13 +17786,13 @@ T_3811: (in d6_82 - d2_124 >= 0<32> : bool)
   Class: Eq_3811
   DataType: bool
   OrigDataType: bool
-T_3812: (in d7_13 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3812: (in d7_13 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: (union (int32 u0) (uint32 u1))
 T_3813: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_3814: (in d2 == 0<32> : bool)
   Class: Eq_3814
@@ -18265,40 +17803,40 @@ T_3815: (in fn0000151E : ptr32)
   DataType: (ptr32 Eq_705)
   OrigDataType: (ptr32 (fn T_3817 (T_3643, T_3644, T_3644, T_3816)))
 T_3816: (in out d1 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_3817: (in fn0000151E(d1, d2, d2, out d1) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_3818: (in d6_17 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3818: (in d6_17 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_3819: (in d5_19 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3819: (in d5_19 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3820: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_3821: (in d0 != 0<32> : bool)
   Class: Eq_3821
   DataType: bool
   OrigDataType: bool
-T_3822: (in d2_22 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3822: (in d2_22 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3823: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3824 (T_3644)))
 T_3824: (in __swap(d2) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3825: (in SLICE(d2_22, word16, 0) : word16)
   Class: Eq_3825
@@ -18313,8 +17851,8 @@ T_3827: (in (word16) d2_22 != 0<16> : bool)
   DataType: bool
   OrigDataType: bool
 T_3828: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_3829: (in d1 == 0<32> : bool)
   Class: Eq_3829
@@ -18349,36 +17887,36 @@ T_3836: (in 0<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_3837: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_3838: (in d2 < 0<32> : bool)
   Class: Eq_3838
   DataType: bool
   OrigDataType: bool
-T_3839: (in d0_281 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3839: (in d0_281 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3840: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3841 (T_3642)))
 T_3841: (in __swap(d0) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_3842: (in d1_282 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3842: (in d1_282 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3843: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3844 (T_3643)))
 T_3844: (in __swap(d1) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3845: (in d0_285 : uint32)
   Class: Eq_3845
@@ -18417,8 +17955,8 @@ T_3853: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3854 (T_3842)))
 T_3854: (in __swap(d1_282) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3855: (in SLICE(__swap(d1_282), word16, 0) : word16)
   Class: Eq_3855
@@ -18445,12 +17983,12 @@ T_3860: (in (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3861: (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3862: (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3863: (in SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16) : word16)
   Class: Eq_3863
@@ -18469,8 +18007,8 @@ T_3866: (in (uint16) (d0_295 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3867: (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_3868: (in __swap : ptr32)
   Class: Eq_760
@@ -18493,12 +18031,12 @@ T_3872: (in 0<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3873: (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3874: (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3875: (in v41_64 : word16)
   Class: Eq_3875
@@ -18513,8 +18051,8 @@ T_3877: (in 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3878: (in d6_17 * 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_3879: (in SLICE(d0_44, word16, 16) : word16)
   Class: Eq_3879
@@ -18545,28 +18083,28 @@ T_3885: (in d5_19 * 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3886: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: up32
 T_3887: (in d6_17 < 0<32> : bool)
   Class: Eq_3887
   DataType: bool
   OrigDataType: bool
 T_3888: (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_3889: (in 2<32> : word32)
   Class: Eq_3889
   DataType: ui32
   OrigDataType: ui32
 T_3890: (in d7_13 * 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_3891: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_3892: (in d7_13 > 0<32> : bool)
   Class: Eq_3892
@@ -18580,9 +18118,9 @@ T_3894: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3903 (T_3902)))
-T_3895: (in d3_74 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3895: (in d3_74 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3896: (in SLICE(d3_74, uint16, 0) : uint16)
   Class: Eq_3896
@@ -18609,12 +18147,12 @@ T_3901: (in (uint16) (d5_19 /u SLICE(d3_74, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3902: (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3903: (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3904: (in SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16) : word16)
   Class: Eq_3904
@@ -18625,24 +18163,24 @@ T_3905: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3906: (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_3907: (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_3908: (in d1_104 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+T_3908: (in d1_104 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: (ptr32 Eq_1583)
 T_3909: (in 0xFFFF<32> : uipr32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: uipr32
-T_3910: (in d6_98 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3910: (in d6_98 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3911: (in __swap : ptr32)
   Class: Eq_760
@@ -18657,48 +18195,48 @@ T_3913: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3914: (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_3915: (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_3916: (in d6_133 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3916: (in d6_133 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3917: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3918 (T_3908)))
 T_3918: (in __swap(d1_104) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_3919: (in d3_140 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3919: (in d3_140 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3920: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3921 (T_3916)))
 T_3921: (in __swap(d6_133) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_3922: (in d4_142 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3922: (in d4_142 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3923: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3924 (T_3812)))
 T_3924: (in __swap(d7_13) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3925: (in d5_141 : uint32)
   Class: Eq_3925
@@ -18712,9 +18250,9 @@ T_3927: (in d7_13 * (word16) d3_140 : word32)
   Class: Eq_3925
   DataType: uint32
   OrigDataType: uint32
-T_3928: (in d6_146 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3928: (in d6_146 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3929: (in __swap : ptr32)
   Class: Eq_760
@@ -18725,12 +18263,12 @@ T_3930: (in SLICE(d7_13, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3931: (in d6_133 * (word16) d7_13 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3932: (in __swap(d6_133 * (word16) d7_13) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3933: (in v55_147 : cup16)
   Class: Eq_3933
@@ -18792,29 +18330,29 @@ T_3947: (in d3_140 * (word16) d4_142 : word32)
   Class: Eq_3945
   DataType: uint32
   OrigDataType: uint32
-T_3948: (in d6_178 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3948: (in d6_178 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3949: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3951 (T_3950)))
 T_3950: (in SEQ(v56_148, v59_155) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_3951: (in __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3952: (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3953: (in d5_181 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3954: (in __swap : ptr32)
   Class: Eq_760
@@ -18829,12 +18367,12 @@ T_3956: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3957: (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_3958: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3959: (in __swap : ptr32)
   Class: Eq_760
@@ -18849,12 +18387,12 @@ T_3961: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3962: (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_3963: (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3964: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
   Class: Eq_3964
@@ -18905,20 +18443,20 @@ T_3975: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ
   DataType: uint32
   OrigDataType: uint32
 T_3976: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: up32
 T_3977: (in d6_178 <u 0<32> : bool)
   Class: Eq_3977
   DataType: Eq_3977
   OrigDataType: (union (bool u0) (uint32 u1))
 T_3978: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3979: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: up32
 T_3980: (in d5_181 >= 0<32> : bool)
   Class: Eq_3980
@@ -18949,12 +18487,12 @@ T_3986: (in 1<32> : word32)
   DataType: uipr32
   OrigDataType: uipr32
 T_3987: (in d1_104 - 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
-T_3988: (in d4_113 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3988: (in d4_113 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3989: (in __swap : ptr32)
   Class: Eq_760
@@ -18965,8 +18503,8 @@ T_3990: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_3991 (T_3812)))
 T_3991: (in __swap(d7_13) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3992: (in SLICE(d1_104, word16, 0) : word16)
   Class: Eq_3992
@@ -18977,12 +18515,12 @@ T_3993: (in __swap(d7_13) * (word16) d1_104 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3994: (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_3995: (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_3996: (in wLoc22_442 : word16)
   Class: Eq_3996
@@ -19041,8 +18579,8 @@ T_4009: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_4010 (T_3812)))
 T_4010: (in __swap(d7_13) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4011: (in SLICE(__swap(d7_13), word16, 16) : word16)
   Class: Eq_4011
@@ -19057,20 +18595,20 @@ T_4013: (in SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : uipr32)
   DataType: uipr32
   OrigDataType: uipr32
 T_4014: (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4015: (in 1<32> : word32)
   Class: Eq_4015
   DataType: uint32
   OrigDataType: uint32
 T_4016: (in d1_104 - 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4017: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: up32
 T_4018: (in d6_178 < 0<32> : bool)
   Class: Eq_4018
@@ -19093,20 +18631,20 @@ T_4022: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4023: (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_4024: (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4025: (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_4026: (in d6_220 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4026: (in d6_220 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4027: (in __swap : ptr32)
   Class: Eq_760
@@ -19121,12 +18659,12 @@ T_4029: (in SLICE(d5_181, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4030: (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_4031: (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4032: (in SLICE(dwLoc24, word16, 16) : word16)
   Class: Eq_4032
@@ -19137,20 +18675,20 @@ T_4033: (in SLICE(d1_104, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4034: (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
-T_4035: (in d5_221 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4035: (in d5_221 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4036: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_4037 (T_3953)))
 T_4037: (in __swap(d5_181) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4038: (in v82_224 : word16)
   Class: Eq_4038
@@ -19168,29 +18706,29 @@ T_4041: (in v41_64 == 0<16> : bool)
   Class: Eq_4041
   DataType: bool
   OrigDataType: bool
-T_4042: (in d5_266 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4042: (in d5_266 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4043: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_4044 (T_3953)))
 T_4044: (in __swap(d5_181) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_4045: (in d6_267 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4045: (in d6_267 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4046: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_4047 (T_3948)))
 T_4047: (in __swap(d6_178) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4048: (in SLICE(d5_266, word16, 16) : word16)
   Class: Eq_4048
@@ -19201,8 +18739,8 @@ T_4049: (in SLICE(d6_267, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4050: (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_4051: (in SLICE(d6_267, word16, 16) : word16)
   Class: Eq_4051
@@ -19213,8 +18751,8 @@ T_4052: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4053: (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_4054: (in true : bool)
   Class: Eq_3833
@@ -19228,25 +18766,25 @@ T_4056: (in SEQ(SLICE(d1_104, word16, 0), wLoc22_442) : word32)
   Class: Eq_3997
   DataType: word32
   OrigDataType: word32
-T_4057: (in d2_73 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4057: (in d2_73 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4058: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_4059 (T_3819)))
 T_4059: (in __swap(d5_19) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4060: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_4061 (T_3812)))
 T_4061: (in __swap(d7_13) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4062: (in d2_73 - d3_74 : word32)
   Class: Eq_4062
@@ -19285,8 +18823,8 @@ T_4070: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_4071: (in d5_221 >> 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4072: (in v86_241 : word16)
   Class: Eq_4072
@@ -19305,8 +18843,8 @@ T_4075: (in signature of __rcr : void)
   DataType: (ptr32 Eq_4074)
   OrigDataType: 
 T_4076: (in  : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: 
 T_4077: (in  : word32)
   Class: Eq_4077
@@ -19329,8 +18867,8 @@ T_4081: (in SLICE(cond(d5_221), bool, 4) : bool)
   DataType: bool
   OrigDataType: bool
 T_4082: (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4083: (in SLICE(d7_230, word16, 16) : word16)
   Class: Eq_4083
@@ -19356,21 +18894,21 @@ T_4088: (in v86_241 != 0<16> : bool)
   Class: Eq_4088
   DataType: bool
   OrigDataType: bool
-T_4089: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4089: (in d1 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_4090: (in d1_171 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4090: (in d1_171 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_4091: (in d3_202 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4091: (in d3_202 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_4092: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_4093: (in dwArg0C != 0<32> : bool)
   Class: Eq_4093
@@ -19401,8 +18939,8 @@ T_4099: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_4100: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_4101: (in dwArg10 != 0<32> : bool)
   Class: Eq_4101
@@ -19417,16 +18955,16 @@ T_4103: (in fn00002664 : ptr32)
   DataType: (ptr32 Eq_3640)
   OrigDataType: (ptr32 (fn T_4106 (T_1964, T_1965, T_1967, T_4104, T_4105)))
 T_4104: (in out d1_171 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_4105: (in out d2_354 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_4106: (in fn00002664(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4107: (in d4_32 : int32)
   Class: Eq_4107
@@ -19436,21 +18974,21 @@ T_4108: (in 24<i32> : int32)
   Class: Eq_4107
   DataType: int32
   OrigDataType: int32
-T_4109: (in d6_33 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4109: (in d6_33 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uip32
 T_4110: (in __rol : ptr32)
   Class: Eq_827
   DataType: (ptr32 Eq_827)
   OrigDataType: (ptr32 (fn T_4112 (T_1966, T_4111)))
 T_4111: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_4112: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4113: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4113
@@ -19553,12 +19091,12 @@ T_4137: (in __rol : ptr32)
   DataType: (ptr32 Eq_827)
   OrigDataType: (ptr32 (fn T_4139 (T_4109, T_4138)))
 T_4138: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_4139: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4140: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4140
@@ -19581,12 +19119,12 @@ T_4144: (in __rol : ptr32)
   DataType: (ptr32 Eq_827)
   OrigDataType: (ptr32 (fn T_4146 (T_4109, T_4145)))
 T_4145: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_4146: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4147: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4147
@@ -19613,8 +19151,8 @@ T_4152: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_4153: (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uip32
 T_4154: (in d1_89 : ui32)
   Class: Eq_4154
@@ -19624,17 +19162,17 @@ T_4155: (in d2_90 : word32)
   Class: Eq_4155
   DataType: word32
   OrigDataType: word32
-T_4156: (in d0_88 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4156: (in d0_88 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4157: (in fn00002664 : ptr32)
   Class: Eq_3640
   DataType: (ptr32 Eq_3640)
   OrigDataType: (ptr32 (fn T_4167 (T_4158, T_4161, T_4164, T_4165, T_4166)))
 T_4158: (in dwArg04 >> d4_64 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4159: (in dwArg04 << d5_66 : word32)
   Class: Eq_4159
@@ -19645,8 +19183,8 @@ T_4160: (in dwArg08 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4161: (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_4162: (in dwArg0C << d5_66 : word32)
   Class: Eq_4162
@@ -19657,52 +19195,52 @@ T_4163: (in dwArg10 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4164: (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_4165: (in out d1_89 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_4166: (in out d2_90 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_4167: (in fn00002664(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_4168: (in d3_75 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4168: (in d3_75 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4169: (in dwArg10 << d5_66 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
-T_4170: (in d7_104 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4170: (in d7_104 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4171: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_4172 (T_4156)))
 T_4172: (in __swap(d0_88) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_4173: (in d6_106 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4173: (in d6_106 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4174: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_4175 (T_4168)))
 T_4175: (in __swap(d3_75) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4176: (in d3_105 : uint32)
   Class: Eq_4176
@@ -19716,9 +19254,9 @@ T_4178: (in d3_75 * (word16) d7_104 : word32)
   Class: Eq_4176
   DataType: uint32
   OrigDataType: uint32
-T_4179: (in d2_110 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4179: (in d2_110 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4180: (in __swap : ptr32)
   Class: Eq_760
@@ -19729,12 +19267,12 @@ T_4181: (in SLICE(d3_75, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4182: (in d0_88 * (word16) d3_75 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4183: (in __swap(d0_88 * (word16) d3_75) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4184: (in v36_111 : cup16)
   Class: Eq_4184
@@ -19784,21 +19322,21 @@ T_4195: (in SLICE(SEQ(v37_112, v36_111) + d4_107, word16, 0) : word16)
   Class: Eq_4192
   DataType: cup16
   OrigDataType: word16
-T_4196: (in d2_127 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4196: (in d2_127 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_4197: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_4199 (T_4198)))
 T_4198: (in SEQ(v37_112, v40_119) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_4199: (in __swap(SEQ(v37_112, v40_119)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4200: (in d7_108 : uint32)
   Class: Eq_4200
@@ -19837,12 +19375,12 @@ T_4208: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4209: (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_4210: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4211: (in __swap : ptr32)
   Class: Eq_760
@@ -19857,12 +19395,12 @@ T_4213: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4214: (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_4215: (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4216: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
   Class: Eq_4216
@@ -19937,8 +19475,8 @@ T_4233: (in dwArg0C - dwArg04 < 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_4234: (in dwArg08 - dwArg10 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4235: (in dwArg10 - dwArg08 : word32)
   Class: Eq_4235
@@ -19952,33 +19490,33 @@ T_4237: (in dwArg10 - dwArg08 > 0<32> : bool)
   Class: Eq_4237
   DataType: bool
   OrigDataType: bool
-T_4238: (in d1_211 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4238: (in d1_211 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_4239: (in d2_212 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4239: (in d2_212 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4240: (in fn00002664 : ptr32)
   Class: Eq_3640
   DataType: (ptr32 Eq_3640)
   OrigDataType: (ptr32 (fn T_4244 (T_4241, T_1964, T_4091, T_4242, T_4243)))
 T_4241: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_4242: (in out d1_211 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_4243: (in out d2_212 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_4244: (in fn00002664(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4245: (in d2_355 : word32)
   Class: Eq_4245
@@ -19989,16 +19527,16 @@ T_4246: (in fn00002664 : ptr32)
   DataType: (ptr32 Eq_3640)
   OrigDataType: (ptr32 (fn T_4249 (T_4238, T_1965, T_4239, T_4247, T_4248)))
 T_4247: (in out d1_171 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: (union (uint32 u0) (ptr32 u1))
 T_4248: (in out d2_355 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_4249: (in fn00002664(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4250: (in 1<i32> : int32)
   Class: Eq_4250
@@ -20041,8 +19579,8 @@ T_4259: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_4260: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_4261: (in d3_135 - d3_75 : word32)
   Class: Eq_4205
@@ -20061,8 +19599,8 @@ T_4264: (in d3_135 < 0<32> : bool)
   DataType: Eq_4264
   OrigDataType: (union (bool u0) (word32 u1))
 T_4265: (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4266: (in 0<32> : word32)
   Class: Eq_4227
@@ -20113,8 +19651,8 @@ T_4277: (in d6_157 >> d5_66 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4278: (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_4279: (in d6_85 - d3_135 : word32)
   Class: Eq_4279
@@ -20280,37 +19818,37 @@ T_4319: (in signature of fn00002C3C : void)
   Class: Eq_4318
   DataType: (ptr32 Eq_4318)
   OrigDataType: 
-T_4320: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4320: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
-T_4321: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4321: (in d1 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
-T_4322: (in a1 : Eq_25)
+T_4322: (in a1 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: Eq_7983
-T_4323: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
+  OrigDataType: (ptr32 (struct (0 T_4744 t0000)))
+T_4323: (in dwArg04 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4324: (in dwArg08 : (ptr32 Eq_620))
   Class: Eq_620
   DataType: (ptr32 Eq_620)
   OrigDataType: (ptr32 (struct (0 T_4380 t0000)))
-T_4325: (in dwArg0C : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4325: (in dwArg0C : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4326: (in 00003F7C : ptr32)
   Class: Eq_4326
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4327 t0000)))
 T_4327: (in Mem10[0x00003F7C<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4328: (in fp : ptr32)
   Class: Eq_4328
@@ -20321,32 +19859,32 @@ T_4329: (in 8<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4330: (in fp + 8<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
-T_4331: (in fn00002C3C(d0, d1, a1, *(union Eq_25 *) 0x3F7C<u32>, dwArg04, fp + 8<i32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+T_4331: (in fn00002C3C(d0, d1, a1, *(union Eq_73 *) 0x3F7C<u32>, dwArg04, fp + 8<i32>) : word32)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_4332: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4332: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_4333: (in bArg07 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4333: (in bArg07 : byte)
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
-T_4334: (in dwArg08 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4334: (in dwArg08 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: (ptr32 (struct (4 T_4332 t0004) (8 T_4343 t0008) (14 T_4349 t0014)))
-T_4335: (in d0_10 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4335: (in d0_10 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: up32
 T_4336: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_4337: (in dwArg08 == 0<32> : bool)
   Class: Eq_4337
@@ -20361,8 +19899,8 @@ T_4339: (in dwArg08 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_4340: (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4341: (in 8<i32> : int32)
   Class: Eq_4341
@@ -20373,8 +19911,8 @@ T_4342: (in dwArg08 + 8<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4343: (in Mem5[dwArg08 + 8<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: up32
 T_4344: (in d0_10 - *((word32) dwArg08 + 8<i32>) : word32)
   Class: Eq_4344
@@ -20398,7 +19936,7 @@ T_4348: (in dwArg08 + 20<i32> : word32)
   OrigDataType: ptr32
 T_4349: (in Mem20[dwArg08 + 20<i32>:word32] : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
 T_4350: (in 1<32> : word32)
   Class: Eq_4350
@@ -20406,7 +19944,7 @@ T_4350: (in 1<32> : word32)
   OrigDataType: word32
 T_4351: (in Mem20[dwArg08 + 20<i32>:word32] + 1<32> : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
 T_4352: (in dwArg08 + 20<i32> : word32)
   Class: Eq_4352
@@ -20414,7 +19952,7 @@ T_4352: (in dwArg08 + 20<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_4353: (in Mem22[dwArg08 + 20<i32>:word32] : word32)
   Class: Eq_2963
-  DataType: Eq_25
+  DataType: Eq_73
   OrigDataType: word32
 T_4354: (in 4<i32> : int32)
   Class: Eq_4354
@@ -20425,24 +19963,24 @@ T_4355: (in dwArg08 + 4<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4356: (in Mem22[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4357: (in 1<32> : word32)
   Class: Eq_4357
   DataType: word32
   OrigDataType: word32
 T_4358: (in *((word32) dwArg08 + 4<i32>) - 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4359: (in dwArg08 + 4<i32> : word32)
   Class: Eq_4359
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4360: (in Mem25[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4361: (in 4<i32> : int32)
   Class: Eq_4361
@@ -20453,8 +19991,8 @@ T_4362: (in dwArg08 + 4<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4363: (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: (ptr32 (struct (0 T_4366 t0000)))
 T_4364: (in 0<32> : word32)
   Class: Eq_4364
@@ -20465,13 +20003,13 @@ T_4365: (in Mem5[dwArg08 + 4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_4366: (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: Eq_73
   OrigDataType: byte
-T_4367: (in a7_1330 : Eq_4367)
+T_4367: (in a7_1330 : (ptr32 Eq_4367))
   Class: Eq_4367
-  DataType: Eq_4367
-  OrigDataType: word32
+  DataType: (ptr32 Eq_4367)
+  OrigDataType: (ptr32 (struct 0004 (2C int32 dw002C) (30 (union (int32 u0) (ptr32 u1) (T_6737 u2) (T_6803 u3) (T_7323 u4)) u0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 (union (int32 u0) (ptr32 u1) (T_6670 u2) (T_6741 u3) (T_6799 u4)) u0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084)))
 T_4368: (in fp : ptr32)
   Class: Eq_4368
   DataType: ptr32
@@ -20482,20 +20020,20 @@ T_4369: (in -120<i32> : int32)
   OrigDataType: int32
 T_4370: (in fp + -120<i32> : word32)
   Class: Eq_4367
-  DataType: Eq_4367
+  DataType: (ptr32 Eq_4367)
   OrigDataType: ptr32
-T_4371: (in d2_1090 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: Eq_4367
+T_4371: (in d2_1090 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: (struct "Eq_4367" 0004 (2C int32 dw002C) (30 Eq_8377 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8378 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_4372: (in a4_274 : (ptr32 Eq_620))
   Class: Eq_620
   DataType: (ptr32 Eq_620)
   OrigDataType: (ptr32 (struct 0001 (0 uint8 b0000)))
-T_4373: (in a2_1014 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: Eq_7879
+T_4373: (in a2_1014 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (ptr32 Eq_73)
 T_4374: (in d4_132 : Eq_4374)
   Class: Eq_4374
   DataType: Eq_4374
@@ -20504,13 +20042,13 @@ T_4375: (in 0<i32> : int32)
   Class: Eq_4374
   DataType: int32
   OrigDataType: int32
-T_4376: (in d5_1044 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: Eq_4367
+T_4376: (in d5_1044 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (struct "Eq_4367" 0004 (2C int32 dw002C) (30 Eq_8377 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8378 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_4377: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_4378: (in 0<32> : word32)
   Class: Eq_4378
@@ -20532,13 +20070,13 @@ T_4382: (in dwArg08->b0000 == 0<8> : bool)
   Class: Eq_4382
   DataType: bool
   OrigDataType: bool
-T_4383: (in d0_3698 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+T_4383: (in d0_3698 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: byte
 T_4384: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_4385: (in d5_1044 != 0xFFFFFFFF<32> : bool)
   Class: Eq_4385
@@ -20633,8 +20171,8 @@ T_4407: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_4408: (in d0_63 & 8<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4409: (in d0_63 & 8<32> : word32)
   Class: Eq_4409
@@ -20662,7 +20200,7 @@ T_4414: (in a7_1330 + 72<i32> : word32)
   OrigDataType: ptr32
 T_4415: (in Mem277[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4412
-  DataType: Eq_4367
+  DataType: byte
   OrigDataType: byte
 T_4416: (in 0<8> : byte)
   Class: Eq_4416
@@ -20678,7 +20216,7 @@ T_4418: (in a7_1330 + 73<i32> : word32)
   OrigDataType: ptr32
 T_4419: (in Mem278[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_4416
-  DataType: Eq_4367
+  DataType: byte
   OrigDataType: byte
 T_4420: (in a3_279 : (ptr32 byte))
   Class: Eq_4420
@@ -20736,21 +20274,21 @@ T_4433: (in (uint32) (uint8) Mem278[0x000028C5<p32> + (uint32) ((uint8) Mem278[a
   Class: Eq_4423
   DataType: uint32
   OrigDataType: uint32
-T_4434: (in d6_1133 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+T_4434: (in d6_1133 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: (ptr32 Eq_1583)
 T_4435: (in -1<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_4436: (in 4<32> : word32)
   Class: Eq_4436
   DataType: ui32
   OrigDataType: ui32
 T_4437: (in d0_289 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4438: (in d0_289 & 4<32> : word32)
   Class: Eq_4438
@@ -20829,16 +20367,16 @@ T_4456: (in (uint32) (uint8) Mem278[0x000028C5<p32> + (uint32) ((uint8) Mem278[a
   DataType: uint32
   OrigDataType: uint32
 T_4457: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_4458: (in 4<32> : word32)
   Class: Eq_4458
   DataType: ui32
   OrigDataType: ui32
 T_4459: (in d0_305 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4460: (in d0_305 & 4<32> : word32)
   Class: Eq_4460
@@ -20852,9 +20390,9 @@ T_4462: (in (d0_305 & 4<32>) == 0<32> : bool)
   Class: Eq_4462
   DataType: bool
   OrigDataType: bool
-T_4463: (in a7_313 : (ptr32 Eq_25))
+T_4463: (in a7_313 : (ptr32 Eq_645))
   Class: Eq_4463
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_645 t0000)))
 T_4464: (in 4<i32> : int32)
   Class: Eq_4464
@@ -20862,7 +20400,7 @@ T_4464: (in 4<i32> : int32)
   OrigDataType: int32
 T_4465: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4463
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: ptr32
 T_4466: (in 0<32> : word32)
   Class: Eq_4466
@@ -20873,8 +20411,8 @@ T_4467: (in a7_313 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4468: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4469: (in d1_322 : uint32)
   Class: Eq_4469
@@ -20885,12 +20423,12 @@ T_4470: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_4472 (T_4471)))
 T_4471: (in 10<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_4472: (in __swap(10<i32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4473: (in SLICE(d6_1133, word16, 0) : word16)
   Class: Eq_4473
@@ -20929,8 +20467,8 @@ T_4481: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_4482 (T_4434)))
 T_4482: (in __swap(d6_1133) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4483: (in 0xA<16> : word16)
   Class: Eq_4483
@@ -20949,12 +20487,12 @@ T_4486: (in SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4487: (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_4488: (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4489: (in SLICE(__swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_4489
@@ -21057,32 +20595,32 @@ T_4513: (in a7_313 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4514: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_4515: (in 0x30<32> : word32)
   Class: Eq_4515
   DataType: uint32
   OrigDataType: uint32
 T_4516: (in d1_340 - 0x30<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_4517: (in d1_340 - 0x30<32> : word32)
   Class: Eq_4517
   DataType: uint32
   OrigDataType: uint32
 T_4518: (in d1_340 - 0x30<32> + d0_331 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_4519: (in 4<32> : word32)
   Class: Eq_4519
   DataType: ui32
   OrigDataType: ui32
 T_4520: (in d0_354 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4521: (in d0_354 & 4<32> : word32)
   Class: Eq_4521
@@ -21137,8 +20675,8 @@ T_4533: (in Mem361[a7_1330 + 72<i32>:byte] : byte)
   DataType: byte
   OrigDataType: byte
 T_4534: (in SEQ(SLICE(d1, word24, 8), Mem361[a7_1330 + 72<i32>:byte]) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4535: (in 0<32> : word32)
   Class: Eq_4535
@@ -21276,7 +20814,7 @@ T_4568: (in 0x6A<8> : byte)
   Class: Eq_4567
   DataType: byte
   OrigDataType: byte
-T_4569: (in *((word32) a7_1330 + 72<i32>) != 0x6A<8> : bool)
+T_4569: (in a7_1330[18<i32>] != 0x6A<8> : bool)
   Class: Eq_4569
   DataType: bool
   OrigDataType: bool
@@ -21325,8 +20863,8 @@ T_4580: (in *a3_279 == 0x68<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_4581: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_4582: (in false : bool)
   Class: Eq_4582
@@ -21365,8 +20903,8 @@ T_4590: (in *a3_279 != 0x68<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_4591: (in 2<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_4592: (in 0<32> : word32)
   Class: Eq_4592
@@ -21522,7 +21060,7 @@ T_4629: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4630: (in Mem463[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4627
-  DataType: Eq_4367
+  DataType: byte
   OrigDataType: byte
 T_4631: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_4631
@@ -21538,7 +21076,7 @@ T_4633: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4634: (in Mem469[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_4631
-  DataType: Eq_4367
+  DataType: byte
   OrigDataType: byte
 T_4635: (in SLICE(d1, word24, 8) : word24)
   Class: Eq_4635
@@ -21557,8 +21095,8 @@ T_4638: (in Mem361[a3_279 + 0<32>:byte] : byte)
   DataType: byte
   OrigDataType: byte
 T_4639: (in SEQ(SLICE(d1, word24, 8), Mem361[a3_279 + 0<32>:byte]) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4640: (in 0<32> : word32)
   Class: Eq_4640
@@ -21581,8 +21119,8 @@ T_4644: (in *a3_279 != 0x6C<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_4645: (in 1<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_4646: (in 72<i32> : int32)
   Class: Eq_4646
@@ -21600,7 +21138,7 @@ T_4649: (in 0x74<8> : byte)
   Class: Eq_4648
   DataType: byte
   OrigDataType: byte
-T_4650: (in *((word32) a7_1330 + 72<i32>) != 0x74<8> : bool)
+T_4650: (in a7_1330[18<i32>] != 0x74<8> : bool)
   Class: Eq_4650
   DataType: bool
   OrigDataType: bool
@@ -21618,7 +21156,7 @@ T_4653: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4654: (in Mem477[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4651
-  DataType: Eq_4367
+  DataType: byte
   OrigDataType: byte
 T_4655: (in 72<i32> : int32)
   Class: Eq_4655
@@ -21636,7 +21174,7 @@ T_4658: (in 0x7A<8> : byte)
   Class: Eq_4657
   DataType: byte
   OrigDataType: byte
-T_4659: (in *((word32) a7_1330 + 72<i32>) != 0x7A<8> : bool)
+T_4659: (in a7_1330[18<i32>] != 0x7A<8> : bool)
   Class: Eq_4659
   DataType: bool
   OrigDataType: bool
@@ -21654,7 +21192,7 @@ T_4662: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4663: (in Mem485[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4660
-  DataType: Eq_4367
+  DataType: byte
   OrigDataType: byte
 T_4664: (in v83_500 : byte)
   Class: Eq_4664
@@ -21718,7 +21256,7 @@ T_4678: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4679: (in Mem493[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4676
-  DataType: Eq_4367
+  DataType: byte
   OrigDataType: byte
 T_4680: (in v147_608 : word24)
   Class: Eq_4680
@@ -21728,9 +21266,9 @@ T_4681: (in SLICE(d1, word24, 8) : word24)
   Class: Eq_4680
   DataType: word24
   OrigDataType: word24
-T_4682: (in d1_612 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4682: (in d1_612 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4683: (in 0x25<8> : byte)
   Class: Eq_4664
@@ -21741,8 +21279,8 @@ T_4684: (in v83_500 - 0x25<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_4685: (in SEQ(v147_608, v83_500 - 0x25<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4686: (in v83_500 == 0x25<8> : bool)
   Class: Eq_4686
@@ -21780,9 +21318,9 @@ T_4694: (in v83_500 == 0x5B<8> : bool)
   Class: Eq_4694
   DataType: bool
   OrigDataType: bool
-T_4695: (in d0_540 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4695: (in d0_540 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4696: (in a0_523 : (ptr32 ui32))
   Class: Eq_4696
@@ -21884,9 +21422,9 @@ T_4720: (in v90_528 < 0<32> : bool)
   Class: Eq_4720
   DataType: bool
   OrigDataType: bool
-T_4721: (in a7_533 : (ptr32 Eq_25))
+T_4721: (in a7_533 : (ptr32 Eq_73))
   Class: Eq_4721
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4323 t0000)))
 T_4722: (in 4<i32> : int32)
   Class: Eq_4722
@@ -21894,7 +21432,7 @@ T_4722: (in 4<i32> : int32)
   OrigDataType: int32
 T_4723: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4721
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_4724: (in 0<32> : word32)
   Class: Eq_4724
@@ -21905,8 +21443,8 @@ T_4725: (in a7_533 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4726: (in Mem535[a7_533 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4727: (in d1_5316 : word32)
   Class: Eq_4727
@@ -21924,13 +21462,13 @@ T_4730: (in signature of fn00003CE0 : void)
   Class: Eq_4729
   DataType: (ptr32 Eq_4729)
   OrigDataType: 
-T_4731: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4731: (in dwArg04 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: (ptr32 (struct (0 T_8181 t0000) (4 T_8154 t0004) (8 T_8154 t0008) (14 T_8132 t0014) (18 T_8119 t0018) (1C T_8142 t001C)))
-T_4732: (in d1Out : Eq_2909)
+T_4732: (in d1Out : (ptr32 (ptr32 Eq_4374)))
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: ptr32
 T_4733: (in a1Out : (ptr32 word32))
   Class: Eq_4733
@@ -21949,12 +21487,12 @@ T_4736: (in a7_533 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4737: (in Mem535[a7_533 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4738: (in out d1_5316 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: ptr32
 T_4739: (in out a1 : ptr32)
   Class: Eq_4733
@@ -21965,8 +21503,8 @@ T_4740: (in out a5_5317 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_4741: (in fn00003CE0(*a7_533, out d1_5316, out a1, out a5_5317) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4742: (in 4<i32> : int32)
   Class: Eq_4742
@@ -21974,7 +21512,7 @@ T_4742: (in 4<i32> : int32)
   OrigDataType: int32
 T_4743: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_4744: (in a0_551 : (ptr32 byte))
   Class: Eq_4744
@@ -21992,9 +21530,9 @@ T_4747: (in Mem529[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
   DataType: (ptr32 byte)
   OrigDataType: word32
-T_4748: (in a7_552 : (ptr32 Eq_25))
+T_4748: (in a7_552 : (ptr32 Eq_73))
   Class: Eq_4748
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4323 t0000)))
 T_4749: (in 4<i32> : int32)
   Class: Eq_4749
@@ -22002,7 +21540,7 @@ T_4749: (in 4<i32> : int32)
   OrigDataType: int32
 T_4750: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4748
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_4751: (in 0<32> : word32)
   Class: Eq_4751
@@ -22013,8 +21551,8 @@ T_4752: (in a7_552 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4753: (in Mem554[a7_552 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4754: (in 1<i32> : int32)
   Class: Eq_4754
@@ -22034,8 +21572,8 @@ T_4757: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_4758: (in Mem558[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: word32
 T_4759: (in v96_562 : byte)
   Class: Eq_4759
   DataType: byte
@@ -22061,24 +21599,24 @@ T_4764: (in a7_552 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4765: (in Mem558[a7_552 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4766: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_4766
   DataType: word24
   OrigDataType: word24
 T_4767: (in SEQ(SLICE(d0, word24, 8), v96_562) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4768: (in (uint8) v96_562 : uint8)
   Class: Eq_4768
   DataType: uint8
   OrigDataType: uint8
 T_4769: (in (uint32) (uint8) v96_562 : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_4770: (in d0_591 : uint32)
   Class: Eq_4770
@@ -22137,8 +21675,8 @@ T_4783: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_4784: (in d0_591 & 8<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4785: (in d0_591 & 8<32> : word32)
   Class: Eq_4785
@@ -22152,9 +21690,9 @@ T_4787: (in (d0_591 & 8<32>) != 0<32> : bool)
   Class: Eq_4787
   DataType: bool
   OrigDataType: bool
-T_4788: (in d0_111 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4788: (in d0_111 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4789: (in a0_70 : (ptr32 ui32))
   Class: Eq_4789
@@ -22256,9 +21794,9 @@ T_4813: (in v126_74 < 0<32> : bool)
   Class: Eq_4813
   DataType: bool
   OrigDataType: bool
-T_4814: (in d0_187 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4814: (in d0_187 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4815: (in a0_170 : (ptr32 ui32))
   Class: Eq_4815
@@ -22360,9 +21898,9 @@ T_4839: (in v105_175 < 0<32> : bool)
   Class: Eq_4839
   DataType: bool
   OrigDataType: bool
-T_4840: (in a7_180 : (ptr32 Eq_25))
+T_4840: (in a7_180 : (ptr32 Eq_73))
   Class: Eq_4840
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4323 t0000)))
 T_4841: (in 4<i32> : int32)
   Class: Eq_4841
@@ -22370,7 +21908,7 @@ T_4841: (in 4<i32> : int32)
   OrigDataType: int32
 T_4842: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4840
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_4843: (in 0<32> : word32)
   Class: Eq_4843
@@ -22381,8 +21919,8 @@ T_4844: (in a7_180 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4845: (in Mem182[a7_180 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4846: (in d1_5318 : word32)
   Class: Eq_4846
@@ -22405,12 +21943,12 @@ T_4850: (in a7_180 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4851: (in Mem182[a7_180 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4852: (in out d1_5318 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: ptr32
 T_4853: (in out a1 : ptr32)
   Class: Eq_4733
@@ -22421,8 +21959,8 @@ T_4854: (in out a5_5319 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_4855: (in fn00003CE0(*a7_180, out d1_5318, out a1, out a5_5319) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4856: (in 4<i32> : int32)
   Class: Eq_4856
@@ -22430,7 +21968,7 @@ T_4856: (in 4<i32> : int32)
   OrigDataType: int32
 T_4857: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_4858: (in a0_198 : (ptr32 byte))
   Class: Eq_4744
@@ -22448,9 +21986,9 @@ T_4861: (in Mem176[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
-T_4862: (in a7_199 : (ptr32 Eq_25))
+T_4862: (in a7_199 : (ptr32 Eq_73))
   Class: Eq_4862
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4323 t0000)))
 T_4863: (in 4<i32> : int32)
   Class: Eq_4863
@@ -22458,7 +21996,7 @@ T_4863: (in 4<i32> : int32)
   OrigDataType: int32
 T_4864: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4862
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_4865: (in 0<32> : word32)
   Class: Eq_4865
@@ -22469,8 +22007,8 @@ T_4866: (in a7_199 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4867: (in Mem201[a7_199 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4868: (in 1<i32> : int32)
   Class: Eq_4868
@@ -22490,8 +22028,8 @@ T_4871: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_4872: (in Mem205[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_4873: (in v109_209 : byte)
   Class: Eq_4759
   DataType: byte
@@ -22517,24 +22055,24 @@ T_4878: (in a7_199 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4879: (in Mem205[a7_199 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4880: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_4880
   DataType: word24
   OrigDataType: word24
 T_4881: (in SEQ(SLICE(d0, word24, 8), v109_209) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4882: (in (uint8) v109_209 : uint8)
   Class: Eq_4882
   DataType: uint8
   OrigDataType: uint8
 T_4883: (in (uint32) (uint8) v109_209 : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_4884: (in d0_238 : uint32)
   Class: Eq_4884
@@ -22593,8 +22131,8 @@ T_4897: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_4898: (in d0_238 & 8<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4899: (in d0_238 & 8<32> : word32)
   Class: Eq_4899
@@ -22613,8 +22151,8 @@ T_4902: (in 1<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4903: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_4904: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_4904
@@ -22632,9 +22170,9 @@ T_4907: (in 1<i32> : int32)
   Class: Eq_4386
   DataType: int32
   OrigDataType: int32
-T_4908: (in a7_248 : (ptr32 Eq_25))
+T_4908: (in a7_248 : (ptr32 Eq_73))
   Class: Eq_4908
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4323 t0000)))
 T_4909: (in 4<i32> : int32)
   Class: Eq_4909
@@ -22642,7 +22180,7 @@ T_4909: (in 4<i32> : int32)
   OrigDataType: int32
 T_4910: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4908
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_4911: (in 0<32> : word32)
   Class: Eq_4911
@@ -22653,8 +22191,8 @@ T_4912: (in a7_248 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4913: (in Mem251[a7_248 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4914: (in 4<i32> : int32)
   Class: Eq_4914
@@ -22662,7 +22200,7 @@ T_4914: (in 4<i32> : int32)
   OrigDataType: int32
 T_4915: (in a7_248 - 4<i32> : word32)
   Class: Eq_4915
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4918 t0000)))
 T_4916: (in 0<32> : word32)
   Class: Eq_4916
@@ -22673,8 +22211,8 @@ T_4917: (in a7_248 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4918: (in Mem254[a7_248 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4919: (in fn00002C0C : ptr32)
   Class: Eq_4919
@@ -22690,7 +22228,7 @@ T_4921: (in 1<i32> : int32)
   OrigDataType: int32
 T_4922: (in a7_248 - 1<i32> : word32)
   Class: Eq_4922
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4925 t0000)))
 T_4923: (in 0<32> : word32)
   Class: Eq_4923
@@ -22701,8 +22239,8 @@ T_4924: (in a7_248 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4925: (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_4926: (in 0<32> : word32)
   Class: Eq_4926
@@ -22713,12 +22251,12 @@ T_4927: (in a7_248 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4928: (in Mem254[a7_248 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4929: (in fn00002C0C(*(a7_248 - 1<i32>), *a7_248) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4930: (in 1<i32> : int32)
   Class: Eq_4930
@@ -22749,8 +22287,8 @@ T_4936: (in a7_79 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4937: (in Mem81[a7_79 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4938: (in a5_5320 : word32)
   Class: Eq_4938
@@ -22769,12 +22307,12 @@ T_4941: (in a7_79 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4942: (in Mem81[a7_79 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4943: (in out d1 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: (union (int32 u1) (uint32 u0) (ptr32 u2))
 T_4944: (in out a1 : ptr32)
   Class: Eq_4733
@@ -22785,8 +22323,8 @@ T_4945: (in out a5_5320 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_4946: (in fn00003CE0(a7_79->t0000, out d1, out a1, out a5_5320) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4947: (in 48<i32> : int32)
   Class: Eq_4947
@@ -22797,8 +22335,8 @@ T_4948: (in a7_79 + 48<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4949: (in Mem94[a7_79 + 48<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4950: (in 4<i32> : int32)
   Class: Eq_4950
@@ -22806,7 +22344,7 @@ T_4950: (in 4<i32> : int32)
   OrigDataType: int32
 T_4951: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_4952: (in a0_98 : (ptr32 byte))
   Class: Eq_4744
@@ -22845,8 +22383,8 @@ T_4960: (in a7_99 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4961: (in Mem101[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4962: (in 1<i32> : int32)
   Class: Eq_4962
@@ -22866,8 +22404,8 @@ T_4965: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_4966: (in Mem105[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_4967: (in v130_109 : byte)
   Class: Eq_4759
   DataType: byte
@@ -22893,8 +22431,8 @@ T_4972: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4973: (in Mem105[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4974: (in 0<32> : word32)
   Class: Eq_4974
@@ -22905,8 +22443,8 @@ T_4975: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4976: (in Mem115[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4977: (in (uint8) v130_109 : uint8)
   Class: Eq_4977
@@ -22937,8 +22475,8 @@ T_4983: (in SLICE(d0_63 & 8<32>, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_4984: (in SEQ(SLICE(d0_63 & 8<32>, word24, 8), v130_109) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4985: (in 0<32> : word32)
   Class: Eq_4985
@@ -22946,12 +22484,12 @@ T_4985: (in 0<32> : word32)
   OrigDataType: word32
 T_4986: (in a7_99 + 0<32> : word32)
   Class: Eq_4986
-  DataType: (ptr32 Eq_4986)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_4987: (in Mem121[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_4988: (in SLICE(d0_111, word24, 8) : word24)
   Class: Eq_4988
   DataType: word24
@@ -22981,8 +22519,8 @@ T_4994: (in (int16) (int8) SEQ(SLICE(d0_111, word24, 8), Mem127[a4_274 + 0<32>:b
   DataType: int16
   OrigDataType: int16
 T_4995: (in (int32) (int16) (int8) SEQ(SLICE(d0_111, word24, 8), Mem127[a4_274 + 0<32>:byte]) : int32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_4996: (in 44<i32> : int32)
   Class: Eq_4996
@@ -22993,8 +22531,8 @@ T_4997: (in a7_1330 + 44<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4998: (in Mem127[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4999: (in 1<32> : word32)
   Class: Eq_4386
@@ -23020,7 +22558,7 @@ T_5004: (in Mem127[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_5004
   DataType: int32
   OrigDataType: int32
-T_5005: (in d0 - *((word32) a7_1330 + 44<i32>) : word32)
+T_5005: (in d0 - a7_1330[11<i32>] : word32)
   Class: Eq_5005
   DataType: int32
   OrigDataType: int32
@@ -23028,7 +22566,7 @@ T_5006: (in 0<32> : word32)
   Class: Eq_5005
   DataType: int32
   OrigDataType: word32
-T_5007: (in d0 - *((word32) a7_1330 + 44<i32>) == 0<32> : bool)
+T_5007: (in d0 - a7_1330[11<i32>] == 0<32> : bool)
   Class: Eq_5007
   DataType: bool
   OrigDataType: bool
@@ -23053,8 +22591,8 @@ T_5012: (in a4_274->b0000 != 0<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_5013: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5014: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5014
@@ -23072,9 +22610,9 @@ T_5017: (in d4_132 - 1<32> : word32)
   Class: Eq_4374
   DataType: Eq_4374
   OrigDataType: int32
-T_5018: (in a7_148 : (ptr32 Eq_25))
+T_5018: (in a7_148 : (ptr32 Eq_73))
   Class: Eq_5018
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_5019: (in 4<i32> : int32)
   Class: Eq_5019
@@ -23082,7 +22620,7 @@ T_5019: (in 4<i32> : int32)
   OrigDataType: int32
 T_5020: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5018
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_5021: (in 0<32> : word32)
   Class: Eq_5021
@@ -23093,8 +22631,8 @@ T_5022: (in a7_148 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5023: (in Mem151[a7_148 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5024: (in 4<i32> : int32)
   Class: Eq_5024
@@ -23102,7 +22640,7 @@ T_5024: (in 4<i32> : int32)
   OrigDataType: int32
 T_5025: (in a7_148 - 4<i32> : word32)
   Class: Eq_5025
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_5028 t0000)))
 T_5026: (in 0<32> : word32)
   Class: Eq_5026
@@ -23113,8 +22651,8 @@ T_5027: (in a7_148 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5028: (in Mem154[a7_148 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5029: (in fn00002C0C : ptr32)
   Class: Eq_4919
@@ -23126,7 +22664,7 @@ T_5030: (in 1<i32> : int32)
   OrigDataType: int32
 T_5031: (in a7_148 - 1<i32> : word32)
   Class: Eq_5031
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5034 t0000)))
 T_5032: (in 0<32> : word32)
   Class: Eq_5032
@@ -23137,8 +22675,8 @@ T_5033: (in a7_148 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5034: (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_5035: (in 0<32> : word32)
   Class: Eq_5035
@@ -23149,12 +22687,12 @@ T_5036: (in a7_148 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5037: (in Mem154[a7_148 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5038: (in fn00002C0C(*(a7_148 - 1<i32>), *a7_148) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5039: (in a0_628 : (ptr32 ui32))
   Class: Eq_5039
@@ -23278,8 +22816,8 @@ T_5068: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5069: (in Mem761[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_5066
-  DataType: Eq_4367
-  OrigDataType: byte
+  DataType: Eq_5066
+  OrigDataType: int32
 T_5070: (in 0<32> : word32)
   Class: Eq_5070
   DataType: word32
@@ -23300,9 +22838,9 @@ T_5074: (in a3_1955->b0000 != 0x5E<8> : bool)
   Class: Eq_5074
   DataType: bool
   OrigDataType: bool
-T_5075: (in d1_1355 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_5075: (in d1_1355 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5076: (in 0x63<8> : byte)
   Class: Eq_4664
@@ -23313,16 +22851,16 @@ T_5077: (in v83_500 - 0x63<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_5078: (in SEQ(v147_608, v83_500 - 0x63<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5079: (in v83_500 == 0x63<8> : bool)
   Class: Eq_5079
   DataType: bool
   OrigDataType: bool
 T_5080: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: word32
 T_5081: (in d6_1133 != 0xFFFFFFFF<32> : bool)
   Class: Eq_5081
@@ -23337,8 +22875,8 @@ T_5083: (in v83_500 - 0x6E<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_5084: (in SEQ(v147_608, v83_500 - 0x6E<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5085: (in v83_500 == 0x6E<8> : bool)
   Class: Eq_5085
@@ -23360,7 +22898,7 @@ T_5089: (in 0<8> : byte)
   Class: Eq_5088
   DataType: byte
   OrigDataType: byte
-T_5090: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5090: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5090
   DataType: bool
   OrigDataType: bool
@@ -23373,8 +22911,8 @@ T_5092: (in v83_500 - 0x73<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_5093: (in SEQ(v147_608, v83_500 - 0x73<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5094: (in v83_500 == 0x73<8> : bool)
   Class: Eq_5094
@@ -23400,7 +22938,7 @@ T_5099: (in 0<8> : byte)
   Class: Eq_5098
   DataType: byte
   OrigDataType: byte
-T_5100: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5100: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5100
   DataType: bool
   OrigDataType: bool
@@ -23418,7 +22956,7 @@ T_5103: (in a7_1330 + 48<i32> : word32)
   OrigDataType: ptr32
 T_5104: (in Mem1948[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_5101
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
 T_5105: (in 0<32> : word32)
   Class: Eq_5105
@@ -23434,7 +22972,7 @@ T_5107: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5108: (in Mem1949[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_5105
-  DataType: Eq_4367
+  DataType: int32
   OrigDataType: int32
 T_5109: (in 0<32> : word32)
   Class: Eq_5109
@@ -23450,7 +22988,7 @@ T_5111: (in a7_1330 + 110<i32> : word32)
   OrigDataType: ptr32
 T_5112: (in Mem1950[a7_1330 + 110<i32>:word32] : word32)
   Class: Eq_5109
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
 T_5113: (in 0<8> : byte)
   Class: Eq_4664
@@ -23481,8 +23019,8 @@ T_5119: (in a7_640 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5120: (in Mem642[a7_640 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5121: (in a5_5321 : word32)
   Class: Eq_5121
@@ -23501,12 +23039,12 @@ T_5124: (in a7_640 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5125: (in Mem642[a7_640 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5126: (in out d1 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: (union (int32 u0) (uint32 u1) (ptr32 u2))
 T_5127: (in out a1 : ptr32)
   Class: Eq_4733
@@ -23517,8 +23055,8 @@ T_5128: (in out a5_5321 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5129: (in fn00003CE0(a7_640->t0000, out d1, out a1, out a5_5321) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5130: (in 48<i32> : int32)
   Class: Eq_5130
@@ -23529,8 +23067,8 @@ T_5131: (in a7_640 + 48<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5132: (in Mem655[a7_640 + 48<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5133: (in 4<i32> : int32)
   Class: Eq_5133
@@ -23538,7 +23076,7 @@ T_5133: (in 4<i32> : int32)
   OrigDataType: int32
 T_5134: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_5135: (in a0_659 : (ptr32 byte))
   Class: Eq_4744
@@ -23577,8 +23115,8 @@ T_5143: (in a7_660 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5144: (in Mem662[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5145: (in 1<i32> : int32)
   Class: Eq_5145
@@ -23598,8 +23136,8 @@ T_5148: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_5149: (in Mem666[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_5150: (in v163_670 : byte)
   Class: Eq_4759
   DataType: byte
@@ -23625,8 +23163,8 @@ T_5155: (in a7_660 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5156: (in Mem666[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5157: (in 0<32> : word32)
   Class: Eq_5157
@@ -23634,12 +23172,12 @@ T_5157: (in 0<32> : word32)
   OrigDataType: word32
 T_5158: (in a7_660 + 0<32> : word32)
   Class: Eq_5158
-  DataType: (ptr32 Eq_5158)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_5159: (in Mem686[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5160: (in (uint8) v163_670 : uint8)
   Class: Eq_5160
   DataType: uint8
@@ -23665,8 +23203,8 @@ T_5165: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5166: (in SEQ(SLICE(d0, word24, 8), v163_670) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5167: (in 0<32> : word32)
   Class: Eq_5167
@@ -23674,12 +23212,12 @@ T_5167: (in 0<32> : word32)
   OrigDataType: word32
 T_5168: (in a7_660 + 0<32> : word32)
   Class: Eq_5168
-  DataType: (ptr32 Eq_5168)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_5169: (in Mem692[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5170: (in 44<i32> : int32)
   Class: Eq_5170
   DataType: int32
@@ -23689,8 +23227,8 @@ T_5171: (in a7_1330 + 44<i32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_5172: (in Mem698[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_5173: (in 1<32> : word32)
   Class: Eq_5173
@@ -23724,7 +23262,7 @@ T_5180: (in 0x25<32> : word32)
   Class: Eq_5179
   DataType: int32
   OrigDataType: word32
-T_5181: (in *((word32) a7_1330 + 44<i32>) == 0x25<32> : bool)
+T_5181: (in a7_1330[11<i32>] == 0x25<32> : bool)
   Class: Eq_5181
   DataType: bool
   OrigDataType: bool
@@ -23745,8 +23283,8 @@ T_5185: (in a3_1955 - 1<i32> : word32)
   DataType: (ptr32 Eq_620)
   OrigDataType: ptr32
 T_5186: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5187: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5187
@@ -23768,9 +23306,9 @@ T_5191: (in d4_132 - 1<32> : word32)
   Class: Eq_4374
   DataType: Eq_4374
   OrigDataType: int32
-T_5192: (in a7_735 : (ptr32 Eq_25))
+T_5192: (in a7_735 : (ptr32 Eq_73))
   Class: Eq_5192
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_5193: (in 4<i32> : int32)
   Class: Eq_5193
@@ -23778,7 +23316,7 @@ T_5193: (in 4<i32> : int32)
   OrigDataType: int32
 T_5194: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5192
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_5195: (in 0<32> : word32)
   Class: Eq_5195
@@ -23789,8 +23327,8 @@ T_5196: (in a7_735 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5197: (in Mem738[a7_735 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5198: (in 4<i32> : int32)
   Class: Eq_5198
@@ -23798,7 +23336,7 @@ T_5198: (in 4<i32> : int32)
   OrigDataType: int32
 T_5199: (in a7_735 - 4<i32> : word32)
   Class: Eq_5199
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_5202 t0000)))
 T_5200: (in 0<32> : word32)
   Class: Eq_5200
@@ -23809,8 +23347,8 @@ T_5201: (in a7_735 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5202: (in Mem741[a7_735 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5203: (in fn00002C0C : ptr32)
   Class: Eq_4919
@@ -23822,7 +23360,7 @@ T_5204: (in 1<i32> : int32)
   OrigDataType: int32
 T_5205: (in a7_735 - 1<i32> : word32)
   Class: Eq_5205
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5208 t0000)))
 T_5206: (in 0<32> : word32)
   Class: Eq_5206
@@ -23833,8 +23371,8 @@ T_5207: (in a7_735 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5208: (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_5209: (in 0<32> : word32)
   Class: Eq_5209
@@ -23845,12 +23383,12 @@ T_5210: (in a7_735 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5211: (in Mem741[a7_735 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5212: (in fn00002C0C(*(a7_735 - 1<i32>), *a7_735) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5213: (in 0<32> : word32)
   Class: Eq_4386
@@ -23861,8 +23399,8 @@ T_5214: (in d3_130 == 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_5215: (in 0x2D<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5216: (in d5_1044 != 0x2D<32> : bool)
   Class: Eq_5216
@@ -23882,7 +23420,7 @@ T_5219: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5220: (in Mem1962[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_5217
-  DataType: Eq_4367
+  DataType: byte
   OrigDataType: byte
 T_5221: (in 120<i32> : int32)
   Class: Eq_4524
@@ -23913,16 +23451,16 @@ T_5227: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5228: (in (word32) d2_1090 + 3<i32> >> 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5229: (in 4<32> : word32)
   Class: Eq_5229
   DataType: word32
   OrigDataType: word32
 T_5230: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_5231: (in 0<32> : word32)
   Class: Eq_5231
@@ -23937,8 +23475,8 @@ T_5233: (in Mem629[d0 + 0<32>:word32] : word32)
   DataType: (ptr32 byte)
   OrigDataType: word32
 T_5234: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5235: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5235
@@ -23970,7 +23508,7 @@ T_5241: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5242: (in Mem1716[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_5240
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
 T_5243: (in 1<i32> : int32)
   Class: Eq_4386
@@ -23992,7 +23530,7 @@ T_5247: (in 1<8> : byte)
   Class: Eq_5246
   DataType: byte
   OrigDataType: byte
-T_5248: (in *((word32) a7_1330 + 72<i32>) != 1<8> : bool)
+T_5248: (in a7_1330[18<i32>] != 1<8> : bool)
   Class: Eq_5248
   DataType: bool
   OrigDataType: bool
@@ -24012,14 +23550,14 @@ T_5252: (in 0x6C<8> : byte)
   Class: Eq_5251
   DataType: byte
   OrigDataType: byte
-T_5253: (in *((word32) a7_1330 + 72<i32>) != 0x6C<8> : bool)
+T_5253: (in a7_1330[18<i32>] != 0x6C<8> : bool)
   Class: Eq_5253
   DataType: bool
   OrigDataType: bool
 T_5254: (in 3<32> : word32)
   Class: Eq_5254
-  DataType: (ptr32 Eq_8391)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8379)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5255: (in d2_1090 + 3<32> : word32)
   Class: Eq_5255
   DataType: Eq_5255
@@ -24037,8 +23575,8 @@ T_5258: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5259: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5260: (in a0_1704 : (ptr32 Eq_5260))
   Class: Eq_5260
@@ -24089,12 +23627,12 @@ T_5271: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5272: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_5273: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5274: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5274
@@ -24149,8 +23687,8 @@ T_5286: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5287: (in d0_1765 & 8<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5288: (in d0_1765 & 8<32> : word32)
   Class: Eq_5288
@@ -24336,18 +23874,18 @@ T_5333: (in 0x68<8> : byte)
   Class: Eq_5332
   DataType: byte
   OrigDataType: byte
-T_5334: (in *((word32) a7_1330 + 72<i32>) != 0x68<8> : bool)
+T_5334: (in a7_1330[18<i32>] != 0x68<8> : bool)
   Class: Eq_5334
   DataType: bool
   OrigDataType: bool
 T_5335: (in 3<32> : word32)
   Class: Eq_5335
-  DataType: (ptr32 Eq_8392)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8380)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5336: (in d2_1090 + 3<32> : word32)
   Class: Eq_5336
-  DataType: (ptr32 Eq_8393)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8381)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5337: (in 2<32> : word32)
   Class: Eq_5337
   DataType: word32
@@ -24361,8 +23899,8 @@ T_5339: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5340: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5341: (in 0<32> : word32)
   Class: Eq_5341
@@ -24386,19 +23924,19 @@ T_5345: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_5346: (in Mem1694[Mem629[d0 + 0<32>:word32] + 0<32>:word32] : word32)
   Class: Eq_4374
-  DataType: Eq_25
+  DataType: Eq_73
   OrigDataType: Eq_4374
 T_5347: (in 4<32> : word32)
   Class: Eq_5347
   DataType: int32
   OrigDataType: int32
 T_5348: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
-T_5349: (in a7_1807 : (ptr32 Eq_25))
+T_5349: (in a7_1807 : (ptr32 Eq_73))
   Class: Eq_5349
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_5350: (in 4<i32> : int32)
   Class: Eq_5350
@@ -24406,7 +23944,7 @@ T_5350: (in 4<i32> : int32)
   OrigDataType: int32
 T_5351: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5349
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_5352: (in 0<32> : word32)
   Class: Eq_5352
@@ -24417,8 +23955,8 @@ T_5353: (in a7_1807 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5354: (in Mem1809[a7_1807 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5355: (in d1_5322 : word32)
   Class: Eq_5355
@@ -24437,12 +23975,12 @@ T_5358: (in a7_1807 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5359: (in Mem1809[a7_1807 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5360: (in out d1_5322 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: ptr32
 T_5361: (in out a1 : ptr32)
   Class: Eq_4733
@@ -24453,8 +23991,8 @@ T_5362: (in out a5_1727 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct 0001 (0 byte b0000)))
 T_5363: (in fn00003CE0(*a7_1807, out d1_5322, out a1, out a5_1727) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5364: (in 4<i32> : int32)
   Class: Eq_5364
@@ -24462,7 +24000,7 @@ T_5364: (in 4<i32> : int32)
   OrigDataType: int32
 T_5365: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_5366: (in a0_1825 : (ptr32 byte))
   Class: Eq_4744
@@ -24480,9 +24018,9 @@ T_5369: (in Mem1802[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
-T_5370: (in a7_1826 : (ptr32 Eq_25))
+T_5370: (in a7_1826 : (ptr32 Eq_73))
   Class: Eq_5370
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_5371: (in 4<i32> : int32)
   Class: Eq_5371
@@ -24490,7 +24028,7 @@ T_5371: (in 4<i32> : int32)
   OrigDataType: int32
 T_5372: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5370
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_5373: (in 0<32> : word32)
   Class: Eq_5373
@@ -24501,8 +24039,8 @@ T_5374: (in a7_1826 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5375: (in Mem1828[a7_1826 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5376: (in 1<i32> : int32)
   Class: Eq_5376
@@ -24522,8 +24060,8 @@ T_5379: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_5380: (in Mem1832[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_5381: (in v201_1836 : byte)
   Class: Eq_4759
   DataType: byte
@@ -24549,24 +24087,24 @@ T_5386: (in a7_1826 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5387: (in Mem1832[a7_1826 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5388: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_5388
   DataType: word24
   OrigDataType: word24
 T_5389: (in SEQ(SLICE(d0, word24, 8), v201_1836) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5390: (in (uint8) v201_1836 : uint8)
   Class: Eq_5390
   DataType: uint8
   OrigDataType: uint8
 T_5391: (in (uint32) (uint8) v201_1836 : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_5392: (in 1<32> : word32)
   Class: Eq_5392
@@ -24585,8 +24123,8 @@ T_5395: (in d4_132 + 1<32> : word32)
   DataType: Eq_4374
   OrigDataType: int32
 T_5396: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5397: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5397
@@ -24608,18 +24146,18 @@ T_5401: (in 2<8> : byte)
   Class: Eq_5400
   DataType: byte
   OrigDataType: byte
-T_5402: (in *((word32) a7_1330 + 72<i32>) != 2<8> : bool)
+T_5402: (in a7_1330[18<i32>] != 2<8> : bool)
   Class: Eq_5402
   DataType: bool
   OrigDataType: bool
 T_5403: (in 3<32> : word32)
   Class: Eq_5403
-  DataType: (ptr32 Eq_8394)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8382)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5404: (in d2_1090 + 3<32> : word32)
   Class: Eq_5404
-  DataType: (ptr32 Eq_8395)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8383)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5405: (in 2<32> : word32)
   Class: Eq_5405
   DataType: word32
@@ -24633,8 +24171,8 @@ T_5407: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5408: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5409: (in SLICE(d4_132, word16, 0) : word16)
   Class: Eq_4374
@@ -24662,15 +24200,15 @@ T_5414: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_5415: (in Mem1682[Mem629[d0 + 0<32>:word32] + 0<32>:word16] : word16)
   Class: Eq_4374
-  DataType: Eq_25
+  DataType: Eq_73
   OrigDataType: Eq_4374
 T_5416: (in 4<32> : word32)
   Class: Eq_5416
   DataType: int32
   OrigDataType: int32
 T_5417: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_5418: (in 73<i32> : int32)
   Class: Eq_5418
@@ -24682,7 +24220,7 @@ T_5419: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5420: (in Mem1889[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_5294
-  DataType: Eq_4367
+  DataType: byte
   OrigDataType: byte
 T_5421: (in d0_1871 : uint32)
   Class: Eq_5421
@@ -24733,8 +24271,8 @@ T_5432: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5433: (in d0_1871 & 8<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5434: (in d0_1871 & 8<32> : word32)
   Class: Eq_5434
@@ -24770,12 +24308,12 @@ T_5441: (in v190_1777 != 0<8> : bool)
   OrigDataType: bool
 T_5442: (in 3<32> : word32)
   Class: Eq_5442
-  DataType: (ptr32 Eq_8396)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8384)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5443: (in d2_1090 + 3<32> : word32)
   Class: Eq_5443
-  DataType: (ptr32 Eq_8397)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8385)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5444: (in 2<32> : word32)
   Class: Eq_5444
   DataType: word32
@@ -24789,8 +24327,8 @@ T_5446: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5447: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5448: (in 0<32> : word32)
   Class: Eq_5448
@@ -24814,24 +24352,24 @@ T_5452: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: (ptr32 int32)
 T_5453: (in Mem1658[Mem629[d0 + 0<32>:word32] + 0<32>:word32] : word32)
   Class: Eq_4374
-  DataType: Eq_25
+  DataType: Eq_73
   OrigDataType: Eq_4374
 T_5454: (in 4<32> : word32)
   Class: Eq_5454
   DataType: int32
   OrigDataType: int32
 T_5455: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_5456: (in 3<32> : word32)
   Class: Eq_5456
-  DataType: (ptr32 Eq_8398)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8386)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5457: (in d2_1090 + 3<32> : word32)
   Class: Eq_5457
-  DataType: (ptr32 Eq_8399)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8387)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5458: (in 2<32> : word32)
   Class: Eq_5458
   DataType: word32
@@ -24845,8 +24383,8 @@ T_5460: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5461: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5462: (in SLICE(d4_132, byte, 0) : byte)
   Class: Eq_4374
@@ -24874,15 +24412,15 @@ T_5467: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: (ptr32 int32)
 T_5468: (in Mem1670[Mem629[d0 + 0<32>:word32] + 0<32>:byte] : byte)
   Class: Eq_4374
-  DataType: Eq_25
+  DataType: Eq_73
   OrigDataType: Eq_4374
 T_5469: (in 4<32> : word32)
   Class: Eq_5469
   DataType: int32
   OrigDataType: int32
 T_5470: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_5471: (in 1<32> : word32)
   Class: Eq_5471
@@ -24916,13 +24454,13 @@ T_5478: (in 0<8> : byte)
   Class: Eq_5477
   DataType: byte
   OrigDataType: byte
-T_5479: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5479: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5479
   DataType: bool
   OrigDataType: bool
-T_5480: (in a7_1897 : (ptr32 Eq_25))
+T_5480: (in a7_1897 : (ptr32 Eq_73))
   Class: Eq_5480
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_5481: (in 4<i32> : int32)
   Class: Eq_5481
@@ -24930,7 +24468,7 @@ T_5481: (in 4<i32> : int32)
   OrigDataType: int32
 T_5482: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5480
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_5483: (in 0<32> : word32)
   Class: Eq_5483
@@ -24941,8 +24479,8 @@ T_5484: (in a7_1897 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5485: (in Mem1903[a7_1897 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5486: (in 4<i32> : int32)
   Class: Eq_5486
@@ -24950,7 +24488,7 @@ T_5486: (in 4<i32> : int32)
   OrigDataType: int32
 T_5487: (in a7_1897 - 4<i32> : word32)
   Class: Eq_5487
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_5490 t0000)))
 T_5488: (in 0<32> : word32)
   Class: Eq_5488
@@ -24961,8 +24499,8 @@ T_5489: (in a7_1897 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5490: (in Mem1906[a7_1897 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5491: (in fn00002C0C : ptr32)
   Class: Eq_4919
@@ -24974,7 +24512,7 @@ T_5492: (in 1<i32> : int32)
   OrigDataType: int32
 T_5493: (in a7_1897 - 1<i32> : word32)
   Class: Eq_5493
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5496 t0000)))
 T_5494: (in 0<32> : word32)
   Class: Eq_5494
@@ -24985,8 +24523,8 @@ T_5495: (in a7_1897 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5496: (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_5497: (in 0<32> : word32)
   Class: Eq_5497
@@ -24997,16 +24535,16 @@ T_5498: (in a7_1897 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5499: (in Mem1906[a7_1897 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5500: (in fn00002C0C(*(a7_1897 - 1<i32>), *a7_1897) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5501: (in 0x2B<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5502: (in d5_1044 != 0x2B<32> : bool)
   Class: Eq_5502
@@ -25057,9 +24595,9 @@ T_5513: (in a7_1330 + 110<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5514: (in Mem1994[a7_1330 + 110<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4367
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_5515: (in a0_1999 : (ptr32 ui32))
   Class: Eq_5515
   DataType: (ptr32 ui32)
@@ -25181,8 +24719,8 @@ T_5544: (in a7_2007 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5545: (in Mem2009[a7_2007 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5546: (in a5_5323 : word32)
   Class: Eq_5546
@@ -25201,12 +24739,12 @@ T_5549: (in a7_2007 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5550: (in Mem2009[a7_2007 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5551: (in out d1 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 (struct (0 T_5346 t0000))) ptr0000))) u0) (uint32 u1) (ptr32 u2))
 T_5552: (in out a1 : ptr32)
   Class: Eq_4733
@@ -25217,8 +24755,8 @@ T_5553: (in out a5_5323 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5554: (in fn00003CE0(a7_2007->t0000, out d1, out a1, out a5_5323) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5555: (in 56<i32> : int32)
   Class: Eq_5555
@@ -25229,8 +24767,8 @@ T_5556: (in a7_2007 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5557: (in Mem2022[a7_2007 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5558: (in 4<i32> : int32)
   Class: Eq_5558
@@ -25238,7 +24776,7 @@ T_5558: (in 4<i32> : int32)
   OrigDataType: int32
 T_5559: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_5560: (in a0_2026 : (ptr32 byte))
   Class: Eq_4744
@@ -25277,8 +24815,8 @@ T_5568: (in a7_2027 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5569: (in Mem2029[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5570: (in 1<i32> : int32)
   Class: Eq_5570
@@ -25298,8 +24836,8 @@ T_5573: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_5574: (in Mem2033[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_5575: (in v231_2037 : byte)
   Class: Eq_4759
   DataType: byte
@@ -25325,8 +24863,8 @@ T_5580: (in a7_2027 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5581: (in Mem2033[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5582: (in 0<32> : word32)
   Class: Eq_5582
@@ -25334,12 +24872,12 @@ T_5582: (in 0<32> : word32)
   OrigDataType: word32
 T_5583: (in a7_2027 + 0<32> : word32)
   Class: Eq_5583
-  DataType: (ptr32 Eq_5583)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_5584: (in Mem2050[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5585: (in (uint8) v231_2037 : uint8)
   Class: Eq_5585
   DataType: uint8
@@ -25365,8 +24903,8 @@ T_5590: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5591: (in SEQ(SLICE(d0, word24, 8), v231_2037) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5592: (in 0<32> : word32)
   Class: Eq_5592
@@ -25374,12 +24912,12 @@ T_5592: (in 0<32> : word32)
   OrigDataType: word32
 T_5593: (in a7_2027 + 0<32> : word32)
   Class: Eq_5593
-  DataType: (ptr32 Eq_5593)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_5594: (in Mem2056[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5595: (in 52<i32> : int32)
   Class: Eq_5595
   DataType: int32
@@ -25389,8 +24927,8 @@ T_5596: (in a7_1330 + 52<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5597: (in Mem2062[a7_1330 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5598: (in 1<32> : word32)
   Class: Eq_5598
@@ -25458,7 +24996,7 @@ T_5613: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5614: (in Mem1946[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_5612
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
 T_5615: (in d4_2510 : Eq_4374)
   Class: Eq_4374
@@ -25481,8 +25019,8 @@ T_5619: (in (byte) d7 != 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_5620: (in 0x30<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5621: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_5621
@@ -25537,8 +25075,8 @@ T_5633: (in 4<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5634: (in d0_2109 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5635: (in d0_2109 & 4<32> : word32)
   Class: Eq_5635
@@ -25564,9 +25102,9 @@ T_5640: (in d6_1133 - d3_1850 < 0<32> : bool)
   Class: Eq_5640
   DataType: bool
   OrigDataType: bool
-T_5641: (in d0_2155 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_5641: (in d0_2155 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5642: (in a0_2139 : (ptr32 ui32))
   Class: Eq_5642
@@ -25689,8 +25227,8 @@ T_5671: (in a7_2148 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5672: (in Mem2150[a7_2148 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5673: (in a5_5324 : word32)
   Class: Eq_5673
@@ -25709,12 +25247,12 @@ T_5676: (in a7_2148 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5677: (in Mem2150[a7_2148 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5678: (in out d1 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: (ptr32 (struct 0004 (0 (ptr32 (struct (0 T_5346 t0000))) ptr0000)))
 T_5679: (in out a1 : ptr32)
   Class: Eq_4733
@@ -25725,8 +25263,8 @@ T_5680: (in out a5_5324 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5681: (in fn00003CE0(a7_2148->t0000, out d1, out a1, out a5_5324) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5682: (in 56<i32> : int32)
   Class: Eq_5682
@@ -25737,8 +25275,8 @@ T_5683: (in a7_2148 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5684: (in Mem2163[a7_2148 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5685: (in 4<i32> : int32)
   Class: Eq_5685
@@ -25746,7 +25284,7 @@ T_5685: (in 4<i32> : int32)
   OrigDataType: int32
 T_5686: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_5687: (in a0_2167 : (ptr32 byte))
   Class: Eq_4744
@@ -25785,8 +25323,8 @@ T_5695: (in a7_2168 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5696: (in Mem2170[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5697: (in 1<i32> : int32)
   Class: Eq_5697
@@ -25806,8 +25344,8 @@ T_5700: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_5701: (in Mem2174[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_5702: (in v249_2178 : byte)
   Class: Eq_4759
   DataType: byte
@@ -25833,8 +25371,8 @@ T_5707: (in a7_2168 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5708: (in Mem2174[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5709: (in 0<32> : word32)
   Class: Eq_5709
@@ -25842,12 +25380,12 @@ T_5709: (in 0<32> : word32)
   OrigDataType: word32
 T_5710: (in a7_2168 + 0<32> : word32)
   Class: Eq_5710
-  DataType: (ptr32 Eq_5710)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_5711: (in Mem2185[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5712: (in (uint8) v249_2178 : uint8)
   Class: Eq_5712
   DataType: uint8
@@ -25873,8 +25411,8 @@ T_5717: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5718: (in SEQ(SLICE(d0, word24, 8), v249_2178) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5719: (in 0<32> : word32)
   Class: Eq_5719
@@ -25882,12 +25420,12 @@ T_5719: (in 0<32> : word32)
   OrigDataType: word32
 T_5720: (in a7_2168 + 0<32> : word32)
   Class: Eq_5720
-  DataType: (ptr32 Eq_5720)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_5721: (in Mem2191[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5722: (in 52<i32> : int32)
   Class: Eq_5722
   DataType: int32
@@ -25926,12 +25464,12 @@ T_5730: (in 55<i32> : int32)
   OrigDataType: int32
 T_5731: (in a7_1330 + 55<i32> : word32)
   Class: Eq_5731
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_5732: (in Mem2199[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_5732
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_5733: (in SEQ(SLICE(d0_2155, word24, 8), Mem2199[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_5728
   DataType: ui32
@@ -25953,8 +25491,8 @@ T_5737: (in 0xFF<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5738: (in d0_2209 & 0xFF<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5739: (in __btst : ptr32)
   Class: Eq_5739
@@ -26024,17 +25562,17 @@ T_5755: (in 0<8> : byte)
   Class: Eq_5754
   DataType: byte
   OrigDataType: byte
-T_5756: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5756: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5756
   DataType: bool
   OrigDataType: bool
 T_5757: (in 1<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: int32
 T_5758: (in 0x78<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5759: (in d0 != 0x78<32> : bool)
   Class: Eq_5759
@@ -26065,8 +25603,8 @@ T_5765: (in (byte) (d0_2209 & 0xFF<32>) | 0x20<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_5766: (in SEQ(SLICE(d0_2209 & 0xFF<32>, word24, 8), SLICE(d0_2209 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5767: (in 0<32> : word32)
   Class: Eq_5751
@@ -26074,12 +25612,12 @@ T_5767: (in 0<32> : word32)
   OrigDataType: word32
 T_5768: (in 3<32> : word32)
   Class: Eq_5768
-  DataType: (ptr32 Eq_8404)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8388)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5769: (in d2_1090 + 3<32> : word32)
   Class: Eq_5769
-  DataType: (ptr32 Eq_8405)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8389)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5770: (in 2<32> : word32)
   Class: Eq_5770
   DataType: word32
@@ -26093,16 +25631,16 @@ T_5772: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5773: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5774: (in 4<32> : word32)
   Class: Eq_5774
   DataType: int32
   OrigDataType: int32
 T_5775: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ptr32
 T_5776: (in 0<32> : word32)
   Class: Eq_5776
@@ -26214,8 +25752,8 @@ T_5802: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5803: (in Mem1393[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_5751
-  DataType: Eq_4367
-  OrigDataType: (ptr32 Eq_4374)
+  DataType: (ptr32 Eq_4374)
+  OrigDataType: int32
 T_5804: (in 0<32> : word32)
   Class: Eq_5804
   DataType: word32
@@ -26252,9 +25790,9 @@ T_5812: (in d6_1133 - d3_2201 < 0<32> : bool)
   Class: Eq_5812
   DataType: bool
   OrigDataType: bool
-T_5813: (in d0_2253 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_5813: (in d0_2253 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5814: (in a0_2236 : (ptr32 ui32))
   Class: Eq_5814
@@ -26377,8 +25915,8 @@ T_5843: (in a7_2246 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5844: (in Mem2248[a7_2246 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5845: (in a5_5325 : word32)
   Class: Eq_5845
@@ -26397,13 +25935,13 @@ T_5848: (in a7_2246 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5849: (in Mem2248[a7_2246 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5850: (in out d1 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4374))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5851: (in out a1 : ptr32)
   Class: Eq_4733
   DataType: (ptr32 word32)
@@ -26413,8 +25951,8 @@ T_5852: (in out a5_5325 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5853: (in fn00003CE0(a7_2246->t0000, out d1, out a1, out a5_5325) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5854: (in 56<i32> : int32)
   Class: Eq_5854
@@ -26425,8 +25963,8 @@ T_5855: (in a7_2246 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5856: (in Mem2261[a7_2246 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5857: (in 4<i32> : int32)
   Class: Eq_5857
@@ -26434,7 +25972,7 @@ T_5857: (in 4<i32> : int32)
   OrigDataType: int32
 T_5858: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_5859: (in a0_2265 : (ptr32 byte))
   Class: Eq_4744
@@ -26473,8 +26011,8 @@ T_5867: (in a7_2266 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5868: (in Mem2268[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5869: (in 1<i32> : int32)
   Class: Eq_5869
@@ -26494,8 +26032,8 @@ T_5872: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_5873: (in Mem2272[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_5874: (in v271_2276 : byte)
   Class: Eq_4759
   DataType: byte
@@ -26521,8 +26059,8 @@ T_5879: (in a7_2266 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5880: (in Mem2272[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5881: (in 0<32> : word32)
   Class: Eq_5881
@@ -26530,12 +26068,12 @@ T_5881: (in 0<32> : word32)
   OrigDataType: word32
 T_5882: (in a7_2266 + 0<32> : word32)
   Class: Eq_5882
-  DataType: (ptr32 Eq_5882)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_5883: (in Mem2283[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5884: (in (uint8) v271_2276 : uint8)
   Class: Eq_5884
   DataType: uint8
@@ -26561,8 +26099,8 @@ T_5889: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5890: (in SEQ(SLICE(d0, word24, 8), v271_2276) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5891: (in 0<32> : word32)
   Class: Eq_5891
@@ -26570,12 +26108,12 @@ T_5891: (in 0<32> : word32)
   OrigDataType: word32
 T_5892: (in a7_2266 + 0<32> : word32)
   Class: Eq_5892
-  DataType: (ptr32 Eq_5892)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_5893: (in Mem2289[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5894: (in 52<i32> : int32)
   Class: Eq_5894
   DataType: int32
@@ -26649,8 +26187,8 @@ T_5911: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5912: (in d0_2317 & 0x44<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5913: (in d0_2317 & 0x44<32> : word32)
   Class: Eq_5913
@@ -26701,8 +26239,8 @@ T_5924: (in a7_1400 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5925: (in Mem1402[a7_1400 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5926: (in 48<i32> : int32)
   Class: Eq_5926
@@ -26737,13 +26275,13 @@ T_5933: (in a7_1400 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5934: (in Mem1404[a7_1400 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5935: (in out d1 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4374))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5936: (in out a1_5326 : ptr32)
   Class: Eq_4733
   DataType: (ptr32 word32)
@@ -26753,8 +26291,8 @@ T_5937: (in out a5_5327 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5938: (in fn00003CE0(a7_1400->t0000, out d1, out a1_5326, out a5_5327) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5939: (in 56<i32> : int32)
   Class: Eq_5939
@@ -26765,8 +26303,8 @@ T_5940: (in a7_1400 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5941: (in Mem1417[a7_1400 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5942: (in 48<i32> : int32)
   Class: Eq_5942
@@ -26841,8 +26379,8 @@ T_5959: (in a7_1425 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5960: (in Mem1427[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5961: (in 1<i32> : int32)
   Class: Eq_5961
@@ -26889,8 +26427,8 @@ T_5971: (in a7_1425 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5972: (in Mem1431[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5973: (in 0<32> : word32)
   Class: Eq_5973
@@ -26898,12 +26436,12 @@ T_5973: (in 0<32> : word32)
   OrigDataType: word32
 T_5974: (in a7_1425 + 0<32> : word32)
   Class: Eq_5974
-  DataType: (ptr32 Eq_5974)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_5975: (in Mem1444[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5976: (in (uint8) v284_1435 : uint8)
   Class: Eq_5976
   DataType: uint8
@@ -26929,8 +26467,8 @@ T_5981: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5982: (in SEQ(SLICE(d0, word24, 8), v284_1435) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5983: (in 0<32> : word32)
   Class: Eq_5983
@@ -26938,12 +26476,12 @@ T_5983: (in 0<32> : word32)
   OrigDataType: word32
 T_5984: (in a7_1425 + 0<32> : word32)
   Class: Eq_5984
-  DataType: (ptr32 Eq_5984)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_5985: (in Mem1450[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_5986: (in 44<i32> : int32)
   Class: Eq_5986
   DataType: int32
@@ -26954,7 +26492,7 @@ T_5987: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5988: (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: int32
 T_5989: (in 52<i32> : int32)
   Class: Eq_5989
@@ -26965,8 +26503,8 @@ T_5990: (in a7_1330 + 52<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5991: (in Mem1456[a7_1330 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5992: (in d3_1462 : Eq_5992)
   Class: Eq_5992
@@ -27008,7 +26546,7 @@ T_6001: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6000
   DataType: word32
   OrigDataType: word32
-T_6002: (in *((word32) a7_1330 + 52<i32>) == 0xFFFFFFFF<32> : bool)
+T_6002: (in a7_1330[13<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6002
   DataType: bool
   OrigDataType: bool
@@ -27028,7 +26566,7 @@ T_6006: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6005
   DataType: word32
   OrigDataType: word32
-T_6007: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_6007: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_6007
   DataType: bool
   OrigDataType: bool
@@ -27057,8 +26595,8 @@ T_6013: (in 120<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_6014: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_6015: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6015
@@ -27074,8 +26612,8 @@ T_6017: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_6018: (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_4367
-  OrigDataType: Eq_25
+  DataType: (ptr32 Eq_25)
+  OrigDataType: int32
 T_6019: (in d6_1133 - d3_1462 : word32)
   Class: Eq_6019
   DataType: Eq_6019
@@ -27269,8 +26807,8 @@ T_6066: (in a7_2334 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6067: (in Mem2338[a7_2334 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6068: (in 78<i32> : int32)
   Class: Eq_6068
@@ -27314,7 +26852,7 @@ T_6077: (in 1<i32> : int32)
   OrigDataType: int32
 T_6078: (in a7_2334 - 1<i32> : word32)
   Class: Eq_6078
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6081 t0000)))
 T_6079: (in 0<32> : word32)
   Class: Eq_6079
@@ -27325,8 +26863,8 @@ T_6080: (in a7_2334 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6081: (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_6082: (in 0<32> : word32)
   Class: Eq_6082
@@ -27337,16 +26875,16 @@ T_6083: (in a7_2334 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6084: (in Mem2342[a7_2334 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6085: (in fn00002C0C(*(a7_2334 - 1<i32>), a7_2334->t0000) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_6086: (in a7_1512 : (ptr32 Eq_25))
+T_6086: (in a7_1512 : (ptr32 Eq_73))
   Class: Eq_6086
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_6087: (in 4<i32> : int32)
   Class: Eq_6087
@@ -27354,7 +26892,7 @@ T_6087: (in 4<i32> : int32)
   OrigDataType: int32
 T_6088: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6086
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_6089: (in 0<32> : word32)
   Class: Eq_6089
@@ -27365,8 +26903,8 @@ T_6090: (in a7_1512 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6091: (in Mem1514[a7_1512 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6092: (in d1_5328 : word32)
   Class: Eq_6092
@@ -27389,12 +26927,12 @@ T_6096: (in a7_1512 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6097: (in Mem1514[a7_1512 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6098: (in out d1_5328 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: ptr32
 T_6099: (in out a1 : ptr32)
   Class: Eq_4733
@@ -27405,8 +26943,8 @@ T_6100: (in out a5_5329 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_6101: (in fn00003CE0(*a7_1512, out d1_5328, out a1, out a5_5329) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6102: (in 4<i32> : int32)
   Class: Eq_6102
@@ -27414,7 +26952,7 @@ T_6102: (in 4<i32> : int32)
   OrigDataType: int32
 T_6103: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_6104: (in a0_1530 : (ptr32 byte))
   Class: Eq_4744
@@ -27432,9 +26970,9 @@ T_6107: (in Mem1507[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
-T_6108: (in a7_1531 : (ptr32 Eq_25))
+T_6108: (in a7_1531 : (ptr32 Eq_73))
   Class: Eq_6108
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_6109: (in 4<i32> : int32)
   Class: Eq_6109
@@ -27442,7 +26980,7 @@ T_6109: (in 4<i32> : int32)
   OrigDataType: int32
 T_6110: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6108
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_6111: (in 0<32> : word32)
   Class: Eq_6111
@@ -27453,8 +26991,8 @@ T_6112: (in a7_1531 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6113: (in Mem1533[a7_1531 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6114: (in 1<i32> : int32)
   Class: Eq_6114
@@ -27474,8 +27012,8 @@ T_6117: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_6118: (in Mem1537[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_6119: (in v314_1541 : byte)
   Class: Eq_4759
   DataType: byte
@@ -27501,24 +27039,24 @@ T_6124: (in a7_1531 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6125: (in Mem1537[a7_1531 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6126: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_6126
   DataType: word24
   OrigDataType: word24
 T_6127: (in SEQ(SLICE(d0, word24, 8), v314_1541) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6128: (in (uint8) v314_1541 : uint8)
   Class: Eq_6128
   DataType: uint8
   OrigDataType: uint8
 T_6129: (in (uint32) (uint8) v314_1541 : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_6130: (in 1<32> : word32)
   Class: Eq_6130
@@ -27537,8 +27075,8 @@ T_6133: (in d4_1466 + 1<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_6134: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_6135: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6135
@@ -27554,7 +27092,7 @@ T_6137: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_6138: (in Mem1577[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_6022
-  DataType: Eq_4367
+  DataType: byte
   OrigDataType: byte
 T_6139: (in d6_1133 - d3_1462 : word32)
   Class: Eq_6139
@@ -27592,7 +27130,7 @@ T_6147: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6146
   DataType: word32
   OrigDataType: word32
-T_6148: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_6148: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6148
   DataType: bool
   OrigDataType: bool
@@ -27628,13 +27166,13 @@ T_6156: (in 0<8> : byte)
   Class: Eq_6155
   DataType: byte
   OrigDataType: byte
-T_6157: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_6157: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_6157
   DataType: bool
   OrigDataType: bool
-T_6158: (in a7_1585 : (ptr32 Eq_25))
+T_6158: (in a7_1585 : (ptr32 Eq_73))
   Class: Eq_6158
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_6159: (in 4<i32> : int32)
   Class: Eq_6159
@@ -27642,7 +27180,7 @@ T_6159: (in 4<i32> : int32)
   OrigDataType: int32
 T_6160: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6158
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_6161: (in 0<32> : word32)
   Class: Eq_6161
@@ -27653,8 +27191,8 @@ T_6162: (in a7_1585 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6163: (in Mem1591[a7_1585 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6164: (in 4<i32> : int32)
   Class: Eq_6164
@@ -27662,7 +27200,7 @@ T_6164: (in 4<i32> : int32)
   OrigDataType: int32
 T_6165: (in a7_1585 - 4<i32> : word32)
   Class: Eq_6165
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6168 t0000)))
 T_6166: (in 0<32> : word32)
   Class: Eq_6166
@@ -27673,8 +27211,8 @@ T_6167: (in a7_1585 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6168: (in Mem1594[a7_1585 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6169: (in fn00002C0C : ptr32)
   Class: Eq_4919
@@ -27686,7 +27224,7 @@ T_6170: (in 1<i32> : int32)
   OrigDataType: int32
 T_6171: (in a7_1585 - 1<i32> : word32)
   Class: Eq_6171
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6174 t0000)))
 T_6172: (in 0<32> : word32)
   Class: Eq_6172
@@ -27697,8 +27235,8 @@ T_6173: (in a7_1585 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6174: (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_6175: (in 0<32> : word32)
   Class: Eq_6175
@@ -27709,12 +27247,12 @@ T_6176: (in a7_1585 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6177: (in Mem1594[a7_1585 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6178: (in fn00002C0C(*(a7_1585 - 1<i32>), *a7_1585) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6179: (in a7_2368 : (ptr32 Eq_6179))
   Class: Eq_6179
@@ -27737,8 +27275,8 @@ T_6183: (in a7_2368 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6184: (in Mem2373[a7_2368 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6185: (in 68<i32> : int32)
   Class: Eq_6185
@@ -27782,7 +27320,7 @@ T_6194: (in 1<i32> : int32)
   OrigDataType: int32
 T_6195: (in a7_2368 - 1<i32> : word32)
   Class: Eq_6195
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6198 t0000)))
 T_6196: (in 0<32> : word32)
   Class: Eq_6196
@@ -27793,8 +27331,8 @@ T_6197: (in a7_2368 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6198: (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_6199: (in 0<32> : word32)
   Class: Eq_6199
@@ -27805,12 +27343,12 @@ T_6200: (in a7_2368 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6201: (in Mem2377[a7_2368 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6202: (in fn00002C0C(*(a7_2368 - 1<i32>), a7_2368->t0000) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6203: (in 0<32> : word32)
   Class: Eq_4386
@@ -27846,7 +27384,7 @@ T_6210: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6211: (in Mem1625[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_6209
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
 T_6212: (in d0_2124 : uint32)
   Class: Eq_6212
@@ -27901,8 +27439,8 @@ T_6224: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6225: (in d0_2124 & 0x44<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6226: (in d0_2124 & 0x44<32> : word32)
   Class: Eq_6226
@@ -27945,8 +27483,8 @@ T_6235: (in (byte) d7 == 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_6236: (in 0x30<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_6237: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_6237
@@ -27964,9 +27502,9 @@ T_6240: (in d6_1133 - d3_1850 < 0<32> : bool)
   Class: Eq_6240
   DataType: bool
   OrigDataType: bool
-T_6241: (in d0_2450 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6241: (in d0_2450 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6242: (in a0_2430 : (ptr32 ui32))
   Class: Eq_6242
@@ -28089,8 +27627,8 @@ T_6271: (in a7_2443 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6272: (in Mem2445[a7_2443 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6273: (in a5_5330 : word32)
   Class: Eq_6273
@@ -28109,13 +27647,13 @@ T_6276: (in a7_2443 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6277: (in Mem2445[a7_2443 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6278: (in out d1 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4374))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_6279: (in out a1 : ptr32)
   Class: Eq_4733
   DataType: (ptr32 word32)
@@ -28125,8 +27663,8 @@ T_6280: (in out a5_5330 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_6281: (in fn00003CE0(a7_2443->t0000, out d1, out a1, out a5_5330) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6282: (in 56<i32> : int32)
   Class: Eq_6282
@@ -28137,8 +27675,8 @@ T_6283: (in a7_2443 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6284: (in Mem2458[a7_2443 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6285: (in 4<i32> : int32)
   Class: Eq_6285
@@ -28146,7 +27684,7 @@ T_6285: (in 4<i32> : int32)
   OrigDataType: int32
 T_6286: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_6287: (in a0_2462 : (ptr32 byte))
   Class: Eq_4744
@@ -28185,8 +27723,8 @@ T_6295: (in a7_2463 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6296: (in Mem2465[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6297: (in 1<i32> : int32)
   Class: Eq_6297
@@ -28206,8 +27744,8 @@ T_6300: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_6301: (in Mem2469[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_6302: (in v351_2473 : byte)
   Class: Eq_4759
   DataType: byte
@@ -28233,8 +27771,8 @@ T_6307: (in a7_2463 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6308: (in Mem2469[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6309: (in 0<32> : word32)
   Class: Eq_6309
@@ -28242,12 +27780,12 @@ T_6309: (in 0<32> : word32)
   OrigDataType: word32
 T_6310: (in a7_2463 + 0<32> : word32)
   Class: Eq_6310
-  DataType: (ptr32 Eq_6310)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_6311: (in Mem2492[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_6312: (in (uint8) v351_2473 : uint8)
   Class: Eq_6312
   DataType: uint8
@@ -28273,8 +27811,8 @@ T_6317: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_6318: (in SEQ(SLICE(d0, word24, 8), v351_2473) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6319: (in 0<32> : word32)
   Class: Eq_6319
@@ -28282,12 +27820,12 @@ T_6319: (in 0<32> : word32)
   OrigDataType: word32
 T_6320: (in a7_2463 + 0<32> : word32)
   Class: Eq_6320
-  DataType: (ptr32 Eq_6320)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_6321: (in Mem2498[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_6322: (in 52<i32> : int32)
   Class: Eq_6322
   DataType: int32
@@ -28326,12 +27864,12 @@ T_6330: (in 55<i32> : int32)
   OrigDataType: int32
 T_6331: (in a7_1330 + 55<i32> : word32)
   Class: Eq_6331
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_6332: (in Mem2506[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_6332
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_6333: (in SEQ(SLICE(d0_2450, word24, 8), Mem2506[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_6328
   DataType: ui32
@@ -28365,8 +27903,8 @@ T_6340: (in 0xFF<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6341: (in d0_2517 & 0xFF<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6342: (in __btst : ptr32)
   Class: Eq_5739
@@ -28405,8 +27943,8 @@ T_6350: (in __btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[(int3
   DataType: bool
   OrigDataType: bool
 T_6351: (in 0x78<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_6352: (in d0 != 0x78<32> : bool)
   Class: Eq_6352
@@ -28437,8 +27975,8 @@ T_6358: (in (byte) (d0_2517 & 0xFF<32>) | 0x20<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_6359: (in SEQ(SLICE(d0_2517 & 0xFF<32>, word24, 8), SLICE(d0_2517 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6360: (in 64<i32> : int32)
   Class: Eq_6360
@@ -28456,7 +27994,7 @@ T_6363: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6362
   DataType: word32
   OrigDataType: word32
-T_6364: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_6364: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6364
   DataType: bool
   OrigDataType: bool
@@ -28472,9 +28010,9 @@ T_6367: (in d6_1133 - d3_2508 < 0<32> : bool)
   Class: Eq_6367
   DataType: bool
   OrigDataType: bool
-T_6368: (in d0_2559 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6368: (in d0_2559 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6369: (in a0_2542 : (ptr32 ui32))
   Class: Eq_6369
@@ -28597,8 +28135,8 @@ T_6398: (in a7_2552 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6399: (in Mem2554[a7_2552 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6400: (in a5_5331 : word32)
   Class: Eq_6400
@@ -28617,13 +28155,13 @@ T_6403: (in a7_2552 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6404: (in Mem2554[a7_2552 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6405: (in out d1 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4374))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_6406: (in out a1 : ptr32)
   Class: Eq_4733
   DataType: (ptr32 word32)
@@ -28633,8 +28171,8 @@ T_6407: (in out a5_5331 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_6408: (in fn00003CE0(a7_2552->t0000, out d1, out a1, out a5_5331) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6409: (in 56<i32> : int32)
   Class: Eq_6409
@@ -28645,8 +28183,8 @@ T_6410: (in a7_2552 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6411: (in Mem2567[a7_2552 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6412: (in 4<i32> : int32)
   Class: Eq_6412
@@ -28654,7 +28192,7 @@ T_6412: (in 4<i32> : int32)
   OrigDataType: int32
 T_6413: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_6414: (in a0_2571 : (ptr32 byte))
   Class: Eq_4744
@@ -28693,8 +28231,8 @@ T_6422: (in a7_2572 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6423: (in Mem2574[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6424: (in 1<i32> : int32)
   Class: Eq_6424
@@ -28714,8 +28252,8 @@ T_6427: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_6428: (in Mem2578[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_6429: (in v372_2582 : byte)
   Class: Eq_4759
   DataType: byte
@@ -28741,8 +28279,8 @@ T_6434: (in a7_2572 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6435: (in Mem2578[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6436: (in 0<32> : word32)
   Class: Eq_6436
@@ -28750,12 +28288,12 @@ T_6436: (in 0<32> : word32)
   OrigDataType: word32
 T_6437: (in a7_2572 + 0<32> : word32)
   Class: Eq_6437
-  DataType: (ptr32 Eq_6437)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_6438: (in Mem2589[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_6439: (in (uint8) v372_2582 : uint8)
   Class: Eq_6439
   DataType: uint8
@@ -28781,8 +28319,8 @@ T_6444: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_6445: (in SEQ(SLICE(d0, word24, 8), v372_2582) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6446: (in 0<32> : word32)
   Class: Eq_6446
@@ -28790,12 +28328,12 @@ T_6446: (in 0<32> : word32)
   OrigDataType: word32
 T_6447: (in a7_2572 + 0<32> : word32)
   Class: Eq_6447
-  DataType: (ptr32 Eq_6447)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_6448: (in Mem2595[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_6449: (in 52<i32> : int32)
   Class: Eq_6449
   DataType: int32
@@ -28838,12 +28376,12 @@ T_6458: (in 55<i32> : int32)
   OrigDataType: int32
 T_6459: (in a7_1330 + 55<i32> : word32)
   Class: Eq_6459
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_6460: (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_6460
-  DataType: Eq_6460
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_6460 u2))
+  DataType: uint8
+  OrigDataType: uint8
 T_6461: (in SEQ(SLICE(d0_2559, word24, 8), Mem2603[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_6461
   DataType: ui32
@@ -28852,7 +28390,7 @@ T_6462: (in 0xFF<32> : word32)
   Class: Eq_6462
   DataType: ui32
   OrigDataType: ui32
-T_6463: (in SEQ(SLICE(d0_2559, word24, 8), *((word32) a7_1330 + 55<i32>)) & 0xFF<32> : word32)
+T_6463: (in SEQ(SLICE(d0_2559, word24, 8), a7_1330->b0037) & 0xFF<32> : word32)
   Class: Eq_6463
   DataType: int32
   OrigDataType: int32
@@ -28893,8 +28431,8 @@ T_6472: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6473: (in d0_2620 & 0x44<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6474: (in d0_2620 & 0x44<32> : word32)
   Class: Eq_6474
@@ -28922,7 +28460,7 @@ T_6479: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6480: (in Mem2726[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_6477
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
 T_6481: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6481
@@ -29025,9 +28563,9 @@ T_6505: (in a7_1330 + 132<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6506: (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4367
-  OrigDataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: word32
 T_6507: (in 52<i32> : int32)
   Class: Eq_6507
   DataType: int32
@@ -29038,8 +28576,8 @@ T_6508: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6509: (in Mem2796[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4374
-  DataType: Eq_4367
-  OrigDataType: Eq_4374
+  DataType: Eq_4374
+  OrigDataType: word32
 T_6510: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6510
   DataType: Eq_6510
@@ -29054,15 +28592,15 @@ T_6512: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6513: (in Mem2801[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6510
-  DataType: Eq_4367
-  OrigDataType: Eq_6510
+  DataType: Eq_6510
+  OrigDataType: word32
 T_6514: (in 0x44<32> : word32)
   Class: Eq_6514
   DataType: ui32
   OrigDataType: ui32
 T_6515: (in d0_2760 & 0x44<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6516: (in d0_2760 & 0x44<32> : word32)
   Class: Eq_6516
@@ -29113,8 +28651,8 @@ T_6527: (in a7_2667 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6528: (in Mem2671[a7_2667 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6529: (in 68<i32> : int32)
   Class: Eq_6529
@@ -29158,7 +28696,7 @@ T_6538: (in 1<i32> : int32)
   OrigDataType: int32
 T_6539: (in a7_2667 - 1<i32> : word32)
   Class: Eq_6539
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6542 t0000)))
 T_6540: (in 0<32> : word32)
   Class: Eq_6540
@@ -29169,8 +28707,8 @@ T_6541: (in a7_2667 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6542: (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_6543: (in 0<32> : word32)
   Class: Eq_6543
@@ -29181,12 +28719,12 @@ T_6544: (in a7_2667 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6545: (in Mem2675[a7_2667 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6546: (in fn00002C0C(*(a7_2667 - 1<i32>), a7_2667->t0000) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6547: (in 74<i32> : int32)
   Class: Eq_6547
@@ -29204,7 +28742,7 @@ T_6550: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6549
   DataType: word32
   OrigDataType: word32
-T_6551: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_6551: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_6551
   DataType: bool
   OrigDataType: bool
@@ -29233,8 +28771,8 @@ T_6557: (in a7_1330 + 74<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6558: (in Mem2603[a7_1330 + 74<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6559: (in v476_3238 : Eq_6559)
   Class: Eq_6559
@@ -29285,8 +28823,8 @@ T_6570: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6571: (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_6572: (in 110<i32> : int32)
   Class: Eq_6572
@@ -29304,7 +28842,7 @@ T_6575: (in 0<32> : word32)
   Class: Eq_6574
   DataType: word32
   OrigDataType: word32
-T_6576: (in *((word32) a7_1330 + 110<i32>) == 0<32> : bool)
+T_6576: (in a7_1330->dw006E == 0<32> : bool)
   Class: Eq_6576
   DataType: bool
   OrigDataType: bool
@@ -29324,7 +28862,7 @@ T_6580: (in 0xA<32> : word32)
   Class: Eq_6579
   DataType: word32
   OrigDataType: word32
-T_6581: (in *((word32) a7_1330 + 114<i32>) != 0xA<32> : bool)
+T_6581: (in a7_1330->dw0072 != 0xA<32> : bool)
   Class: Eq_6581
   DataType: bool
   OrigDataType: bool
@@ -29344,7 +28882,7 @@ T_6585: (in 8<32> : word32)
   Class: Eq_6584
   DataType: word32
   OrigDataType: word32
-T_6586: (in *((word32) a7_1330 + 114<i32>) != 8<32> : bool)
+T_6586: (in a7_1330->dw0072 != 8<32> : bool)
   Class: Eq_6586
   DataType: bool
   OrigDataType: bool
@@ -29405,9 +28943,9 @@ T_6600: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6601: (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4367
-  OrigDataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: word32
 T_6602: (in 52<i32> : int32)
   Class: Eq_6602
   DataType: int32
@@ -29418,8 +28956,8 @@ T_6603: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6604: (in Mem2823[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4374
-  DataType: Eq_4367
-  OrigDataType: Eq_4374
+  DataType: Eq_4374
+  OrigDataType: word32
 T_6605: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6605
   DataType: Eq_6605
@@ -29434,15 +28972,15 @@ T_6607: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6608: (in Mem2825[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6605
-  DataType: Eq_4367
-  OrigDataType: Eq_6605
+  DataType: Eq_6605
+  OrigDataType: word32
 T_6609: (in 4<32> : word32)
   Class: Eq_6609
   DataType: ui32
   OrigDataType: ui32
 T_6610: (in d0_2818 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6611: (in d0_2818 & 4<32> : word32)
   Class: Eq_6611
@@ -29465,9 +29003,9 @@ T_6615: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6616: (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4367
-  OrigDataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: word32
 T_6617: (in 52<i32> : int32)
   Class: Eq_6617
   DataType: int32
@@ -29478,8 +29016,8 @@ T_6618: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6619: (in Mem2854[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4374
-  DataType: Eq_4367
-  OrigDataType: Eq_4374
+  DataType: Eq_4374
+  OrigDataType: word32
 T_6620: (in 64<i32> : int32)
   Class: Eq_6620
   DataType: int32
@@ -29489,9 +29027,9 @@ T_6621: (in a7_1330 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6622: (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4367
-  OrigDataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: word32
 T_6623: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6623
   DataType: Eq_6623
@@ -29506,8 +29044,8 @@ T_6625: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6626: (in Mem2869[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6623
-  DataType: Eq_4367
-  OrigDataType: Eq_6623
+  DataType: Eq_6623
+  OrigDataType: word32
 T_6627: (in d6_1133 - d3_2423 : word32)
   Class: Eq_6627
   DataType: Eq_6627
@@ -29529,9 +29067,9 @@ T_6631: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6632: (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4367
-  OrigDataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: word32
 T_6633: (in 52<i32> : int32)
   Class: Eq_6633
   DataType: int32
@@ -29542,8 +29080,8 @@ T_6634: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6635: (in Mem2840[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4374
-  DataType: Eq_4367
-  OrigDataType: Eq_4374
+  DataType: Eq_4374
+  OrigDataType: word32
 T_6636: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6636
   DataType: Eq_6636
@@ -29558,11 +29096,11 @@ T_6638: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6639: (in Mem2843[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6636
-  DataType: Eq_4367
-  OrigDataType: Eq_6636
+  DataType: Eq_6636
+  OrigDataType: word32
 T_6640: (in 0x37<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_6641: (in d5_1044 > 0x37<32> : bool)
   Class: Eq_6641
@@ -29612,9 +29150,9 @@ T_6652: (in d6_3015 : Eq_6652)
   Class: Eq_6652
   DataType: Eq_6652
   OrigDataType: int32
-T_6653: (in v419_2893 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6653: (in v419_2893 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_6654: (in 4<i32> : int32)
   Class: Eq_6654
@@ -29622,7 +29160,7 @@ T_6654: (in 4<i32> : int32)
   OrigDataType: int32
 T_6655: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6655
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_6658 t0000)))
 T_6656: (in 0<32> : word32)
   Class: Eq_6656
@@ -29633,8 +29171,8 @@ T_6657: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6658: (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_6659: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6659
@@ -29698,8 +29236,8 @@ T_6673: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6674: (in Mem2980[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6667
-  DataType: Eq_4367
-  OrigDataType: Eq_6667
+  DataType: Eq_6667
+  OrigDataType: word32
 T_6675: (in 8<i32> : int32)
   Class: Eq_6675
   DataType: int32
@@ -29770,8 +29308,8 @@ T_6691: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_6692: (in Mem2992[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_6689
-  DataType: Eq_4367
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_6693: (in v441_2993 : word32)
   Class: Eq_6693
   DataType: word32
@@ -29966,8 +29504,8 @@ T_6740: (in a7_1330 + 68<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (ptr32 u1) (T_6670 u2)))
 T_6741: (in Mem3040[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_6734
-  DataType: Eq_4367
-  OrigDataType: Eq_6734
+  DataType: Eq_6734
+  OrigDataType: (union (int32 u0) (ptr32 u1) (T_6670 u2))
 T_6742: (in 8<i32> : int32)
   Class: Eq_6742
   DataType: int32
@@ -30024,7 +29562,7 @@ T_6755: (in d2_3037 < 0<32> : bool)
   Class: Eq_6755
   DataType: bool
   OrigDataType: bool
-T_6756: (in (word32) *((word32) a7_1330 + 44<i32>) + d0_3029 + (d2_3037 < 0<32>) : word32)
+T_6756: (in (word32) a7_1330[11<i32>] + d0_3029 + (d2_3037 < 0<32>) : word32)
   Class: Eq_6756
   DataType: int32
   OrigDataType: int32
@@ -30038,8 +29576,8 @@ T_6758: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6759: (in Mem3051[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_6756
-  DataType: Eq_4367
-  OrigDataType: int32
+  DataType: int32
+  OrigDataType: word32
 T_6760: (in v453_3052 : word32)
   Class: Eq_6760
   DataType: word32
@@ -30132,9 +29670,9 @@ T_6782: (in d5_1044 - 0x57<32> : word32)
   Class: Eq_6721
   DataType: Eq_6721
   OrigDataType: ptr32
-T_6783: (in d0_3135 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6783: (in d0_3135 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_6784: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6784
@@ -30214,8 +29752,8 @@ T_6802: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (ptr32 u1) (T_6737 u2)))
 T_6803: (in Mem3098[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6796
-  DataType: Eq_4367
-  OrigDataType: Eq_6796
+  DataType: Eq_6796
+  OrigDataType: (union (int32 u0) (ptr32 u1) (T_6737 u2))
 T_6804: (in 8<i32> : int32)
   Class: Eq_6804
   DataType: int32
@@ -30282,8 +29820,8 @@ T_6819: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_6820: (in Mem3108[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_6817
-  DataType: Eq_4367
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_6821: (in a0_3119 : (ptr32 ui32))
   Class: Eq_6821
   DataType: (ptr32 ui32)
@@ -30322,7 +29860,7 @@ T_6829: (in Mem3108[a7_1330 - 8<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_6830: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6830
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_6833 t0000)))
 T_6831: (in 0<32> : word32)
   Class: Eq_6831
@@ -30333,8 +29871,8 @@ T_6832: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6833: (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_6834: (in 0<32> : word32)
   Class: Eq_6834
@@ -30426,7 +29964,7 @@ T_6855: (in v468_3124 < 0<32> : bool)
   OrigDataType: bool
 T_6856: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6856
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6859 t0000)))
 T_6857: (in 0<32> : word32)
   Class: Eq_6857
@@ -30437,8 +29975,8 @@ T_6858: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6859: (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6860: (in d1_5332 : word32)
   Class: Eq_6860
@@ -30454,7 +29992,7 @@ T_6862: (in fn00003CE0 : ptr32)
   OrigDataType: (ptr32 (fn T_6870 (T_6866, T_6867, T_6868, T_6869)))
 T_6863: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6863
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6866 t0000)))
 T_6864: (in 0<32> : word32)
   Class: Eq_6864
@@ -30465,12 +30003,12 @@ T_6865: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6866: (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6867: (in out d1_5332 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: ptr32
 T_6868: (in out a1 : ptr32)
   Class: Eq_4733
@@ -30481,8 +30019,8 @@ T_6869: (in out a5_5333 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_6870: (in fn00003CE0(*(a7_1330 - 4<i32>), out d1_5332, out a1, out a5_5333) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6871: (in 4<i32> : int32)
   Class: Eq_6871
@@ -30490,7 +30028,7 @@ T_6871: (in 4<i32> : int32)
   OrigDataType: int32
 T_6872: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_6873: (in a0_3146 : (ptr32 byte))
   Class: Eq_4744
@@ -30510,7 +30048,7 @@ T_6876: (in Mem3125[a1 + 0<32>:word32] : word32)
   OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_6877: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6877
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6880 t0000)))
 T_6878: (in 0<32> : word32)
   Class: Eq_6878
@@ -30521,8 +30059,8 @@ T_6879: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6880: (in Mem3149[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6881: (in 1<i32> : int32)
   Class: Eq_6881
@@ -30542,8 +30080,8 @@ T_6884: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_6885: (in Mem3153[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_6886: (in 0<32> : word32)
   Class: Eq_6886
   DataType: word32
@@ -30561,12 +30099,12 @@ T_6889: (in (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_6890: (in (uint32) (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_6891: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6891
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6894 t0000)))
 T_6892: (in 0<32> : word32)
   Class: Eq_6892
@@ -30577,8 +30115,8 @@ T_6893: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6894: (in Mem3153[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6895: (in SLICE(d0_3135, byte, 0) : byte)
   Class: Eq_6895
@@ -30589,8 +30127,8 @@ T_6896: (in (uint8) SLICE(d0_3135, byte, 0) : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_6897: (in (uint32) (uint8) SLICE(d0_3135, byte, 0) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_6898: (in 52<i32> : int32)
   Class: Eq_6898
@@ -30622,7 +30160,7 @@ T_6904: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6905: (in Mem3172[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_6902
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
 T_6906: (in d0_3184 : uint32)
   Class: Eq_6906
@@ -30681,8 +30219,8 @@ T_6919: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6920: (in d0_3184 & 0x44<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6921: (in d0_3184 & 0x44<32> : word32)
   Class: Eq_6921
@@ -30697,8 +30235,8 @@ T_6923: (in (d0_3184 & 0x44<32>) == 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_6924: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_6925: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6925
@@ -30713,8 +30251,8 @@ T_6927: (in d3_2423 != 2<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_6928: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_6929: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6929
@@ -30745,12 +30283,12 @@ T_6935: (in a7_1330 + 110<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6936: (in Mem3291[a7_1330 + 110<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_6937: (in a7_3259 : (ptr32 Eq_25))
+T_6937: (in a7_3259 : (ptr32 Eq_73))
   Class: Eq_6937
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_6938: (in 4<i32> : int32)
   Class: Eq_6938
@@ -30758,7 +30296,7 @@ T_6938: (in 4<i32> : int32)
   OrigDataType: int32
 T_6939: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6937
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_6940: (in 0<32> : word32)
   Class: Eq_6940
@@ -30769,8 +30307,8 @@ T_6941: (in a7_3259 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6942: (in Mem3272[a7_3259 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6943: (in 4<i32> : int32)
   Class: Eq_6943
@@ -30778,7 +30316,7 @@ T_6943: (in 4<i32> : int32)
   OrigDataType: int32
 T_6944: (in a7_3259 - 4<i32> : word32)
   Class: Eq_6944
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6947 t0000)))
 T_6945: (in 0<32> : word32)
   Class: Eq_6945
@@ -30789,8 +30327,8 @@ T_6946: (in a7_3259 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6947: (in Mem3275[a7_3259 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6948: (in fn00002C0C : ptr32)
   Class: Eq_4919
@@ -30802,7 +30340,7 @@ T_6949: (in 1<i32> : int32)
   OrigDataType: int32
 T_6950: (in a7_3259 - 1<i32> : word32)
   Class: Eq_6950
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6953 t0000)))
 T_6951: (in 0<32> : word32)
   Class: Eq_6951
@@ -30813,8 +30351,8 @@ T_6952: (in a7_3259 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6953: (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_6954: (in 0<32> : word32)
   Class: Eq_6954
@@ -30825,12 +30363,12 @@ T_6955: (in a7_3259 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6956: (in Mem3275[a7_3259 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6957: (in fn00002C0C(*(a7_3259 - 1<i32>), *a7_3259) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6958: (in a7_2635 : (ptr32 Eq_6958))
   Class: Eq_6958
@@ -30853,8 +30391,8 @@ T_6962: (in a7_2635 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6963: (in Mem2639[a7_2635 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6964: (in 78<i32> : int32)
   Class: Eq_6964
@@ -30898,7 +30436,7 @@ T_6973: (in 1<i32> : int32)
   OrigDataType: int32
 T_6974: (in a7_2635 - 1<i32> : word32)
   Class: Eq_6974
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6977 t0000)))
 T_6975: (in 0<32> : word32)
   Class: Eq_6975
@@ -30909,8 +30447,8 @@ T_6976: (in a7_2635 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6977: (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_6978: (in 0<32> : word32)
   Class: Eq_6978
@@ -30921,12 +30459,12 @@ T_6979: (in a7_2635 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6980: (in Mem2643[a7_2635 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6981: (in fn00002C0C(*(a7_2635 - 1<i32>), a7_2635->t0000) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6982: (in 0xA<32> : word32)
   Class: Eq_4524
@@ -30997,8 +30535,8 @@ T_6998: (in 4<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6999: (in d0_3206 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_7000: (in d0_3206 & 4<32> : word32)
   Class: Eq_7000
@@ -31029,8 +30567,8 @@ T_7006: (in a4_2881 - (v465_3109 + 1<32>) >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_7007: (in 0x37<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_7008: (in d1 > 0x37<32> : bool)
   Class: Eq_7008
@@ -31053,8 +30591,8 @@ T_7012: (in a7_2886 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7013: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_7014: (in 0<32> : word32)
   Class: Eq_7014
@@ -31065,16 +30603,16 @@ T_7015: (in a7_2886 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7016: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_7017: (in 31<i32> : int32)
   Class: Eq_7017
   DataType: int32
   OrigDataType: int32
 T_7018: (in d7 >> 31<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_7019: (in 0<32> : word32)
   Class: Eq_7019
@@ -31085,8 +30623,8 @@ T_7020: (in a7_2886 + 0<32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_7021: (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: int32
 T_7022: (in 4<i32> : int32)
   Class: Eq_7022
@@ -31114,7 +30652,7 @@ T_7027: (in 8<i32> : int32)
   OrigDataType: int32
 T_7028: (in a7_2886 - 8<i32> : word32)
   Class: Eq_7028
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 (ptr32 Eq_25))
   OrigDataType: (ptr32 (struct (0 T_7031 t0000)))
 T_7029: (in 0<32> : word32)
   Class: Eq_7029
@@ -31126,7 +30664,7 @@ T_7030: (in a7_2886 - 8<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_7031: (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_7032: (in 52<i32> : int32)
   Class: Eq_7032
@@ -31252,21 +30790,21 @@ T_7062: (in d4 : Eq_4374)
   Class: Eq_4374
   DataType: Eq_4374
   OrigDataType: word32
-T_7063: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7063: (in dwArg04 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_7064: (in dwArg08 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7064: (in dwArg08 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_7065: (in dwArg0C : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7065: (in dwArg0C : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
-T_7066: (in dwArg10 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7066: (in dwArg10 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_7067: (in d1Out : ptr32)
   Class: Eq_7067
@@ -31274,7 +30812,7 @@ T_7067: (in d1Out : ptr32)
   OrigDataType: ptr32
 T_7068: (in a7_2886 - 24<i32> : word32)
   Class: Eq_7068
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_7071 t0000)))
 T_7069: (in 0<32> : word32)
   Class: Eq_7069
@@ -31285,8 +30823,8 @@ T_7070: (in a7_2886 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7071: (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_7072: (in 20<i32> : int32)
   Class: Eq_7072
@@ -31294,7 +30832,7 @@ T_7072: (in 20<i32> : int32)
   OrigDataType: int32
 T_7073: (in a7_2886 - 20<i32> : word32)
   Class: Eq_7073
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_7076 t0000)))
 T_7074: (in 0<32> : word32)
   Class: Eq_7074
@@ -31305,8 +30843,8 @@ T_7075: (in a7_2886 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7076: (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_7077: (in 16<i32> : int32)
   Class: Eq_7077
@@ -31314,7 +30852,7 @@ T_7077: (in 16<i32> : int32)
   OrigDataType: int32
 T_7078: (in a7_2886 - 16<i32> : word32)
   Class: Eq_7078
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_7081 t0000)))
 T_7079: (in 0<32> : word32)
   Class: Eq_7079
@@ -31325,8 +30863,8 @@ T_7080: (in a7_2886 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7081: (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_7082: (in 12<i32> : int32)
   Class: Eq_7082
@@ -31334,7 +30872,7 @@ T_7082: (in 12<i32> : int32)
   OrigDataType: int32
 T_7083: (in a7_2886 - 12<i32> : word32)
   Class: Eq_7083
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_645)
   OrigDataType: (ptr32 (struct (0 T_7086 t0000)))
 T_7084: (in 0<32> : word32)
   Class: Eq_7084
@@ -31345,8 +30883,8 @@ T_7085: (in a7_2886 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7086: (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_7087: (in out d1_2921 : ptr32)
   Class: Eq_7067
@@ -31390,25 +30928,25 @@ T_7096: (in 1<32> : word32)
   OrigDataType: word32
 T_7097: (in a7_2886 + 1<32> : word32)
   Class: Eq_7097
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7098: (in Mem2934[a7_2886 + 1<32>:word24] : word24)
   Class: Eq_7098
-  DataType: Eq_7098
-  OrigDataType: (union (int24 u0) (int32 u1))
+  DataType: ui24
+  OrigDataType: ui24
 T_7099: (in SLICE(d5_1044, byte, 0) : byte)
   Class: Eq_7099
   DataType: uint8
   OrigDataType: uint8
 T_7100: (in SEQ(Mem2934[a7_2886 + 1<32>:word24], SLICE(d5_1044, byte, 0)) : uip32)
   Class: Eq_7100
-  DataType: int32
-  OrigDataType: int32
+  DataType: ui32
+  OrigDataType: ui32
 T_7101: (in 0xFF<32> : word32)
   Class: Eq_7101
   DataType: ui32
   OrigDataType: ui32
-T_7102: (in SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32> : word32)
+T_7102: (in SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32> : word32)
   Class: Eq_7102
   DataType: int32
   OrigDataType: int32
@@ -31432,7 +30970,7 @@ T_7107: (in 4<32> : word32)
   Class: Eq_7107
   DataType: ui32
   OrigDataType: ui32
-T_7108: (in (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32> : word32)
+T_7108: (in (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32> : word32)
   Class: Eq_7108
   DataType: ui32
   OrigDataType: ui32
@@ -31440,7 +30978,7 @@ T_7109: (in 0<32> : word32)
   Class: Eq_7108
   DataType: ui32
   OrigDataType: word32
-T_7110: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32>) == 0<32> : bool)
+T_7110: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32>) == 0<32> : bool)
   Class: Eq_7110
   DataType: bool
   OrigDataType: bool
@@ -31476,13 +31014,13 @@ T_7118: (in 0<8> : byte)
   Class: Eq_7117
   DataType: byte
   OrigDataType: byte
-T_7119: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7119: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7119
   DataType: bool
   OrigDataType: bool
-T_7120: (in a7_3299 : (ptr32 Eq_25))
+T_7120: (in a7_3299 : (ptr32 Eq_73))
   Class: Eq_7120
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_7121: (in 4<i32> : int32)
   Class: Eq_7121
@@ -31490,7 +31028,7 @@ T_7121: (in 4<i32> : int32)
   OrigDataType: int32
 T_7122: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7120
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_7123: (in 0<32> : word32)
   Class: Eq_7123
@@ -31501,8 +31039,8 @@ T_7124: (in a7_3299 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7125: (in Mem3303[a7_3299 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7126: (in 4<i32> : int32)
   Class: Eq_7126
@@ -31510,7 +31048,7 @@ T_7126: (in 4<i32> : int32)
   OrigDataType: int32
 T_7127: (in a7_3299 - 4<i32> : word32)
   Class: Eq_7127
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7130 t0000)))
 T_7128: (in 0<32> : word32)
   Class: Eq_7128
@@ -31521,8 +31059,8 @@ T_7129: (in a7_3299 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7130: (in Mem3306[a7_3299 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7131: (in fn00002C0C : ptr32)
   Class: Eq_4919
@@ -31534,7 +31072,7 @@ T_7132: (in 1<i32> : int32)
   OrigDataType: int32
 T_7133: (in a7_3299 - 1<i32> : word32)
   Class: Eq_7133
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7136 t0000)))
 T_7134: (in 0<32> : word32)
   Class: Eq_7134
@@ -31545,8 +31083,8 @@ T_7135: (in a7_3299 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7136: (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_7137: (in 0<32> : word32)
   Class: Eq_7137
@@ -31557,12 +31095,12 @@ T_7138: (in a7_3299 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7139: (in Mem3306[a7_3299 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7140: (in fn00002C0C(*(a7_3299 - 1<i32>), *a7_3299) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7141: (in 0xA<32> : word32)
   Class: Eq_7141
@@ -31578,7 +31116,7 @@ T_7143: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7144: (in Mem2714[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7141
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
 T_7145: (in 8<32> : word32)
   Class: Eq_7145
@@ -31594,7 +31132,7 @@ T_7147: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7148: (in Mem2717[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7145
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
 T_7149: (in 52<i32> : int32)
   Class: Eq_7149
@@ -31652,7 +31190,7 @@ T_7162: (in 0x2D<32> : word32)
   Class: Eq_7161
   DataType: word32
   OrigDataType: word32
-T_7163: (in *((word32) a7_1330 + 110<i32>) != 0x2D<32> : bool)
+T_7163: (in a7_1330->dw006E != 0x2D<32> : bool)
   Class: Eq_7163
   DataType: bool
   OrigDataType: bool
@@ -31677,8 +31215,8 @@ T_7168: (in a7_3474 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7169: (in Mem3476[a7_3474 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7170: (in 76<i32> : int32)
   Class: Eq_7170
@@ -31718,7 +31256,7 @@ T_7178: (in 4<i32> : int32)
   OrigDataType: int32
 T_7179: (in a7_3474 + 4<i32> : word32)
   Class: Eq_4367
-  DataType: Eq_4367
+  DataType: (ptr32 Eq_4367)
   OrigDataType: ptr32
 T_7180: (in 56<i32> : int32)
   Class: Eq_7180
@@ -31746,12 +31284,12 @@ T_7185: (in d0_3495 : word32)
   OrigDataType: uint32
 T_7186: (in 3<32> : word32)
   Class: Eq_7186
-  DataType: (ptr32 Eq_8414)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8390)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7187: (in d2_1090 + 3<32> : word32)
   Class: Eq_7187
-  DataType: (ptr32 Eq_8415)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8391)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7188: (in 2<32> : word32)
   Class: Eq_7188
   DataType: word32
@@ -31773,8 +31311,8 @@ T_7192: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7193: (in (d0_3495 << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_7194: (in a0_3501 : (ptr32 Eq_7194))
   Class: Eq_7194
@@ -31786,8 +31324,8 @@ T_7195: (in -4<i32> : int32)
   OrigDataType: int32
 T_7196: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7196
-  DataType: (ptr32 Eq_8416)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8392)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7197: (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7194
   DataType: (ptr32 Eq_7194)
@@ -31801,8 +31339,8 @@ T_7199: (in a7_3474 + 52<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7200: (in Mem3485[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7201: (in 4<i32> : int32)
   Class: Eq_7201
@@ -31813,8 +31351,8 @@ T_7202: (in a0_3501 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7203: (in Mem3503[a0_3501 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7204: (in 48<i32> : int32)
   Class: Eq_7204
@@ -31841,8 +31379,8 @@ T_7209: (in Mem3505[a0_3501 + 0<32>:word32] : word32)
   DataType: word32
   OrigDataType: word32
 T_7210: (in d0_3495 << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_7211: (in v517_3507 : byte)
   Class: Eq_7174
@@ -31890,12 +31428,12 @@ T_7221: (in v517_3507 == 0<8> : bool)
   OrigDataType: bool
 T_7222: (in 3<32> : word32)
   Class: Eq_7222
-  DataType: (ptr32 Eq_8417)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8393)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7223: (in d2_1090 + 3<32> : word32)
   Class: Eq_7223
-  DataType: (ptr32 Eq_8418)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8394)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7224: (in 2<32> : word32)
   Class: Eq_7224
   DataType: word32
@@ -31917,8 +31455,8 @@ T_7228: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7229: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_7230: (in 52<i32> : int32)
   Class: Eq_7230
@@ -31929,12 +31467,12 @@ T_7231: (in a7_3474 + 52<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7232: (in Mem3508[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7233: (in SLICE(d0, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_7234: (in -4<i32> : int32)
   Class: Eq_7234
@@ -31942,11 +31480,11 @@ T_7234: (in -4<i32> : int32)
   OrigDataType: int32
 T_7235: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7235
-  DataType: (ptr32 Eq_8419)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8395)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7236: (in Mem3508[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7236
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7239 t0000)))
 T_7237: (in 0<32> : word32)
   Class: Eq_7237
@@ -31957,9 +31495,9 @@ T_7238: (in Mem3508[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7239: (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: byte
+  Class: Eq_73
+  DataType: Eq_645
+  OrigDataType: Eq_73
 T_7240: (in v518_3524 : byte)
   Class: Eq_7174
   DataType: byte
@@ -32006,12 +31544,12 @@ T_7250: (in v518_3524 == 0<8> : bool)
   OrigDataType: bool
 T_7251: (in 3<32> : word32)
   Class: Eq_7251
-  DataType: (ptr32 Eq_8420)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8396)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7252: (in d2_1090 + 3<32> : word32)
   Class: Eq_7252
-  DataType: (ptr32 Eq_8421)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8397)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7253: (in 2<32> : word32)
   Class: Eq_7253
   DataType: word32
@@ -32033,8 +31571,8 @@ T_7257: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7258: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_7259: (in 52<i32> : int32)
   Class: Eq_7259
@@ -32042,15 +31580,15 @@ T_7259: (in 52<i32> : int32)
   OrigDataType: int32
 T_7260: (in a7_3474 + 52<i32> : word32)
   Class: Eq_7260
-  DataType: (ptr32 Eq_7260)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_7261: (in Mem3525[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7262: (in SLICE(d0, word16, 0) : word16)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word16
 T_7263: (in -4<i32> : int32)
   Class: Eq_7263
@@ -32058,11 +31596,11 @@ T_7263: (in -4<i32> : int32)
   OrigDataType: int32
 T_7264: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7264
-  DataType: (ptr32 Eq_8423)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8398)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7265: (in Mem3525[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7265
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7268 t0000)))
 T_7266: (in 0<32> : word32)
   Class: Eq_7266
@@ -32073,9 +31611,9 @@ T_7267: (in Mem3525[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7268: (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word16
+  Class: Eq_73
+  DataType: Eq_645
+  OrigDataType: Eq_73
 T_7269: (in v519_3541 : byte)
   Class: Eq_7174
   DataType: byte
@@ -32122,12 +31660,12 @@ T_7279: (in v519_3541 == 0<8> : bool)
   OrigDataType: bool
 T_7280: (in 3<32> : word32)
   Class: Eq_7280
-  DataType: (ptr32 Eq_8424)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8399)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7281: (in d2_1090 + 3<32> : word32)
   Class: Eq_7281
-  DataType: (ptr32 Eq_8425)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8400)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7282: (in 2<32> : word32)
   Class: Eq_7282
   DataType: word32
@@ -32149,8 +31687,8 @@ T_7286: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7287: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_7288: (in 52<i32> : int32)
   Class: Eq_7288
@@ -32158,23 +31696,23 @@ T_7288: (in 52<i32> : int32)
   OrigDataType: int32
 T_7289: (in a7_3474 + 52<i32> : word32)
   Class: Eq_7289
-  DataType: (ptr32 Eq_7289)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_7290: (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7291: (in -4<i32> : int32)
   Class: Eq_7291
   DataType: int32
   OrigDataType: int32
 T_7292: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7292
-  DataType: (ptr32 Eq_8427)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8401)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7293: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7293
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7296 t0000)))
 T_7294: (in 0<32> : word32)
   Class: Eq_7294
@@ -32185,17 +31723,17 @@ T_7295: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7296: (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_645
+  OrigDataType: Eq_73
 T_7297: (in 3<32> : word32)
   Class: Eq_7297
-  DataType: (ptr32 Eq_8428)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8402)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7298: (in d2_1090 + 3<32> : word32)
   Class: Eq_7298
-  DataType: (ptr32 Eq_8429)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8403)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7299: (in 2<32> : word32)
   Class: Eq_7299
   DataType: word32
@@ -32217,8 +31755,8 @@ T_7303: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7304: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_7305: (in 52<i32> : int32)
   Class: Eq_7305
@@ -32226,23 +31764,23 @@ T_7305: (in 52<i32> : int32)
   OrigDataType: int32
 T_7306: (in a7_3474 + 52<i32> : word32)
   Class: Eq_7306
-  DataType: (ptr32 Eq_7306)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_7307: (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7308: (in -4<i32> : int32)
   Class: Eq_7308
   DataType: int32
   OrigDataType: int32
 T_7309: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7309
-  DataType: (ptr32 Eq_8431)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8404)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7310: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7310
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7313 t0000)))
 T_7311: (in 0<32> : word32)
   Class: Eq_7311
@@ -32253,9 +31791,9 @@ T_7312: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7313: (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_645
+  OrigDataType: Eq_73
 T_7314: (in 60<i32> : int32)
   Class: Eq_7314
   DataType: int32
@@ -32282,7 +31820,7 @@ T_7319: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7320: (in Mem3574[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_7318
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
 T_7321: (in 48<i32> : int32)
   Class: Eq_7321
@@ -32302,12 +31840,12 @@ T_7324: (in 56<i32> : int32)
   OrigDataType: int32
 T_7325: (in a7_1330 + 56<i32> : word32)
   Class: Eq_7325
-  DataType: (ptr32 Eq_7325)
-  OrigDataType: (ptr32 (union (uint8 u0) (word32 u1) (T_6460 u2)))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7326: (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
   Class: Eq_7323
   DataType: Eq_7323
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_6460 u2))
+  OrigDataType: word32
 T_7327: (in 44<i32> : int32)
   Class: Eq_7327
   DataType: int32
@@ -32357,8 +31895,8 @@ T_7338: (in Mem3324[v528_3348 + 4<i32>:word32] : word32)
   DataType: word32
   OrigDataType: word32
 T_7339: (in -v528_3348->dw0004 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7340: (in 0<32> : word32)
   Class: Eq_7340
@@ -32377,16 +31915,16 @@ T_7343: (in -v528_3348->dw0000 : word32)
   DataType: int32
   OrigDataType: int32
 T_7344: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: up32
 T_7345: (in d1 < 0<32> : bool)
   Class: Eq_7345
   DataType: Eq_7345
   OrigDataType: (union (bool u0) (int32 u1))
 T_7346: (in -v528_3348->dw0000 - (d1 < 0<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_7347: (in 0x38<32> : word32)
   Class: Eq_7347
@@ -32394,44 +31932,44 @@ T_7347: (in 0x38<32> : word32)
   OrigDataType: word32
 T_7348: (in a7_1330 + 0x38<32> : word32)
   Class: Eq_7348
-  DataType: (ptr32 Eq_7348)
-  OrigDataType: (ptr32 (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3)))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7349: (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
   Class: Eq_4367
-  DataType: Eq_4367
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
-T_7350: (in a7_3364 : Eq_7350)
+  DataType: (ptr32 Eq_4367)
+  OrigDataType: word32
+T_7350: (in a7_3364 : (ptr32 Eq_7350))
   Class: Eq_7350
-  DataType: Eq_7350
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_7350)
+  OrigDataType: (ptr32 (struct (0 T_7355 t0000) (30 T_7360 t0030) (38 T_7411 t0038) (3C T_73 t003C) (4C T_7358 t004C)))
 T_7351: (in 4<i32> : int32)
   Class: Eq_7351
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7352: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7350
-  DataType: Eq_7350
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_7350)
+  OrigDataType: ptr32
 T_7353: (in 0<32> : word32)
   Class: Eq_7353
   DataType: word32
   OrigDataType: word32
 T_7354: (in a7_3364 + 0<32> : word32)
   Class: Eq_7354
-  DataType: Eq_7354
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7355: (in Mem3375[a7_3364 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7350
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7356: (in 76<i32> : int32)
   Class: Eq_7356
   DataType: int32
   OrigDataType: int32
 T_7357: (in a7_3364 + 76<i32> : word32)
   Class: Eq_7357
-  DataType: Eq_7357
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7358: (in Mem3375[a7_3364 + 76<i32>:byte] : byte)
   Class: Eq_7358
   DataType: byte
@@ -32440,7 +31978,7 @@ T_7359: (in 1<8> : byte)
   Class: Eq_7359
   DataType: byte
   OrigDataType: byte
-T_7360: (in *((word32) a7_3364 + 76<i32>) - 1<8> : byte)
+T_7360: (in a7_3364->b004C - 1<8> : byte)
   Class: Eq_7360
   DataType: byte
   OrigDataType: byte
@@ -32450,37 +31988,37 @@ T_7361: (in 48<i32> : int32)
   OrigDataType: int32
 T_7362: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7362
-  DataType: Eq_7362
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7363: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
   Class: Eq_7360
-  DataType: Eq_7350
+  DataType: byte
   OrigDataType: byte
 T_7364: (in 4<i32> : int32)
   Class: Eq_7364
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7365: (in a7_3364 + 4<i32> : word32)
   Class: Eq_4367
-  DataType: Eq_4367
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_4367)
+  OrigDataType: ptr32
 T_7366: (in 48<i32> : int32)
   Class: Eq_7366
   DataType: int32
   OrigDataType: int32
 T_7367: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7367
-  DataType: Eq_7367
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7368: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7368
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7369: (in 0<8> : byte)
-  Class: Eq_7368
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
-T_7370: (in *((word32) a7_3364 + 48<i32>) == 0<8> : bool)
+T_7370: (in a7_3364->b0030 == 0<8> : bool)
   Class: Eq_7370
   DataType: bool
   OrigDataType: bool
@@ -32494,35 +32032,35 @@ T_7372: (in 52<i32> : int32)
   OrigDataType: int32
 T_7373: (in a7_1330 + 52<i32> : word32)
   Class: Eq_7373
-  DataType: Eq_7373
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7374: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7371
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
-T_7375: (in v544_774 : byte)
+T_7375: (in v544_774 : Eq_7375)
   Class: Eq_7375
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7375
+  OrigDataType: (union (int32 u0) (byte u1))
 T_7376: (in 44<i32> : int32)
   Class: Eq_7376
   DataType: int32
   OrigDataType: int32
 T_7377: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7377
-  DataType: Eq_7377
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7378: (in Mem773[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7375
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7375
+  OrigDataType: int32
 T_7379: (in SEQ(v84_506, v544_774) : uip32)
   Class: Eq_4524
   DataType: int32
   OrigDataType: uip32
-T_7380: (in d1_1027 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7380: (in d1_1027 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7381: (in 52<i32> : int32)
   Class: Eq_7381
@@ -32530,11 +32068,11 @@ T_7381: (in 52<i32> : int32)
   OrigDataType: int32
 T_7382: (in a7_1330 + 52<i32> : word32)
   Class: Eq_7382
-  DataType: Eq_7382
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7383: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7384: (in 1<8> : byte)
   Class: Eq_7384
@@ -32546,12 +32084,12 @@ T_7385: (in 44<i32> : int32)
   OrigDataType: int32
 T_7386: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7386
-  DataType: Eq_7386
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7387: (in Mem769[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7384
-  DataType: Eq_4367
-  OrigDataType: byte
+  DataType: Eq_7384
+  OrigDataType: int32
 T_7388: (in 1<i32> : int32)
   Class: Eq_7388
   DataType: int32
@@ -32566,12 +32104,12 @@ T_7390: (in d0_3398 : word32)
   OrigDataType: uint32
 T_7391: (in 3<32> : word32)
   Class: Eq_7391
-  DataType: (ptr32 Eq_8438)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8405)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7392: (in d2_1090 + 3<32> : word32)
   Class: Eq_7392
-  DataType: (ptr32 Eq_8439)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8406)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7393: (in 2<32> : word32)
   Class: Eq_7393
   DataType: word32
@@ -32593,8 +32131,8 @@ T_7397: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7398: (in (d0_3398 << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_7399: (in a0_3404 : (ptr32 Eq_7399))
   Class: Eq_7399
@@ -32606,8 +32144,8 @@ T_7400: (in -4<i32> : int32)
   OrigDataType: int32
 T_7401: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7401
-  DataType: (ptr32 Eq_8440)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8407)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7402: (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7399
   DataType: (ptr32 Eq_7399)
@@ -32618,11 +32156,11 @@ T_7403: (in 60<i32> : int32)
   OrigDataType: int32
 T_7404: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7404
-  DataType: Eq_7404
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7405: (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_7405
-  DataType: word32
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7406: (in 4<i32> : int32)
   Class: Eq_7406
@@ -32633,8 +32171,8 @@ T_7407: (in a0_3404 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7408: (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
-  Class: Eq_7405
-  DataType: word32
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7409: (in 56<i32> : int32)
   Class: Eq_7409
@@ -32642,8 +32180,8 @@ T_7409: (in 56<i32> : int32)
   OrigDataType: int32
 T_7410: (in a7_3364 + 56<i32> : word32)
   Class: Eq_7410
-  DataType: Eq_7410
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7411: (in Mem3406[a7_3364 + 56<i32>:word32] : word32)
   Class: Eq_7411
   DataType: word32
@@ -32661,11 +32199,11 @@ T_7414: (in Mem3408[a0_3404 + 0<32>:word32] : word32)
   DataType: word32
   OrigDataType: word32
 T_7415: (in d0_3398 << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_7416: (in v540_3410 : byte)
-  Class: Eq_7416
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7417: (in 48<i32> : int32)
@@ -32674,18 +32212,18 @@ T_7417: (in 48<i32> : int32)
   OrigDataType: int32
 T_7418: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7418
-  DataType: Eq_7418
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7419: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7419
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7420: (in 1<8> : byte)
   Class: Eq_7420
   DataType: byte
   OrigDataType: byte
-T_7421: (in *((word32) a7_3364 + 48<i32>) - 1<8> : byte)
-  Class: Eq_7416
+T_7421: (in a7_3364->b0030 - 1<8> : byte)
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7422: (in 48<i32> : int32)
@@ -32694,14 +32232,14 @@ T_7422: (in 48<i32> : int32)
   OrigDataType: int32
 T_7423: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7423
-  DataType: Eq_7423
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7424: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7416
-  DataType: Eq_7350
+  Class: Eq_7360
+  DataType: byte
   OrigDataType: byte
 T_7425: (in 0<8> : byte)
-  Class: Eq_7416
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7426: (in v540_3410 == 0<8> : bool)
@@ -32710,12 +32248,12 @@ T_7426: (in v540_3410 == 0<8> : bool)
   OrigDataType: bool
 T_7427: (in 3<32> : word32)
   Class: Eq_7427
-  DataType: (ptr32 Eq_8441)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8408)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7428: (in d2_1090 + 3<32> : word32)
   Class: Eq_7428
-  DataType: (ptr32 Eq_8442)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8409)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7429: (in 2<32> : word32)
   Class: Eq_7429
   DataType: word32
@@ -32737,8 +32275,8 @@ T_7433: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7434: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_7435: (in 60<i32> : int32)
   Class: Eq_7435
@@ -32746,15 +32284,15 @@ T_7435: (in 60<i32> : int32)
   OrigDataType: int32
 T_7436: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7436
-  DataType: Eq_7436
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7437: (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7438: (in SLICE(d0, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_7439: (in -4<i32> : int32)
   Class: Eq_7439
@@ -32762,11 +32300,11 @@ T_7439: (in -4<i32> : int32)
   OrigDataType: int32
 T_7440: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7440
-  DataType: (ptr32 Eq_8443)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8410)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7441: (in Mem3411[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7441
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7444 t0000)))
 T_7442: (in 0<32> : word32)
   Class: Eq_7442
@@ -32777,11 +32315,11 @@ T_7443: (in Mem3411[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7444: (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: byte
+  Class: Eq_73
+  DataType: Eq_645
+  OrigDataType: Eq_73
 T_7445: (in v541_3427 : byte)
-  Class: Eq_7445
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7446: (in 48<i32> : int32)
@@ -32790,18 +32328,18 @@ T_7446: (in 48<i32> : int32)
   OrigDataType: int32
 T_7447: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7447
-  DataType: Eq_7447
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7448: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7448
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7449: (in 0x66<8> : byte)
   Class: Eq_7449
   DataType: byte
   OrigDataType: byte
-T_7450: (in *((word32) a7_3364 + 48<i32>) - 0x66<8> : byte)
-  Class: Eq_7445
+T_7450: (in a7_3364->b0030 - 0x66<8> : byte)
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7451: (in 48<i32> : int32)
@@ -32810,14 +32348,14 @@ T_7451: (in 48<i32> : int32)
   OrigDataType: int32
 T_7452: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7452
-  DataType: Eq_7452
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7453: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7445
-  DataType: Eq_7350
+  Class: Eq_7360
+  DataType: byte
   OrigDataType: byte
 T_7454: (in 0<8> : byte)
-  Class: Eq_7445
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7455: (in v541_3427 == 0<8> : bool)
@@ -32826,12 +32364,12 @@ T_7455: (in v541_3427 == 0<8> : bool)
   OrigDataType: bool
 T_7456: (in 3<32> : word32)
   Class: Eq_7456
-  DataType: (ptr32 Eq_8444)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8411)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7457: (in d2_1090 + 3<32> : word32)
   Class: Eq_7457
-  DataType: (ptr32 Eq_8445)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8412)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7458: (in 2<32> : word32)
   Class: Eq_7458
   DataType: word32
@@ -32853,8 +32391,8 @@ T_7462: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7463: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_7464: (in 60<i32> : int32)
   Class: Eq_7464
@@ -32862,15 +32400,15 @@ T_7464: (in 60<i32> : int32)
   OrigDataType: int32
 T_7465: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7465
-  DataType: Eq_7465
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_7466: (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7467: (in SLICE(d0, word16, 0) : word16)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word16
 T_7468: (in -4<i32> : int32)
   Class: Eq_7468
@@ -32878,11 +32416,11 @@ T_7468: (in -4<i32> : int32)
   OrigDataType: int32
 T_7469: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7469
-  DataType: (ptr32 Eq_8446)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8413)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7470: (in Mem3428[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7470
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7473 t0000)))
 T_7471: (in 0<32> : word32)
   Class: Eq_7471
@@ -32893,11 +32431,11 @@ T_7472: (in Mem3428[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7473: (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word16
+  Class: Eq_73
+  DataType: Eq_645
+  OrigDataType: Eq_73
 T_7474: (in v542_3444 : byte)
-  Class: Eq_7474
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7475: (in 48<i32> : int32)
@@ -32906,18 +32444,18 @@ T_7475: (in 48<i32> : int32)
   OrigDataType: int32
 T_7476: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7476
-  DataType: Eq_7476
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7477: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7477
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7478: (in 4<8> : byte)
   Class: Eq_7478
   DataType: byte
   OrigDataType: byte
-T_7479: (in *((word32) a7_3364 + 48<i32>) - 4<8> : byte)
-  Class: Eq_7474
+T_7479: (in a7_3364->b0030 - 4<8> : byte)
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7480: (in 48<i32> : int32)
@@ -32926,14 +32464,14 @@ T_7480: (in 48<i32> : int32)
   OrigDataType: int32
 T_7481: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7481
-  DataType: Eq_7481
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7482: (in Mem3445[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7474
-  DataType: Eq_7350
+  Class: Eq_7360
+  DataType: byte
   OrigDataType: byte
 T_7483: (in 0<8> : byte)
-  Class: Eq_7474
+  Class: Eq_7360
   DataType: byte
   OrigDataType: byte
 T_7484: (in v542_3444 == 0<8> : bool)
@@ -32942,12 +32480,12 @@ T_7484: (in v542_3444 == 0<8> : bool)
   OrigDataType: bool
 T_7485: (in 3<32> : word32)
   Class: Eq_7485
-  DataType: (ptr32 Eq_8447)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8414)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7486: (in d2_1090 + 3<32> : word32)
   Class: Eq_7486
-  DataType: (ptr32 Eq_8448)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8415)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7487: (in 2<32> : word32)
   Class: Eq_7487
   DataType: word32
@@ -32969,8 +32507,8 @@ T_7491: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7492: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_7493: (in 60<i32> : int32)
   Class: Eq_7493
@@ -32978,23 +32516,23 @@ T_7493: (in 60<i32> : int32)
   OrigDataType: int32
 T_7494: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7494
-  DataType: Eq_7494
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_7495: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7496: (in -4<i32> : int32)
   Class: Eq_7496
   DataType: int32
   OrigDataType: int32
 T_7497: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7497
-  DataType: (ptr32 Eq_8449)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8416)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7498: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7498
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7501 t0000)))
 T_7499: (in 0<32> : word32)
   Class: Eq_7499
@@ -33005,17 +32543,17 @@ T_7500: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7501: (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_645
+  OrigDataType: Eq_73
 T_7502: (in 3<32> : word32)
   Class: Eq_7502
-  DataType: (ptr32 Eq_8450)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8417)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7503: (in d2_1090 + 3<32> : word32)
   Class: Eq_7503
-  DataType: (ptr32 Eq_8451)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8418)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7504: (in 2<32> : word32)
   Class: Eq_7504
   DataType: word32
@@ -33037,8 +32575,8 @@ T_7508: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7509: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_7510: (in 60<i32> : int32)
   Class: Eq_7510
@@ -33046,23 +32584,23 @@ T_7510: (in 60<i32> : int32)
   OrigDataType: int32
 T_7511: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7511
-  DataType: Eq_7511
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_7512: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7513: (in -4<i32> : int32)
   Class: Eq_7513
   DataType: int32
   OrigDataType: int32
 T_7514: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7514
-  DataType: (ptr32 Eq_8452)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8419)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7515: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7515
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7518 t0000)))
 T_7516: (in 0<32> : word32)
   Class: Eq_7516
@@ -33073,9 +32611,9 @@ T_7517: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7518: (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_645
+  OrigDataType: Eq_73
 T_7519: (in 0<i32> : int32)
   Class: Eq_7519
   DataType: int32
@@ -33089,36 +32627,36 @@ T_7521: (in 0xFF<32> : word32)
   DataType: int32
   OrigDataType: word32
 T_7522: (in SLICE(d5_785, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7522
+  DataType: byte
   OrigDataType: byte
 T_7523: (in 78<i32> : int32)
   Class: Eq_7523
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7524: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7524
-  DataType: Eq_7524
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7525: (in a7_1330 + 78<i32> + d1_1027 : word32)
   Class: Eq_7525
-  DataType: Eq_7525
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7526 t0000)))
 T_7526: (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7522
+  DataType: byte
   OrigDataType: byte
 T_7527: (in 1<32> : word32)
   Class: Eq_7527
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: word32
+  OrigDataType: word32
 T_7528: (in d1_1027 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: int32
 T_7529: (in 0x20<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: up32
 T_7530: (in d1_1027 < 0x20<32> : bool)
   Class: Eq_7530
@@ -33138,40 +32676,40 @@ T_7533: (in 132<i32> : int32)
   OrigDataType: int32
 T_7534: (in a7_1330 + 132<i32> : word32)
   Class: Eq_7534
-  DataType: Eq_7534
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7535: (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4367
-  OrigDataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
+  OrigDataType: word32
 T_7536: (in 44<i32> : int32)
   Class: Eq_7536
   DataType: int32
   OrigDataType: int32
 T_7537: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7537
-  DataType: Eq_7537
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7538: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7375
-  DataType: Eq_4367
-  OrigDataType: byte
-T_7539: (in v554_824 : byte)
+  DataType: Eq_7375
+  OrigDataType: int32
+T_7539: (in v554_824 : Eq_7539)
   Class: Eq_7539
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7539
+  OrigDataType: (union (int32 u1) (byte u0))
 T_7540: (in 44<i32> : int32)
   Class: Eq_7540
   DataType: int32
   OrigDataType: int32
 T_7541: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7541
-  DataType: Eq_7541
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7542: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7539
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7539
+  OrigDataType: int32
 T_7543: (in a6_1164 : (ptr32 byte))
   Class: Eq_7543
   DataType: (ptr32 byte)
@@ -33182,11 +32720,11 @@ T_7544: (in 132<i32> : int32)
   OrigDataType: int32
 T_7545: (in a7_1330 + 132<i32> : word32)
   Class: Eq_7545
-  DataType: Eq_7545
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7546: (in Mem946[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_7547: (in 1<i32> : int32)
   Class: Eq_7547
@@ -33202,8 +32740,8 @@ T_7549: (in 73<i32> : int32)
   OrigDataType: int32
 T_7550: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7550
-  DataType: Eq_7550
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7551: (in Mem946[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7551
   DataType: byte
@@ -33212,7 +32750,7 @@ T_7552: (in 0<8> : byte)
   Class: Eq_7551
   DataType: byte
   OrigDataType: byte
-T_7553: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7553: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7553
   DataType: bool
   OrigDataType: bool
@@ -33245,8 +32783,8 @@ T_7560: (in SLICE(d1_1027, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_7561: (in SEQ(SLICE(d1_1027, word24, 8), v556_834) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_7562: (in 0<32> : word32)
   Class: Eq_7562
@@ -33328,17 +32866,17 @@ T_7581: (in SEQ(SLICE(d7, word24, 8), Mem829[a3_1955 + 1<i32>:byte]) : uip32)
   Class: Eq_4524
   DataType: int32
   OrigDataType: uip32
-T_7582: (in d5_862 : Eq_7582)
+T_7582: (in d5_862 : (ptr32 (ptr32 Eq_4374)))
   Class: Eq_7582
-  DataType: Eq_7582
-  OrigDataType: word32
+  DataType: (ptr32 (ptr32 Eq_4374))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7583: (in (uint8) v556_834 : uint8)
   Class: Eq_7583
   DataType: uint8
   OrigDataType: uint8
 T_7584: (in (uint32) (uint8) v556_834 : uint32)
   Class: Eq_7582
-  DataType: Eq_7582
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: uint32
 T_7585: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_7585
@@ -33349,18 +32887,18 @@ T_7586: (in (uint8) SLICE(d7, byte, 0) : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_7587: (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7588: (in d0 - d5_862 : word32)
   Class: Eq_7588
-  DataType: Eq_7588
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4374))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7589: (in 0<32> : word32)
   Class: Eq_7588
-  DataType: byte
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: up32
-T_7590: (in d0 - d5_862 < 0<32> : bool)
+T_7590: (in d0 - d5_862 < null : bool)
   Class: Eq_7590
   DataType: bool
   OrigDataType: bool
@@ -33392,18 +32930,18 @@ T_7597: (in v554_824 == 0<8> : bool)
   Class: Eq_7597
   DataType: bool
   OrigDataType: bool
-T_7598: (in a0_881 : Eq_7598)
+T_7598: (in a0_881 : word32)
   Class: Eq_7598
-  DataType: Eq_7598
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7606 t0000)))
 T_7599: (in 78<i32> : int32)
   Class: Eq_7599
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7600: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7600
-  DataType: Eq_7600
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7601: (in 3<32> : word32)
   Class: Eq_7601
   DataType: word32
@@ -33411,30 +32949,30 @@ T_7601: (in 3<32> : word32)
 T_7602: (in d5_862 >> 3<32> : word32)
   Class: Eq_7602
   DataType: Eq_7602
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_7603: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_7598
-  DataType: Eq_7598
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_7604: (in 0<32> : word32)
   Class: Eq_7604
   DataType: word32
   OrigDataType: word32
 T_7605: (in a0_881 + 0<32> : word32)
   Class: Eq_7605
-  DataType: Eq_7605
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7606: (in Mem889[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7606
+  DataType: byte
   OrigDataType: byte
 T_7607: (in (uint8) Mem889[a0_881 + 0<32>:byte] : uint8)
   Class: Eq_7607
   DataType: uint8
   OrigDataType: uint8
 T_7608: (in (uint32) (uint8) Mem889[a0_881 + 0<32>:byte] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7609: (in 1<i32> : int32)
   Class: Eq_7609
@@ -33457,8 +32995,8 @@ T_7613: (in 1<i32> << (d5_862 & 7<i32>) | d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7614: (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7606
+  DataType: byte
   OrigDataType: byte
 T_7615: (in 0<32> : word32)
   Class: Eq_7615
@@ -33466,24 +33004,24 @@ T_7615: (in 0<32> : word32)
   OrigDataType: word32
 T_7616: (in a0_881 + 0<32> : word32)
   Class: Eq_7616
-  DataType: Eq_7616
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7617: (in Mem895[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_7598
-  OrigDataType: Eq_25
-T_7618: (in a0_900 : Eq_7618)
+  Class: Eq_7606
+  DataType: byte
+  OrigDataType: byte
+T_7618: (in a0_900 : word32)
   Class: Eq_7618
-  DataType: Eq_7618
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7626 t0000)))
 T_7619: (in 78<i32> : int32)
   Class: Eq_7619
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7620: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7620
-  DataType: Eq_7620
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7621: (in 3<32> : word32)
   Class: Eq_7621
   DataType: word32
@@ -33491,30 +33029,30 @@ T_7621: (in 3<32> : word32)
 T_7622: (in d5_862 >> 3<32> : word32)
   Class: Eq_7622
   DataType: Eq_7622
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_7623: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_7618
-  DataType: Eq_7618
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_7624: (in 0<32> : word32)
   Class: Eq_7624
   DataType: word32
   OrigDataType: word32
 T_7625: (in a0_900 + 0<32> : word32)
   Class: Eq_7625
-  DataType: Eq_7625
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7626: (in Mem889[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7626
+  DataType: byte
   OrigDataType: byte
 T_7627: (in (uint8) Mem889[a0_900 + 0<32>:byte] : uint8)
   Class: Eq_7627
   DataType: uint8
   OrigDataType: uint8
 T_7628: (in (uint32) (uint8) Mem889[a0_900 + 0<32>:byte] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7629: (in 1<i32> : int32)
   Class: Eq_7629
@@ -33541,8 +33079,8 @@ T_7634: (in ~(1<i32> << (d5_862 & 7<i32>)) & d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7635: (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7626
+  DataType: byte
   OrigDataType: byte
 T_7636: (in 0<32> : word32)
   Class: Eq_7636
@@ -33550,20 +33088,20 @@ T_7636: (in 0<32> : word32)
   OrigDataType: word32
 T_7637: (in a0_900 + 0<32> : word32)
   Class: Eq_7637
-  DataType: Eq_7637
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7638: (in Mem914[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_7618
-  OrigDataType: Eq_25
+  Class: Eq_7626
+  DataType: byte
+  OrigDataType: byte
 T_7639: (in 1<32> : word32)
   Class: Eq_7639
-  DataType: byte
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4374))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7640: (in d5_862 + 1<32> : word32)
   Class: Eq_7582
-  DataType: Eq_7582
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4374))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7641: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_7641
   DataType: byte
@@ -33573,18 +33111,18 @@ T_7642: (in (uint8) SLICE(d7, byte, 0) : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_7643: (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7644: (in d0 - d5_862 : word32)
   Class: Eq_7644
-  DataType: Eq_7644
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4374))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7645: (in 0<32> : word32)
   Class: Eq_7644
-  DataType: byte
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: up32
-T_7646: (in d0 - d5_862 >= 0<32> : bool)
+T_7646: (in d0 - d5_862 >= null : bool)
   Class: Eq_7646
   DataType: bool
   OrigDataType: bool
@@ -33598,12 +33136,12 @@ T_7648: (in d0_957 : word32)
   OrigDataType: uint32
 T_7649: (in 3<32> : word32)
   Class: Eq_7649
-  DataType: (ptr32 Eq_8457)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8420)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7650: (in d2_1090 + 3<32> : word32)
   Class: Eq_7650
-  DataType: (ptr32 Eq_8458)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8421)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7651: (in 2<32> : word32)
   Class: Eq_7651
   DataType: word32
@@ -33625,12 +33163,12 @@ T_7655: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7656: (in (d0_957 << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: ui32
 T_7657: (in d0_957 << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_7658: (in -4<i32> : int32)
   Class: Eq_7658
@@ -33638,8 +33176,8 @@ T_7658: (in -4<i32> : int32)
   OrigDataType: int32
 T_7659: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7659
-  DataType: (ptr32 Eq_8459)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8422)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7660: (in Mem946[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7543
   DataType: (ptr32 byte)
@@ -33764,30 +33302,30 @@ T_7690: (in a3_1955->b0000 == 0<8> : bool)
   Class: Eq_7690
   DataType: bool
   OrigDataType: bool
-T_7691: (in a7_985 : Eq_7691)
+T_7691: (in a7_985 : (ptr32 Eq_7691))
   Class: Eq_7691
-  DataType: Eq_7691
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_7691)
+  OrigDataType: (ptr32 (struct (0 T_73 t0000) (30 T_7708 t0030)))
 T_7692: (in 4<i32> : int32)
   Class: Eq_7692
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7693: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7691
-  DataType: Eq_7691
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_7691)
+  OrigDataType: ptr32
 T_7694: (in 0<32> : word32)
   Class: Eq_7694
   DataType: word32
   OrigDataType: word32
 T_7695: (in a7_985 + 0<32> : word32)
   Class: Eq_7695
-  DataType: Eq_7695
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7696: (in Mem987[a7_985 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7691
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7697: (in a5_5334 : word32)
   Class: Eq_7697
   DataType: word32
@@ -33802,16 +33340,16 @@ T_7699: (in 0<32> : word32)
   OrigDataType: word32
 T_7700: (in a7_985 + 0<32> : word32)
   Class: Eq_7700
-  DataType: Eq_7700
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7701: (in Mem987[a7_985 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7702: (in out d1 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4374) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2963 t0014) (18 Eq_3427 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4374))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7703: (in out a1 : ptr32)
   Class: Eq_4733
   DataType: (ptr32 word32)
@@ -33820,9 +33358,9 @@ T_7704: (in out a5_5334 : ptr32)
   Class: Eq_4734
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_7705: (in fn00003CE0(*a7_985, out d1, out a1, out a5_5334) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+T_7705: (in fn00003CE0(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7706: (in 48<i32> : int32)
   Class: Eq_7706
@@ -33830,19 +33368,19 @@ T_7706: (in 48<i32> : int32)
   OrigDataType: int32
 T_7707: (in a7_985 + 48<i32> : word32)
   Class: Eq_7707
-  DataType: Eq_7707
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7708: (in Mem1000[a7_985 + 48<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7691
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7709: (in 4<i32> : int32)
   Class: Eq_7709
   DataType: int32
   OrigDataType: int32
 T_7710: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_7711: (in a0_1004 : (ptr32 byte))
   Class: Eq_4744
@@ -33860,30 +33398,30 @@ T_7714: (in Mem981[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
-T_7715: (in a7_1005 : Eq_7715)
+T_7715: (in a7_1005 : (ptr32 Eq_7715))
   Class: Eq_7715
-  DataType: Eq_7715
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_7715)
+  OrigDataType: (ptr32 (struct (0 T_73 t0000) (30 T_7740 t0030)))
 T_7716: (in 4<i32> : int32)
   Class: Eq_7716
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7717: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7715
-  DataType: Eq_7715
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_7715)
+  OrigDataType: ptr32
 T_7718: (in 0<32> : word32)
   Class: Eq_7718
   DataType: word32
   OrigDataType: word32
 T_7719: (in a7_1005 + 0<32> : word32)
   Class: Eq_7719
-  DataType: Eq_7719
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7720: (in Mem1007[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7715
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7721: (in 1<i32> : int32)
   Class: Eq_7721
   DataType: int32
@@ -33902,8 +33440,8 @@ T_7724: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_7725: (in Mem1011[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_7726: (in v585_1015 : byte)
   Class: Eq_4759
   DataType: byte
@@ -33926,11 +33464,11 @@ T_7730: (in 0<32> : word32)
   OrigDataType: word32
 T_7731: (in a7_1005 + 0<32> : word32)
   Class: Eq_7731
-  DataType: Eq_7731
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7732: (in Mem1011[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7733: (in 0<32> : word32)
   Class: Eq_7733
@@ -33938,12 +33476,12 @@ T_7733: (in 0<32> : word32)
   OrigDataType: word32
 T_7734: (in a7_1005 + 0<32> : word32)
   Class: Eq_7734
-  DataType: Eq_7734
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_7735: (in Mem1031[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7715
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7736: (in (uint8) v585_1015 : uint8)
   Class: Eq_7736
   DataType: uint8
@@ -33958,19 +33496,19 @@ T_7738: (in 48<i32> : int32)
   OrigDataType: int32
 T_7739: (in a7_1005 + 48<i32> : word32)
   Class: Eq_7739
-  DataType: Eq_7739
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7740: (in Mem1037[a7_1005 + 48<i32>:word32] : word32)
   Class: Eq_7737
-  DataType: Eq_7715
-  OrigDataType: uint32
+  DataType: uint32
+  OrigDataType: word32
 T_7741: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_7741
   DataType: word24
   OrigDataType: word24
 T_7742: (in SEQ(SLICE(d0, word24, 8), v585_1015) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_7743: (in 0<32> : word32)
   Class: Eq_7743
@@ -33978,24 +33516,24 @@ T_7743: (in 0<32> : word32)
   OrigDataType: word32
 T_7744: (in a7_1005 + 0<32> : word32)
   Class: Eq_7744
-  DataType: Eq_7744
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4374)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0)))
 T_7745: (in Mem1037[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4374)) u1) (ptr32 u0))
 T_7746: (in 44<i32> : int32)
   Class: Eq_7746
   DataType: int32
   OrigDataType: int32
 T_7747: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7747
-  DataType: Eq_7747
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7748: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: int32
 T_7749: (in d3_1057 : Eq_7749)
   Class: Eq_7749
   DataType: Eq_7749
@@ -34026,135 +33564,135 @@ T_7755: (in 44<i32> : int32)
   OrigDataType: int32
 T_7756: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7756
-  DataType: Eq_7756
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7757: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_7757
-  DataType: word32
-  OrigDataType: word32
+  DataType: int32
+  OrigDataType: int32
 T_7758: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_7757
-  DataType: word32
+  DataType: int32
   OrigDataType: word32
-T_7759: (in *((word32) a7_1330 + 44<i32>) == 0xFFFFFFFF<32> : bool)
+T_7759: (in a7_1330[11<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_7759
   DataType: bool
   OrigDataType: bool
 T_7760: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_7761: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_7761
   DataType: bool
   OrigDataType: bool
-T_7762: (in a7_1076 : Eq_7762)
+T_7762: (in a7_1076 : (ptr32 Eq_7762))
   Class: Eq_7762
-  DataType: Eq_7762
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_7762)
+  OrigDataType: (ptr32 (struct (0 T_7766 t0000) (4D T_7823 t004D)))
 T_7763: (in 4<i32> : int32)
   Class: Eq_7763
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7764: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7762
-  DataType: Eq_7762
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_7762)
+  OrigDataType: ptr32
 T_7765: (in 78<i32> : int32)
   Class: Eq_7765
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7766: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  Class: Eq_7766
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7767: (in 0<32> : word32)
   Class: Eq_7767
   DataType: word32
   OrigDataType: word32
 T_7768: (in a7_1076 + 0<32> : word32)
   Class: Eq_7768
-  DataType: Eq_7768
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7769: (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7762
+  Class: Eq_7766
+  DataType: ptr32
   OrigDataType: word32
 T_7770: (in 4<i32> : int32)
   Class: Eq_7770
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7771: (in a7_1076 - 4<i32> : word32)
   Class: Eq_7771
-  DataType: Eq_7771
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 (ptr32 Eq_25))
+  OrigDataType: (ptr32 (struct (0 T_7774 t0000)))
 T_7772: (in 0<32> : word32)
   Class: Eq_7772
   DataType: word32
   OrigDataType: word32
 T_7773: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_7773
-  DataType: Eq_7773
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7774: (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_7771
-  OrigDataType: Eq_25
+  DataType: (ptr32 Eq_25)
+  OrigDataType: word32
 T_7775: (in 00000008 : ptr32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_7775
+  DataType: ptr32
   OrigDataType: ptr32
 T_7776: (in 8<i32> : int32)
   Class: Eq_7776
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7777: (in a7_1076 - 8<i32> : word32)
   Class: Eq_7777
-  DataType: Eq_7777
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7780 t0000)))
 T_7778: (in 0<32> : word32)
   Class: Eq_7778
   DataType: word32
   OrigDataType: word32
 T_7779: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_7779
-  DataType: Eq_7779
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7780: (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7777
-  OrigDataType: uint8
+  Class: Eq_7775
+  DataType: ptr32
+  OrigDataType: word32
 T_7781: (in 12<i32> : int32)
   Class: Eq_7781
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7782: (in a7_1076 - 12<i32> : word32)
   Class: Eq_7782
-  DataType: Eq_7782
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_7785 t0000)))
 T_7783: (in 0<32> : word32)
   Class: Eq_7783
   DataType: word32
   OrigDataType: word32
 T_7784: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_7784
-  DataType: Eq_7784
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7785: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7782
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7786: (in 0<32> : word32)
   Class: Eq_7786
   DataType: word32
   OrigDataType: word32
 T_7787: (in a7_1076 + 0<32> : word32)
   Class: Eq_7787
-  DataType: Eq_7787
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7788: (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7766
+  DataType: ptr32
   OrigDataType: ptr32
 T_7789: (in fn000014EC : ptr32)
   Class: Eq_7789
@@ -34166,45 +33704,45 @@ T_7790: (in signature of fn000014EC : void)
   OrigDataType: 
 T_7791: (in a7_1076 - 12<i32> : word32)
   Class: Eq_7791
-  DataType: Eq_7791
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_645)
+  OrigDataType: (ptr32 (struct (0 T_7794 t0000)))
 T_7792: (in 0<32> : word32)
   Class: Eq_7792
   DataType: word32
   OrigDataType: word32
 T_7793: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_7793
-  DataType: Eq_7793
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7794: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_7795: (in 8<i32> : int32)
   Class: Eq_7795
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7796: (in a7_1076 - 8<i32> : word32)
   Class: Eq_7796
-  DataType: Eq_7796
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_645)
+  OrigDataType: (ptr32 (struct (0 T_7799 t0000)))
 T_7797: (in 0<32> : word32)
   Class: Eq_7797
   DataType: word32
   OrigDataType: word32
 T_7798: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_7798
-  DataType: Eq_7798
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7799: (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_7800: (in fn000014EC(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_7800
   DataType: int32
   OrigDataType: int32
-T_7801: (in Mem1087[a7_1076 + 0<32>:word32] + fn000014EC(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
+T_7801: (in a7_1076->ptr0000 + fn000014EC(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_7801
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7802 t0000)))
@@ -34217,28 +33755,28 @@ T_7803: (in (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn000014EC(d2_1090
   DataType: uint8
   OrigDataType: uint8
 T_7804: (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn000014EC(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)):byte] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7805: (in 4<i32> : int32)
   Class: Eq_7805
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7806: (in a7_1076 - 4<i32> : word32)
   Class: Eq_7806
-  DataType: Eq_7806
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 (ptr32 Eq_25))
+  OrigDataType: (ptr32 (struct (0 T_7809 t0000)))
 T_7807: (in 0<32> : word32)
   Class: Eq_7807
   DataType: word32
   OrigDataType: word32
 T_7808: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_7808
-  DataType: Eq_7808
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7809: (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_7810: (in 1<i32> : int32)
   Class: Eq_7810
@@ -34257,12 +33795,12 @@ T_7813: (in 1<i32> << (d5_1044 & 7<i32>) : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7814: (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_7815: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_7816: (in d0 == 0<32> : bool)
   Class: Eq_7816
@@ -34290,8 +33828,8 @@ T_7821: (in 77<i32> : int32)
   OrigDataType: int32
 T_7822: (in a7_1076 + 77<i32> : word32)
   Class: Eq_7822
-  DataType: Eq_7822
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7823: (in Mem1087[a7_1076 + 77<i32>:byte] : byte)
   Class: Eq_7820
   DataType: byte
@@ -34428,30 +33966,30 @@ T_7856: (in a6_1164 + 1<i32> : word32)
   Class: Eq_7543
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_7857: (in a7_1182 : Eq_7857)
+T_7857: (in a7_1182 : (ptr32 Eq_73))
   Class: Eq_7857
-  DataType: Eq_7857
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_7858: (in 4<i32> : int32)
   Class: Eq_7858
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7859: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7857
-  DataType: Eq_7857
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: ptr32
 T_7860: (in 0<32> : word32)
   Class: Eq_7860
   DataType: word32
   OrigDataType: word32
 T_7861: (in a7_1182 + 0<32> : word32)
   Class: Eq_7861
-  DataType: Eq_7861
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7862: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7857
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7863: (in d1_5335 : word32)
   Class: Eq_7863
   DataType: word32
@@ -34470,15 +34008,15 @@ T_7866: (in 0<32> : word32)
   OrigDataType: word32
 T_7867: (in a7_1182 + 0<32> : word32)
   Class: Eq_7867
-  DataType: Eq_7867
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7868: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7869: (in out d1_5335 : ptr32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: ptr32
 T_7870: (in out a1 : ptr32)
   Class: Eq_4733
@@ -34489,8 +34027,8 @@ T_7871: (in out a5_5336 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_7872: (in fn00003CE0(*a7_1182, out d1_5335, out a1, out a5_5336) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7873: (in 4<i32> : int32)
   Class: Eq_7873
@@ -34498,7 +34036,7 @@ T_7873: (in 4<i32> : int32)
   OrigDataType: int32
 T_7874: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_7875: (in a0_1200 : (ptr32 byte))
   Class: Eq_4744
@@ -34516,30 +34054,30 @@ T_7878: (in Mem1177[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
-T_7879: (in a7_1201 : Eq_7879)
+T_7879: (in a7_1201 : (ptr32 Eq_73))
   Class: Eq_7879
-  DataType: Eq_7879
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_7880: (in 4<i32> : int32)
   Class: Eq_7880
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7881: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7879
-  DataType: Eq_7879
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: ptr32
 T_7882: (in 0<32> : word32)
   Class: Eq_7882
   DataType: word32
   OrigDataType: word32
 T_7883: (in a7_1201 + 0<32> : word32)
   Class: Eq_7883
-  DataType: Eq_7883
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7884: (in Mem1203[a7_1201 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7879
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7885: (in 1<i32> : int32)
   Class: Eq_7885
   DataType: int32
@@ -34558,8 +34096,8 @@ T_7888: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4762 t0000))))
 T_7889: (in Mem1207[a1 + 0<32>:word32] : word32)
   Class: Eq_4744
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4762 t0000)))
 T_7890: (in v611_1211 : byte)
   Class: Eq_4759
   DataType: byte
@@ -34582,27 +34120,27 @@ T_7894: (in 0<32> : word32)
   OrigDataType: word32
 T_7895: (in a7_1201 + 0<32> : word32)
   Class: Eq_7895
-  DataType: Eq_7895
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7896: (in Mem1207[a7_1201 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7897: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_7897
   DataType: word24
   OrigDataType: word24
 T_7898: (in SEQ(SLICE(d0, word24, 8), v611_1211) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_7899: (in (uint8) v611_1211 : uint8)
   Class: Eq_7899
   DataType: uint8
   OrigDataType: uint8
 T_7900: (in (uint32) (uint8) v611_1211 : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7901: (in 1<32> : word32)
   Class: Eq_7901
@@ -34621,8 +34159,8 @@ T_7904: (in d4_1070 + 1<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_7905: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_7906: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_7906
@@ -34650,8 +34188,8 @@ T_7911: (in 73<i32> : int32)
   OrigDataType: int32
 T_7912: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7912
-  DataType: Eq_7912
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7913: (in Mem1331[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7913
   DataType: byte
@@ -34660,77 +34198,77 @@ T_7914: (in 0<8> : byte)
   Class: Eq_7913
   DataType: byte
   OrigDataType: byte
-T_7915: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7915: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7915
   DataType: bool
   OrigDataType: bool
-T_7916: (in a7_1302 : Eq_7916)
+T_7916: (in a7_1302 : (ptr32 Eq_73))
   Class: Eq_7916
-  DataType: Eq_7916
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_7917: (in 4<i32> : int32)
   Class: Eq_7917
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7918: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7916
-  DataType: Eq_7916
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: ptr32
 T_7919: (in 0<32> : word32)
   Class: Eq_7919
   DataType: word32
   OrigDataType: word32
 T_7920: (in a7_1302 + 0<32> : word32)
   Class: Eq_7920
-  DataType: Eq_7920
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7921: (in Mem1308[a7_1302 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7916
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7922: (in 4<i32> : int32)
   Class: Eq_7922
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7923: (in a7_1302 - 4<i32> : word32)
   Class: Eq_7923
-  DataType: Eq_7923
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_7926 t0000)))
 T_7924: (in 0<32> : word32)
   Class: Eq_7924
   DataType: word32
   OrigDataType: word32
 T_7925: (in a7_1302 - 4<i32> + 0<32> : word32)
   Class: Eq_7925
-  DataType: Eq_7925
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7926: (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7923
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7927: (in fn00002C0C : ptr32)
   Class: Eq_4919
   DataType: (ptr32 Eq_4919)
   OrigDataType: (ptr32 (fn T_7936 (T_7932, T_7935)))
 T_7928: (in 1<i32> : int32)
   Class: Eq_7928
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7929: (in a7_1302 - 1<i32> : word32)
   Class: Eq_7929
-  DataType: Eq_7929
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7932 t0000)))
 T_7930: (in 0<32> : word32)
   Class: Eq_7930
   DataType: word32
   OrigDataType: word32
 T_7931: (in a7_1302 - 1<i32> + 0<32> : word32)
   Class: Eq_7931
-  DataType: Eq_7931
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7932: (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4333
+  DataType: byte
   OrigDataType: byte
 T_7933: (in 0<32> : word32)
   Class: Eq_7933
@@ -34738,15 +34276,15 @@ T_7933: (in 0<32> : word32)
   OrigDataType: word32
 T_7934: (in a7_1302 + 0<32> : word32)
   Class: Eq_7934
-  DataType: Eq_7934
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7935: (in Mem1311[a7_1302 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7936: (in fn00002C0C(*(a7_1302 - 1<i32>), *a7_1302) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7937: (in 73<i32> : int32)
   Class: Eq_7937
@@ -34754,119 +34292,119 @@ T_7937: (in 73<i32> : int32)
   OrigDataType: int32
 T_7938: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7938
-  DataType: Eq_7938
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7939: (in Mem1294[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7820
-  DataType: Eq_4367
+  DataType: byte
   OrigDataType: byte
-T_7940: (in a7_1237 : Eq_7940)
+T_7940: (in a7_1237 : (ptr32 ptr32))
   Class: Eq_7940
-  DataType: Eq_7940
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7944 t0000)))
 T_7941: (in 4<i32> : int32)
   Class: Eq_7941
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7942: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7940
-  DataType: Eq_7940
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
 T_7943: (in 78<i32> : int32)
   Class: Eq_7943
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7944: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  Class: Eq_7944
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7945: (in 0<32> : word32)
   Class: Eq_7945
   DataType: word32
   OrigDataType: word32
 T_7946: (in a7_1237 + 0<32> : word32)
   Class: Eq_7946
-  DataType: Eq_7946
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7947: (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7940
+  Class: Eq_7944
+  DataType: ptr32
   OrigDataType: word32
 T_7948: (in 4<i32> : int32)
   Class: Eq_7948
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7949: (in a7_1237 - 4<i32> : word32)
   Class: Eq_7949
-  DataType: Eq_7949
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 (ptr32 Eq_25))
+  OrigDataType: (ptr32 (struct (0 T_7952 t0000)))
 T_7950: (in 0<32> : word32)
   Class: Eq_7950
   DataType: word32
   OrigDataType: word32
 T_7951: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_7951
-  DataType: Eq_7951
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7952: (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_7949
-  OrigDataType: Eq_25
+  DataType: (ptr32 Eq_25)
+  OrigDataType: word32
 T_7953: (in 00000008 : ptr32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_7953
+  DataType: ptr32
   OrigDataType: ptr32
 T_7954: (in 8<i32> : int32)
   Class: Eq_7954
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7955: (in a7_1237 - 8<i32> : word32)
   Class: Eq_7955
-  DataType: Eq_7955
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7958 t0000)))
 T_7956: (in 0<32> : word32)
   Class: Eq_7956
   DataType: word32
   OrigDataType: word32
 T_7957: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_7957
-  DataType: Eq_7957
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7958: (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7955
-  OrigDataType: uint8
+  Class: Eq_7953
+  DataType: ptr32
+  OrigDataType: word32
 T_7959: (in 12<i32> : int32)
   Class: Eq_7959
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7960: (in a7_1237 - 12<i32> : word32)
   Class: Eq_7960
-  DataType: Eq_7960
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_7963 t0000)))
 T_7961: (in 0<32> : word32)
   Class: Eq_7961
   DataType: word32
   OrigDataType: word32
 T_7962: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_7962
-  DataType: Eq_7962
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7963: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7960
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7964: (in 0<32> : word32)
   Class: Eq_7964
   DataType: word32
   OrigDataType: word32
 T_7965: (in a7_1237 + 0<32> : word32)
   Class: Eq_7965
-  DataType: Eq_7965
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7966: (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7944
+  DataType: ptr32
   OrigDataType: ptr32
 T_7967: (in fn000014EC : ptr32)
   Class: Eq_7789
@@ -34874,45 +34412,45 @@ T_7967: (in fn000014EC : ptr32)
   OrigDataType: (ptr32 (fn T_7977 (T_4371, T_7971, T_7976)))
 T_7968: (in a7_1237 - 12<i32> : word32)
   Class: Eq_7968
-  DataType: Eq_7968
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_645)
+  OrigDataType: (ptr32 (struct (0 T_7971 t0000)))
 T_7969: (in 0<32> : word32)
   Class: Eq_7969
   DataType: word32
   OrigDataType: word32
 T_7970: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_7970
-  DataType: Eq_7970
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7971: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_7972: (in 8<i32> : int32)
   Class: Eq_7972
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7973: (in a7_1237 - 8<i32> : word32)
   Class: Eq_7973
-  DataType: Eq_7973
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 Eq_645)
+  OrigDataType: (ptr32 (struct (0 T_7976 t0000)))
 T_7974: (in 0<32> : word32)
   Class: Eq_7974
   DataType: word32
   OrigDataType: word32
 T_7975: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_7975
-  DataType: Eq_7975
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7976: (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_7977: (in fn000014EC(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_7800
   DataType: int32
   OrigDataType: int32
-T_7978: (in Mem1248[a7_1237 + 0<32>:word32] + fn000014EC(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
+T_7978: (in *a7_1237 + fn000014EC(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_7978
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7979 t0000)))
@@ -34925,28 +34463,28 @@ T_7980: (in (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn000014EC(d2_1090
   DataType: uint8
   OrigDataType: uint8
 T_7981: (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn000014EC(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)):byte] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7982: (in 4<i32> : int32)
   Class: Eq_7982
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7983: (in a7_1237 - 4<i32> : word32)
   Class: Eq_7983
-  DataType: Eq_7983
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 (ptr32 Eq_25))
+  OrigDataType: (ptr32 (struct (0 T_7986 t0000)))
 T_7984: (in 0<32> : word32)
   Class: Eq_7984
   DataType: word32
   OrigDataType: word32
 T_7985: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_7985
-  DataType: Eq_7985
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7986: (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_7987: (in 1<i32> : int32)
   Class: Eq_7987
@@ -34965,12 +34503,12 @@ T_7990: (in 1<i32> << (d1 & 7<i32>) : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7991: (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_7992: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_7993: (in d0 == 0<32> : bool)
   Class: Eq_7993
@@ -35026,8 +34564,8 @@ T_8005: (in 60<i32> : int32)
   OrigDataType: int32
 T_8006: (in a7_1330 + 60<i32> : word32)
   Class: Eq_8006
-  DataType: Eq_8006
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8007: (in Mem1348[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_8007
   DataType: word32
@@ -35042,39 +34580,39 @@ T_8009: (in Mem1348[a7_1330 + 60<i32>:word32] + 1<32> : word32)
   OrigDataType: word32
 T_8010: (in a7_1330 + 60<i32> : word32)
   Class: Eq_8010
-  DataType: Eq_8010
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8437) u1) (T_6460 u2) (T_7326 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8011: (in Mem1351[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_8009
-  DataType: Eq_4367
+  DataType: word32
   OrigDataType: word32
 T_8012: (in d0 : uint32)
   Class: Eq_8012
   DataType: uint32
   OrigDataType: word32
-T_8013: (in d0_23 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_8013: (in d0_23 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_8014: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_8015 (T_7064)))
 T_8015: (in __swap(dwArg08) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
-T_8016: (in d1_25 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_8016: (in d1_25 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_8017: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_8018 (T_7066)))
 T_8018: (in __swap(dwArg10) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_8019: (in d4_29 : uint32)
   Class: Eq_8019
@@ -35112,9 +34650,9 @@ T_8027: (in d1_25 * (word16) d0_23 : word32)
   Class: Eq_8025
   DataType: uint32
   OrigDataType: uint32
-T_8028: (in d2_39 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_8028: (in d2_39 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_8029: (in SLICE(d1_25, word16, 0) : word16)
   Class: Eq_8029
@@ -35145,12 +34683,12 @@ T_8035: (in (word16) d4_29 ^ (word16) d4_29 : word16)
   DataType: ui16
   OrigDataType: ui16
 T_8036: (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_8037: (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_8038: (in dwArg08 *u SLICE(d1_25, word16, 0) + __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
   Class: Eq_8038
@@ -35165,28 +34703,28 @@ T_8040: (in dwArg10 * (word16) d0_23 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_8041: (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_8042: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_645
+  DataType: (ptr32 Eq_1583)
   OrigDataType: up32
 T_8043: (in d2_39 >= 0<32> : bool)
   Class: Eq_8043
   DataType: bool
   OrigDataType: bool
-T_8044: (in d2_45 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_8044: (in d2_45 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_8045: (in __swap : ptr32)
   Class: Eq_760
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_8046 (T_8028)))
 T_8046: (in __swap(d2_39) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_8047: (in d3_65 : uint32)
   Class: Eq_8047
@@ -35197,8 +34735,8 @@ T_8048: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_8049 (T_7065)))
 T_8049: (in __swap(dwArg0C) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_8050: (in SLICE(dwArg08, word16, 0) : word16)
   Class: Eq_8050
@@ -35208,9 +34746,9 @@ T_8051: (in __swap(dwArg0C) * (word16) dwArg08 : word32)
   Class: Eq_8047
   DataType: uint32
   OrigDataType: uint32
-T_8052: (in d3_71 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_8052: (in d3_71 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_8053: (in __swap : ptr32)
   Class: Eq_760
@@ -35225,8 +34763,8 @@ T_8055: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_8056 (T_7064)))
 T_8056: (in __swap(dwArg08) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_8057: (in SLICE(dwArg0C, word16, 0) : word16)
   Class: Eq_8057
@@ -35245,12 +34783,12 @@ T_8060: (in SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_8061: (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_8062: (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_8063: (in d3_83 : uint32)
   Class: Eq_8063
@@ -35261,8 +34799,8 @@ T_8064: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_8065 (T_7063)))
 T_8065: (in __swap(dwArg04) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_8066: (in SLICE(dwArg10, word16, 0) : word16)
   Class: Eq_8066
@@ -35272,9 +34810,9 @@ T_8067: (in __swap(dwArg04) * (word16) dwArg10 : word32)
   Class: Eq_8063
   DataType: uint32
   OrigDataType: uint32
-T_8068: (in d3_89 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_8068: (in d3_89 : Eq_645)
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_8069: (in __swap : ptr32)
   Class: Eq_760
@@ -35289,8 +34827,8 @@ T_8071: (in __swap : ptr32)
   DataType: (ptr32 Eq_760)
   OrigDataType: (ptr32 (fn T_8072 (T_7066)))
 T_8072: (in __swap(dwArg10) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uint32
 T_8073: (in SLICE(dwArg04, word16, 0) : word16)
   Class: Eq_8073
@@ -35309,12 +34847,12 @@ T_8076: (in SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_8077: (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: uipr32
 T_8078: (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_645
+  DataType: Eq_645
   OrigDataType: word32
 T_8079: (in SLICE(d2_45, word16, 16) : word16)
   Class: Eq_8079
@@ -35440,10 +34978,10 @@ T_8109: (in a1_116 : (ptr32 word32))
   Class: Eq_4733
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_8110: (in d1_118 : Eq_2909)
+T_8110: (in d1_118 : (ptr32 (ptr32 Eq_4374)))
   Class: Eq_2909
-  DataType: Eq_2909
-  OrigDataType: Eq_25
+  DataType: (ptr32 (ptr32 Eq_4374))
+  OrigDataType: word32
 T_8111: (in fn00002530 : ptr32)
   Class: Eq_2903
   DataType: (ptr32 Eq_2903)
@@ -35458,11 +34996,11 @@ T_8113: (in out a5_279 : ptr32)
   OrigDataType: ptr32
 T_8114: (in fn00002530(out a1_116, out a5_279) : word32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: word32
 T_8115: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_8116: (in dwArg04 != 0<32> : bool)
   Class: Eq_8116
@@ -35477,8 +35015,8 @@ T_8118: (in dwArg04 + 24<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_8119: (in Mem26[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3427
-  DataType: Eq_3427
+  Class: Eq_8119
+  DataType: ui32
   OrigDataType: ui32
 T_8120: (in 42<i32> : int32)
   Class: Eq_8120
@@ -35509,36 +35047,36 @@ T_8126: (in dwArg04 + 24<i32> : word32)
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8127: (in Mem26[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3427
-  DataType: Eq_3427
+  Class: Eq_8119
+  DataType: ui32
   OrigDataType: ui32
 T_8128: (in 1<i32> : int32)
   Class: Eq_8128
   DataType: int32
   OrigDataType: int32
 T_8129: (in *((word32) dwArg04 + 24<i32>) | 1<i32> : word32)
-  Class: Eq_3427
-  DataType: Eq_3427
+  Class: Eq_8119
+  DataType: ui32
   OrigDataType: ui32
 T_8130: (in dwArg04 + 24<i32> : word32)
   Class: Eq_8130
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8131: (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3427
-  DataType: Eq_25
-  OrigDataType: Eq_3427
-T_8132: (in d0_125 : (ptr32 Eq_2963))
+  Class: Eq_8119
+  DataType: Eq_73
+  OrigDataType: ui32
+T_8132: (in d0_125 : int32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: int32
 T_8133: (in dwArg04 + 24<i32> : word32)
   Class: Eq_8133
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8134: (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3427
-  DataType: Eq_3427
+  Class: Eq_8119
+  DataType: ui32
   OrigDataType: ui32
 T_8135: (in 0x200<32> : word32)
   Class: Eq_8135
@@ -35546,13 +35084,13 @@ T_8135: (in 0x200<32> : word32)
   OrigDataType: ui32
 T_8136: (in *((word32) dwArg04 + 24<i32>) & 0x200<32> : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: ui32
 T_8137: (in 0<32> : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
-T_8138: (in d0_125 == null : bool)
+T_8138: (in d0_125 == 0<32> : bool)
   Class: Eq_8138
   DataType: bool
   OrigDataType: bool
@@ -35569,11 +35107,11 @@ T_8141: (in dwArg04 + 28<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_8142: (in Mem49[dwArg04 + 28<i32>:word32] : word32)
-  Class: Eq_3455
+  Class: Eq_8142
   DataType: int32
   OrigDataType: word32
 T_8143: (in 0<32> : word32)
-  Class: Eq_3455
+  Class: Eq_8142
   DataType: int32
   OrigDataType: word32
 T_8144: (in *((word32) dwArg04 + 28<i32>) != 0<32> : bool)
@@ -35606,7 +35144,7 @@ T_8150: (in out a5_279 : ptr32)
   OrigDataType: ptr32
 T_8151: (in fn00003DDC(out a1_116, out a5_279) : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
 T_8152: (in 8<i32> : int32)
   Class: Eq_8152
@@ -35617,12 +35155,12 @@ T_8153: (in dwArg04 + 8<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_8154: (in Mem86[dwArg04 + 8<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8155: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_8156: (in *((word32) dwArg04 + 8<i32>) != 0<32> : bool)
   Class: Eq_8156
@@ -35637,8 +35175,8 @@ T_8158: (in dwArg04 + 24<i32> : word32)
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8159: (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3427
-  DataType: Eq_3427
+  Class: Eq_8119
+  DataType: ui32
   OrigDataType: ui32
 T_8160: (in 4<i32> : int32)
   Class: Eq_8160
@@ -35646,18 +35184,18 @@ T_8160: (in 4<i32> : int32)
   OrigDataType: int32
 T_8161: (in *((word32) dwArg04 + 24<i32>) & 4<i32> : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: ui32
 T_8162: (in 0<32> : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
-T_8163: (in d0_125 == null : bool)
+T_8163: (in d0_125 == 0<32> : bool)
   Class: Eq_8163
   DataType: bool
   OrigDataType: bool
 T_8164: (in 0x400<32> : word32)
-  Class: Eq_3455
+  Class: Eq_8142
   DataType: int32
   OrigDataType: word32
 T_8165: (in 28<i32> : int32)
@@ -35669,11 +35207,11 @@ T_8166: (in dwArg04 + 28<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8167: (in Mem79[dwArg04 + 28<i32>:word32] : word32)
-  Class: Eq_3455
-  DataType: Eq_25
+  Class: Eq_8142
+  DataType: Eq_73
   OrigDataType: int32
 T_8168: (in 1<i32> : int32)
-  Class: Eq_3455
+  Class: Eq_8142
   DataType: int32
   OrigDataType: int32
 T_8169: (in 28<i32> : int32)
@@ -35685,12 +35223,12 @@ T_8170: (in dwArg04 + 28<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8171: (in Mem83[dwArg04 + 28<i32>:word32] : word32)
-  Class: Eq_3455
-  DataType: Eq_25
+  Class: Eq_8142
+  DataType: Eq_73
   OrigDataType: int32
 T_8172: (in 1<i32> : int32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: int32
 T_8173: (in 8<i32> : int32)
   Class: Eq_8173
@@ -35701,8 +35239,8 @@ T_8174: (in dwArg04 + 8<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8175: (in Mem135[dwArg04 + 8<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8176: (in 4<i32> : int32)
   Class: Eq_8176
@@ -35713,8 +35251,8 @@ T_8177: (in dwArg04 + 4<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_8178: (in Mem137[dwArg04 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8179: (in 0<32> : word32)
   Class: Eq_8179
@@ -35726,7 +35264,7 @@ T_8180: (in dwArg04 + 0<32> : word32)
   OrigDataType: ptr32
 T_8181: (in Mem137[dwArg04 + 0<32>:word32] : word32)
   Class: Eq_2909
-  DataType: Eq_2909
+  DataType: (ptr32 (ptr32 Eq_4374))
   OrigDataType: word32
 T_8182: (in execPrivate2 : ptr32)
   Class: Eq_8182
@@ -35750,11 +35288,11 @@ T_8186: (in dwArg04 + 20<i32> : word32)
   OrigDataType: ptr32
 T_8187: (in Mem147[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2963
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_2963)
-T_8188: (in v26_148 : (ptr32 Eq_2963))
+  DataType: Eq_73
+  OrigDataType: int32
+T_8188: (in v26_148 : int32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: int32
 T_8189: (in dwArg04 + 20<i32> : word32)
   Class: Eq_8189
@@ -35762,7 +35300,7 @@ T_8189: (in dwArg04 + 20<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_8190: (in Mem147[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
 T_8191: (in 1<32> : word32)
   Class: Eq_8191
@@ -35770,7 +35308,7 @@ T_8191: (in 1<32> : word32)
   OrigDataType: word32
 T_8192: (in *((word32) dwArg04 + 20<i32>) - 1<32> : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
 T_8193: (in dwArg04 + 20<i32> : word32)
   Class: Eq_8193
@@ -35778,13 +35316,13 @@ T_8193: (in dwArg04 + 20<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_8194: (in Mem149[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2963
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_2963)
+  DataType: Eq_73
+  OrigDataType: int32
 T_8195: (in 0<32> : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: int32
-T_8196: (in v26_148 >= null : bool)
+T_8196: (in v26_148 >= 0<32> : bool)
   Class: Eq_8196
   DataType: bool
   OrigDataType: bool
@@ -35801,8 +35339,8 @@ T_8199: (in dwArg04 + 24<i32> : word32)
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8200: (in Mem86[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3427
-  DataType: Eq_3427
+  Class: Eq_8119
+  DataType: ui32
   OrigDataType: ui32
 T_8201: (in 0x80<32> : word32)
   Class: Eq_8201
@@ -35832,9 +35370,9 @@ T_8207: (in a0_318 : word32)
   Class: Eq_8207
   DataType: word32
   OrigDataType: word32
-T_8208: (in d0_117 : (ptr32 Eq_2963))
+T_8208: (in d0_117 : int32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
 T_8209: (in fn0000215C : ptr32)
   Class: Eq_2964
@@ -35849,7 +35387,7 @@ T_8211: (in dwArg04 + 28<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8212: (in Mem86[dwArg04 + 28<i32>:word32] : word32)
-  Class: Eq_3455
+  Class: Eq_8142
   DataType: int32
   OrigDataType: word32
 T_8213: (in d4_100 + Mem86[dwArg04 + 28<i32>:word32] : word32)
@@ -35870,19 +35408,19 @@ T_8216: (in out a1_116 : ptr32)
   OrigDataType: ptr32
 T_8217: (in fn0000215C((word32) *((word32) dwArg04 + 28<i32>) + d4_100, out d1_118, out a0_318, out a1_116) : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
 T_8218: (in 0<32> : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
-T_8219: (in d0_117 != null : bool)
+T_8219: (in d0_117 != 0<32> : bool)
   Class: Eq_8219
   DataType: bool
   OrigDataType: bool
-T_8220: (in a0_153 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_8220: (in a0_153 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: (ptr32 (struct (0 T_8232 t0000)))
 T_8221: (in 4<i32> : int32)
   Class: Eq_8221
@@ -35893,24 +35431,24 @@ T_8222: (in dwArg04 + 4<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8223: (in Mem149[dwArg04 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8224: (in 1<i32> : int32)
   Class: Eq_8224
   DataType: int32
   OrigDataType: int32
 T_8225: (in a0_153 + 1<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8226: (in dwArg04 + 4<i32> : word32)
   Class: Eq_8226
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8227: (in Mem157[dwArg04 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8228: (in dwArg04 + 4<i32> : word32)
   Class: Eq_4733
@@ -35954,13 +35492,13 @@ T_8237: (in dwArg04 + 20<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_8238: (in Mem149[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: int32
 T_8239: (in -1<i32> : int32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: int32
-T_8240: (in *((word32) dwArg04 + 20<i32>) != (struct Eq_2963 *) -1<i32> : bool)
+T_8240: (in *((word32) dwArg04 + 20<i32>) != -1<i32> : bool)
   Class: Eq_8240
   DataType: bool
   OrigDataType: bool
@@ -35973,25 +35511,25 @@ T_8242: (in dwArg04 + 24<i32> : word32)
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8243: (in Mem149[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3427
-  DataType: Eq_3427
+  Class: Eq_8119
+  DataType: ui32
   OrigDataType: ui32
 T_8244: (in 16<i32> : int32)
   Class: Eq_8244
   DataType: int32
   OrigDataType: int32
 T_8245: (in *((word32) dwArg04 + 24<i32>) | 16<i32> : word32)
-  Class: Eq_3427
-  DataType: Eq_3427
+  Class: Eq_8119
+  DataType: ui32
   OrigDataType: ui32
 T_8246: (in dwArg04 + 24<i32> : word32)
   Class: Eq_8246
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8247: (in Mem172[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3427
-  DataType: Eq_25
-  OrigDataType: Eq_3427
+  Class: Eq_8119
+  DataType: Eq_73
+  OrigDataType: ui32
 T_8248: (in 24<i32> : int32)
   Class: Eq_8248
   DataType: int32
@@ -36001,28 +35539,28 @@ T_8249: (in dwArg04 + 24<i32> : word32)
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8250: (in Mem149[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3427
-  DataType: Eq_3427
+  Class: Eq_8119
+  DataType: ui32
   OrigDataType: ui32
 T_8251: (in 8<i32> : int32)
   Class: Eq_8251
   DataType: int32
   OrigDataType: int32
 T_8252: (in *((word32) dwArg04 + 24<i32>) | 8<i32> : word32)
-  Class: Eq_3427
-  DataType: Eq_3427
+  Class: Eq_8119
+  DataType: ui32
   OrigDataType: ui32
 T_8253: (in dwArg04 + 24<i32> : word32)
   Class: Eq_8253
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8254: (in Mem179[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3427
-  DataType: Eq_25
-  OrigDataType: Eq_3427
+  Class: Eq_8119
+  DataType: Eq_73
+  OrigDataType: ui32
 T_8255: (in 0<32> : word32)
   Class: Eq_2963
-  DataType: (ptr32 Eq_2963)
+  DataType: int32
   OrigDataType: word32
 T_8256: (in 20<i32> : int32)
   Class: Eq_8256
@@ -36034,8 +35572,8 @@ T_8257: (in dwArg04 + 20<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_8258: (in Mem184[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2963
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_2963)
+  DataType: Eq_73
+  OrigDataType: int32
 T_8259: (in -1<i32> : int32)
   Class: Eq_8106
   DataType: int32
@@ -36045,8 +35583,8 @@ T_8260: (in 1<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_8261: (in d0_117 + 1<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8262: (in 8<i32> : int32)
   Class: Eq_8262
@@ -36057,9 +35595,9 @@ T_8263: (in dwArg04 + 8<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8264: (in Mem131[dwArg04 + 8<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (ptr32 char)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_8265: (in d0_117 + 1<i32> : word32)
   Class: Eq_4733
   DataType: (ptr32 word32)
@@ -36692,191 +36230,47 @@ T_8422:
   Class: Eq_8422
   DataType: Eq_8422
   OrigDataType: 
-T_8423:
-  Class: Eq_8423
-  DataType: Eq_8423
-  OrigDataType: 
-T_8424:
-  Class: Eq_8424
-  DataType: Eq_8424
-  OrigDataType: 
-T_8425:
-  Class: Eq_8425
-  DataType: Eq_8425
-  OrigDataType: 
-T_8426:
-  Class: Eq_8426
-  DataType: Eq_8426
-  OrigDataType: 
-T_8427:
-  Class: Eq_8427
-  DataType: Eq_8427
-  OrigDataType: 
-T_8428:
-  Class: Eq_8428
-  DataType: Eq_8428
-  OrigDataType: 
-T_8429:
-  Class: Eq_8429
-  DataType: Eq_8429
-  OrigDataType: 
-T_8430:
-  Class: Eq_8430
-  DataType: Eq_8430
-  OrigDataType: 
-T_8431:
-  Class: Eq_8431
-  DataType: Eq_8431
-  OrigDataType: 
-T_8432:
-  Class: Eq_8432
-  DataType: Eq_8432
-  OrigDataType: 
-T_8433:
-  Class: Eq_8433
-  DataType: Eq_8433
-  OrigDataType: 
-T_8434:
-  Class: Eq_8434
-  DataType: Eq_8434
-  OrigDataType: 
-T_8435:
-  Class: Eq_8435
-  DataType: Eq_8435
-  OrigDataType: 
-T_8436:
-  Class: Eq_8436
-  DataType: Eq_8436
-  OrigDataType: 
-T_8437:
-  Class: Eq_8437
-  DataType: Eq_8437
-  OrigDataType: 
-T_8438:
-  Class: Eq_8438
-  DataType: Eq_8438
-  OrigDataType: 
-T_8439:
-  Class: Eq_8439
-  DataType: Eq_8439
-  OrigDataType: 
-T_8440:
-  Class: Eq_8440
-  DataType: Eq_8440
-  OrigDataType: 
-T_8441:
-  Class: Eq_8441
-  DataType: Eq_8441
-  OrigDataType: 
-T_8442:
-  Class: Eq_8442
-  DataType: Eq_8442
-  OrigDataType: 
-T_8443:
-  Class: Eq_8443
-  DataType: Eq_8443
-  OrigDataType: 
-T_8444:
-  Class: Eq_8444
-  DataType: Eq_8444
-  OrigDataType: 
-T_8445:
-  Class: Eq_8445
-  DataType: Eq_8445
-  OrigDataType: 
-T_8446:
-  Class: Eq_8446
-  DataType: Eq_8446
-  OrigDataType: 
-T_8447:
-  Class: Eq_8447
-  DataType: Eq_8447
-  OrigDataType: 
-T_8448:
-  Class: Eq_8448
-  DataType: Eq_8448
-  OrigDataType: 
-T_8449:
-  Class: Eq_8449
-  DataType: Eq_8449
-  OrigDataType: 
-T_8450:
-  Class: Eq_8450
-  DataType: Eq_8450
-  OrigDataType: 
-T_8451:
-  Class: Eq_8451
-  DataType: Eq_8451
-  OrigDataType: 
-T_8452:
-  Class: Eq_8452
-  DataType: Eq_8452
-  OrigDataType: 
-T_8453:
-  Class: Eq_8453
-  DataType: Eq_8453
-  OrigDataType: 
-T_8454:
-  Class: Eq_8454
-  DataType: Eq_8454
-  OrigDataType: 
-T_8455:
-  Class: Eq_8455
-  DataType: Eq_8455
-  OrigDataType: 
-T_8456:
-  Class: Eq_8456
-  DataType: Eq_8456
-  OrigDataType: 
-T_8457:
-  Class: Eq_8457
-  DataType: Eq_8457
-  OrigDataType: 
-T_8458:
-  Class: Eq_8458
-  DataType: Eq_8458
-  OrigDataType: 
-T_8459:
-  Class: Eq_8459
-  DataType: Eq_8459
-  OrigDataType: 
 */
-typedef struct Eq_620;
+typedef struct Eq_25;
+struct Eq_620;
 struct Globals {
 	struct Eq_116 * ptr0000;	// 0
 	Eq_1022 t0001;	// 1
 	struct Eq_4 * ptr0004;	// 4
 	word32 a0008[];	// 8
 	ui32 a0010[];	// 10
+	struct Eq_25 t12BC;	// 12BC
 	struct Eq_620 t147C;	// 147C
 	struct Eq_620 t149C;	// 149C
 	struct Eq_620 t14A0;	// 14A0
 	Eq_4404 t28C5;	// 28C5
 	ptr32 ptr3E20;	// 3E20
 	struct Eq_4 * ptr3E24;	// 3E24
-	Eq_25 t3E28;	// 3E28
+	struct Eq_25 * ptr3E28;	// 3E28
 	struct Eq_61 * ptr3E2C;	// 3E2C
 	struct Eq_61 * ptr3E30;	// 3E30
-	Eq_25 t3E34;	// 3E34
-	Eq_25 t3E38;	// 3E38
-	Eq_25 t3E3C;	// 3E3C
+	Eq_134 t3E34;	// 3E34
+	Eq_134 t3E38;	// 3E38
+	Eq_134 t3E3C;	// 3E3C
 	word32 dw3E48;	// 3E48
 	ptr32 ptr3E4C;	// 3E4C
 	int32 dw3E50;	// 3E50
-	struct Eq_2963 * ptr3E54;	// 3E54
+	struct Eq_3186 * ptr3E54;	// 3E54
 	struct Eq_4 * ptr3E58;	// 3E58
 	Eq_3672 t3E5C;	// 3E5C
 	word32 dw3F60;	// 3F60
 	Eq_542 t3F68;	// 3F68
 	word32 dw3F6C;	// 3F6C
 	struct Eq_557 * ptr3F78;	// 3F78
-	Eq_25 t3F7C;	// 3F7C
+	Eq_73 t3F7C;	// 3F7C
 	struct Eq_922 * ptr3F80;	// 3F80
 	struct Eq_922 * ptr3F88;	// 3F88
 	Eq_4 t4000;	// 4000
 	Eq_61 t10202;	// 10202
 	Eq_61 t3030303;	// 3030303
-	Eq_2963 t6060606;	// 6060606
+	Eq_3186 t6060606;	// 6060606
+	Eq_3186 t48E72030;	// 48E72030
+	Eq_25 t61727900;	// 61727900
 } Eq_1;
 
 typedef struct Eq_4 {
@@ -36897,34 +36291,44 @@ typedef union Eq_11 {
 typedef struct Eq_19 {
 	byte b0008;	// 8
 	word32 dw003A;	// 3A
-	Eq_25 t009C;	// 9C
-	Eq_25 t00A0;	// A0
+	Eq_134 t009C;	// 9C
+	Eq_134 t00A0;	// A0
 	word32 dw00A4;	// A4
 	struct Eq_61 * ptr00AC;	// AC
 	word32 * ptr00B0;	// B0
-	Eq_25 t00E0;	// E0
+	Eq_134 t00E0;	// E0
 } Eq_19;
 
 typedef Eq_19 * (Eq_20)(word32);
 
-typedef union Eq_25 {
-	uint8 u0;
-	word16 u1;
-	struct Eq_8363 * u2;
-	Eq_6460 u3;
-	Eq_7323 u4;
+typedef struct Eq_25 {	// size: 4 4
+	word32 dw0000;	// 0
+	Eq_134 t0004;	// 4
+	struct Eq_25 * ptr0008;	// 8
+	Eq_106 t000C;	// C
+	Eq_160 (* ptr0010)[];	// 10
+	struct Eq_3186 * ptr0014;	// 14
+	ptr32 ptr0018;	// 18
+	word32 dw001C;	// 1C
+	word32 dw0020;	// 20
 } Eq_25;
 
-typedef Eq_25 (Eq_28)(ptr32, int32);
+typedef Eq_25 * (Eq_28)(ptr32, int32);
 
 typedef void (Eq_51)(word32);
 
 typedef struct Eq_61 {
 	word32 dw0000;	// 0
-	Eq_25 t0024;	// 24
+	Eq_134 t0024;	// 24
 } Eq_61;
 
-typedef Eq_25 (Eq_75)(Eq_77, Eq_78);
+typedef union Eq_73 {
+	byte u0;
+	word16 u1;
+	struct Eq_8357 * u2;
+} Eq_73;
+
+typedef Eq_25 * (Eq_75)(Eq_77, Eq_78);
 
 typedef union Eq_77 {
 	int32 u0;
@@ -36936,7 +36340,7 @@ typedef union Eq_78 {
 	ptr32 u1;
 } Eq_78;
 
-typedef void (Eq_90)(Eq_25);
+typedef void (Eq_90)(Eq_25 *);
 
 typedef union Eq_106 {
 	int32 u0;
@@ -36948,6 +36352,11 @@ typedef struct Eq_116 {
 } Eq_116;
 
 typedef void (Eq_124)(Eq_19 *);
+
+typedef union Eq_134 {
+	int32 u0;
+	uint32 u1;
+} Eq_134;
 
 typedef struct Eq_160 {	// size: 1 1
 	Eq_160 a0000[];	// 0
@@ -36962,9 +36371,9 @@ typedef void (Eq_200)();
 
 typedef void (Eq_205)();
 
-typedef void (Eq_306)(Eq_25);
+typedef void (Eq_306)(Eq_25 *);
 
-typedef void (Eq_310)(Eq_25);
+typedef void (Eq_310)(Eq_25 *);
 
 typedef void (Eq_320)();
 
@@ -36975,7 +36384,7 @@ typedef struct Eq_379 {
 	word32 dw0004;	// 4
 } Eq_379;
 
-typedef void (Eq_425)(Eq_25, Eq_25, int32, Eq_61 *);
+typedef void (Eq_425)(Eq_73, Eq_25 *, int32, Eq_61 *);
 
 typedef void (Eq_432)(word32);
 
@@ -36983,7 +36392,7 @@ typedef void (Eq_438)(word32);
 
 typedef void (Eq_444)();
 
-typedef void (Eq_447)(Eq_25);
+typedef void (Eq_447)(Eq_25 *);
 
 typedef void (Eq_484)();
 
@@ -37004,31 +36413,37 @@ typedef word32 (Eq_565)(ptr32, ptr32, ptr32);
 
 typedef word32 (Eq_587)(ptr32, ptr32, ptr32);
 
-typedef ptr32 (Eq_589)(Eq_25, Eq_25, Eq_25);
+typedef ptr32 (Eq_589)(Eq_73, Eq_73, Eq_25 *);
 
-typedef Eq_25 (Eq_615)(Eq_25, Eq_25, Eq_25, Eq_620 *);
+typedef Eq_73 (Eq_615)(Eq_73, Eq_73, Eq_25 *, Eq_620 *);
 
 typedef struct Eq_620 {	// size: 1 1
 	uint8 b0000;	// 0
 	cu8 b0001;	// 1
 } Eq_620;
 
-typedef Eq_25 (Eq_622)(Eq_25, Eq_625, ptr32, ptr32);
+typedef Eq_73 (Eq_622)(Eq_73, Eq_625, ptr32, ptr32);
 
 typedef union Eq_625 {
 	byte u0;
 	byte * u1;
 } Eq_625;
 
-typedef void (Eq_663)(Eq_25, Eq_25, Eq_25);
+typedef union Eq_645 {
+	struct Eq_1583 * u0;
+	struct Eq_8358 * u1;
+	struct Eq_8359 * u2;
+} Eq_645;
 
-typedef Eq_25 (Eq_705)(Eq_25, Eq_25, Eq_25, Eq_25);
+typedef void (Eq_663)(Eq_645, Eq_645, Eq_645);
 
-typedef Eq_25 (Eq_760)(Eq_25);
+typedef Eq_645 (Eq_705)(Eq_645, Eq_645, Eq_645, Eq_645);
 
-typedef Eq_25 (Eq_827)(Eq_25, Eq_25);
+typedef Eq_645 (Eq_760)(Eq_645);
 
-typedef Eq_25 (Eq_919)(Eq_25, Eq_922 *, Eq_625, Eq_924, Eq_925 *, Eq_625);
+typedef Eq_645 (Eq_827)(Eq_645, Eq_645);
+
+typedef Eq_73 (Eq_919)(Eq_73, Eq_922 *, Eq_625, Eq_924, Eq_925 *, Eq_625);
 
 typedef struct Eq_922 {
 	word32 dw0000;	// 0
@@ -37051,25 +36466,25 @@ typedef struct Eq_925 {
 } Eq_925;
 
 typedef struct Eq_936 {	// size: 4 4
-	Eq_8364 t002C;	// 2C
+	Eq_8360 t002C;	// 2C
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
-	word32 dw0037;	// 37
+	byte b0037;	// 37
 	word32 dw0038;	// 38
 	word32 dw003C;	// 3C
-	word32 dw003E;	// 3E
-	word32 dw003F;	// 3F
+	word16 w003E;	// 3E
+	byte b003F;	// 3F
 	word32 dw0040;	// 40
 	word32 dw0044;	// 44
 	ui32 dw0048;	// 48
 	word32 dw0062;	// 62
-	Eq_8365 t0066;	// 66
+	Eq_8361 t0066;	// 66
 	byte b006A;	// 6A
 	word32 dw006C;	// 6C
 	word32 dw007C;	// 7C
 } Eq_936;
 
-typedef Eq_25 (Eq_977)(int32, Eq_922 *, Eq_981, ui32 *, Eq_983, ptr32);
+typedef Eq_73 (Eq_977)(int32, Eq_922 *, Eq_981, ui32 *, Eq_983, ptr32);
 
 typedef union Eq_981 {
 	int32 u0;
@@ -37090,8 +36505,8 @@ typedef struct Eq_1022 {
 } Eq_1022;
 
 typedef struct Eq_1052 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0004;	// 4
+	Eq_73 t0000;	// 0
+	Eq_73 t0004;	// 4
 } Eq_1052;
 
 typedef union Eq_1130 {
@@ -37290,7 +36705,7 @@ typedef union Eq_1915 {
 
 typedef struct Eq_1922 {
 	int32 dw0000;	// 0
-	Eq_25 t0034;	// 34
+	Eq_73 t0034;	// 34
 	Eq_1410 t0048;	// 48
 	ui32 dw004C;	// 4C
 	struct Eq_1022 * ptr0066;	// 66
@@ -37298,9 +36713,9 @@ typedef struct Eq_1922 {
 	Eq_924 t0080;	// 80
 } Eq_1922;
 
-typedef int32 (Eq_1962)(Eq_25, Eq_25, Eq_25, Eq_25);
+typedef int32 (Eq_1962)(Eq_645, Eq_645, Eq_645, Eq_645);
 
-typedef word32 (Eq_2046)(Eq_25, Eq_25, Eq_25, Eq_25, Eq_25, Eq_25);
+typedef word32 (Eq_2046)(Eq_645, Eq_645, Eq_645, Eq_645, Eq_645, Eq_645);
 
 typedef union Eq_2086 {
 	bool u0;
@@ -37443,11 +36858,6 @@ typedef union Eq_2348 {
 	up32 u1;
 } Eq_2348;
 
-typedef union Eq_2441 {
-	byte u0;
-	word32 u1;
-} Eq_2441;
-
 typedef struct Eq_2445 {
 	struct Eq_925 * ptr0000;	// 0
 	int32 dw0034;	// 34
@@ -37468,11 +36878,6 @@ typedef union Eq_2483 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2483;
-
-typedef union Eq_2506 {
-	word16 u0;
-	word32 u1;
-} Eq_2506;
 
 typedef struct Eq_2510 {
 	struct Eq_925 * ptr0000;	// 0
@@ -37536,11 +36941,6 @@ typedef union Eq_2602 {
 	Eq_1530 u4;
 	Eq_2600 u5;
 } Eq_2602;
-
-typedef union Eq_2606 {
-	byte u0;
-	word32 u1;
-} Eq_2606;
 
 typedef struct Eq_2610 {
 	struct Eq_925 * ptr0000;	// 0
@@ -37752,19 +37152,9 @@ typedef union Eq_2837 {
 
 typedef Eq_981 (Eq_2861)(int32, Eq_922 *, ui32 *, ptr32, ptr32);
 
-typedef Eq_2909 (Eq_2903)(ptr32, ptr32);
+typedef Eq_4374 * * (Eq_2903)(ptr32, ptr32);
 
-typedef union Eq_2909 {
-	byte u0;
-	struct Eq_8381 * u1;
-} Eq_2909;
-
-typedef struct Eq_2963 {
-	word32 dw0000;	// 0
-	word32 dw0004;	// 4
-} Eq_2963;
-
-typedef Eq_2963 * (Eq_2964)(int32, ptr32, ptr32, int32 *);
+typedef int32 (Eq_2964)(int32, ptr32, ptr32, int32 *);
 
 typedef void (Eq_2997)();
 
@@ -37775,7 +37165,12 @@ typedef union Eq_3170 {
 	ptr32 u1;
 } Eq_3170;
 
-typedef Eq_4 * (Eq_3191)(Eq_106, Eq_2963 *, Eq_2963 *, Eq_2963 *, Eq_4 *, Eq_25);
+typedef struct Eq_3186 {
+	word32 dw0000;	// 0
+	word32 dw0004;	// 4
+} Eq_3186;
+
+typedef Eq_4 * (Eq_3191)(Eq_106, Eq_3186 *, Eq_3186 *, Eq_3186 *, Eq_4 *, Eq_25 *);
 
 typedef int32 * (Eq_3207)(Eq_4 *, up32, Eq_78, Eq_4 *);
 
@@ -37787,25 +37182,20 @@ typedef void (Eq_3278)(Eq_4 *);
 
 typedef void (Eq_3316)(Eq_4 *, up32, up32);
 
-typedef Eq_25 (Eq_3345)(up32, Eq_4 *);
+typedef Eq_25 * (Eq_3345)(up32, Eq_4 *);
 
 typedef union Eq_3364 {
 	int32 u0;
 	up32 u1;
 } Eq_3364;
 
-typedef Eq_25 (Eq_3396)(Eq_4 *, up32);
-
-typedef union Eq_3427 {
-	ui32 u0;
-	ptr32 u1;
-} Eq_3427;
+typedef Eq_25 * (Eq_3396)(Eq_4 *, up32);
 
 typedef void (Eq_3459)(Eq_4 *, ptr32);
 
 typedef void (Eq_3497)(Eq_4 *, ptr32);
 
-typedef Eq_25 (Eq_3526)(Eq_106, Eq_2963 *, Eq_2963 *);
+typedef Eq_25 * (Eq_3526)(Eq_106, Eq_3186 *, Eq_3186 *);
 
 typedef void (Eq_3576)(Eq_379 *);
 
@@ -37813,7 +37203,7 @@ typedef void (Eq_3580)(Eq_379 *);
 
 typedef void (Eq_3604)(int32, word32);
 
-typedef Eq_25 (Eq_3640)(Eq_25, Eq_25, Eq_25, Eq_25, Eq_25);
+typedef Eq_645 (Eq_3640)(Eq_645, Eq_645, Eq_645, Eq_645, Eq_645);
 
 typedef struct Eq_3672 {	// size: 1 1
 	Eq_3672 a0000[];	// 0
@@ -37854,7 +37244,7 @@ typedef union Eq_3977 {
 	uint32 u1;
 } Eq_3977;
 
-typedef Eq_25 (Eq_4074)(Eq_25, word32, bool);
+typedef Eq_645 (Eq_4074)(Eq_645, word32, bool);
 
 typedef union Eq_4220 {
 	bool u0;
@@ -37881,13 +37271,23 @@ typedef union Eq_4272 {
 	ui32 u1;
 } Eq_4272;
 
-typedef Eq_25 (Eq_4318)(Eq_25, Eq_25, Eq_25, Eq_25, Eq_620 *, Eq_25);
+typedef Eq_73 (Eq_4318)(Eq_73, Eq_73, Eq_25 *, Eq_73, Eq_620 *, Eq_645);
 
-typedef union Eq_4367 {
-	uint8 u0;
-	struct Eq_8387 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
+typedef struct Eq_4367 {	// size: 4 4
+	int32 dw002C;	// 2C
+	Eq_8377 t0030;	// 30
+	word32 dw0034;	// 34
+	uint8 b0037;	// 37
+	word32 dw0038;	// 38
+	word32 dw003C;	// 3C
+	word32 dw0040;	// 40
+	Eq_8378 t0044;	// 44
+	byte b0048;	// 48
+	byte b0049;	// 49
+	word32 dw004A;	// 4A
+	word32 dw006E;	// 6E
+	word32 dw0072;	// 72
+	word32 dw0084;	// 84
 } Eq_4367;
 
 typedef union Eq_4374 {
@@ -37931,24 +37331,19 @@ typedef union Eq_4507 {
 	uint32 u1;
 } Eq_4507;
 
-typedef Eq_25 (Eq_4729)(Eq_25, Eq_2909, word32 *, byte *);
+typedef Eq_73 (Eq_4729)(Eq_73, Eq_4374 * *, word32 *, byte *);
 
-typedef Eq_25 (Eq_4919)(Eq_25, Eq_25);
+typedef Eq_73 (Eq_4919)(byte, Eq_73);
 
 typedef struct Eq_4932 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0030;	// 30
+	Eq_73 t0000;	// 0
+	Eq_73 t0030;	// 30
 } Eq_4932;
 
 typedef struct Eq_4956 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0030;	// 30
 } Eq_4956;
-
-typedef union Eq_4986 {
-	byte u0;
-	struct Eq_8388 * u1;
-} Eq_4986;
 
 typedef union Eq_5066 {
 	int32 u0;
@@ -37956,24 +37351,14 @@ typedef union Eq_5066 {
 } Eq_5066;
 
 typedef struct Eq_5115 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0030;	// 30
+	Eq_73 t0000;	// 0
+	Eq_73 t0030;	// 30
 } Eq_5115;
 
 typedef struct Eq_5139 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0030;	// 30
 } Eq_5139;
-
-typedef union Eq_5158 {
-	byte u0;
-	struct Eq_8389 * u1;
-} Eq_5158;
-
-typedef union Eq_5168 {
-	byte u0;
-	struct Eq_8390 * u1;
-} Eq_5168;
 
 typedef union Eq_5255 {
 	int32 u0;
@@ -38011,24 +37396,14 @@ typedef union Eq_5506 {
 } Eq_5506;
 
 typedef struct Eq_5540 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0038;	// 38
+	Eq_73 t0000;	// 0
+	Eq_73 t0038;	// 38
 } Eq_5540;
 
 typedef struct Eq_5564 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5564;
-
-typedef union Eq_5583 {
-	byte u0;
-	struct Eq_8400 * u1;
-} Eq_5583;
-
-typedef union Eq_5593 {
-	byte u0;
-	struct Eq_8401 * u1;
-} Eq_5593;
 
 typedef union Eq_5598 {
 	int32 u0;
@@ -38041,24 +37416,14 @@ typedef union Eq_5638 {
 } Eq_5638;
 
 typedef struct Eq_5667 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0038;	// 38
+	Eq_73 t0000;	// 0
+	Eq_73 t0038;	// 38
 } Eq_5667;
 
 typedef struct Eq_5691 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5691;
-
-typedef union Eq_5710 {
-	byte u0;
-	struct Eq_8402 * u1;
-} Eq_5710;
-
-typedef union Eq_5720 {
-	byte u0;
-	struct Eq_8403 * u1;
-} Eq_5720;
 
 typedef union Eq_5734 {
 	int32 u0;
@@ -38078,45 +37443,25 @@ typedef union Eq_5810 {
 } Eq_5810;
 
 typedef struct Eq_5839 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0038;	// 38
+	Eq_73 t0000;	// 0
+	Eq_73 t0038;	// 38
 } Eq_5839;
 
 typedef struct Eq_5863 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5863;
 
-typedef union Eq_5882 {
-	byte u0;
-	struct Eq_8406 * u1;
-} Eq_5882;
-
-typedef union Eq_5892 {
-	byte u0;
-	struct Eq_8407 * u1;
-} Eq_5892;
-
 typedef struct Eq_5920 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	int32 dw0030;	// 30
-	Eq_25 t0038;	// 38
+	Eq_73 t0038;	// 38
 } Eq_5920;
 
 typedef struct Eq_5955 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5955;
-
-typedef union Eq_5974 {
-	byte u0;
-	struct Eq_8408 * u1;
-} Eq_5974;
-
-typedef union Eq_5984 {
-	byte u0;
-	struct Eq_8409 * u1;
-} Eq_5984;
 
 typedef union Eq_5992 {
 	int32 u0;
@@ -38149,7 +37494,7 @@ typedef union Eq_6019 {
 } Eq_6019;
 
 typedef struct Eq_6062 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	word32 dw004E;	// 4E
 } Eq_6062;
 
@@ -38169,7 +37514,7 @@ typedef union Eq_6149 {
 } Eq_6149;
 
 typedef struct Eq_6179 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	word32 dw0044;	// 44
 } Eq_6179;
 
@@ -38184,24 +37529,14 @@ typedef union Eq_6238 {
 } Eq_6238;
 
 typedef struct Eq_6267 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0038;	// 38
+	Eq_73 t0000;	// 0
+	Eq_73 t0038;	// 38
 } Eq_6267;
 
 typedef struct Eq_6291 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_6291;
-
-typedef union Eq_6310 {
-	byte u0;
-	struct Eq_8410 * u1;
-} Eq_6310;
-
-typedef union Eq_6320 {
-	byte u0;
-	struct Eq_8411 * u1;
-} Eq_6320;
 
 typedef union Eq_6334 {
 	int32 u0;
@@ -38219,29 +37554,14 @@ typedef union Eq_6365 {
 } Eq_6365;
 
 typedef struct Eq_6394 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0038;	// 38
+	Eq_73 t0000;	// 0
+	Eq_73 t0038;	// 38
 } Eq_6394;
 
 typedef struct Eq_6418 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_6418;
-
-typedef union Eq_6437 {
-	byte u0;
-	struct Eq_8412 * u1;
-} Eq_6437;
-
-typedef union Eq_6447 {
-	byte u0;
-	struct Eq_8413 * u1;
-} Eq_6447;
-
-typedef union Eq_6460 {
-	uint8 u0;
-	word32 u1;
-} Eq_6460;
 
 typedef union Eq_6468 {
 	int32 u0;
@@ -38259,7 +37579,7 @@ typedef union Eq_6519 {
 } Eq_6519;
 
 typedef struct Eq_6523 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	word32 dw0044;	// 44
 } Eq_6523;
 
@@ -38378,25 +37698,20 @@ typedef union Eq_6930 {
 } Eq_6930;
 
 typedef struct Eq_6958 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	word32 dw004E;	// 4E
 } Eq_6958;
 
 typedef struct Eq_7009 {
-	Eq_25 t0000;	// 0
-	Eq_7098 t0001;	// 1
+	Eq_645 t0000;	// 0
+	ui24 n0001;	// 1
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
 	word32 dw0044;	// 44
 	word32 dw0048;	// 48
 } Eq_7009;
 
-typedef word32 (Eq_7060)(Eq_4374, Eq_25, Eq_25, Eq_25, Eq_25, ptr32);
-
-typedef union Eq_7098 {
-	int24 u0;
-	int32 u1;
-} Eq_7098;
+typedef word32 (Eq_7060)(Eq_4374, Eq_645, Eq_645, Eq_645, Eq_645, ptr32);
 
 typedef union Eq_7111 {
 	int32 u0;
@@ -38404,32 +37719,17 @@ typedef union Eq_7111 {
 } Eq_7111;
 
 typedef struct Eq_7164 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	word32 dw0030;	// 30
-	Eq_25 t0034;	// 34
+	Eq_73 t0034;	// 34
 	byte b0038;	// 38
 	byte b004C;	// 4C
 } Eq_7164;
 
 typedef struct Eq_7194 {
 	word32 dw0000;	// 0
-	Eq_25 t0004;	// 4
+	Eq_73 t0004;	// 4
 } Eq_7194;
-
-typedef union Eq_7260 {
-	byte u0;
-	struct Eq_8422 * u1;
-} Eq_7260;
-
-typedef union Eq_7289 {
-	byte u0;
-	struct Eq_8426 * u1;
-} Eq_7289;
-
-typedef union Eq_7306 {
-	byte u0;
-	struct Eq_8430 * u1;
-} Eq_7306;
 
 typedef union Eq_7322 {
 	int32 u0;
@@ -38440,18 +37740,10 @@ typedef union Eq_7322 {
 
 typedef union Eq_7323 {
 	int32 u0;
-	uint8 u1;
-	ptr32 u2;
-	Eq_6460 u3;
-	Eq_6737 u4;
-	Eq_6796 u5;
+	ptr32 u1;
+	Eq_6737 u2;
+	Eq_6796 u3;
 } Eq_7323;
-
-typedef union Eq_7325 {
-	uint8 u0;
-	word32 u1;
-	Eq_6460 u2;
-} Eq_7325;
 
 typedef struct Eq_7333 {
 	int32 dw0000;	// 0
@@ -38463,436 +37755,53 @@ typedef union Eq_7345 {
 	int32 u1;
 } Eq_7345;
 
-typedef union Eq_7348 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7348;
-
-typedef union Eq_7350 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
+typedef struct Eq_7350 {
+	Eq_73 t0000;	// 0
+	byte b0030;	// 30
+	word32 dw0038;	// 38
+	Eq_73 t003C;	// 3C
+	byte b004C;	// 4C
 } Eq_7350;
 
-typedef union Eq_7351 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7351;
+typedef union Eq_7375 {
+	int32 u0;
+	byte u1;
+} Eq_7375;
 
-typedef union Eq_7354 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7354;
-
-typedef union Eq_7357 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7357;
-
-typedef union Eq_7362 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7362;
-
-typedef union Eq_7364 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7364;
-
-typedef union Eq_7367 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7367;
-
-typedef union Eq_7373 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7373;
-
-typedef union Eq_7377 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7377;
-
-typedef union Eq_7382 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7382;
-
-typedef union Eq_7386 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7386;
+typedef union Eq_7384 {
+	int32 u0;
+	byte u1;
+} Eq_7384;
 
 typedef struct Eq_7399 {
 	word32 dw0000;	// 0
-	word32 dw0004;	// 4
+	Eq_73 t0004;	// 4
 } Eq_7399;
 
-typedef union Eq_7404 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7404;
-
-typedef union Eq_7410 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7410;
-
-typedef union Eq_7418 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7418;
-
-typedef union Eq_7423 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7423;
-
-typedef union Eq_7436 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7436;
-
-typedef union Eq_7447 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7447;
-
-typedef union Eq_7452 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7452;
-
-typedef union Eq_7465 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7465;
-
-typedef union Eq_7476 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7476;
-
-typedef union Eq_7481 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7481;
-
-typedef union Eq_7494 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7494;
-
-typedef union Eq_7511 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7511;
-
-typedef union Eq_7523 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7523;
-
-typedef union Eq_7524 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7524;
-
-typedef union Eq_7525 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7525;
-
-typedef union Eq_7527 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7527;
-
-typedef union Eq_7534 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7534;
-
-typedef union Eq_7537 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7537;
-
-typedef union Eq_7541 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7541;
-
-typedef union Eq_7545 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7545;
-
-typedef union Eq_7550 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7550;
-
-typedef union Eq_7582 {
-	byte u0;
-	struct Eq_8453 * u1;
-} Eq_7582;
-
-typedef union Eq_7588 {
-	byte u0;
-	struct Eq_8454 * u1;
-} Eq_7588;
-
-typedef union Eq_7598 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7598;
-
-typedef union Eq_7599 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7599;
-
-typedef union Eq_7600 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7600;
+typedef union Eq_7539 {
+	int32 u0;
+	byte u1;
+} Eq_7539;
 
 typedef union Eq_7602 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_7602;
 
-typedef union Eq_7605 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7605;
-
-typedef union Eq_7616 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7616;
-
-typedef union Eq_7618 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7618;
-
-typedef union Eq_7619 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7619;
-
-typedef union Eq_7620 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7620;
-
 typedef union Eq_7622 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_7622;
 
-typedef union Eq_7625 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7625;
-
-typedef union Eq_7637 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7637;
-
-typedef union Eq_7639 {
-	byte u0;
-	struct Eq_8455 * u1;
-} Eq_7639;
-
-typedef union Eq_7644 {
-	byte u0;
-	struct Eq_8456 * u1;
-} Eq_7644;
-
-typedef union Eq_7691 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
+typedef struct Eq_7691 {
+	Eq_73 t0000;	// 0
+	Eq_73 t0030;	// 30
 } Eq_7691;
 
-typedef union Eq_7692 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7692;
-
-typedef union Eq_7695 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7695;
-
-typedef union Eq_7700 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7700;
-
-typedef union Eq_7707 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7707;
-
-typedef union Eq_7715 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
+typedef struct Eq_7715 {
+	Eq_73 t0000;	// 0
+	uint32 dw0030;	// 30
 } Eq_7715;
-
-typedef union Eq_7716 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7716;
-
-typedef union Eq_7719 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7719;
-
-typedef union Eq_7731 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7731;
-
-typedef union Eq_7734 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7734;
-
-typedef union Eq_7739 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7739;
-
-typedef union Eq_7744 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7744;
-
-typedef union Eq_7747 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7747;
 
 typedef union Eq_7749 {
 	int32 u0;
@@ -38904,236 +37813,17 @@ typedef union Eq_7750 {
 	uint32 u1;
 } Eq_7750;
 
-typedef union Eq_7756 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7756;
-
-typedef union Eq_7762 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
+typedef struct Eq_7762 {
+	ptr32 ptr0000;	// 0
+	byte b004D;	// 4D
 } Eq_7762;
 
-typedef union Eq_7763 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7763;
-
-typedef union Eq_7765 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7765;
-
-typedef union Eq_7768 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7768;
-
-typedef union Eq_7770 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7770;
-
-typedef union Eq_7771 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7771;
-
-typedef union Eq_7773 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7773;
-
-typedef union Eq_7776 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7776;
-
-typedef union Eq_7777 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7777;
-
-typedef union Eq_7779 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7779;
-
-typedef union Eq_7781 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7781;
-
-typedef union Eq_7782 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7782;
-
-typedef union Eq_7784 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7784;
-
-typedef union Eq_7787 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7787;
-
-typedef int32 (Eq_7789)(Eq_25, Eq_25, Eq_25);
-
-typedef union Eq_7791 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7791;
-
-typedef union Eq_7793 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7793;
-
-typedef union Eq_7795 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7795;
-
-typedef union Eq_7796 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7796;
-
-typedef union Eq_7798 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7798;
-
-typedef union Eq_7805 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7805;
-
-typedef union Eq_7806 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7806;
-
-typedef union Eq_7808 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7808;
+typedef int32 (Eq_7789)(Eq_645, Eq_645, Eq_645);
 
 typedef union Eq_7817 {
 	int32 u0;
 	uint32 u1;
 } Eq_7817;
-
-typedef union Eq_7822 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7822;
-
-typedef union Eq_7857 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7857;
-
-typedef union Eq_7858 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7858;
-
-typedef union Eq_7861 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7861;
-
-typedef union Eq_7867 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7867;
-
-typedef union Eq_7879 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7879;
-
-typedef union Eq_7880 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7880;
-
-typedef union Eq_7883 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7883;
-
-typedef union Eq_7895 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7895;
 
 typedef union Eq_7901 {
 	int32 u0;
@@ -39145,264 +37835,12 @@ typedef union Eq_7907 {
 	uint32 u1;
 } Eq_7907;
 
-typedef union Eq_7912 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7912;
-
-typedef union Eq_7916 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7916;
-
-typedef union Eq_7917 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7917;
-
-typedef union Eq_7920 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7920;
-
-typedef union Eq_7922 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7922;
-
-typedef union Eq_7923 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7923;
-
-typedef union Eq_7925 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7925;
-
-typedef union Eq_7928 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7928;
-
-typedef union Eq_7929 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7929;
-
-typedef union Eq_7931 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7931;
-
-typedef union Eq_7934 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7934;
-
-typedef union Eq_7938 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7938;
-
-typedef union Eq_7940 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7940;
-
-typedef union Eq_7941 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7941;
-
-typedef union Eq_7943 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7943;
-
-typedef union Eq_7946 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7946;
-
-typedef union Eq_7948 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7948;
-
-typedef union Eq_7949 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7949;
-
-typedef union Eq_7951 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7951;
-
-typedef union Eq_7954 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7954;
-
-typedef union Eq_7955 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7955;
-
-typedef union Eq_7957 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7957;
-
-typedef union Eq_7959 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7959;
-
-typedef union Eq_7960 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7960;
-
-typedef union Eq_7962 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7962;
-
-typedef union Eq_7965 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7965;
-
-typedef union Eq_7968 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7968;
-
-typedef union Eq_7970 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7970;
-
-typedef union Eq_7972 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7972;
-
-typedef union Eq_7973 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7973;
-
-typedef union Eq_7975 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7975;
-
-typedef union Eq_7982 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7982;
-
-typedef union Eq_7983 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7983;
-
-typedef union Eq_7985 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_7985;
-
 typedef union Eq_7994 {
 	int32 u0;
 	uint32 u1;
 } Eq_7994;
 
-typedef union Eq_8006 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_8006;
-
-typedef union Eq_8010 {
-	uint8 u0;
-	struct Eq_8437 * u1;
-	Eq_6460 u2;
-	Eq_7323 u3;
-} Eq_8010;
-
-typedef Eq_2963 * (Eq_8145)(ptr32, ptr32);
+typedef int32 (Eq_8145)(ptr32, ptr32);
 
 typedef void (Eq_8182)();
 
@@ -39410,79 +37848,24 @@ typedef struct Eq_8300 {	// size: 4 4
 	byte b0000;	// 0
 } Eq_8300;
 
-typedef struct Eq_8357 {
-	Eq_25 t0000;	// 0
+typedef struct Eq_8357 {	// size: 4 4
+	union Eq_4374 * ptr0000;	// 0
+	Eq_73 t0004;	// 4
+	Eq_73 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8357;
 
-typedef union Eq_8358 {
-	int32 u0;
-	byte u1;
-	Eq_25 u2;
+typedef struct Eq_8358 {	// size: 1 1
+	word32 dw0000;	// 0
 } Eq_8358;
 
-typedef union Eq_8359 {
-	int32 u0;
-	uint32 u1;
-	byte u2;
-	ptr32 u3;
-	Eq_25 u4;
-	Eq_6737 u5;
-	Eq_6796 u6;
-	Eq_7323 u7;
+typedef struct Eq_8359 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8359;
 
 typedef union Eq_8360 {
-	uint8 u0;
-	word32 u1;
-	Eq_6460 u2;
-} Eq_8360;
-
-typedef union Eq_8361 {
-	uint8 u0;
-	word32 u1;
-	Eq_4367 u2;
-	Eq_6460 u3;
-	Eq_7323 u4;
-} Eq_8361;
-
-typedef union Eq_8362 {
-	int32 u0;
-	ptr32 u1;
-	Eq_6670 u2;
-	Eq_6734 u3;
-	Eq_6799 u4;
-} Eq_8362;
-
-typedef struct Eq_8363 {	// size: 4 4
-	struct Eq_8357 * ptrFFFFFFFC;	// FFFFFFFC
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (* ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-	Eq_8358 t002C;	// 2C
-	Eq_8359 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8360 t0037;	// 37
-	Eq_8361 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8362 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
-} Eq_8363;
-
-typedef union Eq_8364 {
 	cu8 u0;
 	word32 u1;
 	Eq_1453 u2;
@@ -39491,9 +37874,9 @@ typedef union Eq_8364 {
 	Eq_2600 u5;
 	Eq_2711 u6;
 	Eq_2752 u7;
-} Eq_8364;
+} Eq_8360;
 
-typedef union Eq_8365 {
+typedef union Eq_8361 {
 	struct Eq_1583 * u0;
 	Eq_2118 u1;
 	Eq_2182 u2;
@@ -39501,6 +37884,26 @@ typedef union Eq_8365 {
 	Eq_2258 u4;
 	Eq_2303 u5;
 	Eq_2835 u6;
+} Eq_8361;
+
+typedef struct Eq_8362 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8362;
+
+typedef struct Eq_8363 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8363;
+
+typedef struct Eq_8364 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8364;
+
+typedef struct Eq_8365 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_8365;
 
 typedef struct Eq_8366 {	// size: 1 1
@@ -39558,593 +37961,195 @@ typedef struct Eq_8376 {	// size: 1 1
 	byte b0003;	// 3
 } Eq_8376;
 
-typedef struct Eq_8377 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef union Eq_8377 {
+	int32 u0;
+	ptr32 u1;
+	Eq_6737 u2;
+	Eq_6796 u3;
+	Eq_7323 u4;
 } Eq_8377;
 
-typedef struct Eq_8378 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef union Eq_8378 {
+	int32 u0;
+	ptr32 u1;
+	Eq_6670 u2;
+	Eq_6734 u3;
+	Eq_6799 u4;
 } Eq_8378;
 
-typedef struct Eq_8379 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8379 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8379;
 
-typedef struct Eq_8380 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8380 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8380;
 
 typedef struct Eq_8381 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (* ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8381;
 
-typedef union Eq_8382 {
-	int32 u0;
-	byte u1;
-	Eq_25 u2;
+typedef struct Eq_8382 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8382;
 
-typedef union Eq_8383 {
-	int32 u0;
-	uint32 u1;
-	byte u2;
-	ptr32 u3;
-	Eq_25 u4;
-	Eq_6737 u5;
-	Eq_6796 u6;
-	Eq_7323 u7;
+typedef struct Eq_8383 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8383;
 
-typedef union Eq_8384 {
-	uint8 u0;
-	word32 u1;
-	Eq_6460 u2;
+typedef struct Eq_8384 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8384;
 
-typedef union Eq_8385 {
-	uint8 u0;
-	word32 u1;
-	Eq_4367 u2;
-	Eq_6460 u3;
-	Eq_7323 u4;
+typedef struct Eq_8385 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8385;
 
-typedef union Eq_8386 {
-	int32 u0;
-	ptr32 u1;
-	Eq_6670 u2;
-	Eq_6734 u3;
-	Eq_6799 u4;
+typedef struct Eq_8386 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8386;
 
 typedef struct Eq_8387 {	// size: 4 4
-	Eq_25 t0000;	// 0
-	Eq_8382 t002C;	// 2C
-	Eq_8383 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8384 t0037;	// 37
-	Eq_8385 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8386 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8387;
 
 typedef struct Eq_8388 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8388;
 
 typedef struct Eq_8389 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8389;
 
 typedef struct Eq_8390 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8390;
 
 typedef struct Eq_8391 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8391;
 
 typedef struct Eq_8392 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8392;
 
 typedef struct Eq_8393 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8393;
 
 typedef struct Eq_8394 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8394;
 
 typedef struct Eq_8395 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8395;
 
 typedef struct Eq_8396 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8396;
 
 typedef struct Eq_8397 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8397;
 
 typedef struct Eq_8398 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8398;
 
 typedef struct Eq_8399 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8399;
 
 typedef struct Eq_8400 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8400;
 
 typedef struct Eq_8401 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8401;
 
 typedef struct Eq_8402 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8402;
 
 typedef struct Eq_8403 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8403;
 
 typedef struct Eq_8404 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8404;
 
 typedef struct Eq_8405 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8405;
 
 typedef struct Eq_8406 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8406;
 
 typedef struct Eq_8407 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8407;
 
 typedef struct Eq_8408 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8408;
 
 typedef struct Eq_8409 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8409;
 
 typedef struct Eq_8410 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8410;
 
 typedef struct Eq_8411 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8411;
 
 typedef struct Eq_8412 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8412;
 
 typedef struct Eq_8413 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8413;
 
 typedef struct Eq_8414 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8414;
 
 typedef struct Eq_8415 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8415;
 
 typedef struct Eq_8416 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8416;
 
 typedef struct Eq_8417 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8417;
 
 typedef struct Eq_8418 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8418;
 
 typedef struct Eq_8419 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8419;
 
 typedef struct Eq_8420 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8420;
 
 typedef struct Eq_8421 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8421;
 
 typedef struct Eq_8422 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8422;
-
-typedef struct Eq_8423 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8423;
-
-typedef struct Eq_8424 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8424;
-
-typedef struct Eq_8425 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8425;
-
-typedef struct Eq_8426 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8426;
-
-typedef struct Eq_8427 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8427;
-
-typedef struct Eq_8428 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8428;
-
-typedef struct Eq_8429 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8429;
-
-typedef struct Eq_8430 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8430;
-
-typedef struct Eq_8431 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8431;
-
-typedef union Eq_8432 {
-	int32 u0;
-	byte u1;
-	Eq_25 u2;
-} Eq_8432;
-
-typedef union Eq_8433 {
-	int32 u0;
-	uint32 u1;
-	byte u2;
-	ptr32 u3;
-	Eq_25 u4;
-	Eq_6737 u5;
-	Eq_6796 u6;
-	Eq_7323 u7;
-} Eq_8433;
-
-typedef union Eq_8434 {
-	uint8 u0;
-	word32 u1;
-	Eq_6460 u2;
-} Eq_8434;
-
-typedef union Eq_8435 {
-	uint8 u0;
-	word32 u1;
-	Eq_4367 u2;
-	Eq_6460 u3;
-	Eq_7323 u4;
-} Eq_8435;
-
-typedef union Eq_8436 {
-	int32 u0;
-	ptr32 u1;
-	Eq_6670 u2;
-	Eq_6734 u3;
-	Eq_6799 u4;
-} Eq_8436;
-
-typedef struct Eq_8437 {	// size: 4 4
-	Eq_25 t0000;	// 0
-	Eq_8432 t002C;	// 2C
-	Eq_8433 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8434 t0037;	// 37
-	Eq_8435 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8436 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
-} Eq_8437;
-
-typedef struct Eq_8438 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8438;
-
-typedef struct Eq_8439 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8439;
-
-typedef struct Eq_8440 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8440;
-
-typedef struct Eq_8441 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8441;
-
-typedef struct Eq_8442 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8442;
-
-typedef struct Eq_8443 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8443;
-
-typedef struct Eq_8444 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8444;
-
-typedef struct Eq_8445 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8445;
-
-typedef struct Eq_8446 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8446;
-
-typedef struct Eq_8447 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8447;
-
-typedef struct Eq_8448 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8448;
-
-typedef struct Eq_8449 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8449;
-
-typedef struct Eq_8450 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8450;
-
-typedef struct Eq_8451 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8451;
-
-typedef struct Eq_8452 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8452;
-
-typedef struct Eq_8453 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (* ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8453;
-
-typedef struct Eq_8454 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8454;
-
-typedef struct Eq_8455 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8455;
-
-typedef struct Eq_8456 {	// size: 4 4
-	union Eq_4374 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2963 * ptr0014;	// 14
-	Eq_3427 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8456;
-
-typedef struct Eq_8457 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8457;
-
-typedef struct Eq_8458 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8458;
-
-typedef struct Eq_8459 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8459;
 

--- a/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG_code.c
+++ b/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG_code.c
@@ -23,12 +23,12 @@ void fn00001000(int32 d0, byte * a0)
 	globals->ptr3E20 = fp;
 	globals->ptr3E24 = a6_n;
 	struct Eq_n * d0_n = FindTask(0x00);
-	Eq_n a1_n = 0x12BC;
-	Eq_n d0_n = OpenLibrary(0x12BC, 0);
-	if (d0_n != 0x00)
+	struct Eq_n * a1_n = &globals->t12BC;
+	struct Eq_n * d0_n = OpenLibrary(0x12BC, 0);
+	if (d0_n != null)
 	{
 		int32 d4_n;
-		globals->t3E28 = d0_n;
+		globals->ptr3E28 = d0_n;
 		if (d0_n->ptr00AC == null)
 		{
 			d4_n = 2;
@@ -50,13 +50,13 @@ void fn00001000(int32 d0, byte * a0)
 		ui32 d0_n = d0_n + d2_n;
 		Eq_n d1_n = 0x00010001;
 		d0_n = AllocMem(d0_n + 0x11, 0x00010001);
-		if (d0_n != 0x00)
+		if (d0_n != null)
 		{
 			struct Eq_n * dwLoc0C_n;
 			word32 a0_n;
-			*d0_n = d0_n + 0x11;
-			*((word32) d0_n + 0x0C) = d4_n - 0x01;
-			*((word32) d0_n + 8) = (word32) d0_n + 16 + d0_n;
+			d0_n->dw0000 = (word32) (d0_n + 0x11);
+			d0_n[3] = (struct Eq_n) (d4_n - 0x01);
+			d0_n[2] = (struct Eq_n) (d0_n + 4 + d0_n / 4);
 			null = null;
 			struct Eq_n * d0_n = d0_n->ptr00AC;
 			if (d0_n == null)
@@ -70,7 +70,7 @@ void fn00001000(int32 d0, byte * a0)
 				if (d0_n != 0x00)
 					Enable();
 				Supervisor(d0_n);
-				*((word32) d0_n + 4) = d0_n;
+				d0_n[1] = (struct Eq_n) d0_n;
 				d1_n.u0 = 4808;
 				if (d0_n == 0x00)
 				{
@@ -92,12 +92,12 @@ l000011F8:
 				goto l00001202;
 			}
 			ui32 d0_n = ((ui32[]) 16)[d0_n];
-			a1_n = *((word32) d0_n + 8);
+			a1_n = (struct Eq_n *) d0_n[2];
 			Eq_n (* a0_n)[] = (d0_n << 0x02) + 1;
 			Eq_n d0_n = (uint32) (uint8) null[d0_n].b0000;
 			Mem263[a0_n + d0_n:byte] = 0x00;
-			*((word32) d0_n + 16) = a0_n;
-			word32 * a6_n = (word32) d0_n + 20;
+			d0_n[4] = (struct Eq_n) a0_n;
+			word32 * a6_n = d0_n + 5;
 			int32 d3_n = 1;
 			struct Eq_n * a0_n = a0 + d2_n;
 			do
@@ -118,15 +118,15 @@ l000010E6:
 				if (v40_n == 0x00)
 					goto l00001148;
 			} while (v40_n == 0x20 || v40_n == 0x09);
-			if (d3_n - *((word32) d0_n + 0x0C) != 0x00)
+			if (d3_n - d0_n[3] != 0x00)
 			{
-				*a6_n = (word32) a1_n;
+				*a6_n = a1_n;
 				++a6_n;
 				d3_n = SEQ(SLICE(d3_n, word16, 16), (word16) d3_n + 0x01);
 				if (v40_n != 0x22)
 				{
-					*a1_n = v40_n;
-					a1_n = (word32) a1_n + 1;
+					a1_n->dw0000 = (word32) v40_n;
+					a1_n = (struct Eq_n *) ((char *) &a1_n->dw0000 + 1);
 					while (true)
 					{
 						byte v50_n = *a2_n;
@@ -136,8 +136,8 @@ l000010E6:
 							break;
 						if (v50_n == 0x20)
 							goto l00001116;
-						*a1_n = v50_n;
-						a1_n = (word32) a1_n + 1;
+						a1_n->dw0000 = (word32) v50_n;
+						a1_n = (struct Eq_n *) ((char *) &a1_n->dw0000 + 1);
 					}
 				}
 				else
@@ -153,8 +153,8 @@ l000010E6:
 						if (v71_n == 0x22)
 						{
 l00001116:
-							*a1_n = 0x00;
-							a1_n = (word32) a1_n + 1;
+							a1_n->dw0000 = (word32) 0x00;
+							a1_n = (struct Eq_n *) ((char *) &a1_n->dw0000 + 1);
 							goto l000010E6;
 						}
 						if (v71_n == 0x2A)
@@ -167,19 +167,19 @@ l00001116:
 							else if ((v75_n & 223) == 0x45)
 								d1_n.u0 = 27;
 						}
-						*a1_n = (byte) d1_n;
-						a1_n = (word32) a1_n + 1;
+						a1_n->dw0000 = (word32) (byte) d1_n;
+						a1_n = (struct Eq_n *) ((char *) &a1_n->dw0000 + 1);
 					}
 				}
 			}
 l00001148:
-			*a1_n = 0x00;
+			a1_n->dw0000 = (word32) 0x00;
 			*a6_n = 0x00;
 			execPrivate4();
 			globals->t3E34 = d0_n;
 			execPrivate5();
 			globals->t3E38 = d0_n;
-			dwLoc0C_n = (word32) d0_n + 16;
+			dwLoc0C_n = (struct Eq_n *) (d0_n + 4);
 			dwLoc10 = d3_n;
 			if (globals->ptr3E24->t0014 >= 0x24)
 			{
@@ -207,7 +207,7 @@ l00001202:
 			globals->t3E3C = d0_n;
 			goto l0000117E;
 		}
-		CloseLibrary(globals->t3E28);
+		CloseLibrary(globals->ptr3E28);
 		Alert(0x00010000);
 	}
 	else
@@ -226,8 +226,8 @@ void fn00001214(struct Eq_n * a3)
 	GetMsg((char *) &a3->dw003A + 0x0022);
 }
 
-// 0000126C: void fn0000126C(Register Eq_n a2)
-void fn0000126C(Eq_n a2)
+// 0000126C: void fn0000126C(Register (ptr32 Eq_n) a2)
+void fn0000126C(struct Eq_n * a2)
 {
 	Forbid();
 	ReplyMsg(a2);
@@ -249,12 +249,12 @@ word32 fn0000127C(struct Eq_n & a1Out, struct Eq_n & a5Out)
 {
 	ptr32 a7_n = globals->ptr3E20;
 	struct Eq_n * v7_n = *(a7_n - 4);
-	Eq_n v5_n = *(a7_n - 8);
+	struct Eq_n * v5_n = *(a7_n - 8);
 	word32 d1_n = v7_n->dw0004;
 	if (d1_n != 0x00)
 		execPrivate1();
-	CloseLibrary(globals->t3E28);
-	if (v5_n != 0x00)
+	CloseLibrary(globals->ptr3E28);
+	if (v5_n != null)
 		fn0000126C(v5_n);
 	FreeMem(v7_n, v7_n->dw0000);
 	a1Out = v7_n;
@@ -305,8 +305,8 @@ word32 fn0000131C(ptr32 dwArg04, ptr32 & a1Out, ptr32 & a5Out)
 	return d1;
 }
 
-// 00001354: void fn00001354(Register Eq_n d1, Register Eq_n a1, Stack int32 dwArg04, Stack (ptr32 Eq_n) dwArg08)
-void fn00001354(Eq_n d1, Eq_n a1, int32 dwArg04, struct Eq_n * dwArg08)
+// 00001354: void fn00001354(Register Eq_n d1, Register (ptr32 Eq_n) a1, Stack int32 dwArg04, Stack (ptr32 Eq_n) dwArg08)
+void fn00001354(Eq_n d1, struct Eq_n * a1, int32 dwArg04, struct Eq_n * dwArg08)
 {
 	<anonymous> ** a3_n = (<anonymous> **) 0x3F60;
 	Eq_n d0_n = 16220;
@@ -323,10 +323,10 @@ void fn00001354(Eq_n d1, Eq_n a1, int32 dwArg04, struct Eq_n * dwArg08)
 	fn0000131C(fn00001390(d0_n, d1, a1), out a1_n, out a5_n);
 }
 
-// 00001390: Register Eq_n fn00001390(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1)
-Eq_n fn00001390(Eq_n d0, Eq_n d1, Eq_n a1)
+// 00001390: Register Eq_n fn00001390(Register Eq_n d0, Register Eq_n d1, Register (ptr32 Eq_n) a1)
+Eq_n fn00001390(Eq_n d0, Eq_n d1, struct Eq_n * a1)
 {
-	Eq_n a1_n;
+	struct Eq_n * a1_n;
 	Eq_n d1_n;
 	Eq_n d0_n = fn00002BF0(fn00002BF0(fn000015A4(fn00002BF0(d0, d1, a1, &globals->t147C), 0x1480, out d1_n, out a1_n), d1_n, a1_n, &globals->t149C), d1_n, a1_n, &globals->t14A0);
 	int32 d3_n = 1;
@@ -441,7 +441,7 @@ Eq_n fn0000151E(Eq_n d0, Eq_n d1, Eq_n d2, union Eq_n & d1Out)
 		if ((word16) d1_n < 0x80)
 		{
 			d1_n = __rol(d1_n, 0x08);
-			d3_n.u0 = 0x08;
+			&d3_n.u0->dw0000 = 0x08;
 		}
 		if ((word16) d1_n < 0x0800)
 		{
@@ -616,7 +616,7 @@ Eq_n fn000015C0(Eq_n d0, struct Eq_n * dwArg04, Eq_n dwArg08, Eq_n dwArg0C, stru
 					{
 						a0_n = 0x28C5 + (SEQ(SLICE(d0_n, word24, 8), *a2_n) & 0xFF);
 						uint32 d0_n = (uint32) (uint8) a0_n->t0000;
-						d5_n.u0 = 0;
+						&d5_n.u0->dw0000 = 0;
 						d0_n = d0_n & 0x04;
 						if ((d0_n & 0x04) != 0x00)
 						{
@@ -804,7 +804,7 @@ l0000183E:
 						}
 						if (d4_n == 0x68)
 						{
-							Eq_n v262_n = a7_n->dw003E;
+							word16 v262_n = a7_n->w003E;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1;
 							a7_n->dw0040 = (uint32) (uint16) v262_n;
@@ -813,7 +813,7 @@ l0000183E:
 						}
 						if (d4_n == 0x02)
 						{
-							Eq_n v277_n = a7_n->dw003F;
+							byte v277_n = a7_n->b003F;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1;
 							a7_n->dw0040 = (uint32) (uint8) v277_n;
@@ -924,7 +924,7 @@ l00001A9A:
 							}
 							if (d4_n == 0x02)
 							{
-								Eq_n v248_n = a7_n->dw0037;
+								byte v248_n = a7_n->b0037;
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->ptr0000 = d1;
 								int32 d1_n = (int32) (int16) (int8) SEQ(SLICE(d1, word24, 8), v248_n);
@@ -1287,13 +1287,13 @@ int32 fn00001F9C(int32 dwArg04, struct Eq_n * dwArg08, ui32 & a0Out, ptr32 & a1O
 		else
 			d4_n = 1;
 		word32 d1_n;
-		struct Eq_n * d0_n = fn0000215C(d4_n + dwArg08->dw001C, out d1_n, out a0, out a1_n);
-		if (d0_n == null)
+		int32 d0_n = fn0000215C(d4_n + dwArg08->dw001C, out d1_n, out a0, out a1_n);
+		if (d0_n == 0x00)
 		{
 			d0_n = -1;
 			goto l000020AA;
 		}
-		dwArg08->ptr0008 = (ui32 *) ((char *) &d0_n->dw0000 + 1);
+		dwArg08->ptr0008 = d0_n + 1;
 	}
 	else
 	{
@@ -1467,10 +1467,10 @@ void fn00002290(struct Eq_n * dwArg04, up32 dwArg08, up32 dwArg0C)
 		FreePooled(dwArg08, dwArg04);
 }
 
-// 0000232C: Register Eq_n fn0000232C(Stack (ptr32 Eq_n) dwArg04, Stack up32 dwArg08, Register out Eq_n d1Out, Register out (ptr32 Eq_n) a0Out)
-Eq_n fn0000232C(struct Eq_n * dwArg04, up32 dwArg08, union Eq_n & d1Out, struct Eq_n & a0Out)
+// 0000232C: Register (ptr32 Eq_n) fn0000232C(Stack (ptr32 Eq_n) dwArg04, Stack up32 dwArg08, Register out Eq_n d1Out, Register out (ptr32 Eq_n) a0Out)
+struct Eq_n * fn0000232C(struct Eq_n * dwArg04, up32 dwArg08, union Eq_n & d1Out, struct Eq_n & a0Out)
 {
-	Eq_n d0_n;
+	struct Eq_n * d0_n;
 	struct Eq_n * a0_n = globals->ptr3E24;
 	if (a0_n->t0014 >= 0x27)
 	{
@@ -1479,7 +1479,7 @@ Eq_n fn0000232C(struct Eq_n * dwArg04, up32 dwArg08, union Eq_n & d1Out, struct 
 	}
 	else
 	{
-		Eq_n a3_n = 0x00;
+		struct Eq_n * a3_n = null;
 		if (dwArg04 != null && dwArg08 != 0x00)
 		{
 			if (dwArg08 - dwArg04->t0014 < 0x00)
@@ -1489,43 +1489,43 @@ Eq_n fn0000232C(struct Eq_n * dwArg04, up32 dwArg08, union Eq_n & d1Out, struct 
 				{
 					if (a5_n->b0008 != 0x00)
 					{
-						Eq_n d0_n = Allocate(a5_n, dwArg08);
+						struct Eq_n * d0_n = Allocate(a5_n, dwArg08);
 						a0_n = a5_n;
 						a3_n = d0_n;
-						if (d0_n != 0x00)
+						if (d0_n != null)
 							goto l000023FE;
 					}
 					a5_n = a5_n->dw0000;
 				}
 				Eq_n d3_n = dwArg04->dw0010 + 40;
 				d1 = dwArg04->t000C;
-				Eq_n d0_n = AllocMem(d3_n, d1);
+				struct Eq_n * d0_n = AllocMem(d3_n, d1);
 				a3_n = d0_n;
-				if (d0_n != 0x00)
+				if (d0_n != null)
 				{
-					*d0_n = d3_n;
-					*((word32) d0_n + 0x0C) = 0x0A;
-					*((word32) d0_n + 20) = (word32) d0_n + 40;
-					*((word32) d0_n + 24) = (word32) d0_n + 40;
-					**((word32) d0_n + 20) = 0x00;
-					struct Eq_n * a2_n = *((word32) d0_n + 20);
+					d0_n->dw0000 = (word32) d3_n;
+					d0_n[3] = (struct Eq_n) 0x0A;
+					d0_n[5] = (struct Eq_n) (d0_n + 0x0A);
+					d0_n[6] = (struct Eq_n) (d0_n + 0x0A);
+					*d0_n[5].dw0000 = (struct Eq_n) 0x00;
+					struct Eq_n * a2_n = d0_n[5];
 					a2_n->dw0004 = dwArg04->dw0010;
-					*((word32) d0_n + 32) = a2_n->dw0004;
+					d0_n[8] = (struct Eq_n) a2_n->dw0004;
 					Mem110[d0_n + 28:word32] = Mem106[d0_n + 32:word32] + Mem106[d0_n + 20:word32];
-					AddHead(dwArg04, (word32) d0_n + 4);
-					a0_n = (word32) d0_n + 4;
-					a3_n = Allocate((word32) d0_n + 4, dwArg08);
+					AddHead(dwArg04, d0_n + 1);
+					a0_n = (struct Eq_n *) (d0_n + 1);
+					a3_n = Allocate(d0_n + 1, dwArg08);
 l000023FE:
 					if ((dwArg04->t000C & 0x00010000) != 0x00)
 					{
-						Eq_n a2_n = a3_n;
+						struct Eq_n * a2_n = a3_n;
 						uint32 d2_n;
 						do
 						{
+							a2_n->dw0000 = 0x00;
+							word32 * a2_n = a2_n + 1;
 							*a2_n = 0x00;
-							word32 * a2_n = (word32) a2_n + 4;
-							*a2_n = 0x00;
-							a2_n = a2_n + 1;
+							a2_n = (struct Eq_n *) (a2_n + 1);
 							--d2_n;
 						} while (d2_n != 0x00);
 					}
@@ -1534,15 +1534,15 @@ l000023FE:
 			else
 			{
 				d1 = dwArg04->t000C;
-				Eq_n d0_n = AllocMem(dwArg08 + 16, d1);
+				struct Eq_n * d0_n = AllocMem(dwArg08 + 16, d1);
 				a3_n = d0_n;
-				if (d0_n != 0x00)
+				if (d0_n != null)
 				{
-					*d0_n = dwArg08 + 16;
-					AddTail(dwArg04, (word32) d0_n + 4);
-					*((word32) d0_n + 0x0C) = 0x00;
+					d0_n->dw0000 = (word32) (dwArg08 + 16);
+					AddTail(dwArg04, d0_n + 1);
+					d0_n[3] = (struct Eq_n) 0x00;
 					a0_n = dwArg04;
-					a3_n = (word32) d0_n + 16;
+					a3_n = d0_n + 4;
 				}
 			}
 		}
@@ -1553,10 +1553,10 @@ l000023FE:
 	return d0_n;
 }
 
-// 00002450: Register Eq_n fn00002450(Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack (ptr32 Eq_n) dwArg0C, Register out (ptr32 Eq_n) d1Out, Register out (ptr32 Eq_n) a0Out, Register out Eq_n a1Out)
-Eq_n fn00002450(Eq_n dwArg04, struct Eq_n * dwArg08, struct Eq_n * dwArg0C, struct Eq_n & d1Out, struct Eq_n & a0Out, union Eq_n & a1Out)
+// 00002450: Register (ptr32 Eq_n) fn00002450(Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack (ptr32 Eq_n) dwArg0C, Register out (ptr32 Eq_n) d1Out, Register out (ptr32 Eq_n) a0Out, Register out (ptr32 Eq_n) a1Out)
+struct Eq_n * fn00002450(Eq_n dwArg04, struct Eq_n * dwArg08, struct Eq_n * dwArg0C, struct Eq_n & d1Out, struct Eq_n & a0Out, struct Eq_n & a1Out)
 {
-	Eq_n d0_n;
+	struct Eq_n * d0_n;
 	struct Eq_n * a0_n = globals->ptr3E24;
 	if (a0_n->t0014 >= 0x27)
 	{
@@ -1565,21 +1565,21 @@ Eq_n fn00002450(Eq_n dwArg04, struct Eq_n * dwArg08, struct Eq_n * dwArg0C, stru
 	}
 	else
 	{
-		a1.u0 = 0x00;
+		a1 = null;
 		if (dwArg08 - dwArg0C >= 0x00)
 		{
-			Eq_n d0_n = AllocMem(24, 0);
+			struct Eq_n * d0_n = AllocMem(24, 0);
 			d1 = null;
 			a1 = d0_n;
-			if (d0_n != 0x00)
+			if (d0_n != null)
 			{
-				*d0_n = (word32) d0_n + 4;
-				((word32) d0_n + 4)->u0 = 0x00;
-				*((word32) d0_n + 8) = d0_n;
-				*((word32) d0_n + 0x0C) = dwArg04;
-				*((word32) d0_n + 16) = (char *) &dwArg08->dw0004 + 3 & -8;
-				*((word32) d0_n + 20) = dwArg0C;
-				a0_n = (word32) d0_n + 4;
+				d0_n->dw0000 = d0_n + 1;
+				d0_n[1] = (struct Eq_n) 0x00;
+				d0_n[2] = (struct Eq_n) d0_n;
+				d0_n[3] = (struct Eq_n) dwArg04;
+				d0_n[4] = (struct Eq_n) ((char *) &dwArg08->dw0004 + 3 & -8);
+				d0_n[5] = (struct Eq_n) dwArg0C;
+				a0_n = (struct Eq_n *) (d0_n + 1);
 			}
 		}
 		d0_n = a1;
@@ -1707,7 +1707,7 @@ l0000265E:
 		word32 d1_n;
 		d1_n = fn00002664(dwArg04, dwArg08, dwArg10, out d1_n, out d2_n);
 l0000265C:
-		d0_n.u0 = 0;
+		&d0_n.u0->dw0000 = 0;
 		goto l0000265E;
 	}
 }
@@ -1765,7 +1765,7 @@ l0000267E:
 					Eq_n d2_n = __swap(d5_n);
 					Eq_n d3_n = __swap(d7_n);
 					if ((word16) (d2_n - d3_n) == 0x00)
-						d1_n.u0 = 0xFFFF;
+						&d1_n.u0->dw0000 = 0xFFFF;
 					else
 						d1_n = __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_n % (uint16) d3_n), (uint16) (d5_n /u (uint16) d3_n))), word16, 16), 0x00));
 					Eq_n d6_n = __swap(SEQ(SLICE(d6_n, word16, 16), 0x00));
@@ -1938,31 +1938,31 @@ void fn00002BAC(struct Eq_n * dwArg04)
 	}
 }
 
-// 00002BF0: Register Eq_n fn00002BF0(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack (ptr32 Eq_n) dwArg04)
-Eq_n fn00002BF0(Eq_n d0, Eq_n d1, Eq_n a1, struct Eq_n * dwArg04)
+// 00002BF0: Register Eq_n fn00002BF0(Register Eq_n d0, Register Eq_n d1, Register (ptr32 Eq_n) a1, Stack (ptr32 Eq_n) dwArg04)
+Eq_n fn00002BF0(Eq_n d0, Eq_n d1, struct Eq_n * a1, struct Eq_n * dwArg04)
 {
 	return fn00002C3C(d0, d1, a1, *(union Eq_n *) 16252, dwArg04, fp + 8);
 }
 
-// 00002C0C: Register Eq_n fn00002C0C(Stack Eq_n bArg07, Stack Eq_n dwArg08)
-Eq_n fn00002C0C(Eq_n bArg07, Eq_n dwArg08)
+// 00002C0C: Register Eq_n fn00002C0C(Stack byte bArg07, Stack Eq_n dwArg08)
+Eq_n fn00002C0C(byte bArg07, Eq_n dwArg08)
 {
 	Eq_n d0_n = dwArg08;
 	if (dwArg08 != 0x00)
 	{
 		d0_n = *((word32) dwArg08 + 4);
 		if (d0_n - *((word32) dwArg08 + 8) < 0x00)
-			**((word32) dwArg08 + 4) = bArg07;
+			(*((word32) dwArg08 + 4))->u0 = bArg07;
 		*((word32) dwArg08 + 20) = (word32) *((word32) dwArg08 + 20) + 1;
 		--*((word32) dwArg08 + 4);
 	}
 	return d0_n;
 }
 
-// 00002C3C: Register Eq_n fn00002C3C(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
-Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
+// 00002C3C: Register Eq_n fn00002C3C(Register Eq_n d0, Register Eq_n d1, Register (ptr32 Eq_n) a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
+Eq_n fn00002C3C(Eq_n d0, Eq_n d1, struct Eq_n * a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
 {
-	Eq_n a7_n = fp + -0x0078;
+	struct Eq_n * a7_n = fp + -0x0078;
 	Eq_n d2_n = dwArg0C;
 	struct Eq_n * a4_n = dwArg08;
 	Eq_n a2_n = dwArg04;
@@ -1976,8 +1976,8 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 			Eq_n d3_n = 0;
 			if (a4_n->b0000 == 0x25)
 			{
-				*((word32) a7_n + 72) = 0x69;
-				*((word32) a7_n + 73) = 0x00;
+				a7_n[18] = (struct Eq_n) 0x69;
+				a7_n->b0049 = 0x00;
 				byte * a3_n = a4_n + 1;
 				uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 				Eq_n d6_n = -1;
@@ -1985,7 +1985,7 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				if ((d0_n & 0x04) != 0x00)
 				{
 					uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-					d6_n.u0 = 0;
+					&d6_n.u0->dw0000 = 0;
 					d0 = d0_n & 0x04;
 					if ((d0_n & 0x04) != 0x00)
 					{
@@ -2007,8 +2007,8 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				}
 				if (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))))
 				{
-					d7 = SEQ(SLICE(d7, word24, 8), *((word32) a7_n + 73));
-					d1 = SEQ(SLICE(d1, word24, 8), *((word32) a7_n + 72));
+					d7 = SEQ(SLICE(d7, word24, 8), a7_n->b0049);
+					d1 = SEQ(SLICE(d1, word24, 8), a7_n[18]);
 					do
 					{
 						if (*a3_n == 0x2A)
@@ -2021,15 +2021,15 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 							d1 = SEQ(SLICE(d1, word24, 8), *a3_n);
 						++a3_n;
 					} while (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))));
-					*((word32) a7_n + 72) = (byte) d1;
-					*((word32) a7_n + 73) = (byte) d7;
+					a7_n[18] = (struct Eq_n) (byte) d1;
+					a7_n->b0049 = (byte) d7;
 				}
-				if (*((word32) a7_n + 72) == 0x6A)
-					*((word32) a7_n + 72) = 0x01;
-				if (*((word32) a7_n + 72) == 116)
-					*((word32) a7_n + 72) = 0x69;
-				if (*((word32) a7_n + 72) == 122)
-					*((word32) a7_n + 72) = 0x6C;
+				if (a7_n[18] == 0x6A)
+					a7_n[18] = (struct Eq_n) 0x01;
+				if (a7_n[18] == 116)
+					a7_n[18] = (struct Eq_n) 0x69;
+				if (a7_n[18] == 122)
+					a7_n[18] = (struct Eq_n) 0x6C;
 				byte v83_n = *a3_n;
 				word24 v84_n = SLICE(d7, word24, 8);
 				struct Eq_n * a3_n = a3_n + 1;
@@ -2047,10 +2047,10 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 						if (v90_n >= 0x00)
 						{
 							a1 = (word32) a2_n + 4;
-							byte * a0_n = *a1;
+							byte * a0_n = a1->dw0000;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							a1->dw0000 = a0_n + 1;
 							byte v96_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v96_n);
@@ -2087,19 +2087,19 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 								d1 = SEQ(v147_n, v83_n - 115);
 								if (v83_n != 115)
 								{
-									*((word32) a7_n + 48) = 0x00;
-									*((word32) a7_n + 44) = 0x00;
-									*((word32) a7_n + 110) = 0x00;
+									a7_n[0x0C] = (struct Eq_n) 0x00;
+									a7_n[11] = (struct Eq_n) 0x00;
+									a7_n->dw006E = 0x00;
 									if (v83_n == 0x00)
 										--a3_n;
 									if (v83_n == 0x70)
 									{
-										*((word32) a7_n + 72) = 0x6C;
+										a7_n[18] = (struct Eq_n) 0x6C;
 										d7 = 0x0078;
 									}
 									if ((d5_n == 0x2D && (byte) d7 != 117 || d5_n == 0x2B) && d6_n - d3_n >= 0x00)
 									{
-										*((word32) a7_n + 110) = d5_n;
+										a7_n->dw006E = (word32) d5_n;
 										ui32 * a0_n = (word32) a2_n + 24;
 										*a0_n |= 0x01;
 										int32 * a0_n = (word32) a2_n + 20;
@@ -2108,10 +2108,10 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 										if (v227_n >= 0x00)
 										{
 											a1 = (word32) a2_n + 4;
-											byte * a0_n = *a1;
+											byte * a0_n = a1->dw0000;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											a1->dw0000 = a0_n + 1;
 											byte v231_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -2127,7 +2127,7 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0 = fn00003CE0(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0;
 										}
-										d5_n = *((word32) a7_n + 52);
+										d5_n = a7_n[0x0D];
 										d3_n = (word32) d3_n + 1;
 										d4_n = (word32) d4_n + 1;
 									}
@@ -2144,10 +2144,10 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											if (v245_n >= 0x00)
 											{
 												a1 = (word32) a2_n + 4;
-												byte * a0_n = *a1;
+												byte * a0_n = a1->dw0000;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												a1->dw0000 = a0_n + 1;
 												byte v249_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -2163,8 +2163,8 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00003CE0(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 64) = *((word32) a7_n + 52);
-											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+											a7_n[16] = a7_n[0x0D];
+											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 											Eq_n d3_n = (word32) d3_n + 1;
 											d0 = d0_n & 0xFF;
 											if (!__btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[(int32) (int16) (d0_n & 0xFF)].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0], 0x00))
@@ -2180,10 +2180,10 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												if (v267_n >= 0x00)
 												{
 													a1 = (word32) a2_n + 4;
-													byte * a0_n = *a1;
+													byte * a0_n = a1->dw0000;
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
-													*a1 = a0_n + 1;
+													a1->dw0000 = a0_n + 1;
 													byte v271_n = *a0_n;
 													a2_n = a7_n->t0000;
 													a7_n->t0000 = d1;
@@ -2199,12 +2199,12 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 													d0_n = fn00003CE0(a7_n->t0000, out d1, out a1, out a5_n);
 													a7_n->t0038 = d0_n;
 												}
-												*((word32) a7_n + 74) = *((word32) a7_n + 52);
+												a7_n->dw004A = (word32) a7_n[0x0D];
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x44;
 												if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 													d7 = 0x0078;
-												if (*((word32) a7_n + 74) != ~0x00)
+												if (a7_n->dw004A != ~0x00)
 												{
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
@@ -2214,7 +2214,7 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											}
 											else
 												d7 = 111;
-											if (*((word32) a7_n + 64) != ~0x00)
+											if (a7_n[16] != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -2248,10 +2248,10 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 										if (v347_n >= 0x00)
 										{
 											a1 = (word32) a2_n + 4;
-											byte * a0_n = *a1;
+											byte * a0_n = a1->dw0000;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											a1->dw0000 = a0_n + 1;
 											byte v351_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -2267,8 +2267,8 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0_n = fn00003CE0(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0_n;
 										}
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
-										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+										a7_n[16] = a7_n[0x0D];
+										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 										Eq_n d3_n = (word32) d3_n + 1;
 										int32 d4_n = (word32) d4_n + 1;
 										d0 = d0_n & 0xFF;
@@ -2285,10 +2285,10 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											if (v368_n >= 0x00)
 											{
 												a1 = (word32) a2_n + 4;
-												byte * a0_n = *a1;
+												byte * a0_n = a1->dw0000;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												a1->dw0000 = a0_n + 1;
 												byte v372_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -2304,17 +2304,17 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00003CE0(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 74) = *((word32) a7_n + 52);
-											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55)) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
+											a7_n->dw004A = (word32) a7_n[0x0D];
+											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(SLICE(d0_n, word24, 8), a7_n->b0037) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 											d3_n = (word32) d3_n + 1;
 											d4_n = d4_n + 0x01;
 											d0 = d0_n & 0x44;
 											if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 											{
-												d5_n = *((word32) a7_n + 74);
+												d5_n = a7_n->dw004A;
 												goto l000036A6;
 											}
-											if (*((word32) a7_n + 74) != ~0x00)
+											if (a7_n->dw004A != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -2322,7 +2322,7 @@ Eq_n fn00002C3C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0 = fn00002C0C(*(a7_n - 1), a7_n->t0000);
 											}
 										}
-										if (*((word32) a7_n + 64) != ~0x00)
+										if (a7_n[16] != ~0x00)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
@@ -2336,52 +2336,52 @@ l000036A6:
 									if ((byte) d7 != 0x78 && (byte) d7 != 88)
 									{
 										if ((byte) d7 == 111)
-											*((word32) a7_n + 52) = 0x08;
+											a7_n[0x0D] = (struct Eq_n) 0x08;
 										else
-											*((word32) a7_n + 52) = 0x0A;
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
+											a7_n[0x0D] = (struct Eq_n) 0x0A;
+										a7_n[16] = a7_n[0x0D];
 									}
 									else
-										*((word32) a7_n + 64) = 0x10;
-									*((word32) a7_n + 114) = *((word32) a7_n + 64);
+										a7_n[16] = (struct Eq_n) 0x10;
+									a7_n->dw0072 = (word32) a7_n[16];
 									uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(SLICE(d0, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-									*((word32) a7_n + 0x0084) = d2_n;
-									*((word32) a7_n + 52) = d4_n;
-									*((word32) a7_n + 74) = (byte) d7;
+									a7_n[33] = (struct Eq_n) d2_n;
+									a7_n[0x0D] = (struct Eq_n) d4_n;
+									a7_n->dw004A = (word32) (byte) d7;
 									d0 = d0_n & 0x44;
 									if ((d0_n & 0x44) != 0x00)
 									{
-										if (*((word32) a7_n + 114) == 0x0A)
+										if (a7_n->dw0072 == 0x0A)
 										{
 											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(SLICE(d0_n & 0x44, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											d0 = d0_n & 0x04;
 											if ((d0_n & 0x04) != 0x00)
 												goto l00003742;
 											goto l00003942;
 										}
 l00003742:
-										if (*((word32) a7_n + 114) == 0x08)
+										if (a7_n->dw0072 == 0x08)
 										{
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d5_n <= 55)
 												goto l00003762;
 										}
 										else
 										{
 l00003762:
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 64) = d6_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n[16] = (struct Eq_n) d6_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d6_n - d3_n >= 0x00)
 											{
-												d7 = (int32) *((word32) a7_n + 114);
-												up32 a4_n = *((word32) a7_n + 64);
+												d7 = a7_n->dw0072;
+												up32 a4_n = a7_n[16];
 												do
 												{
 													struct Eq_n * a7_n = a7_n - 4;
@@ -2389,7 +2389,7 @@ l00003762:
 													Eq_n v419_n = a7_n->t0000;
 													a7_n->t0000 = d7 >> 31;
 													*(a7_n - 4) = d7;
-													*(a7_n - 8) = (union Eq_n *) a1;
+													*(a7_n - 8) = (struct Eq_n **) a1;
 													*(a7_n - 0x0C) = a7_n->dw0034;
 													*(a7_n - 16) = a7_n->dw0030;
 													*(a7_n - 20) = d7;
@@ -2397,7 +2397,7 @@ l00003762:
 													word32 d1_n;
 													a7_n->dw0044 = fn00003C60(d4_n, *(a7_n - 24), *(a7_n - 20), *(a7_n - 16), *(a7_n - 0x0C), out d1_n);
 													a7_n->dw0048 = d1_n;
-													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(a7_n->t0001, (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x04) != 0x00)
+													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(a7_n->n0001, (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x04) != 0x00)
 														d4_n = d5_n - 0x30;
 													else
 														d4_n.u0 = 0;
@@ -2405,10 +2405,10 @@ l00003762:
 													*(a7_n - 4) = (union Eq_n *) v419_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d4_n + Mem2975[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = (union Eq_n *) d3_n;
 													int32 d0_n = d4_n >> 31;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + d0_n);
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < 0x00) + ((word32) a7_n[16] + d0_n));
 													word32 v441_n = *(a7_n - 8);
 													word32 v442_n = *(a7_n - 4);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x01) != 0x00)
@@ -2419,10 +2419,10 @@ l00003762:
 													*(a7_n - 4) = v442_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d6_n + Mem3035[a7_n + 48:word32];
-													*((word32) a7_n + 0x0044) = d2_n;
+													a7_n[0x0011] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v441_n;
 													int32 d0_n = d6_n >> 31;
-													*((word32) a7_n + 64) = (word32) *((word32) a7_n + 44) + d0_n + (d2_n < 0x00);
+													a7_n[16] = (struct Eq_n) ((word32) a7_n[11] + d0_n + (d2_n < 0x00));
 													word32 v453_n = *(a7_n - 8);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x02) != 0x00)
 														d2_n = d5_n - 0x57;
@@ -2432,9 +2432,9 @@ l00003762:
 													*(a7_n - 4) = (union Eq_n *) d2_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d2_n + Mem3093[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v453_n;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + (d2_n >> 31));
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < 0x00) + ((word32) a7_n[16] + (d2_n >> 31)));
 													ui32 * a0_n = (word32) a2_n + 24;
 													up32 v465_n = *(a7_n - 8);
 													d2_n = *(a7_n - 4);
@@ -2445,9 +2445,9 @@ l00003762:
 													if (v468_n >= 0x00)
 													{
 														a1 = (word32) a2_n + 4;
-														byte * a0_n = *a1;
+														byte * a0_n = a1->dw0000;
 														*(a7_n - 4) = (union Eq_n *) a2_n;
-														*a1 = a0_n + 1;
+														a1->dw0000 = a0_n + 1;
 														d0_n = (uint32) (uint8) *a0_n;
 														a2_n = *(a7_n - 4);
 														d1 = (uint32) (uint8) (byte) d0_n;
@@ -2460,7 +2460,7 @@ l00003762:
 														d0_n = fn00003CE0(*(a7_n - 4), out d1_n, out a1, out a5_n);
 														d1 = d0_n;
 													}
-													*((word32) a7_n + 52) = (word32) *((word32) a7_n + 52) + 1;
+													a7_n[0x0D] = (struct Eq_n) ((word32) a7_n[0x0D] + 1);
 													uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(SLICE(d0_n, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 													d5_n = d1;
 													d3_n = v465_n + 0x01;
@@ -2479,11 +2479,11 @@ l00003762:
 										}
 									}
 l00003942:
-									Eq_n v476_n = *((word32) a7_n + 74);
+									Eq_n v476_n = a7_n->dw004A;
 									d7 = SEQ(SLICE(d7, word24, 8), v476_n);
-									word32 d4_n = *((word32) a7_n + 52);
-									d2_n = *((word32) a7_n + 0x0084);
-									if (*((word32) a7_n + 110) != 0x00 && d3_n == 0x02)
+									word32 d4_n = a7_n[0x0D];
+									d2_n = a7_n[33];
+									if (a7_n->dw006E != 0x00 && d3_n == 0x02)
 									{
 										if (d5_n != ~0x00)
 										{
@@ -2494,7 +2494,7 @@ l00003942:
 										}
 										--d3_n;
 										--d4_n;
-										d5_n = *((word32) a7_n + 110);
+										d5_n = a7_n->dw006E;
 									}
 									if (d5_n != ~0x00)
 									{
@@ -2505,14 +2505,14 @@ l00003942:
 									}
 									d3_n = d3_n - 0x01;
 									d4_n = d4_n - 0x01;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										if (v476_n == 117)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = d0;
 											a7_n->b0038 = a7_n->b004C - 0x01;
-											a7_n = (char *) &a7_n->t0000 + 4;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
 											if (a7_n->b0038 != 0x00)
 											{
 												byte v517_n = a7_n->b0038 - 0x01;
@@ -2564,58 +2564,58 @@ l00003942:
 										}
 										else
 										{
-											if (*((word32) a7_n + 110) == 0x2D)
+											if (a7_n->dw006E == 0x2D)
 											{
-												struct Eq_n * v528_n = (word32) a7_n + 44;
+												struct Eq_n * v528_n = a7_n + 11;
 												d1 = -v528_n->dw0004;
 												d0 = -v528_n->dw0000 - (d1 < 0x00);
-												a7_n = *((word32) a7_n + 56);
+												a7_n = (struct Eq_n *) a7_n[0x0E];
 											}
 											else
 											{
-												*((word32) a7_n + 56) = *((word32) a7_n + 48);
-												*((word32) a7_n + 52) = *((word32) a7_n + 44);
+												a7_n[0x0E] = a7_n[0x0C];
+												a7_n[0x0D] = a7_n[11];
 											}
-											Eq_n a7_n = a7_n - 4;
-											*a7_n = d0;
-											*((word32) a7_n + 48) = *((word32) a7_n + 76) - 0x01;
-											a7_n = (word32) a7_n + 4;
-											if (*((word32) a7_n + 48) != 0x00)
+											struct Eq_n * a7_n = a7_n - 4;
+											a7_n->t0000 = d0;
+											a7_n->b0030 = a7_n->b004C - 0x01;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
+											if (a7_n->b0030 != 0x00)
 											{
-												byte v540_n = *((word32) a7_n + 48) - 0x01;
-												*((word32) a7_n + 48) = v540_n;
+												byte v540_n = a7_n->b0030 - 0x01;
+												a7_n->b0030 = v540_n;
 												if (v540_n != 0x00)
 												{
-													byte v541_n = *((word32) a7_n + 48) - 0x66;
-													*((word32) a7_n + 48) = v541_n;
+													byte v541_n = a7_n->b0030 - 0x66;
+													a7_n->b0030 = v541_n;
 													if (v541_n != 0x00)
 													{
-														byte v542_n = *((word32) a7_n + 48) - 0x04;
-														*((word32) a7_n + 48) = v542_n;
+														byte v542_n = a7_n->b0030 - 0x04;
+														a7_n->b0030 = v542_n;
 														if (v542_n != 0x00)
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 														else
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 													}
 													else
 													{
 														d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-														d0 = *((word32) a7_n + 60);
+														d0 = a7_n->t003C;
 														**((word32) d2_n - 4) = (word16) d0;
 													}
 												}
 												else
 												{
 													d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-													d0 = *((word32) a7_n + 60);
+													d0 = a7_n->t003C;
 													**((word32) d2_n - 4) = (byte) d0;
 												}
 											}
@@ -2624,18 +2624,18 @@ l00003942:
 												word32 d0_n = d2_n + 0x03 >>u 0x02;
 												d2_n = (d0_n << 0x02) + 0x04;
 												struct Eq_n * a0_n = *((word32) d2_n - 4);
-												a0_n->dw0004 = (word32) *((word32) a7_n + 60);
-												a0_n->dw0000 = (word32) *((word32) a7_n + 56);
+												a0_n->t0004 = a7_n->t003C;
+												a0_n->dw0000 = a7_n->dw0038;
 												d0 = d0_n << 0x02;
 											}
 										}
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 								else
 								{
 									byte * a5_n;
-									if (*((word32) a7_n + 73) == 0x00)
+									if (a7_n->b0049 == 0x00)
 									{
 										d0 = (word32) d2_n + 3 >> 0x02 << 0x02;
 										d2_n = (word32) d0 + 4;
@@ -2649,7 +2649,7 @@ l00003942:
 										d0 = d0_n & 0x08;
 										if ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00)
 										{
-											byte v190_n = *((word32) a7_n + 73);
+											byte v190_n = a7_n->b0049;
 											d7 = SEQ(v84_n, v190_n);
 											do
 											{
@@ -2666,10 +2666,10 @@ l00003942:
 												if (v197_n >= 0x00)
 												{
 													a1 = (word32) a2_n + 4;
-													byte * a0_n = *a1;
+													byte * a0_n = a1->dw0000;
 													union Eq_n * a7_n = a7_n - 4;
 													*a7_n = (union Eq_n *) a2_n;
-													*a1 = a0_n + 1;
+													a1->dw0000 = a0_n + 1;
 													byte v201_n = *a0_n;
 													a2_n = *a7_n;
 													d0 = SEQ(SLICE(d0, word24, 8), v201_n);
@@ -2691,7 +2691,7 @@ l00003942:
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28C5)[SEQ(SLICE(d0, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x08;
 											} while ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00);
-											*((word32) a7_n + 73) = v190_n;
+											a7_n->b0049 = v190_n;
 										}
 									}
 									if (d5_n != ~0x00)
@@ -2703,18 +2703,18 @@ l00003942:
 									}
 									d3_n = d3_n - 0x01;
 									--d4_n;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										*a5_n = 0x00;
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 							}
 							else
 							{
-								if (*((word32) a7_n + 73) == 0x00)
+								if (a7_n->b0049 == 0x00)
 								{
-									if (*((word32) a7_n + 72) == 0x01)
+									if (a7_n[18] == 0x01)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										struct Eq_n * a0_n = *d0;
@@ -2722,19 +2722,19 @@ l00003942:
 										a0_n->dw0000 = 0x00;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x6C)
+									else if (a7_n[18] == 0x6C)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x68)
+									else if (a7_n[18] == 0x68)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (word16) d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x02)
+									else if (a7_n[18] == 0x02)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (byte) d4_n;
@@ -2747,16 +2747,16 @@ l00003942:
 										d2_n = (word32) d0 + 4;
 									}
 								}
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 								d3_n.u0 = 1;
 							}
 						}
 						else
 						{
 							if (d6_n == ~0x00)
-								d6_n.u0 = 1;
+								&d6_n.u0->dw0000 = 1;
 							union Eq_n * a1_n;
-							if (*((word32) a7_n + 73) == 0x00)
+							if (a7_n->b0049 == 0x00)
 							{
 								d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 								d2_n = (word32) d0 + 4;
@@ -2768,7 +2768,7 @@ l00003942:
 							*a0_n |= 0x01;
 							int32 * a0_n = (word32) a2_n + 20;
 							--*a0_n;
-							*((word32) a7_n + 44) = a1_n;
+							a7_n[11] = (struct Eq_n) a1_n;
 							if (*a0_n >= 0x00)
 							{
 								byte ** a1_n = (word32) a2_n + 4;
@@ -2785,7 +2785,7 @@ l00003942:
 							}
 							else
 							{
-								int32 a1_n = *((word32) a7_n + 44);
+								int32 a1_n = a7_n[11];
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->t0000 = a2_n;
 								a7_n->dw0030 = a1_n;
@@ -2795,18 +2795,18 @@ l00003942:
 								a7_n->t0038 = d0;
 								a7_n->dw0030 = a7_n->dw0030;
 							}
-							a1 = *((word32) a7_n + 44);
-							d5_n = *((word32) a7_n + 52);
+							a1 = (struct Eq_n *) a7_n[11];
+							d5_n = a7_n[0x0D];
 							Eq_n d3_n = (word32) d3_n + 1;
 							int32 d4_n = (word32) d4_n + 1;
-							if (*((word32) a7_n + 52) != ~0x00)
+							if (a7_n[0x0D] != ~0x00)
 							{
-								*((word32) a7_n + 44) = a1;
+								a7_n[11] = (struct Eq_n) a1;
 								if (d6_n - d3_n >= 0x00)
 								{
-									byte v302_n = *((word32) a7_n + 73);
+									byte v302_n = a7_n->b0049;
 									d7 = SEQ(v84_n, v302_n);
-									byte * a4_n = *((word32) a7_n + 44);
+									byte * a4_n = a7_n[11];
 									do
 									{
 										if (v302_n == 0x00)
@@ -2822,10 +2822,10 @@ l00003942:
 										if (v310_n >= 0x00)
 										{
 											a1 = (word32) a2_n + 4;
-											byte * a0_n = *a1;
+											byte * a0_n = a1->dw0000;
 											union Eq_n * a7_n = a7_n - 4;
 											*a7_n = (union Eq_n *) a2_n;
-											*a1 = a0_n + 1;
+											a1->dw0000 = a0_n + 1;
 											byte v314_n = *a0_n;
 											a2_n = *a7_n;
 											d0 = SEQ(SLICE(d0, word24, 8), v314_n);
@@ -2844,7 +2844,7 @@ l00003942:
 										d3_n = (word32) d3_n + 1;
 										++d4_n;
 									} while (d1 != ~0x00 && d6_n - d3_n >= 0x00);
-									*((word32) a7_n + 73) = v302_n;
+									a7_n->b0049 = v302_n;
 								}
 							}
 							if (d5_n != ~0x00)
@@ -2856,22 +2856,22 @@ l00003942:
 							}
 							d3_n = d3_n - 0x01;
 							d4_n = d4_n - 0x01;
-							if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							if (a7_n->b0049 == 0x00 && d3_n != 0x00)
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 					else
 					{
-						*((word32) a7_n + 44) = 0x00;
+						a7_n[11] = (struct Eq_n) 0x00;
 						if (a3_n->b0000 == 0x5E)
 						{
-							*((word32) a7_n + 44) = 0x01;
+							a7_n[11] = (struct Eq_n) 0x01;
 							++a3_n;
 						}
-						*((word32) a7_n + 52) = 0x00;
-						byte v544_n = *((word32) a7_n + 44);
+						a7_n[0x0D] = (struct Eq_n) 0x00;
+						Eq_n v544_n = a7_n[11];
 						d7 = SEQ(v84_n, v544_n);
-						Eq_n d1_n = *((word32) a7_n + 52);
+						Eq_n d1_n = a7_n[0x0D];
 						do
 						{
 							int32 d5_n;
@@ -2879,12 +2879,12 @@ l00003942:
 								d5_n = 0xFF;
 							else
 								d5_n = 0;
-							*((word32) d1_n + ((word32) a7_n + 78)) = (byte) d5_n;
+							Mem796[a7_n + 78 + d1_n:byte] = SLICE(d5_n, byte, 0);
 							d1_n = (word32) d1_n + 1;
 						} while (d1_n < 0x20);
-						*((word32) a7_n + 0x0084) = d2_n;
-						*((word32) a7_n + 44) = v544_n;
-						byte v554_n = *((word32) a7_n + 44);
+						a7_n[33] = (struct Eq_n) d2_n;
+						a7_n[11] = (struct Eq_n) v544_n;
+						Eq_n v554_n = a7_n[11];
 						while (a3_n->b0000 != 0x00)
 						{
 							cu8 v556_n = a3_n->b0000;
@@ -2897,32 +2897,32 @@ l00003942:
 							}
 							else
 								d7 = SEQ(SLICE(d7, word24, 8), v556_n);
-							Eq_n d5_n = (uint32) (uint8) v556_n;
+							union Eq_n ** d5_n = (uint32) (uint8) v556_n;
 							d0 = (uint32) (uint8) (byte) d7;
-							while (d0 - d5_n >= 0x00)
+							while (d0 - d5_n >= null)
 							{
 								if (v554_n != 0x00)
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (~(1 << (d5_n & 7)) & d1_n);
 								}
 								else
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (1 << (d5_n & 7) | d1_n);
 								}
-								d5_n = (word32) d5_n + 1;
+								++d5_n;
 								d0 = (uint32) (uint8) (byte) d7;
 							}
 							if (a3_n->b0000 == 0x5D)
 								break;
 						}
 						byte * a6_n;
-						d2_n = *((word32) a7_n + 0x0084);
+						d2_n = a7_n[33];
 						++a3_n;
-						if (*((word32) a7_n + 73) == 0x00)
+						if (a7_n->b0049 == 0x00)
 						{
 							word32 d0_n = d2_n + 0x03 >>u 0x02;
 							d2_n = (d0_n << 0x02) + 0x04;
@@ -2939,41 +2939,41 @@ l00003942:
 						if (v581_n >= 0x00)
 						{
 							a1 = (word32) a2_n + 4;
-							byte * a0_n = *a1;
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*a1 = a0_n + 1;
+							byte * a0_n = a1->dw0000;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
+							a1->dw0000 = a0_n + 1;
 							byte v585_n = *a0_n;
-							a2_n = *a7_n;
-							*a7_n = d1_n;
-							*((word32) a7_n + 48) = (uint32) (uint8) v585_n;
+							a2_n = a7_n->t0000;
+							a7_n->t0000 = d1_n;
+							a7_n->dw0030 = (uint32) (uint8) v585_n;
 							d0 = SEQ(SLICE(d0, word24, 8), v585_n);
-							d1 = *a7_n;
+							d1 = a7_n->t0000;
 						}
 						else
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
 							word32 a5_n;
-							d0 = fn00003CE0(*a7_n, out d1, out a1, out a5_n);
-							*((word32) a7_n + 48) = d0;
+							d0 = fn00003CE0(a7_n->t0000, out d1, out a1, out a5_n);
+							a7_n->t0030 = d0;
 						}
-						d5_n = *((word32) a7_n + 44);
+						d5_n = a7_n[11];
 						Eq_n d3_n = (word32) d3_n + 1;
 						int32 d4_n = (word32) d4_n + 1;
-						if (*((word32) a7_n + 44) != ~0x00)
+						if (a7_n[11] != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = (word32) a7_n + 78;
-							*(a7_n - 4) = a1;
-							(a7_n - 8)->u0 = 0x08;
-							*(a7_n - 0x0C) = d5_n;
-							d1 = (uint32) (uint8) *((word32) *a7_n + fn000014EC(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-							a1 = *(a7_n - 4);
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->ptr0000 = &a7_n->dw004A + 1;
+							*(a7_n - 4) = (struct Eq_n **) a1;
+							*(a7_n - 8) = 0x08;
+							*(a7_n - 0x0C) = (union Eq_n *) d5_n;
+							d1 = (uint32) (uint8) (a7_n->ptr0000 + fn000014EC(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+							a1 = (struct Eq_n *) *(a7_n - 4);
 							d0 = 1 << (d5_n & 7) & d1;
 							if (d0 != 0x00 && d6_n - d3_n >= 0x00)
 							{
-								byte v601_n = *((word32) a7_n + 77);
+								byte v601_n = a7_n->b004D;
 								d7 = SEQ(SLICE(d7, word24, 8), v601_n);
 								do
 								{
@@ -2990,10 +2990,10 @@ l00003942:
 									if (v607_n >= 0x00)
 									{
 										a1 = (word32) a2_n + 4;
-										byte * a0_n = *a1;
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
-										*a1 = a0_n + 1;
+										byte * a0_n = a1->dw0000;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
+										a1->dw0000 = a0_n + 1;
 										byte v611_n = *a0_n;
 										a2_n = *a7_n;
 										d0 = SEQ(SLICE(d0, word24, 8), v611_n);
@@ -3001,8 +3001,8 @@ l00003942:
 									}
 									else
 									{
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
 										word32 d1_n;
 										word32 a5_n;
 										d0 = fn00003CE0(*a7_n, out d1_n, out a1, out a5_n);
@@ -3013,31 +3013,31 @@ l00003942:
 									++d4_n;
 									if (d1 == ~0x00)
 										break;
-									Eq_n a7_n = a7_n - 4;
-									*a7_n = (word32) a7_n + 78;
-									*(a7_n - 4) = a1;
-									(a7_n - 8)->u0 = 0x08;
-									*(a7_n - 0x0C) = d1;
-									d1 = (uint32) (uint8) *((word32) *a7_n + fn000014EC(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-									a1 = *(a7_n - 4);
+									ptr32 * a7_n = a7_n - 4;
+									*a7_n = &a7_n->dw004A + 1;
+									*(a7_n - 4) = (struct Eq_n **) a1;
+									*(a7_n - 8) = 0x08;
+									*(a7_n - 0x0C) = (union Eq_n *) d1;
+									d1 = (uint32) (uint8) (*a7_n + fn000014EC(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+									a1 = (struct Eq_n *) *(a7_n - 4);
 									d0 = 1 << (d1 & 7) & d1;
 								} while (d0 != 0x00 && d6_n - d3_n >= 0x00);
-								*((word32) a7_n + 73) = v601_n;
+								a7_n->b0049 = v601_n;
 							}
 						}
 						if (d5_n != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*(a7_n - 4) = d5_n;
+							union Eq_n * a7_n = a7_n - 4;
+							*a7_n = (union Eq_n *) a2_n;
+							*(a7_n - 4) = (union Eq_n *) d5_n;
 							d0 = fn00002C0C(*(a7_n - 1), *a7_n);
 						}
 						d3_n = d3_n - 0x01;
 						d4_n = d4_n - 0x01;
-						if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+						if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 						{
 							*a6_n = 0x00;
-							*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 				}
@@ -3051,10 +3051,10 @@ l00003942:
 					if (v159_n >= 0x00)
 					{
 						a1 = (word32) a2_n + 4;
-						byte * a0_n = *a1;
+						byte * a0_n = a1->dw0000;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						a1->dw0000 = a0_n + 1;
 						byte v163_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1_n;
@@ -3070,10 +3070,10 @@ l00003942:
 						d0 = fn00003CE0(a7_n->t0000, out d1, out a1, out a5_n);
 						a7_n->t0030 = d0;
 					}
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n = (word32) d3_n.u0 + 1;
 					d4_n = (word32) d4_n + 1;
-					if (*((word32) a7_n + 44) != 0x25)
+					if (a7_n[11] != 0x25)
 					{
 						if (d5_n != ~0x00)
 						{
@@ -3105,10 +3105,10 @@ l00003942:
 						if (v105_n >= 0x00)
 						{
 							a1 = (word32) a2_n + 4;
-							byte * a0_n = *a1;
+							byte * a0_n = a1->dw0000;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							a1->dw0000 = a0_n + 1;
 							byte v109_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v109_n);
@@ -3149,10 +3149,10 @@ l00003942:
 					if (v126_n >= 0x00)
 					{
 						a1 = (word32) a2_n + 4;
-						byte * a0_n = *a1;
+						byte * a0_n = a1->dw0000;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						a1->dw0000 = a0_n + 1;
 						byte v130_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1;
@@ -3169,10 +3169,10 @@ l00003942:
 						a7_n->t0030 = d0_n;
 					}
 					d0 = (int32) (int16) (int8) SEQ(SLICE(d0_n, word24, 8), a4_n->b0000);
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n.u0 = 0x01;
 					d4_n = (word32) d4_n + 1;
-					if (d0 - *((word32) a7_n + 44) != 0x00)
+					if (d0 - a7_n[11] != 0x00)
 					{
 						if (d5_n != ~0x00)
 						{
@@ -3216,13 +3216,13 @@ uint32 fn00003C60(Eq_n d4, Eq_n dwArg04, Eq_n dwArg08, Eq_n dwArg0C, Eq_n dwArg1
 	return (uint32) (uint16) (word16) d2_n + d1_n + (dwArg0C * (word16) dwArg08 + SEQ(SLICE(d3_n, word16, 16), (word16) d3_n ^ (word16) d3_n)) + (dwArg04 * (word16) dwArg10 + SEQ(SLICE(d3_n, word16, 16), (word16) d3_n ^ (word16) d3_n));
 }
 
-// 00003CE0: Register int32 fn00003CE0(Stack Eq_n dwArg04, Register out Eq_n d1Out, Register out (ptr32 word32) a1Out, Register out (ptr32 byte) a5Out)
+// 00003CE0: Register int32 fn00003CE0(Stack Eq_n dwArg04, Register out (ptr32 (ptr32 Eq_n)) d1Out, Register out (ptr32 word32) a1Out, Register out (ptr32 byte) a5Out)
 int32 fn00003CE0(Eq_n dwArg04, union Eq_n & d1Out, word32 & a1Out, byte & a5Out)
 {
 	int32 d0_n;
 	byte * a5_n;
 	word32 * a1_n;
-	Eq_n d1_n = fn00002530(out a1_n, out a5_n);
+	union Eq_n ** d1_n = fn00002530(out a1_n, out a5_n);
 	if (dwArg04 == 0x00)
 	{
 		d0_n = -1;
@@ -3234,16 +3234,16 @@ int32 fn00003CE0(Eq_n dwArg04, union Eq_n & d1Out, word32 & a1Out, byte & a5Out)
 		goto l00003DD6;
 	}
 	*((word32) dwArg04 + 24) |= 1;
-	struct Eq_n * d0_n = *((word32) dwArg04 + 24) & 0x0200;
-	if (d0_n != null)
+	int32 d0_n = *((word32) dwArg04 + 24) & 0x0200;
+	if (d0_n != 0x00)
 		d0_n = fn00003DDC(out a1_n, out a5_n);
 	if (*((word32) dwArg04 + 28) == 0x00)
 	{
 		d0_n = *((word32) dwArg04 + 24) & 4;
-		if (d0_n != null)
+		if (d0_n != 0x00)
 		{
 			*((word32) dwArg04 + 28) = 1;
-			d0_n = (struct Eq_n *) 1;
+			d0_n = 1;
 		}
 		else
 			*((word32) dwArg04 + 28) = 0x0400;
@@ -3256,29 +3256,29 @@ int32 fn00003CE0(Eq_n dwArg04, union Eq_n & d1Out, word32 & a1Out, byte & a5Out)
 		else
 			d4_n = 1;
 		word32 a0_n;
-		struct Eq_n * d0_n = fn0000215C((word32) *((word32) dwArg04 + 28) + d4_n, out d1_n, out a0_n, out a1_n);
+		int32 d0_n = fn0000215C((word32) *((word32) dwArg04 + 28) + d4_n, out d1_n, out a0_n, out a1_n);
 		d0_n = d0_n;
-		if (d0_n == null)
+		if (d0_n == 0x00)
 		{
 			d0_n = -1;
 			goto l00003DD6;
 		}
-		*((word32) dwArg04 + 8) = (char *) &d0_n->dw0000 + 1;
-		a1_n = (word32 *) ((char *) &d0_n->dw0000 + 1);
+		*((word32) dwArg04 + 8) = d0_n + 1;
+		a1_n = d0_n + 1;
 	}
 	*((word32) dwArg04 + 4) = *((word32) dwArg04 + 8);
-	d1_n = *dwArg04;
+	d1_n = (union Eq_n **) *dwArg04;
 	execPrivate2();
 	*((word32) dwArg04 + 20) = d0_n;
-	struct Eq_n * v26_n = *((word32) dwArg04 + 20) - 0x01;
+	int32 v26_n = *((word32) dwArg04 + 20) - 0x01;
 	*((word32) dwArg04 + 20) = v26_n;
-	if (v26_n < null)
+	if (v26_n < 0x00)
 	{
-		if (*((word32) dwArg04 + 20) == (struct Eq_n *) -1)
+		if (*((word32) dwArg04 + 20) == -1)
 			*((word32) dwArg04 + 24) |= 8;
 		else
 			*((word32) dwArg04 + 24) |= 16;
-		*((word32) dwArg04 + 20) = null;
+		*((word32) dwArg04 + 20) = 0x00;
 		d0_n = -1;
 	}
 	else

--- a/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL.h
+++ b/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL.h
@@ -327,16 +327,13 @@ Eq_581: (fn word32 (ptr32, ptr32, ptr32))
 Eq_583: (fn ptr32 ())
 	T_583 (in fn00001390 : ptr32)
 	T_584 (in signature of fn00001390 : void)
-Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9002) u3) ((ptr32 Eq_8951) u4) ((ptr32 Eq_8958) u5) (Eq_6954 u6) (Eq_7817 u7))
+Eq_603: (union "Eq_603" (byte u0) (word16 u1) ((ptr32 Eq_8993) u2) ((ptr32 Eq_8951) u3))
 	T_603 (in d0 : Eq_603)
-	T_604 (in a1_23 : Eq_603)
 	T_605 (in d1_25 : Eq_603)
-	T_606 (in a1_52 : Eq_603)
 	T_607 (in d1_54 : Eq_603)
 	T_608 (in d0_495 : Eq_603)
 	T_611 (in d0 : Eq_603)
 	T_612 (in d1 : Eq_603)
-	T_613 (in a1 : Eq_603)
 	T_618 (in d0 : Eq_603)
 	T_631 (in fn00004068(&globals->b16B0, out d1_25, out a1_23) : word32)
 	T_633 (in fn00002E40(fn00004068(&globals->b16B0, out d1_25, out a1_23), d1_25, a1_23, &globals->t16CC) : word32)
@@ -345,158 +342,6 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_641 (in fn00002E40(fn00002E40(fn000016FC(fn00002E40(fn00004068(&globals->b16B0, out d1_25, out a1_23), d1_25, a1_23, &globals->t16CC), 0x16D0<u32>, out d1_54, out a1_52), d1_54, a1_52, &globals->t16EC), d1_54, a1_52, &globals->t16F0) : word32)
 	T_656 (in fn000016FC(d0_495, 0x16F4<u32>, out d1_552, out a1_553) : word32)
 	T_657 (in 40<i32> : int32)
-	T_663 (in  : word32)
-	T_664 (in 3<i32> : int32)
-	T_665 (in __swap(3<i32>) : word32)
-	T_666 (in dwLoc14 : word32)
-	T_669 (in d0_119 : Eq_603)
-	T_676 (in __swap(dwLoc14) : word32)
-	T_681 (in SEQ(SLICE(d4_110, word16, 16), SLICE(d4_110 + __swap(dwLoc14) *u 3<16>, word16, 0)) : uipr32)
-	T_682 (in __swap(SEQ(SLICE(d4_110, word16, 16), (word16) (d4_110 + __swap(dwLoc14) * 3<16>))) : word32)
-	T_686 (in (word16) dwLoc14 * 3<i32> + SEQ(SLICE(__swap(SEQ(SLICE(d4_110, word16, 16), (word16) (d4_110 + __swap(dwLoc14) * 3<16>))), word16, 16), 0<16>) : word32)
-	T_689 (in __swap(d0_119) : word32)
-	T_692 (in d0_134 : Eq_603)
-	T_698 (in __swap(dwLoc14) : word32)
-	T_703 (in SEQ(SLICE(d4_125, word16, 16), SLICE(d4_125 + __swap(dwLoc14) *u SLICE(d0_119, word16, 0), word16, 0)) : uipr32)
-	T_704 (in __swap(SEQ(SLICE(d4_125, word16, 16), (word16) (d4_125 + __swap(dwLoc14) * (word16) d0_119))) : word32)
-	T_708 (in d0_119 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_125, word16, 16), (word16) (d4_125 + __swap(dwLoc14) * (word16) d0_119))), word16, 16), 0<16>) : word32)
-	T_711 (in __swap(d0_134) : word32)
-	T_714 (in d0_149 : Eq_603)
-	T_720 (in __swap(dwLoc14) : word32)
-	T_725 (in SEQ(SLICE(d4_140, word16, 16), SLICE(d4_140 + __swap(dwLoc14) *u SLICE(d0_134, word16, 0), word16, 0)) : uipr32)
-	T_726 (in __swap(SEQ(SLICE(d4_140, word16, 16), (word16) (d4_140 + __swap(dwLoc14) * (word16) d0_134))) : word32)
-	T_730 (in d0_134 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_140, word16, 16), (word16) (d4_140 + __swap(dwLoc14) * (word16) d0_134))), word16, 16), 0<16>) : word32)
-	T_733 (in __swap(d0_149) : word32)
-	T_736 (in d0_164 : Eq_603)
-	T_742 (in __swap(dwLoc14) : word32)
-	T_747 (in SEQ(SLICE(d4_155, word16, 16), SLICE(d4_155 + __swap(dwLoc14) *u SLICE(d0_149, word16, 0), word16, 0)) : uipr32)
-	T_748 (in __swap(SEQ(SLICE(d4_155, word16, 16), (word16) (d4_155 + __swap(dwLoc14) * (word16) d0_149))) : word32)
-	T_752 (in d0_149 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_155, word16, 16), (word16) (d4_155 + __swap(dwLoc14) * (word16) d0_149))), word16, 16), 0<16>) : word32)
-	T_755 (in __swap(d0_164) : word32)
-	T_758 (in d0_179 : Eq_603)
-	T_764 (in __swap(dwLoc14) : word32)
-	T_769 (in SEQ(SLICE(d4_170, word16, 16), SLICE(d4_170 + __swap(dwLoc14) *u SLICE(d0_164, word16, 0), word16, 0)) : uipr32)
-	T_770 (in __swap(SEQ(SLICE(d4_170, word16, 16), (word16) (d4_170 + __swap(dwLoc14) * (word16) d0_164))) : word32)
-	T_774 (in d0_164 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_170, word16, 16), (word16) (d4_170 + __swap(dwLoc14) * (word16) d0_164))), word16, 16), 0<16>) : word32)
-	T_777 (in __swap(d0_179) : word32)
-	T_780 (in d0_194 : Eq_603)
-	T_786 (in __swap(dwLoc14) : word32)
-	T_791 (in SEQ(SLICE(d4_185, word16, 16), SLICE(d4_185 + __swap(dwLoc14) *u SLICE(d0_179, word16, 0), word16, 0)) : uipr32)
-	T_792 (in __swap(SEQ(SLICE(d4_185, word16, 16), (word16) (d4_185 + __swap(dwLoc14) * (word16) d0_179))) : word32)
-	T_796 (in d0_179 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_185, word16, 16), (word16) (d4_185 + __swap(dwLoc14) * (word16) d0_179))), word16, 16), 0<16>) : word32)
-	T_799 (in __swap(d0_194) : word32)
-	T_802 (in d0_209 : Eq_603)
-	T_808 (in __swap(dwLoc14) : word32)
-	T_813 (in SEQ(SLICE(d4_200, word16, 16), SLICE(d4_200 + __swap(dwLoc14) *u SLICE(d0_194, word16, 0), word16, 0)) : uipr32)
-	T_814 (in __swap(SEQ(SLICE(d4_200, word16, 16), (word16) (d4_200 + __swap(dwLoc14) * (word16) d0_194))) : word32)
-	T_818 (in d0_194 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_200, word16, 16), (word16) (d4_200 + __swap(dwLoc14) * (word16) d0_194))), word16, 16), 0<16>) : word32)
-	T_821 (in __swap(d0_209) : word32)
-	T_824 (in d0_224 : Eq_603)
-	T_830 (in __swap(dwLoc14) : word32)
-	T_835 (in SEQ(SLICE(d4_215, word16, 16), SLICE(d4_215 + __swap(dwLoc14) *u SLICE(d0_209, word16, 0), word16, 0)) : uipr32)
-	T_836 (in __swap(SEQ(SLICE(d4_215, word16, 16), (word16) (d4_215 + __swap(dwLoc14) * (word16) d0_209))) : word32)
-	T_840 (in d0_209 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_215, word16, 16), (word16) (d4_215 + __swap(dwLoc14) * (word16) d0_209))), word16, 16), 0<16>) : word32)
-	T_843 (in __swap(d0_224) : word32)
-	T_846 (in d0_239 : Eq_603)
-	T_852 (in __swap(dwLoc14) : word32)
-	T_857 (in SEQ(SLICE(d4_230, word16, 16), SLICE(d4_230 + __swap(dwLoc14) *u SLICE(d0_224, word16, 0), word16, 0)) : uipr32)
-	T_858 (in __swap(SEQ(SLICE(d4_230, word16, 16), (word16) (d4_230 + __swap(dwLoc14) * (word16) d0_224))) : word32)
-	T_862 (in d0_224 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_230, word16, 16), (word16) (d4_230 + __swap(dwLoc14) * (word16) d0_224))), word16, 16), 0<16>) : word32)
-	T_865 (in __swap(d0_239) : word32)
-	T_868 (in d0_254 : Eq_603)
-	T_874 (in __swap(dwLoc14) : word32)
-	T_879 (in SEQ(SLICE(d4_245, word16, 16), SLICE(d4_245 + __swap(dwLoc14) *u SLICE(d0_239, word16, 0), word16, 0)) : uipr32)
-	T_880 (in __swap(SEQ(SLICE(d4_245, word16, 16), (word16) (d4_245 + __swap(dwLoc14) * (word16) d0_239))) : word32)
-	T_884 (in d0_239 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_245, word16, 16), (word16) (d4_245 + __swap(dwLoc14) * (word16) d0_239))), word16, 16), 0<16>) : word32)
-	T_887 (in __swap(d0_254) : word32)
-	T_890 (in d0_269 : Eq_603)
-	T_896 (in __swap(dwLoc14) : word32)
-	T_901 (in SEQ(SLICE(d4_260, word16, 16), SLICE(d4_260 + __swap(dwLoc14) *u SLICE(d0_254, word16, 0), word16, 0)) : uipr32)
-	T_902 (in __swap(SEQ(SLICE(d4_260, word16, 16), (word16) (d4_260 + __swap(dwLoc14) * (word16) d0_254))) : word32)
-	T_906 (in d0_254 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_260, word16, 16), (word16) (d4_260 + __swap(dwLoc14) * (word16) d0_254))), word16, 16), 0<16>) : word32)
-	T_909 (in __swap(d0_269) : word32)
-	T_912 (in d0_284 : Eq_603)
-	T_918 (in __swap(dwLoc14) : word32)
-	T_923 (in SEQ(SLICE(d4_275, word16, 16), SLICE(d4_275 + __swap(dwLoc14) *u SLICE(d0_269, word16, 0), word16, 0)) : uipr32)
-	T_924 (in __swap(SEQ(SLICE(d4_275, word16, 16), (word16) (d4_275 + __swap(dwLoc14) * (word16) d0_269))) : word32)
-	T_928 (in d0_269 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_275, word16, 16), (word16) (d4_275 + __swap(dwLoc14) * (word16) d0_269))), word16, 16), 0<16>) : word32)
-	T_931 (in __swap(d0_284) : word32)
-	T_934 (in d0_299 : Eq_603)
-	T_940 (in __swap(dwLoc14) : word32)
-	T_945 (in SEQ(SLICE(d4_290, word16, 16), SLICE(d4_290 + __swap(dwLoc14) *u SLICE(d0_284, word16, 0), word16, 0)) : uipr32)
-	T_946 (in __swap(SEQ(SLICE(d4_290, word16, 16), (word16) (d4_290 + __swap(dwLoc14) * (word16) d0_284))) : word32)
-	T_950 (in d0_284 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_290, word16, 16), (word16) (d4_290 + __swap(dwLoc14) * (word16) d0_284))), word16, 16), 0<16>) : word32)
-	T_953 (in __swap(d0_299) : word32)
-	T_956 (in d0_314 : Eq_603)
-	T_962 (in __swap(dwLoc14) : word32)
-	T_967 (in SEQ(SLICE(d4_305, word16, 16), SLICE(d4_305 + __swap(dwLoc14) *u SLICE(d0_299, word16, 0), word16, 0)) : uipr32)
-	T_968 (in __swap(SEQ(SLICE(d4_305, word16, 16), (word16) (d4_305 + __swap(dwLoc14) * (word16) d0_299))) : word32)
-	T_972 (in d0_299 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_305, word16, 16), (word16) (d4_305 + __swap(dwLoc14) * (word16) d0_299))), word16, 16), 0<16>) : word32)
-	T_975 (in __swap(d0_314) : word32)
-	T_978 (in d0_329 : Eq_603)
-	T_984 (in __swap(dwLoc14) : word32)
-	T_989 (in SEQ(SLICE(d4_320, word16, 16), SLICE(d4_320 + __swap(dwLoc14) *u SLICE(d0_314, word16, 0), word16, 0)) : uipr32)
-	T_990 (in __swap(SEQ(SLICE(d4_320, word16, 16), (word16) (d4_320 + __swap(dwLoc14) * (word16) d0_314))) : word32)
-	T_994 (in d0_314 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_320, word16, 16), (word16) (d4_320 + __swap(dwLoc14) * (word16) d0_314))), word16, 16), 0<16>) : word32)
-	T_997 (in __swap(d0_329) : word32)
-	T_1000 (in d0_344 : Eq_603)
-	T_1006 (in __swap(dwLoc14) : word32)
-	T_1011 (in SEQ(SLICE(d4_335, word16, 16), SLICE(d4_335 + __swap(dwLoc14) *u SLICE(d0_329, word16, 0), word16, 0)) : uipr32)
-	T_1012 (in __swap(SEQ(SLICE(d4_335, word16, 16), (word16) (d4_335 + __swap(dwLoc14) * (word16) d0_329))) : word32)
-	T_1016 (in d0_329 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_335, word16, 16), (word16) (d4_335 + __swap(dwLoc14) * (word16) d0_329))), word16, 16), 0<16>) : word32)
-	T_1019 (in __swap(d0_344) : word32)
-	T_1022 (in d0_359 : Eq_603)
-	T_1028 (in __swap(dwLoc14) : word32)
-	T_1033 (in SEQ(SLICE(d4_350, word16, 16), SLICE(d4_350 + __swap(dwLoc14) *u SLICE(d0_344, word16, 0), word16, 0)) : uipr32)
-	T_1034 (in __swap(SEQ(SLICE(d4_350, word16, 16), (word16) (d4_350 + __swap(dwLoc14) * (word16) d0_344))) : word32)
-	T_1038 (in d0_344 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_350, word16, 16), (word16) (d4_350 + __swap(dwLoc14) * (word16) d0_344))), word16, 16), 0<16>) : word32)
-	T_1041 (in __swap(d0_359) : word32)
-	T_1044 (in d0_374 : Eq_603)
-	T_1050 (in __swap(dwLoc14) : word32)
-	T_1055 (in SEQ(SLICE(d4_365, word16, 16), SLICE(d4_365 + __swap(dwLoc14) *u SLICE(d0_359, word16, 0), word16, 0)) : uipr32)
-	T_1056 (in __swap(SEQ(SLICE(d4_365, word16, 16), (word16) (d4_365 + __swap(dwLoc14) * (word16) d0_359))) : word32)
-	T_1060 (in d0_359 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_365, word16, 16), (word16) (d4_365 + __swap(dwLoc14) * (word16) d0_359))), word16, 16), 0<16>) : word32)
-	T_1063 (in __swap(d0_374) : word32)
-	T_1066 (in d0_389 : Eq_603)
-	T_1072 (in __swap(dwLoc14) : word32)
-	T_1077 (in SEQ(SLICE(d4_380, word16, 16), SLICE(d4_380 + __swap(dwLoc14) *u SLICE(d0_374, word16, 0), word16, 0)) : uipr32)
-	T_1078 (in __swap(SEQ(SLICE(d4_380, word16, 16), (word16) (d4_380 + __swap(dwLoc14) * (word16) d0_374))) : word32)
-	T_1082 (in d0_374 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_380, word16, 16), (word16) (d4_380 + __swap(dwLoc14) * (word16) d0_374))), word16, 16), 0<16>) : word32)
-	T_1085 (in __swap(d0_389) : word32)
-	T_1088 (in d0_404 : Eq_603)
-	T_1094 (in __swap(dwLoc14) : word32)
-	T_1099 (in SEQ(SLICE(d4_395, word16, 16), SLICE(d4_395 + __swap(dwLoc14) *u SLICE(d0_389, word16, 0), word16, 0)) : uipr32)
-	T_1100 (in __swap(SEQ(SLICE(d4_395, word16, 16), (word16) (d4_395 + __swap(dwLoc14) * (word16) d0_389))) : word32)
-	T_1104 (in d0_389 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_395, word16, 16), (word16) (d4_395 + __swap(dwLoc14) * (word16) d0_389))), word16, 16), 0<16>) : word32)
-	T_1107 (in __swap(d0_404) : word32)
-	T_1110 (in d0_419 : Eq_603)
-	T_1116 (in __swap(dwLoc14) : word32)
-	T_1121 (in SEQ(SLICE(d4_410, word16, 16), SLICE(d4_410 + __swap(dwLoc14) *u SLICE(d0_404, word16, 0), word16, 0)) : uipr32)
-	T_1122 (in __swap(SEQ(SLICE(d4_410, word16, 16), (word16) (d4_410 + __swap(dwLoc14) * (word16) d0_404))) : word32)
-	T_1126 (in d0_404 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_410, word16, 16), (word16) (d4_410 + __swap(dwLoc14) * (word16) d0_404))), word16, 16), 0<16>) : word32)
-	T_1129 (in __swap(d0_419) : word32)
-	T_1132 (in d0_434 : Eq_603)
-	T_1138 (in __swap(dwLoc14) : word32)
-	T_1143 (in SEQ(SLICE(d4_425, word16, 16), SLICE(d4_425 + __swap(dwLoc14) *u SLICE(d0_419, word16, 0), word16, 0)) : uipr32)
-	T_1144 (in __swap(SEQ(SLICE(d4_425, word16, 16), (word16) (d4_425 + __swap(dwLoc14) * (word16) d0_419))) : word32)
-	T_1148 (in d0_419 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_425, word16, 16), (word16) (d4_425 + __swap(dwLoc14) * (word16) d0_419))), word16, 16), 0<16>) : word32)
-	T_1151 (in __swap(d0_434) : word32)
-	T_1154 (in d0_449 : Eq_603)
-	T_1160 (in __swap(dwLoc14) : word32)
-	T_1165 (in SEQ(SLICE(d4_440, word16, 16), SLICE(d4_440 + __swap(dwLoc14) *u SLICE(d0_434, word16, 0), word16, 0)) : uipr32)
-	T_1166 (in __swap(SEQ(SLICE(d4_440, word16, 16), (word16) (d4_440 + __swap(dwLoc14) * (word16) d0_434))) : word32)
-	T_1170 (in d0_434 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_440, word16, 16), (word16) (d4_440 + __swap(dwLoc14) * (word16) d0_434))), word16, 16), 0<16>) : word32)
-	T_1173 (in __swap(d0_449) : word32)
-	T_1176 (in d0_464 : Eq_603)
-	T_1182 (in __swap(dwLoc14) : word32)
-	T_1187 (in SEQ(SLICE(d4_455, word16, 16), SLICE(d4_455 + __swap(dwLoc14) *u SLICE(d0_449, word16, 0), word16, 0)) : uipr32)
-	T_1188 (in __swap(SEQ(SLICE(d4_455, word16, 16), (word16) (d4_455 + __swap(dwLoc14) * (word16) d0_449))) : word32)
-	T_1192 (in d0_449 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_455, word16, 16), (word16) (d4_455 + __swap(dwLoc14) * (word16) d0_449))), word16, 16), 0<16>) : word32)
-	T_1195 (in __swap(d0_464) : word32)
-	T_1203 (in __swap(dwLoc14) : word32)
-	T_1208 (in SEQ(SLICE(d5_471, word16, 16), SLICE(d5_471 + __swap(dwLoc14) *u SLICE(d0_464, word16, 0), word16, 0)) : uipr32)
-	T_1209 (in __swap(SEQ(SLICE(d5_471, word16, 16), (word16) (d5_471 + __swap(dwLoc14) * (word16) d0_464))) : word32)
-	T_1213 (in d0_464 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d5_471, word16, 16), (word16) (d5_471 + __swap(dwLoc14) * (word16) d0_464))), word16, 16), 0<16>) : word32)
 	T_1220 (in d0_17 : Eq_603)
 	T_1223 (in d0 : Eq_603)
 	T_1236 (in fn00001718(d0, *(struct Eq_1224 **) 0x4258<u32>, dwArg04, fp + 8<i32>, out d1_20, out a1_19) : word32)
@@ -505,10 +350,6 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_1246 (in 0<i32> : int32)
 	T_1300 (in fn00002098(*(a7_51 - 4<i32>), *a7_51, out d1, out a0_66, out a1, out a5_1579) : word32)
 	T_1303 (in 0xFFFFFFFF<32> : word32)
-	T_1317 (in d5_256 : Eq_603)
-	T_1318 (in -1<i32> : int32)
-	T_1329 (in d2_1005 : Eq_603)
-	T_1332 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
 	T_1333 (in d1_103 : Eq_603)
 	T_1335 (in d1_103 + 1<32> : word32)
 	T_1336 (in 5<32> : word32)
@@ -516,68 +357,24 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_1342 (in d1_123 : Eq_603)
 	T_1344 (in 1<i32> << d1_103 : word32)
 	T_1347 (in Mem121[a7_99 + 0<32>:word32] : word32)
-	T_1348 (in d2_1005 | d1_123 : word32)
 	T_1351 (in 5<32> : word32)
 	T_1353 (in 0<i32> : int32)
-	T_1358 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
 	T_1376 (in Mem143[a0_1447 + 0<32>:byte] : byte)
 	T_1433 (in Mem102[a7_99 + 0<32>:word32] : word32)
 	T_1436 (in Mem102[a7_99 + 0<32>:word32] : word32)
 	T_1471 (in Mem248[a0_1447 + 0<32>:byte] : byte)
-	T_1474 (in 0<i32> : int32)
-	T_1502 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-	T_1508 (in Mem278[a7_275 + 0<32>:word32] : word32)
-	T_1511 (in 10<i32> : int32)
-	T_1512 (in __swap(10<i32>) : word32)
-	T_1519 (in __swap(d5_256) : word32)
-	T_1524 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-	T_1525 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
 	T_1557 (in Mem278[a0_1447 + 0<32>:byte] : byte)
-	T_1562 (in Mem278[a7_275 + 0<32>:word32] : word32)
 	T_1564 (in d1_303 - 0x30<32> : word32)
-	T_1566 (in d1_303 - 0x30<32> + d0_293 : word32)
-	T_1611 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-	T_1619 (in 10<i32> : int32)
-	T_1620 (in __swap(10<i32>) : word32)
-	T_1627 (in __swap(d2_1005) : word32)
-	T_1632 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-	T_1633 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
 	T_1665 (in Mem171[a0_1447 + 0<32>:byte] : byte)
 	T_1673 (in d1_196 - 0x30<32> : word32)
-	T_1675 (in d1_196 - 0x30<32> + d0_186 : word32)
-	T_1683 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
 	T_1711 (in d6_1480 + 1<32> : word32)
-	T_1780 (in 0<32> : word32)
-	T_1859 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-	T_1908 (in 0<32> : word32)
 	T_2083 (in d0_1566 : Eq_603)
 	T_2088 (in a7_1465[18<i32>] & 2<i32> : word32)
 	T_2089 (in 0<32> : word32)
-	T_2128 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
 	T_2131 (in Mem1359[a7_1020 + 48<i32>:word32] : word32)
 	T_2210 (in fn00002098(*(a7_1578 - 4<i32>), a7_1578->ptr0000, out d1, out a0_1447, out a1, out a5_1579) : word32)
 	T_2211 (in 0xFFFFFFFF<32> : word32)
 	T_2216 (in d6_1480 + 1<32> : word32)
-	T_2266 (in dwArg04 : Eq_603)
-	T_2267 (in dwArg08 : Eq_603)
-	T_2268 (in dwArg0C : Eq_603)
-	T_2269 (in dwArg10 : Eq_603)
-	T_2273 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_2278 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_2283 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_2288 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_2350 (in dwArg04 : Eq_603)
-	T_2351 (in dwArg08 : Eq_603)
-	T_2352 (in dwArg0C : Eq_603)
-	T_2353 (in dwArg10 : Eq_603)
-	T_2354 (in d1Out : Eq_603)
-	T_2355 (in a0Out : Eq_603)
-	T_2359 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_2364 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_2369 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_2374 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_2375 (in out d1_1450 : ptr32)
-	T_2376 (in out a0_1447 : ptr32)
 	T_2400 (in Mem1478[a7_1383 + 52<i32>:word32] : word32)
 	T_2424 (in d0_1691 : Eq_603)
 	T_2429 (in a7_1465[18<i32>] & 2<i32> : word32)
@@ -603,12 +400,8 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_2882 (in 0<32> : word32)
 	T_2885 (in Mem624[a0_1447 + 0<32>:word32] : word32)
 	T_2943 (in Mem611[a0_1447 + 0<32>:word32] : word32)
-	T_2950 (in 0<32> : word32)
-	T_2980 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-	T_2984 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
 	T_3009 (in SLICE(d6_1480, word16, 0) : word16)
 	T_3012 (in Mem599[a0_1447 + 0<32>:word16] : word16)
-	T_3040 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
 	T_3090 (in Mem575[a0_1447 + 0<32>:word32] : word32)
 	T_3100 (in SLICE(d6_1480, byte, 0) : byte)
 	T_3103 (in Mem587[a0_1447 + 0<32>:byte] : byte)
@@ -617,290 +410,12 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_3191 (in Mem66[a0_104 + 0<32>:byte] : byte)
 	T_3316 (in SLICE(dwArg04, byte, 0) : byte)
 	T_3319 (in Mem118[a0_112 + 0<32>:byte] : byte)
-	T_3925 (in d0 : Eq_603)
-	T_3926 (in d0_196 : Eq_603)
-	T_3927 (in d1_142 : Eq_603)
-	T_3928 (in a0_20 : Eq_603)
-	T_3929 (in d3_166 : Eq_603)
-	T_3930 (in 0<32> : word32)
-	T_3938 (in 0<32> : word32)
-	T_3944 (in d0 : Eq_603)
-	T_3945 (in d1 : Eq_603)
-	T_3946 (in d2 : Eq_603)
-	T_3947 (in d1Out : Eq_603)
-	T_3948 (in d2Out : Eq_603)
-	T_3949 (in out d1_318 : ptr32)
-	T_3950 (in out d2_319 : ptr32)
-	T_3951 (in fn000027BC(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-	T_3952 (in 0<i32> : int32)
-	T_3955 (in d6_30 : Eq_603)
-	T_3958 (in  : word32)
-	T_3959 (in  : word32)
-	T_3960 (in 8<32> : word32)
-	T_3961 (in __rol(dwArg0C, 8<32>) : word32)
-	T_3987 (in 8<32> : word32)
-	T_3988 (in __rol(d6_30, 8<32>) : word32)
-	T_3994 (in 8<32> : word32)
-	T_3995 (in __rol(d6_30, 8<32>) : word32)
-	T_4002 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_4003 (in d1_175 : Eq_603)
-	T_4004 (in d2_176 : Eq_603)
-	T_4005 (in d0_174 : Eq_603)
-	T_4007 (in 0<i32> : int32)
-	T_4008 (in out d1_175 : ptr32)
-	T_4009 (in out d2_176 : ptr32)
-	T_4010 (in fn000027BC(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-	T_4014 (in out d1_320 : ptr32)
-	T_4015 (in out d2_321 : ptr32)
-	T_4016 (in fn000027BC(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-	T_4027 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_4030 (in d0_85 : Eq_603)
-	T_4032 (in dwArg04 >> d4_61 : word32)
-	T_4035 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-	T_4038 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-	T_4039 (in out d1_86 : ptr32)
-	T_4040 (in out d2_322 : ptr32)
-	T_4041 (in fn000027BC(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-	T_4042 (in d3_72 : Eq_603)
-	T_4043 (in dwArg10 << d5_63 : word32)
-	T_4044 (in d5_101 : Eq_603)
-	T_4046 (in __swap(d0_85) : word32)
-	T_4047 (in d6_103 : Eq_603)
-	T_4049 (in __swap(d3_72) : word32)
-	T_4053 (in d2_107 : Eq_603)
-	T_4056 (in d0_85 * (word16) d3_72 : word32)
-	T_4057 (in __swap(d0_85 * (word16) d3_72) : word32)
-	T_4070 (in d6_82 : Eq_603)
-	T_4071 (in dwArg08 << d5_63 : word32)
-	T_4072 (in d2_124 : Eq_603)
-	T_4074 (in SEQ(v35_109, v39_116) : uipr32)
-	T_4075 (in __swap(SEQ(v35_109, v39_116)) : word32)
-	T_4083 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-	T_4084 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-	T_4088 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-	T_4089 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-	T_4111 (in d0_85 - 1<32> : word32)
-	T_4117 (in d7_13 : Eq_603)
-	T_4118 (in 0<32> : word32)
-	T_4122 (in d0 : Eq_603)
-	T_4123 (in d1 : Eq_603)
-	T_4124 (in d2 : Eq_603)
-	T_4125 (in d1Out : Eq_603)
-	T_4126 (in out d1 : ptr32)
-	T_4127 (in fn0000297A(d1, d2, d2, out d1) : word32)
-	T_4128 (in d6_17 : Eq_603)
-	T_4129 (in d5_19 : Eq_603)
-	T_4130 (in 0<32> : word32)
-	T_4132 (in d2_22 : Eq_603)
-	T_4134 (in __swap(d2) : word32)
-	T_4138 (in 0<32> : word32)
-	T_4147 (in 0<32> : word32)
-	T_4149 (in d0_281 : Eq_603)
-	T_4151 (in __swap(d0) : word32)
-	T_4152 (in d1_282 : Eq_603)
-	T_4154 (in __swap(d1) : word32)
-	T_4164 (in __swap(d1_282) : word32)
-	T_4171 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-	T_4172 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-	T_4177 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-	T_4183 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-	T_4184 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-	T_4188 (in d6_17 * 2<32> : word32)
-	T_4196 (in 0<32> : word32)
-	T_4198 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-	T_4200 (in d7_13 * 2<32> : word32)
-	T_4201 (in 0<32> : word32)
-	T_4205 (in d3_74 : Eq_603)
-	T_4212 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-	T_4213 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-	T_4216 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-	T_4217 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-	T_4218 (in d1_104 : Eq_603)
-	T_4219 (in 0xFFFF<32> : uipr32)
-	T_4220 (in d6_98 : Eq_603)
-	T_4224 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-	T_4225 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-	T_4226 (in d6_133 : Eq_603)
-	T_4228 (in __swap(d1_104) : word32)
-	T_4229 (in d3_140 : Eq_603)
-	T_4231 (in __swap(d6_133) : word32)
-	T_4232 (in d4_142 : Eq_603)
-	T_4234 (in __swap(d7_13) : word32)
-	T_4238 (in d6_146 : Eq_603)
-	T_4241 (in d6_133 * (word16) d7_13 : word32)
-	T_4242 (in __swap(d6_133 * (word16) d7_13) : word32)
-	T_4258 (in d6_178 : Eq_603)
-	T_4260 (in SEQ(v56_148, v59_155) : uipr32)
-	T_4261 (in __swap(SEQ(v56_148, v59_155)) : word32)
-	T_4262 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-	T_4263 (in d5_181 : word32)
-	T_4267 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-	T_4268 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-	T_4272 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-	T_4273 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-	T_4286 (in 0<32> : word32)
-	T_4288 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-	T_4289 (in 0<32> : word32)
-	T_4297 (in d1_104 - 1<32> : word32)
-	T_4298 (in d4_113 : Eq_603)
-	T_4301 (in __swap(d7_13) : word32)
-	T_4304 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-	T_4305 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-	T_4320 (in __swap(d7_13) : word32)
-	T_4324 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-	T_4326 (in d1_104 - 1<32> : word32)
-	T_4327 (in 0<32> : word32)
-	T_4333 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-	T_4334 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_4335 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_4336 (in d6_220 : Eq_603)
-	T_4340 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-	T_4341 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-	T_4344 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-	T_4345 (in d5_221 : Eq_603)
-	T_4347 (in __swap(d5_181) : word32)
-	T_4352 (in d5_266 : Eq_603)
-	T_4354 (in __swap(d5_181) : word32)
-	T_4355 (in d6_267 : Eq_603)
-	T_4357 (in __swap(d6_178) : word32)
-	T_4360 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-	T_4363 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-	T_4367 (in d2_73 : Eq_603)
-	T_4369 (in __swap(d5_19) : word32)
-	T_4371 (in __swap(d7_13) : word32)
-	T_4381 (in d5_221 >> 1<32> : word32)
-	T_4386 (in  : word32)
-	T_4392 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-	T_4399 (in d0 : Eq_603)
-	T_4400 (in d2 : Eq_603)
-	T_4401 (in dwArg04 : Eq_603)
-	T_4402 (in dwArg08 : Eq_603)
-	T_4403 (in 0<32> : word32)
-	T_4405 (in 0<32> : word32)
-	T_4407 (in d0_36 : Eq_603)
-	T_4408 (in -dwArg04 : word32)
-	T_4409 (in 0<32> : word32)
-	T_4413 (in out d1_43 : ptr32)
-	T_4414 (in fn0000297A(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_4415 (in -fn0000297A(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_4418 (in -dwArg08 : word32)
-	T_4419 (in out d1_55 : ptr32)
-	T_4420 (in fn0000297A(d0_36, -dwArg08, d2, out d1_55) : word32)
-	T_4423 (in out d1_88 : ptr32)
-	T_4424 (in fn0000297A(dwArg04, dwArg08, d2, out d1_88) : word32)
-	T_4427 (in -dwArg08 : word32)
-	T_4428 (in out d1_89 : ptr32)
-	T_4429 (in fn0000297A(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_4430 (in -fn0000297A(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_4431 (in d1_22 : Eq_603)
-	T_4433 (in __swap(d1) : word32)
-	T_4438 (in d2_11 : Eq_603)
-	T_4439 (in SEQ(v11_10, v10_9) : uipr32)
-	T_4442 (in d3_18 : Eq_603)
-	T_4443 (in 16<i32> : int32)
-	T_4447 (in d0_134 : Eq_603)
-	T_4449 (in __swap(d0) : word32)
-	T_4450 (in d1_135 : Eq_603)
-	T_4452 (in __swap(d1_22) : word32)
-	T_4457 (in __swap(d2_11) : word32)
-	T_4462 (in d0_150 : Eq_603)
-	T_4464 (in __swap(d0_134) : word32)
-	T_4478 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-	T_4479 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-	T_4481 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-	T_4483 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-	T_4493 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-	T_4498 (in 8<32> : word32)
-	T_4499 (in __rol(d1_22, 8<32>) : word32)
-	T_4500 (in 8<32> : uipr32)
-	T_4505 (in 4<32> : word32)
-	T_4506 (in __rol(d1_22, 4<32>) : word32)
-	T_4511 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-	T_4516 (in 2<32> : word32)
-	T_4517 (in __rol(d1_22, 2<32>) : word32)
-	T_4522 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-	T_4528 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-	T_4529 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-	T_4536 (in __swap(d3_18) : word32)
-	T_4542 (in d1_90 : Eq_603)
-	T_4544 (in __swap(d1_22) : word32)
-	T_4545 (in d3_102 : Eq_603)
-	T_4546 (in SEQ(v53_82, v51_79) : uipr32)
-	T_4547 (in d0_108 : Eq_603)
-	T_4557 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-	T_4558 (in 0<32> : word32)
-	T_4561 (in 1<32> : word32)
-	T_4562 (in __rol(d1_22, 1<32>) : word32)
-	T_4567 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-	T_4571 (in __swap(d3_102) : word32)
-	T_4572 (in __rol(d0_108, __swap(d3_102)) : word32)
-	T_4573 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-	T_4576 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-	T_4579 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-	T_4580 (in d0_108 + d1_90 : word32)
-	T_4581 (in 0<32> : word32)
-	T_4583 (in d1 : Eq_603)
-	T_4584 (in d1_171 : Eq_603)
-	T_4585 (in d3_202 : Eq_603)
-	T_4586 (in 0<32> : word32)
-	T_4594 (in 0<32> : word32)
-	T_4598 (in out d1_171 : ptr32)
-	T_4599 (in out d2_354 : ptr32)
-	T_4600 (in fn000027BC(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-	T_4603 (in d6_33 : Eq_603)
-	T_4605 (in 8<32> : word32)
-	T_4606 (in __rol(dwArg0C, 8<32>) : word32)
-	T_4632 (in 8<32> : word32)
-	T_4633 (in __rol(d6_33, 8<32>) : word32)
-	T_4639 (in 8<32> : word32)
-	T_4640 (in __rol(d6_33, 8<32>) : word32)
-	T_4647 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_4650 (in d0_88 : Eq_603)
-	T_4652 (in dwArg04 >> d4_64 : word32)
-	T_4655 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-	T_4658 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-	T_4659 (in out d1_89 : ptr32)
-	T_4660 (in out d2_90 : ptr32)
-	T_4661 (in fn000027BC(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-	T_4662 (in d3_75 : Eq_603)
-	T_4663 (in dwArg10 << d5_66 : word32)
-	T_4664 (in d7_104 : Eq_603)
-	T_4666 (in __swap(d0_88) : word32)
-	T_4667 (in d6_106 : Eq_603)
-	T_4669 (in __swap(d3_75) : word32)
-	T_4673 (in d2_110 : Eq_603)
-	T_4676 (in d0_88 * (word16) d3_75 : word32)
-	T_4677 (in __swap(d0_88 * (word16) d3_75) : word32)
-	T_4690 (in d2_127 : Eq_603)
-	T_4692 (in SEQ(v37_112, v40_119) : uipr32)
-	T_4693 (in __swap(SEQ(v37_112, v40_119)) : word32)
-	T_4703 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-	T_4704 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-	T_4708 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-	T_4709 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-	T_4728 (in dwArg08 - dwArg10 : word32)
-	T_4732 (in d1_211 : Eq_603)
-	T_4733 (in d2_212 : Eq_603)
-	T_4735 (in 0<i32> : int32)
-	T_4736 (in out d1_211 : ptr32)
-	T_4737 (in out d2_212 : ptr32)
-	T_4738 (in fn000027BC(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-	T_4741 (in out d1_171 : ptr32)
-	T_4742 (in out d2_355 : ptr32)
-	T_4743 (in fn000027BC(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-	T_4754 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_4759 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-	T_4772 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
 	T_4814 (in d0 : Eq_603)
 	T_4815 (in d1 : Eq_603)
-	T_4816 (in a1 : Eq_603)
 	T_4817 (in dwArg04 : Eq_603)
-	T_4819 (in dwArg0C : Eq_603)
 	T_4821 (in Mem10[0x00004254<p32>:word32] : word32)
-	T_4824 (in fp + 8<i32> : word32)
 	T_4825 (in fn00002E8C(d0, d1, a1, *(union Eq_603 *) 0x4254<u32>, dwArg04, fp + 8<i32>) : word32)
 	T_4826 (in d0 : Eq_603)
-	T_4827 (in bArg07 : Eq_603)
 	T_4828 (in dwArg08 : Eq_603)
 	T_4829 (in d0_10 : Eq_603)
 	T_4830 (in 0<32> : word32)
@@ -910,28 +425,15 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_4852 (in *((word32) dwArg08 + 4<i32>) - 1<32> : word32)
 	T_4854 (in Mem25[dwArg08 + 4<i32>:word32] : word32)
 	T_4857 (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-	T_4860 (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-	T_4865 (in d2_1090 : Eq_603)
 	T_4867 (in a2_1014 : Eq_603)
 	T_4870 (in d5_1044 : Eq_603)
 	T_4871 (in 0<i32> : int32)
 	T_4877 (in d0_3698 : Eq_603)
 	T_4878 (in 0xFFFFFFFF<32> : word32)
 	T_4902 (in d0_63 & 8<32> : word32)
-	T_4928 (in d6_1133 : Eq_603)
-	T_4929 (in -1<i32> : int32)
 	T_4931 (in d0_289 & 4<32> : word32)
-	T_4951 (in 0<i32> : int32)
 	T_4953 (in d0_305 & 4<32> : word32)
-	T_4962 (in Mem316[a7_313 + 0<32>:word32] : word32)
-	T_4965 (in 10<i32> : int32)
-	T_4966 (in __swap(10<i32>) : word32)
-	T_4976 (in __swap(d6_1133) : word32)
-	T_4981 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-	T_4982 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-	T_5008 (in Mem316[a7_313 + 0<32>:word32] : word32)
 	T_5010 (in d1_340 - 0x30<32> : word32)
-	T_5012 (in d1_340 - 0x30<32> + d0_331 : word32)
 	T_5014 (in d0_354 & 4<32> : word32)
 	T_5028 (in SEQ(SLICE(d1, word24, 8), Mem361[a7_1330 + 72<i32>:byte]) : uip32)
 	T_5075 (in 0<32> : word32)
@@ -945,7 +447,6 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_5225 (in dwArg04 : Eq_603)
 	T_5231 (in Mem535[a7_533 + 0<32>:word32] : word32)
 	T_5235 (in fn00003F30(*a7_533, out d1_5316, out a1, out a5_5317) : word32)
-	T_5237 (in a2_1014 + 4<i32> : word32)
 	T_5247 (in Mem554[a7_552 + 0<32>:word32] : word32)
 	T_5259 (in Mem558[a7_552 + 0<32>:word32] : word32)
 	T_5261 (in SEQ(SLICE(d0, word24, 8), v96_562) : uip32)
@@ -956,7 +457,6 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_5339 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_5345 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_5349 (in fn00003F30(*a7_180, out d1_5318, out a1, out a5_5319) : word32)
-	T_5351 (in a2_1014 + 4<i32> : word32)
 	T_5361 (in Mem201[a7_199 + 0<32>:word32] : word32)
 	T_5373 (in Mem205[a7_199 + 0<32>:word32] : word32)
 	T_5375 (in SEQ(SLICE(d0, word24, 8), v109_209) : uip32)
@@ -965,14 +465,12 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_5397 (in 0xFFFFFFFF<32> : word32)
 	T_5407 (in Mem251[a7_248 + 0<32>:word32] : word32)
 	T_5412 (in Mem254[a7_248 - 4<i32> + 0<32>:word32] : word32)
-	T_5419 (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
 	T_5422 (in Mem254[a7_248 + 0<32>:word32] : word32)
 	T_5423 (in fn00002E5C(*(a7_248 - 1<i32>), *a7_248) : word32)
 	T_5431 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_5436 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_5440 (in fn00003F30(a7_79->t0000, out d1, out a1, out a5_5320) : word32)
 	T_5443 (in Mem94[a7_79 + 48<i32>:word32] : word32)
-	T_5445 (in a2_1014 + 4<i32> : word32)
 	T_5455 (in Mem101[a7_99 + 0<32>:word32] : word32)
 	T_5467 (in Mem105[a7_99 + 0<32>:word32] : word32)
 	T_5470 (in Mem115[a7_99 + 0<32>:word32] : word32)
@@ -983,19 +481,16 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_5507 (in 0xFFFFFFFF<32> : word32)
 	T_5517 (in Mem151[a7_148 + 0<32>:word32] : word32)
 	T_5522 (in Mem154[a7_148 - 4<i32> + 0<32>:word32] : word32)
-	T_5528 (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
 	T_5531 (in Mem154[a7_148 + 0<32>:word32] : word32)
 	T_5532 (in fn00002E5C(*(a7_148 - 1<i32>), *a7_148) : word32)
 	T_5569 (in d1_1355 : Eq_603)
 	T_5572 (in SEQ(v147_608, v83_500 - 0x63<8>) : uip32)
-	T_5574 (in 0xFFFFFFFF<32> : word32)
 	T_5578 (in SEQ(v147_608, v83_500 - 0x6E<8>) : uip32)
 	T_5587 (in SEQ(v147_608, v83_500 - 0x73<8>) : uip32)
 	T_5614 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_5619 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_5623 (in fn00003F30(a7_640->t0000, out d1, out a1, out a5_5321) : word32)
 	T_5626 (in Mem655[a7_640 + 48<i32>:word32] : word32)
-	T_5628 (in a2_1014 + 4<i32> : word32)
 	T_5638 (in Mem662[a7_660 + 0<32>:word32] : word32)
 	T_5650 (in Mem666[a7_660 + 0<32>:word32] : word32)
 	T_5653 (in Mem686[a7_660 + 0<32>:word32] : word32)
@@ -1005,38 +500,29 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_5680 (in 0xFFFFFFFF<32> : word32)
 	T_5691 (in Mem738[a7_735 + 0<32>:word32] : word32)
 	T_5696 (in Mem741[a7_735 - 4<i32> + 0<32>:word32] : word32)
-	T_5702 (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
 	T_5705 (in Mem741[a7_735 + 0<32>:word32] : word32)
 	T_5706 (in fn00002E5C(*(a7_735 - 1<i32>), *a7_735) : word32)
 	T_5709 (in 0x2D<32> : word32)
 	T_5722 (in (word32) d2_1090 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_5724 (in d0 + 4<32> : word32)
 	T_5728 (in 0xFFFFFFFF<32> : word32)
 	T_5753 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5766 (in d0 + 4<32> : word32)
 	T_5767 (in 0xFFFFFFFF<32> : word32)
 	T_5781 (in d0_1765 & 8<32> : word32)
 	T_5834 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5842 (in d0 + 4<32> : word32)
 	T_5848 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_5853 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_5857 (in fn00003F30(*a7_1807, out d1_5322, out a1, out a5_1727) : word32)
-	T_5859 (in a2_1014 + 4<i32> : word32)
 	T_5869 (in Mem1828[a7_1826 + 0<32>:word32] : word32)
 	T_5881 (in Mem1832[a7_1826 + 0<32>:word32] : word32)
 	T_5883 (in SEQ(SLICE(d0, word24, 8), v201_1836) : uip32)
 	T_5885 (in (uint32) (uint8) v201_1836 : uint32)
 	T_5890 (in 0xFFFFFFFF<32> : word32)
 	T_5902 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5911 (in d0 + 4<32> : word32)
 	T_5927 (in d0_1871 & 8<32> : word32)
 	T_5941 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5949 (in d0 + 4<32> : word32)
 	T_5955 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5964 (in d0 + 4<32> : word32)
 	T_5979 (in Mem1903[a7_1897 + 0<32>:word32] : word32)
 	T_5984 (in Mem1906[a7_1897 - 4<i32> + 0<32>:word32] : word32)
-	T_5990 (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
 	T_5993 (in Mem1906[a7_1897 + 0<32>:word32] : word32)
 	T_5994 (in fn00002E5C(*(a7_1897 - 1<i32>), *a7_1897) : word32)
 	T_5995 (in 0x2B<32> : word32)
@@ -1045,7 +531,6 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_6044 (in Mem2009[a7_2007 + 0<32>:word32] : word32)
 	T_6048 (in fn00003F30(a7_2007->t0000, out d1, out a1, out a5_5323) : word32)
 	T_6051 (in Mem2022[a7_2007 + 56<i32>:word32] : word32)
-	T_6053 (in a2_1014 + 4<i32> : word32)
 	T_6063 (in Mem2029[a7_2027 + 0<32>:word32] : word32)
 	T_6075 (in Mem2033[a7_2027 + 0<32>:word32] : word32)
 	T_6078 (in Mem2050[a7_2027 + 0<32>:word32] : word32)
@@ -1059,24 +544,20 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_6171 (in Mem2150[a7_2148 + 0<32>:word32] : word32)
 	T_6175 (in fn00003F30(a7_2148->t0000, out d1, out a1, out a5_5324) : word32)
 	T_6178 (in Mem2163[a7_2148 + 56<i32>:word32] : word32)
-	T_6180 (in a2_1014 + 4<i32> : word32)
 	T_6190 (in Mem2170[a7_2168 + 0<32>:word32] : word32)
 	T_6202 (in Mem2174[a7_2168 + 0<32>:word32] : word32)
 	T_6205 (in Mem2185[a7_2168 + 0<32>:word32] : word32)
 	T_6212 (in SEQ(SLICE(d0, word24, 8), v249_2178) : uip32)
 	T_6215 (in Mem2191[a7_2168 + 0<32>:word32] : word32)
 	T_6232 (in d0_2209 & 0xFF<32> : word32)
-	T_6251 (in 1<i32> : int32)
 	T_6252 (in 0x78<32> : word32)
 	T_6260 (in SEQ(SLICE(d0_2209 & 0xFF<32>, word24, 8), SLICE(d0_2209 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
 	T_6267 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_6269 (in d0 + 4<32> : word32)
 	T_6307 (in d0_2253 : Eq_603)
 	T_6338 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_6343 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_6347 (in fn00003F30(a7_2246->t0000, out d1, out a1, out a5_5325) : word32)
 	T_6350 (in Mem2261[a7_2246 + 56<i32>:word32] : word32)
-	T_6352 (in a2_1014 + 4<i32> : word32)
 	T_6362 (in Mem2268[a7_2266 + 0<32>:word32] : word32)
 	T_6374 (in Mem2272[a7_2266 + 0<32>:word32] : word32)
 	T_6377 (in Mem2283[a7_2266 + 0<32>:word32] : word32)
@@ -1092,18 +573,14 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_6469 (in Mem1444[a7_1425 + 0<32>:word32] : word32)
 	T_6476 (in SEQ(SLICE(d0, word24, 8), v284_1435) : uip32)
 	T_6479 (in Mem1450[a7_1425 + 0<32>:word32] : word32)
-	T_6482 (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
 	T_6485 (in Mem1456[a7_1330 + 52<i32>:word32] : word32)
 	T_6508 (in 0xFFFFFFFF<32> : word32)
-	T_6512 (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
 	T_6561 (in Mem2338[a7_2334 + 0<32>:word32] : word32)
-	T_6575 (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
 	T_6578 (in Mem2342[a7_2334 + 0<32>:word32] : word32)
 	T_6579 (in fn00002E5C(*(a7_2334 - 1<i32>), a7_2334->t0000) : word32)
 	T_6585 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_6591 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_6595 (in fn00003F30(*a7_1512, out d1_5328, out a1, out a5_5329) : word32)
-	T_6597 (in a2_1014 + 4<i32> : word32)
 	T_6607 (in Mem1533[a7_1531 + 0<32>:word32] : word32)
 	T_6619 (in Mem1537[a7_1531 + 0<32>:word32] : word32)
 	T_6621 (in SEQ(SLICE(d0, word24, 8), v314_1541) : uip32)
@@ -1111,11 +588,9 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_6628 (in 0xFFFFFFFF<32> : word32)
 	T_6657 (in Mem1591[a7_1585 + 0<32>:word32] : word32)
 	T_6662 (in Mem1594[a7_1585 - 4<i32> + 0<32>:word32] : word32)
-	T_6668 (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
 	T_6671 (in Mem1594[a7_1585 + 0<32>:word32] : word32)
 	T_6672 (in fn00002E5C(*(a7_1585 - 1<i32>), *a7_1585) : word32)
 	T_6678 (in Mem2373[a7_2368 + 0<32>:word32] : word32)
-	T_6692 (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
 	T_6695 (in Mem2377[a7_2368 + 0<32>:word32] : word32)
 	T_6696 (in fn00002E5C(*(a7_2368 - 1<i32>), a7_2368->t0000) : word32)
 	T_6719 (in d0_2124 & 0x44<32> : word32)
@@ -1125,7 +600,6 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_6771 (in Mem2445[a7_2443 + 0<32>:word32] : word32)
 	T_6775 (in fn00003F30(a7_2443->t0000, out d1, out a1, out a5_5330) : word32)
 	T_6778 (in Mem2458[a7_2443 + 56<i32>:word32] : word32)
-	T_6780 (in a2_1014 + 4<i32> : word32)
 	T_6790 (in Mem2465[a7_2463 + 0<32>:word32] : word32)
 	T_6802 (in Mem2469[a7_2463 + 0<32>:word32] : word32)
 	T_6805 (in Mem2492[a7_2463 + 0<32>:word32] : word32)
@@ -1139,35 +613,23 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_6898 (in Mem2554[a7_2552 + 0<32>:word32] : word32)
 	T_6902 (in fn00003F30(a7_2552->t0000, out d1, out a1, out a5_5331) : word32)
 	T_6905 (in Mem2567[a7_2552 + 56<i32>:word32] : word32)
-	T_6907 (in a2_1014 + 4<i32> : word32)
 	T_6917 (in Mem2574[a7_2572 + 0<32>:word32] : word32)
 	T_6929 (in Mem2578[a7_2572 + 0<32>:word32] : word32)
 	T_6932 (in Mem2589[a7_2572 + 0<32>:word32] : word32)
 	T_6939 (in SEQ(SLICE(d0, word24, 8), v372_2582) : uip32)
 	T_6942 (in Mem2595[a7_2572 + 0<32>:word32] : word32)
 	T_6967 (in d0_2620 & 0x44<32> : word32)
-	T_7000 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
 	T_7009 (in d0_2760 & 0x44<32> : word32)
 	T_7022 (in Mem2671[a7_2667 + 0<32>:word32] : word32)
-	T_7036 (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
 	T_7039 (in Mem2675[a7_2667 + 0<32>:word32] : word32)
 	T_7040 (in fn00002E5C(*(a7_2667 - 1<i32>), a7_2667->t0000) : word32)
 	T_7052 (in Mem2603[a7_1330 + 74<i32>:word32] : word32)
-	T_7065 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-	T_7095 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
 	T_7104 (in d0_2818 & 4<32> : word32)
-	T_7110 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-	T_7116 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-	T_7126 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
 	T_7134 (in 0x37<32> : word32)
-	T_7147 (in v419_2893 : Eq_603)
-	T_7152 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_7277 (in d0_3135 : Eq_603)
-	T_7327 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_7353 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_7360 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_7364 (in fn00003F30(*(a7_1330 - 4<i32>), out d1_5332, out a1, out a5_5333) : word32)
-	T_7366 (in a2_1014 + 4<i32> : word32)
 	T_7374 (in Mem3149[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_7384 (in (uint32) (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint32)
 	T_7388 (in Mem3153[a7_1330 - 4<i32> + 0<32>:word32] : word32)
@@ -1178,50 +640,29 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_7430 (in Mem3291[a7_1330 + 110<i32>:word32] : word32)
 	T_7436 (in Mem3272[a7_3259 + 0<32>:word32] : word32)
 	T_7441 (in Mem3275[a7_3259 - 4<i32> + 0<32>:word32] : word32)
-	T_7447 (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
 	T_7450 (in Mem3275[a7_3259 + 0<32>:word32] : word32)
 	T_7451 (in fn00002E5C(*(a7_3259 - 1<i32>), *a7_3259) : word32)
 	T_7457 (in Mem2639[a7_2635 + 0<32>:word32] : word32)
-	T_7471 (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
 	T_7474 (in Mem2643[a7_2635 + 0<32>:word32] : word32)
 	T_7475 (in fn00002E5C(*(a7_2635 - 1<i32>), a7_2635->t0000) : word32)
 	T_7493 (in d0_3206 & 4<32> : word32)
 	T_7501 (in 0x37<32> : word32)
-	T_7507 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_7510 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_7512 (in d7 >> 31<i32> : word32)
-	T_7515 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-	T_7525 (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
-	T_7557 (in dwArg04 : Eq_603)
-	T_7558 (in dwArg08 : Eq_603)
-	T_7559 (in dwArg0C : Eq_603)
-	T_7560 (in dwArg10 : Eq_603)
-	T_7565 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-	T_7570 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-	T_7575 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-	T_7580 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
 	T_7619 (in Mem3303[a7_3299 + 0<32>:word32] : word32)
 	T_7624 (in Mem3306[a7_3299 - 4<i32> + 0<32>:word32] : word32)
-	T_7630 (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
 	T_7633 (in Mem3306[a7_3299 + 0<32>:word32] : word32)
 	T_7634 (in fn00002E5C(*(a7_3299 - 1<i32>), *a7_3299) : word32)
 	T_7663 (in Mem3476[a7_3474 + 0<32>:word32] : word32)
-	T_7687 (in (d0_3495 << 2<32>) + 4<32> : word32)
 	T_7694 (in Mem3485[a7_3474 + 52<i32>:word32] : word32)
 	T_7697 (in Mem3503[a0_3501 + 4<i32>:word32] : word32)
 	T_7704 (in d0_3495 << 2<32> : word32)
-	T_7723 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7726 (in Mem3508[a7_3474 + 52<i32>:word32] : word32)
 	T_7727 (in SLICE(d0, byte, 0) : byte)
 	T_7733 (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_7752 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7755 (in Mem3525[a7_3474 + 52<i32>:word32] : word32)
 	T_7756 (in SLICE(d0, word16, 0) : word16)
 	T_7762 (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_7781 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7784 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_7790 (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7798 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7801 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_7807 (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
 	T_7833 (in -v528_3348->dw0004 : word32)
@@ -1230,46 +671,31 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_7849 (in Mem3375[a7_3364 + 0<32>:word32] : word32)
 	T_7874 (in d1_1027 : Eq_603)
 	T_7877 (in Mem773[a7_1330 + 52<i32>:word32] : word32)
-	T_7892 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_7899 (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
+	T_7902 (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
 	T_7909 (in d0_3398 << 2<32> : word32)
-	T_7928 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7931 (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
 	T_7932 (in SLICE(d0, byte, 0) : byte)
 	T_7938 (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_7957 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7960 (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
 	T_7961 (in SLICE(d0, word16, 0) : word16)
 	T_7967 (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_7986 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7989 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_7995 (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_8003 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_8006 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_8012 (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_8016 (in SLICE(d5_785, byte, 0) : byte)
-	T_8020 (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
 	T_8022 (in d1_1027 + 1<32> : word32)
 	T_8023 (in 0x20<32> : word32)
-	T_8029 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-	T_8040 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
 	T_8055 (in SEQ(SLICE(d1_1027, word24, 8), v556_834) : uip32)
 	T_8081 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_8100 (in Mem889[a0_881 + 0<32>:byte] : byte)
 	T_8102 (in (uint32) (uint8) Mem889[a0_881 + 0<32>:byte] : uint32)
-	T_8108 (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-	T_8111 (in Mem895[a0_881 + 0<32>:byte] : byte)
-	T_8120 (in Mem889[a0_900 + 0<32>:byte] : byte)
 	T_8122 (in (uint32) (uint8) Mem889[a0_900 + 0<32>:byte] : uint32)
-	T_8129 (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-	T_8132 (in Mem914[a0_900 + 0<32>:byte] : byte)
 	T_8137 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_8150 (in (d0_957 << 2<32>) + 4<32> : word32)
 	T_8151 (in d0_957 << 2<32> : word32)
 	T_8190 (in Mem987[a7_985 + 0<32>:word32] : word32)
 	T_8195 (in Mem987[a7_985 + 0<32>:word32] : word32)
-	T_8199 (in fn00003F30(*a7_985, out d1, out a1, out a5_5334) : word32)
+	T_8199 (in fn00003F30(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
 	T_8202 (in Mem1000[a7_985 + 48<i32>:word32] : word32)
-	T_8204 (in a2_1014 + 4<i32> : word32)
 	T_8214 (in Mem1007[a7_1005 + 0<32>:word32] : word32)
 	T_8226 (in Mem1011[a7_1005 + 0<32>:word32] : word32)
 	T_8229 (in Mem1031[a7_1005 + 0<32>:word32] : word32)
@@ -1277,23 +703,13 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_8239 (in Mem1037[a7_1005 + 0<32>:word32] : word32)
 	T_8242 (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
 	T_8254 (in 0xFFFFFFFF<32> : word32)
-	T_8260 (in a7_1330 + 78<i32> : word32)
-	T_8263 (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-	T_8268 (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-	T_8269 (in 00000008 : ptr32)
-	T_8274 (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_8279 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_8282 (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-	T_8288 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_8293 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_8298 (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn00002948(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)):byte] : uint32)
-	T_8303 (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
 	T_8308 (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
 	T_8309 (in 0<32> : word32)
 	T_8356 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_8362 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_8366 (in fn00003F30(*a7_1182, out d1_5335, out a1, out a5_5336) : word32)
-	T_8368 (in a2_1014 + 4<i32> : word32)
 	T_8378 (in Mem1203[a7_1201 + 0<32>:word32] : word32)
 	T_8390 (in Mem1207[a7_1201 + 0<32>:word32] : word32)
 	T_8392 (in SEQ(SLICE(d0, word24, 8), v611_1211) : uip32)
@@ -1301,43 +717,12 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_8399 (in 0xFFFFFFFF<32> : word32)
 	T_8415 (in Mem1308[a7_1302 + 0<32>:word32] : word32)
 	T_8420 (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
-	T_8426 (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
 	T_8429 (in Mem1311[a7_1302 + 0<32>:word32] : word32)
 	T_8430 (in fn00002E5C(*(a7_1302 - 1<i32>), *a7_1302) : word32)
-	T_8438 (in a7_1330 + 78<i32> : word32)
-	T_8441 (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-	T_8446 (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-	T_8447 (in 00000008 : ptr32)
-	T_8452 (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_8457 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_8460 (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-	T_8465 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_8470 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_8475 (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn00002948(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)):byte] : uint32)
-	T_8480 (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
 	T_8485 (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
 	T_8486 (in 0<32> : word32)
-	T_8507 (in d0_23 : Eq_603)
-	T_8509 (in __swap(dwArg08) : word32)
-	T_8510 (in d1_25 : Eq_603)
-	T_8512 (in __swap(dwArg10) : word32)
-	T_8522 (in d2_39 : Eq_603)
-	T_8530 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-	T_8531 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-	T_8535 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-	T_8536 (in 0<32> : word32)
-	T_8538 (in d2_45 : Eq_603)
-	T_8540 (in __swap(d2_39) : word32)
-	T_8543 (in __swap(dwArg0C) : word32)
-	T_8546 (in d3_71 : Eq_603)
-	T_8550 (in __swap(dwArg08) : word32)
-	T_8555 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-	T_8556 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-	T_8559 (in __swap(dwArg04) : word32)
-	T_8562 (in d3_89 : Eq_603)
-	T_8566 (in __swap(dwArg10) : word32)
-	T_8571 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-	T_8572 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
 	T_8609 (in 0<32> : word32)
 	T_8648 (in Mem86[dwArg04 + 8<i32>:word32] : word32)
 	T_8649 (in 0<32> : word32)
@@ -1349,7 +734,7 @@ Eq_603: (union "Eq_603" (uint8 u0) (word16 u1) ((ptr32 Eq_1885) u2) ((ptr32 Eq_9
 	T_8721 (in Mem157[dwArg04 + 4<i32>:word32] : word32)
 	T_8755 (in d0_117 + 1<i32> : word32)
 	T_8758 (in Mem131[dwArg04 + 8<i32>:word32] : word32)
-Eq_609: (fn Eq_603 (Eq_603, Eq_603, Eq_603, (ptr32 Eq_614)))
+Eq_609: (fn Eq_603 (Eq_603, Eq_603, (ptr32 (ptr32 byte)), (ptr32 Eq_614)))
 	T_609 (in fn00002E40 : ptr32)
 	T_610 (in signature of fn00002E40 : void)
 	T_615 (in fn00002E40 : ptr32)
@@ -1418,7 +803,7 @@ Eq_626: (union "Eq_626" (int32 u0) (uint32 u1) (ptr32 u2))
 	T_8843 (in d1 : word32)
 	T_8871 (in (uint32) (uint8) Mem81[a0_74 + 0<32>:byte] : uint32)
 	T_8881 (in -1<i32> : int32)
-Eq_661: (fn Eq_603 (Eq_603))
+Eq_661: (fn Eq_663 (Eq_663))
 	T_661 (in __swap : ptr32)
 	T_662 (in signature of __swap : void)
 	T_673 (in __swap : ptr32)
@@ -1563,6 +948,567 @@ Eq_661: (fn Eq_603 (Eq_603))
 	T_8558 (in __swap : ptr32)
 	T_8563 (in __swap : ptr32)
 	T_8565 (in __swap : ptr32)
+Eq_663: (union "Eq_663" ((ptr32 Eq_1885) u0) ((ptr32 Eq_8952) u1) ((ptr32 Eq_8953) u2))
+	T_663 (in  : word32)
+	T_664 (in 3<i32> : int32)
+	T_665 (in __swap(3<i32>) : word32)
+	T_666 (in dwLoc14 : word32)
+	T_669 (in d0_119 : Eq_663)
+	T_676 (in __swap(dwLoc14) : word32)
+	T_681 (in SEQ(SLICE(d4_110, word16, 16), SLICE(d4_110 + __swap(dwLoc14) *u 3<16>, word16, 0)) : uipr32)
+	T_682 (in __swap(SEQ(SLICE(d4_110, word16, 16), (word16) (d4_110 + __swap(dwLoc14) * 3<16>))) : word32)
+	T_686 (in (word16) dwLoc14 * 3<i32> + SEQ(SLICE(__swap(SEQ(SLICE(d4_110, word16, 16), (word16) (d4_110 + __swap(dwLoc14) * 3<16>))), word16, 16), 0<16>) : word32)
+	T_689 (in __swap(d0_119) : word32)
+	T_692 (in d0_134 : Eq_663)
+	T_698 (in __swap(dwLoc14) : word32)
+	T_703 (in SEQ(SLICE(d4_125, word16, 16), SLICE(d4_125 + __swap(dwLoc14) *u SLICE(d0_119, word16, 0), word16, 0)) : uipr32)
+	T_704 (in __swap(SEQ(SLICE(d4_125, word16, 16), (word16) (d4_125 + __swap(dwLoc14) * (word16) d0_119))) : word32)
+	T_708 (in d0_119 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_125, word16, 16), (word16) (d4_125 + __swap(dwLoc14) * (word16) d0_119))), word16, 16), 0<16>) : word32)
+	T_711 (in __swap(d0_134) : word32)
+	T_714 (in d0_149 : Eq_663)
+	T_720 (in __swap(dwLoc14) : word32)
+	T_725 (in SEQ(SLICE(d4_140, word16, 16), SLICE(d4_140 + __swap(dwLoc14) *u SLICE(d0_134, word16, 0), word16, 0)) : uipr32)
+	T_726 (in __swap(SEQ(SLICE(d4_140, word16, 16), (word16) (d4_140 + __swap(dwLoc14) * (word16) d0_134))) : word32)
+	T_730 (in d0_134 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_140, word16, 16), (word16) (d4_140 + __swap(dwLoc14) * (word16) d0_134))), word16, 16), 0<16>) : word32)
+	T_733 (in __swap(d0_149) : word32)
+	T_736 (in d0_164 : Eq_663)
+	T_742 (in __swap(dwLoc14) : word32)
+	T_747 (in SEQ(SLICE(d4_155, word16, 16), SLICE(d4_155 + __swap(dwLoc14) *u SLICE(d0_149, word16, 0), word16, 0)) : uipr32)
+	T_748 (in __swap(SEQ(SLICE(d4_155, word16, 16), (word16) (d4_155 + __swap(dwLoc14) * (word16) d0_149))) : word32)
+	T_752 (in d0_149 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_155, word16, 16), (word16) (d4_155 + __swap(dwLoc14) * (word16) d0_149))), word16, 16), 0<16>) : word32)
+	T_755 (in __swap(d0_164) : word32)
+	T_758 (in d0_179 : Eq_663)
+	T_764 (in __swap(dwLoc14) : word32)
+	T_769 (in SEQ(SLICE(d4_170, word16, 16), SLICE(d4_170 + __swap(dwLoc14) *u SLICE(d0_164, word16, 0), word16, 0)) : uipr32)
+	T_770 (in __swap(SEQ(SLICE(d4_170, word16, 16), (word16) (d4_170 + __swap(dwLoc14) * (word16) d0_164))) : word32)
+	T_774 (in d0_164 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_170, word16, 16), (word16) (d4_170 + __swap(dwLoc14) * (word16) d0_164))), word16, 16), 0<16>) : word32)
+	T_777 (in __swap(d0_179) : word32)
+	T_780 (in d0_194 : Eq_663)
+	T_786 (in __swap(dwLoc14) : word32)
+	T_791 (in SEQ(SLICE(d4_185, word16, 16), SLICE(d4_185 + __swap(dwLoc14) *u SLICE(d0_179, word16, 0), word16, 0)) : uipr32)
+	T_792 (in __swap(SEQ(SLICE(d4_185, word16, 16), (word16) (d4_185 + __swap(dwLoc14) * (word16) d0_179))) : word32)
+	T_796 (in d0_179 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_185, word16, 16), (word16) (d4_185 + __swap(dwLoc14) * (word16) d0_179))), word16, 16), 0<16>) : word32)
+	T_799 (in __swap(d0_194) : word32)
+	T_802 (in d0_209 : Eq_663)
+	T_808 (in __swap(dwLoc14) : word32)
+	T_813 (in SEQ(SLICE(d4_200, word16, 16), SLICE(d4_200 + __swap(dwLoc14) *u SLICE(d0_194, word16, 0), word16, 0)) : uipr32)
+	T_814 (in __swap(SEQ(SLICE(d4_200, word16, 16), (word16) (d4_200 + __swap(dwLoc14) * (word16) d0_194))) : word32)
+	T_818 (in d0_194 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_200, word16, 16), (word16) (d4_200 + __swap(dwLoc14) * (word16) d0_194))), word16, 16), 0<16>) : word32)
+	T_821 (in __swap(d0_209) : word32)
+	T_824 (in d0_224 : Eq_663)
+	T_830 (in __swap(dwLoc14) : word32)
+	T_835 (in SEQ(SLICE(d4_215, word16, 16), SLICE(d4_215 + __swap(dwLoc14) *u SLICE(d0_209, word16, 0), word16, 0)) : uipr32)
+	T_836 (in __swap(SEQ(SLICE(d4_215, word16, 16), (word16) (d4_215 + __swap(dwLoc14) * (word16) d0_209))) : word32)
+	T_840 (in d0_209 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_215, word16, 16), (word16) (d4_215 + __swap(dwLoc14) * (word16) d0_209))), word16, 16), 0<16>) : word32)
+	T_843 (in __swap(d0_224) : word32)
+	T_846 (in d0_239 : Eq_663)
+	T_852 (in __swap(dwLoc14) : word32)
+	T_857 (in SEQ(SLICE(d4_230, word16, 16), SLICE(d4_230 + __swap(dwLoc14) *u SLICE(d0_224, word16, 0), word16, 0)) : uipr32)
+	T_858 (in __swap(SEQ(SLICE(d4_230, word16, 16), (word16) (d4_230 + __swap(dwLoc14) * (word16) d0_224))) : word32)
+	T_862 (in d0_224 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_230, word16, 16), (word16) (d4_230 + __swap(dwLoc14) * (word16) d0_224))), word16, 16), 0<16>) : word32)
+	T_865 (in __swap(d0_239) : word32)
+	T_868 (in d0_254 : Eq_663)
+	T_874 (in __swap(dwLoc14) : word32)
+	T_879 (in SEQ(SLICE(d4_245, word16, 16), SLICE(d4_245 + __swap(dwLoc14) *u SLICE(d0_239, word16, 0), word16, 0)) : uipr32)
+	T_880 (in __swap(SEQ(SLICE(d4_245, word16, 16), (word16) (d4_245 + __swap(dwLoc14) * (word16) d0_239))) : word32)
+	T_884 (in d0_239 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_245, word16, 16), (word16) (d4_245 + __swap(dwLoc14) * (word16) d0_239))), word16, 16), 0<16>) : word32)
+	T_887 (in __swap(d0_254) : word32)
+	T_890 (in d0_269 : Eq_663)
+	T_896 (in __swap(dwLoc14) : word32)
+	T_901 (in SEQ(SLICE(d4_260, word16, 16), SLICE(d4_260 + __swap(dwLoc14) *u SLICE(d0_254, word16, 0), word16, 0)) : uipr32)
+	T_902 (in __swap(SEQ(SLICE(d4_260, word16, 16), (word16) (d4_260 + __swap(dwLoc14) * (word16) d0_254))) : word32)
+	T_906 (in d0_254 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_260, word16, 16), (word16) (d4_260 + __swap(dwLoc14) * (word16) d0_254))), word16, 16), 0<16>) : word32)
+	T_909 (in __swap(d0_269) : word32)
+	T_912 (in d0_284 : Eq_663)
+	T_918 (in __swap(dwLoc14) : word32)
+	T_923 (in SEQ(SLICE(d4_275, word16, 16), SLICE(d4_275 + __swap(dwLoc14) *u SLICE(d0_269, word16, 0), word16, 0)) : uipr32)
+	T_924 (in __swap(SEQ(SLICE(d4_275, word16, 16), (word16) (d4_275 + __swap(dwLoc14) * (word16) d0_269))) : word32)
+	T_928 (in d0_269 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_275, word16, 16), (word16) (d4_275 + __swap(dwLoc14) * (word16) d0_269))), word16, 16), 0<16>) : word32)
+	T_931 (in __swap(d0_284) : word32)
+	T_934 (in d0_299 : Eq_663)
+	T_940 (in __swap(dwLoc14) : word32)
+	T_945 (in SEQ(SLICE(d4_290, word16, 16), SLICE(d4_290 + __swap(dwLoc14) *u SLICE(d0_284, word16, 0), word16, 0)) : uipr32)
+	T_946 (in __swap(SEQ(SLICE(d4_290, word16, 16), (word16) (d4_290 + __swap(dwLoc14) * (word16) d0_284))) : word32)
+	T_950 (in d0_284 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_290, word16, 16), (word16) (d4_290 + __swap(dwLoc14) * (word16) d0_284))), word16, 16), 0<16>) : word32)
+	T_953 (in __swap(d0_299) : word32)
+	T_956 (in d0_314 : Eq_663)
+	T_962 (in __swap(dwLoc14) : word32)
+	T_967 (in SEQ(SLICE(d4_305, word16, 16), SLICE(d4_305 + __swap(dwLoc14) *u SLICE(d0_299, word16, 0), word16, 0)) : uipr32)
+	T_968 (in __swap(SEQ(SLICE(d4_305, word16, 16), (word16) (d4_305 + __swap(dwLoc14) * (word16) d0_299))) : word32)
+	T_972 (in d0_299 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_305, word16, 16), (word16) (d4_305 + __swap(dwLoc14) * (word16) d0_299))), word16, 16), 0<16>) : word32)
+	T_975 (in __swap(d0_314) : word32)
+	T_978 (in d0_329 : Eq_663)
+	T_984 (in __swap(dwLoc14) : word32)
+	T_989 (in SEQ(SLICE(d4_320, word16, 16), SLICE(d4_320 + __swap(dwLoc14) *u SLICE(d0_314, word16, 0), word16, 0)) : uipr32)
+	T_990 (in __swap(SEQ(SLICE(d4_320, word16, 16), (word16) (d4_320 + __swap(dwLoc14) * (word16) d0_314))) : word32)
+	T_994 (in d0_314 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_320, word16, 16), (word16) (d4_320 + __swap(dwLoc14) * (word16) d0_314))), word16, 16), 0<16>) : word32)
+	T_997 (in __swap(d0_329) : word32)
+	T_1000 (in d0_344 : Eq_663)
+	T_1006 (in __swap(dwLoc14) : word32)
+	T_1011 (in SEQ(SLICE(d4_335, word16, 16), SLICE(d4_335 + __swap(dwLoc14) *u SLICE(d0_329, word16, 0), word16, 0)) : uipr32)
+	T_1012 (in __swap(SEQ(SLICE(d4_335, word16, 16), (word16) (d4_335 + __swap(dwLoc14) * (word16) d0_329))) : word32)
+	T_1016 (in d0_329 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_335, word16, 16), (word16) (d4_335 + __swap(dwLoc14) * (word16) d0_329))), word16, 16), 0<16>) : word32)
+	T_1019 (in __swap(d0_344) : word32)
+	T_1022 (in d0_359 : Eq_663)
+	T_1028 (in __swap(dwLoc14) : word32)
+	T_1033 (in SEQ(SLICE(d4_350, word16, 16), SLICE(d4_350 + __swap(dwLoc14) *u SLICE(d0_344, word16, 0), word16, 0)) : uipr32)
+	T_1034 (in __swap(SEQ(SLICE(d4_350, word16, 16), (word16) (d4_350 + __swap(dwLoc14) * (word16) d0_344))) : word32)
+	T_1038 (in d0_344 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_350, word16, 16), (word16) (d4_350 + __swap(dwLoc14) * (word16) d0_344))), word16, 16), 0<16>) : word32)
+	T_1041 (in __swap(d0_359) : word32)
+	T_1044 (in d0_374 : Eq_663)
+	T_1050 (in __swap(dwLoc14) : word32)
+	T_1055 (in SEQ(SLICE(d4_365, word16, 16), SLICE(d4_365 + __swap(dwLoc14) *u SLICE(d0_359, word16, 0), word16, 0)) : uipr32)
+	T_1056 (in __swap(SEQ(SLICE(d4_365, word16, 16), (word16) (d4_365 + __swap(dwLoc14) * (word16) d0_359))) : word32)
+	T_1060 (in d0_359 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_365, word16, 16), (word16) (d4_365 + __swap(dwLoc14) * (word16) d0_359))), word16, 16), 0<16>) : word32)
+	T_1063 (in __swap(d0_374) : word32)
+	T_1066 (in d0_389 : Eq_663)
+	T_1072 (in __swap(dwLoc14) : word32)
+	T_1077 (in SEQ(SLICE(d4_380, word16, 16), SLICE(d4_380 + __swap(dwLoc14) *u SLICE(d0_374, word16, 0), word16, 0)) : uipr32)
+	T_1078 (in __swap(SEQ(SLICE(d4_380, word16, 16), (word16) (d4_380 + __swap(dwLoc14) * (word16) d0_374))) : word32)
+	T_1082 (in d0_374 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_380, word16, 16), (word16) (d4_380 + __swap(dwLoc14) * (word16) d0_374))), word16, 16), 0<16>) : word32)
+	T_1085 (in __swap(d0_389) : word32)
+	T_1088 (in d0_404 : Eq_663)
+	T_1094 (in __swap(dwLoc14) : word32)
+	T_1099 (in SEQ(SLICE(d4_395, word16, 16), SLICE(d4_395 + __swap(dwLoc14) *u SLICE(d0_389, word16, 0), word16, 0)) : uipr32)
+	T_1100 (in __swap(SEQ(SLICE(d4_395, word16, 16), (word16) (d4_395 + __swap(dwLoc14) * (word16) d0_389))) : word32)
+	T_1104 (in d0_389 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_395, word16, 16), (word16) (d4_395 + __swap(dwLoc14) * (word16) d0_389))), word16, 16), 0<16>) : word32)
+	T_1107 (in __swap(d0_404) : word32)
+	T_1110 (in d0_419 : Eq_663)
+	T_1116 (in __swap(dwLoc14) : word32)
+	T_1121 (in SEQ(SLICE(d4_410, word16, 16), SLICE(d4_410 + __swap(dwLoc14) *u SLICE(d0_404, word16, 0), word16, 0)) : uipr32)
+	T_1122 (in __swap(SEQ(SLICE(d4_410, word16, 16), (word16) (d4_410 + __swap(dwLoc14) * (word16) d0_404))) : word32)
+	T_1126 (in d0_404 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_410, word16, 16), (word16) (d4_410 + __swap(dwLoc14) * (word16) d0_404))), word16, 16), 0<16>) : word32)
+	T_1129 (in __swap(d0_419) : word32)
+	T_1132 (in d0_434 : Eq_663)
+	T_1138 (in __swap(dwLoc14) : word32)
+	T_1143 (in SEQ(SLICE(d4_425, word16, 16), SLICE(d4_425 + __swap(dwLoc14) *u SLICE(d0_419, word16, 0), word16, 0)) : uipr32)
+	T_1144 (in __swap(SEQ(SLICE(d4_425, word16, 16), (word16) (d4_425 + __swap(dwLoc14) * (word16) d0_419))) : word32)
+	T_1148 (in d0_419 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_425, word16, 16), (word16) (d4_425 + __swap(dwLoc14) * (word16) d0_419))), word16, 16), 0<16>) : word32)
+	T_1151 (in __swap(d0_434) : word32)
+	T_1154 (in d0_449 : Eq_663)
+	T_1160 (in __swap(dwLoc14) : word32)
+	T_1165 (in SEQ(SLICE(d4_440, word16, 16), SLICE(d4_440 + __swap(dwLoc14) *u SLICE(d0_434, word16, 0), word16, 0)) : uipr32)
+	T_1166 (in __swap(SEQ(SLICE(d4_440, word16, 16), (word16) (d4_440 + __swap(dwLoc14) * (word16) d0_434))) : word32)
+	T_1170 (in d0_434 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_440, word16, 16), (word16) (d4_440 + __swap(dwLoc14) * (word16) d0_434))), word16, 16), 0<16>) : word32)
+	T_1173 (in __swap(d0_449) : word32)
+	T_1176 (in d0_464 : Eq_663)
+	T_1182 (in __swap(dwLoc14) : word32)
+	T_1187 (in SEQ(SLICE(d4_455, word16, 16), SLICE(d4_455 + __swap(dwLoc14) *u SLICE(d0_449, word16, 0), word16, 0)) : uipr32)
+	T_1188 (in __swap(SEQ(SLICE(d4_455, word16, 16), (word16) (d4_455 + __swap(dwLoc14) * (word16) d0_449))) : word32)
+	T_1192 (in d0_449 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_455, word16, 16), (word16) (d4_455 + __swap(dwLoc14) * (word16) d0_449))), word16, 16), 0<16>) : word32)
+	T_1195 (in __swap(d0_464) : word32)
+	T_1203 (in __swap(dwLoc14) : word32)
+	T_1208 (in SEQ(SLICE(d5_471, word16, 16), SLICE(d5_471 + __swap(dwLoc14) *u SLICE(d0_464, word16, 0), word16, 0)) : uipr32)
+	T_1209 (in __swap(SEQ(SLICE(d5_471, word16, 16), (word16) (d5_471 + __swap(dwLoc14) * (word16) d0_464))) : word32)
+	T_1213 (in d0_464 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d5_471, word16, 16), (word16) (d5_471 + __swap(dwLoc14) * (word16) d0_464))), word16, 16), 0<16>) : word32)
+	T_1317 (in d5_256 : Eq_663)
+	T_1318 (in -1<i32> : int32)
+	T_1329 (in d2_1005 : Eq_663)
+	T_1332 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
+	T_1348 (in d2_1005 | d1_123 : word32)
+	T_1358 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
+	T_1474 (in 0<i32> : int32)
+	T_1502 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
+	T_1508 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_1511 (in 10<i32> : int32)
+	T_1512 (in __swap(10<i32>) : word32)
+	T_1519 (in __swap(d5_256) : word32)
+	T_1524 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
+	T_1525 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
+	T_1562 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_1566 (in d1_303 - 0x30<32> + d0_293 : word32)
+	T_1611 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
+	T_1619 (in 10<i32> : int32)
+	T_1620 (in __swap(10<i32>) : word32)
+	T_1627 (in __swap(d2_1005) : word32)
+	T_1632 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
+	T_1633 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
+	T_1675 (in d1_196 - 0x30<32> + d0_186 : word32)
+	T_1683 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
+	T_1780 (in 0<32> : word32)
+	T_1859 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
+	T_1908 (in 0<32> : word32)
+	T_2128 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
+	T_2266 (in dwArg04 : Eq_663)
+	T_2267 (in dwArg08 : Eq_663)
+	T_2268 (in dwArg0C : Eq_663)
+	T_2269 (in dwArg10 : Eq_663)
+	T_2273 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_2278 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_2283 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_2288 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_2350 (in dwArg04 : Eq_663)
+	T_2351 (in dwArg08 : Eq_663)
+	T_2352 (in dwArg0C : Eq_663)
+	T_2353 (in dwArg10 : Eq_663)
+	T_2354 (in d1Out : Eq_663)
+	T_2355 (in a0Out : Eq_663)
+	T_2359 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_2364 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_2369 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_2374 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_2375 (in out d1_1450 : ptr32)
+	T_2376 (in out a0_1447 : ptr32)
+	T_2950 (in 0<32> : word32)
+	T_2980 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_2984 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_3040 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
+	T_3925 (in d0 : Eq_663)
+	T_3926 (in d0_196 : Eq_663)
+	T_3927 (in d1_142 : Eq_663)
+	T_3928 (in a0_20 : Eq_663)
+	T_3929 (in d3_166 : Eq_663)
+	T_3930 (in 0<32> : word32)
+	T_3938 (in 0<32> : word32)
+	T_3944 (in d0 : Eq_663)
+	T_3945 (in d1 : Eq_663)
+	T_3946 (in d2 : Eq_663)
+	T_3947 (in d1Out : Eq_663)
+	T_3948 (in d2Out : Eq_663)
+	T_3949 (in out d1_318 : ptr32)
+	T_3950 (in out d2_319 : ptr32)
+	T_3951 (in fn000027BC(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
+	T_3952 (in 0<i32> : int32)
+	T_3955 (in d6_30 : Eq_663)
+	T_3958 (in  : word32)
+	T_3959 (in  : word32)
+	T_3960 (in 8<32> : word32)
+	T_3961 (in __rol(dwArg0C, 8<32>) : word32)
+	T_3987 (in 8<32> : word32)
+	T_3988 (in __rol(d6_30, 8<32>) : word32)
+	T_3994 (in 8<32> : word32)
+	T_3995 (in __rol(d6_30, 8<32>) : word32)
+	T_4002 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_4003 (in d1_175 : Eq_663)
+	T_4004 (in d2_176 : Eq_663)
+	T_4005 (in d0_174 : Eq_663)
+	T_4007 (in 0<i32> : int32)
+	T_4008 (in out d1_175 : ptr32)
+	T_4009 (in out d2_176 : ptr32)
+	T_4010 (in fn000027BC(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
+	T_4014 (in out d1_320 : ptr32)
+	T_4015 (in out d2_321 : ptr32)
+	T_4016 (in fn000027BC(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
+	T_4027 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_4030 (in d0_85 : Eq_663)
+	T_4032 (in dwArg04 >> d4_61 : word32)
+	T_4035 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
+	T_4038 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
+	T_4039 (in out d1_86 : ptr32)
+	T_4040 (in out d2_322 : ptr32)
+	T_4041 (in fn000027BC(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
+	T_4042 (in d3_72 : Eq_663)
+	T_4043 (in dwArg10 << d5_63 : word32)
+	T_4044 (in d5_101 : Eq_663)
+	T_4046 (in __swap(d0_85) : word32)
+	T_4047 (in d6_103 : Eq_663)
+	T_4049 (in __swap(d3_72) : word32)
+	T_4053 (in d2_107 : Eq_663)
+	T_4056 (in d0_85 * (word16) d3_72 : word32)
+	T_4057 (in __swap(d0_85 * (word16) d3_72) : word32)
+	T_4070 (in d6_82 : Eq_663)
+	T_4071 (in dwArg08 << d5_63 : word32)
+	T_4072 (in d2_124 : Eq_663)
+	T_4074 (in SEQ(v35_109, v39_116) : uipr32)
+	T_4075 (in __swap(SEQ(v35_109, v39_116)) : word32)
+	T_4083 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
+	T_4084 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
+	T_4088 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
+	T_4089 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
+	T_4111 (in d0_85 - 1<32> : word32)
+	T_4117 (in d7_13 : Eq_663)
+	T_4118 (in 0<32> : word32)
+	T_4122 (in d0 : Eq_663)
+	T_4123 (in d1 : Eq_663)
+	T_4124 (in d2 : Eq_663)
+	T_4125 (in d1Out : Eq_663)
+	T_4126 (in out d1 : ptr32)
+	T_4127 (in fn0000297A(d1, d2, d2, out d1) : word32)
+	T_4128 (in d6_17 : Eq_663)
+	T_4129 (in d5_19 : Eq_663)
+	T_4130 (in 0<32> : word32)
+	T_4132 (in d2_22 : Eq_663)
+	T_4134 (in __swap(d2) : word32)
+	T_4138 (in 0<32> : word32)
+	T_4147 (in 0<32> : word32)
+	T_4149 (in d0_281 : Eq_663)
+	T_4151 (in __swap(d0) : word32)
+	T_4152 (in d1_282 : Eq_663)
+	T_4154 (in __swap(d1) : word32)
+	T_4164 (in __swap(d1_282) : word32)
+	T_4171 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
+	T_4172 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
+	T_4177 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
+	T_4183 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
+	T_4184 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
+	T_4188 (in d6_17 * 2<32> : word32)
+	T_4196 (in 0<32> : word32)
+	T_4198 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
+	T_4200 (in d7_13 * 2<32> : word32)
+	T_4201 (in 0<32> : word32)
+	T_4205 (in d3_74 : Eq_663)
+	T_4212 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
+	T_4213 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
+	T_4216 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
+	T_4217 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
+	T_4218 (in d1_104 : Eq_663)
+	T_4219 (in 0xFFFF<32> : uipr32)
+	T_4220 (in d6_98 : Eq_663)
+	T_4224 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
+	T_4225 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
+	T_4226 (in d6_133 : Eq_663)
+	T_4228 (in __swap(d1_104) : word32)
+	T_4229 (in d3_140 : Eq_663)
+	T_4231 (in __swap(d6_133) : word32)
+	T_4232 (in d4_142 : Eq_663)
+	T_4234 (in __swap(d7_13) : word32)
+	T_4238 (in d6_146 : Eq_663)
+	T_4241 (in d6_133 * (word16) d7_13 : word32)
+	T_4242 (in __swap(d6_133 * (word16) d7_13) : word32)
+	T_4258 (in d6_178 : Eq_663)
+	T_4260 (in SEQ(v56_148, v59_155) : uipr32)
+	T_4261 (in __swap(SEQ(v56_148, v59_155)) : word32)
+	T_4262 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
+	T_4263 (in d5_181 : word32)
+	T_4267 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
+	T_4268 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
+	T_4272 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
+	T_4273 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
+	T_4286 (in 0<32> : word32)
+	T_4288 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
+	T_4289 (in 0<32> : word32)
+	T_4297 (in d1_104 - 1<32> : word32)
+	T_4298 (in d4_113 : Eq_663)
+	T_4301 (in __swap(d7_13) : word32)
+	T_4304 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
+	T_4305 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
+	T_4320 (in __swap(d7_13) : word32)
+	T_4324 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
+	T_4326 (in d1_104 - 1<32> : word32)
+	T_4327 (in 0<32> : word32)
+	T_4333 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
+	T_4334 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_4335 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_4336 (in d6_220 : Eq_663)
+	T_4340 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
+	T_4341 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
+	T_4344 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
+	T_4345 (in d5_221 : Eq_663)
+	T_4347 (in __swap(d5_181) : word32)
+	T_4352 (in d5_266 : Eq_663)
+	T_4354 (in __swap(d5_181) : word32)
+	T_4355 (in d6_267 : Eq_663)
+	T_4357 (in __swap(d6_178) : word32)
+	T_4360 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
+	T_4363 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
+	T_4367 (in d2_73 : Eq_663)
+	T_4369 (in __swap(d5_19) : word32)
+	T_4371 (in __swap(d7_13) : word32)
+	T_4381 (in d5_221 >> 1<32> : word32)
+	T_4386 (in  : word32)
+	T_4392 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
+	T_4399 (in d0 : Eq_663)
+	T_4400 (in d2 : Eq_663)
+	T_4401 (in dwArg04 : Eq_663)
+	T_4402 (in dwArg08 : Eq_663)
+	T_4403 (in 0<32> : word32)
+	T_4405 (in 0<32> : word32)
+	T_4407 (in d0_36 : Eq_663)
+	T_4408 (in -dwArg04 : word32)
+	T_4409 (in 0<32> : word32)
+	T_4413 (in out d1_43 : ptr32)
+	T_4414 (in fn0000297A(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_4415 (in -fn0000297A(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_4418 (in -dwArg08 : word32)
+	T_4419 (in out d1_55 : ptr32)
+	T_4420 (in fn0000297A(d0_36, -dwArg08, d2, out d1_55) : word32)
+	T_4423 (in out d1_88 : ptr32)
+	T_4424 (in fn0000297A(dwArg04, dwArg08, d2, out d1_88) : word32)
+	T_4427 (in -dwArg08 : word32)
+	T_4428 (in out d1_89 : ptr32)
+	T_4429 (in fn0000297A(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_4430 (in -fn0000297A(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_4431 (in d1_22 : Eq_663)
+	T_4433 (in __swap(d1) : word32)
+	T_4438 (in d2_11 : Eq_663)
+	T_4439 (in SEQ(v11_10, v10_9) : uipr32)
+	T_4442 (in d3_18 : Eq_663)
+	T_4443 (in 16<i32> : int32)
+	T_4447 (in d0_134 : Eq_663)
+	T_4449 (in __swap(d0) : word32)
+	T_4450 (in d1_135 : Eq_663)
+	T_4452 (in __swap(d1_22) : word32)
+	T_4457 (in __swap(d2_11) : word32)
+	T_4462 (in d0_150 : Eq_663)
+	T_4464 (in __swap(d0_134) : word32)
+	T_4478 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
+	T_4479 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
+	T_4481 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
+	T_4483 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
+	T_4493 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
+	T_4498 (in 8<32> : word32)
+	T_4499 (in __rol(d1_22, 8<32>) : word32)
+	T_4500 (in 8<32> : uipr32)
+	T_4505 (in 4<32> : word32)
+	T_4506 (in __rol(d1_22, 4<32>) : word32)
+	T_4511 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
+	T_4516 (in 2<32> : word32)
+	T_4517 (in __rol(d1_22, 2<32>) : word32)
+	T_4522 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
+	T_4528 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
+	T_4529 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
+	T_4536 (in __swap(d3_18) : word32)
+	T_4542 (in d1_90 : Eq_663)
+	T_4544 (in __swap(d1_22) : word32)
+	T_4545 (in d3_102 : Eq_663)
+	T_4546 (in SEQ(v53_82, v51_79) : uipr32)
+	T_4547 (in d0_108 : Eq_663)
+	T_4557 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
+	T_4558 (in 0<32> : word32)
+	T_4561 (in 1<32> : word32)
+	T_4562 (in __rol(d1_22, 1<32>) : word32)
+	T_4567 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
+	T_4571 (in __swap(d3_102) : word32)
+	T_4572 (in __rol(d0_108, __swap(d3_102)) : word32)
+	T_4573 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
+	T_4576 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
+	T_4579 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
+	T_4580 (in d0_108 + d1_90 : word32)
+	T_4581 (in 0<32> : word32)
+	T_4583 (in d1 : Eq_663)
+	T_4584 (in d1_171 : Eq_663)
+	T_4585 (in d3_202 : Eq_663)
+	T_4586 (in 0<32> : word32)
+	T_4594 (in 0<32> : word32)
+	T_4598 (in out d1_171 : ptr32)
+	T_4599 (in out d2_354 : ptr32)
+	T_4600 (in fn000027BC(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
+	T_4603 (in d6_33 : Eq_663)
+	T_4605 (in 8<32> : word32)
+	T_4606 (in __rol(dwArg0C, 8<32>) : word32)
+	T_4632 (in 8<32> : word32)
+	T_4633 (in __rol(d6_33, 8<32>) : word32)
+	T_4639 (in 8<32> : word32)
+	T_4640 (in __rol(d6_33, 8<32>) : word32)
+	T_4647 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_4650 (in d0_88 : Eq_663)
+	T_4652 (in dwArg04 >> d4_64 : word32)
+	T_4655 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
+	T_4658 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
+	T_4659 (in out d1_89 : ptr32)
+	T_4660 (in out d2_90 : ptr32)
+	T_4661 (in fn000027BC(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
+	T_4662 (in d3_75 : Eq_663)
+	T_4663 (in dwArg10 << d5_66 : word32)
+	T_4664 (in d7_104 : Eq_663)
+	T_4666 (in __swap(d0_88) : word32)
+	T_4667 (in d6_106 : Eq_663)
+	T_4669 (in __swap(d3_75) : word32)
+	T_4673 (in d2_110 : Eq_663)
+	T_4676 (in d0_88 * (word16) d3_75 : word32)
+	T_4677 (in __swap(d0_88 * (word16) d3_75) : word32)
+	T_4690 (in d2_127 : Eq_663)
+	T_4692 (in SEQ(v37_112, v40_119) : uipr32)
+	T_4693 (in __swap(SEQ(v37_112, v40_119)) : word32)
+	T_4703 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
+	T_4704 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
+	T_4708 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
+	T_4709 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
+	T_4728 (in dwArg08 - dwArg10 : word32)
+	T_4732 (in d1_211 : Eq_663)
+	T_4733 (in d2_212 : Eq_663)
+	T_4735 (in 0<i32> : int32)
+	T_4736 (in out d1_211 : ptr32)
+	T_4737 (in out d2_212 : ptr32)
+	T_4738 (in fn000027BC(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
+	T_4741 (in out d1_171 : ptr32)
+	T_4742 (in out d2_355 : ptr32)
+	T_4743 (in fn000027BC(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
+	T_4754 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_4759 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
+	T_4772 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
+	T_4819 (in dwArg0C : Eq_663)
+	T_4824 (in fp + 8<i32> : word32)
+	T_4865 (in d2_1090 : Eq_663)
+	T_4928 (in d6_1133 : Eq_663)
+	T_4929 (in -1<i32> : int32)
+	T_4951 (in 0<i32> : int32)
+	T_4962 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_4965 (in 10<i32> : int32)
+	T_4966 (in __swap(10<i32>) : word32)
+	T_4976 (in __swap(d6_1133) : word32)
+	T_4981 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
+	T_4982 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
+	T_5008 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_5012 (in d1_340 - 0x30<32> + d0_331 : word32)
+	T_5574 (in 0xFFFFFFFF<32> : word32)
+	T_5724 (in d0 + 4<32> : word32)
+	T_5766 (in d0 + 4<32> : word32)
+	T_5842 (in d0 + 4<32> : word32)
+	T_5911 (in d0 + 4<32> : word32)
+	T_5949 (in d0 + 4<32> : word32)
+	T_5964 (in d0 + 4<32> : word32)
+	T_6251 (in 1<i32> : int32)
+	T_6269 (in d0 + 4<32> : word32)
+	T_7000 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
+	T_7065 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
+	T_7095 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
+	T_7110 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
+	T_7116 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
+	T_7126 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
+	T_7147 (in v419_2893 : Eq_663)
+	T_7152 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_7327 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_7507 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_7510 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_7512 (in d7 >> 31<i32> : word32)
+	T_7515 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
+	T_7557 (in dwArg04 : Eq_663)
+	T_7558 (in dwArg08 : Eq_663)
+	T_7559 (in dwArg0C : Eq_663)
+	T_7560 (in dwArg10 : Eq_663)
+	T_7565 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
+	T_7570 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
+	T_7575 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
+	T_7580 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
+	T_7687 (in (d0_3495 << 2<32>) + 4<32> : word32)
+	T_7723 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7752 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7781 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7798 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7892 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_7928 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7957 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7986 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_8003 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_8029 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
+	T_8040 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
+	T_8150 (in (d0_957 << 2<32>) + 4<32> : word32)
+	T_8288 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
+	T_8293 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
+	T_8465 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
+	T_8470 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
+	T_8507 (in d0_23 : Eq_663)
+	T_8509 (in __swap(dwArg08) : word32)
+	T_8510 (in d1_25 : Eq_663)
+	T_8512 (in __swap(dwArg10) : word32)
+	T_8522 (in d2_39 : Eq_663)
+	T_8530 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
+	T_8531 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
+	T_8535 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
+	T_8536 (in 0<32> : word32)
+	T_8538 (in d2_45 : Eq_663)
+	T_8540 (in __swap(d2_39) : word32)
+	T_8543 (in __swap(dwArg0C) : word32)
+	T_8546 (in d3_71 : Eq_663)
+	T_8550 (in __swap(dwArg08) : word32)
+	T_8555 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
+	T_8556 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
+	T_8559 (in __swap(dwArg04) : word32)
+	T_8562 (in d3_89 : Eq_663)
+	T_8566 (in __swap(dwArg10) : word32)
+	T_8571 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
+	T_8572 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
 Eq_671: (union "Eq_671" (int32 u0) (uint32 u1))
 	T_671 (in 3<i32> : int32)
 Eq_1221: (fn Eq_603 (Eq_603, (ptr32 Eq_1224), Eq_619, Eq_1226, (ptr32 Eq_1227), Eq_619))
@@ -1655,7 +1601,7 @@ Eq_1227: (struct "Eq_1227" (0 word32 dw0000) (4 word32 dw0004))
 	T_2967 (in Mem916[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_2989 (in Mem935[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_3027 (in Mem1000[a7_992 - 4<i32> + 0<32>:word32] : word32)
-Eq_1238: (struct "Eq_1238" 0004 (2C Eq_8959 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8960 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+Eq_1238: (struct "Eq_1238" 0004 (2C Eq_8954 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8955 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 	T_1238 (in a7_1968 : (ptr32 Eq_1238))
 	T_1241 (in fp + -112<i32> : word32)
 	T_1302 (in a7_51 + 4<i32> : word32)
@@ -1830,10 +1776,10 @@ Eq_2217: (union "Eq_2217" (int32 u0) (up32 u1))
 Eq_2224: (struct "Eq_2224" (0 int32 dw0000) (34 Eq_603 t0034) (48 Eq_1712 t0048) (4C ui32 dw004C) (66 (ptr32 Eq_1324) ptr0066) (6A word32 dw006A) (80 Eq_1226 t0080))
 	T_2224 (in a7_1383 : (ptr32 Eq_2224))
 	T_2226 (in a7_1020 - 4<i32> : word32)
-Eq_2264: (fn int32 (Eq_603, Eq_603, Eq_603, Eq_603))
+Eq_2264: (fn int32 (Eq_663, Eq_663, Eq_663, Eq_663))
 	T_2264 (in fn00002A00 : ptr32)
 	T_2265 (in signature of fn00002A00 : void)
-Eq_2348: (fn word32 (Eq_603, Eq_603, Eq_603, Eq_603, Eq_603, Eq_603))
+Eq_2348: (fn word32 (Eq_663, Eq_663, Eq_663, Eq_663, Eq_663, Eq_663))
 	T_2348 (in fn000026B8 : ptr32)
 	T_2349 (in signature of fn000026B8 : void)
 Eq_2388: (union "Eq_2388" (bool u0) (word32 u1))
@@ -1899,9 +1845,6 @@ Eq_2650: (union "Eq_2650" (int32 u0) (up32 u1))
 	T_2650 (in d2_1847 : Eq_2650)
 	T_2651 (in 0<i32> : int32)
 	T_2662 (in d2_1847 + 1<32> : word32)
-Eq_2743: (union "Eq_2743" (byte u0) (word32 u1))
-	T_2743 (in v248_1105 : Eq_2743)
-	T_2746 (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
 Eq_2747: (struct "Eq_2747" (0 (ptr32 Eq_1227) ptr0000) (34 int32 dw0034) (38 int32 dw0038))
 	T_2747 (in a7_1109 : (ptr32 Eq_2747))
 	T_2749 (in a7_1968 - 4<i32> : word32)
@@ -1912,9 +1855,6 @@ Eq_2784: (union "Eq_2784" (uint32 u0) (ptr32 u1))
 	T_2784 (in 3<32> : word32)
 Eq_2785: (union "Eq_2785" (uint32 u0) (ptr32 u1))
 	T_2785 (in d3_1482 + 3<32> : word32)
-Eq_2808: (union "Eq_2808" (word16 u0) (word32 u1))
-	T_2808 (in v262_844 : Eq_2808)
-	T_2811 (in Mem843[a7_1968 + 62<i32>:word16] : word16)
 Eq_2812: (struct "Eq_2812" (0 (ptr32 Eq_1227) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2812 (in a7_848 : (ptr32 Eq_2812))
 	T_2814 (in a7_1968 - 4<i32> : word32)
@@ -1946,9 +1886,6 @@ Eq_2902: (union "Eq_2902" (cu8 u0) (word32 u1) (Eq_1755 u2) (Eq_1758 u3) (Eq_183
 	T_2905 (in Mem894[a7_1968 + 44<i32>:byte] : byte)
 Eq_2904: (union "Eq_2904" (cu8 u0) (word32 u1) (Eq_1755 u2) (Eq_1758 u3) (Eq_1832 u4) (Eq_2902 u5))
 	T_2904 (in a7_1968 + 44<i32> : word32)
-Eq_2908: (union "Eq_2908" (byte u0) (word32 u1))
-	T_2908 (in v277_869 : Eq_2908)
-	T_2911 (in Mem868[a7_1968 + 63<i32>:byte] : byte)
 Eq_2912: (struct "Eq_2912" (0 (ptr32 Eq_1227) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2912 (in a7_873 : (ptr32 Eq_2912))
 	T_2914 (in a7_1968 - 4<i32> : word32)
@@ -2031,7 +1968,7 @@ Eq_3205: (fn Eq_3211 (ptr32, ptr32))
 	T_3206 (in signature of fn00002688 : void)
 	T_3381 (in fn00002688 : ptr32)
 	T_8605 (in fn00002688 : ptr32)
-Eq_3211: (union "Eq_3211" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1))
+Eq_3211: (union "Eq_3211" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1))
 	T_3211 (in fn00002688(out a1_125, out a5_127) : word32)
 	T_3384 (in fn00002688(out a1_21, out a5_23) : word32)
 	T_5226 (in d1Out : Eq_3211)
@@ -2138,7 +2075,7 @@ Eq_3882: (fn void ((ptr32 Eq_377)))
 Eq_3906: (fn void (int32, word32))
 	T_3906 (in SetSignal : ptr32)
 	T_3907 (in signature of SetSignal : void)
-Eq_3942: (fn Eq_603 (Eq_603, Eq_603, Eq_603, Eq_603, Eq_603))
+Eq_3942: (fn Eq_663 (Eq_663, Eq_663, Eq_663, Eq_663, Eq_663))
 	T_3942 (in fn000027BC : ptr32)
 	T_3943 (in signature of fn000027BC : void)
 	T_4006 (in fn000027BC : ptr32)
@@ -2148,7 +2085,7 @@ Eq_3942: (fn Eq_603 (Eq_603, Eq_603, Eq_603, Eq_603, Eq_603))
 	T_4651 (in fn000027BC : ptr32)
 	T_4734 (in fn000027BC : ptr32)
 	T_4740 (in fn000027BC : ptr32)
-Eq_3956: (fn Eq_603 (Eq_603, Eq_603))
+Eq_3956: (fn Eq_663 (Eq_663, Eq_663))
 	T_3956 (in __rol : ptr32)
 	T_3957 (in signature of __rol : void)
 	T_3986 (in __rol : ptr32)
@@ -2174,7 +2111,7 @@ Eq_4094: (union "Eq_4094" (bool u0) (word16 u1))
 	T_4094 (in v34_108 <u 0<16> : bool)
 Eq_4097: (union "Eq_4097" (bool u0) (word16 u1))
 	T_4097 (in v39_116 <u 0<16> : bool)
-Eq_4120: (fn Eq_603 (Eq_603, Eq_603, Eq_603, Eq_603))
+Eq_4120: (fn Eq_663 (Eq_663, Eq_663, Eq_663, Eq_663))
 	T_4120 (in fn0000297A : ptr32)
 	T_4121 (in signature of fn0000297A : void)
 	T_4412 (in fn0000297A : ptr32)
@@ -2192,7 +2129,7 @@ Eq_4281: (union "Eq_4281" (bool u0) (word16 u1))
 	T_4281 (in v59_155 <u 0<16> : bool)
 Eq_4287: (union "Eq_4287" (bool u0) (uint32 u1))
 	T_4287 (in d6_178 <u 0<32> : bool)
-Eq_4384: (fn Eq_603 (Eq_603, word32, bool))
+Eq_4384: (fn Eq_663 (Eq_663, word32, bool))
 	T_4384 (in __rcr : ptr32)
 	T_4385 (in signature of __rcr : void)
 Eq_4714: (union "Eq_4714" (bool u0) (word16 u1))
@@ -2205,16 +2142,16 @@ Eq_4758: (union "Eq_4758" (bool u0) (word32 u1))
 	T_4758 (in d3_135 < 0<32> : bool)
 Eq_4766: (union "Eq_4766" (bool u0) (ui32 u1))
 	T_4766 (in d6_157 < 0<32> : bool)
-Eq_4812: (fn Eq_603 (Eq_603, Eq_603, Eq_603, Eq_603, (ptr32 Eq_614), Eq_603))
+Eq_4812: (fn Eq_603 (Eq_603, Eq_603, (ptr32 (ptr32 byte)), Eq_603, (ptr32 Eq_614), Eq_663))
 	T_4812 (in fn00002E8C : ptr32)
 	T_4813 (in signature of fn00002E8C : void)
-Eq_4861: (union "Eq_4861" (uint8 u0) ((ptr32 Eq_8981) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_4861 (in a7_1330 : Eq_4861)
+Eq_4861: (struct "Eq_4861" 0004 (2C int32 dw002C) (30 Eq_8971 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8972 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+	T_4861 (in a7_1330 : (ptr32 Eq_4861))
 	T_4864 (in fp + -120<i32> : word32)
 	T_7673 (in a7_3474 + 4<i32> : word32)
 	T_7843 (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
 	T_7859 (in a7_3364 + 4<i32> : word32)
-Eq_4868: (union "Eq_4868" (byte u0) (word16 u1) ((ptr32 Eq_9002) u2) ((ptr32 Eq_8983) u3))
+Eq_4868: (union "Eq_4868" (byte u0) (word16 u1) ((ptr32 Eq_8993) u2) ((ptr32 Eq_8974) u3))
 	T_4868 (in d4_132 : Eq_4868)
 	T_4869 (in 0<i32> : int32)
 	T_5276 (in d4_132 + 1<32> : word32)
@@ -2367,7 +2304,7 @@ Eq_5223: (fn Eq_603 (Eq_603, Eq_3211, (ptr32 word32), (ptr32 byte)))
 	T_7356 (in fn00003F30 : ptr32)
 	T_8192 (in fn00003F30 : ptr32)
 	T_8359 (in fn00003F30 : ptr32)
-Eq_5413: (fn Eq_603 (Eq_603, Eq_603))
+Eq_5413: (fn Eq_603 (byte, Eq_603))
 	T_5413 (in fn00002E5C : ptr32)
 	T_5414 (in signature of fn00002E5C : void)
 	T_5523 (in fn00002E5C : ptr32)
@@ -2510,8 +2447,6 @@ Eq_6888: (struct "Eq_6888" (0 Eq_603 t0000) (38 Eq_603 t0038))
 Eq_6912: (struct "Eq_6912" (0 Eq_603 t0000) (38 uint32 dw0038))
 	T_6912 (in a7_2572 : (ptr32 Eq_6912))
 	T_6914 (in a7_1330 - 4<i32> : word32)
-Eq_6954: (union "Eq_6954" (uint8 u0) (word32 u1))
-	T_6954 (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
 Eq_6962: (union "Eq_6962" (int32 u0) (uint32 u1))
 	T_6962 (in 1<32> : word32)
 Eq_7004: (union "Eq_7004" (byte u0) (word32 u1))
@@ -2543,47 +2478,47 @@ Eq_7121: (union "Eq_7121" (int32 u0) (uint32 u1))
 Eq_7130: (union "Eq_7130" (byte u0) (word32 u1))
 	T_7130 (in SLICE(d7, byte, 0) : byte)
 	T_7133 (in Mem2843[a7_1330 + 74<i32>:byte] : byte)
-Eq_7144: (union "Eq_7144" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1))
+Eq_7144: (union "Eq_7144" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1))
 	T_7144 (in 0x30<32> : word32)
-Eq_7146: (union "Eq_7146" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1))
+Eq_7146: (union "Eq_7146" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1))
 	T_7146 (in d6_3015 : Eq_7146)
 	T_7212 (in 0<i32> : int32)
 	T_7214 (in d5_1044 - 0x37<32> : word32)
-Eq_7161: (union "Eq_7161" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1))
+Eq_7161: (union "Eq_7161" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1))
 	T_7161 (in d2_2977 : word32)
 	T_7165 (in d4_2510 + Mem2975[a7_1330 + 68<i32>:word32] : word32)
 	T_7168 (in Mem2980[a7_1330 + 48<i32>:word32] : word32)
 	T_7181 (in 0<32> : word32)
-Eq_7164: (union "Eq_7164" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1))
+Eq_7164: (union "Eq_7164" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1))
 	T_7164 (in Mem2975[a7_1330 + 68<i32>:word32] : word32)
 Eq_7182: (union "Eq_7182" (bool u0) (word32 u1))
 	T_7182 (in d2_2977 < 0<32> : bool)
-Eq_7213: (union "Eq_7213" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1))
+Eq_7213: (union "Eq_7213" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1))
 	T_7213 (in 0x37<32> : word32)
-Eq_7215: (union "Eq_7215" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1))
+Eq_7215: (union "Eq_7215" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1))
 	T_7215 (in d2_3074 : Eq_7215)
 	T_7274 (in 0<i32> : int32)
 	T_7276 (in d5_1044 - 0x57<32> : word32)
 	T_7281 (in Mem3085[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-Eq_7228: (union "Eq_7228" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1) (Eq_7164 u2))
+Eq_7228: (union "Eq_7228" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1) (Eq_7164 u2))
 	T_7228 (in d2_3037 : word32)
 	T_7232 (in d6_3015 + Mem3035[a7_1330 + 48<i32>:word32] : word32)
 	T_7235 (in Mem3040[a7_1330 + 68<i32>:word32] : word32)
 	T_7248 (in 0<32> : word32)
 Eq_7234: (union "Eq_7234" ((ptr32 (ptr32 Eq_4868)) u0) (Eq_7164 u1))
 	T_7234 (in a7_1330 + 68<i32> : word32)
-Eq_7275: (union "Eq_7275" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1))
+Eq_7275: (union "Eq_7275" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1))
 	T_7275 (in 0x57<32> : word32)
-Eq_7290: (union "Eq_7290" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1))
+Eq_7290: (union "Eq_7290" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1))
 	T_7290 (in d2_3095 : word32)
 	T_7294 (in d2_3074 + Mem3093[a7_1330 + 68<i32>:word32] : word32)
 	T_7297 (in Mem3098[a7_1330 + 48<i32>:word32] : word32)
 	T_7309 (in 0<32> : word32)
 Eq_7292: (union "Eq_7292" ((ptr32 (ptr32 Eq_4868)) u0) (Eq_7164 u1) (Eq_7228 u2))
 	T_7292 (in a7_1330 + 68<i32> : word32)
-Eq_7293: (union "Eq_7293" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1) (Eq_7164 u2) (Eq_7228 u3))
+Eq_7293: (union "Eq_7293" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1) (Eq_7164 u2) (Eq_7228 u3))
 	T_7293 (in Mem3093[a7_1330 + 68<i32>:word32] : word32)
-Eq_7296: (union "Eq_7296" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1))
+Eq_7296: (union "Eq_7296" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1))
 	T_7296 (in a7_1330 + 48<i32> : word32)
 Eq_7310: (union "Eq_7310" (bool u0) (word32 u1))
 	T_7310 (in d2_3095 < 0<32> : bool)
@@ -2592,10 +2527,10 @@ Eq_7424: (union "Eq_7424" (int32 u0) (uint32 u1))
 Eq_7452: (struct "Eq_7452" (0 Eq_603 t0000) (4E word32 dw004E))
 	T_7452 (in a7_2635 : (ptr32 Eq_7452))
 	T_7454 (in a7_1330 - 4<i32> : word32)
-Eq_7503: (struct "Eq_7503" (0 Eq_603 t0000) (1 ui24 n0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
+Eq_7503: (struct "Eq_7503" (0 Eq_663 t0000) (1 ui24 n0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
 	T_7503 (in a7_2886 : (ptr32 Eq_7503))
 	T_7504 (in a7_1330 - 4<i32> : word32)
-Eq_7554: (fn word32 (Eq_4868, Eq_603, Eq_603, Eq_603, Eq_603, ptr32))
+Eq_7554: (fn word32 (Eq_4868, Eq_663, Eq_663, Eq_663, Eq_663, ptr32))
 	T_7554 (in fn00003EB0 : ptr32)
 	T_7555 (in signature of fn00003EB0 : void)
 Eq_7605: (union "Eq_7605" (int32 u0) (uint32 u1))
@@ -2606,303 +2541,67 @@ Eq_7658: (struct "Eq_7658" (0 Eq_603 t0000) (30 word32 dw0030) (34 Eq_603 t0034)
 Eq_7688: (struct "Eq_7688" (0 word32 dw0000) (4 Eq_603 t0004))
 	T_7688 (in a0_3501 : (ptr32 Eq_7688))
 	T_7691 (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
-Eq_7816: (union "Eq_7816" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1) (Eq_7290 u2))
+Eq_7816: (union "Eq_7816" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1) (Eq_7290 u2))
 	T_7816 (in a7_1330 + 48<i32> : word32)
-Eq_7817: (union "Eq_7817" (uint8 u0) ((ptr32 (ptr32 Eq_4868)) u1) ((ptr32 Eq_9002) u2) (Eq_6954 u3) (Eq_7290 u4))
+Eq_7817: (union "Eq_7817" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1) (Eq_7290 u2))
 	T_7817 (in Mem3324[a7_1330 + 48<i32>:word32] : word32)
 	T_7820 (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
-Eq_7819: (union "Eq_7819" (uint8 u0) (word32 u1) (Eq_6954 u2))
-	T_7819 (in a7_1330 + 56<i32> : word32)
 Eq_7827: (struct "Eq_7827" (0 int32 dw0000) (4 word32 dw0004))
 	T_7827 (in v528_3348 : (ptr32 Eq_7827))
 	T_7829 (in a7_1330 + 44<i32> : word32)
 Eq_7839: (union "Eq_7839" (bool u0) (int32 u1))
 	T_7839 (in d1 < 0<32> : bool)
-Eq_7842: (union "Eq_7842" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7842 (in a7_1330 + 0x38<32> : word32)
-Eq_7844: (union "Eq_7844" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7844 (in a7_3364 : Eq_7844)
+Eq_7844: (struct "Eq_7844" (0 Eq_603 t0000) (30 byte b0030) (38 word32 dw0038) (3C Eq_603 t003C) (4C byte b004C))
+	T_7844 (in a7_3364 : (ptr32 Eq_7844))
 	T_7846 (in a7_1330 - 4<i32> : word32)
-Eq_7845: (union "Eq_7845" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7845 (in 4<i32> : int32)
-Eq_7848: (union "Eq_7848" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7848 (in a7_3364 + 0<32> : word32)
-Eq_7851: (union "Eq_7851" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7851 (in a7_3364 + 76<i32> : word32)
-Eq_7856: (union "Eq_7856" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7856 (in a7_3364 + 48<i32> : word32)
-Eq_7858: (union "Eq_7858" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7858 (in 4<i32> : int32)
-Eq_7861: (union "Eq_7861" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7861 (in a7_3364 + 48<i32> : word32)
-Eq_7867: (union "Eq_7867" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7867 (in a7_1330 + 52<i32> : word32)
-Eq_7871: (union "Eq_7871" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7871 (in a7_1330 + 44<i32> : word32)
-Eq_7876: (union "Eq_7876" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7876 (in a7_1330 + 52<i32> : word32)
-Eq_7880: (union "Eq_7880" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7880 (in a7_1330 + 44<i32> : word32)
-Eq_7893: (struct "Eq_7893" (0 word32 dw0000) (4 word32 dw0004))
+Eq_7869: (union "Eq_7869" (int32 u0) (byte u1))
+	T_7869 (in v544_774 : Eq_7869)
+	T_7872 (in Mem773[a7_1330 + 44<i32>:byte] : byte)
+	T_8025 (in 0<8> : byte)
+	T_8032 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+Eq_7878: (union "Eq_7878" (int32 u0) (byte u1))
+	T_7878 (in 1<8> : byte)
+	T_7881 (in Mem769[a7_1330 + 44<i32>:byte] : byte)
+Eq_7893: (struct "Eq_7893" (0 word32 dw0000) (4 Eq_603 t0004))
 	T_7893 (in a0_3404 : (ptr32 Eq_7893))
 	T_7896 (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
-Eq_7898: (union "Eq_7898" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7898 (in a7_3364 + 60<i32> : word32)
-Eq_7904: (union "Eq_7904" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7904 (in a7_3364 + 56<i32> : word32)
-Eq_7912: (union "Eq_7912" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7912 (in a7_3364 + 48<i32> : word32)
-Eq_7917: (union "Eq_7917" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7917 (in a7_3364 + 48<i32> : word32)
-Eq_7930: (union "Eq_7930" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7930 (in a7_3364 + 60<i32> : word32)
-Eq_7941: (union "Eq_7941" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7941 (in a7_3364 + 48<i32> : word32)
-Eq_7946: (union "Eq_7946" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7946 (in a7_3364 + 48<i32> : word32)
-Eq_7959: (union "Eq_7959" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7959 (in a7_3364 + 60<i32> : word32)
-Eq_7970: (union "Eq_7970" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7970 (in a7_3364 + 48<i32> : word32)
-Eq_7975: (union "Eq_7975" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7975 (in a7_3364 + 48<i32> : word32)
-Eq_7988: (union "Eq_7988" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_7988 (in a7_3364 + 60<i32> : word32)
-Eq_8005: (union "Eq_8005" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8005 (in a7_3364 + 60<i32> : word32)
-Eq_8017: (union "Eq_8017" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8017 (in 78<i32> : int32)
-Eq_8018: (union "Eq_8018" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8018 (in a7_1330 + 78<i32> : word32)
-Eq_8019: (union "Eq_8019" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8019 (in a7_1330 + 78<i32> + d1_1027 : word32)
-Eq_8021: (union "Eq_8021" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8021 (in 1<32> : word32)
-Eq_8028: (union "Eq_8028" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8028 (in a7_1330 + 132<i32> : word32)
-Eq_8031: (union "Eq_8031" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8031 (in a7_1330 + 44<i32> : word32)
-Eq_8035: (union "Eq_8035" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8035 (in a7_1330 + 44<i32> : word32)
-Eq_8039: (union "Eq_8039" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8039 (in a7_1330 + 132<i32> : word32)
-Eq_8044: (union "Eq_8044" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8044 (in a7_1330 + 73<i32> : word32)
-Eq_8092: (union "Eq_8092" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8092 (in a0_881 : Eq_8092)
-	T_8097 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_8093: (union "Eq_8093" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8093 (in 78<i32> : int32)
-Eq_8094: (union "Eq_8094" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8094 (in a7_1330 + 78<i32> : word32)
-Eq_8096: (union "Eq_8096" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
+Eq_8033: (union "Eq_8033" (int32 u0) (byte u1))
+	T_8033 (in v554_824 : Eq_8033)
+	T_8036 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+	T_8090 (in 0<8> : byte)
+Eq_8096: (union "Eq_8096" (int32 u0) (uint32 u1))
 	T_8096 (in d5_862 >> 3<32> : word32)
-Eq_8099: (union "Eq_8099" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8099 (in a0_881 + 0<32> : word32)
-Eq_8110: (union "Eq_8110" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8110 (in a0_881 + 0<32> : word32)
-Eq_8112: (union "Eq_8112" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8112 (in a0_900 : Eq_8112)
-	T_8117 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_8113: (union "Eq_8113" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8113 (in 78<i32> : int32)
-Eq_8114: (union "Eq_8114" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8114 (in a7_1330 + 78<i32> : word32)
-Eq_8116: (union "Eq_8116" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
+Eq_8116: (union "Eq_8116" (int32 u0) (uint32 u1))
 	T_8116 (in d5_862 >> 3<32> : word32)
-Eq_8119: (union "Eq_8119" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8119 (in a0_900 + 0<32> : word32)
-Eq_8131: (union "Eq_8131" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8131 (in a0_900 + 0<32> : word32)
-Eq_8185: (union "Eq_8185" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8185 (in a7_985 : Eq_8185)
+Eq_8185: (struct "Eq_8185" (0 Eq_603 t0000) (30 Eq_603 t0030))
+	T_8185 (in a7_985 : (ptr32 Eq_8185))
 	T_8187 (in a7_1330 - 4<i32> : word32)
-Eq_8186: (union "Eq_8186" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8186 (in 4<i32> : int32)
-Eq_8189: (union "Eq_8189" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8189 (in a7_985 + 0<32> : word32)
-Eq_8194: (union "Eq_8194" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8194 (in a7_985 + 0<32> : word32)
-Eq_8201: (union "Eq_8201" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8201 (in a7_985 + 48<i32> : word32)
-Eq_8209: (union "Eq_8209" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8209 (in a7_1005 : Eq_8209)
+Eq_8209: (struct "Eq_8209" (0 Eq_603 t0000) (30 uint32 dw0030))
+	T_8209 (in a7_1005 : (ptr32 Eq_8209))
 	T_8211 (in a7_1330 - 4<i32> : word32)
-Eq_8210: (union "Eq_8210" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8210 (in 4<i32> : int32)
-Eq_8213: (union "Eq_8213" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8213 (in a7_1005 + 0<32> : word32)
-Eq_8225: (union "Eq_8225" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8225 (in a7_1005 + 0<32> : word32)
-Eq_8228: (union "Eq_8228" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8228 (in a7_1005 + 0<32> : word32)
-Eq_8233: (union "Eq_8233" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8233 (in a7_1005 + 48<i32> : word32)
-Eq_8238: (union "Eq_8238" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8238 (in a7_1005 + 0<32> : word32)
-Eq_8241: (union "Eq_8241" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8241 (in a7_1330 + 44<i32> : word32)
 Eq_8243: (union "Eq_8243" (int32 u0) (uint32 u1))
 	T_8243 (in d3_1057 : Eq_8243)
 	T_8245 (in d3_1850 + 1<32> : word32)
 	T_8396 (in d3_1057 + 1<32> : word32)
 Eq_8244: (union "Eq_8244" (int32 u0) (uint32 u1))
 	T_8244 (in 1<32> : word32)
-Eq_8250: (union "Eq_8250" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8250 (in a7_1330 + 44<i32> : word32)
-Eq_8256: (union "Eq_8256" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8256 (in a7_1076 : Eq_8256)
+Eq_8256: (struct "Eq_8256" (0 ptr32 ptr0000) (4D byte b004D))
+	T_8256 (in a7_1076 : (ptr32 Eq_8256))
 	T_8258 (in a7_1330 - 4<i32> : word32)
-Eq_8257: (union "Eq_8257" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8257 (in 4<i32> : int32)
-Eq_8259: (union "Eq_8259" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8259 (in 78<i32> : int32)
-Eq_8262: (union "Eq_8262" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8262 (in a7_1076 + 0<32> : word32)
-Eq_8264: (union "Eq_8264" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8264 (in 4<i32> : int32)
-Eq_8265: (union "Eq_8265" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8265 (in a7_1076 - 4<i32> : word32)
-Eq_8267: (union "Eq_8267" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8267 (in a7_1076 - 4<i32> + 0<32> : word32)
-Eq_8270: (union "Eq_8270" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8270 (in 8<i32> : int32)
-Eq_8271: (union "Eq_8271" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8271 (in a7_1076 - 8<i32> : word32)
-Eq_8273: (union "Eq_8273" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8273 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_8275: (union "Eq_8275" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8275 (in 12<i32> : int32)
-Eq_8276: (union "Eq_8276" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8276 (in a7_1076 - 12<i32> : word32)
-Eq_8278: (union "Eq_8278" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8278 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_8281: (union "Eq_8281" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8281 (in a7_1076 + 0<32> : word32)
-Eq_8283: (fn int32 (Eq_603, Eq_603, Eq_603))
+Eq_8283: (fn int32 (Eq_663, Eq_663, Eq_663))
 	T_8283 (in fn00002948 : ptr32)
 	T_8284 (in signature of fn00002948 : void)
 	T_8461 (in fn00002948 : ptr32)
-Eq_8285: (union "Eq_8285" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8285 (in a7_1076 - 12<i32> : word32)
-Eq_8287: (union "Eq_8287" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8287 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_8289: (union "Eq_8289" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8289 (in 8<i32> : int32)
-Eq_8290: (union "Eq_8290" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8290 (in a7_1076 - 8<i32> : word32)
-Eq_8292: (union "Eq_8292" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8292 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_8299: (union "Eq_8299" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8299 (in 4<i32> : int32)
-Eq_8300: (union "Eq_8300" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8300 (in a7_1076 - 4<i32> : word32)
-Eq_8302: (union "Eq_8302" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8302 (in a7_1076 - 4<i32> + 0<32> : word32)
 Eq_8311: (union "Eq_8311" (int32 u0) (uint32 u1))
 	T_8311 (in d6_1133 - d3_1057 : word32)
 	T_8312 (in 0<32> : word32)
-Eq_8316: (union "Eq_8316" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8316 (in a7_1076 + 77<i32> : word32)
-Eq_8351: (union "Eq_8351" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8351 (in a7_1182 : Eq_8351)
-	T_8353 (in a7_1330 - 4<i32> : word32)
-Eq_8352: (union "Eq_8352" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8352 (in 4<i32> : int32)
-Eq_8355: (union "Eq_8355" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8355 (in a7_1182 + 0<32> : word32)
-Eq_8361: (union "Eq_8361" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8361 (in a7_1182 + 0<32> : word32)
-Eq_8373: (union "Eq_8373" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8373 (in a7_1201 : Eq_8373)
-	T_8375 (in a7_1330 - 4<i32> : word32)
-Eq_8374: (union "Eq_8374" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8374 (in 4<i32> : int32)
-Eq_8377: (union "Eq_8377" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8377 (in a7_1201 + 0<32> : word32)
-Eq_8389: (union "Eq_8389" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8389 (in a7_1201 + 0<32> : word32)
 Eq_8395: (union "Eq_8395" (int32 u0) (uint32 u1))
 	T_8395 (in 1<32> : word32)
 Eq_8401: (union "Eq_8401" (int32 u0) (uint32 u1))
 	T_8401 (in 1<32> : word32)
-Eq_8406: (union "Eq_8406" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8406 (in a7_1330 + 73<i32> : word32)
-Eq_8410: (union "Eq_8410" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8410 (in a7_1302 : Eq_8410)
-	T_8412 (in a7_1330 - 4<i32> : word32)
-Eq_8411: (union "Eq_8411" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8411 (in 4<i32> : int32)
-Eq_8414: (union "Eq_8414" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8414 (in a7_1302 + 0<32> : word32)
-Eq_8416: (union "Eq_8416" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8416 (in 4<i32> : int32)
-Eq_8417: (union "Eq_8417" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8417 (in a7_1302 - 4<i32> : word32)
-Eq_8419: (union "Eq_8419" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8419 (in a7_1302 - 4<i32> + 0<32> : word32)
-Eq_8422: (union "Eq_8422" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8422 (in 1<i32> : int32)
-Eq_8423: (union "Eq_8423" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8423 (in a7_1302 - 1<i32> : word32)
-Eq_8425: (union "Eq_8425" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8425 (in a7_1302 - 1<i32> + 0<32> : word32)
-Eq_8428: (union "Eq_8428" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8428 (in a7_1302 + 0<32> : word32)
-Eq_8432: (union "Eq_8432" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8432 (in a7_1330 + 73<i32> : word32)
-Eq_8434: (union "Eq_8434" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8434 (in a7_1237 : Eq_8434)
-	T_8436 (in a7_1330 - 4<i32> : word32)
-Eq_8435: (union "Eq_8435" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8435 (in 4<i32> : int32)
-Eq_8437: (union "Eq_8437" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8437 (in 78<i32> : int32)
-Eq_8440: (union "Eq_8440" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8440 (in a7_1237 + 0<32> : word32)
-Eq_8442: (union "Eq_8442" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8442 (in 4<i32> : int32)
-Eq_8443: (union "Eq_8443" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8443 (in a7_1237 - 4<i32> : word32)
-Eq_8445: (union "Eq_8445" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8445 (in a7_1237 - 4<i32> + 0<32> : word32)
-Eq_8448: (union "Eq_8448" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8448 (in 8<i32> : int32)
-Eq_8449: (union "Eq_8449" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8449 (in a7_1237 - 8<i32> : word32)
-Eq_8451: (union "Eq_8451" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8451 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_8453: (union "Eq_8453" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8453 (in 12<i32> : int32)
-Eq_8454: (union "Eq_8454" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8454 (in a7_1237 - 12<i32> : word32)
-Eq_8456: (union "Eq_8456" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8456 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_8459: (union "Eq_8459" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8459 (in a7_1237 + 0<32> : word32)
-Eq_8462: (union "Eq_8462" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8462 (in a7_1237 - 12<i32> : word32)
-Eq_8464: (union "Eq_8464" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8464 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_8466: (union "Eq_8466" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8466 (in 8<i32> : int32)
-Eq_8467: (union "Eq_8467" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8467 (in a7_1237 - 8<i32> : word32)
-Eq_8469: (union "Eq_8469" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8469 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_8476: (union "Eq_8476" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8476 (in 4<i32> : int32)
-Eq_8477: (union "Eq_8477" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8477 (in a7_1237 - 4<i32> : word32)
-Eq_8479: (union "Eq_8479" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8479 (in a7_1237 - 4<i32> + 0<32> : word32)
 Eq_8488: (union "Eq_8488" (int32 u0) (uint32 u1))
 	T_8488 (in d6_1133 - d3_1057 : word32)
 	T_8489 (in 0<32> : word32)
-Eq_8500: (union "Eq_8500" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8500 (in a7_1330 + 60<i32> : word32)
-Eq_8504: (union "Eq_8504" (uint8 u0) ((ptr32 Eq_9025) u1) (Eq_6954 u2) (Eq_7817 u3))
-	T_8504 (in a7_1330 + 60<i32> : word32)
 Eq_8639: (fn int32 (ptr32, ptr32))
 	T_8639 (in fn0000402C : ptr32)
 	T_8640 (in signature of fn0000402C : void)
@@ -2911,25 +2610,25 @@ Eq_8676: (fn void ())
 	T_8677 (in signature of execPrivate2 : void)
 Eq_8894: (struct "Eq_8894" 0004 (0 byte b0000))
 	T_8894
-Eq_8951: (struct "Eq_8951" 0001 (0 word32 dw0000) (4 Eq_603 t0004) (8 Eq_603 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
+Eq_8951: (struct "Eq_8951" 0004 (0 (ptr32 Eq_4868) ptr0000) (4 Eq_603 t0004) (8 Eq_603 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8951
-Eq_8952: (struct "Eq_8952" (0 Eq_603 t0000))
+Eq_8952: (struct "Eq_8952" 0001 (0 word32 dw0000))
 	T_8952
-Eq_8953: (union "Eq_8953" (int32 u0) (byte u1) (Eq_603 u2))
+Eq_8953: (struct "Eq_8953" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8953
-Eq_8954: (union "Eq_8954" (byte u0) ((ptr32 (ptr32 Eq_4868)) u1) ((ptr32 Eq_9002) u2) (Eq_603 u3) (Eq_7290 u4) (Eq_7817 u5))
+Eq_8954: (union "Eq_8954" (cu8 u0) (word32 u1) (Eq_1755 u2) (Eq_1758 u3) (Eq_1832 u4) (Eq_2902 u5) (Eq_3013 u6) (Eq_3054 u7))
 	T_8954
-Eq_8955: (union "Eq_8955" (uint8 u0) (word32 u1) (Eq_6954 u2))
+Eq_8955: (union "Eq_8955" ((ptr32 Eq_1885) u0) (Eq_2420 u1) (Eq_2484 u2) (Eq_2490 u3) (Eq_2560 u4) (Eq_2605 u5) (Eq_3137 u6))
 	T_8955
-Eq_8956: (union "Eq_8956" (uint8 u0) (word32 u1) (Eq_4861 u2) (Eq_6954 u3) (Eq_7817 u4))
+Eq_8956: (struct "Eq_8956" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8956
-Eq_8957: (union "Eq_8957" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1) (Eq_7164 u2) (Eq_7228 u3) (Eq_7293 u4))
+Eq_8957: (struct "Eq_8957" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8957
-Eq_8958: (struct "Eq_8958" 0004 (FFFFFFFC (ptr32 Eq_8952) ptrFFFFFFFC) (0 (ptr32 Eq_4868) ptr0000) (2C Eq_8953 t002C) (30 Eq_8954 t0030) (34 word32 dw0034) (37 Eq_8955 t0037) (38 Eq_8956 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8957 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8958: (struct "Eq_8958" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8958
-Eq_8959: (union "Eq_8959" (cu8 u0) (word32 u1) (Eq_1755 u2) (Eq_1758 u3) (Eq_1832 u4) (Eq_2902 u5) (Eq_3013 u6) (Eq_3054 u7))
+Eq_8959: (struct "Eq_8959" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8959
-Eq_8960: (union "Eq_8960" ((ptr32 Eq_1885) u0) (Eq_2420 u1) (Eq_2484 u2) (Eq_2490 u3) (Eq_2560 u4) (Eq_2605 u5) (Eq_3137 u6))
+Eq_8960: (struct "Eq_8960" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8960
 Eq_8961: (struct "Eq_8961" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8961
@@ -2951,58 +2650,58 @@ Eq_8969: (struct "Eq_8969" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8969
 Eq_8970: (struct "Eq_8970" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8970
-Eq_8971: (struct "Eq_8971" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8971: (union "Eq_8971" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1) (Eq_7290 u2) (Eq_7817 u3))
 	T_8971
-Eq_8972: (struct "Eq_8972" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8972: (union "Eq_8972" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_8993) u1) (Eq_7164 u2) (Eq_7228 u3) (Eq_7293 u4))
 	T_8972
-Eq_8973: (struct "Eq_8973" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8973: (struct "Eq_8973" (0 Eq_4868 t0000))
 	T_8973
-Eq_8974: (struct "Eq_8974" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8974: (struct "Eq_8974" 0004 (0 (ptr32 Eq_8973) ptr0000))
 	T_8974
-Eq_8975: (struct "Eq_8975" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8975: (struct "Eq_8975" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8975
-Eq_8976: (union "Eq_8976" (int32 u0) (byte u1) (Eq_603 u2))
+Eq_8976: (struct "Eq_8976" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8976
-Eq_8977: (union "Eq_8977" (byte u0) ((ptr32 (ptr32 Eq_4868)) u1) ((ptr32 Eq_9002) u2) (Eq_603 u3) (Eq_7290 u4) (Eq_7817 u5))
+Eq_8977: (struct "Eq_8977" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8977
-Eq_8978: (union "Eq_8978" (uint8 u0) (word32 u1) (Eq_6954 u2))
+Eq_8978: (struct "Eq_8978" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8978
-Eq_8979: (union "Eq_8979" (uint8 u0) (word32 u1) (Eq_4861 u2) (Eq_6954 u3) (Eq_7817 u4))
+Eq_8979: (struct "Eq_8979" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8979
-Eq_8980: (union "Eq_8980" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1) (Eq_7164 u2) (Eq_7228 u3) (Eq_7293 u4))
+Eq_8980: (struct "Eq_8980" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8980
-Eq_8981: (struct "Eq_8981" 0004 (0 Eq_603 t0000) (2C Eq_8976 t002C) (30 Eq_8977 t0030) (34 word32 dw0034) (37 Eq_8978 t0037) (38 Eq_8979 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8980 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8981: (struct "Eq_8981" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8981
-Eq_8982: (struct "Eq_8982" (0 Eq_4868 t0000))
+Eq_8982: (struct "Eq_8982" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8982
-Eq_8983: (struct "Eq_8983" 0004 (0 (ptr32 Eq_8982) ptr0000))
+Eq_8983: (struct "Eq_8983" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8983
 Eq_8984: (struct "Eq_8984" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8984
 Eq_8985: (struct "Eq_8985" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_8985
-Eq_8986: (struct "Eq_8986" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_8986
-Eq_8987: (struct "Eq_8987" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_8987
-Eq_8988: (struct "Eq_8988" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_8988
-Eq_8989: (struct "Eq_8989" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_8989
-Eq_8990: (struct "Eq_8990" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_8990
-Eq_8991: (struct "Eq_8991" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_8991
-Eq_8992: (struct "Eq_8992" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
+Eq_8992: (struct "Eq_8992" (0 Eq_4868 t0000))
 	T_8992
-Eq_8993: (struct "Eq_8993" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
+Eq_8993: (struct "Eq_8993" 0004 (0 (ptr32 Eq_8992) ptr0000))
 	T_8993
-Eq_8994: (struct "Eq_8994" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_8994
-Eq_9001: (struct "Eq_9001" (0 Eq_4868 t0000))
+Eq_8996: (struct "Eq_8996" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
+	T_8996
+Eq_8997: (struct "Eq_8997" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
+	T_8997
+Eq_8998: (struct "Eq_8998" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
+	T_8998
+Eq_8999: (struct "Eq_8999" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
+	T_8999
+Eq_9000: (struct "Eq_9000" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
+	T_9000
+Eq_9001: (struct "Eq_9001" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9001
-Eq_9002: (struct "Eq_9002" 0004 (0 (ptr32 Eq_9001) ptr0000))
+Eq_9002: (struct "Eq_9002" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9002
+Eq_9003: (struct "Eq_9003" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
+	T_9003
+Eq_9004: (struct "Eq_9004" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
+	T_9004
 Eq_9005: (struct "Eq_9005" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9005
 Eq_9006: (struct "Eq_9006" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
@@ -3033,17 +2732,17 @@ Eq_9018: (struct "Eq_9018" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9018
 Eq_9019: (struct "Eq_9019" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9019
-Eq_9020: (union "Eq_9020" (int32 u0) (byte u1) (Eq_603 u2))
+Eq_9020: (struct "Eq_9020" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9020
-Eq_9021: (union "Eq_9021" (byte u0) ((ptr32 (ptr32 Eq_4868)) u1) ((ptr32 Eq_9002) u2) (Eq_603 u3) (Eq_7290 u4) (Eq_7817 u5))
+Eq_9021: (struct "Eq_9021" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9021
-Eq_9022: (union "Eq_9022" (uint8 u0) (word32 u1) (Eq_6954 u2))
+Eq_9022: (struct "Eq_9022" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9022
-Eq_9023: (union "Eq_9023" (uint8 u0) (word32 u1) (Eq_4861 u2) (Eq_6954 u3) (Eq_7817 u4))
+Eq_9023: (struct "Eq_9023" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9023
-Eq_9024: (union "Eq_9024" ((ptr32 (ptr32 Eq_4868)) u0) ((ptr32 Eq_9002) u1) (Eq_7164 u2) (Eq_7228 u3) (Eq_7293 u4))
+Eq_9024: (struct "Eq_9024" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9024
-Eq_9025: (struct "Eq_9025" 0004 (0 Eq_603 t0000) (2C Eq_9020 t002C) (30 Eq_9021 t0030) (34 word32 dw0034) (37 Eq_9022 t0037) (38 Eq_9023 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_9024 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_9025: (struct "Eq_9025" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9025
 Eq_9026: (struct "Eq_9026" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9026
@@ -3051,36 +2750,6 @@ Eq_9027: (struct "Eq_9027" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9027
 Eq_9028: (struct "Eq_9028" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
 	T_9028
-Eq_9029: (struct "Eq_9029" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9029
-Eq_9030: (struct "Eq_9030" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9030
-Eq_9031: (struct "Eq_9031" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9031
-Eq_9032: (struct "Eq_9032" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9032
-Eq_9033: (struct "Eq_9033" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9033
-Eq_9034: (struct "Eq_9034" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9034
-Eq_9035: (struct "Eq_9035" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9035
-Eq_9036: (struct "Eq_9036" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9036
-Eq_9037: (struct "Eq_9037" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9037
-Eq_9038: (struct "Eq_9038" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9038
-Eq_9039: (struct "Eq_9039" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9039
-Eq_9040: (struct "Eq_9040" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9040
-Eq_9041: (struct "Eq_9041" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9041
-Eq_9042: (struct "Eq_9042" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9042
-Eq_9043: (struct "Eq_9043" 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))
-	T_9043
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -5494,17 +5163,17 @@ T_603: (in d0 : Eq_603)
   Class: Eq_603
   DataType: Eq_603
   OrigDataType: word32
-T_604: (in a1_23 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_604: (in a1_23 : (ptr32 (ptr32 byte)))
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_605: (in d1_25 : Eq_603)
   Class: Eq_603
   DataType: Eq_603
   OrigDataType: word32
-T_606: (in a1_52 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_606: (in a1_52 : (ptr32 (ptr32 byte)))
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_607: (in d1_54 : Eq_603)
   Class: Eq_603
@@ -5513,7 +5182,7 @@ T_607: (in d1_54 : Eq_603)
 T_608: (in d0_495 : Eq_603)
   Class: Eq_603
   DataType: Eq_603
-  OrigDataType: uint8
+  OrigDataType: byte
 T_609: (in fn00002E40 : ptr32)
   Class: Eq_609
   DataType: (ptr32 Eq_609)
@@ -5530,9 +5199,9 @@ T_612: (in d1 : Eq_603)
   Class: Eq_603
   DataType: Eq_603
   OrigDataType: word32
-T_613: (in a1 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_613: (in a1 : (ptr32 (ptr32 byte)))
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_614: (in dwArg04 : (ptr32 Eq_614))
   Class: Eq_614
@@ -5708,7 +5377,7 @@ T_656: (in fn000016FC(d0_495, 0x16F4<u32>, out d1_552, out a1_553) : word32)
   OrigDataType: word32
 T_657: (in 40<i32> : int32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_658: (in 40<i32> : int32)
   Class: Eq_648
@@ -5731,20 +5400,20 @@ T_662: (in signature of __swap : void)
   DataType: (ptr32 Eq_661)
   OrigDataType: 
 T_663: (in  : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: 
 T_664: (in 3<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_665: (in __swap(3<i32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_666: (in dwLoc14 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_667: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_667
@@ -5754,9 +5423,9 @@ T_668: (in __swap(3<i32>) * (word16) dwLoc14 : word32)
   Class: Eq_660
   DataType: uint32
   OrigDataType: uint32
-T_669: (in d0_119 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_669: (in d0_119 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_670: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_670
@@ -5783,8 +5452,8 @@ T_675: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_676 (T_666)))
 T_676: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_677: (in 3<16> : word16)
   Class: Eq_677
@@ -5803,12 +5472,12 @@ T_680: (in SLICE(d4_110 + __swap(dwLoc14) *u 3<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_681: (in SEQ(SLICE(d4_110, word16, 16), SLICE(d4_110 + __swap(dwLoc14) *u 3<16>, word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_682: (in __swap(SEQ(SLICE(d4_110, word16, 16), (word16) (d4_110 + __swap(dwLoc14) * 3<16>))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_683: (in SLICE(__swap(SEQ(SLICE(d4_110, word16, 16), (word16) (d4_110 + __swap(dwLoc14) * 3<16>))), word16, 16) : word16)
   Class: Eq_683
@@ -5823,8 +5492,8 @@ T_685: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_110, word16, 16), (word16) (d4_110 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_686: (in (word16) dwLoc14 * 3<i32> + SEQ(SLICE(__swap(SEQ(SLICE(d4_110, word16, 16), (word16) (d4_110 + __swap(dwLoc14) * 3<16>))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_687: (in d4_125 : uint32)
   Class: Eq_687
@@ -5835,8 +5504,8 @@ T_688: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_689 (T_669)))
 T_689: (in __swap(d0_119) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_690: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_690
@@ -5846,9 +5515,9 @@ T_691: (in __swap(d0_119) * (word16) dwLoc14 : word32)
   Class: Eq_687
   DataType: uint32
   OrigDataType: uint32
-T_692: (in d0_134 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_692: (in d0_134 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_693: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_693
@@ -5871,8 +5540,8 @@ T_697: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_698 (T_666)))
 T_698: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_699: (in SLICE(d0_119, word16, 0) : word16)
   Class: Eq_699
@@ -5891,12 +5560,12 @@ T_702: (in SLICE(d4_125 + __swap(dwLoc14) *u SLICE(d0_119, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_703: (in SEQ(SLICE(d4_125, word16, 16), SLICE(d4_125 + __swap(dwLoc14) *u SLICE(d0_119, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_704: (in __swap(SEQ(SLICE(d4_125, word16, 16), (word16) (d4_125 + __swap(dwLoc14) * (word16) d0_119))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_705: (in SLICE(__swap(SEQ(SLICE(d4_125, word16, 16), (word16) (d4_125 + __swap(dwLoc14) * (word16) d0_119))), word16, 16) : word16)
   Class: Eq_705
@@ -5911,8 +5580,8 @@ T_707: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_125, word16, 16), (word16) (d4_125 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_708: (in d0_119 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_125, word16, 16), (word16) (d4_125 + __swap(dwLoc14) * (word16) d0_119))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_709: (in d4_140 : uint32)
   Class: Eq_709
@@ -5923,8 +5592,8 @@ T_710: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_711 (T_692)))
 T_711: (in __swap(d0_134) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_712: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_712
@@ -5934,9 +5603,9 @@ T_713: (in __swap(d0_134) * (word16) dwLoc14 : word32)
   Class: Eq_709
   DataType: uint32
   OrigDataType: uint32
-T_714: (in d0_149 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_714: (in d0_149 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_715: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_715
@@ -5959,8 +5628,8 @@ T_719: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_720 (T_666)))
 T_720: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_721: (in SLICE(d0_134, word16, 0) : word16)
   Class: Eq_721
@@ -5979,12 +5648,12 @@ T_724: (in SLICE(d4_140 + __swap(dwLoc14) *u SLICE(d0_134, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_725: (in SEQ(SLICE(d4_140, word16, 16), SLICE(d4_140 + __swap(dwLoc14) *u SLICE(d0_134, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_726: (in __swap(SEQ(SLICE(d4_140, word16, 16), (word16) (d4_140 + __swap(dwLoc14) * (word16) d0_134))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_727: (in SLICE(__swap(SEQ(SLICE(d4_140, word16, 16), (word16) (d4_140 + __swap(dwLoc14) * (word16) d0_134))), word16, 16) : word16)
   Class: Eq_727
@@ -5999,8 +5668,8 @@ T_729: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_140, word16, 16), (word16) (d4_140 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_730: (in d0_134 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_140, word16, 16), (word16) (d4_140 + __swap(dwLoc14) * (word16) d0_134))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_731: (in d4_155 : uint32)
   Class: Eq_731
@@ -6011,8 +5680,8 @@ T_732: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_733 (T_714)))
 T_733: (in __swap(d0_149) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_734: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_734
@@ -6022,9 +5691,9 @@ T_735: (in __swap(d0_149) * (word16) dwLoc14 : word32)
   Class: Eq_731
   DataType: uint32
   OrigDataType: uint32
-T_736: (in d0_164 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_736: (in d0_164 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_737: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_737
@@ -6047,8 +5716,8 @@ T_741: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_742 (T_666)))
 T_742: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_743: (in SLICE(d0_149, word16, 0) : word16)
   Class: Eq_743
@@ -6067,12 +5736,12 @@ T_746: (in SLICE(d4_155 + __swap(dwLoc14) *u SLICE(d0_149, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_747: (in SEQ(SLICE(d4_155, word16, 16), SLICE(d4_155 + __swap(dwLoc14) *u SLICE(d0_149, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_748: (in __swap(SEQ(SLICE(d4_155, word16, 16), (word16) (d4_155 + __swap(dwLoc14) * (word16) d0_149))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_749: (in SLICE(__swap(SEQ(SLICE(d4_155, word16, 16), (word16) (d4_155 + __swap(dwLoc14) * (word16) d0_149))), word16, 16) : word16)
   Class: Eq_749
@@ -6087,8 +5756,8 @@ T_751: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_155, word16, 16), (word16) (d4_155 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_752: (in d0_149 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_155, word16, 16), (word16) (d4_155 + __swap(dwLoc14) * (word16) d0_149))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_753: (in d4_170 : uint32)
   Class: Eq_753
@@ -6099,8 +5768,8 @@ T_754: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_755 (T_736)))
 T_755: (in __swap(d0_164) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_756: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_756
@@ -6110,9 +5779,9 @@ T_757: (in __swap(d0_164) * (word16) dwLoc14 : word32)
   Class: Eq_753
   DataType: uint32
   OrigDataType: uint32
-T_758: (in d0_179 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_758: (in d0_179 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_759: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_759
@@ -6135,8 +5804,8 @@ T_763: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_764 (T_666)))
 T_764: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_765: (in SLICE(d0_164, word16, 0) : word16)
   Class: Eq_765
@@ -6155,12 +5824,12 @@ T_768: (in SLICE(d4_170 + __swap(dwLoc14) *u SLICE(d0_164, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_769: (in SEQ(SLICE(d4_170, word16, 16), SLICE(d4_170 + __swap(dwLoc14) *u SLICE(d0_164, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_770: (in __swap(SEQ(SLICE(d4_170, word16, 16), (word16) (d4_170 + __swap(dwLoc14) * (word16) d0_164))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_771: (in SLICE(__swap(SEQ(SLICE(d4_170, word16, 16), (word16) (d4_170 + __swap(dwLoc14) * (word16) d0_164))), word16, 16) : word16)
   Class: Eq_771
@@ -6175,8 +5844,8 @@ T_773: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_170, word16, 16), (word16) (d4_170 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_774: (in d0_164 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_170, word16, 16), (word16) (d4_170 + __swap(dwLoc14) * (word16) d0_164))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_775: (in d4_185 : uint32)
   Class: Eq_775
@@ -6187,8 +5856,8 @@ T_776: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_777 (T_758)))
 T_777: (in __swap(d0_179) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_778: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_778
@@ -6198,9 +5867,9 @@ T_779: (in __swap(d0_179) * (word16) dwLoc14 : word32)
   Class: Eq_775
   DataType: uint32
   OrigDataType: uint32
-T_780: (in d0_194 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_780: (in d0_194 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_781: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_781
@@ -6223,8 +5892,8 @@ T_785: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_786 (T_666)))
 T_786: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_787: (in SLICE(d0_179, word16, 0) : word16)
   Class: Eq_787
@@ -6243,12 +5912,12 @@ T_790: (in SLICE(d4_185 + __swap(dwLoc14) *u SLICE(d0_179, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_791: (in SEQ(SLICE(d4_185, word16, 16), SLICE(d4_185 + __swap(dwLoc14) *u SLICE(d0_179, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_792: (in __swap(SEQ(SLICE(d4_185, word16, 16), (word16) (d4_185 + __swap(dwLoc14) * (word16) d0_179))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_793: (in SLICE(__swap(SEQ(SLICE(d4_185, word16, 16), (word16) (d4_185 + __swap(dwLoc14) * (word16) d0_179))), word16, 16) : word16)
   Class: Eq_793
@@ -6263,8 +5932,8 @@ T_795: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_185, word16, 16), (word16) (d4_185 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_796: (in d0_179 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_185, word16, 16), (word16) (d4_185 + __swap(dwLoc14) * (word16) d0_179))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_797: (in d4_200 : uint32)
   Class: Eq_797
@@ -6275,8 +5944,8 @@ T_798: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_799 (T_780)))
 T_799: (in __swap(d0_194) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_800: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_800
@@ -6286,9 +5955,9 @@ T_801: (in __swap(d0_194) * (word16) dwLoc14 : word32)
   Class: Eq_797
   DataType: uint32
   OrigDataType: uint32
-T_802: (in d0_209 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_802: (in d0_209 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_803: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_803
@@ -6311,8 +5980,8 @@ T_807: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_808 (T_666)))
 T_808: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_809: (in SLICE(d0_194, word16, 0) : word16)
   Class: Eq_809
@@ -6331,12 +6000,12 @@ T_812: (in SLICE(d4_200 + __swap(dwLoc14) *u SLICE(d0_194, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_813: (in SEQ(SLICE(d4_200, word16, 16), SLICE(d4_200 + __swap(dwLoc14) *u SLICE(d0_194, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_814: (in __swap(SEQ(SLICE(d4_200, word16, 16), (word16) (d4_200 + __swap(dwLoc14) * (word16) d0_194))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_815: (in SLICE(__swap(SEQ(SLICE(d4_200, word16, 16), (word16) (d4_200 + __swap(dwLoc14) * (word16) d0_194))), word16, 16) : word16)
   Class: Eq_815
@@ -6351,8 +6020,8 @@ T_817: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_200, word16, 16), (word16) (d4_200 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_818: (in d0_194 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_200, word16, 16), (word16) (d4_200 + __swap(dwLoc14) * (word16) d0_194))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_819: (in d4_215 : uint32)
   Class: Eq_819
@@ -6363,8 +6032,8 @@ T_820: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_821 (T_802)))
 T_821: (in __swap(d0_209) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_822: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_822
@@ -6374,9 +6043,9 @@ T_823: (in __swap(d0_209) * (word16) dwLoc14 : word32)
   Class: Eq_819
   DataType: uint32
   OrigDataType: uint32
-T_824: (in d0_224 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_824: (in d0_224 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_825: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_825
@@ -6399,8 +6068,8 @@ T_829: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_830 (T_666)))
 T_830: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_831: (in SLICE(d0_209, word16, 0) : word16)
   Class: Eq_831
@@ -6419,12 +6088,12 @@ T_834: (in SLICE(d4_215 + __swap(dwLoc14) *u SLICE(d0_209, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_835: (in SEQ(SLICE(d4_215, word16, 16), SLICE(d4_215 + __swap(dwLoc14) *u SLICE(d0_209, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_836: (in __swap(SEQ(SLICE(d4_215, word16, 16), (word16) (d4_215 + __swap(dwLoc14) * (word16) d0_209))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_837: (in SLICE(__swap(SEQ(SLICE(d4_215, word16, 16), (word16) (d4_215 + __swap(dwLoc14) * (word16) d0_209))), word16, 16) : word16)
   Class: Eq_837
@@ -6439,8 +6108,8 @@ T_839: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_215, word16, 16), (word16) (d4_215 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_840: (in d0_209 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_215, word16, 16), (word16) (d4_215 + __swap(dwLoc14) * (word16) d0_209))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_841: (in d4_230 : uint32)
   Class: Eq_841
@@ -6451,8 +6120,8 @@ T_842: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_843 (T_824)))
 T_843: (in __swap(d0_224) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_844: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_844
@@ -6462,9 +6131,9 @@ T_845: (in __swap(d0_224) * (word16) dwLoc14 : word32)
   Class: Eq_841
   DataType: uint32
   OrigDataType: uint32
-T_846: (in d0_239 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_846: (in d0_239 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_847: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_847
@@ -6487,8 +6156,8 @@ T_851: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_852 (T_666)))
 T_852: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_853: (in SLICE(d0_224, word16, 0) : word16)
   Class: Eq_853
@@ -6507,12 +6176,12 @@ T_856: (in SLICE(d4_230 + __swap(dwLoc14) *u SLICE(d0_224, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_857: (in SEQ(SLICE(d4_230, word16, 16), SLICE(d4_230 + __swap(dwLoc14) *u SLICE(d0_224, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_858: (in __swap(SEQ(SLICE(d4_230, word16, 16), (word16) (d4_230 + __swap(dwLoc14) * (word16) d0_224))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_859: (in SLICE(__swap(SEQ(SLICE(d4_230, word16, 16), (word16) (d4_230 + __swap(dwLoc14) * (word16) d0_224))), word16, 16) : word16)
   Class: Eq_859
@@ -6527,8 +6196,8 @@ T_861: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_230, word16, 16), (word16) (d4_230 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_862: (in d0_224 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_230, word16, 16), (word16) (d4_230 + __swap(dwLoc14) * (word16) d0_224))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_863: (in d4_245 : uint32)
   Class: Eq_863
@@ -6539,8 +6208,8 @@ T_864: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_865 (T_846)))
 T_865: (in __swap(d0_239) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_866: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_866
@@ -6550,9 +6219,9 @@ T_867: (in __swap(d0_239) * (word16) dwLoc14 : word32)
   Class: Eq_863
   DataType: uint32
   OrigDataType: uint32
-T_868: (in d0_254 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_868: (in d0_254 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_869: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_869
@@ -6575,8 +6244,8 @@ T_873: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_874 (T_666)))
 T_874: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_875: (in SLICE(d0_239, word16, 0) : word16)
   Class: Eq_875
@@ -6595,12 +6264,12 @@ T_878: (in SLICE(d4_245 + __swap(dwLoc14) *u SLICE(d0_239, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_879: (in SEQ(SLICE(d4_245, word16, 16), SLICE(d4_245 + __swap(dwLoc14) *u SLICE(d0_239, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_880: (in __swap(SEQ(SLICE(d4_245, word16, 16), (word16) (d4_245 + __swap(dwLoc14) * (word16) d0_239))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_881: (in SLICE(__swap(SEQ(SLICE(d4_245, word16, 16), (word16) (d4_245 + __swap(dwLoc14) * (word16) d0_239))), word16, 16) : word16)
   Class: Eq_881
@@ -6615,8 +6284,8 @@ T_883: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_245, word16, 16), (word16) (d4_245 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_884: (in d0_239 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_245, word16, 16), (word16) (d4_245 + __swap(dwLoc14) * (word16) d0_239))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_885: (in d4_260 : uint32)
   Class: Eq_885
@@ -6627,8 +6296,8 @@ T_886: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_887 (T_868)))
 T_887: (in __swap(d0_254) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_888: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_888
@@ -6638,9 +6307,9 @@ T_889: (in __swap(d0_254) * (word16) dwLoc14 : word32)
   Class: Eq_885
   DataType: uint32
   OrigDataType: uint32
-T_890: (in d0_269 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_890: (in d0_269 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_891: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_891
@@ -6663,8 +6332,8 @@ T_895: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_896 (T_666)))
 T_896: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_897: (in SLICE(d0_254, word16, 0) : word16)
   Class: Eq_897
@@ -6683,12 +6352,12 @@ T_900: (in SLICE(d4_260 + __swap(dwLoc14) *u SLICE(d0_254, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_901: (in SEQ(SLICE(d4_260, word16, 16), SLICE(d4_260 + __swap(dwLoc14) *u SLICE(d0_254, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_902: (in __swap(SEQ(SLICE(d4_260, word16, 16), (word16) (d4_260 + __swap(dwLoc14) * (word16) d0_254))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_903: (in SLICE(__swap(SEQ(SLICE(d4_260, word16, 16), (word16) (d4_260 + __swap(dwLoc14) * (word16) d0_254))), word16, 16) : word16)
   Class: Eq_903
@@ -6703,8 +6372,8 @@ T_905: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_260, word16, 16), (word16) (d4_260 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_906: (in d0_254 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_260, word16, 16), (word16) (d4_260 + __swap(dwLoc14) * (word16) d0_254))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_907: (in d4_275 : uint32)
   Class: Eq_907
@@ -6715,8 +6384,8 @@ T_908: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_909 (T_890)))
 T_909: (in __swap(d0_269) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_910: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_910
@@ -6726,9 +6395,9 @@ T_911: (in __swap(d0_269) * (word16) dwLoc14 : word32)
   Class: Eq_907
   DataType: uint32
   OrigDataType: uint32
-T_912: (in d0_284 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_912: (in d0_284 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_913: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_913
@@ -6751,8 +6420,8 @@ T_917: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_918 (T_666)))
 T_918: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_919: (in SLICE(d0_269, word16, 0) : word16)
   Class: Eq_919
@@ -6771,12 +6440,12 @@ T_922: (in SLICE(d4_275 + __swap(dwLoc14) *u SLICE(d0_269, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_923: (in SEQ(SLICE(d4_275, word16, 16), SLICE(d4_275 + __swap(dwLoc14) *u SLICE(d0_269, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_924: (in __swap(SEQ(SLICE(d4_275, word16, 16), (word16) (d4_275 + __swap(dwLoc14) * (word16) d0_269))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_925: (in SLICE(__swap(SEQ(SLICE(d4_275, word16, 16), (word16) (d4_275 + __swap(dwLoc14) * (word16) d0_269))), word16, 16) : word16)
   Class: Eq_925
@@ -6791,8 +6460,8 @@ T_927: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_275, word16, 16), (word16) (d4_275 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_928: (in d0_269 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_275, word16, 16), (word16) (d4_275 + __swap(dwLoc14) * (word16) d0_269))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_929: (in d4_290 : uint32)
   Class: Eq_929
@@ -6803,8 +6472,8 @@ T_930: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_931 (T_912)))
 T_931: (in __swap(d0_284) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_932: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_932
@@ -6814,9 +6483,9 @@ T_933: (in __swap(d0_284) * (word16) dwLoc14 : word32)
   Class: Eq_929
   DataType: uint32
   OrigDataType: uint32
-T_934: (in d0_299 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_934: (in d0_299 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_935: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_935
@@ -6839,8 +6508,8 @@ T_939: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_940 (T_666)))
 T_940: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_941: (in SLICE(d0_284, word16, 0) : word16)
   Class: Eq_941
@@ -6859,12 +6528,12 @@ T_944: (in SLICE(d4_290 + __swap(dwLoc14) *u SLICE(d0_284, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_945: (in SEQ(SLICE(d4_290, word16, 16), SLICE(d4_290 + __swap(dwLoc14) *u SLICE(d0_284, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_946: (in __swap(SEQ(SLICE(d4_290, word16, 16), (word16) (d4_290 + __swap(dwLoc14) * (word16) d0_284))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_947: (in SLICE(__swap(SEQ(SLICE(d4_290, word16, 16), (word16) (d4_290 + __swap(dwLoc14) * (word16) d0_284))), word16, 16) : word16)
   Class: Eq_947
@@ -6879,8 +6548,8 @@ T_949: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_290, word16, 16), (word16) (d4_290 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_950: (in d0_284 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_290, word16, 16), (word16) (d4_290 + __swap(dwLoc14) * (word16) d0_284))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_951: (in d4_305 : uint32)
   Class: Eq_951
@@ -6891,8 +6560,8 @@ T_952: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_953 (T_934)))
 T_953: (in __swap(d0_299) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_954: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_954
@@ -6902,9 +6571,9 @@ T_955: (in __swap(d0_299) * (word16) dwLoc14 : word32)
   Class: Eq_951
   DataType: uint32
   OrigDataType: uint32
-T_956: (in d0_314 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_956: (in d0_314 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_957: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_957
@@ -6927,8 +6596,8 @@ T_961: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_962 (T_666)))
 T_962: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_963: (in SLICE(d0_299, word16, 0) : word16)
   Class: Eq_963
@@ -6947,12 +6616,12 @@ T_966: (in SLICE(d4_305 + __swap(dwLoc14) *u SLICE(d0_299, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_967: (in SEQ(SLICE(d4_305, word16, 16), SLICE(d4_305 + __swap(dwLoc14) *u SLICE(d0_299, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_968: (in __swap(SEQ(SLICE(d4_305, word16, 16), (word16) (d4_305 + __swap(dwLoc14) * (word16) d0_299))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_969: (in SLICE(__swap(SEQ(SLICE(d4_305, word16, 16), (word16) (d4_305 + __swap(dwLoc14) * (word16) d0_299))), word16, 16) : word16)
   Class: Eq_969
@@ -6967,8 +6636,8 @@ T_971: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_305, word16, 16), (word16) (d4_305 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_972: (in d0_299 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_305, word16, 16), (word16) (d4_305 + __swap(dwLoc14) * (word16) d0_299))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_973: (in d4_320 : uint32)
   Class: Eq_973
@@ -6979,8 +6648,8 @@ T_974: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_975 (T_956)))
 T_975: (in __swap(d0_314) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_976: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_976
@@ -6990,9 +6659,9 @@ T_977: (in __swap(d0_314) * (word16) dwLoc14 : word32)
   Class: Eq_973
   DataType: uint32
   OrigDataType: uint32
-T_978: (in d0_329 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_978: (in d0_329 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_979: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_979
@@ -7015,8 +6684,8 @@ T_983: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_984 (T_666)))
 T_984: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_985: (in SLICE(d0_314, word16, 0) : word16)
   Class: Eq_985
@@ -7035,12 +6704,12 @@ T_988: (in SLICE(d4_320 + __swap(dwLoc14) *u SLICE(d0_314, word16, 0), word16, 0
   DataType: word16
   OrigDataType: word16
 T_989: (in SEQ(SLICE(d4_320, word16, 16), SLICE(d4_320 + __swap(dwLoc14) *u SLICE(d0_314, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_990: (in __swap(SEQ(SLICE(d4_320, word16, 16), (word16) (d4_320 + __swap(dwLoc14) * (word16) d0_314))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_991: (in SLICE(__swap(SEQ(SLICE(d4_320, word16, 16), (word16) (d4_320 + __swap(dwLoc14) * (word16) d0_314))), word16, 16) : word16)
   Class: Eq_991
@@ -7055,8 +6724,8 @@ T_993: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_320, word16, 16), (word16) (d4_320 + __
   DataType: uipr32
   OrigDataType: uipr32
 T_994: (in d0_314 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_320, word16, 16), (word16) (d4_320 + __swap(dwLoc14) * (word16) d0_314))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_995: (in d4_335 : uint32)
   Class: Eq_995
@@ -7067,8 +6736,8 @@ T_996: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_997 (T_978)))
 T_997: (in __swap(d0_329) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_998: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_998
@@ -7078,9 +6747,9 @@ T_999: (in __swap(d0_329) * (word16) dwLoc14 : word32)
   Class: Eq_995
   DataType: uint32
   OrigDataType: uint32
-T_1000: (in d0_344 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_1000: (in d0_344 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1001: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1001
@@ -7103,8 +6772,8 @@ T_1005: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1006 (T_666)))
 T_1006: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1007: (in SLICE(d0_329, word16, 0) : word16)
   Class: Eq_1007
@@ -7123,12 +6792,12 @@ T_1010: (in SLICE(d4_335 + __swap(dwLoc14) *u SLICE(d0_329, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_1011: (in SEQ(SLICE(d4_335, word16, 16), SLICE(d4_335 + __swap(dwLoc14) *u SLICE(d0_329, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1012: (in __swap(SEQ(SLICE(d4_335, word16, 16), (word16) (d4_335 + __swap(dwLoc14) * (word16) d0_329))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1013: (in SLICE(__swap(SEQ(SLICE(d4_335, word16, 16), (word16) (d4_335 + __swap(dwLoc14) * (word16) d0_329))), word16, 16) : word16)
   Class: Eq_1013
@@ -7143,8 +6812,8 @@ T_1015: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_335, word16, 16), (word16) (d4_335 + _
   DataType: uipr32
   OrigDataType: uipr32
 T_1016: (in d0_329 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_335, word16, 16), (word16) (d4_335 + __swap(dwLoc14) * (word16) d0_329))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1017: (in d4_350 : uint32)
   Class: Eq_1017
@@ -7155,8 +6824,8 @@ T_1018: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1019 (T_1000)))
 T_1019: (in __swap(d0_344) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1020: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1020
@@ -7166,9 +6835,9 @@ T_1021: (in __swap(d0_344) * (word16) dwLoc14 : word32)
   Class: Eq_1017
   DataType: uint32
   OrigDataType: uint32
-T_1022: (in d0_359 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_1022: (in d0_359 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1023: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1023
@@ -7191,8 +6860,8 @@ T_1027: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1028 (T_666)))
 T_1028: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1029: (in SLICE(d0_344, word16, 0) : word16)
   Class: Eq_1029
@@ -7211,12 +6880,12 @@ T_1032: (in SLICE(d4_350 + __swap(dwLoc14) *u SLICE(d0_344, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_1033: (in SEQ(SLICE(d4_350, word16, 16), SLICE(d4_350 + __swap(dwLoc14) *u SLICE(d0_344, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1034: (in __swap(SEQ(SLICE(d4_350, word16, 16), (word16) (d4_350 + __swap(dwLoc14) * (word16) d0_344))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1035: (in SLICE(__swap(SEQ(SLICE(d4_350, word16, 16), (word16) (d4_350 + __swap(dwLoc14) * (word16) d0_344))), word16, 16) : word16)
   Class: Eq_1035
@@ -7231,8 +6900,8 @@ T_1037: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_350, word16, 16), (word16) (d4_350 + _
   DataType: uipr32
   OrigDataType: uipr32
 T_1038: (in d0_344 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_350, word16, 16), (word16) (d4_350 + __swap(dwLoc14) * (word16) d0_344))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1039: (in d4_365 : uint32)
   Class: Eq_1039
@@ -7243,8 +6912,8 @@ T_1040: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1041 (T_1022)))
 T_1041: (in __swap(d0_359) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1042: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1042
@@ -7254,9 +6923,9 @@ T_1043: (in __swap(d0_359) * (word16) dwLoc14 : word32)
   Class: Eq_1039
   DataType: uint32
   OrigDataType: uint32
-T_1044: (in d0_374 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_1044: (in d0_374 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1045: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1045
@@ -7279,8 +6948,8 @@ T_1049: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1050 (T_666)))
 T_1050: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1051: (in SLICE(d0_359, word16, 0) : word16)
   Class: Eq_1051
@@ -7299,12 +6968,12 @@ T_1054: (in SLICE(d4_365 + __swap(dwLoc14) *u SLICE(d0_359, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_1055: (in SEQ(SLICE(d4_365, word16, 16), SLICE(d4_365 + __swap(dwLoc14) *u SLICE(d0_359, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1056: (in __swap(SEQ(SLICE(d4_365, word16, 16), (word16) (d4_365 + __swap(dwLoc14) * (word16) d0_359))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1057: (in SLICE(__swap(SEQ(SLICE(d4_365, word16, 16), (word16) (d4_365 + __swap(dwLoc14) * (word16) d0_359))), word16, 16) : word16)
   Class: Eq_1057
@@ -7319,8 +6988,8 @@ T_1059: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_365, word16, 16), (word16) (d4_365 + _
   DataType: uipr32
   OrigDataType: uipr32
 T_1060: (in d0_359 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_365, word16, 16), (word16) (d4_365 + __swap(dwLoc14) * (word16) d0_359))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1061: (in d4_380 : uint32)
   Class: Eq_1061
@@ -7331,8 +7000,8 @@ T_1062: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1063 (T_1044)))
 T_1063: (in __swap(d0_374) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1064: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1064
@@ -7342,9 +7011,9 @@ T_1065: (in __swap(d0_374) * (word16) dwLoc14 : word32)
   Class: Eq_1061
   DataType: uint32
   OrigDataType: uint32
-T_1066: (in d0_389 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_1066: (in d0_389 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1067: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1067
@@ -7367,8 +7036,8 @@ T_1071: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1072 (T_666)))
 T_1072: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1073: (in SLICE(d0_374, word16, 0) : word16)
   Class: Eq_1073
@@ -7387,12 +7056,12 @@ T_1076: (in SLICE(d4_380 + __swap(dwLoc14) *u SLICE(d0_374, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_1077: (in SEQ(SLICE(d4_380, word16, 16), SLICE(d4_380 + __swap(dwLoc14) *u SLICE(d0_374, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1078: (in __swap(SEQ(SLICE(d4_380, word16, 16), (word16) (d4_380 + __swap(dwLoc14) * (word16) d0_374))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1079: (in SLICE(__swap(SEQ(SLICE(d4_380, word16, 16), (word16) (d4_380 + __swap(dwLoc14) * (word16) d0_374))), word16, 16) : word16)
   Class: Eq_1079
@@ -7407,8 +7076,8 @@ T_1081: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_380, word16, 16), (word16) (d4_380 + _
   DataType: uipr32
   OrigDataType: uipr32
 T_1082: (in d0_374 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_380, word16, 16), (word16) (d4_380 + __swap(dwLoc14) * (word16) d0_374))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1083: (in d4_395 : uint32)
   Class: Eq_1083
@@ -7419,8 +7088,8 @@ T_1084: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1085 (T_1066)))
 T_1085: (in __swap(d0_389) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1086: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1086
@@ -7430,9 +7099,9 @@ T_1087: (in __swap(d0_389) * (word16) dwLoc14 : word32)
   Class: Eq_1083
   DataType: uint32
   OrigDataType: uint32
-T_1088: (in d0_404 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_1088: (in d0_404 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1089: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1089
@@ -7455,8 +7124,8 @@ T_1093: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1094 (T_666)))
 T_1094: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1095: (in SLICE(d0_389, word16, 0) : word16)
   Class: Eq_1095
@@ -7475,12 +7144,12 @@ T_1098: (in SLICE(d4_395 + __swap(dwLoc14) *u SLICE(d0_389, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_1099: (in SEQ(SLICE(d4_395, word16, 16), SLICE(d4_395 + __swap(dwLoc14) *u SLICE(d0_389, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1100: (in __swap(SEQ(SLICE(d4_395, word16, 16), (word16) (d4_395 + __swap(dwLoc14) * (word16) d0_389))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1101: (in SLICE(__swap(SEQ(SLICE(d4_395, word16, 16), (word16) (d4_395 + __swap(dwLoc14) * (word16) d0_389))), word16, 16) : word16)
   Class: Eq_1101
@@ -7495,8 +7164,8 @@ T_1103: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_395, word16, 16), (word16) (d4_395 + _
   DataType: uipr32
   OrigDataType: uipr32
 T_1104: (in d0_389 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_395, word16, 16), (word16) (d4_395 + __swap(dwLoc14) * (word16) d0_389))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1105: (in d4_410 : uint32)
   Class: Eq_1105
@@ -7507,8 +7176,8 @@ T_1106: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1107 (T_1088)))
 T_1107: (in __swap(d0_404) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1108: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1108
@@ -7518,9 +7187,9 @@ T_1109: (in __swap(d0_404) * (word16) dwLoc14 : word32)
   Class: Eq_1105
   DataType: uint32
   OrigDataType: uint32
-T_1110: (in d0_419 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_1110: (in d0_419 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1111: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1111
@@ -7543,8 +7212,8 @@ T_1115: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1116 (T_666)))
 T_1116: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1117: (in SLICE(d0_404, word16, 0) : word16)
   Class: Eq_1117
@@ -7563,12 +7232,12 @@ T_1120: (in SLICE(d4_410 + __swap(dwLoc14) *u SLICE(d0_404, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_1121: (in SEQ(SLICE(d4_410, word16, 16), SLICE(d4_410 + __swap(dwLoc14) *u SLICE(d0_404, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1122: (in __swap(SEQ(SLICE(d4_410, word16, 16), (word16) (d4_410 + __swap(dwLoc14) * (word16) d0_404))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1123: (in SLICE(__swap(SEQ(SLICE(d4_410, word16, 16), (word16) (d4_410 + __swap(dwLoc14) * (word16) d0_404))), word16, 16) : word16)
   Class: Eq_1123
@@ -7583,8 +7252,8 @@ T_1125: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_410, word16, 16), (word16) (d4_410 + _
   DataType: uipr32
   OrigDataType: uipr32
 T_1126: (in d0_404 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_410, word16, 16), (word16) (d4_410 + __swap(dwLoc14) * (word16) d0_404))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1127: (in d4_425 : uint32)
   Class: Eq_1127
@@ -7595,8 +7264,8 @@ T_1128: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1129 (T_1110)))
 T_1129: (in __swap(d0_419) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1130: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1130
@@ -7606,9 +7275,9 @@ T_1131: (in __swap(d0_419) * (word16) dwLoc14 : word32)
   Class: Eq_1127
   DataType: uint32
   OrigDataType: uint32
-T_1132: (in d0_434 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_1132: (in d0_434 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1133: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1133
@@ -7631,8 +7300,8 @@ T_1137: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1138 (T_666)))
 T_1138: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1139: (in SLICE(d0_419, word16, 0) : word16)
   Class: Eq_1139
@@ -7651,12 +7320,12 @@ T_1142: (in SLICE(d4_425 + __swap(dwLoc14) *u SLICE(d0_419, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_1143: (in SEQ(SLICE(d4_425, word16, 16), SLICE(d4_425 + __swap(dwLoc14) *u SLICE(d0_419, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1144: (in __swap(SEQ(SLICE(d4_425, word16, 16), (word16) (d4_425 + __swap(dwLoc14) * (word16) d0_419))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1145: (in SLICE(__swap(SEQ(SLICE(d4_425, word16, 16), (word16) (d4_425 + __swap(dwLoc14) * (word16) d0_419))), word16, 16) : word16)
   Class: Eq_1145
@@ -7671,8 +7340,8 @@ T_1147: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_425, word16, 16), (word16) (d4_425 + _
   DataType: uipr32
   OrigDataType: uipr32
 T_1148: (in d0_419 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_425, word16, 16), (word16) (d4_425 + __swap(dwLoc14) * (word16) d0_419))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1149: (in d4_440 : uint32)
   Class: Eq_1149
@@ -7683,8 +7352,8 @@ T_1150: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1151 (T_1132)))
 T_1151: (in __swap(d0_434) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1152: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1152
@@ -7694,9 +7363,9 @@ T_1153: (in __swap(d0_434) * (word16) dwLoc14 : word32)
   Class: Eq_1149
   DataType: uint32
   OrigDataType: uint32
-T_1154: (in d0_449 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_1154: (in d0_449 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1155: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1155
@@ -7719,8 +7388,8 @@ T_1159: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1160 (T_666)))
 T_1160: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1161: (in SLICE(d0_434, word16, 0) : word16)
   Class: Eq_1161
@@ -7739,12 +7408,12 @@ T_1164: (in SLICE(d4_440 + __swap(dwLoc14) *u SLICE(d0_434, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_1165: (in SEQ(SLICE(d4_440, word16, 16), SLICE(d4_440 + __swap(dwLoc14) *u SLICE(d0_434, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1166: (in __swap(SEQ(SLICE(d4_440, word16, 16), (word16) (d4_440 + __swap(dwLoc14) * (word16) d0_434))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1167: (in SLICE(__swap(SEQ(SLICE(d4_440, word16, 16), (word16) (d4_440 + __swap(dwLoc14) * (word16) d0_434))), word16, 16) : word16)
   Class: Eq_1167
@@ -7759,8 +7428,8 @@ T_1169: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_440, word16, 16), (word16) (d4_440 + _
   DataType: uipr32
   OrigDataType: uipr32
 T_1170: (in d0_434 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_440, word16, 16), (word16) (d4_440 + __swap(dwLoc14) * (word16) d0_434))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1171: (in d4_455 : uint32)
   Class: Eq_1171
@@ -7771,8 +7440,8 @@ T_1172: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1173 (T_1154)))
 T_1173: (in __swap(d0_449) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1174: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1174
@@ -7782,9 +7451,9 @@ T_1175: (in __swap(d0_449) * (word16) dwLoc14 : word32)
   Class: Eq_1171
   DataType: uint32
   OrigDataType: uint32
-T_1176: (in d0_464 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_1176: (in d0_464 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1177: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1177
@@ -7807,8 +7476,8 @@ T_1181: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1182 (T_666)))
 T_1182: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1183: (in SLICE(d0_449, word16, 0) : word16)
   Class: Eq_1183
@@ -7827,12 +7496,12 @@ T_1186: (in SLICE(d4_455 + __swap(dwLoc14) *u SLICE(d0_449, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_1187: (in SEQ(SLICE(d4_455, word16, 16), SLICE(d4_455 + __swap(dwLoc14) *u SLICE(d0_449, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1188: (in __swap(SEQ(SLICE(d4_455, word16, 16), (word16) (d4_455 + __swap(dwLoc14) * (word16) d0_449))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1189: (in SLICE(__swap(SEQ(SLICE(d4_455, word16, 16), (word16) (d4_455 + __swap(dwLoc14) * (word16) d0_449))), word16, 16) : word16)
   Class: Eq_1189
@@ -7847,8 +7516,8 @@ T_1191: (in SEQ(SLICE(__swap(SEQ(SLICE(d4_455, word16, 16), (word16) (d4_455 + _
   DataType: uipr32
   OrigDataType: uipr32
 T_1192: (in d0_449 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d4_455, word16, 16), (word16) (d4_455 + __swap(dwLoc14) * (word16) d0_449))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1193: (in d5_471 : uint32)
   Class: Eq_1193
@@ -7859,8 +7528,8 @@ T_1194: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1195 (T_1176)))
 T_1195: (in __swap(d0_464) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1196: (in SLICE(dwLoc14, word16, 0) : word16)
   Class: Eq_1196
@@ -7891,8 +7560,8 @@ T_1202: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1203 (T_666)))
 T_1203: (in __swap(dwLoc14) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1204: (in SLICE(d0_464, word16, 0) : word16)
   Class: Eq_1204
@@ -7911,12 +7580,12 @@ T_1207: (in SLICE(d5_471 + __swap(dwLoc14) *u SLICE(d0_464, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_1208: (in SEQ(SLICE(d5_471, word16, 16), SLICE(d5_471 + __swap(dwLoc14) *u SLICE(d0_464, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1209: (in __swap(SEQ(SLICE(d5_471, word16, 16), (word16) (d5_471 + __swap(dwLoc14) * (word16) d0_464))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1210: (in SLICE(__swap(SEQ(SLICE(d5_471, word16, 16), (word16) (d5_471 + __swap(dwLoc14) * (word16) d0_464))), word16, 16) : word16)
   Class: Eq_1210
@@ -7931,8 +7600,8 @@ T_1212: (in SEQ(SLICE(__swap(SEQ(SLICE(d5_471, word16, 16), (word16) (d5_471 + _
   DataType: uipr32
   OrigDataType: uipr32
 T_1213: (in d0_464 * (word16) dwLoc14 + SEQ(SLICE(__swap(SEQ(SLICE(d5_471, word16, 16), (word16) (d5_471 + __swap(dwLoc14) * (word16) d0_464))), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1214: (in 1<32> : word32)
   Class: Eq_1214
@@ -8033,7 +7702,7 @@ T_1237: (in d0_1952 : Eq_603)
 T_1238: (in a7_1968 : (ptr32 Eq_1238))
   Class: Eq_1238
   DataType: (ptr32 Eq_1238)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1755 u2) (T_1761 u3) (T_1835 u4) (T_2905 u5) (T_3016 u6) (T_3057 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1885 u2) (T_1892 u3) (T_1903 u4) (T_2420 u5) (T_2487 u6) (T_2490 u7) (T_2560 u8) (T_2608 u9) (T_3140 u10)) u0066) (6A byte b006A)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1755 u2) (T_1761 u3) (T_1835 u4) (T_2905 u5) (T_3016 u6) (T_3057 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1885 u2) (T_1892 u3) (T_1903 u4) (T_2420 u5) (T_2487 u6) (T_2490 u7) (T_2560 u8) (T_2608 u9) (T_3140 u10)) u0066) (6A byte b006A)))
 T_1239: (in fp : ptr32)
   Class: Eq_1239
   DataType: ptr32
@@ -8064,7 +7733,7 @@ T_1245: (in d6_1480 : Eq_603)
   OrigDataType: word32
 T_1246: (in 0<i32> : int32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_1247: (in 0<32> : word32)
   Class: Eq_1247
@@ -8292,7 +7961,7 @@ T_1302: (in a7_51 + 4<i32> : word32)
   OrigDataType: ptr32
 T_1303: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_1304: (in d0 != 0xFFFFFFFF<32> : bool)
   Class: Eq_1304
@@ -8344,15 +8013,15 @@ T_1315: (in a7_1968 + 102<i32> : word32)
   OrigDataType: ptr32
 T_1316: (in Mem91[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1313
-  DataType: Eq_8960
+  DataType: Eq_8955
   OrigDataType: word32
-T_1317: (in d5_256 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: (struct "Eq_1238" 0004 (2C Eq_8959 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8960 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+T_1317: (in d5_256 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: (struct "Eq_1238" 0004 (2C Eq_8954 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8955 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 T_1318: (in -1<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_1319: (in d4_376 : int32)
   Class: Eq_1319
@@ -8394,10 +8063,10 @@ T_1328: (in a4_1925 + 1<i32> : word32)
   Class: Eq_1326
   DataType: (ptr32 uint8)
   OrigDataType: ptr32
-T_1329: (in d2_1005 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: (ptr32 Eq_603)
+T_1329: (in d2_1005 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: (ptr32 Eq_663)
 T_1330: (in 72<i32> : int32)
   Class: Eq_1330
   DataType: int32
@@ -8407,8 +8076,8 @@ T_1331: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1332: (in Mem91[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1333: (in d1_103 : Eq_603)
   Class: Eq_603
@@ -8424,7 +8093,7 @@ T_1335: (in d1_103 + 1<32> : word32)
   OrigDataType: word32
 T_1336: (in 5<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: up32
 T_1337: (in d1_103 < 5<32> : bool)
   Class: Eq_1337
@@ -8471,8 +8140,8 @@ T_1347: (in Mem121[a7_99 + 0<32>:word32] : word32)
   DataType: Eq_603
   OrigDataType: word32
 T_1348: (in d2_1005 | d1_123 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_1349: (in 1<i32> : int32)
   Class: Eq_1349
@@ -8484,7 +8153,7 @@ T_1350: (in a2_135 + 1<i32> : word32)
   OrigDataType: ptr32
 T_1351: (in 5<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: up32
 T_1352: (in d1_103 < 5<32> : bool)
   Class: Eq_1352
@@ -8492,7 +8161,7 @@ T_1352: (in d1_103 < 5<32> : bool)
   OrigDataType: bool
 T_1353: (in 0<i32> : int32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_1354: (in a0_1447 : (ptr32 Eq_1354))
   Class: Eq_1354
@@ -8511,8 +8180,8 @@ T_1357: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1358: (in Mem143[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1359: (in 0<32> : word32)
   Class: Eq_1359
@@ -8975,8 +8644,8 @@ T_1473: (in (uint32) (uint8) Mem248[a0_1447 + 0<32>:byte] : uint32)
   DataType: uint32
   OrigDataType: uint32
 T_1474: (in 0<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_1475: (in 4<32> : word32)
   Class: Eq_1475
@@ -9087,12 +8756,12 @@ T_1501: (in a7_1968 + 44<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1502: (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_1503: (in a7_275 : (ptr32 Eq_603))
+T_1503: (in a7_275 : (ptr32 Eq_663))
   Class: Eq_1503
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_663 t0000)))
 T_1504: (in 4<i32> : int32)
   Class: Eq_1504
@@ -9100,7 +8769,7 @@ T_1504: (in 4<i32> : int32)
   OrigDataType: int32
 T_1505: (in a7_1968 - 4<i32> : word32)
   Class: Eq_1503
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: ptr32
 T_1506: (in 0<32> : word32)
   Class: Eq_1506
@@ -9111,8 +8780,8 @@ T_1507: (in a7_275 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1508: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1509: (in d1_284 : uint32)
   Class: Eq_1509
@@ -9123,12 +8792,12 @@ T_1510: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1512 (T_1511)))
 T_1511: (in 10<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_1512: (in __swap(10<i32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1513: (in SLICE(d5_256, word16, 0) : word16)
   Class: Eq_1513
@@ -9155,8 +8824,8 @@ T_1518: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1519 (T_1317)))
 T_1519: (in __swap(d5_256) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1520: (in 0xA<16> : word16)
   Class: Eq_1520
@@ -9175,12 +8844,12 @@ T_1523: (in SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_1524: (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1525: (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1526: (in SLICE(__swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_1526
@@ -9327,8 +8996,8 @@ T_1561: (in a7_275 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1562: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1563: (in 0x30<32> : word32)
   Class: Eq_1563
@@ -9343,8 +9012,8 @@ T_1565: (in d1_303 - 0x30<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1566: (in d1_303 - 0x30<32> + d0_293 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1567: (in 4<32> : word32)
   Class: Eq_1567
@@ -9523,8 +9192,8 @@ T_1610: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1611: (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1612: (in 4<i32> : int32)
   Class: Eq_1612
@@ -9555,12 +9224,12 @@ T_1618: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1620 (T_1619)))
 T_1619: (in 10<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_1620: (in __swap(10<i32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1621: (in SLICE(d2_1005, word16, 0) : word16)
   Class: Eq_1621
@@ -9587,8 +9256,8 @@ T_1626: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_1627 (T_1329)))
 T_1627: (in __swap(d2_1005) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1628: (in 0xA<16> : word16)
   Class: Eq_1628
@@ -9607,12 +9276,12 @@ T_1631: (in SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_1632: (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_1633: (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1634: (in SLICE(__swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_1634
@@ -9779,8 +9448,8 @@ T_1674: (in d1_196 - 0x30<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1675: (in d1_196 - 0x30<32> + d0_186 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_1676: (in 4<32> : word32)
   Class: Eq_1676
@@ -9811,8 +9480,8 @@ T_1682: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1683: (in Mem217[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1684: (in 0x6C<32> : word32)
   Class: Eq_1319
@@ -10004,7 +9673,7 @@ T_1730: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1731: (in Mem465[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1728
-  DataType: Eq_8960
+  DataType: Eq_8955
   OrigDataType: word32
 T_1732: (in 0000206C : ptr32)
   Class: Eq_619
@@ -10184,7 +9853,7 @@ T_1775: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1776: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1773
-  DataType: Eq_8960
+  DataType: Eq_8955
   OrigDataType: word32
 T_1777: (in 4<32> : word32)
   Class: Eq_1777
@@ -10199,8 +9868,8 @@ T_1779: (in d0_1471 + 4<32> : word32)
   DataType: (ptr32 Eq_1354)
   OrigDataType: ptr32
 T_1780: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_1781: (in d5_256 == 0<32> : bool)
   Class: Eq_1781
@@ -10237,7 +9906,7 @@ T_1788: (in d3_1050 : ptr32)
 T_1789: (in a7_1020 : (ptr32 Eq_1238))
   Class: Eq_1238
   DataType: (ptr32 Eq_1238)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1755 u2) (T_1761 u3) (T_1835 u4) (T_2905 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1885 u2) (T_1892 u3) (T_1903 u4) (T_2420 u5) (T_2487 u6) (T_2490 u7) (T_2560 u8) (T_2608 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1755 u2) (T_1761 u3) (T_1835 u4) (T_2905 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1885 u2) (T_1892 u3) (T_1903 u4) (T_2420 u5) (T_2487 u6) (T_2490 u7) (T_2560 u8) (T_2608 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
 T_1790: (in SLICE(d1, byte, 0) : byte)
   Class: Eq_1790
   DataType: byte
@@ -10504,7 +10173,7 @@ T_1855: (in 8<i32> : int32)
   OrigDataType: int32
 T_1856: (in a7_1174 - 8<i32> : word32)
   Class: Eq_1856
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_1859 t0000)))
 T_1857: (in 0<32> : word32)
   Class: Eq_1857
@@ -10515,8 +10184,8 @@ T_1858: (in a7_1174 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1859: (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_1860: (in 4<i32> : int32)
   Class: Eq_1860
@@ -10560,7 +10229,7 @@ T_1869: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1870: (in Mem756[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1722
-  DataType: Eq_8960
+  DataType: Eq_8955
   OrigDataType: (ptr32 Eq_1885)
 T_1871: (in 0<32> : word32)
   Class: Eq_1871
@@ -10692,7 +10361,7 @@ T_1902: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (T_1885 u2) (T_1892 u3)))
 T_1903: (in Mem719[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1722
-  DataType: Eq_8960
+  DataType: Eq_8955
   OrigDataType: (ptr32 Eq_1885)
 T_1904: (in 1<32> : word32)
   Class: Eq_1904
@@ -10711,8 +10380,8 @@ T_1907: (in a1 + 1<i32> : word32)
   DataType: Eq_619
   OrigDataType: ptr32
 T_1908: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: up32
 T_1909: (in d5_256 <= 0<32> : bool)
   Class: Eq_1909
@@ -11436,7 +11105,7 @@ T_2088: (in a7_1465[18<i32>] & 2<i32> : word32)
   OrigDataType: ui32
 T_2089: (in 0<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2090: (in d0_1566 == 0<32> : bool)
   Class: Eq_2090
@@ -11591,8 +11260,8 @@ T_2127: (in a7_1020 + 68<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2128: (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_2129: (in 48<i32> : int32)
   Class: Eq_2129
@@ -11924,7 +11593,7 @@ T_2210: (in fn00002098(*(a7_1578 - 4<i32>), a7_1578->ptr0000, out d1, out a0_144
   OrigDataType: word32
 T_2211: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2212: (in d0_1566 != 0xFFFFFFFF<32> : bool)
   Class: Eq_2212
@@ -12142,25 +11811,25 @@ T_2265: (in signature of fn00002A00 : void)
   Class: Eq_2264
   DataType: (ptr32 Eq_2264)
   OrigDataType: 
-T_2266: (in dwArg04 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_2266: (in dwArg04 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_2267: (in dwArg08 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_2267: (in dwArg08 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_2268: (in dwArg0C : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_2268: (in dwArg0C : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_2269: (in dwArg10 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_2269: (in dwArg10 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_2270: (in a7_1383 - 24<i32> : word32)
   Class: Eq_2270
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_2273 t0000)))
 T_2271: (in 0<32> : word32)
   Class: Eq_2271
@@ -12171,8 +11840,8 @@ T_2272: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2273: (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_2274: (in 20<i32> : int32)
   Class: Eq_2274
@@ -12180,7 +11849,7 @@ T_2274: (in 20<i32> : int32)
   OrigDataType: int32
 T_2275: (in a7_1383 - 20<i32> : word32)
   Class: Eq_2275
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_2278 t0000)))
 T_2276: (in 0<32> : word32)
   Class: Eq_2276
@@ -12191,8 +11860,8 @@ T_2277: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2278: (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_2279: (in 16<i32> : int32)
   Class: Eq_2279
@@ -12200,7 +11869,7 @@ T_2279: (in 16<i32> : int32)
   OrigDataType: int32
 T_2280: (in a7_1383 - 16<i32> : word32)
   Class: Eq_2280
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_2283 t0000)))
 T_2281: (in 0<32> : word32)
   Class: Eq_2281
@@ -12211,8 +11880,8 @@ T_2282: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2283: (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_2284: (in 12<i32> : int32)
   Class: Eq_2284
@@ -12220,7 +11889,7 @@ T_2284: (in 12<i32> : int32)
   OrigDataType: int32
 T_2285: (in a7_1383 - 12<i32> : word32)
   Class: Eq_2285
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_2288 t0000)))
 T_2286: (in 0<32> : word32)
   Class: Eq_2286
@@ -12231,8 +11900,8 @@ T_2287: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2288: (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_2289: (in fn00002A00(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>)) : word32)
   Class: Eq_2263
@@ -12478,33 +12147,33 @@ T_2349: (in signature of fn000026B8 : void)
   Class: Eq_2348
   DataType: (ptr32 Eq_2348)
   OrigDataType: 
-T_2350: (in dwArg04 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_2350: (in dwArg04 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_2351: (in dwArg08 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_2351: (in dwArg08 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_2352: (in dwArg0C : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_2352: (in dwArg0C : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_2353: (in dwArg10 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_2353: (in dwArg10 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_2354: (in d1Out : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_2354: (in d1Out : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
-T_2355: (in a0Out : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_2355: (in a0Out : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_2356: (in a7_1383 - 24<i32> : word32)
   Class: Eq_2356
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_2359 t0000)))
 T_2357: (in 0<32> : word32)
   Class: Eq_2357
@@ -12515,8 +12184,8 @@ T_2358: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2359: (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_2360: (in 20<i32> : int32)
   Class: Eq_2360
@@ -12524,7 +12193,7 @@ T_2360: (in 20<i32> : int32)
   OrigDataType: int32
 T_2361: (in a7_1383 - 20<i32> : word32)
   Class: Eq_2361
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_2364 t0000)))
 T_2362: (in 0<32> : word32)
   Class: Eq_2362
@@ -12535,8 +12204,8 @@ T_2363: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2364: (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_2365: (in 16<i32> : int32)
   Class: Eq_2365
@@ -12544,7 +12213,7 @@ T_2365: (in 16<i32> : int32)
   OrigDataType: int32
 T_2366: (in a7_1383 - 16<i32> : word32)
   Class: Eq_2366
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_2369 t0000)))
 T_2367: (in 0<32> : word32)
   Class: Eq_2367
@@ -12555,8 +12224,8 @@ T_2368: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2369: (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_2370: (in 12<i32> : int32)
   Class: Eq_2370
@@ -12564,7 +12233,7 @@ T_2370: (in 12<i32> : int32)
   OrigDataType: int32
 T_2371: (in a7_1383 - 12<i32> : word32)
   Class: Eq_2371
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_2374 t0000)))
 T_2372: (in 0<32> : word32)
   Class: Eq_2372
@@ -12575,16 +12244,16 @@ T_2373: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2374: (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_2375: (in out d1_1450 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_2376: (in out a0_1447 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: (ptr32 (struct (0 T_1376 t0000)))
 T_2377: (in fn000026B8(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>), out d1_1450, out a0_1447) : word32)
   Class: Eq_2138
@@ -12800,7 +12469,7 @@ T_2429: (in a7_1465[18<i32>] & 2<i32> : word32)
   OrigDataType: ui32
 T_2430: (in 0<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2431: (in d0_1691 != 0<32> : bool)
   Class: Eq_2431
@@ -12980,7 +12649,7 @@ T_2474: (in fn00002098(*(a7_1465 - 8<i32>), *(a7_1465 - 4<i32>), out d1, out a0_
   OrigDataType: word32
 T_2475: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2476: (in fn00002098(*(a7_1465 - 8<i32>), *(a7_1465 - 4<i32>), out d1, out a0_1447, out a1, out a5_1579) != 0xFFFFFFFF<32> : bool)
   Class: Eq_2476
@@ -13208,7 +12877,7 @@ T_2531: (in fn00002098(*(a7_1706 - 4<i32>), a7_1706->ptr0000, out d1, out a0_292
   OrigDataType: word32
 T_2532: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2533: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_2533
@@ -13436,7 +13105,7 @@ T_2588: (in fn00002098(*(a7_1761 - 4<i32>), *a7_1761, out d1, out a0_2921, out a
   OrigDataType: word32
 T_2589: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2590: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_2590
@@ -13492,7 +13161,7 @@ T_2602: (in a7_1465[18<i32>] & 4<i32> : word32)
   OrigDataType: ui32
 T_2603: (in 0<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2604: (in d0 == 0<32> : bool)
   Class: Eq_2604
@@ -13672,7 +13341,7 @@ T_2647: (in fn00002098(*(a7_1800 - 4<i32>), *a7_1800, out d1, out a0_2922, out a
   OrigDataType: word32
 T_2648: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2649: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_2649
@@ -13876,7 +13545,7 @@ T_2698: (in fn00002098(*(a7_1854 - 4<i32>), *a7_1854, out d1, out a0_2923, out a
   OrigDataType: word32
 T_2699: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2700: (in d0 != 0xFFFFFFFF<32> : bool)
   Class: Eq_2700
@@ -14050,22 +13719,22 @@ T_2742: (in Mem1091[a7_1057 + 0<32>:word32] : word32)
   Class: Eq_1227
   DataType: (ptr32 Eq_1227)
   OrigDataType: ptr32
-T_2743: (in v248_1105 : Eq_2743)
+T_2743: (in v248_1105 : byte)
   Class: Eq_2743
-  DataType: Eq_2743
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2744: (in 55<i32> : int32)
   Class: Eq_2744
   DataType: int32
   OrigDataType: int32
 T_2745: (in a7_1968 + 55<i32> : word32)
   Class: Eq_2745
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2746: (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
   Class: Eq_2743
-  DataType: Eq_2743
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2747: (in a7_1109 : (ptr32 Eq_2747))
   Class: Eq_2747
   DataType: (ptr32 Eq_2747)
@@ -14280,8 +13949,8 @@ T_2799: (in 56<i32> : int32)
   OrigDataType: int32
 T_2800: (in a7_1968 + 56<i32> : word32)
   Class: Eq_2800
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2801: (in Mem836[a7_1968 + 56<i32>:word32] : word32)
   Class: Eq_2798
   DataType: word32
@@ -14310,22 +13979,22 @@ T_2807: (in d4_376 != 2<32> : bool)
   Class: Eq_2807
   DataType: bool
   OrigDataType: bool
-T_2808: (in v262_844 : Eq_2808)
+T_2808: (in v262_844 : word16)
   Class: Eq_2808
-  DataType: Eq_2808
-  OrigDataType: (union (word16 u0) (word32 u1))
+  DataType: word16
+  OrigDataType: word16
 T_2809: (in 62<i32> : int32)
   Class: Eq_2809
   DataType: int32
   OrigDataType: int32
 T_2810: (in a7_1968 + 62<i32> : word32)
   Class: Eq_2810
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2811: (in Mem843[a7_1968 + 62<i32>:word16] : word16)
   Class: Eq_2808
-  DataType: Eq_2808
-  OrigDataType: word32
+  DataType: word16
+  OrigDataType: word16
 T_2812: (in a7_848 : (ptr32 Eq_2812))
   Class: Eq_2812
   DataType: (ptr32 Eq_2812)
@@ -14608,7 +14277,7 @@ T_2881: (in Mem623[a0_1447 + 4<i32>:word32] : word32)
   OrigDataType: word32
 T_2882: (in 0<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2883: (in 0<32> : word32)
   Class: Eq_2883
@@ -14621,7 +14290,7 @@ T_2884: (in a0_1447 + 0<32> : word32)
 T_2885: (in Mem624[a0_1447 + 0<32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
-  OrigDataType: uint8
+  OrigDataType: byte
 T_2886: (in d3_1482 + 3<32> : word32)
   Class: Eq_2886
   DataType: Eq_2886
@@ -14710,22 +14379,22 @@ T_2907: (in d0_891 == 0<32> : bool)
   Class: Eq_2907
   DataType: bool
   OrigDataType: bool
-T_2908: (in v277_869 : Eq_2908)
+T_2908: (in v277_869 : byte)
   Class: Eq_2908
-  DataType: Eq_2908
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2909: (in 63<i32> : int32)
   Class: Eq_2909
   DataType: int32
   OrigDataType: int32
 T_2910: (in a7_1968 + 63<i32> : word32)
   Class: Eq_2910
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2911: (in Mem868[a7_1968 + 63<i32>:byte] : byte)
   Class: Eq_2908
-  DataType: Eq_2908
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2912: (in a7_873 : (ptr32 Eq_2912))
   Class: Eq_2912
   DataType: (ptr32 Eq_2912)
@@ -14879,8 +14548,8 @@ T_2949: (in (byte) d1 == 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_2950: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_2951: (in d5_256 != 0<32> : bool)
   Class: Eq_2951
@@ -14988,7 +14657,7 @@ T_2976: (in 8<i32> : int32)
   OrigDataType: int32
 T_2977: (in a7_911 - 8<i32> : word32)
   Class: Eq_2977
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_2980 t0000)))
 T_2978: (in 0<32> : word32)
   Class: Eq_2978
@@ -14999,12 +14668,12 @@ T_2979: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2980: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_2981: (in a7_911 - 8<i32> : word32)
   Class: Eq_2981
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_2984 t0000)))
 T_2982: (in 0<32> : word32)
   Class: Eq_2982
@@ -15015,8 +14684,8 @@ T_2983: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2984: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_2985: (in 4<i32> : int32)
   Class: Eq_2985
@@ -15228,7 +14897,7 @@ T_3036: (in 8<i32> : int32)
   OrigDataType: int32
 T_3037: (in a7_992 - 8<i32> : word32)
   Class: Eq_3037
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_3040 t0000)))
 T_3038: (in 0<32> : word32)
   Class: Eq_3038
@@ -15239,8 +14908,8 @@ T_3039: (in a7_992 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3040: (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_3041: (in d1_1017 : word32)
   Class: Eq_3041
@@ -15640,7 +15309,7 @@ T_3139: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (Eq_1885 u2) (Eq_1722 u3) (Eq_1722 u4) (Eq_2420 u5) (Eq_2484 u6) (Eq_2490 u7) (Eq_2560 u8) (Eq_2605 u9)))
 T_3140: (in Mem525[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_3137
-  DataType: Eq_8960
+  DataType: Eq_8955
   OrigDataType: (ptr32 Eq_1885)
 T_3141: (in 0<i32> : int32)
   Class: Eq_1712
@@ -18778,29 +18447,29 @@ T_3924: (in fn0000131C(0x14<u32>, out a1, out a5) : word32)
   Class: Eq_588
   DataType: word32
   OrigDataType: word32
-T_3925: (in d0 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_3925: (in d0 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_3926: (in d0_196 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: uint8
-T_3927: (in d1_142 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_3926: (in d0_196 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: (ptr32 Eq_1885)
+T_3927: (in d1_142 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_3928: (in a0_20 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_3928: (in a0_20 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
-T_3929: (in d3_166 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_3929: (in d3_166 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
 T_3930: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_3931: (in dwArg0C != 0<32> : bool)
   Class: Eq_3931
@@ -18831,8 +18500,8 @@ T_3937: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_3938: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_3939: (in dwArg10 != 0<32> : bool)
   Class: Eq_3939
@@ -18854,41 +18523,41 @@ T_3943: (in signature of fn000027BC : void)
   Class: Eq_3942
   DataType: (ptr32 Eq_3942)
   OrigDataType: 
-T_3944: (in d0 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_3944: (in d0 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: (union (int32 u1) (up32 u0))
-T_3945: (in d1 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_3945: (in d1 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: up32
-T_3946: (in d2 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_3946: (in d2 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: (union (int32 u0) (up32 u1))
-T_3947: (in d1Out : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_3947: (in d1Out : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
-T_3948: (in d2Out : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_3948: (in d2Out : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_3949: (in out d1_318 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_3950: (in out d2_319 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_3951: (in fn000027BC(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_3952: (in 0<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_3953: (in d4_29 : int32)
   Class: Eq_3953
@@ -18898,9 +18567,9 @@ T_3954: (in 24<i32> : int32)
   Class: Eq_3953
   DataType: int32
   OrigDataType: int32
-T_3955: (in d6_30 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_3955: (in d6_30 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uip32
 T_3956: (in __rol : ptr32)
   Class: Eq_3956
@@ -18911,20 +18580,20 @@ T_3957: (in signature of __rol : void)
   DataType: (ptr32 Eq_3956)
   OrigDataType: 
 T_3958: (in  : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: 
 T_3959: (in  : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: 
 T_3960: (in 8<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_3961: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_3962: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3962
@@ -19027,12 +18696,12 @@ T_3986: (in __rol : ptr32)
   DataType: (ptr32 Eq_3956)
   OrigDataType: (ptr32 (fn T_3988 (T_3955, T_3987)))
 T_3987: (in 8<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_3988: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_3989: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3989
@@ -19055,12 +18724,12 @@ T_3993: (in __rol : ptr32)
   DataType: (ptr32 Eq_3956)
   OrigDataType: (ptr32 (fn T_3995 (T_3955, T_3994)))
 T_3994: (in 8<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_3995: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_3996: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3996
@@ -19087,40 +18756,40 @@ T_4001: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_4002: (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uip32
-T_4003: (in d1_175 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4003: (in d1_175 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4004: (in d2_176 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4004: (in d2_176 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4005: (in d0_174 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4005: (in d0_174 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4006: (in fn000027BC : ptr32)
   Class: Eq_3942
   DataType: (ptr32 Eq_3942)
   OrigDataType: (ptr32 (fn T_4010 (T_4007, T_2350, T_3929, T_4008, T_4009)))
 T_4007: (in 0<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_4008: (in out d1_175 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4009: (in out d2_176 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4010: (in fn000027BC(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4011: (in d2_321 : word32)
   Class: Eq_4011
@@ -19135,16 +18804,16 @@ T_4013: (in fn000027BC : ptr32)
   DataType: (ptr32 Eq_3942)
   OrigDataType: (ptr32 (fn T_4016 (T_4003, T_2351, T_4004, T_4014, T_4015)))
 T_4014: (in out d1_320 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4015: (in out d2_321 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4016: (in fn000027BC(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4017: (in 1<i32> : int32)
   Class: Eq_4017
@@ -19187,8 +18856,8 @@ T_4026: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_4027: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
 T_4028: (in d1_86 : word32)
   Class: Eq_4028
@@ -19198,17 +18867,17 @@ T_4029: (in d2_322 : word32)
   Class: Eq_4029
   DataType: word32
   OrigDataType: word32
-T_4030: (in d0_85 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4030: (in d0_85 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4031: (in fn000027BC : ptr32)
   Class: Eq_3942
   DataType: (ptr32 Eq_3942)
   OrigDataType: (ptr32 (fn T_4041 (T_4032, T_4035, T_4038, T_4039, T_4040)))
 T_4032: (in dwArg04 >> d4_61 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4033: (in dwArg04 << d5_63 : word32)
   Class: Eq_4033
@@ -19219,8 +18888,8 @@ T_4034: (in dwArg08 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4035: (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_4036: (in dwArg0C << d5_63 : word32)
   Class: Eq_4036
@@ -19231,52 +18900,52 @@ T_4037: (in dwArg10 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4038: (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_4039: (in out d1_86 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4040: (in out d2_322 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4041: (in fn000027BC(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4042: (in d3_72 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4042: (in d3_72 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4043: (in dwArg10 << d5_63 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
-T_4044: (in d5_101 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4044: (in d5_101 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4045: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4046 (T_4030)))
 T_4046: (in __swap(d0_85) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4047: (in d6_103 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4047: (in d6_103 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4048: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4049 (T_4042)))
 T_4049: (in __swap(d3_72) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4050: (in d3_102 : uint32)
   Class: Eq_4050
@@ -19290,9 +18959,9 @@ T_4052: (in d3_72 * (word16) d5_101 : word32)
   Class: Eq_4050
   DataType: uint32
   OrigDataType: uint32
-T_4053: (in d2_107 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4053: (in d2_107 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4054: (in __swap : ptr32)
   Class: Eq_661
@@ -19303,12 +18972,12 @@ T_4055: (in SLICE(d3_72, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4056: (in d0_85 * (word16) d3_72 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4057: (in __swap(d0_85 * (word16) d3_72) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4058: (in v34_108 : cup16)
   Class: Eq_4058
@@ -19358,29 +19027,29 @@ T_4069: (in SLICE(SEQ(v35_109, v34_108) + d4_104, word16, 0) : word16)
   Class: Eq_4066
   DataType: cup16
   OrigDataType: word16
-T_4070: (in d6_82 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4070: (in d6_82 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4071: (in dwArg08 << d5_63 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
-T_4072: (in d2_124 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4072: (in d2_124 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4073: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4075 (T_4074)))
 T_4074: (in SEQ(v35_109, v39_116) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4075: (in __swap(SEQ(v35_109, v39_116)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4076: (in d5_105 : uint32)
   Class: Eq_4076
@@ -19411,12 +19080,12 @@ T_4082: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4083: (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4084: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4085: (in __swap : ptr32)
   Class: Eq_661
@@ -19431,12 +19100,12 @@ T_4087: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4088: (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4089: (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4090: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
   Class: Eq_4090
@@ -19523,8 +19192,8 @@ T_4110: (in 1<32> : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4111: (in d0_85 - 1<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4112: (in 0<32> : word32)
   Class: Eq_4079
@@ -19546,13 +19215,13 @@ T_4116: (in d6_82 - d2_124 >= 0<32> : bool)
   Class: Eq_4116
   DataType: bool
   OrigDataType: bool
-T_4117: (in d7_13 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4117: (in d7_13 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: (union (int32 u0) (uint32 u1))
 T_4118: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4119: (in d2 == 0<32> : bool)
   Class: Eq_4119
@@ -19566,57 +19235,57 @@ T_4121: (in signature of fn0000297A : void)
   Class: Eq_4120
   DataType: (ptr32 Eq_4120)
   OrigDataType: 
-T_4122: (in d0 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4122: (in d0 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_4123: (in d1 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4123: (in d1 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4124: (in d2 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4124: (in d2 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4125: (in d1Out : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4125: (in d1Out : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4126: (in out d1 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4127: (in fn0000297A(d1, d2, d2, out d1) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4128: (in d6_17 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4128: (in d6_17 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_4129: (in d5_19 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4129: (in d5_19 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4130: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4131: (in d0 != 0<32> : bool)
   Class: Eq_4131
   DataType: bool
   OrigDataType: bool
-T_4132: (in d2_22 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4132: (in d2_22 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4133: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4134 (T_3946)))
 T_4134: (in __swap(d2) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4135: (in SLICE(d2_22, word16, 0) : word16)
   Class: Eq_4135
@@ -19631,8 +19300,8 @@ T_4137: (in (word16) d2_22 != 0<16> : bool)
   DataType: bool
   OrigDataType: bool
 T_4138: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4139: (in d1 == 0<32> : bool)
   Class: Eq_4139
@@ -19667,36 +19336,36 @@ T_4146: (in 0<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4147: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_4148: (in d2 < 0<32> : bool)
   Class: Eq_4148
   DataType: bool
   OrigDataType: bool
-T_4149: (in d0_281 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4149: (in d0_281 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4150: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4151 (T_3944)))
 T_4151: (in __swap(d0) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4152: (in d1_282 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4152: (in d1_282 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4153: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4154 (T_3945)))
 T_4154: (in __swap(d1) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4155: (in d0_285 : uint32)
   Class: Eq_4155
@@ -19735,8 +19404,8 @@ T_4163: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4164 (T_4152)))
 T_4164: (in __swap(d1_282) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4165: (in SLICE(__swap(d1_282), word16, 0) : word16)
   Class: Eq_4165
@@ -19763,12 +19432,12 @@ T_4170: (in (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_4171: (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4172: (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4173: (in SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16) : word16)
   Class: Eq_4173
@@ -19787,8 +19456,8 @@ T_4176: (in (uint16) (d0_295 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_4177: (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4178: (in __swap : ptr32)
   Class: Eq_661
@@ -19811,12 +19480,12 @@ T_4182: (in 0<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4183: (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4184: (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4185: (in v41_64 : word16)
   Class: Eq_4185
@@ -19831,8 +19500,8 @@ T_4187: (in 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_4188: (in d6_17 * 2<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_4189: (in SLICE(d0_44, word16, 16) : word16)
   Class: Eq_4189
@@ -19863,28 +19532,28 @@ T_4195: (in d5_19 * 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_4196: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: up32
 T_4197: (in d6_17 < 0<32> : bool)
   Class: Eq_4197
   DataType: bool
   OrigDataType: bool
 T_4198: (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_4199: (in 2<32> : word32)
   Class: Eq_4199
   DataType: ui32
   OrigDataType: ui32
 T_4200: (in d7_13 * 2<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_4201: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_4202: (in d7_13 > 0<32> : bool)
   Class: Eq_4202
@@ -19898,9 +19567,9 @@ T_4204: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4213 (T_4212)))
-T_4205: (in d3_74 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4205: (in d3_74 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4206: (in SLICE(d3_74, uint16, 0) : uint16)
   Class: Eq_4206
@@ -19927,12 +19596,12 @@ T_4211: (in (uint16) (d5_19 /u SLICE(d3_74, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_4212: (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4213: (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4214: (in SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16) : word16)
   Class: Eq_4214
@@ -19943,24 +19612,24 @@ T_4215: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4216: (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4217: (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4218: (in d1_104 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: uint8
+T_4218: (in d1_104 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: (ptr32 Eq_1885)
 T_4219: (in 0xFFFF<32> : uipr32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: uipr32
-T_4220: (in d6_98 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4220: (in d6_98 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4221: (in __swap : ptr32)
   Class: Eq_661
@@ -19975,48 +19644,48 @@ T_4223: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4224: (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4225: (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4226: (in d6_133 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4226: (in d6_133 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4227: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4228 (T_4218)))
 T_4228: (in __swap(d1_104) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4229: (in d3_140 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4229: (in d3_140 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4230: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4231 (T_4226)))
 T_4231: (in __swap(d6_133) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4232: (in d4_142 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4232: (in d4_142 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4233: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4234 (T_4117)))
 T_4234: (in __swap(d7_13) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4235: (in d5_141 : uint32)
   Class: Eq_4235
@@ -20030,9 +19699,9 @@ T_4237: (in d7_13 * (word16) d3_140 : word32)
   Class: Eq_4235
   DataType: uint32
   OrigDataType: uint32
-T_4238: (in d6_146 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4238: (in d6_146 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4239: (in __swap : ptr32)
   Class: Eq_661
@@ -20043,12 +19712,12 @@ T_4240: (in SLICE(d7_13, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4241: (in d6_133 * (word16) d7_13 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4242: (in __swap(d6_133 * (word16) d7_13) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4243: (in v55_147 : cup16)
   Class: Eq_4243
@@ -20110,29 +19779,29 @@ T_4257: (in d3_140 * (word16) d4_142 : word32)
   Class: Eq_4255
   DataType: uint32
   OrigDataType: uint32
-T_4258: (in d6_178 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4258: (in d6_178 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4259: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4261 (T_4260)))
 T_4260: (in SEQ(v56_148, v59_155) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4261: (in __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4262: (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4263: (in d5_181 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4264: (in __swap : ptr32)
   Class: Eq_661
@@ -20147,12 +19816,12 @@ T_4266: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4267: (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4268: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4269: (in __swap : ptr32)
   Class: Eq_661
@@ -20167,12 +19836,12 @@ T_4271: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4272: (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4273: (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4274: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
   Class: Eq_4274
@@ -20223,20 +19892,20 @@ T_4285: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ
   DataType: uint32
   OrigDataType: uint32
 T_4286: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: up32
 T_4287: (in d6_178 <u 0<32> : bool)
   Class: Eq_4287
   DataType: Eq_4287
   OrigDataType: (union (bool u0) (uint32 u1))
 T_4288: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4289: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: up32
 T_4290: (in d5_181 >= 0<32> : bool)
   Class: Eq_4290
@@ -20267,12 +19936,12 @@ T_4296: (in 1<32> : word32)
   DataType: uipr32
   OrigDataType: uipr32
 T_4297: (in d1_104 - 1<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
-T_4298: (in d4_113 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4298: (in d4_113 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4299: (in __swap : ptr32)
   Class: Eq_661
@@ -20283,8 +19952,8 @@ T_4300: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4301 (T_4117)))
 T_4301: (in __swap(d7_13) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4302: (in SLICE(d1_104, word16, 0) : word16)
   Class: Eq_4302
@@ -20295,12 +19964,12 @@ T_4303: (in __swap(d7_13) * (word16) d1_104 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4304: (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4305: (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4306: (in wLoc22_442 : word16)
   Class: Eq_4306
@@ -20359,8 +20028,8 @@ T_4319: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4320 (T_4117)))
 T_4320: (in __swap(d7_13) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4321: (in SLICE(__swap(d7_13), word16, 16) : word16)
   Class: Eq_4321
@@ -20375,20 +20044,20 @@ T_4323: (in SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : uipr32)
   DataType: uipr32
   OrigDataType: uipr32
 T_4324: (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4325: (in 1<32> : word32)
   Class: Eq_4325
   DataType: uint32
   OrigDataType: uint32
 T_4326: (in d1_104 - 1<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4327: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: up32
 T_4328: (in d6_178 < 0<32> : bool)
   Class: Eq_4328
@@ -20411,20 +20080,20 @@ T_4332: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4333: (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4334: (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4335: (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_4336: (in d6_220 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4336: (in d6_220 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4337: (in __swap : ptr32)
   Class: Eq_661
@@ -20439,12 +20108,12 @@ T_4339: (in SLICE(d5_181, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4340: (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4341: (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4342: (in SLICE(dwLoc24, word16, 16) : word16)
   Class: Eq_4342
@@ -20455,20 +20124,20 @@ T_4343: (in SLICE(d1_104, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4344: (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
-T_4345: (in d5_221 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4345: (in d5_221 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4346: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4347 (T_4263)))
 T_4347: (in __swap(d5_181) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4348: (in v82_224 : word16)
   Class: Eq_4348
@@ -20486,29 +20155,29 @@ T_4351: (in v41_64 == 0<16> : bool)
   Class: Eq_4351
   DataType: bool
   OrigDataType: bool
-T_4352: (in d5_266 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4352: (in d5_266 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4353: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4354 (T_4263)))
 T_4354: (in __swap(d5_181) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4355: (in d6_267 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4355: (in d6_267 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4356: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4357 (T_4258)))
 T_4357: (in __swap(d6_178) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4358: (in SLICE(d5_266, word16, 16) : word16)
   Class: Eq_4358
@@ -20519,8 +20188,8 @@ T_4359: (in SLICE(d6_267, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4360: (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4361: (in SLICE(d6_267, word16, 16) : word16)
   Class: Eq_4361
@@ -20531,8 +20200,8 @@ T_4362: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4363: (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4364: (in true : bool)
   Class: Eq_4143
@@ -20546,25 +20215,25 @@ T_4366: (in SEQ(SLICE(d1_104, word16, 0), wLoc22_442) : word32)
   Class: Eq_4307
   DataType: word32
   OrigDataType: word32
-T_4367: (in d2_73 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4367: (in d2_73 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4368: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4369 (T_4129)))
 T_4369: (in __swap(d5_19) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4370: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4371 (T_4117)))
 T_4371: (in __swap(d7_13) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4372: (in d2_73 - d3_74 : word32)
   Class: Eq_4372
@@ -20603,8 +20272,8 @@ T_4380: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_4381: (in d5_221 >> 1<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4382: (in v86_241 : word16)
   Class: Eq_4382
@@ -20623,8 +20292,8 @@ T_4385: (in signature of __rcr : void)
   DataType: (ptr32 Eq_4384)
   OrigDataType: 
 T_4386: (in  : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: 
 T_4387: (in  : word32)
   Class: Eq_4387
@@ -20647,8 +20316,8 @@ T_4391: (in SLICE(cond(d5_221), bool, 4) : bool)
   DataType: bool
   OrigDataType: bool
 T_4392: (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4393: (in SLICE(d7_230, word16, 16) : word16)
   Class: Eq_4393
@@ -20674,49 +20343,49 @@ T_4398: (in v86_241 != 0<16> : bool)
   Class: Eq_4398
   DataType: bool
   OrigDataType: bool
-T_4399: (in d0 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4399: (in d0 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4400: (in d2 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4400: (in d2 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4401: (in dwArg04 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4401: (in dwArg04 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
-T_4402: (in dwArg08 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4402: (in dwArg08 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
 T_4403: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_4404: (in dwArg04 > 0<32> : bool)
   Class: Eq_4404
   DataType: bool
   OrigDataType: bool
 T_4405: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_4406: (in dwArg08 > 0<32> : bool)
   Class: Eq_4406
   DataType: bool
   OrigDataType: bool
-T_4407: (in d0_36 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4407: (in d0_36 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
 T_4408: (in -dwArg04 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
 T_4409: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_4410: (in dwArg08 > 0<32> : bool)
   Class: Eq_4410
@@ -20731,16 +20400,16 @@ T_4412: (in fn0000297A : ptr32)
   DataType: (ptr32 Eq_4120)
   OrigDataType: (ptr32 (fn T_4414 (T_4407, T_4402, T_4400, T_4413)))
 T_4413: (in out d1_43 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4414: (in fn0000297A(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4415: (in -fn0000297A(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4416: (in d1_55 : word32)
   Class: Eq_4416
@@ -20751,16 +20420,16 @@ T_4417: (in fn0000297A : ptr32)
   DataType: (ptr32 Eq_4120)
   OrigDataType: (ptr32 (fn T_4420 (T_4407, T_4418, T_4400, T_4419)))
 T_4418: (in -dwArg08 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
 T_4419: (in out d1_55 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4420: (in fn0000297A(d0_36, -dwArg08, d2, out d1_55) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4421: (in d1_88 : word32)
   Class: Eq_4421
@@ -20771,12 +20440,12 @@ T_4422: (in fn0000297A : ptr32)
   DataType: (ptr32 Eq_4120)
   OrigDataType: (ptr32 (fn T_4424 (T_4401, T_4402, T_4400, T_4423)))
 T_4423: (in out d1_88 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4424: (in fn0000297A(dwArg04, dwArg08, d2, out d1_88) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4425: (in d1_89 : word32)
   Class: Eq_4425
@@ -20787,32 +20456,32 @@ T_4426: (in fn0000297A : ptr32)
   DataType: (ptr32 Eq_4120)
   OrigDataType: (ptr32 (fn T_4429 (T_4401, T_4427, T_4400, T_4428)))
 T_4427: (in -dwArg08 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
 T_4428: (in out d1_89 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4429: (in fn0000297A(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4430: (in -fn0000297A(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4431: (in d1_22 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4431: (in d1_22 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4432: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4433 (T_4123)))
 T_4433: (in __swap(d1) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4434: (in v10_9 : word16)
   Class: Eq_4434
@@ -20830,13 +20499,13 @@ T_4437: (in SLICE(d2, word16, 16) : word16)
   Class: Eq_4436
   DataType: word16
   OrigDataType: word16
-T_4438: (in d2_11 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4438: (in d2_11 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4439: (in SEQ(v11_10, v10_9) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4440: (in 0<16> : word16)
   Class: Eq_4434
@@ -20846,13 +20515,13 @@ T_4441: (in v10_9 != 0<16> : bool)
   Class: Eq_4441
   DataType: bool
   OrigDataType: bool
-T_4442: (in d3_18 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: uint8
+T_4442: (in d3_18 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: (ptr32 Eq_1885)
 T_4443: (in 16<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_4444: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_4444
@@ -20866,29 +20535,29 @@ T_4446: (in (word16) d1_22 >= 0x80<16> : bool)
   Class: Eq_4446
   DataType: bool
   OrigDataType: bool
-T_4447: (in d0_134 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4447: (in d0_134 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4448: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4449 (T_4122)))
 T_4449: (in __swap(d0) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4450: (in d1_135 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4450: (in d1_135 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4451: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4452 (T_4431)))
 T_4452: (in __swap(d1_22) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4453: (in v14_137 : word16)
   Class: Eq_4453
@@ -20907,8 +20576,8 @@ T_4456: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4457 (T_4438)))
 T_4457: (in __swap(d2_11) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4458: (in SLICE(__swap(d2_11), word16, 16) : word16)
   Class: Eq_4458
@@ -20926,17 +20595,17 @@ T_4461: (in v14_137 == 0<16> : bool)
   Class: Eq_4461
   DataType: bool
   OrigDataType: bool
-T_4462: (in d0_150 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4462: (in d0_150 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4463: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4464 (T_4447)))
 T_4464: (in __swap(d0_134) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4465: (in d2_154 : uint32)
   Class: Eq_4465
@@ -20991,28 +20660,28 @@ T_4477: (in (uint16) (d2_154 % SLICE(d1_135, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_4478: (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4479: (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4480: (in SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0) : word16)
   Class: Eq_4480
   DataType: word16
   OrigDataType: word16
 T_4481: (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4482: (in SLICE(d0_150, word16, 16) : word16)
   Class: Eq_4482
   DataType: word16
   OrigDataType: word16
 T_4483: (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4484: (in v17_143 : uint16)
   Class: Eq_4484
@@ -21051,8 +20720,8 @@ T_4492: (in SLICE(d0_134, word16, 16) : word16)
   DataType: word16
   OrigDataType: word16
 T_4493: (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4494: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_4494
@@ -21071,16 +20740,16 @@ T_4497: (in __rol : ptr32)
   DataType: (ptr32 Eq_3956)
   OrigDataType: (ptr32 (fn T_4499 (T_4431, T_4498)))
 T_4498: (in 8<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4499: (in __rol(d1_22, 8<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4500: (in 8<32> : uipr32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: uipr32
 T_4501: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_4501
@@ -21099,12 +20768,12 @@ T_4504: (in __rol : ptr32)
   DataType: (ptr32 Eq_3956)
   OrigDataType: (ptr32 (fn T_4506 (T_4431, T_4505)))
 T_4505: (in 4<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4506: (in __rol(d1_22, 4<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4507: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_4507
@@ -21123,8 +20792,8 @@ T_4510: (in (word16) d3_18 - 4<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4511: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4512: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_4512
@@ -21143,12 +20812,12 @@ T_4515: (in __rol : ptr32)
   DataType: (ptr32 Eq_3956)
   OrigDataType: (ptr32 (fn T_4517 (T_4431, T_4516)))
 T_4516: (in 2<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4517: (in __rol(d1_22, 2<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4518: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_4518
@@ -21167,8 +20836,8 @@ T_4521: (in (word16) d3_18 - 2<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4522: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4523: (in d0_71 : uint32)
   Class: Eq_4523
@@ -21191,12 +20860,12 @@ T_4527: (in SLICE(d0, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4528: (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4529: (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4530: (in SLICE(__swap(SEQ(v11_10, (word16) d0)), word16, 16) : word16)
   Class: Eq_4530
@@ -21223,8 +20892,8 @@ T_4535: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4536 (T_4442)))
 T_4536: (in __swap(d3_18) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4537: (in SLICE(__swap(d3_18), word16, 16) : word16)
   Class: Eq_4534
@@ -21246,29 +20915,29 @@ T_4541: (in (uint16) (d0_71 /u SLICE(d1_22, uint16, 0)) : uint16)
   Class: Eq_4538
   DataType: uint16
   OrigDataType: uint16
-T_4542: (in d1_90 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4542: (in d1_90 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4543: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4544 (T_4431)))
 T_4544: (in __swap(d1_22) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4545: (in d3_102 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4545: (in d3_102 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4546: (in SEQ(v53_82, v51_79) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
-T_4547: (in d0_108 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4547: (in d0_108 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4548: (in SLICE(d1_22, uint16, 0) : uint16)
   Class: Eq_4548
@@ -21307,12 +20976,12 @@ T_4556: (in SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4557: (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4558: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: up32
 T_4559: (in d0_108 >= 0<32> : bool)
   Class: Eq_4559
@@ -21323,12 +20992,12 @@ T_4560: (in __rol : ptr32)
   DataType: (ptr32 Eq_3956)
   OrigDataType: (ptr32 (fn T_4562 (T_4431, T_4561)))
 T_4561: (in 1<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4562: (in __rol(d1_22, 1<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4563: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_4563
@@ -21347,8 +21016,8 @@ T_4566: (in (word16) d3_18 - 1<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4567: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4568: (in __swap : ptr32)
   Class: Eq_661
@@ -21363,16 +21032,16 @@ T_4570: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4571 (T_4545)))
 T_4571: (in __swap(d3_102) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4572: (in __rol(d0_108, __swap(d3_102)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4573: (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4574: (in SLICE(d3_102, word16, 0) : word16)
   Class: Eq_4574
@@ -21383,8 +21052,8 @@ T_4575: (in (uint16) SLICE(d3_102, word16, 0) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_4576: (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4577: (in 1<16> : word16)
   Class: Eq_4577
@@ -21395,36 +21064,36 @@ T_4578: (in v51_79 - 1<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4579: (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4580: (in d0_108 + d1_90 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4581: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: up32
 T_4582: (in d0_108 >= 0<32> : bool)
   Class: Eq_4582
   DataType: bool
   OrigDataType: bool
-T_4583: (in d1 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4583: (in d1 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4584: (in d1_171 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4584: (in d1_171 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_4585: (in d3_202 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4585: (in d3_202 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
 T_4586: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4587: (in dwArg0C != 0<32> : bool)
   Class: Eq_4587
@@ -21455,8 +21124,8 @@ T_4593: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_4594: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4595: (in dwArg10 != 0<32> : bool)
   Class: Eq_4595
@@ -21471,16 +21140,16 @@ T_4597: (in fn000027BC : ptr32)
   DataType: (ptr32 Eq_3942)
   OrigDataType: (ptr32 (fn T_4600 (T_2266, T_2267, T_2269, T_4598, T_4599)))
 T_4598: (in out d1_171 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4599: (in out d2_354 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4600: (in fn000027BC(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4601: (in d4_32 : int32)
   Class: Eq_4601
@@ -21490,21 +21159,21 @@ T_4602: (in 24<i32> : int32)
   Class: Eq_4601
   DataType: int32
   OrigDataType: int32
-T_4603: (in d6_33 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4603: (in d6_33 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uip32
 T_4604: (in __rol : ptr32)
   Class: Eq_3956
   DataType: (ptr32 Eq_3956)
   OrigDataType: (ptr32 (fn T_4606 (T_2268, T_4605)))
 T_4605: (in 8<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4606: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4607: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4607
@@ -21607,12 +21276,12 @@ T_4631: (in __rol : ptr32)
   DataType: (ptr32 Eq_3956)
   OrigDataType: (ptr32 (fn T_4633 (T_4603, T_4632)))
 T_4632: (in 8<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4633: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4634: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4634
@@ -21635,12 +21304,12 @@ T_4638: (in __rol : ptr32)
   DataType: (ptr32 Eq_3956)
   OrigDataType: (ptr32 (fn T_4640 (T_4603, T_4639)))
 T_4639: (in 8<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_4640: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4641: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4641
@@ -21667,8 +21336,8 @@ T_4646: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_4647: (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uip32
 T_4648: (in d1_89 : ui32)
   Class: Eq_4648
@@ -21678,17 +21347,17 @@ T_4649: (in d2_90 : word32)
   Class: Eq_4649
   DataType: word32
   OrigDataType: word32
-T_4650: (in d0_88 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4650: (in d0_88 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4651: (in fn000027BC : ptr32)
   Class: Eq_3942
   DataType: (ptr32 Eq_3942)
   OrigDataType: (ptr32 (fn T_4661 (T_4652, T_4655, T_4658, T_4659, T_4660)))
 T_4652: (in dwArg04 >> d4_64 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4653: (in dwArg04 << d5_66 : word32)
   Class: Eq_4653
@@ -21699,8 +21368,8 @@ T_4654: (in dwArg08 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4655: (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_4656: (in dwArg0C << d5_66 : word32)
   Class: Eq_4656
@@ -21711,52 +21380,52 @@ T_4657: (in dwArg10 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4658: (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_4659: (in out d1_89 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4660: (in out d2_90 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4661: (in fn000027BC(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4662: (in d3_75 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4662: (in d3_75 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4663: (in dwArg10 << d5_66 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
-T_4664: (in d7_104 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4664: (in d7_104 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4665: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4666 (T_4650)))
 T_4666: (in __swap(d0_88) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4667: (in d6_106 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4667: (in d6_106 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4668: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4669 (T_4662)))
 T_4669: (in __swap(d3_75) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4670: (in d3_105 : uint32)
   Class: Eq_4670
@@ -21770,9 +21439,9 @@ T_4672: (in d3_75 * (word16) d7_104 : word32)
   Class: Eq_4670
   DataType: uint32
   OrigDataType: uint32
-T_4673: (in d2_110 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4673: (in d2_110 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4674: (in __swap : ptr32)
   Class: Eq_661
@@ -21783,12 +21452,12 @@ T_4675: (in SLICE(d3_75, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4676: (in d0_88 * (word16) d3_75 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4677: (in __swap(d0_88 * (word16) d3_75) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4678: (in v36_111 : cup16)
   Class: Eq_4678
@@ -21838,21 +21507,21 @@ T_4689: (in SLICE(SEQ(v37_112, v36_111) + d4_107, word16, 0) : word16)
   Class: Eq_4686
   DataType: cup16
   OrigDataType: word16
-T_4690: (in d2_127 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4690: (in d2_127 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_4691: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4693 (T_4692)))
 T_4692: (in SEQ(v37_112, v40_119) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4693: (in __swap(SEQ(v37_112, v40_119)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4694: (in d7_108 : uint32)
   Class: Eq_4694
@@ -21891,12 +21560,12 @@ T_4702: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4703: (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4704: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4705: (in __swap : ptr32)
   Class: Eq_661
@@ -21911,12 +21580,12 @@ T_4707: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4708: (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4709: (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4710: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
   Class: Eq_4710
@@ -21991,8 +21660,8 @@ T_4727: (in dwArg0C - dwArg04 < 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_4728: (in dwArg08 - dwArg10 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4729: (in dwArg10 - dwArg08 : word32)
   Class: Eq_4729
@@ -22006,33 +21675,33 @@ T_4731: (in dwArg10 - dwArg08 > 0<32> : bool)
   Class: Eq_4731
   DataType: bool
   OrigDataType: bool
-T_4732: (in d1_211 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4732: (in d1_211 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_4733: (in d2_212 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4733: (in d2_212 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4734: (in fn000027BC : ptr32)
   Class: Eq_3942
   DataType: (ptr32 Eq_3942)
   OrigDataType: (ptr32 (fn T_4738 (T_4735, T_2266, T_4585, T_4736, T_4737)))
 T_4735: (in 0<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_4736: (in out d1_211 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4737: (in out d2_212 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4738: (in fn000027BC(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4739: (in d2_355 : word32)
   Class: Eq_4739
@@ -22043,16 +21712,16 @@ T_4740: (in fn000027BC : ptr32)
   DataType: (ptr32 Eq_3942)
   OrigDataType: (ptr32 (fn T_4743 (T_4732, T_2267, T_4733, T_4741, T_4742)))
 T_4741: (in out d1_171 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: (union (uint32 u0) (ptr32 u1))
 T_4742: (in out d2_355 : ptr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4743: (in fn000027BC(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4744: (in 1<i32> : int32)
   Class: Eq_4744
@@ -22095,8 +21764,8 @@ T_4753: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_4754: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
 T_4755: (in d3_135 - d3_75 : word32)
   Class: Eq_4699
@@ -22115,8 +21784,8 @@ T_4758: (in d3_135 < 0<32> : bool)
   DataType: Eq_4758
   OrigDataType: (union (bool u0) (word32 u1))
 T_4759: (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4760: (in 0<32> : word32)
   Class: Eq_4721
@@ -22167,8 +21836,8 @@ T_4771: (in d6_157 >> d5_66 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4772: (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_4773: (in d6_85 - d3_135 : word32)
   Class: Eq_4773
@@ -22342,10 +22011,10 @@ T_4815: (in d1 : Eq_603)
   Class: Eq_603
   DataType: Eq_603
   OrigDataType: uint32
-T_4816: (in a1 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: Eq_8477
+T_4816: (in a1 : (ptr32 (ptr32 byte)))
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: (ptr32 (struct (0 T_5238 t0000)))
 T_4817: (in dwArg04 : Eq_603)
   Class: Eq_603
   DataType: Eq_603
@@ -22354,9 +22023,9 @@ T_4818: (in dwArg08 : (ptr32 Eq_614))
   Class: Eq_614
   DataType: (ptr32 Eq_614)
   OrigDataType: (ptr32 (struct (0 T_4874 t0000)))
-T_4819: (in dwArg0C : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4819: (in dwArg0C : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4820: (in 00004254 : ptr32)
   Class: Eq_4820
@@ -22375,8 +22044,8 @@ T_4823: (in 8<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4824: (in fp + 8<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_4825: (in fn00002E8C(d0, d1, a1, *(union Eq_603 *) 0x4254<u32>, dwArg04, fp + 8<i32>) : word32)
   Class: Eq_603
@@ -22386,9 +22055,9 @@ T_4826: (in d0 : Eq_603)
   Class: Eq_603
   DataType: Eq_603
   OrigDataType: word32
-T_4827: (in bArg07 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_4827: (in bArg07 : byte)
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_4828: (in dwArg08 : Eq_603)
   Class: Eq_603
@@ -22400,7 +22069,7 @@ T_4829: (in d0_10 : Eq_603)
   OrigDataType: up32
 T_4830: (in 0<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4831: (in dwArg08 == 0<32> : bool)
   Class: Eq_4831
@@ -22519,13 +22188,13 @@ T_4859: (in Mem5[dwArg08 + 4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_4860: (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_603
+  Class: Eq_4827
   DataType: Eq_603
   OrigDataType: byte
-T_4861: (in a7_1330 : Eq_4861)
+T_4861: (in a7_1330 : (ptr32 Eq_4861))
   Class: Eq_4861
-  DataType: Eq_4861
-  OrigDataType: word32
+  DataType: (ptr32 Eq_4861)
+  OrigDataType: (ptr32 (struct 0004 (2C int32 dw002C) (30 (union ((ptr32 (ptr32 Eq_4868)) u0) (T_7231 u1) (T_7297 u2) (T_7817 u3)) u0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 (union ((ptr32 (ptr32 Eq_4868)) u0) (T_7164 u1) (T_7231 u2) (T_7235 u3) (T_7293 u4)) u0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084)))
 T_4862: (in fp : ptr32)
   Class: Eq_4862
   DataType: ptr32
@@ -22536,12 +22205,12 @@ T_4863: (in -120<i32> : int32)
   OrigDataType: int32
 T_4864: (in fp + -120<i32> : word32)
   Class: Eq_4861
-  DataType: Eq_4861
+  DataType: (ptr32 Eq_4861)
   OrigDataType: ptr32
-T_4865: (in d2_1090 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: Eq_4861
+T_4865: (in d2_1090 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: (struct "Eq_4861" 0004 (2C int32 dw002C) (30 Eq_8971 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8972 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_4866: (in a4_274 : (ptr32 Eq_614))
   Class: Eq_614
   DataType: (ptr32 Eq_614)
@@ -22549,7 +22218,7 @@ T_4866: (in a4_274 : (ptr32 Eq_614))
 T_4867: (in a2_1014 : Eq_603)
   Class: Eq_603
   DataType: Eq_603
-  OrigDataType: Eq_8373
+  OrigDataType: (ptr32 Eq_603)
 T_4868: (in d4_132 : Eq_4868)
   Class: Eq_4868
   DataType: Eq_4868
@@ -22561,10 +22230,10 @@ T_4869: (in 0<i32> : int32)
 T_4870: (in d5_1044 : Eq_603)
   Class: Eq_603
   DataType: Eq_603
-  OrigDataType: Eq_4861
+  OrigDataType: (struct "Eq_4861" 0004 (2C int32 dw002C) (30 Eq_8971 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8972 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_4871: (in 0<i32> : int32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_4872: (in 0<32> : word32)
   Class: Eq_4872
@@ -22589,10 +22258,10 @@ T_4876: (in dwArg08->b0000 == 0<8> : bool)
 T_4877: (in d0_3698 : Eq_603)
   Class: Eq_603
   DataType: Eq_603
-  OrigDataType: uint8
+  OrigDataType: byte
 T_4878: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4879: (in d5_1044 != 0xFFFFFFFF<32> : bool)
   Class: Eq_4879
@@ -22716,7 +22385,7 @@ T_4908: (in a7_1330 + 72<i32> : word32)
   OrigDataType: ptr32
 T_4909: (in Mem277[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4906
-  DataType: Eq_4861
+  DataType: byte
   OrigDataType: byte
 T_4910: (in 0<8> : byte)
   Class: Eq_4910
@@ -22732,7 +22401,7 @@ T_4912: (in a7_1330 + 73<i32> : word32)
   OrigDataType: ptr32
 T_4913: (in Mem278[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_4910
-  DataType: Eq_4861
+  DataType: byte
   OrigDataType: byte
 T_4914: (in a3_279 : (ptr32 byte))
   Class: Eq_4914
@@ -22790,13 +22459,13 @@ T_4927: (in (uint32) (uint8) Mem278[0x00002B15<p32> + (uint32) ((uint8) Mem278[a
   Class: Eq_4917
   DataType: uint32
   OrigDataType: uint32
-T_4928: (in d6_1133 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: uint8
+T_4928: (in d6_1133 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: (ptr32 Eq_1885)
 T_4929: (in -1<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_4930: (in 4<32> : word32)
   Class: Eq_4930
@@ -22883,8 +22552,8 @@ T_4950: (in (uint32) (uint8) Mem278[0x00002B15<p32> + (uint32) ((uint8) Mem278[a
   DataType: uint32
   OrigDataType: uint32
 T_4951: (in 0<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_4952: (in 4<32> : word32)
   Class: Eq_4952
@@ -22906,9 +22575,9 @@ T_4956: (in (d0_305 & 4<32>) == 0<32> : bool)
   Class: Eq_4956
   DataType: bool
   OrigDataType: bool
-T_4957: (in a7_313 : (ptr32 Eq_603))
+T_4957: (in a7_313 : (ptr32 Eq_663))
   Class: Eq_4957
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_663 t0000)))
 T_4958: (in 4<i32> : int32)
   Class: Eq_4958
@@ -22916,7 +22585,7 @@ T_4958: (in 4<i32> : int32)
   OrigDataType: int32
 T_4959: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4957
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: ptr32
 T_4960: (in 0<32> : word32)
   Class: Eq_4960
@@ -22927,8 +22596,8 @@ T_4961: (in a7_313 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4962: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4963: (in d1_322 : uint32)
   Class: Eq_4963
@@ -22939,12 +22608,12 @@ T_4964: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4966 (T_4965)))
 T_4965: (in 10<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_4966: (in __swap(10<i32>) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4967: (in SLICE(d6_1133, word16, 0) : word16)
   Class: Eq_4967
@@ -22983,8 +22652,8 @@ T_4975: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_4976 (T_4928)))
 T_4976: (in __swap(d6_1133) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_4977: (in 0xA<16> : word16)
   Class: Eq_4977
@@ -23003,12 +22672,12 @@ T_4980: (in SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4981: (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_4982: (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_4983: (in SLICE(__swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_4983
@@ -23111,8 +22780,8 @@ T_5007: (in a7_313 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5008: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_5009: (in 0x30<32> : word32)
   Class: Eq_5009
@@ -23127,8 +22796,8 @@ T_5011: (in d1_340 - 0x30<32> : word32)
   DataType: uint32
   OrigDataType: uint32
 T_5012: (in d1_340 - 0x30<32> + d0_331 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_5013: (in 4<32> : word32)
   Class: Eq_5013
@@ -23330,7 +22999,7 @@ T_5062: (in 0x6A<8> : byte)
   Class: Eq_5061
   DataType: byte
   OrigDataType: byte
-T_5063: (in *((word32) a7_1330 + 72<i32>) != 0x6A<8> : bool)
+T_5063: (in a7_1330[18<i32>] != 0x6A<8> : bool)
   Class: Eq_5063
   DataType: bool
   OrigDataType: bool
@@ -23380,7 +23049,7 @@ T_5074: (in *a3_279 == 0x68<8> : bool)
   OrigDataType: bool
 T_5075: (in 0<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5076: (in false : bool)
   Class: Eq_5076
@@ -23420,7 +23089,7 @@ T_5084: (in *a3_279 != 0x68<8> : bool)
   OrigDataType: bool
 T_5085: (in 2<i32> : int32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_5086: (in 0<32> : word32)
   Class: Eq_5086
@@ -23576,7 +23245,7 @@ T_5123: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5124: (in Mem463[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_5121
-  DataType: Eq_4861
+  DataType: byte
   OrigDataType: byte
 T_5125: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_5125
@@ -23592,7 +23261,7 @@ T_5127: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5128: (in Mem469[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_5125
-  DataType: Eq_4861
+  DataType: byte
   OrigDataType: byte
 T_5129: (in SLICE(d1, word24, 8) : word24)
   Class: Eq_5129
@@ -23636,7 +23305,7 @@ T_5138: (in *a3_279 != 0x6C<8> : bool)
   OrigDataType: bool
 T_5139: (in 1<i32> : int32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_5140: (in 72<i32> : int32)
   Class: Eq_5140
@@ -23654,7 +23323,7 @@ T_5143: (in 0x74<8> : byte)
   Class: Eq_5142
   DataType: byte
   OrigDataType: byte
-T_5144: (in *((word32) a7_1330 + 72<i32>) != 0x74<8> : bool)
+T_5144: (in a7_1330[18<i32>] != 0x74<8> : bool)
   Class: Eq_5144
   DataType: bool
   OrigDataType: bool
@@ -23672,7 +23341,7 @@ T_5147: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5148: (in Mem477[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_5145
-  DataType: Eq_4861
+  DataType: byte
   OrigDataType: byte
 T_5149: (in 72<i32> : int32)
   Class: Eq_5149
@@ -23690,7 +23359,7 @@ T_5152: (in 0x7A<8> : byte)
   Class: Eq_5151
   DataType: byte
   OrigDataType: byte
-T_5153: (in *((word32) a7_1330 + 72<i32>) != 0x7A<8> : bool)
+T_5153: (in a7_1330[18<i32>] != 0x7A<8> : bool)
   Class: Eq_5153
   DataType: bool
   OrigDataType: bool
@@ -23708,7 +23377,7 @@ T_5156: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5157: (in Mem485[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_5154
-  DataType: Eq_4861
+  DataType: byte
   OrigDataType: byte
 T_5158: (in v83_500 : byte)
   Class: Eq_5158
@@ -23772,7 +23441,7 @@ T_5172: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5173: (in Mem493[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_5170
-  DataType: Eq_4861
+  DataType: byte
   OrigDataType: byte
 T_5174: (in v147_608 : word24)
   Class: Eq_5174
@@ -24027,8 +23696,8 @@ T_5236: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5237: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5238: (in a0_551 : (ptr32 byte))
   Class: Eq_5238
@@ -24088,8 +23757,8 @@ T_5251: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_5252: (in Mem558[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: word32
 T_5253: (in v96_562 : byte)
   Class: Eq_5253
   DataType: byte
@@ -24483,8 +24152,8 @@ T_5350: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5351: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5352: (in a0_198 : (ptr32 byte))
   Class: Eq_5238
@@ -24544,8 +24213,8 @@ T_5365: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_5366: (in Mem205[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_5367: (in v109_209 : byte)
   Class: Eq_5253
   DataType: byte
@@ -24668,7 +24337,7 @@ T_5396: (in 1<i32> : int32)
   OrigDataType: int32
 T_5397: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5398: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5398
@@ -24744,7 +24413,7 @@ T_5415: (in 1<i32> : int32)
   OrigDataType: int32
 T_5416: (in a7_248 - 1<i32> : word32)
   Class: Eq_5416
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5419 t0000)))
 T_5417: (in 0<32> : word32)
   Class: Eq_5417
@@ -24755,8 +24424,8 @@ T_5418: (in a7_248 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5419: (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_5420: (in 0<32> : word32)
   Class: Eq_5420
@@ -24859,8 +24528,8 @@ T_5444: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5445: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5446: (in a0_98 : (ptr32 byte))
   Class: Eq_5238
@@ -24920,8 +24589,8 @@ T_5459: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_5460: (in Mem105[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_5461: (in v130_109 : byte)
   Class: Eq_5253
   DataType: byte
@@ -25074,7 +24743,7 @@ T_5498: (in Mem127[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_5498
   DataType: int32
   OrigDataType: int32
-T_5499: (in d0 - *((word32) a7_1330 + 44<i32>) : word32)
+T_5499: (in d0 - a7_1330[11<i32>] : word32)
   Class: Eq_5499
   DataType: int32
   OrigDataType: int32
@@ -25082,7 +24751,7 @@ T_5500: (in 0<32> : word32)
   Class: Eq_5499
   DataType: int32
   OrigDataType: word32
-T_5501: (in d0 - *((word32) a7_1330 + 44<i32>) == 0<32> : bool)
+T_5501: (in d0 - a7_1330[11<i32>] == 0<32> : bool)
   Class: Eq_5501
   DataType: bool
   OrigDataType: bool
@@ -25108,7 +24777,7 @@ T_5506: (in a4_274->b0000 != 0<8> : bool)
   OrigDataType: bool
 T_5507: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5508: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5508
@@ -25180,7 +24849,7 @@ T_5524: (in 1<i32> : int32)
   OrigDataType: int32
 T_5525: (in a7_148 - 1<i32> : word32)
   Class: Eq_5525
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5528 t0000)))
 T_5526: (in 0<32> : word32)
   Class: Eq_5526
@@ -25191,8 +24860,8 @@ T_5527: (in a7_148 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5528: (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_5529: (in 0<32> : word32)
   Class: Eq_5529
@@ -25332,8 +25001,8 @@ T_5562: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5563: (in Mem761[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_5560
-  DataType: Eq_4861
-  OrigDataType: byte
+  DataType: Eq_5560
+  OrigDataType: int32
 T_5564: (in 0<32> : word32)
   Class: Eq_5564
   DataType: word32
@@ -25375,8 +25044,8 @@ T_5573: (in v83_500 == 0x63<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_5574: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: word32
 T_5575: (in d6_1133 != 0xFFFFFFFF<32> : bool)
   Class: Eq_5575
@@ -25414,7 +25083,7 @@ T_5583: (in 0<8> : byte)
   Class: Eq_5582
   DataType: byte
   OrigDataType: byte
-T_5584: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5584: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5584
   DataType: bool
   OrigDataType: bool
@@ -25454,7 +25123,7 @@ T_5593: (in 0<8> : byte)
   Class: Eq_5592
   DataType: byte
   OrigDataType: byte
-T_5594: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5594: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5594
   DataType: bool
   OrigDataType: bool
@@ -25472,7 +25141,7 @@ T_5597: (in a7_1330 + 48<i32> : word32)
   OrigDataType: ptr32
 T_5598: (in Mem1948[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_5595
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
 T_5599: (in 0<32> : word32)
   Class: Eq_5599
@@ -25488,7 +25157,7 @@ T_5601: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5602: (in Mem1949[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_5599
-  DataType: Eq_4861
+  DataType: int32
   OrigDataType: int32
 T_5603: (in 0<32> : word32)
   Class: Eq_5603
@@ -25504,7 +25173,7 @@ T_5605: (in a7_1330 + 110<i32> : word32)
   OrigDataType: ptr32
 T_5606: (in Mem1950[a7_1330 + 110<i32>:word32] : word32)
   Class: Eq_5603
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
 T_5607: (in 0<8> : byte)
   Class: Eq_5158
@@ -25591,8 +25260,8 @@ T_5627: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5628: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5629: (in a0_659 : (ptr32 byte))
   Class: Eq_5238
@@ -25652,8 +25321,8 @@ T_5642: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_5643: (in Mem666[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_5644: (in v163_670 : byte)
   Class: Eq_5253
   DataType: byte
@@ -25778,7 +25447,7 @@ T_5674: (in 0x25<32> : word32)
   Class: Eq_5673
   DataType: int32
   OrigDataType: word32
-T_5675: (in *((word32) a7_1330 + 44<i32>) == 0x25<32> : bool)
+T_5675: (in a7_1330[11<i32>] == 0x25<32> : bool)
   Class: Eq_5675
   DataType: bool
   OrigDataType: bool
@@ -25800,7 +25469,7 @@ T_5679: (in a3_1955 - 1<i32> : word32)
   OrigDataType: ptr32
 T_5680: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5681: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5681
@@ -25876,7 +25545,7 @@ T_5698: (in 1<i32> : int32)
   OrigDataType: int32
 T_5699: (in a7_735 - 1<i32> : word32)
   Class: Eq_5699
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5702 t0000)))
 T_5700: (in 0<32> : word32)
   Class: Eq_5700
@@ -25887,8 +25556,8 @@ T_5701: (in a7_735 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5702: (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_5703: (in 0<32> : word32)
   Class: Eq_5703
@@ -25916,7 +25585,7 @@ T_5708: (in d3_130 == 0<32> : bool)
   OrigDataType: bool
 T_5709: (in 0x2D<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5710: (in d5_1044 != 0x2D<32> : bool)
   Class: Eq_5710
@@ -25936,7 +25605,7 @@ T_5713: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5714: (in Mem1962[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_5711
-  DataType: Eq_4861
+  DataType: byte
   OrigDataType: byte
 T_5715: (in 120<i32> : int32)
   Class: Eq_5018
@@ -25975,8 +25644,8 @@ T_5723: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5724: (in d0 + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
 T_5725: (in 0<32> : word32)
   Class: Eq_5725
@@ -25992,7 +25661,7 @@ T_5727: (in Mem629[d0 + 0<32>:word32] : word32)
   OrigDataType: word32
 T_5728: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5729: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5729
@@ -26024,7 +25693,7 @@ T_5735: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5736: (in Mem1716[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_5734
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
 T_5737: (in 1<i32> : int32)
   Class: Eq_4880
@@ -26046,7 +25715,7 @@ T_5741: (in 1<8> : byte)
   Class: Eq_5740
   DataType: byte
   OrigDataType: byte
-T_5742: (in *((word32) a7_1330 + 72<i32>) != 1<8> : bool)
+T_5742: (in a7_1330[18<i32>] != 1<8> : bool)
   Class: Eq_5742
   DataType: bool
   OrigDataType: bool
@@ -26066,13 +25735,13 @@ T_5746: (in 0x6C<8> : byte)
   Class: Eq_5745
   DataType: byte
   OrigDataType: byte
-T_5747: (in *((word32) a7_1330 + 72<i32>) != 0x6C<8> : bool)
+T_5747: (in a7_1330[18<i32>] != 0x6C<8> : bool)
   Class: Eq_5747
   DataType: bool
   OrigDataType: bool
 T_5748: (in 3<32> : word32)
   Class: Eq_5748
-  DataType: (ptr32 Eq_8984)
+  DataType: (ptr32 Eq_8975)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5749: (in d2_1090 + 3<32> : word32)
   Class: Eq_5749
@@ -26143,12 +25812,12 @@ T_5765: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5766: (in d0 + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_5767: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5768: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5768
@@ -26390,17 +26059,17 @@ T_5827: (in 0x68<8> : byte)
   Class: Eq_5826
   DataType: byte
   OrigDataType: byte
-T_5828: (in *((word32) a7_1330 + 72<i32>) != 0x68<8> : bool)
+T_5828: (in a7_1330[18<i32>] != 0x68<8> : bool)
   Class: Eq_5828
   DataType: bool
   OrigDataType: bool
 T_5829: (in 3<32> : word32)
   Class: Eq_5829
-  DataType: (ptr32 Eq_8985)
+  DataType: (ptr32 Eq_8976)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5830: (in d2_1090 + 3<32> : word32)
   Class: Eq_5830
-  DataType: (ptr32 Eq_8986)
+  DataType: (ptr32 Eq_8977)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5831: (in 2<32> : word32)
   Class: Eq_5831
@@ -26447,8 +26116,8 @@ T_5841: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5842: (in d0 + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_5843: (in a7_1807 : (ptr32 Eq_603))
   Class: Eq_5843
@@ -26515,8 +26184,8 @@ T_5858: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5859: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5860: (in a0_1825 : (ptr32 byte))
   Class: Eq_5238
@@ -26576,8 +26245,8 @@ T_5873: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_5874: (in Mem1832[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_5875: (in v201_1836 : byte)
   Class: Eq_5253
   DataType: byte
@@ -26640,7 +26309,7 @@ T_5889: (in d4_132 + 1<32> : word32)
   OrigDataType: int32
 T_5890: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5891: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5891
@@ -26662,17 +26331,17 @@ T_5895: (in 2<8> : byte)
   Class: Eq_5894
   DataType: byte
   OrigDataType: byte
-T_5896: (in *((word32) a7_1330 + 72<i32>) != 2<8> : bool)
+T_5896: (in a7_1330[18<i32>] != 2<8> : bool)
   Class: Eq_5896
   DataType: bool
   OrigDataType: bool
 T_5897: (in 3<32> : word32)
   Class: Eq_5897
-  DataType: (ptr32 Eq_8987)
+  DataType: (ptr32 Eq_8978)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5898: (in d2_1090 + 3<32> : word32)
   Class: Eq_5898
-  DataType: (ptr32 Eq_8988)
+  DataType: (ptr32 Eq_8979)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5899: (in 2<32> : word32)
   Class: Eq_5899
@@ -26723,8 +26392,8 @@ T_5910: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5911: (in d0 + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_5912: (in 73<i32> : int32)
   Class: Eq_5912
@@ -26736,7 +26405,7 @@ T_5913: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5914: (in Mem1889[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_5788
-  DataType: Eq_4861
+  DataType: byte
   OrigDataType: byte
 T_5915: (in d0_1871 : uint32)
   Class: Eq_5915
@@ -26824,11 +26493,11 @@ T_5935: (in v190_1777 != 0<8> : bool)
   OrigDataType: bool
 T_5936: (in 3<32> : word32)
   Class: Eq_5936
-  DataType: (ptr32 Eq_8989)
+  DataType: (ptr32 Eq_8980)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5937: (in d2_1090 + 3<32> : word32)
   Class: Eq_5937
-  DataType: (ptr32 Eq_8990)
+  DataType: (ptr32 Eq_8981)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5938: (in 2<32> : word32)
   Class: Eq_5938
@@ -26875,16 +26544,16 @@ T_5948: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5949: (in d0 + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_5950: (in 3<32> : word32)
   Class: Eq_5950
-  DataType: (ptr32 Eq_8991)
+  DataType: (ptr32 Eq_8982)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5951: (in d2_1090 + 3<32> : word32)
   Class: Eq_5951
-  DataType: (ptr32 Eq_8992)
+  DataType: (ptr32 Eq_8983)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5952: (in 2<32> : word32)
   Class: Eq_5952
@@ -26935,8 +26604,8 @@ T_5963: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5964: (in d0 + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_5965: (in 1<32> : word32)
   Class: Eq_5965
@@ -26970,7 +26639,7 @@ T_5972: (in 0<8> : byte)
   Class: Eq_5971
   DataType: byte
   OrigDataType: byte
-T_5973: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5973: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5973
   DataType: bool
   OrigDataType: bool
@@ -27028,7 +26697,7 @@ T_5986: (in 1<i32> : int32)
   OrigDataType: int32
 T_5987: (in a7_1897 - 1<i32> : word32)
   Class: Eq_5987
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5990 t0000)))
 T_5988: (in 0<32> : word32)
   Class: Eq_5988
@@ -27039,8 +26708,8 @@ T_5989: (in a7_1897 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5990: (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_5991: (in 0<32> : word32)
   Class: Eq_5991
@@ -27060,7 +26729,7 @@ T_5994: (in fn00002E5C(*(a7_1897 - 1<i32>), *a7_1897) : word32)
   OrigDataType: word32
 T_5995: (in 0x2B<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5996: (in d5_1044 != 0x2B<32> : bool)
   Class: Eq_5996
@@ -27112,8 +26781,8 @@ T_6007: (in a7_1330 + 110<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6008: (in Mem1994[a7_1330 + 110<i32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_4861
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_6009: (in a0_1999 : (ptr32 ui32))
   Class: Eq_6009
   DataType: (ptr32 ui32)
@@ -27291,8 +26960,8 @@ T_6052: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_6053: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6054: (in a0_2026 : (ptr32 byte))
   Class: Eq_5238
@@ -27352,8 +27021,8 @@ T_6067: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_6068: (in Mem2033[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_6069: (in v231_2037 : byte)
   Class: Eq_5253
   DataType: byte
@@ -27512,7 +27181,7 @@ T_6107: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6108: (in Mem1946[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_6106
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
 T_6109: (in d4_2510 : Eq_4868)
   Class: Eq_4868
@@ -27536,7 +27205,7 @@ T_6113: (in (byte) d7 != 0x78<8> : bool)
   OrigDataType: bool
 T_6114: (in 0x30<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6115: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_6115
@@ -27799,8 +27468,8 @@ T_6179: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_6180: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6181: (in a0_2167 : (ptr32 byte))
   Class: Eq_5238
@@ -27860,8 +27529,8 @@ T_6194: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_6195: (in Mem2174[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_6196: (in v249_2178 : byte)
   Class: Eq_5253
   DataType: byte
@@ -27980,12 +27649,12 @@ T_6224: (in 55<i32> : int32)
   OrigDataType: int32
 T_6225: (in a7_1330 + 55<i32> : word32)
   Class: Eq_6225
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_6226: (in Mem2199[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_6226
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_6227: (in SEQ(SLICE(d0_2155, word24, 8), Mem2199[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_6222
   DataType: ui32
@@ -28078,17 +27747,17 @@ T_6249: (in 0<8> : byte)
   Class: Eq_6248
   DataType: byte
   OrigDataType: byte
-T_6250: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_6250: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_6250
   DataType: bool
   OrigDataType: bool
 T_6251: (in 1<i32> : int32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: int32
 T_6252: (in 0x78<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6253: (in d0 != 0x78<32> : bool)
   Class: Eq_6253
@@ -28128,11 +27797,11 @@ T_6261: (in 0<32> : word32)
   OrigDataType: word32
 T_6262: (in 3<32> : word32)
   Class: Eq_6262
-  DataType: (ptr32 Eq_8993)
+  DataType: (ptr32 Eq_8984)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_6263: (in d2_1090 + 3<32> : word32)
   Class: Eq_6263
-  DataType: (ptr32 Eq_8994)
+  DataType: (ptr32 Eq_8985)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_6264: (in 2<32> : word32)
   Class: Eq_6264
@@ -28155,8 +27824,8 @@ T_6268: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_6269: (in d0 + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ptr32
 T_6270: (in 0<32> : word32)
   Class: Eq_6270
@@ -28268,8 +27937,8 @@ T_6296: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_6297: (in Mem1393[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_6245
-  DataType: Eq_4861
-  OrigDataType: (ptr32 Eq_4868)
+  DataType: (ptr32 Eq_4868)
+  OrigDataType: int32
 T_6298: (in 0<32> : word32)
   Class: Eq_6298
   DataType: word32
@@ -28487,8 +28156,8 @@ T_6351: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_6352: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6353: (in a0_2265 : (ptr32 byte))
   Class: Eq_5238
@@ -28548,8 +28217,8 @@ T_6366: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_6367: (in Mem2272[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_6368: (in v271_2276 : byte)
   Class: Eq_5253
   DataType: byte
@@ -29007,8 +28676,8 @@ T_6481: (in a7_1330 + 44<i32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_6482: (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: int32
 T_6483: (in 52<i32> : int32)
   Class: Eq_6483
@@ -29062,7 +28731,7 @@ T_6495: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6494
   DataType: word32
   OrigDataType: word32
-T_6496: (in *((word32) a7_1330 + 52<i32>) == 0xFFFFFFFF<32> : bool)
+T_6496: (in a7_1330[13<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6496
   DataType: bool
   OrigDataType: bool
@@ -29082,7 +28751,7 @@ T_6500: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6499
   DataType: word32
   OrigDataType: word32
-T_6501: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_6501: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_6501
   DataType: bool
   OrigDataType: bool
@@ -29112,7 +28781,7 @@ T_6507: (in 120<i32> : int32)
   OrigDataType: int32
 T_6508: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6509: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6509
@@ -29127,9 +28796,9 @@ T_6511: (in a7_1330 + 44<i32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_6512: (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_4861
-  OrigDataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: int32
 T_6513: (in d6_1133 - d3_1462 : word32)
   Class: Eq_6513
   DataType: Eq_6513
@@ -29368,7 +29037,7 @@ T_6571: (in 1<i32> : int32)
   OrigDataType: int32
 T_6572: (in a7_2334 - 1<i32> : word32)
   Class: Eq_6572
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6575 t0000)))
 T_6573: (in 0<32> : word32)
   Class: Eq_6573
@@ -29379,8 +29048,8 @@ T_6574: (in a7_2334 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6575: (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_6576: (in 0<32> : word32)
   Class: Eq_6576
@@ -29467,8 +29136,8 @@ T_6596: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_6597: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6598: (in a0_1530 : (ptr32 byte))
   Class: Eq_5238
@@ -29528,8 +29197,8 @@ T_6611: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_6612: (in Mem1537[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_6613: (in v314_1541 : byte)
   Class: Eq_5253
   DataType: byte
@@ -29592,7 +29261,7 @@ T_6627: (in d4_1466 + 1<32> : word32)
   OrigDataType: int32
 T_6628: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6629: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6629
@@ -29608,7 +29277,7 @@ T_6631: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_6632: (in Mem1577[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_6516
-  DataType: Eq_4861
+  DataType: byte
   OrigDataType: byte
 T_6633: (in d6_1133 - d3_1462 : word32)
   Class: Eq_6633
@@ -29646,7 +29315,7 @@ T_6641: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6640
   DataType: word32
   OrigDataType: word32
-T_6642: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_6642: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6642
   DataType: bool
   OrigDataType: bool
@@ -29682,7 +29351,7 @@ T_6650: (in 0<8> : byte)
   Class: Eq_6649
   DataType: byte
   OrigDataType: byte
-T_6651: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_6651: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_6651
   DataType: bool
   OrigDataType: bool
@@ -29740,7 +29409,7 @@ T_6664: (in 1<i32> : int32)
   OrigDataType: int32
 T_6665: (in a7_1585 - 1<i32> : word32)
   Class: Eq_6665
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6668 t0000)))
 T_6666: (in 0<32> : word32)
   Class: Eq_6666
@@ -29751,8 +29420,8 @@ T_6667: (in a7_1585 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6668: (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_6669: (in 0<32> : word32)
   Class: Eq_6669
@@ -29836,7 +29505,7 @@ T_6688: (in 1<i32> : int32)
   OrigDataType: int32
 T_6689: (in a7_2368 - 1<i32> : word32)
   Class: Eq_6689
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6692 t0000)))
 T_6690: (in 0<32> : word32)
   Class: Eq_6690
@@ -29847,8 +29516,8 @@ T_6691: (in a7_2368 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6692: (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_6693: (in 0<32> : word32)
   Class: Eq_6693
@@ -29900,7 +29569,7 @@ T_6704: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6705: (in Mem1625[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_6703
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
 T_6706: (in d0_2124 : uint32)
   Class: Eq_6706
@@ -30000,7 +29669,7 @@ T_6729: (in (byte) d7 == 0x78<8> : bool)
   OrigDataType: bool
 T_6730: (in 0x30<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6731: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_6731
@@ -30199,8 +29868,8 @@ T_6779: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_6780: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6781: (in a0_2462 : (ptr32 byte))
   Class: Eq_5238
@@ -30260,8 +29929,8 @@ T_6794: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_6795: (in Mem2469[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_6796: (in v351_2473 : byte)
   Class: Eq_5253
   DataType: byte
@@ -30380,12 +30049,12 @@ T_6824: (in 55<i32> : int32)
   OrigDataType: int32
 T_6825: (in a7_1330 + 55<i32> : word32)
   Class: Eq_6825
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_6826: (in Mem2506[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_6826
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_6827: (in SEQ(SLICE(d0_2450, word24, 8), Mem2506[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_6822
   DataType: ui32
@@ -30460,7 +30129,7 @@ T_6844: (in __btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[(int3
   OrigDataType: bool
 T_6845: (in 0x78<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6846: (in d0 != 0x78<32> : bool)
   Class: Eq_6846
@@ -30510,7 +30179,7 @@ T_6857: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6856
   DataType: word32
   OrigDataType: word32
-T_6858: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_6858: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6858
   DataType: bool
   OrigDataType: bool
@@ -30707,8 +30376,8 @@ T_6906: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_6907: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6908: (in a0_2571 : (ptr32 byte))
   Class: Eq_5238
@@ -30768,8 +30437,8 @@ T_6921: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_6922: (in Mem2578[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_6923: (in v372_2582 : byte)
   Class: Eq_5253
   DataType: byte
@@ -30892,12 +30561,12 @@ T_6952: (in 55<i32> : int32)
   OrigDataType: int32
 T_6953: (in a7_1330 + 55<i32> : word32)
   Class: Eq_6953
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_6954: (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_6954
-  DataType: Eq_6954
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_6954 u2))
+  DataType: uint8
+  OrigDataType: uint8
 T_6955: (in SEQ(SLICE(d0_2559, word24, 8), Mem2603[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_6955
   DataType: ui32
@@ -30906,7 +30575,7 @@ T_6956: (in 0xFF<32> : word32)
   Class: Eq_6956
   DataType: ui32
   OrigDataType: ui32
-T_6957: (in SEQ(SLICE(d0_2559, word24, 8), *((word32) a7_1330 + 55<i32>)) & 0xFF<32> : word32)
+T_6957: (in SEQ(SLICE(d0_2559, word24, 8), a7_1330->b0037) & 0xFF<32> : word32)
   Class: Eq_6957
   DataType: int32
   OrigDataType: int32
@@ -30976,7 +30645,7 @@ T_6973: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6974: (in Mem2726[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_6971
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
 T_6975: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6975
@@ -31079,9 +30748,9 @@ T_6999: (in a7_1330 + 132<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7000: (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_4861
-  OrigDataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: word32
 T_7001: (in 52<i32> : int32)
   Class: Eq_7001
   DataType: int32
@@ -31092,8 +30761,8 @@ T_7002: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7003: (in Mem2796[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4868
-  DataType: Eq_4861
-  OrigDataType: Eq_4868
+  DataType: Eq_4868
+  OrigDataType: word32
 T_7004: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_7004
   DataType: Eq_7004
@@ -31108,8 +30777,8 @@ T_7006: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7007: (in Mem2801[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_7004
-  DataType: Eq_4861
-  OrigDataType: Eq_7004
+  DataType: Eq_7004
+  OrigDataType: word32
 T_7008: (in 0x44<32> : word32)
   Class: Eq_7008
   DataType: ui32
@@ -31212,7 +30881,7 @@ T_7032: (in 1<i32> : int32)
   OrigDataType: int32
 T_7033: (in a7_2667 - 1<i32> : word32)
   Class: Eq_7033
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7036 t0000)))
 T_7034: (in 0<32> : word32)
   Class: Eq_7034
@@ -31223,8 +30892,8 @@ T_7035: (in a7_2667 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7036: (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_7037: (in 0<32> : word32)
   Class: Eq_7037
@@ -31258,7 +30927,7 @@ T_7044: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_7043
   DataType: word32
   OrigDataType: word32
-T_7045: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_7045: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_7045
   DataType: bool
   OrigDataType: bool
@@ -31339,8 +31008,8 @@ T_7064: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7065: (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_7066: (in 110<i32> : int32)
   Class: Eq_7066
@@ -31358,7 +31027,7 @@ T_7069: (in 0<32> : word32)
   Class: Eq_7068
   DataType: word32
   OrigDataType: word32
-T_7070: (in *((word32) a7_1330 + 110<i32>) == 0<32> : bool)
+T_7070: (in a7_1330->dw006E == 0<32> : bool)
   Class: Eq_7070
   DataType: bool
   OrigDataType: bool
@@ -31378,7 +31047,7 @@ T_7074: (in 0xA<32> : word32)
   Class: Eq_7073
   DataType: word32
   OrigDataType: word32
-T_7075: (in *((word32) a7_1330 + 114<i32>) != 0xA<32> : bool)
+T_7075: (in a7_1330->dw0072 != 0xA<32> : bool)
   Class: Eq_7075
   DataType: bool
   OrigDataType: bool
@@ -31398,7 +31067,7 @@ T_7079: (in 8<32> : word32)
   Class: Eq_7078
   DataType: word32
   OrigDataType: word32
-T_7080: (in *((word32) a7_1330 + 114<i32>) != 8<32> : bool)
+T_7080: (in a7_1330->dw0072 != 8<32> : bool)
   Class: Eq_7080
   DataType: bool
   OrigDataType: bool
@@ -31459,9 +31128,9 @@ T_7094: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7095: (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_4861
-  OrigDataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: word32
 T_7096: (in 52<i32> : int32)
   Class: Eq_7096
   DataType: int32
@@ -31472,8 +31141,8 @@ T_7097: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7098: (in Mem2823[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4868
-  DataType: Eq_4861
-  OrigDataType: Eq_4868
+  DataType: Eq_4868
+  OrigDataType: word32
 T_7099: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_7099
   DataType: Eq_7099
@@ -31488,8 +31157,8 @@ T_7101: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7102: (in Mem2825[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_7099
-  DataType: Eq_4861
-  OrigDataType: Eq_7099
+  DataType: Eq_7099
+  OrigDataType: word32
 T_7103: (in 4<32> : word32)
   Class: Eq_7103
   DataType: ui32
@@ -31519,9 +31188,9 @@ T_7109: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7110: (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_4861
-  OrigDataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: word32
 T_7111: (in 52<i32> : int32)
   Class: Eq_7111
   DataType: int32
@@ -31532,8 +31201,8 @@ T_7112: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7113: (in Mem2854[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4868
-  DataType: Eq_4861
-  OrigDataType: Eq_4868
+  DataType: Eq_4868
+  OrigDataType: word32
 T_7114: (in 64<i32> : int32)
   Class: Eq_7114
   DataType: int32
@@ -31543,9 +31212,9 @@ T_7115: (in a7_1330 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7116: (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_4861
-  OrigDataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: word32
 T_7117: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_7117
   DataType: Eq_7117
@@ -31560,8 +31229,8 @@ T_7119: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7120: (in Mem2869[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_7117
-  DataType: Eq_4861
-  OrigDataType: Eq_7117
+  DataType: Eq_7117
+  OrigDataType: word32
 T_7121: (in d6_1133 - d3_2423 : word32)
   Class: Eq_7121
   DataType: Eq_7121
@@ -31583,9 +31252,9 @@ T_7125: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7126: (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_4861
-  OrigDataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: word32
 T_7127: (in 52<i32> : int32)
   Class: Eq_7127
   DataType: int32
@@ -31596,8 +31265,8 @@ T_7128: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7129: (in Mem2840[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4868
-  DataType: Eq_4861
-  OrigDataType: Eq_4868
+  DataType: Eq_4868
+  OrigDataType: word32
 T_7130: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_7130
   DataType: Eq_7130
@@ -31612,11 +31281,11 @@ T_7132: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7133: (in Mem2843[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_7130
-  DataType: Eq_4861
-  OrigDataType: Eq_7130
+  DataType: Eq_7130
+  OrigDataType: word32
 T_7134: (in 0x37<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_7135: (in d5_1044 > 0x37<32> : bool)
   Class: Eq_7135
@@ -31666,9 +31335,9 @@ T_7146: (in d6_3015 : Eq_7146)
   Class: Eq_7146
   DataType: Eq_7146
   OrigDataType: (ptr32 (ptr32 Eq_4868))
-T_7147: (in v419_2893 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_7147: (in v419_2893 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_7148: (in 4<i32> : int32)
   Class: Eq_7148
@@ -31676,7 +31345,7 @@ T_7148: (in 4<i32> : int32)
   OrigDataType: int32
 T_7149: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7149
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_7152 t0000)))
 T_7150: (in 0<32> : word32)
   Class: Eq_7150
@@ -31687,8 +31356,8 @@ T_7151: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7152: (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_7153: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7153
@@ -31752,8 +31421,8 @@ T_7167: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7168: (in Mem2980[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_7161
-  DataType: Eq_4861
-  OrigDataType: Eq_7161
+  DataType: Eq_7161
+  OrigDataType: word32
 T_7169: (in 8<i32> : int32)
   Class: Eq_7169
   DataType: int32
@@ -31824,8 +31493,8 @@ T_7185: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_7186: (in Mem2992[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_7183
-  DataType: Eq_4861
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_7187: (in v441_2993 : word32)
   Class: Eq_7187
   DataType: word32
@@ -32004,7 +31673,7 @@ T_7230: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7231: (in Mem3035[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_7231
-  DataType: (ptr32 Eq_9002)
+  DataType: (ptr32 Eq_8993)
   OrigDataType: (union ((ptr32 (ptr32 Eq_4868)) u1) (uint32 u0) (ptr32 u2) (Eq_7231 u3))
 T_7232: (in d6_3015 + Mem3035[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_7228
@@ -32020,8 +31689,8 @@ T_7234: (in a7_1330 + 68<i32> : word32)
   OrigDataType: (ptr32 (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4868)) u1) (T_7164 u3)))
 T_7235: (in Mem3040[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_7228
-  DataType: Eq_4861
-  OrigDataType: Eq_7228
+  DataType: Eq_7228
+  OrigDataType: (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4868)) u1) (T_7164 u3))
 T_7236: (in 8<i32> : int32)
   Class: Eq_7236
   DataType: int32
@@ -32078,7 +31747,7 @@ T_7249: (in d2_3037 < 0<32> : bool)
   Class: Eq_7249
   DataType: bool
   OrigDataType: bool
-T_7250: (in (word32) *((word32) a7_1330 + 44<i32>) + d0_3029 + (d2_3037 < 0<32>) : word32)
+T_7250: (in (word32) a7_1330[11<i32>] + d0_3029 + (d2_3037 < 0<32>) : word32)
   Class: Eq_7250
   DataType: int32
   OrigDataType: int32
@@ -32092,8 +31761,8 @@ T_7252: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7253: (in Mem3051[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_7250
-  DataType: Eq_4861
-  OrigDataType: int32
+  DataType: int32
+  OrigDataType: word32
 T_7254: (in v453_3052 : word32)
   Class: Eq_7254
   DataType: word32
@@ -32268,8 +31937,8 @@ T_7296: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4868)) u1) (T_7231 u3)))
 T_7297: (in Mem3098[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_7290
-  DataType: Eq_4861
-  OrigDataType: Eq_7290
+  DataType: Eq_7290
+  OrigDataType: (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4868)) u1) (T_7231 u3))
 T_7298: (in 8<i32> : int32)
   Class: Eq_7298
   DataType: int32
@@ -32336,8 +32005,8 @@ T_7313: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_7314: (in Mem3108[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_7311
-  DataType: Eq_4861
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_7315: (in a0_3119 : (ptr32 ui32))
   Class: Eq_7315
   DataType: (ptr32 ui32)
@@ -32376,7 +32045,7 @@ T_7323: (in Mem3108[a7_1330 - 8<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_7324: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7324
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_7327 t0000)))
 T_7325: (in 0<32> : word32)
   Class: Eq_7325
@@ -32387,8 +32056,8 @@ T_7326: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7327: (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_7328: (in 0<32> : word32)
   Class: Eq_7328
@@ -32543,8 +32212,8 @@ T_7365: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_7366: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_7367: (in a0_3146 : (ptr32 byte))
   Class: Eq_5238
@@ -32596,8 +32265,8 @@ T_7378: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_7379: (in Mem3153[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_7380: (in 0<32> : word32)
   Class: Eq_7380
   DataType: word32
@@ -32676,7 +32345,7 @@ T_7398: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7399: (in Mem3172[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7396
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
 T_7400: (in d0_3184 : uint32)
   Class: Eq_7400
@@ -32752,7 +32421,7 @@ T_7417: (in (d0_3184 & 0x44<32>) == 0<32> : bool)
   OrigDataType: bool
 T_7418: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_7419: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_7419
@@ -32768,7 +32437,7 @@ T_7421: (in d3_2423 != 2<32> : bool)
   OrigDataType: bool
 T_7422: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_7423: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_7423
@@ -32856,7 +32525,7 @@ T_7443: (in 1<i32> : int32)
   OrigDataType: int32
 T_7444: (in a7_3259 - 1<i32> : word32)
   Class: Eq_7444
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7447 t0000)))
 T_7445: (in 0<32> : word32)
   Class: Eq_7445
@@ -32867,8 +32536,8 @@ T_7446: (in a7_3259 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7447: (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_7448: (in 0<32> : word32)
   Class: Eq_7448
@@ -32952,7 +32621,7 @@ T_7467: (in 1<i32> : int32)
   OrigDataType: int32
 T_7468: (in a7_2635 - 1<i32> : word32)
   Class: Eq_7468
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7471 t0000)))
 T_7469: (in 0<32> : word32)
   Class: Eq_7469
@@ -32963,8 +32632,8 @@ T_7470: (in a7_2635 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7471: (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_7472: (in 0<32> : word32)
   Class: Eq_7472
@@ -33084,7 +32753,7 @@ T_7500: (in a4_2881 - (v465_3109 + 1<32>) >= 0<32> : bool)
   OrigDataType: bool
 T_7501: (in 0x37<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_7502: (in d1 > 0x37<32> : bool)
   Class: Eq_7502
@@ -33107,8 +32776,8 @@ T_7506: (in a7_2886 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7507: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_7508: (in 0<32> : word32)
   Class: Eq_7508
@@ -33119,16 +32788,16 @@ T_7509: (in a7_2886 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7510: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_7511: (in 31<i32> : int32)
   Class: Eq_7511
   DataType: int32
   OrigDataType: int32
 T_7512: (in d7 >> 31<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: int32
 T_7513: (in 0<32> : word32)
   Class: Eq_7513
@@ -33139,8 +32808,8 @@ T_7514: (in a7_2886 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7515: (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_7516: (in 4<i32> : int32)
   Class: Eq_7516
@@ -33168,7 +32837,7 @@ T_7521: (in 8<i32> : int32)
   OrigDataType: int32
 T_7522: (in a7_2886 - 8<i32> : word32)
   Class: Eq_7522
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
   OrigDataType: (ptr32 (struct (0 T_7525 t0000)))
 T_7523: (in 0<32> : word32)
   Class: Eq_7523
@@ -33179,8 +32848,8 @@ T_7524: (in a7_2886 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7525: (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_7526: (in 52<i32> : int32)
   Class: Eq_7526
@@ -33306,21 +32975,21 @@ T_7556: (in d4 : Eq_4868)
   Class: Eq_4868
   DataType: Eq_4868
   OrigDataType: word32
-T_7557: (in dwArg04 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_7557: (in dwArg04 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_7558: (in dwArg08 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_7558: (in dwArg08 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_7559: (in dwArg0C : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_7559: (in dwArg0C : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
-T_7560: (in dwArg10 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_7560: (in dwArg10 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_7561: (in d1Out : ptr32)
   Class: Eq_7561
@@ -33328,7 +32997,7 @@ T_7561: (in d1Out : ptr32)
   OrigDataType: ptr32
 T_7562: (in a7_2886 - 24<i32> : word32)
   Class: Eq_7562
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_7565 t0000)))
 T_7563: (in 0<32> : word32)
   Class: Eq_7563
@@ -33339,8 +33008,8 @@ T_7564: (in a7_2886 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7565: (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_7566: (in 20<i32> : int32)
   Class: Eq_7566
@@ -33348,7 +33017,7 @@ T_7566: (in 20<i32> : int32)
   OrigDataType: int32
 T_7567: (in a7_2886 - 20<i32> : word32)
   Class: Eq_7567
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_7570 t0000)))
 T_7568: (in 0<32> : word32)
   Class: Eq_7568
@@ -33359,8 +33028,8 @@ T_7569: (in a7_2886 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7570: (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_7571: (in 16<i32> : int32)
   Class: Eq_7571
@@ -33368,7 +33037,7 @@ T_7571: (in 16<i32> : int32)
   OrigDataType: int32
 T_7572: (in a7_2886 - 16<i32> : word32)
   Class: Eq_7572
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_7575 t0000)))
 T_7573: (in 0<32> : word32)
   Class: Eq_7573
@@ -33379,8 +33048,8 @@ T_7574: (in a7_2886 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7575: (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_7576: (in 12<i32> : int32)
   Class: Eq_7576
@@ -33388,7 +33057,7 @@ T_7576: (in 12<i32> : int32)
   OrigDataType: int32
 T_7577: (in a7_2886 - 12<i32> : word32)
   Class: Eq_7577
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 Eq_663)
   OrigDataType: (ptr32 (struct (0 T_7580 t0000)))
 T_7578: (in 0<32> : word32)
   Class: Eq_7578
@@ -33399,8 +33068,8 @@ T_7579: (in a7_2886 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7580: (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_7581: (in out d1_2921 : ptr32)
   Class: Eq_7561
@@ -33530,7 +33199,7 @@ T_7612: (in 0<8> : byte)
   Class: Eq_7611
   DataType: byte
   OrigDataType: byte
-T_7613: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7613: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7613
   DataType: bool
   OrigDataType: bool
@@ -33588,7 +33257,7 @@ T_7626: (in 1<i32> : int32)
   OrigDataType: int32
 T_7627: (in a7_3299 - 1<i32> : word32)
   Class: Eq_7627
-  DataType: (ptr32 Eq_603)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7630 t0000)))
 T_7628: (in 0<32> : word32)
   Class: Eq_7628
@@ -33599,8 +33268,8 @@ T_7629: (in a7_3299 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7630: (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_7631: (in 0<32> : word32)
   Class: Eq_7631
@@ -33632,7 +33301,7 @@ T_7637: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7638: (in Mem2714[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7635
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
 T_7639: (in 8<32> : word32)
   Class: Eq_7639
@@ -33648,7 +33317,7 @@ T_7641: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7642: (in Mem2717[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7639
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
 T_7643: (in 52<i32> : int32)
   Class: Eq_7643
@@ -33706,7 +33375,7 @@ T_7656: (in 0x2D<32> : word32)
   Class: Eq_7655
   DataType: word32
   OrigDataType: word32
-T_7657: (in *((word32) a7_1330 + 110<i32>) != 0x2D<32> : bool)
+T_7657: (in a7_1330->dw006E != 0x2D<32> : bool)
   Class: Eq_7657
   DataType: bool
   OrigDataType: bool
@@ -33772,7 +33441,7 @@ T_7672: (in 4<i32> : int32)
   OrigDataType: int32
 T_7673: (in a7_3474 + 4<i32> : word32)
   Class: Eq_4861
-  DataType: Eq_4861
+  DataType: (ptr32 Eq_4861)
   OrigDataType: ptr32
 T_7674: (in 56<i32> : int32)
   Class: Eq_7674
@@ -33800,11 +33469,11 @@ T_7679: (in d0_3495 : word32)
   OrigDataType: uint32
 T_7680: (in 3<32> : word32)
   Class: Eq_7680
-  DataType: (ptr32 Eq_9005)
+  DataType: (ptr32 Eq_8996)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7681: (in d2_1090 + 3<32> : word32)
   Class: Eq_7681
-  DataType: (ptr32 Eq_9006)
+  DataType: (ptr32 Eq_8997)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7682: (in 2<32> : word32)
   Class: Eq_7682
@@ -33827,8 +33496,8 @@ T_7686: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7687: (in (d0_3495 << 2<32>) + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_7688: (in a0_3501 : (ptr32 Eq_7688))
   Class: Eq_7688
@@ -33840,7 +33509,7 @@ T_7689: (in -4<i32> : int32)
   OrigDataType: int32
 T_7690: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7690
-  DataType: (ptr32 Eq_9007)
+  DataType: (ptr32 Eq_8998)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7691: (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7688
@@ -33944,11 +33613,11 @@ T_7715: (in v517_3507 == 0<8> : bool)
   OrigDataType: bool
 T_7716: (in 3<32> : word32)
   Class: Eq_7716
-  DataType: (ptr32 Eq_9008)
+  DataType: (ptr32 Eq_8999)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7717: (in d2_1090 + 3<32> : word32)
   Class: Eq_7717
-  DataType: (ptr32 Eq_9009)
+  DataType: (ptr32 Eq_9000)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7718: (in 2<32> : word32)
   Class: Eq_7718
@@ -33971,8 +33640,8 @@ T_7722: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7723: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_7724: (in 52<i32> : int32)
   Class: Eq_7724
@@ -33996,7 +33665,7 @@ T_7728: (in -4<i32> : int32)
   OrigDataType: int32
 T_7729: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7729
-  DataType: (ptr32 Eq_9010)
+  DataType: (ptr32 Eq_9001)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7730: (in Mem3508[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7730
@@ -34012,8 +33681,8 @@ T_7732: (in Mem3508[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7733: (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
   Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: byte
+  DataType: Eq_663
+  OrigDataType: Eq_603
 T_7734: (in v518_3524 : byte)
   Class: Eq_7668
   DataType: byte
@@ -34060,11 +33729,11 @@ T_7744: (in v518_3524 == 0<8> : bool)
   OrigDataType: bool
 T_7745: (in 3<32> : word32)
   Class: Eq_7745
-  DataType: (ptr32 Eq_9011)
+  DataType: (ptr32 Eq_9002)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7746: (in d2_1090 + 3<32> : word32)
   Class: Eq_7746
-  DataType: (ptr32 Eq_9012)
+  DataType: (ptr32 Eq_9003)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7747: (in 2<32> : word32)
   Class: Eq_7747
@@ -34087,8 +33756,8 @@ T_7751: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7752: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_7753: (in 52<i32> : int32)
   Class: Eq_7753
@@ -34112,7 +33781,7 @@ T_7757: (in -4<i32> : int32)
   OrigDataType: int32
 T_7758: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7758
-  DataType: (ptr32 Eq_9013)
+  DataType: (ptr32 Eq_9004)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7759: (in Mem3525[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7759
@@ -34128,8 +33797,8 @@ T_7761: (in Mem3525[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7762: (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
   Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: word16
+  DataType: Eq_663
+  OrigDataType: Eq_603
 T_7763: (in v519_3541 : byte)
   Class: Eq_7668
   DataType: byte
@@ -34176,11 +33845,11 @@ T_7773: (in v519_3541 == 0<8> : bool)
   OrigDataType: bool
 T_7774: (in 3<32> : word32)
   Class: Eq_7774
-  DataType: (ptr32 Eq_9014)
+  DataType: (ptr32 Eq_9005)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7775: (in d2_1090 + 3<32> : word32)
   Class: Eq_7775
-  DataType: (ptr32 Eq_9015)
+  DataType: (ptr32 Eq_9006)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7776: (in 2<32> : word32)
   Class: Eq_7776
@@ -34203,8 +33872,8 @@ T_7780: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7781: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_7782: (in 52<i32> : int32)
   Class: Eq_7782
@@ -34224,7 +33893,7 @@ T_7785: (in -4<i32> : int32)
   OrigDataType: int32
 T_7786: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7786
-  DataType: (ptr32 Eq_9016)
+  DataType: (ptr32 Eq_9007)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7787: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7787
@@ -34240,15 +33909,15 @@ T_7789: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7790: (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: word32
+  DataType: Eq_663
+  OrigDataType: Eq_603
 T_7791: (in 3<32> : word32)
   Class: Eq_7791
-  DataType: (ptr32 Eq_9017)
+  DataType: (ptr32 Eq_9008)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7792: (in d2_1090 + 3<32> : word32)
   Class: Eq_7792
-  DataType: (ptr32 Eq_9018)
+  DataType: (ptr32 Eq_9009)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7793: (in 2<32> : word32)
   Class: Eq_7793
@@ -34271,8 +33940,8 @@ T_7797: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7798: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_7799: (in 52<i32> : int32)
   Class: Eq_7799
@@ -34292,7 +33961,7 @@ T_7802: (in -4<i32> : int32)
   OrigDataType: int32
 T_7803: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7803
-  DataType: (ptr32 Eq_9019)
+  DataType: (ptr32 Eq_9010)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7804: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7804
@@ -34308,8 +33977,8 @@ T_7806: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7807: (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: word32
+  DataType: Eq_663
+  OrigDataType: Eq_603
 T_7808: (in 60<i32> : int32)
   Class: Eq_7808
   DataType: int32
@@ -34336,7 +34005,7 @@ T_7813: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7814: (in Mem3574[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_7812
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
 T_7815: (in 48<i32> : int32)
   Class: Eq_7815
@@ -34356,12 +34025,12 @@ T_7818: (in 56<i32> : int32)
   OrigDataType: int32
 T_7819: (in a7_1330 + 56<i32> : word32)
   Class: Eq_7819
-  DataType: (ptr32 Eq_7819)
-  OrigDataType: (ptr32 (union (uint8 u0) (word32 u1) (T_6954 u2)))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7820: (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
   Class: Eq_7817
   DataType: Eq_7817
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_6954 u2))
+  OrigDataType: word32
 T_7821: (in 44<i32> : int32)
   Class: Eq_7821
   DataType: int32
@@ -34432,7 +34101,7 @@ T_7837: (in -v528_3348->dw0000 : word32)
   OrigDataType: int32
 T_7838: (in 0<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: up32
 T_7839: (in d1 < 0<32> : bool)
   Class: Eq_7839
@@ -34448,44 +34117,44 @@ T_7841: (in 0x38<32> : word32)
   OrigDataType: word32
 T_7842: (in a7_1330 + 0x38<32> : word32)
   Class: Eq_7842
-  DataType: (ptr32 Eq_7842)
-  OrigDataType: (ptr32 (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3)))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7843: (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
   Class: Eq_4861
-  DataType: Eq_4861
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
-T_7844: (in a7_3364 : Eq_7844)
+  DataType: (ptr32 Eq_4861)
+  OrigDataType: word32
+T_7844: (in a7_3364 : (ptr32 Eq_7844))
   Class: Eq_7844
-  DataType: Eq_7844
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_7844)
+  OrigDataType: (ptr32 (struct (0 T_7849 t0000) (30 T_7854 t0030) (38 T_7905 t0038) (3C T_605 t003C) (4C T_7852 t004C)))
 T_7845: (in 4<i32> : int32)
   Class: Eq_7845
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7846: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7844
-  DataType: Eq_7844
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_7844)
+  OrigDataType: ptr32
 T_7847: (in 0<32> : word32)
   Class: Eq_7847
   DataType: word32
   OrigDataType: word32
 T_7848: (in a7_3364 + 0<32> : word32)
   Class: Eq_7848
-  DataType: Eq_7848
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7849: (in Mem3375[a7_3364 + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_7844
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_7850: (in 76<i32> : int32)
   Class: Eq_7850
   DataType: int32
   OrigDataType: int32
 T_7851: (in a7_3364 + 76<i32> : word32)
   Class: Eq_7851
-  DataType: Eq_7851
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7852: (in Mem3375[a7_3364 + 76<i32>:byte] : byte)
   Class: Eq_7852
   DataType: byte
@@ -34494,7 +34163,7 @@ T_7853: (in 1<8> : byte)
   Class: Eq_7853
   DataType: byte
   OrigDataType: byte
-T_7854: (in *((word32) a7_3364 + 76<i32>) - 1<8> : byte)
+T_7854: (in a7_3364->b004C - 1<8> : byte)
   Class: Eq_7854
   DataType: byte
   OrigDataType: byte
@@ -34504,37 +34173,37 @@ T_7855: (in 48<i32> : int32)
   OrigDataType: int32
 T_7856: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7856
-  DataType: Eq_7856
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7857: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
   Class: Eq_7854
-  DataType: Eq_7844
+  DataType: byte
   OrigDataType: byte
 T_7858: (in 4<i32> : int32)
   Class: Eq_7858
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7859: (in a7_3364 + 4<i32> : word32)
   Class: Eq_4861
-  DataType: Eq_4861
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_4861)
+  OrigDataType: ptr32
 T_7860: (in 48<i32> : int32)
   Class: Eq_7860
   DataType: int32
   OrigDataType: int32
 T_7861: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7861
-  DataType: Eq_7861
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7862: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7862
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7863: (in 0<8> : byte)
-  Class: Eq_7862
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
-T_7864: (in *((word32) a7_3364 + 48<i32>) == 0<8> : bool)
+T_7864: (in a7_3364->b0030 == 0<8> : bool)
   Class: Eq_7864
   DataType: bool
   OrigDataType: bool
@@ -34548,28 +34217,28 @@ T_7866: (in 52<i32> : int32)
   OrigDataType: int32
 T_7867: (in a7_1330 + 52<i32> : word32)
   Class: Eq_7867
-  DataType: Eq_7867
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7868: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7865
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
-T_7869: (in v544_774 : byte)
+T_7869: (in v544_774 : Eq_7869)
   Class: Eq_7869
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7869
+  OrigDataType: (union (int32 u0) (byte u1))
 T_7870: (in 44<i32> : int32)
   Class: Eq_7870
   DataType: int32
   OrigDataType: int32
 T_7871: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7871
-  DataType: Eq_7871
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7872: (in Mem773[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7869
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7869
+  OrigDataType: int32
 T_7873: (in SEQ(v84_506, v544_774) : uip32)
   Class: Eq_5018
   DataType: int32
@@ -34584,8 +34253,8 @@ T_7875: (in 52<i32> : int32)
   OrigDataType: int32
 T_7876: (in a7_1330 + 52<i32> : word32)
   Class: Eq_7876
-  DataType: Eq_7876
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7877: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
@@ -34600,12 +34269,12 @@ T_7879: (in 44<i32> : int32)
   OrigDataType: int32
 T_7880: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7880
-  DataType: Eq_7880
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7881: (in Mem769[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7878
-  DataType: Eq_4861
-  OrigDataType: byte
+  DataType: Eq_7878
+  OrigDataType: int32
 T_7882: (in 1<i32> : int32)
   Class: Eq_7882
   DataType: int32
@@ -34620,11 +34289,11 @@ T_7884: (in d0_3398 : word32)
   OrigDataType: uint32
 T_7885: (in 3<32> : word32)
   Class: Eq_7885
-  DataType: (ptr32 Eq_9026)
+  DataType: (ptr32 Eq_9011)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7886: (in d2_1090 + 3<32> : word32)
   Class: Eq_7886
-  DataType: (ptr32 Eq_9027)
+  DataType: (ptr32 Eq_9012)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7887: (in 2<32> : word32)
   Class: Eq_7887
@@ -34647,8 +34316,8 @@ T_7891: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7892: (in (d0_3398 << 2<32>) + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_7893: (in a0_3404 : (ptr32 Eq_7893))
   Class: Eq_7893
@@ -34660,7 +34329,7 @@ T_7894: (in -4<i32> : int32)
   OrigDataType: int32
 T_7895: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7895
-  DataType: (ptr32 Eq_9028)
+  DataType: (ptr32 Eq_9013)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7896: (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7893
@@ -34672,11 +34341,11 @@ T_7897: (in 60<i32> : int32)
   OrigDataType: int32
 T_7898: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7898
-  DataType: Eq_7898
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7899: (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_7899
-  DataType: word32
+  Class: Eq_603
+  DataType: Eq_603
   OrigDataType: word32
 T_7900: (in 4<i32> : int32)
   Class: Eq_7900
@@ -34687,8 +34356,8 @@ T_7901: (in a0_3404 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7902: (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
-  Class: Eq_7899
-  DataType: word32
+  Class: Eq_603
+  DataType: Eq_603
   OrigDataType: word32
 T_7903: (in 56<i32> : int32)
   Class: Eq_7903
@@ -34696,8 +34365,8 @@ T_7903: (in 56<i32> : int32)
   OrigDataType: int32
 T_7904: (in a7_3364 + 56<i32> : word32)
   Class: Eq_7904
-  DataType: Eq_7904
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7905: (in Mem3406[a7_3364 + 56<i32>:word32] : word32)
   Class: Eq_7905
   DataType: word32
@@ -34719,7 +34388,7 @@ T_7909: (in d0_3398 << 2<32> : word32)
   DataType: Eq_603
   OrigDataType: ui32
 T_7910: (in v540_3410 : byte)
-  Class: Eq_7910
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7911: (in 48<i32> : int32)
@@ -34728,18 +34397,18 @@ T_7911: (in 48<i32> : int32)
   OrigDataType: int32
 T_7912: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7912
-  DataType: Eq_7912
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7913: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7913
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7914: (in 1<8> : byte)
   Class: Eq_7914
   DataType: byte
   OrigDataType: byte
-T_7915: (in *((word32) a7_3364 + 48<i32>) - 1<8> : byte)
-  Class: Eq_7910
+T_7915: (in a7_3364->b0030 - 1<8> : byte)
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7916: (in 48<i32> : int32)
@@ -34748,14 +34417,14 @@ T_7916: (in 48<i32> : int32)
   OrigDataType: int32
 T_7917: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7917
-  DataType: Eq_7917
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7918: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7910
-  DataType: Eq_7844
+  Class: Eq_7854
+  DataType: byte
   OrigDataType: byte
 T_7919: (in 0<8> : byte)
-  Class: Eq_7910
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7920: (in v540_3410 == 0<8> : bool)
@@ -34764,11 +34433,11 @@ T_7920: (in v540_3410 == 0<8> : bool)
   OrigDataType: bool
 T_7921: (in 3<32> : word32)
   Class: Eq_7921
-  DataType: (ptr32 Eq_9029)
+  DataType: (ptr32 Eq_9014)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7922: (in d2_1090 + 3<32> : word32)
   Class: Eq_7922
-  DataType: (ptr32 Eq_9030)
+  DataType: (ptr32 Eq_9015)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7923: (in 2<32> : word32)
   Class: Eq_7923
@@ -34791,8 +34460,8 @@ T_7927: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7928: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_7929: (in 60<i32> : int32)
   Class: Eq_7929
@@ -34800,8 +34469,8 @@ T_7929: (in 60<i32> : int32)
   OrigDataType: int32
 T_7930: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7930
-  DataType: Eq_7930
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7931: (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
@@ -34816,7 +34485,7 @@ T_7933: (in -4<i32> : int32)
   OrigDataType: int32
 T_7934: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7934
-  DataType: (ptr32 Eq_9031)
+  DataType: (ptr32 Eq_9016)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7935: (in Mem3411[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7935
@@ -34832,10 +34501,10 @@ T_7937: (in Mem3411[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7938: (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
   Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: byte
+  DataType: Eq_663
+  OrigDataType: Eq_603
 T_7939: (in v541_3427 : byte)
-  Class: Eq_7939
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7940: (in 48<i32> : int32)
@@ -34844,18 +34513,18 @@ T_7940: (in 48<i32> : int32)
   OrigDataType: int32
 T_7941: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7941
-  DataType: Eq_7941
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7942: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7942
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7943: (in 0x66<8> : byte)
   Class: Eq_7943
   DataType: byte
   OrigDataType: byte
-T_7944: (in *((word32) a7_3364 + 48<i32>) - 0x66<8> : byte)
-  Class: Eq_7939
+T_7944: (in a7_3364->b0030 - 0x66<8> : byte)
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7945: (in 48<i32> : int32)
@@ -34864,14 +34533,14 @@ T_7945: (in 48<i32> : int32)
   OrigDataType: int32
 T_7946: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7946
-  DataType: Eq_7946
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7947: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7939
-  DataType: Eq_7844
+  Class: Eq_7854
+  DataType: byte
   OrigDataType: byte
 T_7948: (in 0<8> : byte)
-  Class: Eq_7939
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7949: (in v541_3427 == 0<8> : bool)
@@ -34880,11 +34549,11 @@ T_7949: (in v541_3427 == 0<8> : bool)
   OrigDataType: bool
 T_7950: (in 3<32> : word32)
   Class: Eq_7950
-  DataType: (ptr32 Eq_9032)
+  DataType: (ptr32 Eq_9017)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7951: (in d2_1090 + 3<32> : word32)
   Class: Eq_7951
-  DataType: (ptr32 Eq_9033)
+  DataType: (ptr32 Eq_9018)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7952: (in 2<32> : word32)
   Class: Eq_7952
@@ -34907,8 +34576,8 @@ T_7956: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7957: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_7958: (in 60<i32> : int32)
   Class: Eq_7958
@@ -34916,8 +34585,8 @@ T_7958: (in 60<i32> : int32)
   OrigDataType: int32
 T_7959: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7959
-  DataType: Eq_7959
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7960: (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
@@ -34932,7 +34601,7 @@ T_7962: (in -4<i32> : int32)
   OrigDataType: int32
 T_7963: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7963
-  DataType: (ptr32 Eq_9034)
+  DataType: (ptr32 Eq_9019)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7964: (in Mem3428[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7964
@@ -34948,10 +34617,10 @@ T_7966: (in Mem3428[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7967: (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
   Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: word16
+  DataType: Eq_663
+  OrigDataType: Eq_603
 T_7968: (in v542_3444 : byte)
-  Class: Eq_7968
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7969: (in 48<i32> : int32)
@@ -34960,18 +34629,18 @@ T_7969: (in 48<i32> : int32)
   OrigDataType: int32
 T_7970: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7970
-  DataType: Eq_7970
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7971: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7971
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7972: (in 4<8> : byte)
   Class: Eq_7972
   DataType: byte
   OrigDataType: byte
-T_7973: (in *((word32) a7_3364 + 48<i32>) - 4<8> : byte)
-  Class: Eq_7968
+T_7973: (in a7_3364->b0030 - 4<8> : byte)
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7974: (in 48<i32> : int32)
@@ -34980,14 +34649,14 @@ T_7974: (in 48<i32> : int32)
   OrigDataType: int32
 T_7975: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7975
-  DataType: Eq_7975
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7976: (in Mem3445[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7968
-  DataType: Eq_7844
+  Class: Eq_7854
+  DataType: byte
   OrigDataType: byte
 T_7977: (in 0<8> : byte)
-  Class: Eq_7968
+  Class: Eq_7854
   DataType: byte
   OrigDataType: byte
 T_7978: (in v542_3444 == 0<8> : bool)
@@ -34996,11 +34665,11 @@ T_7978: (in v542_3444 == 0<8> : bool)
   OrigDataType: bool
 T_7979: (in 3<32> : word32)
   Class: Eq_7979
-  DataType: (ptr32 Eq_9035)
+  DataType: (ptr32 Eq_9020)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7980: (in d2_1090 + 3<32> : word32)
   Class: Eq_7980
-  DataType: (ptr32 Eq_9036)
+  DataType: (ptr32 Eq_9021)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7981: (in 2<32> : word32)
   Class: Eq_7981
@@ -35023,8 +34692,8 @@ T_7985: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7986: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_7987: (in 60<i32> : int32)
   Class: Eq_7987
@@ -35032,8 +34701,8 @@ T_7987: (in 60<i32> : int32)
   OrigDataType: int32
 T_7988: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7988
-  DataType: Eq_7988
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7989: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
@@ -35044,7 +34713,7 @@ T_7990: (in -4<i32> : int32)
   OrigDataType: int32
 T_7991: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7991
-  DataType: (ptr32 Eq_9037)
+  DataType: (ptr32 Eq_9022)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7992: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7992
@@ -35060,15 +34729,15 @@ T_7994: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_7995: (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: word32
+  DataType: Eq_663
+  OrigDataType: Eq_603
 T_7996: (in 3<32> : word32)
   Class: Eq_7996
-  DataType: (ptr32 Eq_9038)
+  DataType: (ptr32 Eq_9023)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7997: (in d2_1090 + 3<32> : word32)
   Class: Eq_7997
-  DataType: (ptr32 Eq_9039)
+  DataType: (ptr32 Eq_9024)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7998: (in 2<32> : word32)
   Class: Eq_7998
@@ -35091,8 +34760,8 @@ T_8002: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_8003: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_8004: (in 60<i32> : int32)
   Class: Eq_8004
@@ -35100,8 +34769,8 @@ T_8004: (in 60<i32> : int32)
   OrigDataType: int32
 T_8005: (in a7_3364 + 60<i32> : word32)
   Class: Eq_8005
-  DataType: Eq_8005
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8006: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
@@ -35112,7 +34781,7 @@ T_8007: (in -4<i32> : int32)
   OrigDataType: int32
 T_8008: (in d2_1090 + -4<i32> : word32)
   Class: Eq_8008
-  DataType: (ptr32 Eq_9040)
+  DataType: (ptr32 Eq_9025)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_8009: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_8009
@@ -35128,8 +34797,8 @@ T_8011: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_8012: (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: word32
+  DataType: Eq_663
+  OrigDataType: Eq_603
 T_8013: (in 0<i32> : int32)
   Class: Eq_8013
   DataType: int32
@@ -35143,36 +34812,36 @@ T_8015: (in 0xFF<32> : word32)
   DataType: int32
   OrigDataType: word32
 T_8016: (in SLICE(d5_785, byte, 0) : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_8016
+  DataType: byte
   OrigDataType: byte
 T_8017: (in 78<i32> : int32)
   Class: Eq_8017
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8018: (in a7_1330 + 78<i32> : word32)
   Class: Eq_8018
-  DataType: Eq_8018
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8019: (in a7_1330 + 78<i32> + d1_1027 : word32)
   Class: Eq_8019
-  DataType: Eq_8019
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_8020 t0000)))
 T_8020: (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_8016
+  DataType: byte
   OrigDataType: byte
 T_8021: (in 1<32> : word32)
   Class: Eq_8021
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: word32
+  OrigDataType: word32
 T_8022: (in d1_1027 + 1<32> : word32)
   Class: Eq_603
   DataType: Eq_603
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  OrigDataType: int32
 T_8023: (in 0x20<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: up32
 T_8024: (in d1_1027 < 0x20<32> : bool)
   Class: Eq_8024
@@ -35192,40 +34861,40 @@ T_8027: (in 132<i32> : int32)
   OrigDataType: int32
 T_8028: (in a7_1330 + 132<i32> : word32)
   Class: Eq_8028
-  DataType: Eq_8028
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8029: (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_4861
-  OrigDataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
+  OrigDataType: word32
 T_8030: (in 44<i32> : int32)
   Class: Eq_8030
   DataType: int32
   OrigDataType: int32
 T_8031: (in a7_1330 + 44<i32> : word32)
   Class: Eq_8031
-  DataType: Eq_8031
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_8032: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7869
-  DataType: Eq_4861
-  OrigDataType: byte
-T_8033: (in v554_824 : byte)
+  DataType: Eq_7869
+  OrigDataType: int32
+T_8033: (in v554_824 : Eq_8033)
   Class: Eq_8033
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_8033
+  OrigDataType: (union (int32 u1) (byte u0))
 T_8034: (in 44<i32> : int32)
   Class: Eq_8034
   DataType: int32
   OrigDataType: int32
 T_8035: (in a7_1330 + 44<i32> : word32)
   Class: Eq_8035
-  DataType: Eq_8035
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_8036: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_8033
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_8033
+  OrigDataType: int32
 T_8037: (in a6_1164 : (ptr32 byte))
   Class: Eq_8037
   DataType: (ptr32 byte)
@@ -35236,11 +34905,11 @@ T_8038: (in 132<i32> : int32)
   OrigDataType: int32
 T_8039: (in a7_1330 + 132<i32> : word32)
   Class: Eq_8039
-  DataType: Eq_8039
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8040: (in Mem946[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8041: (in 1<i32> : int32)
   Class: Eq_8041
@@ -35256,8 +34925,8 @@ T_8043: (in 73<i32> : int32)
   OrigDataType: int32
 T_8044: (in a7_1330 + 73<i32> : word32)
   Class: Eq_8044
-  DataType: Eq_8044
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_8045: (in Mem946[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_8045
   DataType: byte
@@ -35266,7 +34935,7 @@ T_8046: (in 0<8> : byte)
   Class: Eq_8045
   DataType: byte
   OrigDataType: byte
-T_8047: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_8047: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_8047
   DataType: bool
   OrigDataType: bool
@@ -35446,18 +35115,18 @@ T_8091: (in v554_824 == 0<8> : bool)
   Class: Eq_8091
   DataType: bool
   OrigDataType: bool
-T_8092: (in a0_881 : Eq_8092)
+T_8092: (in a0_881 : word32)
   Class: Eq_8092
-  DataType: Eq_8092
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_8100 t0000)))
 T_8093: (in 78<i32> : int32)
   Class: Eq_8093
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8094: (in a7_1330 + 78<i32> : word32)
   Class: Eq_8094
-  DataType: Eq_8094
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8095: (in 3<32> : word32)
   Class: Eq_8095
   DataType: word32
@@ -35465,22 +35134,22 @@ T_8095: (in 3<32> : word32)
 T_8096: (in d5_862 >> 3<32> : word32)
   Class: Eq_8096
   DataType: Eq_8096
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_8097: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_8092
-  DataType: Eq_8092
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_8098: (in 0<32> : word32)
   Class: Eq_8098
   DataType: word32
   OrigDataType: word32
 T_8099: (in a0_881 + 0<32> : word32)
   Class: Eq_8099
-  DataType: Eq_8099
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8100: (in Mem889[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_8100
+  DataType: byte
   OrigDataType: byte
 T_8101: (in (uint8) Mem889[a0_881 + 0<32>:byte] : uint8)
   Class: Eq_8101
@@ -35511,8 +35180,8 @@ T_8107: (in 1<i32> << (d5_862 & 7<i32>) | d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_8108: (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_8100
+  DataType: byte
   OrigDataType: byte
 T_8109: (in 0<32> : word32)
   Class: Eq_8109
@@ -35520,24 +35189,24 @@ T_8109: (in 0<32> : word32)
   OrigDataType: word32
 T_8110: (in a0_881 + 0<32> : word32)
   Class: Eq_8110
-  DataType: Eq_8110
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_8111: (in Mem895[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_8092
-  OrigDataType: Eq_603
-T_8112: (in a0_900 : Eq_8112)
+  Class: Eq_8100
+  DataType: byte
+  OrigDataType: byte
+T_8112: (in a0_900 : word32)
   Class: Eq_8112
-  DataType: Eq_8112
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_8120 t0000)))
 T_8113: (in 78<i32> : int32)
   Class: Eq_8113
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8114: (in a7_1330 + 78<i32> : word32)
   Class: Eq_8114
-  DataType: Eq_8114
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8115: (in 3<32> : word32)
   Class: Eq_8115
   DataType: word32
@@ -35545,22 +35214,22 @@ T_8115: (in 3<32> : word32)
 T_8116: (in d5_862 >> 3<32> : word32)
   Class: Eq_8116
   DataType: Eq_8116
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_8117: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_8112
-  DataType: Eq_8112
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_8118: (in 0<32> : word32)
   Class: Eq_8118
   DataType: word32
   OrigDataType: word32
 T_8119: (in a0_900 + 0<32> : word32)
   Class: Eq_8119
-  DataType: Eq_8119
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8120: (in Mem889[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_8120
+  DataType: byte
   OrigDataType: byte
 T_8121: (in (uint8) Mem889[a0_900 + 0<32>:byte] : uint8)
   Class: Eq_8121
@@ -35595,8 +35264,8 @@ T_8128: (in ~(1<i32> << (d5_862 & 7<i32>)) & d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_8129: (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_8120
+  DataType: byte
   OrigDataType: byte
 T_8130: (in 0<32> : word32)
   Class: Eq_8130
@@ -35604,12 +35273,12 @@ T_8130: (in 0<32> : word32)
   OrigDataType: word32
 T_8131: (in a0_900 + 0<32> : word32)
   Class: Eq_8131
-  DataType: Eq_8131
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_8132: (in Mem914[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_8112
-  OrigDataType: Eq_603
+  Class: Eq_8120
+  DataType: byte
+  OrigDataType: byte
 T_8133: (in 1<32> : word32)
   Class: Eq_8133
   DataType: word32
@@ -35652,11 +35321,11 @@ T_8142: (in d0_957 : word32)
   OrigDataType: uint32
 T_8143: (in 3<32> : word32)
   Class: Eq_8143
-  DataType: (ptr32 Eq_9041)
+  DataType: (ptr32 Eq_9026)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_8144: (in d2_1090 + 3<32> : word32)
   Class: Eq_8144
-  DataType: (ptr32 Eq_9042)
+  DataType: (ptr32 Eq_9027)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_8145: (in 2<32> : word32)
   Class: Eq_8145
@@ -35679,8 +35348,8 @@ T_8149: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_8150: (in (d0_957 << 2<32>) + 4<32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: ui32
 T_8151: (in d0_957 << 2<32> : word32)
   Class: Eq_603
@@ -35692,7 +35361,7 @@ T_8152: (in -4<i32> : int32)
   OrigDataType: int32
 T_8153: (in d2_1090 + -4<i32> : word32)
   Class: Eq_8153
-  DataType: (ptr32 Eq_9043)
+  DataType: (ptr32 Eq_9028)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_603) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_8154: (in Mem946[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_8037
@@ -35818,30 +35487,30 @@ T_8184: (in a3_1955->b0000 == 0<8> : bool)
   Class: Eq_8184
   DataType: bool
   OrigDataType: bool
-T_8185: (in a7_985 : Eq_8185)
+T_8185: (in a7_985 : (ptr32 Eq_8185))
   Class: Eq_8185
-  DataType: Eq_8185
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_8185)
+  OrigDataType: (ptr32 (struct (0 T_605 t0000) (30 T_8202 t0030)))
 T_8186: (in 4<i32> : int32)
   Class: Eq_8186
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8187: (in a7_1330 - 4<i32> : word32)
   Class: Eq_8185
-  DataType: Eq_8185
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_8185)
+  OrigDataType: ptr32
 T_8188: (in 0<32> : word32)
   Class: Eq_8188
   DataType: word32
   OrigDataType: word32
 T_8189: (in a7_985 + 0<32> : word32)
   Class: Eq_8189
-  DataType: Eq_8189
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8190: (in Mem987[a7_985 + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_8185
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_8191: (in a5_5334 : word32)
   Class: Eq_8191
   DataType: word32
@@ -35856,8 +35525,8 @@ T_8193: (in 0<32> : word32)
   OrigDataType: word32
 T_8194: (in a7_985 + 0<32> : word32)
   Class: Eq_8194
-  DataType: Eq_8194
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8195: (in Mem987[a7_985 + 0<32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
@@ -35874,7 +35543,7 @@ T_8198: (in out a5_5334 : ptr32)
   Class: Eq_5228
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_8199: (in fn00003F30(*a7_985, out d1, out a1, out a5_5334) : word32)
+T_8199: (in fn00003F30(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
   Class: Eq_603
   DataType: Eq_603
   OrigDataType: word32
@@ -35884,19 +35553,19 @@ T_8200: (in 48<i32> : int32)
   OrigDataType: int32
 T_8201: (in a7_985 + 48<i32> : word32)
   Class: Eq_8201
-  DataType: Eq_8201
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8202: (in Mem1000[a7_985 + 48<i32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_8185
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_8203: (in 4<i32> : int32)
   Class: Eq_8203
   DataType: int32
   OrigDataType: int32
 T_8204: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_8205: (in a0_1004 : (ptr32 byte))
   Class: Eq_5238
@@ -35914,30 +35583,30 @@ T_8208: (in Mem981[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
-T_8209: (in a7_1005 : Eq_8209)
+T_8209: (in a7_1005 : (ptr32 Eq_8209))
   Class: Eq_8209
-  DataType: Eq_8209
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_8209)
+  OrigDataType: (ptr32 (struct (0 T_605 t0000) (30 T_8234 t0030)))
 T_8210: (in 4<i32> : int32)
   Class: Eq_8210
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8211: (in a7_1330 - 4<i32> : word32)
   Class: Eq_8209
-  DataType: Eq_8209
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_8209)
+  OrigDataType: ptr32
 T_8212: (in 0<32> : word32)
   Class: Eq_8212
   DataType: word32
   OrigDataType: word32
 T_8213: (in a7_1005 + 0<32> : word32)
   Class: Eq_8213
-  DataType: Eq_8213
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8214: (in Mem1007[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_8209
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_8215: (in 1<i32> : int32)
   Class: Eq_8215
   DataType: int32
@@ -35956,8 +35625,8 @@ T_8218: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_8219: (in Mem1011[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_8220: (in v585_1015 : byte)
   Class: Eq_5253
   DataType: byte
@@ -35980,8 +35649,8 @@ T_8224: (in 0<32> : word32)
   OrigDataType: word32
 T_8225: (in a7_1005 + 0<32> : word32)
   Class: Eq_8225
-  DataType: Eq_8225
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8226: (in Mem1011[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
@@ -35992,12 +35661,12 @@ T_8227: (in 0<32> : word32)
   OrigDataType: word32
 T_8228: (in a7_1005 + 0<32> : word32)
   Class: Eq_8228
-  DataType: Eq_8228
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8229: (in Mem1031[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_8209
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_8230: (in (uint8) v585_1015 : uint8)
   Class: Eq_8230
   DataType: uint8
@@ -36012,12 +35681,12 @@ T_8232: (in 48<i32> : int32)
   OrigDataType: int32
 T_8233: (in a7_1005 + 48<i32> : word32)
   Class: Eq_8233
-  DataType: Eq_8233
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8234: (in Mem1037[a7_1005 + 48<i32>:word32] : word32)
   Class: Eq_8231
-  DataType: Eq_8209
-  OrigDataType: uint32
+  DataType: uint32
+  OrigDataType: word32
 T_8235: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_8235
   DataType: word24
@@ -36032,8 +35701,8 @@ T_8237: (in 0<32> : word32)
   OrigDataType: word32
 T_8238: (in a7_1005 + 0<32> : word32)
   Class: Eq_8238
-  DataType: Eq_8238
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8239: (in Mem1037[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
@@ -36044,12 +35713,12 @@ T_8240: (in 44<i32> : int32)
   OrigDataType: int32
 T_8241: (in a7_1330 + 44<i32> : word32)
   Class: Eq_8241
-  DataType: Eq_8241
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_8242: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
-  OrigDataType: word32
+  OrigDataType: int32
 T_8243: (in d3_1057 : Eq_8243)
   Class: Eq_8243
   DataType: Eq_8243
@@ -36080,135 +35749,135 @@ T_8249: (in 44<i32> : int32)
   OrigDataType: int32
 T_8250: (in a7_1330 + 44<i32> : word32)
   Class: Eq_8250
-  DataType: Eq_8250
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_8251: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_8251
-  DataType: word32
-  OrigDataType: word32
+  DataType: int32
+  OrigDataType: int32
 T_8252: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_8251
-  DataType: word32
+  DataType: int32
   OrigDataType: word32
-T_8253: (in *((word32) a7_1330 + 44<i32>) == 0xFFFFFFFF<32> : bool)
+T_8253: (in a7_1330[11<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_8253
   DataType: bool
   OrigDataType: bool
 T_8254: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_8255: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_8255
   DataType: bool
   OrigDataType: bool
-T_8256: (in a7_1076 : Eq_8256)
+T_8256: (in a7_1076 : (ptr32 Eq_8256))
   Class: Eq_8256
-  DataType: Eq_8256
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_8256)
+  OrigDataType: (ptr32 (struct (0 T_8260 t0000) (4D T_8317 t004D)))
 T_8257: (in 4<i32> : int32)
   Class: Eq_8257
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8258: (in a7_1330 - 4<i32> : word32)
   Class: Eq_8256
-  DataType: Eq_8256
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_8256)
+  OrigDataType: ptr32
 T_8259: (in 78<i32> : int32)
   Class: Eq_8259
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8260: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  Class: Eq_8260
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8261: (in 0<32> : word32)
   Class: Eq_8261
   DataType: word32
   OrigDataType: word32
 T_8262: (in a7_1076 + 0<32> : word32)
   Class: Eq_8262
-  DataType: Eq_8262
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8263: (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_8256
+  Class: Eq_8260
+  DataType: ptr32
   OrigDataType: word32
 T_8264: (in 4<i32> : int32)
   Class: Eq_8264
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8265: (in a7_1076 - 4<i32> : word32)
   Class: Eq_8265
-  DataType: Eq_8265
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_8268 t0000)))
 T_8266: (in 0<32> : word32)
   Class: Eq_8266
   DataType: word32
   OrigDataType: word32
 T_8267: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_8267
-  DataType: Eq_8267
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8268: (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_8265
-  OrigDataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: word32
 T_8269: (in 00000008 : ptr32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_8269
+  DataType: ptr32
   OrigDataType: ptr32
 T_8270: (in 8<i32> : int32)
   Class: Eq_8270
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8271: (in a7_1076 - 8<i32> : word32)
   Class: Eq_8271
-  DataType: Eq_8271
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_8274 t0000)))
 T_8272: (in 0<32> : word32)
   Class: Eq_8272
   DataType: word32
   OrigDataType: word32
 T_8273: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_8273
-  DataType: Eq_8273
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8274: (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_8271
-  OrigDataType: uint8
+  Class: Eq_8269
+  DataType: ptr32
+  OrigDataType: word32
 T_8275: (in 12<i32> : int32)
   Class: Eq_8275
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8276: (in a7_1076 - 12<i32> : word32)
   Class: Eq_8276
-  DataType: Eq_8276
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_603)
+  OrigDataType: (ptr32 (struct (0 T_8279 t0000)))
 T_8277: (in 0<32> : word32)
   Class: Eq_8277
   DataType: word32
   OrigDataType: word32
 T_8278: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_8278
-  DataType: Eq_8278
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8279: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_8276
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_8280: (in 0<32> : word32)
   Class: Eq_8280
   DataType: word32
   OrigDataType: word32
 T_8281: (in a7_1076 + 0<32> : word32)
   Class: Eq_8281
-  DataType: Eq_8281
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8282: (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_8260
+  DataType: ptr32
   OrigDataType: ptr32
 T_8283: (in fn00002948 : ptr32)
   Class: Eq_8283
@@ -36220,45 +35889,45 @@ T_8284: (in signature of fn00002948 : void)
   OrigDataType: 
 T_8285: (in a7_1076 - 12<i32> : word32)
   Class: Eq_8285
-  DataType: Eq_8285
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_663)
+  OrigDataType: (ptr32 (struct (0 T_8288 t0000)))
 T_8286: (in 0<32> : word32)
   Class: Eq_8286
   DataType: word32
   OrigDataType: word32
 T_8287: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_8287
-  DataType: Eq_8287
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8288: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8289: (in 8<i32> : int32)
   Class: Eq_8289
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8290: (in a7_1076 - 8<i32> : word32)
   Class: Eq_8290
-  DataType: Eq_8290
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_663)
+  OrigDataType: (ptr32 (struct (0 T_8293 t0000)))
 T_8291: (in 0<32> : word32)
   Class: Eq_8291
   DataType: word32
   OrigDataType: word32
 T_8292: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_8292
-  DataType: Eq_8292
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8293: (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8294: (in fn00002948(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_8294
   DataType: int32
   OrigDataType: int32
-T_8295: (in Mem1087[a7_1076 + 0<32>:word32] + fn00002948(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
+T_8295: (in a7_1076->ptr0000 + fn00002948(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_8295
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_8296 t0000)))
@@ -36276,23 +35945,23 @@ T_8298: (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn0000294
   OrigDataType: uint32
 T_8299: (in 4<i32> : int32)
   Class: Eq_8299
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8300: (in a7_1076 - 4<i32> : word32)
   Class: Eq_8300
-  DataType: Eq_8300
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_8303 t0000)))
 T_8301: (in 0<32> : word32)
   Class: Eq_8301
   DataType: word32
   OrigDataType: word32
 T_8302: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_8302
-  DataType: Eq_8302
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8303: (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_8304: (in 1<i32> : int32)
   Class: Eq_8304
@@ -36316,7 +35985,7 @@ T_8308: (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
   OrigDataType: ui32
 T_8309: (in 0<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_8310: (in d0 == 0<32> : bool)
   Class: Eq_8310
@@ -36344,8 +36013,8 @@ T_8315: (in 77<i32> : int32)
   OrigDataType: int32
 T_8316: (in a7_1076 + 77<i32> : word32)
   Class: Eq_8316
-  DataType: Eq_8316
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8317: (in Mem1087[a7_1076 + 77<i32>:byte] : byte)
   Class: Eq_8314
   DataType: byte
@@ -36482,30 +36151,30 @@ T_8350: (in a6_1164 + 1<i32> : word32)
   Class: Eq_8037
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_8351: (in a7_1182 : Eq_8351)
+T_8351: (in a7_1182 : (ptr32 Eq_603))
   Class: Eq_8351
-  DataType: Eq_8351
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_603)
+  OrigDataType: (ptr32 (struct (0 T_605 t0000)))
 T_8352: (in 4<i32> : int32)
   Class: Eq_8352
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8353: (in a7_1330 - 4<i32> : word32)
   Class: Eq_8351
-  DataType: Eq_8351
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_603)
+  OrigDataType: ptr32
 T_8354: (in 0<32> : word32)
   Class: Eq_8354
   DataType: word32
   OrigDataType: word32
 T_8355: (in a7_1182 + 0<32> : word32)
   Class: Eq_8355
-  DataType: Eq_8355
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8356: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_8351
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_8357: (in d1_5335 : word32)
   Class: Eq_8357
   DataType: word32
@@ -36524,8 +36193,8 @@ T_8360: (in 0<32> : word32)
   OrigDataType: word32
 T_8361: (in a7_1182 + 0<32> : word32)
   Class: Eq_8361
-  DataType: Eq_8361
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8362: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
@@ -36551,8 +36220,8 @@ T_8367: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_8368: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_8369: (in a0_1200 : (ptr32 byte))
   Class: Eq_5238
@@ -36570,30 +36239,30 @@ T_8372: (in Mem1177[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
-T_8373: (in a7_1201 : Eq_8373)
+T_8373: (in a7_1201 : (ptr32 Eq_603))
   Class: Eq_8373
-  DataType: Eq_8373
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_603)
+  OrigDataType: (ptr32 (struct (0 T_605 t0000)))
 T_8374: (in 4<i32> : int32)
   Class: Eq_8374
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8375: (in a7_1330 - 4<i32> : word32)
   Class: Eq_8373
-  DataType: Eq_8373
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_603)
+  OrigDataType: ptr32
 T_8376: (in 0<32> : word32)
   Class: Eq_8376
   DataType: word32
   OrigDataType: word32
 T_8377: (in a7_1201 + 0<32> : word32)
   Class: Eq_8377
-  DataType: Eq_8377
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8378: (in Mem1203[a7_1201 + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_8373
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_8379: (in 1<i32> : int32)
   Class: Eq_8379
   DataType: int32
@@ -36612,8 +36281,8 @@ T_8382: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_5256 t0000))))
 T_8383: (in Mem1207[a1 + 0<32>:word32] : word32)
   Class: Eq_5238
-  DataType: Eq_603
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_5256 t0000)))
 T_8384: (in v611_1211 : byte)
   Class: Eq_5253
   DataType: byte
@@ -36636,8 +36305,8 @@ T_8388: (in 0<32> : word32)
   OrigDataType: word32
 T_8389: (in a7_1201 + 0<32> : word32)
   Class: Eq_8389
-  DataType: Eq_8389
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8390: (in Mem1207[a7_1201 + 0<32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
@@ -36676,7 +36345,7 @@ T_8398: (in d4_1070 + 1<32> : word32)
   OrigDataType: int32
 T_8399: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_8400: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_8400
@@ -36704,8 +36373,8 @@ T_8405: (in 73<i32> : int32)
   OrigDataType: int32
 T_8406: (in a7_1330 + 73<i32> : word32)
   Class: Eq_8406
-  DataType: Eq_8406
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_8407: (in Mem1331[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_8407
   DataType: byte
@@ -36714,77 +36383,77 @@ T_8408: (in 0<8> : byte)
   Class: Eq_8407
   DataType: byte
   OrigDataType: byte
-T_8409: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_8409: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_8409
   DataType: bool
   OrigDataType: bool
-T_8410: (in a7_1302 : Eq_8410)
+T_8410: (in a7_1302 : (ptr32 Eq_603))
   Class: Eq_8410
-  DataType: Eq_8410
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_603)
+  OrigDataType: (ptr32 (struct (0 T_605 t0000)))
 T_8411: (in 4<i32> : int32)
   Class: Eq_8411
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8412: (in a7_1330 - 4<i32> : word32)
   Class: Eq_8410
-  DataType: Eq_8410
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_603)
+  OrigDataType: ptr32
 T_8413: (in 0<32> : word32)
   Class: Eq_8413
   DataType: word32
   OrigDataType: word32
 T_8414: (in a7_1302 + 0<32> : word32)
   Class: Eq_8414
-  DataType: Eq_8414
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8415: (in Mem1308[a7_1302 + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_8410
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_8416: (in 4<i32> : int32)
   Class: Eq_8416
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8417: (in a7_1302 - 4<i32> : word32)
   Class: Eq_8417
-  DataType: Eq_8417
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_603)
+  OrigDataType: (ptr32 (struct (0 T_8420 t0000)))
 T_8418: (in 0<32> : word32)
   Class: Eq_8418
   DataType: word32
   OrigDataType: word32
 T_8419: (in a7_1302 - 4<i32> + 0<32> : word32)
   Class: Eq_8419
-  DataType: Eq_8419
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8420: (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_8417
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_8421: (in fn00002E5C : ptr32)
   Class: Eq_5413
   DataType: (ptr32 Eq_5413)
   OrigDataType: (ptr32 (fn T_8430 (T_8426, T_8429)))
 T_8422: (in 1<i32> : int32)
   Class: Eq_8422
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8423: (in a7_1302 - 1<i32> : word32)
   Class: Eq_8423
-  DataType: Eq_8423
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_8426 t0000)))
 T_8424: (in 0<32> : word32)
   Class: Eq_8424
   DataType: word32
   OrigDataType: word32
 T_8425: (in a7_1302 - 1<i32> + 0<32> : word32)
   Class: Eq_8425
-  DataType: Eq_8425
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8426: (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_4827
+  DataType: byte
   OrigDataType: byte
 T_8427: (in 0<32> : word32)
   Class: Eq_8427
@@ -36792,8 +36461,8 @@ T_8427: (in 0<32> : word32)
   OrigDataType: word32
 T_8428: (in a7_1302 + 0<32> : word32)
   Class: Eq_8428
-  DataType: Eq_8428
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8429: (in Mem1311[a7_1302 + 0<32>:word32] : word32)
   Class: Eq_603
   DataType: Eq_603
@@ -36808,119 +36477,119 @@ T_8431: (in 73<i32> : int32)
   OrigDataType: int32
 T_8432: (in a7_1330 + 73<i32> : word32)
   Class: Eq_8432
-  DataType: Eq_8432
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_8433: (in Mem1294[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_8314
-  DataType: Eq_4861
+  DataType: byte
   OrigDataType: byte
-T_8434: (in a7_1237 : Eq_8434)
+T_8434: (in a7_1237 : (ptr32 ptr32))
   Class: Eq_8434
-  DataType: Eq_8434
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_8438 t0000)))
 T_8435: (in 4<i32> : int32)
   Class: Eq_8435
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8436: (in a7_1330 - 4<i32> : word32)
   Class: Eq_8434
-  DataType: Eq_8434
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
 T_8437: (in 78<i32> : int32)
   Class: Eq_8437
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8438: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_603
-  DataType: Eq_603
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  Class: Eq_8438
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8439: (in 0<32> : word32)
   Class: Eq_8439
   DataType: word32
   OrigDataType: word32
 T_8440: (in a7_1237 + 0<32> : word32)
   Class: Eq_8440
-  DataType: Eq_8440
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8441: (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_8434
+  Class: Eq_8438
+  DataType: ptr32
   OrigDataType: word32
 T_8442: (in 4<i32> : int32)
   Class: Eq_8442
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8443: (in a7_1237 - 4<i32> : word32)
   Class: Eq_8443
-  DataType: Eq_8443
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_8446 t0000)))
 T_8444: (in 0<32> : word32)
   Class: Eq_8444
   DataType: word32
   OrigDataType: word32
 T_8445: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_8445
-  DataType: Eq_8445
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8446: (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_8443
-  OrigDataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: word32
 T_8447: (in 00000008 : ptr32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_8447
+  DataType: ptr32
   OrigDataType: ptr32
 T_8448: (in 8<i32> : int32)
   Class: Eq_8448
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8449: (in a7_1237 - 8<i32> : word32)
   Class: Eq_8449
-  DataType: Eq_8449
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_8452 t0000)))
 T_8450: (in 0<32> : word32)
   Class: Eq_8450
   DataType: word32
   OrigDataType: word32
 T_8451: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_8451
-  DataType: Eq_8451
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8452: (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_8449
-  OrigDataType: uint8
+  Class: Eq_8447
+  DataType: ptr32
+  OrigDataType: word32
 T_8453: (in 12<i32> : int32)
   Class: Eq_8453
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8454: (in a7_1237 - 12<i32> : word32)
   Class: Eq_8454
-  DataType: Eq_8454
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_603)
+  OrigDataType: (ptr32 (struct (0 T_8457 t0000)))
 T_8455: (in 0<32> : word32)
   Class: Eq_8455
   DataType: word32
   OrigDataType: word32
 T_8456: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_8456
-  DataType: Eq_8456
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8457: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
   Class: Eq_603
-  DataType: Eq_8454
-  OrigDataType: Eq_603
+  DataType: Eq_603
+  OrigDataType: word32
 T_8458: (in 0<32> : word32)
   Class: Eq_8458
   DataType: word32
   OrigDataType: word32
 T_8459: (in a7_1237 + 0<32> : word32)
   Class: Eq_8459
-  DataType: Eq_8459
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8460: (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_8438
+  DataType: ptr32
   OrigDataType: ptr32
 T_8461: (in fn00002948 : ptr32)
   Class: Eq_8283
@@ -36928,45 +36597,45 @@ T_8461: (in fn00002948 : ptr32)
   OrigDataType: (ptr32 (fn T_8471 (T_4865, T_8465, T_8470)))
 T_8462: (in a7_1237 - 12<i32> : word32)
   Class: Eq_8462
-  DataType: Eq_8462
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_663)
+  OrigDataType: (ptr32 (struct (0 T_8465 t0000)))
 T_8463: (in 0<32> : word32)
   Class: Eq_8463
   DataType: word32
   OrigDataType: word32
 T_8464: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_8464
-  DataType: Eq_8464
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8465: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8466: (in 8<i32> : int32)
   Class: Eq_8466
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8467: (in a7_1237 - 8<i32> : word32)
   Class: Eq_8467
-  DataType: Eq_8467
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 Eq_663)
+  OrigDataType: (ptr32 (struct (0 T_8470 t0000)))
 T_8468: (in 0<32> : word32)
   Class: Eq_8468
   DataType: word32
   OrigDataType: word32
 T_8469: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_8469
-  DataType: Eq_8469
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8470: (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8471: (in fn00002948(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_8294
   DataType: int32
   OrigDataType: int32
-T_8472: (in Mem1248[a7_1237 + 0<32>:word32] + fn00002948(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
+T_8472: (in *a7_1237 + fn00002948(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_8472
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_8473 t0000)))
@@ -36984,23 +36653,23 @@ T_8475: (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn0000294
   OrigDataType: uint32
 T_8476: (in 4<i32> : int32)
   Class: Eq_8476
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: int32
+  OrigDataType: int32
 T_8477: (in a7_1237 - 4<i32> : word32)
   Class: Eq_8477
-  DataType: Eq_8477
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_8480 t0000)))
 T_8478: (in 0<32> : word32)
   Class: Eq_8478
   DataType: word32
   OrigDataType: word32
 T_8479: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_8479
-  DataType: Eq_8479
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_8480: (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_604
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_8481: (in 1<i32> : int32)
   Class: Eq_8481
@@ -37024,7 +36693,7 @@ T_8485: (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
   OrigDataType: ui32
 T_8486: (in 0<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_8487: (in d0 == 0<32> : bool)
   Class: Eq_8487
@@ -37080,8 +36749,8 @@ T_8499: (in 60<i32> : int32)
   OrigDataType: int32
 T_8500: (in a7_1330 + 60<i32> : word32)
   Class: Eq_8500
-  DataType: Eq_8500
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8501: (in Mem1348[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_8501
   DataType: word32
@@ -37096,39 +36765,39 @@ T_8503: (in Mem1348[a7_1330 + 60<i32>:word32] + 1<32> : word32)
   OrigDataType: word32
 T_8504: (in a7_1330 + 60<i32> : word32)
   Class: Eq_8504
-  DataType: Eq_8504
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_9025) u1) (T_6954 u2) (T_7820 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_8505: (in Mem1351[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_8503
-  DataType: Eq_4861
+  DataType: word32
   OrigDataType: word32
 T_8506: (in d0 : uint32)
   Class: Eq_8506
   DataType: uint32
   OrigDataType: word32
-T_8507: (in d0_23 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_8507: (in d0_23 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8508: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_8509 (T_7558)))
 T_8509: (in __swap(dwArg08) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
-T_8510: (in d1_25 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_8510: (in d1_25 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_8511: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_8512 (T_7560)))
 T_8512: (in __swap(dwArg10) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8513: (in d4_29 : uint32)
   Class: Eq_8513
@@ -37166,9 +36835,9 @@ T_8521: (in d1_25 * (word16) d0_23 : word32)
   Class: Eq_8519
   DataType: uint32
   OrigDataType: uint32
-T_8522: (in d2_39 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_8522: (in d2_39 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_8523: (in SLICE(d1_25, word16, 0) : word16)
   Class: Eq_8523
@@ -37199,12 +36868,12 @@ T_8529: (in (word16) d4_29 ^ (word16) d4_29 : word16)
   DataType: ui16
   OrigDataType: ui16
 T_8530: (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_8531: (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8532: (in dwArg08 *u SLICE(d1_25, word16, 0) + __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
   Class: Eq_8532
@@ -37219,28 +36888,28 @@ T_8534: (in dwArg10 * (word16) d0_23 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_8535: (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_8536: (in 0<32> : word32)
-  Class: Eq_603
-  DataType: uint8
+  Class: Eq_663
+  DataType: (ptr32 Eq_1885)
   OrigDataType: up32
 T_8537: (in d2_39 >= 0<32> : bool)
   Class: Eq_8537
   DataType: bool
   OrigDataType: bool
-T_8538: (in d2_45 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_8538: (in d2_45 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8539: (in __swap : ptr32)
   Class: Eq_661
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_8540 (T_8522)))
 T_8540: (in __swap(d2_39) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8541: (in d3_65 : uint32)
   Class: Eq_8541
@@ -37251,8 +36920,8 @@ T_8542: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_8543 (T_7559)))
 T_8543: (in __swap(dwArg0C) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_8544: (in SLICE(dwArg08, word16, 0) : word16)
   Class: Eq_8544
@@ -37262,9 +36931,9 @@ T_8545: (in __swap(dwArg0C) * (word16) dwArg08 : word32)
   Class: Eq_8541
   DataType: uint32
   OrigDataType: uint32
-T_8546: (in d3_71 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_8546: (in d3_71 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8547: (in __swap : ptr32)
   Class: Eq_661
@@ -37279,8 +36948,8 @@ T_8549: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_8550 (T_7558)))
 T_8550: (in __swap(dwArg08) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_8551: (in SLICE(dwArg0C, word16, 0) : word16)
   Class: Eq_8551
@@ -37299,12 +36968,12 @@ T_8554: (in SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_8555: (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_8556: (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8557: (in d3_83 : uint32)
   Class: Eq_8557
@@ -37315,8 +36984,8 @@ T_8558: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_8559 (T_7557)))
 T_8559: (in __swap(dwArg04) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_8560: (in SLICE(dwArg10, word16, 0) : word16)
   Class: Eq_8560
@@ -37326,9 +36995,9 @@ T_8561: (in __swap(dwArg04) * (word16) dwArg10 : word32)
   Class: Eq_8557
   DataType: uint32
   OrigDataType: uint32
-T_8562: (in d3_89 : Eq_603)
-  Class: Eq_603
-  DataType: Eq_603
+T_8562: (in d3_89 : Eq_663)
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8563: (in __swap : ptr32)
   Class: Eq_661
@@ -37343,8 +37012,8 @@ T_8565: (in __swap : ptr32)
   DataType: (ptr32 Eq_661)
   OrigDataType: (ptr32 (fn T_8566 (T_7560)))
 T_8566: (in __swap(dwArg10) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uint32
 T_8567: (in SLICE(dwArg04, word16, 0) : word16)
   Class: Eq_8567
@@ -37363,12 +37032,12 @@ T_8570: (in SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_8571: (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: uipr32
 T_8572: (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
-  Class: Eq_603
-  DataType: Eq_603
+  Class: Eq_663
+  DataType: Eq_663
   OrigDataType: word32
 T_8573: (in SLICE(d2_45, word16, 16) : word16)
   Class: Eq_8573
@@ -37516,7 +37185,7 @@ T_8608: (in fn00002688(out a1_116, out a5_279) : word32)
   OrigDataType: word32
 T_8609: (in 0<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_8610: (in dwArg04 != 0<32> : bool)
   Class: Eq_8610
@@ -37676,7 +37345,7 @@ T_8648: (in Mem86[dwArg04 + 8<i32>:word32] : word32)
   OrigDataType: word32
 T_8649: (in 0<32> : word32)
   Class: Eq_603
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_8650: (in *((word32) dwArg04 + 8<i32>) != 0<32> : bool)
   Class: Eq_8650
@@ -39024,27 +38693,27 @@ T_8985:
   OrigDataType: 
 T_8986:
   Class: Eq_8986
-  DataType: Eq_8986
+  DataType: Eq_4868
   OrigDataType: 
 T_8987:
   Class: Eq_8987
-  DataType: Eq_8987
+  DataType: (ptr32 Eq_4868)
   OrigDataType: 
 T_8988:
   Class: Eq_8988
-  DataType: Eq_8988
+  DataType: Eq_4868
   OrigDataType: 
 T_8989:
   Class: Eq_8989
-  DataType: Eq_8989
+  DataType: (ptr32 Eq_4868)
   OrigDataType: 
 T_8990:
   Class: Eq_8990
-  DataType: Eq_8990
+  DataType: Eq_4868
   OrigDataType: 
 T_8991:
   Class: Eq_8991
-  DataType: Eq_8991
+  DataType: (ptr32 Eq_4868)
   OrigDataType: 
 T_8992:
   Class: Eq_8992
@@ -39056,31 +38725,31 @@ T_8993:
   OrigDataType: 
 T_8994:
   Class: Eq_8994
-  DataType: Eq_8994
+  DataType: Eq_4868
   OrigDataType: 
 T_8995:
   Class: Eq_8995
-  DataType: Eq_4868
+  DataType: (ptr32 Eq_4868)
   OrigDataType: 
 T_8996:
   Class: Eq_8996
-  DataType: (ptr32 Eq_4868)
+  DataType: Eq_8996
   OrigDataType: 
 T_8997:
   Class: Eq_8997
-  DataType: Eq_4868
+  DataType: Eq_8997
   OrigDataType: 
 T_8998:
   Class: Eq_8998
-  DataType: (ptr32 Eq_4868)
+  DataType: Eq_8998
   OrigDataType: 
 T_8999:
   Class: Eq_8999
-  DataType: Eq_4868
+  DataType: Eq_8999
   OrigDataType: 
 T_9000:
   Class: Eq_9000
-  DataType: (ptr32 Eq_4868)
+  DataType: Eq_9000
   OrigDataType: 
 T_9001:
   Class: Eq_9001
@@ -39092,11 +38761,11 @@ T_9002:
   OrigDataType: 
 T_9003:
   Class: Eq_9003
-  DataType: Eq_4868
+  DataType: Eq_9003
   OrigDataType: 
 T_9004:
   Class: Eq_9004
-  DataType: (ptr32 Eq_4868)
+  DataType: Eq_9004
   OrigDataType: 
 T_9005:
   Class: Eq_9005
@@ -39193,66 +38862,6 @@ T_9027:
 T_9028:
   Class: Eq_9028
   DataType: Eq_9028
-  OrigDataType: 
-T_9029:
-  Class: Eq_9029
-  DataType: Eq_9029
-  OrigDataType: 
-T_9030:
-  Class: Eq_9030
-  DataType: Eq_9030
-  OrigDataType: 
-T_9031:
-  Class: Eq_9031
-  DataType: Eq_9031
-  OrigDataType: 
-T_9032:
-  Class: Eq_9032
-  DataType: Eq_9032
-  OrigDataType: 
-T_9033:
-  Class: Eq_9033
-  DataType: Eq_9033
-  OrigDataType: 
-T_9034:
-  Class: Eq_9034
-  DataType: Eq_9034
-  OrigDataType: 
-T_9035:
-  Class: Eq_9035
-  DataType: Eq_9035
-  OrigDataType: 
-T_9036:
-  Class: Eq_9036
-  DataType: Eq_9036
-  OrigDataType: 
-T_9037:
-  Class: Eq_9037
-  DataType: Eq_9037
-  OrigDataType: 
-T_9038:
-  Class: Eq_9038
-  DataType: Eq_9038
-  OrigDataType: 
-T_9039:
-  Class: Eq_9039
-  DataType: Eq_9039
-  OrigDataType: 
-T_9040:
-  Class: Eq_9040
-  DataType: Eq_9040
-  OrigDataType: 
-T_9041:
-  Class: Eq_9041
-  DataType: Eq_9041
-  OrigDataType: 
-T_9042:
-  Class: Eq_9042
-  DataType: Eq_9042
-  OrigDataType: 
-T_9043:
-  Class: Eq_9043
-  DataType: Eq_9043
   OrigDataType: 
 */
 typedef struct Eq_614;
@@ -39431,17 +39040,13 @@ typedef word32 (Eq_581)(ptr32, ptr32, ptr32);
 typedef ptr32 (Eq_583)();
 
 typedef union Eq_603 {
-	uint8 u0;
+	byte u0;
 	word16 u1;
-	struct Eq_1885 * u2;
-	struct Eq_9002 * u3;
-	struct Eq_8951 * u4;
-	struct Eq_8958 * u5;
-	Eq_6954 u6;
-	Eq_7817 u7;
+	struct Eq_8993 * u2;
+	struct Eq_8951 * u3;
 } Eq_603;
 
-typedef Eq_603 (Eq_609)(Eq_603, Eq_603, Eq_603, Eq_614 *);
+typedef Eq_603 (Eq_609)(Eq_603, Eq_603, byte * *, Eq_614 *);
 
 typedef struct Eq_614 {	// size: 1 1
 	uint8 b0000;	// 0
@@ -39463,7 +39068,13 @@ typedef union Eq_626 {
 	ptr32 u2;
 } Eq_626;
 
-typedef Eq_603 (Eq_661)(Eq_603);
+typedef Eq_663 (Eq_661)(Eq_663);
+
+typedef union Eq_663 {
+	struct Eq_1885 * u0;
+	struct Eq_8952 * u1;
+	struct Eq_8953 * u2;
+} Eq_663;
 
 typedef union Eq_671 {
 	int32 u0;
@@ -39493,19 +39104,19 @@ typedef struct Eq_1227 {
 } Eq_1227;
 
 typedef struct Eq_1238 {	// size: 4 4
-	Eq_8959 t002C;	// 2C
+	Eq_8954 t002C;	// 2C
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
-	word32 dw0037;	// 37
+	byte b0037;	// 37
 	word32 dw0038;	// 38
 	word32 dw003C;	// 3C
-	word32 dw003E;	// 3E
-	word32 dw003F;	// 3F
+	word16 w003E;	// 3E
+	byte b003F;	// 3F
 	word32 dw0040;	// 40
 	word32 dw0044;	// 44
 	ui32 dw0048;	// 48
 	word32 dw0062;	// 62
-	Eq_8960 t0066;	// 66
+	Eq_8955 t0066;	// 66
 	byte b006A;	// 6A
 	word32 dw006C;	// 6C
 	word32 dw007C;	// 7C
@@ -39734,9 +39345,9 @@ typedef struct Eq_2224 {
 	Eq_1226 t0080;	// 80
 } Eq_2224;
 
-typedef int32 (Eq_2264)(Eq_603, Eq_603, Eq_603, Eq_603);
+typedef int32 (Eq_2264)(Eq_663, Eq_663, Eq_663, Eq_663);
 
-typedef word32 (Eq_2348)(Eq_603, Eq_603, Eq_603, Eq_603, Eq_603, Eq_603);
+typedef word32 (Eq_2348)(Eq_663, Eq_663, Eq_663, Eq_663, Eq_663, Eq_663);
 
 typedef union Eq_2388 {
 	bool u0;
@@ -39879,11 +39490,6 @@ typedef union Eq_2650 {
 	up32 u1;
 } Eq_2650;
 
-typedef union Eq_2743 {
-	byte u0;
-	word32 u1;
-} Eq_2743;
-
 typedef struct Eq_2747 {
 	struct Eq_1227 * ptr0000;	// 0
 	int32 dw0034;	// 34
@@ -39904,11 +39510,6 @@ typedef union Eq_2785 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2785;
-
-typedef union Eq_2808 {
-	word16 u0;
-	word32 u1;
-} Eq_2808;
 
 typedef struct Eq_2812 {
 	struct Eq_1227 * ptr0000;	// 0
@@ -39972,11 +39573,6 @@ typedef union Eq_2904 {
 	Eq_1832 u4;
 	Eq_2902 u5;
 } Eq_2904;
-
-typedef union Eq_2908 {
-	byte u0;
-	word32 u1;
-} Eq_2908;
 
 typedef struct Eq_2912 {
 	struct Eq_1227 * ptr0000;	// 0
@@ -40192,7 +39788,7 @@ typedef Eq_3211 (Eq_3205)(ptr32, ptr32);
 
 typedef union Eq_3211 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 } Eq_3211;
 
 typedef int32 (Eq_3266)(int32, ptr32, ptr32, int32 *);
@@ -40244,9 +39840,9 @@ typedef void (Eq_3882)(Eq_377 *);
 
 typedef void (Eq_3906)(int32, word32);
 
-typedef Eq_603 (Eq_3942)(Eq_603, Eq_603, Eq_603, Eq_603, Eq_603);
+typedef Eq_663 (Eq_3942)(Eq_663, Eq_663, Eq_663, Eq_663, Eq_663);
 
-typedef Eq_603 (Eq_3956)(Eq_603, Eq_603);
+typedef Eq_663 (Eq_3956)(Eq_663, Eq_663);
 
 typedef struct Eq_3977 {	// size: 1 1
 	Eq_3977 a0000[];	// 0
@@ -40267,7 +39863,7 @@ typedef union Eq_4097 {
 	word16 u1;
 } Eq_4097;
 
-typedef Eq_603 (Eq_4120)(Eq_603, Eq_603, Eq_603, Eq_603);
+typedef Eq_663 (Eq_4120)(Eq_663, Eq_663, Eq_663, Eq_663);
 
 typedef union Eq_4143 {
 	bool u0;
@@ -40289,7 +39885,7 @@ typedef union Eq_4287 {
 	uint32 u1;
 } Eq_4287;
 
-typedef Eq_603 (Eq_4384)(Eq_603, word32, bool);
+typedef Eq_663 (Eq_4384)(Eq_663, word32, bool);
 
 typedef union Eq_4714 {
 	bool u0;
@@ -40316,20 +39912,30 @@ typedef union Eq_4766 {
 	ui32 u1;
 } Eq_4766;
 
-typedef Eq_603 (Eq_4812)(Eq_603, Eq_603, Eq_603, Eq_603, Eq_614 *, Eq_603);
+typedef Eq_603 (Eq_4812)(Eq_603, Eq_603, byte * *, Eq_603, Eq_614 *, Eq_663);
 
-typedef union Eq_4861 {
-	uint8 u0;
-	struct Eq_8981 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
+typedef struct Eq_4861 {	// size: 4 4
+	int32 dw002C;	// 2C
+	Eq_8971 t0030;	// 30
+	word32 dw0034;	// 34
+	uint8 b0037;	// 37
+	word32 dw0038;	// 38
+	word32 dw003C;	// 3C
+	word32 dw0040;	// 40
+	Eq_8972 t0044;	// 44
+	byte b0048;	// 48
+	byte b0049;	// 49
+	word32 dw004A;	// 4A
+	word32 dw006E;	// 6E
+	word32 dw0072;	// 72
+	word32 dw0084;	// 84
 } Eq_4861;
 
 typedef union Eq_4868 {
 	byte u0;
 	word16 u1;
-	struct Eq_9002 * u2;
-	struct Eq_8983 * u3;
+	struct Eq_8993 * u2;
+	struct Eq_8974 * u3;
 } Eq_4868;
 
 typedef union Eq_4880 {
@@ -40368,7 +39974,7 @@ typedef union Eq_5001 {
 
 typedef Eq_603 (Eq_5223)(Eq_603, Eq_3211, word32 *, byte *);
 
-typedef Eq_603 (Eq_5413)(Eq_603, Eq_603);
+typedef Eq_603 (Eq_5413)(byte, Eq_603);
 
 typedef struct Eq_5426 {
 	Eq_603 t0000;	// 0
@@ -40598,11 +40204,6 @@ typedef struct Eq_6912 {
 	uint32 dw0038;	// 38
 } Eq_6912;
 
-typedef union Eq_6954 {
-	uint8 u0;
-	word32 u1;
-} Eq_6954;
-
 typedef union Eq_6962 {
 	int32 u0;
 	uint32 u1;
@@ -40660,22 +40261,22 @@ typedef union Eq_7130 {
 
 typedef union Eq_7144 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 } Eq_7144;
 
 typedef union Eq_7146 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 } Eq_7146;
 
 typedef union Eq_7161 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 } Eq_7161;
 
 typedef union Eq_7164 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 } Eq_7164;
 
 typedef union Eq_7182 {
@@ -40685,17 +40286,17 @@ typedef union Eq_7182 {
 
 typedef union Eq_7213 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 } Eq_7213;
 
 typedef union Eq_7215 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 } Eq_7215;
 
 typedef union Eq_7228 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 	Eq_7164 u2;
 } Eq_7228;
 
@@ -40706,12 +40307,12 @@ typedef union Eq_7234 {
 
 typedef union Eq_7275 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 } Eq_7275;
 
 typedef union Eq_7290 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 } Eq_7290;
 
 typedef union Eq_7292 {
@@ -40722,14 +40323,14 @@ typedef union Eq_7292 {
 
 typedef union Eq_7293 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 	Eq_7164 u2;
 	Eq_7228 u3;
 } Eq_7293;
 
 typedef union Eq_7296 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 } Eq_7296;
 
 typedef union Eq_7310 {
@@ -40748,7 +40349,7 @@ typedef struct Eq_7452 {
 } Eq_7452;
 
 typedef struct Eq_7503 {
-	Eq_603 t0000;	// 0
+	Eq_663 t0000;	// 0
 	ui24 n0001;	// 1
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
@@ -40756,7 +40357,7 @@ typedef struct Eq_7503 {
 	word32 dw0048;	// 48
 } Eq_7503;
 
-typedef word32 (Eq_7554)(Eq_4868, Eq_603, Eq_603, Eq_603, Eq_603, ptr32);
+typedef word32 (Eq_7554)(Eq_4868, Eq_663, Eq_663, Eq_663, Eq_663, ptr32);
 
 typedef union Eq_7605 {
 	int32 u0;
@@ -40778,23 +40379,15 @@ typedef struct Eq_7688 {
 
 typedef union Eq_7816 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 	Eq_7290 u2;
 } Eq_7816;
 
 typedef union Eq_7817 {
-	uint8 u0;
-	union Eq_4868 ** u1;
-	struct Eq_9002 * u2;
-	Eq_6954 u3;
-	Eq_7290 u4;
+	union Eq_4868 ** u0;
+	struct Eq_8993 * u1;
+	Eq_7290 u2;
 } Eq_7817;
-
-typedef union Eq_7819 {
-	uint8 u0;
-	word32 u1;
-	Eq_6954 u2;
-} Eq_7819;
 
 typedef struct Eq_7827 {
 	int32 dw0000;	// 0
@@ -40806,416 +40399,53 @@ typedef union Eq_7839 {
 	int32 u1;
 } Eq_7839;
 
-typedef union Eq_7842 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7842;
-
-typedef union Eq_7844 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
+typedef struct Eq_7844 {
+	Eq_603 t0000;	// 0
+	byte b0030;	// 30
+	word32 dw0038;	// 38
+	Eq_603 t003C;	// 3C
+	byte b004C;	// 4C
 } Eq_7844;
 
-typedef union Eq_7845 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7845;
+typedef union Eq_7869 {
+	int32 u0;
+	byte u1;
+} Eq_7869;
 
-typedef union Eq_7848 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7848;
-
-typedef union Eq_7851 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7851;
-
-typedef union Eq_7856 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7856;
-
-typedef union Eq_7858 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7858;
-
-typedef union Eq_7861 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7861;
-
-typedef union Eq_7867 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7867;
-
-typedef union Eq_7871 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7871;
-
-typedef union Eq_7876 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7876;
-
-typedef union Eq_7880 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7880;
+typedef union Eq_7878 {
+	int32 u0;
+	byte u1;
+} Eq_7878;
 
 typedef struct Eq_7893 {
 	word32 dw0000;	// 0
-	word32 dw0004;	// 4
+	Eq_603 t0004;	// 4
 } Eq_7893;
 
-typedef union Eq_7898 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7898;
-
-typedef union Eq_7904 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7904;
-
-typedef union Eq_7912 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7912;
-
-typedef union Eq_7917 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7917;
-
-typedef union Eq_7930 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7930;
-
-typedef union Eq_7941 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7941;
-
-typedef union Eq_7946 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7946;
-
-typedef union Eq_7959 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7959;
-
-typedef union Eq_7970 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7970;
-
-typedef union Eq_7975 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7975;
-
-typedef union Eq_7988 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_7988;
-
-typedef union Eq_8005 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8005;
-
-typedef union Eq_8017 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8017;
-
-typedef union Eq_8018 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8018;
-
-typedef union Eq_8019 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8019;
-
-typedef union Eq_8021 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8021;
-
-typedef union Eq_8028 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8028;
-
-typedef union Eq_8031 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8031;
-
-typedef union Eq_8035 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8035;
-
-typedef union Eq_8039 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8039;
-
-typedef union Eq_8044 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8044;
-
-typedef union Eq_8092 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8092;
-
-typedef union Eq_8093 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8093;
-
-typedef union Eq_8094 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8094;
+typedef union Eq_8033 {
+	int32 u0;
+	byte u1;
+} Eq_8033;
 
 typedef union Eq_8096 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_8096;
 
-typedef union Eq_8099 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8099;
-
-typedef union Eq_8110 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8110;
-
-typedef union Eq_8112 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8112;
-
-typedef union Eq_8113 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8113;
-
-typedef union Eq_8114 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8114;
-
 typedef union Eq_8116 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_8116;
 
-typedef union Eq_8119 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8119;
-
-typedef union Eq_8131 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8131;
-
-typedef union Eq_8185 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
+typedef struct Eq_8185 {
+	Eq_603 t0000;	// 0
+	Eq_603 t0030;	// 30
 } Eq_8185;
 
-typedef union Eq_8186 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8186;
-
-typedef union Eq_8189 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8189;
-
-typedef union Eq_8194 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8194;
-
-typedef union Eq_8201 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8201;
-
-typedef union Eq_8209 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
+typedef struct Eq_8209 {
+	Eq_603 t0000;	// 0
+	uint32 dw0030;	// 30
 } Eq_8209;
-
-typedef union Eq_8210 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8210;
-
-typedef union Eq_8213 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8213;
-
-typedef union Eq_8225 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8225;
-
-typedef union Eq_8228 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8228;
-
-typedef union Eq_8233 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8233;
-
-typedef union Eq_8238 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8238;
-
-typedef union Eq_8241 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8241;
 
 typedef union Eq_8243 {
 	int32 u0;
@@ -41227,236 +40457,17 @@ typedef union Eq_8244 {
 	uint32 u1;
 } Eq_8244;
 
-typedef union Eq_8250 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8250;
-
-typedef union Eq_8256 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
+typedef struct Eq_8256 {
+	ptr32 ptr0000;	// 0
+	byte b004D;	// 4D
 } Eq_8256;
 
-typedef union Eq_8257 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8257;
-
-typedef union Eq_8259 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8259;
-
-typedef union Eq_8262 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8262;
-
-typedef union Eq_8264 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8264;
-
-typedef union Eq_8265 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8265;
-
-typedef union Eq_8267 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8267;
-
-typedef union Eq_8270 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8270;
-
-typedef union Eq_8271 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8271;
-
-typedef union Eq_8273 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8273;
-
-typedef union Eq_8275 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8275;
-
-typedef union Eq_8276 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8276;
-
-typedef union Eq_8278 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8278;
-
-typedef union Eq_8281 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8281;
-
-typedef int32 (Eq_8283)(Eq_603, Eq_603, Eq_603);
-
-typedef union Eq_8285 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8285;
-
-typedef union Eq_8287 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8287;
-
-typedef union Eq_8289 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8289;
-
-typedef union Eq_8290 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8290;
-
-typedef union Eq_8292 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8292;
-
-typedef union Eq_8299 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8299;
-
-typedef union Eq_8300 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8300;
-
-typedef union Eq_8302 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8302;
+typedef int32 (Eq_8283)(Eq_663, Eq_663, Eq_663);
 
 typedef union Eq_8311 {
 	int32 u0;
 	uint32 u1;
 } Eq_8311;
-
-typedef union Eq_8316 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8316;
-
-typedef union Eq_8351 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8351;
-
-typedef union Eq_8352 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8352;
-
-typedef union Eq_8355 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8355;
-
-typedef union Eq_8361 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8361;
-
-typedef union Eq_8373 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8373;
-
-typedef union Eq_8374 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8374;
-
-typedef union Eq_8377 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8377;
-
-typedef union Eq_8389 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8389;
 
 typedef union Eq_8395 {
 	int32 u0;
@@ -41468,262 +40479,10 @@ typedef union Eq_8401 {
 	uint32 u1;
 } Eq_8401;
 
-typedef union Eq_8406 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8406;
-
-typedef union Eq_8410 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8410;
-
-typedef union Eq_8411 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8411;
-
-typedef union Eq_8414 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8414;
-
-typedef union Eq_8416 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8416;
-
-typedef union Eq_8417 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8417;
-
-typedef union Eq_8419 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8419;
-
-typedef union Eq_8422 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8422;
-
-typedef union Eq_8423 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8423;
-
-typedef union Eq_8425 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8425;
-
-typedef union Eq_8428 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8428;
-
-typedef union Eq_8432 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8432;
-
-typedef union Eq_8434 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8434;
-
-typedef union Eq_8435 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8435;
-
-typedef union Eq_8437 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8437;
-
-typedef union Eq_8440 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8440;
-
-typedef union Eq_8442 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8442;
-
-typedef union Eq_8443 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8443;
-
-typedef union Eq_8445 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8445;
-
-typedef union Eq_8448 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8448;
-
-typedef union Eq_8449 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8449;
-
-typedef union Eq_8451 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8451;
-
-typedef union Eq_8453 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8453;
-
-typedef union Eq_8454 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8454;
-
-typedef union Eq_8456 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8456;
-
-typedef union Eq_8459 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8459;
-
-typedef union Eq_8462 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8462;
-
-typedef union Eq_8464 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8464;
-
-typedef union Eq_8466 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8466;
-
-typedef union Eq_8467 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8467;
-
-typedef union Eq_8469 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8469;
-
-typedef union Eq_8476 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8476;
-
-typedef union Eq_8477 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8477;
-
-typedef union Eq_8479 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8479;
-
 typedef union Eq_8488 {
 	int32 u0;
 	uint32 u1;
 } Eq_8488;
-
-typedef union Eq_8500 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8500;
-
-typedef union Eq_8504 {
-	uint8 u0;
-	struct Eq_9025 * u1;
-	Eq_6954 u2;
-	Eq_7817 u3;
-} Eq_8504;
 
 typedef int32 (Eq_8639)(ptr32, ptr32);
 
@@ -41733,8 +40492,8 @@ typedef struct Eq_8894 {	// size: 4 4
 	byte b0000;	// 0
 } Eq_8894;
 
-typedef struct Eq_8951 {	// size: 1 1
-	word32 dw0000;	// 0
+typedef struct Eq_8951 {	// size: 4 4
+	union Eq_4868 * ptr0000;	// 0
 	Eq_603 t0004;	// 4
 	Eq_603 t0008;	// 8
 	int32 dw0014;	// 14
@@ -41742,69 +40501,15 @@ typedef struct Eq_8951 {	// size: 1 1
 	int32 dw001C;	// 1C
 } Eq_8951;
 
-typedef struct Eq_8952 {
-	Eq_603 t0000;	// 0
+typedef struct Eq_8952 {	// size: 1 1
+	word32 dw0000;	// 0
 } Eq_8952;
 
-typedef union Eq_8953 {
-	int32 u0;
-	byte u1;
-	Eq_603 u2;
+typedef struct Eq_8953 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8953;
 
 typedef union Eq_8954 {
-	byte u0;
-	union Eq_4868 ** u1;
-	struct Eq_9002 * u2;
-	Eq_603 u3;
-	Eq_7290 u4;
-	Eq_7817 u5;
-} Eq_8954;
-
-typedef union Eq_8955 {
-	uint8 u0;
-	word32 u1;
-	Eq_6954 u2;
-} Eq_8955;
-
-typedef union Eq_8956 {
-	uint8 u0;
-	word32 u1;
-	Eq_4861 u2;
-	Eq_6954 u3;
-	Eq_7817 u4;
-} Eq_8956;
-
-typedef union Eq_8957 {
-	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
-	Eq_7164 u2;
-	Eq_7228 u3;
-	Eq_7293 u4;
-} Eq_8957;
-
-typedef struct Eq_8958 {	// size: 4 4
-	struct Eq_8952 * ptrFFFFFFFC;	// FFFFFFFC
-	union Eq_4868 * ptr0000;	// 0
-	Eq_8953 t002C;	// 2C
-	Eq_8954 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8955 t0037;	// 37
-	Eq_8956 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8957 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
-} Eq_8958;
-
-typedef union Eq_8959 {
 	cu8 u0;
 	word32 u1;
 	Eq_1755 u2;
@@ -41813,9 +40518,9 @@ typedef union Eq_8959 {
 	Eq_2902 u5;
 	Eq_3013 u6;
 	Eq_3054 u7;
-} Eq_8959;
+} Eq_8954;
 
-typedef union Eq_8960 {
+typedef union Eq_8955 {
 	struct Eq_1885 * u0;
 	Eq_2420 u1;
 	Eq_2484 u2;
@@ -41823,6 +40528,31 @@ typedef union Eq_8960 {
 	Eq_2560 u4;
 	Eq_2605 u5;
 	Eq_3137 u6;
+} Eq_8955;
+
+typedef struct Eq_8956 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8956;
+
+typedef struct Eq_8957 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8957;
+
+typedef struct Eq_8958 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8958;
+
+typedef struct Eq_8959 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8959;
+
+typedef struct Eq_8960 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_8960;
 
 typedef struct Eq_8961 {	// size: 1 1
@@ -41875,94 +40605,63 @@ typedef struct Eq_8970 {	// size: 1 1
 	byte b0003;	// 3
 } Eq_8970;
 
-typedef struct Eq_8971 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef union Eq_8971 {
+	union Eq_4868 ** u0;
+	struct Eq_8993 * u1;
+	Eq_7290 u2;
+	Eq_7817 u3;
 } Eq_8971;
 
-typedef struct Eq_8972 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
-} Eq_8972;
-
-typedef struct Eq_8973 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
-} Eq_8973;
-
-typedef struct Eq_8974 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
-} Eq_8974;
-
-typedef struct Eq_8975 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
-} Eq_8975;
-
-typedef union Eq_8976 {
-	int32 u0;
-	byte u1;
-	Eq_603 u2;
-} Eq_8976;
-
-typedef union Eq_8977 {
-	byte u0;
-	union Eq_4868 ** u1;
-	struct Eq_9002 * u2;
-	Eq_603 u3;
-	Eq_7290 u4;
-	Eq_7817 u5;
-} Eq_8977;
-
-typedef union Eq_8978 {
-	uint8 u0;
-	word32 u1;
-	Eq_6954 u2;
-} Eq_8978;
-
-typedef union Eq_8979 {
-	uint8 u0;
-	word32 u1;
-	Eq_4861 u2;
-	Eq_6954 u3;
-	Eq_7817 u4;
-} Eq_8979;
-
-typedef union Eq_8980 {
+typedef union Eq_8972 {
 	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
+	struct Eq_8993 * u1;
 	Eq_7164 u2;
 	Eq_7228 u3;
 	Eq_7293 u4;
+} Eq_8972;
+
+typedef struct Eq_8973 {
+	Eq_4868 t0000;	// 0
+} Eq_8973;
+
+typedef struct Eq_8974 {	// size: 4 4
+	struct Eq_8973 * ptr0000;	// 0
+} Eq_8974;
+
+typedef struct Eq_8975 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8975;
+
+typedef struct Eq_8976 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8976;
+
+typedef struct Eq_8977 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8977;
+
+typedef struct Eq_8978 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8978;
+
+typedef struct Eq_8979 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8979;
+
+typedef struct Eq_8980 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8980;
 
 typedef struct Eq_8981 {	// size: 4 4
-	Eq_603 t0000;	// 0
-	Eq_8976 t002C;	// 2C
-	Eq_8977 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8978 t0037;	// 37
-	Eq_8979 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8980 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8981;
 
-typedef struct Eq_8982 {
-	Eq_4868 t0000;	// 0
+typedef struct Eq_8982 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8982;
 
 typedef struct Eq_8983 {	// size: 4 4
-	struct Eq_8982 * ptr0000;	// 0
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8983;
 
 typedef struct Eq_8984 {	// size: 4 4
@@ -41973,49 +40672,49 @@ typedef struct Eq_8985 {	// size: 4 4
 	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8985;
 
-typedef struct Eq_8986 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8986;
-
-typedef struct Eq_8987 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8987;
-
-typedef struct Eq_8988 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8988;
-
-typedef struct Eq_8989 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8989;
-
-typedef struct Eq_8990 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8990;
-
-typedef struct Eq_8991 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8991;
-
-typedef struct Eq_8992 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+typedef struct Eq_8992 {
+	Eq_4868 t0000;	// 0
 } Eq_8992;
 
 typedef struct Eq_8993 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+	struct Eq_8992 * ptr0000;	// 0
 } Eq_8993;
 
-typedef struct Eq_8994 {	// size: 4 4
+typedef struct Eq_8996 {	// size: 4 4
 	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8994;
+} Eq_8996;
 
-typedef struct Eq_9001 {
-	Eq_4868 t0000;	// 0
+typedef struct Eq_8997 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8997;
+
+typedef struct Eq_8998 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8998;
+
+typedef struct Eq_8999 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8999;
+
+typedef struct Eq_9000 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_9000;
+
+typedef struct Eq_9001 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_9001;
 
 typedef struct Eq_9002 {	// size: 4 4
-	struct Eq_9001 * ptr0000;	// 0
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_9002;
+
+typedef struct Eq_9003 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_9003;
+
+typedef struct Eq_9004 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_9004;
 
 typedef struct Eq_9005 {	// size: 4 4
 	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
@@ -42077,61 +40776,28 @@ typedef struct Eq_9019 {	// size: 4 4
 	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_9019;
 
-typedef union Eq_9020 {
-	int32 u0;
-	byte u1;
-	Eq_603 u2;
+typedef struct Eq_9020 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_9020;
 
-typedef union Eq_9021 {
-	byte u0;
-	union Eq_4868 ** u1;
-	struct Eq_9002 * u2;
-	Eq_603 u3;
-	Eq_7290 u4;
-	Eq_7817 u5;
+typedef struct Eq_9021 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_9021;
 
-typedef union Eq_9022 {
-	uint8 u0;
-	word32 u1;
-	Eq_6954 u2;
+typedef struct Eq_9022 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_9022;
 
-typedef union Eq_9023 {
-	uint8 u0;
-	word32 u1;
-	Eq_4861 u2;
-	Eq_6954 u3;
-	Eq_7817 u4;
+typedef struct Eq_9023 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_9023;
 
-typedef union Eq_9024 {
-	union Eq_4868 ** u0;
-	struct Eq_9002 * u1;
-	Eq_7164 u2;
-	Eq_7228 u3;
-	Eq_7293 u4;
+typedef struct Eq_9024 {	// size: 4 4
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_9024;
 
 typedef struct Eq_9025 {	// size: 4 4
-	Eq_603 t0000;	// 0
-	Eq_9020 t002C;	// 2C
-	Eq_9021 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_9022 t0037;	// 37
-	Eq_9023 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_9024 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
+	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_9025;
 
 typedef struct Eq_9026 {	// size: 4 4
@@ -42145,64 +40811,4 @@ typedef struct Eq_9027 {	// size: 4 4
 typedef struct Eq_9028 {	// size: 4 4
 	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_9028;
-
-typedef struct Eq_9029 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9029;
-
-typedef struct Eq_9030 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9030;
-
-typedef struct Eq_9031 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9031;
-
-typedef struct Eq_9032 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9032;
-
-typedef struct Eq_9033 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9033;
-
-typedef struct Eq_9034 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9034;
-
-typedef struct Eq_9035 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9035;
-
-typedef struct Eq_9036 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9036;
-
-typedef struct Eq_9037 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9037;
-
-typedef struct Eq_9038 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9038;
-
-typedef struct Eq_9039 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9039;
-
-typedef struct Eq_9040 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9040;
-
-typedef struct Eq_9041 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9041;
-
-typedef struct Eq_9042 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9042;
-
-typedef struct Eq_9043 {	// size: 4 4
-	union Eq_603 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_9043;
 

--- a/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL_code.c
+++ b/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL_code.c
@@ -323,9 +323,9 @@ void fn00001354(int32 dwArg04, struct Eq_n * dwArg08)
 // 00001390: Register Eq_n fn00001390()
 Eq_n fn00001390()
 {
-	Eq_n a1_n;
+	byte ** a1_n;
 	Eq_n d1_n;
-	Eq_n a1_n;
+	byte ** a1_n;
 	Eq_n d1_n;
 	Eq_n d0_n = fn00002E40(fn00002E40(fn000016FC(fn00002E40(fn00004068(&globals->b16B0, out d1_n, out a1_n), d1_n, a1_n, &globals->t16CC), 0x16D0, out d1_n, out a1_n), d1_n, a1_n, &globals->t16EC), d1_n, a1_n, &globals->t16F0);
 	int32 d3_n = 1;
@@ -516,7 +516,7 @@ Eq_n fn00001718(Eq_n d0, struct Eq_n * dwArg04, Eq_n dwArg08, Eq_n dwArg0C, stru
 					{
 						a0_n = 11029 + (SEQ(SLICE(d0_n, word24, 8), *a2_n) & 0xFF);
 						uint32 d0_n = (uint32) (uint8) a0_n->t0000;
-						d5_n.u0 = 0;
+						&d5_n.u0->dw0000 = 0;
 						d0_n = d0_n & 0x04;
 						if ((d0_n & 0x04) != 0x00)
 						{
@@ -704,7 +704,7 @@ l00001996:
 						}
 						if (d4_n == 0x68)
 						{
-							Eq_n v262_n = a7_n->dw003E;
+							word16 v262_n = a7_n->w003E;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1;
 							a7_n->dw0040 = (uint32) (uint16) v262_n;
@@ -713,7 +713,7 @@ l00001996:
 						}
 						if (d4_n == 0x02)
 						{
-							Eq_n v277_n = a7_n->dw003F;
+							byte v277_n = a7_n->b003F;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1;
 							a7_n->dw0040 = (uint32) (uint8) v277_n;
@@ -824,7 +824,7 @@ l00001BF2:
 							}
 							if (d4_n == 0x02)
 							{
-								Eq_n v248_n = a7_n->dw0037;
+								byte v248_n = a7_n->b0037;
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->ptr0000 = d1;
 								int32 d1_n = (int32) (int16) (int8) SEQ(SLICE(d1, word24, 8), v248_n);
@@ -1607,7 +1607,7 @@ l000027B6:
 		word32 d1_n;
 		d1_n = fn000027BC(dwArg04, dwArg08, dwArg10, out d1_n, out d2_n);
 l000027B4:
-		d0_n.u0 = 0;
+		&d0_n.u0->dw0000 = 0;
 		goto l000027B6;
 	}
 }
@@ -1665,7 +1665,7 @@ l000027D6:
 					Eq_n d2_n = __swap(d5_n);
 					Eq_n d3_n = __swap(d7_n);
 					if ((word16) (d2_n - d3_n) == 0x00)
-						d1_n.u0 = 0xFFFF;
+						&d1_n.u0->dw0000 = 0xFFFF;
 					else
 						d1_n = __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_n % (uint16) d3_n), (uint16) (d5_n /u (uint16) d3_n))), word16, 16), 0x00));
 					Eq_n d6_n = __swap(SEQ(SLICE(d6_n, word16, 16), 0x00));
@@ -1777,7 +1777,7 @@ Eq_n fn0000297A(Eq_n d0, Eq_n d1, Eq_n d2, union Eq_n & d1Out)
 		if ((word16) d1_n < 0x80)
 		{
 			d1_n = __rol(d1_n, 0x08);
-			d3_n.u0 = 0x08;
+			&d3_n.u0->dw0000 = 0x08;
 		}
 		if ((word16) d1_n < 0x0800)
 		{
@@ -1938,31 +1938,31 @@ void fn00002DFC(struct Eq_n * dwArg04)
 	}
 }
 
-// 00002E40: Register Eq_n fn00002E40(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack (ptr32 Eq_n) dwArg04)
-Eq_n fn00002E40(Eq_n d0, Eq_n d1, Eq_n a1, struct Eq_n * dwArg04)
+// 00002E40: Register Eq_n fn00002E40(Register Eq_n d0, Register Eq_n d1, Register (ptr32 (ptr32 byte)) a1, Stack (ptr32 Eq_n) dwArg04)
+Eq_n fn00002E40(Eq_n d0, Eq_n d1, byte ** a1, struct Eq_n * dwArg04)
 {
 	return fn00002E8C(d0, d1, a1, *(union Eq_n *) 0x4254, dwArg04, fp + 8);
 }
 
-// 00002E5C: Register Eq_n fn00002E5C(Stack Eq_n bArg07, Stack Eq_n dwArg08)
-Eq_n fn00002E5C(Eq_n bArg07, Eq_n dwArg08)
+// 00002E5C: Register Eq_n fn00002E5C(Stack byte bArg07, Stack Eq_n dwArg08)
+Eq_n fn00002E5C(byte bArg07, Eq_n dwArg08)
 {
 	Eq_n d0_n = dwArg08;
 	if (dwArg08 != 0x00)
 	{
 		d0_n = *((word32) dwArg08 + 4);
 		if (d0_n - *((word32) dwArg08 + 8) < 0x00)
-			**((word32) dwArg08 + 4) = bArg07;
+			(*((word32) dwArg08 + 4))->u0 = bArg07;
 		*((word32) dwArg08 + 20) = (word32) *((word32) dwArg08 + 20) + 1;
 		--*((word32) dwArg08 + 4);
 	}
 	return d0_n;
 }
 
-// 00002E8C: Register Eq_n fn00002E8C(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
-Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
+// 00002E8C: Register Eq_n fn00002E8C(Register Eq_n d0, Register Eq_n d1, Register (ptr32 (ptr32 byte)) a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
+Eq_n fn00002E8C(Eq_n d0, Eq_n d1, byte ** a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
 {
-	Eq_n a7_n = fp + -0x0078;
+	struct Eq_n * a7_n = fp + -0x0078;
 	Eq_n d2_n = dwArg0C;
 	struct Eq_n * a4_n = dwArg08;
 	Eq_n a2_n = dwArg04;
@@ -1976,8 +1976,8 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 			Eq_n d3_n = 0;
 			if (a4_n->b0000 == 0x25)
 			{
-				*((word32) a7_n + 72) = 0x69;
-				*((word32) a7_n + 73) = 0x00;
+				a7_n[18] = (struct Eq_n) 0x69;
+				a7_n->b0049 = 0x00;
 				byte * a3_n = a4_n + 1;
 				uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 				Eq_n d6_n = -1;
@@ -1985,7 +1985,7 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				if ((d0_n & 0x04) != 0x00)
 				{
 					uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-					d6_n.u0 = 0;
+					&d6_n.u0->dw0000 = 0;
 					d0 = d0_n & 0x04;
 					if ((d0_n & 0x04) != 0x00)
 					{
@@ -2007,8 +2007,8 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				}
 				if (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))))
 				{
-					d7 = SEQ(SLICE(d7, word24, 8), *((word32) a7_n + 73));
-					d1 = SEQ(SLICE(d1, word24, 8), *((word32) a7_n + 72));
+					d7 = SEQ(SLICE(d7, word24, 8), a7_n->b0049);
+					d1 = SEQ(SLICE(d1, word24, 8), a7_n[18]);
 					do
 					{
 						if (*a3_n == 0x2A)
@@ -2021,15 +2021,15 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 							d1 = SEQ(SLICE(d1, word24, 8), *a3_n);
 						++a3_n;
 					} while (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))));
-					*((word32) a7_n + 72) = (byte) d1;
-					*((word32) a7_n + 73) = (byte) d7;
+					a7_n[18] = (struct Eq_n) (byte) d1;
+					a7_n->b0049 = (byte) d7;
 				}
-				if (*((word32) a7_n + 72) == 0x6A)
-					*((word32) a7_n + 72) = 0x01;
-				if (*((word32) a7_n + 72) == 116)
-					*((word32) a7_n + 72) = 0x69;
-				if (*((word32) a7_n + 72) == 122)
-					*((word32) a7_n + 72) = 0x6C;
+				if (a7_n[18] == 0x6A)
+					a7_n[18] = (struct Eq_n) 0x01;
+				if (a7_n[18] == 116)
+					a7_n[18] = (struct Eq_n) 0x69;
+				if (a7_n[18] == 122)
+					a7_n[18] = (struct Eq_n) 0x6C;
 				byte v83_n = *a3_n;
 				word24 v84_n = SLICE(d7, word24, 8);
 				struct Eq_n * a3_n = a3_n + 1;
@@ -2050,7 +2050,7 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 							byte * a0_n = *a1;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							*a1 = (byte **) (a0_n + 1);
 							byte v96_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v96_n);
@@ -2087,19 +2087,19 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 								d1 = SEQ(v147_n, v83_n - 115);
 								if (v83_n != 115)
 								{
-									*((word32) a7_n + 48) = 0x00;
-									*((word32) a7_n + 44) = 0x00;
-									*((word32) a7_n + 110) = 0x00;
+									a7_n[0x0C] = (struct Eq_n) 0x00;
+									a7_n[11] = (struct Eq_n) 0x00;
+									a7_n->dw006E = 0x00;
 									if (v83_n == 0x00)
 										--a3_n;
 									if (v83_n == 0x70)
 									{
-										*((word32) a7_n + 72) = 0x6C;
+										a7_n[18] = (struct Eq_n) 0x6C;
 										d7 = 0x0078;
 									}
 									if ((d5_n == 0x2D && (byte) d7 != 117 || d5_n == 0x2B) && d6_n - d3_n >= 0x00)
 									{
-										*((word32) a7_n + 110) = d5_n;
+										a7_n->dw006E = (word32) d5_n;
 										ui32 * a0_n = (word32) a2_n + 24;
 										*a0_n |= 0x01;
 										int32 * a0_n = (word32) a2_n + 20;
@@ -2111,7 +2111,7 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											byte * a0_n = *a1;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v231_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -2127,7 +2127,7 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0 = fn00003F30(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0;
 										}
-										d5_n = *((word32) a7_n + 52);
+										d5_n = a7_n[0x0D];
 										d3_n = (word32) d3_n + 1;
 										d4_n = (word32) d4_n + 1;
 									}
@@ -2147,7 +2147,7 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												byte * a0_n = *a1;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												*a1 = (byte **) (a0_n + 1);
 												byte v249_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -2163,8 +2163,8 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00003F30(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 64) = *((word32) a7_n + 52);
-											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+											a7_n[16] = a7_n[0x0D];
+											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 											Eq_n d3_n = (word32) d3_n + 1;
 											d0 = d0_n & 0xFF;
 											if (!__btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[(int32) (int16) (d0_n & 0xFF)].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0], 0x00))
@@ -2183,7 +2183,7 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 													byte * a0_n = *a1;
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
-													*a1 = a0_n + 1;
+													*a1 = (byte **) (a0_n + 1);
 													byte v271_n = *a0_n;
 													a2_n = a7_n->t0000;
 													a7_n->t0000 = d1;
@@ -2199,12 +2199,12 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 													d0_n = fn00003F30(a7_n->t0000, out d1, out a1, out a5_n);
 													a7_n->t0038 = d0_n;
 												}
-												*((word32) a7_n + 74) = *((word32) a7_n + 52);
+												a7_n->dw004A = (word32) a7_n[0x0D];
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x44;
 												if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 													d7 = 0x0078;
-												if (*((word32) a7_n + 74) != ~0x00)
+												if (a7_n->dw004A != ~0x00)
 												{
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
@@ -2214,7 +2214,7 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											}
 											else
 												d7 = 111;
-											if (*((word32) a7_n + 64) != ~0x00)
+											if (a7_n[16] != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -2251,7 +2251,7 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											byte * a0_n = *a1;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v351_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -2267,8 +2267,8 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0_n = fn00003F30(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0_n;
 										}
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
-										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+										a7_n[16] = a7_n[0x0D];
+										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 										Eq_n d3_n = (word32) d3_n + 1;
 										int32 d4_n = (word32) d4_n + 1;
 										d0 = d0_n & 0xFF;
@@ -2288,7 +2288,7 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												byte * a0_n = *a1;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												*a1 = (byte **) (a0_n + 1);
 												byte v372_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -2304,17 +2304,17 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00003F30(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 74) = *((word32) a7_n + 52);
-											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55)) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
+											a7_n->dw004A = (word32) a7_n[0x0D];
+											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[SEQ(SLICE(d0_n, word24, 8), a7_n->b0037) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 											d3_n = (word32) d3_n + 1;
 											d4_n = d4_n + 0x01;
 											d0 = d0_n & 0x44;
 											if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 											{
-												d5_n = *((word32) a7_n + 74);
+												d5_n = a7_n->dw004A;
 												goto l000038F6;
 											}
-											if (*((word32) a7_n + 74) != ~0x00)
+											if (a7_n->dw004A != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -2322,7 +2322,7 @@ Eq_n fn00002E8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0 = fn00002E5C(*(a7_n - 1), a7_n->t0000);
 											}
 										}
-										if (*((word32) a7_n + 64) != ~0x00)
+										if (a7_n[16] != ~0x00)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
@@ -2336,52 +2336,52 @@ l000038F6:
 									if ((byte) d7 != 0x78 && (byte) d7 != 88)
 									{
 										if ((byte) d7 == 111)
-											*((word32) a7_n + 52) = 0x08;
+											a7_n[0x0D] = (struct Eq_n) 0x08;
 										else
-											*((word32) a7_n + 52) = 0x0A;
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
+											a7_n[0x0D] = (struct Eq_n) 0x0A;
+										a7_n[16] = a7_n[0x0D];
 									}
 									else
-										*((word32) a7_n + 64) = 0x10;
-									*((word32) a7_n + 114) = *((word32) a7_n + 64);
+										a7_n[16] = (struct Eq_n) 0x10;
+									a7_n->dw0072 = (word32) a7_n[16];
 									uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[SEQ(SLICE(d0, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-									*((word32) a7_n + 0x0084) = d2_n;
-									*((word32) a7_n + 52) = d4_n;
-									*((word32) a7_n + 74) = (byte) d7;
+									a7_n[33] = (struct Eq_n) d2_n;
+									a7_n[0x0D] = (struct Eq_n) d4_n;
+									a7_n->dw004A = (word32) (byte) d7;
 									d0 = d0_n & 0x44;
 									if ((d0_n & 0x44) != 0x00)
 									{
-										if (*((word32) a7_n + 114) == 0x0A)
+										if (a7_n->dw0072 == 0x0A)
 										{
 											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[SEQ(SLICE(d0_n & 0x44, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											d0 = d0_n & 0x04;
 											if ((d0_n & 0x04) != 0x00)
 												goto l00003992;
 											goto l00003B92;
 										}
 l00003992:
-										if (*((word32) a7_n + 114) == 0x08)
+										if (a7_n->dw0072 == 0x08)
 										{
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d5_n <= 55)
 												goto l000039B2;
 										}
 										else
 										{
 l000039B2:
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 64) = d6_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n[16] = (struct Eq_n) d6_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d6_n - d3_n >= 0x00)
 											{
-												d7 = (int32) *((word32) a7_n + 114);
-												up32 a4_n = *((word32) a7_n + 64);
+												d7 = a7_n->dw0072;
+												up32 a4_n = a7_n[16];
 												do
 												{
 													struct Eq_n * a7_n = a7_n - 4;
@@ -2389,7 +2389,7 @@ l000039B2:
 													Eq_n v419_n = a7_n->t0000;
 													a7_n->t0000 = d7 >> 31;
 													*(a7_n - 4) = d7;
-													*(a7_n - 8) = (union Eq_n *) a1;
+													*(a7_n - 8) = (byte ***) a1;
 													*(a7_n - 0x0C) = a7_n->dw0034;
 													*(a7_n - 16) = a7_n->dw0030;
 													*(a7_n - 20) = d7;
@@ -2405,10 +2405,10 @@ l000039B2:
 													*(a7_n - 4) = (union Eq_n *) v419_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d4_n + Mem2975[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = (union Eq_n *) d3_n;
 													int32 d0_n = d4_n >> 31;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + d0_n);
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < 0x00) + ((word32) a7_n[16] + d0_n));
 													word32 v441_n = *(a7_n - 8);
 													word32 v442_n = *(a7_n - 4);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x01) != 0x00)
@@ -2419,10 +2419,10 @@ l000039B2:
 													*(a7_n - 4) = v442_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d6_n + Mem3035[a7_n + 48:word32];
-													*((word32) a7_n + 0x0044) = d2_n;
+													a7_n[0x0011] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v441_n;
 													int32 d0_n = d6_n >> 31;
-													*((word32) a7_n + 64) = (word32) *((word32) a7_n + 44) + d0_n + (d2_n < 0x00);
+													a7_n[16] = (struct Eq_n) ((word32) a7_n[11] + d0_n + (d2_n < 0x00));
 													word32 v453_n = *(a7_n - 8);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x02) != 0x00)
 														d2_n = d5_n - 0x57;
@@ -2432,9 +2432,9 @@ l000039B2:
 													*(a7_n - 4) = (union Eq_n *) d2_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d2_n + Mem3093[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v453_n;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + (d2_n >> 31));
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < 0x00) + ((word32) a7_n[16] + (d2_n >> 31)));
 													ui32 * a0_n = (word32) a2_n + 24;
 													up32 v465_n = *(a7_n - 8);
 													d2_n = *(a7_n - 4);
@@ -2447,7 +2447,7 @@ l000039B2:
 														a1 = (word32) a2_n + 4;
 														byte * a0_n = *a1;
 														*(a7_n - 4) = (union Eq_n *) a2_n;
-														*a1 = a0_n + 1;
+														*a1 = (byte **) (a0_n + 1);
 														d0_n = (uint32) (uint8) *a0_n;
 														a2_n = *(a7_n - 4);
 														d1 = (uint32) (uint8) (byte) d0_n;
@@ -2460,7 +2460,7 @@ l000039B2:
 														d0_n = fn00003F30(*(a7_n - 4), out d1_n, out a1, out a5_n);
 														d1 = d0_n;
 													}
-													*((word32) a7_n + 52) = (word32) *((word32) a7_n + 52) + 1;
+													a7_n[0x0D] = (struct Eq_n) ((word32) a7_n[0x0D] + 1);
 													uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[SEQ(SLICE(d0_n, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 													d5_n = d1;
 													d3_n = v465_n + 0x01;
@@ -2479,11 +2479,11 @@ l000039B2:
 										}
 									}
 l00003B92:
-									Eq_n v476_n = *((word32) a7_n + 74);
+									Eq_n v476_n = a7_n->dw004A;
 									d7 = SEQ(SLICE(d7, word24, 8), v476_n);
-									word32 d4_n = *((word32) a7_n + 52);
-									d2_n = *((word32) a7_n + 0x0084);
-									if (*((word32) a7_n + 110) != 0x00 && d3_n == 0x02)
+									word32 d4_n = a7_n[0x0D];
+									d2_n = a7_n[33];
+									if (a7_n->dw006E != 0x00 && d3_n == 0x02)
 									{
 										if (d5_n != ~0x00)
 										{
@@ -2494,7 +2494,7 @@ l00003B92:
 										}
 										--d3_n;
 										--d4_n;
-										d5_n = *((word32) a7_n + 110);
+										d5_n = a7_n->dw006E;
 									}
 									if (d5_n != ~0x00)
 									{
@@ -2505,14 +2505,14 @@ l00003B92:
 									}
 									d3_n = d3_n - 0x01;
 									d4_n = d4_n - 0x01;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										if (v476_n == 117)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = d0;
 											a7_n->b0038 = a7_n->b004C - 0x01;
-											a7_n = (char *) &a7_n->t0000 + 4;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
 											if (a7_n->b0038 != 0x00)
 											{
 												byte v517_n = a7_n->b0038 - 0x01;
@@ -2564,58 +2564,58 @@ l00003B92:
 										}
 										else
 										{
-											if (*((word32) a7_n + 110) == 0x2D)
+											if (a7_n->dw006E == 0x2D)
 											{
-												struct Eq_n * v528_n = (word32) a7_n + 44;
+												struct Eq_n * v528_n = a7_n + 11;
 												d1 = -v528_n->dw0004;
 												d0 = -v528_n->dw0000 - (d1 < 0x00);
-												a7_n = *((word32) a7_n + 56);
+												a7_n = (struct Eq_n *) a7_n[0x0E];
 											}
 											else
 											{
-												*((word32) a7_n + 56) = *((word32) a7_n + 48);
-												*((word32) a7_n + 52) = *((word32) a7_n + 44);
+												a7_n[0x0E] = a7_n[0x0C];
+												a7_n[0x0D] = a7_n[11];
 											}
-											Eq_n a7_n = a7_n - 4;
-											*a7_n = d0;
-											*((word32) a7_n + 48) = *((word32) a7_n + 76) - 0x01;
-											a7_n = (word32) a7_n + 4;
-											if (*((word32) a7_n + 48) != 0x00)
+											struct Eq_n * a7_n = a7_n - 4;
+											a7_n->t0000 = d0;
+											a7_n->b0030 = a7_n->b004C - 0x01;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
+											if (a7_n->b0030 != 0x00)
 											{
-												byte v540_n = *((word32) a7_n + 48) - 0x01;
-												*((word32) a7_n + 48) = v540_n;
+												byte v540_n = a7_n->b0030 - 0x01;
+												a7_n->b0030 = v540_n;
 												if (v540_n != 0x00)
 												{
-													byte v541_n = *((word32) a7_n + 48) - 0x66;
-													*((word32) a7_n + 48) = v541_n;
+													byte v541_n = a7_n->b0030 - 0x66;
+													a7_n->b0030 = v541_n;
 													if (v541_n != 0x00)
 													{
-														byte v542_n = *((word32) a7_n + 48) - 0x04;
-														*((word32) a7_n + 48) = v542_n;
+														byte v542_n = a7_n->b0030 - 0x04;
+														a7_n->b0030 = v542_n;
 														if (v542_n != 0x00)
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 														else
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 													}
 													else
 													{
 														d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-														d0 = *((word32) a7_n + 60);
+														d0 = a7_n->t003C;
 														**((word32) d2_n - 4) = (word16) d0;
 													}
 												}
 												else
 												{
 													d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-													d0 = *((word32) a7_n + 60);
+													d0 = a7_n->t003C;
 													**((word32) d2_n - 4) = (byte) d0;
 												}
 											}
@@ -2624,18 +2624,18 @@ l00003B92:
 												word32 d0_n = d2_n + 0x03 >>u 0x02;
 												d2_n = (d0_n << 0x02) + 0x04;
 												struct Eq_n * a0_n = *((word32) d2_n - 4);
-												a0_n->dw0004 = (word32) *((word32) a7_n + 60);
-												a0_n->dw0000 = (word32) *((word32) a7_n + 56);
+												a0_n->t0004 = a7_n->t003C;
+												a0_n->dw0000 = a7_n->dw0038;
 												d0 = d0_n << 0x02;
 											}
 										}
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 								else
 								{
 									byte * a5_n;
-									if (*((word32) a7_n + 73) == 0x00)
+									if (a7_n->b0049 == 0x00)
 									{
 										d0 = (word32) d2_n + 3 >> 0x02 << 0x02;
 										d2_n = (word32) d0 + 4;
@@ -2649,7 +2649,7 @@ l00003B92:
 										d0 = d0_n & 0x08;
 										if ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00)
 										{
-											byte v190_n = *((word32) a7_n + 73);
+											byte v190_n = a7_n->b0049;
 											d7 = SEQ(v84_n, v190_n);
 											do
 											{
@@ -2669,7 +2669,7 @@ l00003B92:
 													byte * a0_n = *a1;
 													union Eq_n * a7_n = a7_n - 4;
 													*a7_n = (union Eq_n *) a2_n;
-													*a1 = a0_n + 1;
+													*a1 = (byte **) (a0_n + 1);
 													byte v201_n = *a0_n;
 													a2_n = *a7_n;
 													d0 = SEQ(SLICE(d0, word24, 8), v201_n);
@@ -2691,7 +2691,7 @@ l00003B92:
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2B15)[SEQ(SLICE(d0, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x08;
 											} while ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00);
-											*((word32) a7_n + 73) = v190_n;
+											a7_n->b0049 = v190_n;
 										}
 									}
 									if (d5_n != ~0x00)
@@ -2703,18 +2703,18 @@ l00003B92:
 									}
 									d3_n = d3_n - 0x01;
 									--d4_n;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										*a5_n = 0x00;
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 							}
 							else
 							{
-								if (*((word32) a7_n + 73) == 0x00)
+								if (a7_n->b0049 == 0x00)
 								{
-									if (*((word32) a7_n + 72) == 0x01)
+									if (a7_n[18] == 0x01)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										struct Eq_n * a0_n = *d0;
@@ -2722,19 +2722,19 @@ l00003B92:
 										a0_n->dw0000 = 0x00;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x6C)
+									else if (a7_n[18] == 0x6C)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x68)
+									else if (a7_n[18] == 0x68)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (word16) d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x02)
+									else if (a7_n[18] == 0x02)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (byte) d4_n;
@@ -2747,16 +2747,16 @@ l00003B92:
 										d2_n = (word32) d0 + 4;
 									}
 								}
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 								d3_n.u0 = 1;
 							}
 						}
 						else
 						{
 							if (d6_n == ~0x00)
-								d6_n.u0 = 1;
+								&d6_n.u0->dw0000 = 1;
 							union Eq_n * a1_n;
-							if (*((word32) a7_n + 73) == 0x00)
+							if (a7_n->b0049 == 0x00)
 							{
 								d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 								d2_n = (word32) d0 + 4;
@@ -2768,7 +2768,7 @@ l00003B92:
 							*a0_n |= 0x01;
 							int32 * a0_n = (word32) a2_n + 20;
 							--*a0_n;
-							*((word32) a7_n + 44) = a1_n;
+							a7_n[11] = (struct Eq_n) a1_n;
 							if (*a0_n >= 0x00)
 							{
 								byte ** a1_n = (word32) a2_n + 4;
@@ -2785,7 +2785,7 @@ l00003B92:
 							}
 							else
 							{
-								int32 a1_n = *((word32) a7_n + 44);
+								int32 a1_n = a7_n[11];
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->t0000 = a2_n;
 								a7_n->dw0030 = a1_n;
@@ -2795,18 +2795,18 @@ l00003B92:
 								a7_n->t0038 = d0;
 								a7_n->dw0030 = a7_n->dw0030;
 							}
-							a1 = *((word32) a7_n + 44);
-							d5_n = *((word32) a7_n + 52);
+							a1 = (byte **) a7_n[11];
+							d5_n = a7_n[0x0D];
 							Eq_n d3_n = (word32) d3_n + 1;
 							int32 d4_n = (word32) d4_n + 1;
-							if (*((word32) a7_n + 52) != ~0x00)
+							if (a7_n[0x0D] != ~0x00)
 							{
-								*((word32) a7_n + 44) = a1;
+								a7_n[11] = (struct Eq_n) a1;
 								if (d6_n - d3_n >= 0x00)
 								{
-									byte v302_n = *((word32) a7_n + 73);
+									byte v302_n = a7_n->b0049;
 									d7 = SEQ(v84_n, v302_n);
-									byte * a4_n = *((word32) a7_n + 44);
+									byte * a4_n = a7_n[11];
 									do
 									{
 										if (v302_n == 0x00)
@@ -2825,7 +2825,7 @@ l00003B92:
 											byte * a0_n = *a1;
 											union Eq_n * a7_n = a7_n - 4;
 											*a7_n = (union Eq_n *) a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v314_n = *a0_n;
 											a2_n = *a7_n;
 											d0 = SEQ(SLICE(d0, word24, 8), v314_n);
@@ -2844,7 +2844,7 @@ l00003B92:
 										d3_n = (word32) d3_n + 1;
 										++d4_n;
 									} while (d1 != ~0x00 && d6_n - d3_n >= 0x00);
-									*((word32) a7_n + 73) = v302_n;
+									a7_n->b0049 = v302_n;
 								}
 							}
 							if (d5_n != ~0x00)
@@ -2856,22 +2856,22 @@ l00003B92:
 							}
 							d3_n = d3_n - 0x01;
 							d4_n = d4_n - 0x01;
-							if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							if (a7_n->b0049 == 0x00 && d3_n != 0x00)
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 					else
 					{
-						*((word32) a7_n + 44) = 0x00;
+						a7_n[11] = (struct Eq_n) 0x00;
 						if (a3_n->b0000 == 0x5E)
 						{
-							*((word32) a7_n + 44) = 0x01;
+							a7_n[11] = (struct Eq_n) 0x01;
 							++a3_n;
 						}
-						*((word32) a7_n + 52) = 0x00;
-						byte v544_n = *((word32) a7_n + 44);
+						a7_n[0x0D] = (struct Eq_n) 0x00;
+						Eq_n v544_n = a7_n[11];
 						d7 = SEQ(v84_n, v544_n);
-						Eq_n d1_n = *((word32) a7_n + 52);
+						Eq_n d1_n = a7_n[0x0D];
 						do
 						{
 							int32 d5_n;
@@ -2879,12 +2879,12 @@ l00003B92:
 								d5_n = 0xFF;
 							else
 								d5_n = 0;
-							*((word32) d1_n + ((word32) a7_n + 78)) = (byte) d5_n;
+							Mem796[a7_n + 78 + d1_n:byte] = SLICE(d5_n, byte, 0);
 							d1_n = (word32) d1_n + 1;
 						} while (d1_n < 0x20);
-						*((word32) a7_n + 0x0084) = d2_n;
-						*((word32) a7_n + 44) = v544_n;
-						byte v554_n = *((word32) a7_n + 44);
+						a7_n[33] = (struct Eq_n) d2_n;
+						a7_n[11] = (struct Eq_n) v544_n;
+						Eq_n v554_n = a7_n[11];
 						while (a3_n->b0000 != 0x00)
 						{
 							cu8 v556_n = a3_n->b0000;
@@ -2903,13 +2903,13 @@ l00003B92:
 							{
 								if (v554_n != 0x00)
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (~(1 << (d5_n & 7)) & d1_n);
 								}
 								else
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (1 << (d5_n & 7) | d1_n);
 								}
@@ -2920,9 +2920,9 @@ l00003B92:
 								break;
 						}
 						byte * a6_n;
-						d2_n = *((word32) a7_n + 0x0084);
+						d2_n = a7_n[33];
 						++a3_n;
-						if (*((word32) a7_n + 73) == 0x00)
+						if (a7_n->b0049 == 0x00)
 						{
 							word32 d0_n = d2_n + 0x03 >>u 0x02;
 							d2_n = (d0_n << 0x02) + 0x04;
@@ -2940,40 +2940,40 @@ l00003B92:
 						{
 							a1 = (word32) a2_n + 4;
 							byte * a0_n = *a1;
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*a1 = a0_n + 1;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
+							*a1 = (byte **) (a0_n + 1);
 							byte v585_n = *a0_n;
-							a2_n = *a7_n;
-							*a7_n = d1_n;
-							*((word32) a7_n + 48) = (uint32) (uint8) v585_n;
+							a2_n = a7_n->t0000;
+							a7_n->t0000 = d1_n;
+							a7_n->dw0030 = (uint32) (uint8) v585_n;
 							d0 = SEQ(SLICE(d0, word24, 8), v585_n);
-							d1 = *a7_n;
+							d1 = a7_n->t0000;
 						}
 						else
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
 							word32 a5_n;
-							d0 = fn00003F30(*a7_n, out d1, out a1, out a5_n);
-							*((word32) a7_n + 48) = d0;
+							d0 = fn00003F30(a7_n->t0000, out d1, out a1, out a5_n);
+							a7_n->t0030 = d0;
 						}
-						d5_n = *((word32) a7_n + 44);
+						d5_n = a7_n[11];
 						Eq_n d3_n = (word32) d3_n + 1;
 						int32 d4_n = (word32) d4_n + 1;
-						if (*((word32) a7_n + 44) != ~0x00)
+						if (a7_n[11] != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = (word32) a7_n + 78;
-							*(a7_n - 4) = a1;
-							(a7_n - 8)->u0 = 0x08;
-							*(a7_n - 0x0C) = d5_n;
-							d1 = (uint32) (uint8) *((word32) *a7_n + fn00002948(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-							a1 = *(a7_n - 4);
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->ptr0000 = &a7_n->dw004A + 1;
+							*(a7_n - 4) = (byte ***) a1;
+							*(a7_n - 8) = 0x08;
+							*(a7_n - 0x0C) = (union Eq_n *) d5_n;
+							d1 = (uint32) (uint8) (a7_n->ptr0000 + fn00002948(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+							a1 = (byte **) *(a7_n - 4);
 							d0 = 1 << (d5_n & 7) & d1;
 							if (d0 != 0x00 && d6_n - d3_n >= 0x00)
 							{
-								byte v601_n = *((word32) a7_n + 77);
+								byte v601_n = a7_n->b004D;
 								d7 = SEQ(SLICE(d7, word24, 8), v601_n);
 								do
 								{
@@ -2991,9 +2991,9 @@ l00003B92:
 									{
 										a1 = (word32) a2_n + 4;
 										byte * a0_n = *a1;
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
-										*a1 = a0_n + 1;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
+										*a1 = (byte **) (a0_n + 1);
 										byte v611_n = *a0_n;
 										a2_n = *a7_n;
 										d0 = SEQ(SLICE(d0, word24, 8), v611_n);
@@ -3001,8 +3001,8 @@ l00003B92:
 									}
 									else
 									{
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
 										word32 d1_n;
 										word32 a5_n;
 										d0 = fn00003F30(*a7_n, out d1_n, out a1, out a5_n);
@@ -3013,31 +3013,31 @@ l00003B92:
 									++d4_n;
 									if (d1 == ~0x00)
 										break;
-									Eq_n a7_n = a7_n - 4;
-									*a7_n = (word32) a7_n + 78;
-									*(a7_n - 4) = a1;
-									(a7_n - 8)->u0 = 0x08;
-									*(a7_n - 0x0C) = d1;
-									d1 = (uint32) (uint8) *((word32) *a7_n + fn00002948(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-									a1 = *(a7_n - 4);
+									ptr32 * a7_n = a7_n - 4;
+									*a7_n = &a7_n->dw004A + 1;
+									*(a7_n - 4) = (byte ***) a1;
+									*(a7_n - 8) = 0x08;
+									*(a7_n - 0x0C) = (union Eq_n *) d1;
+									d1 = (uint32) (uint8) (*a7_n + fn00002948(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+									a1 = (byte **) *(a7_n - 4);
 									d0 = 1 << (d1 & 7) & d1;
 								} while (d0 != 0x00 && d6_n - d3_n >= 0x00);
-								*((word32) a7_n + 73) = v601_n;
+								a7_n->b0049 = v601_n;
 							}
 						}
 						if (d5_n != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*(a7_n - 4) = d5_n;
+							union Eq_n * a7_n = a7_n - 4;
+							*a7_n = (union Eq_n *) a2_n;
+							*(a7_n - 4) = (union Eq_n *) d5_n;
 							d0 = fn00002E5C(*(a7_n - 1), *a7_n);
 						}
 						d3_n = d3_n - 0x01;
 						d4_n = d4_n - 0x01;
-						if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+						if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 						{
 							*a6_n = 0x00;
-							*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 				}
@@ -3054,7 +3054,7 @@ l00003B92:
 						byte * a0_n = *a1;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						*a1 = (byte **) (a0_n + 1);
 						byte v163_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1_n;
@@ -3070,10 +3070,10 @@ l00003B92:
 						d0 = fn00003F30(a7_n->t0000, out d1, out a1, out a5_n);
 						a7_n->t0030 = d0;
 					}
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n = (word32) d3_n.u0 + 1;
 					d4_n = (word32) d4_n + 1;
-					if (*((word32) a7_n + 44) != 0x25)
+					if (a7_n[11] != 0x25)
 					{
 						if (d5_n != ~0x00)
 						{
@@ -3108,7 +3108,7 @@ l00003B92:
 							byte * a0_n = *a1;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							*a1 = (byte **) (a0_n + 1);
 							byte v109_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v109_n);
@@ -3152,7 +3152,7 @@ l00003B92:
 						byte * a0_n = *a1;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						*a1 = (byte **) (a0_n + 1);
 						byte v130_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1;
@@ -3169,10 +3169,10 @@ l00003B92:
 						a7_n->t0030 = d0_n;
 					}
 					d0 = (int32) (int16) (int8) SEQ(SLICE(d0_n, word24, 8), a4_n->b0000);
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n.u0 = 0x01;
 					d4_n = (word32) d4_n + 1;
-					if (d0 - *((word32) a7_n + 44) != 0x00)
+					if (d0 - a7_n[11] != 0x00)
 					{
 						if (d5_n != ~0x00)
 						{

--- a/subjects/Hunk-m68k/BYTEOPS.reko/BYTEOPS.h
+++ b/subjects/Hunk-m68k/BYTEOPS.reko/BYTEOPS.h
@@ -492,7 +492,7 @@ Eq_663: (union "Eq_663" (uint32 u0) (ptr32 u1))
 	T_1834 (in Mem1478[a7_1383 + 128<i32>:word32] : word32)
 	T_2308 (in ((word32) d3_1482 + 3<i32> >> 2<32> << 2<32>) + 4<32> : word32)
 	T_2554 (in ((word32) d3_1482 + 3<i32> >> 2<32> << 2<32>) + 4<32> : word32)
-Eq_671: (struct "Eq_671" 0004 (2C Eq_4228 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_4229 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+Eq_671: (struct "Eq_671" 0004 (2C Eq_4228 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_4229 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 	T_671 (in a7_1968 : (ptr32 Eq_671))
 	T_674 (in fp + -112<i32> : word32)
 	T_729 (in a7_51 + 4<i32> : word32)
@@ -758,9 +758,6 @@ Eq_2070: (union "Eq_2070" (int32 u0) (up32 u1))
 	T_2070 (in d2_1847 : Eq_2070)
 	T_2071 (in 0<i32> : int32)
 	T_2082 (in d2_1847 + 1<32> : word32)
-Eq_2161: (union "Eq_2161" (byte u0) (word32 u1))
-	T_2161 (in v248_1105 : Eq_2161)
-	T_2164 (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
 Eq_2165: (struct "Eq_2165" (0 (ptr32 Eq_1147) ptr0000) (34 int32 dw0034) (38 int32 dw0038))
 	T_2165 (in a7_1109 : (ptr32 Eq_2165))
 	T_2167 (in a7_1968 - 4<i32> : word32)
@@ -771,9 +768,6 @@ Eq_2202: (union "Eq_2202" (uint32 u0) (ptr32 u1))
 	T_2202 (in 3<32> : word32)
 Eq_2203: (union "Eq_2203" (uint32 u0) (ptr32 u1))
 	T_2203 (in d3_1482 + 3<32> : word32)
-Eq_2226: (union "Eq_2226" (word16 u0) (word32 u1))
-	T_2226 (in v262_844 : Eq_2226)
-	T_2229 (in Mem843[a7_1968 + 62<i32>:word16] : word16)
 Eq_2230: (struct "Eq_2230" (0 (ptr32 Eq_1147) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2230 (in a7_848 : (ptr32 Eq_2230))
 	T_2232 (in a7_1968 - 4<i32> : word32)
@@ -805,9 +799,6 @@ Eq_2320: (union "Eq_2320" (cu8 u0) (word32 u1) (Eq_1183 u2) (Eq_1186 u3) (Eq_126
 	T_2323 (in Mem894[a7_1968 + 44<i32>:byte] : byte)
 Eq_2322: (union "Eq_2322" (cu8 u0) (word32 u1) (Eq_1183 u2) (Eq_1186 u3) (Eq_1261 u4) (Eq_2320 u5))
 	T_2322 (in a7_1968 + 44<i32> : word32)
-Eq_2326: (union "Eq_2326" (byte u0) (word32 u1))
-	T_2326 (in v277_869 : Eq_2326)
-	T_2329 (in Mem868[a7_1968 + 63<i32>:byte] : byte)
 Eq_2330: (struct "Eq_2330" (0 (ptr32 Eq_1147) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2330 (in a7_873 : (ptr32 Eq_2330))
 	T_2332 (in a7_1968 - 4<i32> : word32)
@@ -3760,7 +3751,7 @@ T_670: (in d0_1952 : Eq_647)
 T_671: (in a7_1968 : (ptr32 Eq_671))
   Class: Eq_671
   DataType: (ptr32 Eq_671)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1183 u2) (T_1189 u3) (T_1264 u4) (T_2323 u5) (T_2434 u6) (T_2475 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1314 u2) (T_1321 u3) (T_1332 u4) (T_1848 u5) (T_1913 u6) (T_1916 u7) (T_1984 u8) (T_2030 u9) (T_2558 u10)) u0066) (6A byte b006A)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1183 u2) (T_1189 u3) (T_1264 u4) (T_2323 u5) (T_2434 u6) (T_2475 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1314 u2) (T_1321 u3) (T_1332 u4) (T_1848 u5) (T_1913 u6) (T_1916 u7) (T_1984 u8) (T_2030 u9) (T_2558 u10)) u0066) (6A byte b006A)))
 T_672: (in fp : ptr32)
   Class: Eq_672
   DataType: ptr32
@@ -5948,7 +5939,7 @@ T_1217: (in d3_1050 : ptr32)
 T_1218: (in a7_1020 : (ptr32 Eq_671))
   Class: Eq_671
   DataType: (ptr32 Eq_671)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1183 u2) (T_1189 u3) (T_1264 u4) (T_2323 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1314 u2) (T_1321 u3) (T_1332 u4) (T_1848 u5) (T_1913 u6) (T_1916 u7) (T_1984 u8) (T_2030 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1183 u2) (T_1189 u3) (T_1264 u4) (T_2323 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1314 u2) (T_1321 u3) (T_1332 u4) (T_1848 u5) (T_1913 u6) (T_1916 u7) (T_1984 u8) (T_2030 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
 T_1219: (in SLICE(d1_1068, byte, 0) : byte)
   Class: Eq_1219
   DataType: byte
@@ -9717,22 +9708,22 @@ T_2160: (in Mem1091[a7_1057 + 0<32>:word32] : word32)
   Class: Eq_1147
   DataType: (ptr32 Eq_1147)
   OrigDataType: int32
-T_2161: (in v248_1105 : Eq_2161)
+T_2161: (in v248_1105 : byte)
   Class: Eq_2161
-  DataType: Eq_2161
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2162: (in 55<i32> : int32)
   Class: Eq_2162
   DataType: int32
   OrigDataType: int32
 T_2163: (in a7_1968 + 55<i32> : word32)
   Class: Eq_2163
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2164: (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
   Class: Eq_2161
-  DataType: Eq_2161
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2165: (in a7_1109 : (ptr32 Eq_2165))
   Class: Eq_2165
   DataType: (ptr32 Eq_2165)
@@ -9947,8 +9938,8 @@ T_2217: (in 56<i32> : int32)
   OrigDataType: int32
 T_2218: (in a7_1968 + 56<i32> : word32)
   Class: Eq_2218
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2219: (in Mem836[a7_1968 + 56<i32>:word32] : word32)
   Class: Eq_2216
   DataType: word32
@@ -9977,22 +9968,22 @@ T_2225: (in d4_376 != 2<32> : bool)
   Class: Eq_2225
   DataType: bool
   OrigDataType: bool
-T_2226: (in v262_844 : Eq_2226)
+T_2226: (in v262_844 : word16)
   Class: Eq_2226
-  DataType: Eq_2226
-  OrigDataType: (union (word16 u0) (word32 u1))
+  DataType: word16
+  OrigDataType: word16
 T_2227: (in 62<i32> : int32)
   Class: Eq_2227
   DataType: int32
   OrigDataType: int32
 T_2228: (in a7_1968 + 62<i32> : word32)
   Class: Eq_2228
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2229: (in Mem843[a7_1968 + 62<i32>:word16] : word16)
   Class: Eq_2226
-  DataType: Eq_2226
-  OrigDataType: word32
+  DataType: word16
+  OrigDataType: word16
 T_2230: (in a7_848 : (ptr32 Eq_2230))
   Class: Eq_2230
   DataType: (ptr32 Eq_2230)
@@ -10377,22 +10368,22 @@ T_2325: (in d0_891 == 0<32> : bool)
   Class: Eq_2325
   DataType: bool
   OrigDataType: bool
-T_2326: (in v277_869 : Eq_2326)
+T_2326: (in v277_869 : byte)
   Class: Eq_2326
-  DataType: Eq_2326
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2327: (in 63<i32> : int32)
   Class: Eq_2327
   DataType: int32
   OrigDataType: int32
 T_2328: (in a7_1968 + 63<i32> : word32)
   Class: Eq_2328
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2329: (in Mem868[a7_1968 + 63<i32>:byte] : byte)
   Class: Eq_2326
-  DataType: Eq_2326
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2330: (in a7_873 : (ptr32 Eq_2330))
   Class: Eq_2330
   DataType: (ptr32 Eq_2330)
@@ -18256,11 +18247,11 @@ typedef struct Eq_671 {	// size: 4 4
 	Eq_4228 t002C;	// 2C
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
-	word32 dw0037;	// 37
+	byte b0037;	// 37
 	word32 dw0038;	// 38
 	word32 dw003C;	// 3C
-	word32 dw003E;	// 3E
-	word32 dw003F;	// 3F
+	word16 w003E;	// 3E
+	byte b003F;	// 3F
 	word32 dw0040;	// 40
 	word32 dw0044;	// 44
 	ui32 dw0048;	// 48
@@ -18643,11 +18634,6 @@ typedef union Eq_2070 {
 	up32 u1;
 } Eq_2070;
 
-typedef union Eq_2161 {
-	byte u0;
-	word32 u1;
-} Eq_2161;
-
 typedef struct Eq_2165 {
 	struct Eq_1147 * ptr0000;	// 0
 	int32 dw0034;	// 34
@@ -18668,11 +18654,6 @@ typedef union Eq_2203 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2203;
-
-typedef union Eq_2226 {
-	word16 u0;
-	word32 u1;
-} Eq_2226;
 
 typedef struct Eq_2230 {
 	struct Eq_1147 * ptr0000;	// 0
@@ -18736,11 +18717,6 @@ typedef union Eq_2322 {
 	Eq_1261 u4;
 	Eq_2320 u5;
 } Eq_2322;
-
-typedef union Eq_2326 {
-	byte u0;
-	word32 u1;
-} Eq_2326;
 
 typedef struct Eq_2330 {
 	struct Eq_1147 * ptr0000;	// 0

--- a/subjects/Hunk-m68k/BYTEOPS.reko/BYTEOPS_code.c
+++ b/subjects/Hunk-m68k/BYTEOPS.reko/BYTEOPS_code.c
@@ -619,7 +619,7 @@ l000016D6:
 						}
 						if (d4_n == 0x68)
 						{
-							Eq_n v262_n = a7_n->dw003E;
+							word16 v262_n = a7_n->w003E;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1_n;
 							a7_n->dw0040 = (uint32) (uint16) v262_n;
@@ -628,7 +628,7 @@ l000016D6:
 						}
 						if (d4_n == 0x02)
 						{
-							Eq_n v277_n = a7_n->dw003F;
+							byte v277_n = a7_n->b003F;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1_n;
 							a7_n->dw0040 = (uint32) (uint8) v277_n;
@@ -739,7 +739,7 @@ l00001932:
 							}
 							if (d4_n == 0x02)
 							{
-								Eq_n v248_n = a7_n->dw0037;
+								byte v248_n = a7_n->b0037;
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->ptr0000 = d1_n;
 								int32 d1_n = (int32) (int16) (int8) SEQ(SLICE(d1_n, word24, 8), v248_n);

--- a/subjects/Hunk-m68k/FIBO.reko/FIBO.h
+++ b/subjects/Hunk-m68k/FIBO.reko/FIBO.h
@@ -4,7 +4,7 @@
 
 /*
 // Equivalence classes ////////////
-Eq_1: (struct "Globals" (0 (ptr32 Eq_114) ptr0000) (1 Eq_790 t0001) (4 (ptr32 Eq_4) ptr0004) (8 (arr word32) a0008) (10 (arr ui32) a0010) (78 Eq_1188 t0078) (1410 byte b1410) (1420 (struct "Eq_630" 0001 (0 uint8 b0000) (1 cu8 b0001)) t1420) (1424 byte b1424) (1438 byte b1438) (1458 (struct "Eq_630" 0001) t1458) (1E08 byte b1E08) (28B1 Eq_4356 t28B1) (3E94 ptr32 ptr3E94) (3E98 (ptr32 Eq_4) ptr3E98) (3E9C (ptr32 Eq_25) ptr3E9C) (3EA0 (ptr32 Eq_59) ptr3EA0) (3EA4 (ptr32 Eq_59) ptr3EA4) (3EA8 Eq_132 t3EA8) (3EAC Eq_132 t3EAC) (3EB0 Eq_132 t3EB0) (3EBC word32 dw3EBC) (3EC0 ptr32 ptr3EC0) (3EC4 int32 dw3EC4) (3EC8 (ptr32 Eq_2946) ptr3EC8) (3ECC (ptr32 Eq_4) ptr3ECC) (3ED0 Eq_3436 t3ED0) (3FD4 word32 dw3FD4) (3FDC Eq_552 t3FDC) (3FE0 word32 dw3FE0) (3FEC (ptr32 Eq_569) ptr3FEC) (3FF0 Eq_623 t3FF0) (3FF4 (ptr32 Eq_701) ptr3FF4) (3FFC (ptr32 Eq_701) ptr3FFC) (4000 Eq_4 t4000) (10202 Eq_59 t10202) (3030303 Eq_59 t3030303) (6060606 Eq_2946 t6060606))
+Eq_1: (struct "Globals" (0 (ptr32 Eq_114) ptr0000) (1 Eq_790 t0001) (4 (ptr32 Eq_4) ptr0004) (8 (arr word32) a0008) (10 (arr ui32) a0010) (78 Eq_1188 t0078) (1410 byte b1410) (1420 (struct "Eq_630" 0001 (0 uint8 b0000) (1 cu8 b0001)) t1420) (1424 byte b1424) (1438 byte b1438) (1458 (struct "Eq_630" 0001) t1458) (1E08 byte b1E08) (28B1 Eq_4356 t28B1) (3E94 ptr32 ptr3E94) (3E98 (ptr32 Eq_4) ptr3E98) (3E9C (ptr32 Eq_25) ptr3E9C) (3EA0 (ptr32 Eq_59) ptr3EA0) (3EA4 (ptr32 Eq_59) ptr3EA4) (3EA8 Eq_132 t3EA8) (3EAC Eq_132 t3EAC) (3EB0 Eq_132 t3EB0) (3EBC word32 dw3EBC) (3EC0 ptr32 ptr3EC0) (3EC4 int32 dw3EC4) (3EC8 (ptr32 Eq_2946) ptr3EC8) (3ECC (ptr32 Eq_4) ptr3ECC) (3ED0 Eq_3436 t3ED0) (3FD4 word32 dw3FD4) (3FDC Eq_552 t3FDC) (3FE0 word32 dw3FE0) (3FEC (ptr32 Eq_569) ptr3FEC) (3FF0 Eq_624 t3FF0) (3FF4 (ptr32 Eq_701) ptr3FF4) (3FFC (ptr32 Eq_701) ptr3FFC) (4000 Eq_4 t4000) (10202 Eq_59 t10202) (3030303 Eq_59 t3030303) (6060606 Eq_2946 t6060606))
 	globals_t (in globals : (ptr32 (struct "Globals")))
 Eq_4: (struct "Eq_4" (0 word32 dw0000) (8 byte b0008) (C Eq_76 t000C) (10 word32 dw0010) (14 Eq_11 t0014) (18 up32 dw0018) (1C word32 dw001C))
 	T_4 (in a6_9 : (ptr32 Eq_4))
@@ -343,354 +343,20 @@ Eq_599: (fn word32 (Eq_378, ptr32, ptr32, ptr32))
 Eq_601: (fn Eq_378 ())
 	T_601 (in fn00001390 : ptr32)
 	T_602 (in signature of fn00001390 : void)
-Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((ptr32 Eq_8408) u4) ((ptr32 Eq_8415) u5) (Eq_1355 u6) (Eq_6411 u7) (Eq_7274 u8))
-	T_623 (in a1_14 : Eq_623)
-	T_624 (in d1_16 : Eq_623)
-	T_627 (in d0 : Eq_623)
-	T_628 (in d1 : Eq_623)
-	T_629 (in a1 : Eq_623)
+Eq_624: (union "Eq_624" (byte u0) (word16 u1) ((ptr32 Eq_8456) u2) ((ptr32 Eq_8409) u3))
+	T_624 (in d1_16 : Eq_624)
+	T_627 (in d0 : Eq_624)
+	T_628 (in d1 : Eq_624)
 	T_639 (in fn00003E04(&globals->b1438, out d1_16, out a1_14) : word32)
-	T_650 (in a1_48 : Eq_623)
-	T_651 (in d1_50 : Eq_623)
+	T_651 (in d1_50 : Eq_624)
 	T_657 (in fn00003E04(&globals->b1410, out d1_50, out a1_48) : word32)
-	T_783 (in d5_256 : Eq_623)
-	T_784 (in -1<i32> : int32)
-	T_795 (in d2_1005 : Eq_623)
-	T_798 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
-	T_814 (in d2_1005 | d1_123 : word32)
-	T_824 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
-	T_940 (in 0<i32> : int32)
-	T_968 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-	T_974 (in Mem278[a7_275 + 0<32>:word32] : word32)
-	T_978 (in  : word32)
-	T_979 (in 10<i32> : int32)
-	T_980 (in __swap(10<i32>) : word32)
-	T_987 (in __swap(d5_256) : word32)
-	T_992 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-	T_993 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
-	T_1030 (in Mem278[a7_275 + 0<32>:word32] : word32)
-	T_1034 (in d1_303 - 0x30<32> + d0_293 : word32)
-	T_1079 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-	T_1087 (in 10<i32> : int32)
-	T_1088 (in __swap(10<i32>) : word32)
-	T_1095 (in __swap(d2_1005) : word32)
-	T_1100 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-	T_1101 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
-	T_1143 (in d1_196 - 0x30<32> + d0_186 : word32)
-	T_1151 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
-	T_1250 (in 0<32> : word32)
-	T_1329 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-	T_1378 (in 0<32> : word32)
-	T_1598 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
-	T_1735 (in dwArg04 : Eq_623)
-	T_1736 (in dwArg08 : Eq_623)
-	T_1737 (in dwArg0C : Eq_623)
-	T_1738 (in dwArg10 : Eq_623)
-	T_1742 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_1747 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1752 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_1757 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_1819 (in dwArg04 : Eq_623)
-	T_1820 (in dwArg08 : Eq_623)
-	T_1821 (in dwArg0C : Eq_623)
-	T_1822 (in dwArg10 : Eq_623)
-	T_1823 (in d1Out : Eq_623)
-	T_1824 (in a0Out : Eq_623)
-	T_1828 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_1833 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1838 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_1843 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_1844 (in out d1_1450 : ptr32)
-	T_1845 (in out a0_1447 : ptr32)
-	T_2409 (in 0<32> : word32)
-	T_2439 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-	T_2443 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-	T_2499 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
-	T_3384 (in d0 : Eq_623)
-	T_3385 (in d0_196 : Eq_623)
-	T_3386 (in d1_142 : Eq_623)
-	T_3387 (in a0_20 : Eq_623)
-	T_3388 (in d3_166 : Eq_623)
-	T_3389 (in 0<32> : word32)
-	T_3397 (in 0<32> : word32)
-	T_3403 (in d0 : Eq_623)
-	T_3404 (in d1 : Eq_623)
-	T_3405 (in d2 : Eq_623)
-	T_3406 (in d1Out : Eq_623)
-	T_3407 (in d2Out : Eq_623)
-	T_3408 (in out d1_318 : ptr32)
-	T_3409 (in out d2_319 : ptr32)
-	T_3410 (in fn00002558(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-	T_3411 (in 0<i32> : int32)
-	T_3414 (in d6_30 : Eq_623)
-	T_3417 (in  : word32)
-	T_3418 (in  : word32)
-	T_3419 (in 8<32> : word32)
-	T_3420 (in __rol(dwArg0C, 8<32>) : word32)
-	T_3446 (in 8<32> : word32)
-	T_3447 (in __rol(d6_30, 8<32>) : word32)
-	T_3453 (in 8<32> : word32)
-	T_3454 (in __rol(d6_30, 8<32>) : word32)
-	T_3461 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_3462 (in d1_175 : Eq_623)
-	T_3463 (in d2_176 : Eq_623)
-	T_3464 (in d0_174 : Eq_623)
-	T_3466 (in 0<i32> : int32)
-	T_3467 (in out d1_175 : ptr32)
-	T_3468 (in out d2_176 : ptr32)
-	T_3469 (in fn00002558(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-	T_3473 (in out d1_320 : ptr32)
-	T_3474 (in out d2_321 : ptr32)
-	T_3475 (in fn00002558(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-	T_3486 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_3489 (in d0_85 : Eq_623)
-	T_3491 (in dwArg04 >> d4_61 : word32)
-	T_3494 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-	T_3497 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-	T_3498 (in out d1_86 : ptr32)
-	T_3499 (in out d2_322 : ptr32)
-	T_3500 (in fn00002558(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-	T_3501 (in d3_72 : Eq_623)
-	T_3502 (in dwArg10 << d5_63 : word32)
-	T_3503 (in d5_101 : Eq_623)
-	T_3505 (in __swap(d0_85) : word32)
-	T_3506 (in d6_103 : Eq_623)
-	T_3508 (in __swap(d3_72) : word32)
-	T_3512 (in d2_107 : Eq_623)
-	T_3515 (in d0_85 * (word16) d3_72 : word32)
-	T_3516 (in __swap(d0_85 * (word16) d3_72) : word32)
-	T_3529 (in d6_82 : Eq_623)
-	T_3530 (in dwArg08 << d5_63 : word32)
-	T_3531 (in d2_124 : Eq_623)
-	T_3533 (in SEQ(v35_109, v39_116) : uipr32)
-	T_3534 (in __swap(SEQ(v35_109, v39_116)) : word32)
-	T_3542 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-	T_3543 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-	T_3547 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-	T_3548 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-	T_3570 (in d0_85 - 1<32> : word32)
-	T_3576 (in d7_13 : Eq_623)
-	T_3577 (in 0<32> : word32)
-	T_3581 (in d0 : Eq_623)
-	T_3582 (in d1 : Eq_623)
-	T_3583 (in d2 : Eq_623)
-	T_3584 (in d1Out : Eq_623)
-	T_3585 (in out d1 : ptr32)
-	T_3586 (in fn00002716(d1, d2, d2, out d1) : word32)
-	T_3587 (in d6_17 : Eq_623)
-	T_3588 (in d5_19 : Eq_623)
-	T_3589 (in 0<32> : word32)
-	T_3591 (in d2_22 : Eq_623)
-	T_3593 (in __swap(d2) : word32)
-	T_3597 (in 0<32> : word32)
-	T_3606 (in 0<32> : word32)
-	T_3608 (in d0_281 : Eq_623)
-	T_3610 (in __swap(d0) : word32)
-	T_3611 (in d1_282 : Eq_623)
-	T_3613 (in __swap(d1) : word32)
-	T_3623 (in __swap(d1_282) : word32)
-	T_3630 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-	T_3631 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-	T_3636 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-	T_3642 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-	T_3643 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-	T_3647 (in d6_17 * 2<32> : word32)
-	T_3655 (in 0<32> : word32)
-	T_3657 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-	T_3659 (in d7_13 * 2<32> : word32)
-	T_3660 (in 0<32> : word32)
-	T_3664 (in d3_74 : Eq_623)
-	T_3671 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-	T_3672 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-	T_3675 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-	T_3676 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-	T_3677 (in d1_104 : Eq_623)
-	T_3678 (in 0xFFFF<32> : uipr32)
-	T_3679 (in d6_98 : Eq_623)
-	T_3683 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-	T_3684 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-	T_3685 (in d6_133 : Eq_623)
-	T_3687 (in __swap(d1_104) : word32)
-	T_3688 (in d3_140 : Eq_623)
-	T_3690 (in __swap(d6_133) : word32)
-	T_3691 (in d4_142 : Eq_623)
-	T_3693 (in __swap(d7_13) : word32)
-	T_3697 (in d6_146 : Eq_623)
-	T_3700 (in d6_133 * (word16) d7_13 : word32)
-	T_3701 (in __swap(d6_133 * (word16) d7_13) : word32)
-	T_3717 (in d6_178 : Eq_623)
-	T_3719 (in SEQ(v56_148, v59_155) : uipr32)
-	T_3720 (in __swap(SEQ(v56_148, v59_155)) : word32)
-	T_3721 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-	T_3722 (in d5_181 : word32)
-	T_3726 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-	T_3727 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-	T_3731 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-	T_3732 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-	T_3745 (in 0<32> : word32)
-	T_3747 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-	T_3748 (in 0<32> : word32)
-	T_3756 (in d1_104 - 1<32> : word32)
-	T_3757 (in d4_113 : Eq_623)
-	T_3760 (in __swap(d7_13) : word32)
-	T_3763 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-	T_3764 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-	T_3779 (in __swap(d7_13) : word32)
-	T_3783 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-	T_3785 (in d1_104 - 1<32> : word32)
-	T_3786 (in 0<32> : word32)
-	T_3792 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-	T_3793 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_3794 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_3795 (in d6_220 : Eq_623)
-	T_3799 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-	T_3800 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-	T_3803 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-	T_3804 (in d5_221 : Eq_623)
-	T_3806 (in __swap(d5_181) : word32)
-	T_3811 (in d5_266 : Eq_623)
-	T_3813 (in __swap(d5_181) : word32)
-	T_3814 (in d6_267 : Eq_623)
-	T_3816 (in __swap(d6_178) : word32)
-	T_3819 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-	T_3822 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-	T_3826 (in d2_73 : Eq_623)
-	T_3828 (in __swap(d5_19) : word32)
-	T_3830 (in __swap(d7_13) : word32)
-	T_3840 (in d5_221 >> 1<32> : word32)
-	T_3845 (in  : word32)
-	T_3851 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-	T_3858 (in d0 : Eq_623)
-	T_3859 (in d2 : Eq_623)
-	T_3860 (in dwArg04 : Eq_623)
-	T_3861 (in dwArg08 : Eq_623)
-	T_3862 (in 0<32> : word32)
-	T_3864 (in 0<32> : word32)
-	T_3866 (in d0_36 : Eq_623)
-	T_3867 (in -dwArg04 : word32)
-	T_3868 (in 0<32> : word32)
-	T_3872 (in out d1_43 : ptr32)
-	T_3873 (in fn00002716(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_3874 (in -fn00002716(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_3877 (in -dwArg08 : word32)
-	T_3878 (in out d1_55 : ptr32)
-	T_3879 (in fn00002716(d0_36, -dwArg08, d2, out d1_55) : word32)
-	T_3882 (in out d1_88 : ptr32)
-	T_3883 (in fn00002716(dwArg04, dwArg08, d2, out d1_88) : word32)
-	T_3886 (in -dwArg08 : word32)
-	T_3887 (in out d1_89 : ptr32)
-	T_3888 (in fn00002716(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_3889 (in -fn00002716(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_3890 (in d1_22 : Eq_623)
-	T_3892 (in __swap(d1) : word32)
-	T_3897 (in d2_11 : Eq_623)
-	T_3898 (in SEQ(v11_10, v10_9) : uipr32)
-	T_3901 (in d3_18 : Eq_623)
-	T_3902 (in 16<i32> : int32)
-	T_3906 (in d0_134 : Eq_623)
-	T_3908 (in __swap(d0) : word32)
-	T_3909 (in d1_135 : Eq_623)
-	T_3911 (in __swap(d1_22) : word32)
-	T_3916 (in __swap(d2_11) : word32)
-	T_3921 (in d0_150 : Eq_623)
-	T_3923 (in __swap(d0_134) : word32)
-	T_3937 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-	T_3938 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-	T_3940 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-	T_3942 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-	T_3952 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-	T_3957 (in 8<32> : word32)
-	T_3958 (in __rol(d1_22, 8<32>) : word32)
-	T_3959 (in 8<32> : uipr32)
-	T_3964 (in 4<32> : word32)
-	T_3965 (in __rol(d1_22, 4<32>) : word32)
-	T_3970 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-	T_3975 (in 2<32> : word32)
-	T_3976 (in __rol(d1_22, 2<32>) : word32)
-	T_3981 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-	T_3987 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-	T_3988 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-	T_3995 (in __swap(d3_18) : word32)
-	T_4001 (in d1_90 : Eq_623)
-	T_4003 (in __swap(d1_22) : word32)
-	T_4004 (in d3_102 : Eq_623)
-	T_4005 (in SEQ(v53_82, v51_79) : uipr32)
-	T_4006 (in d0_108 : Eq_623)
-	T_4016 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-	T_4017 (in 0<32> : word32)
-	T_4020 (in 1<32> : word32)
-	T_4021 (in __rol(d1_22, 1<32>) : word32)
-	T_4026 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-	T_4030 (in __swap(d3_102) : word32)
-	T_4031 (in __rol(d0_108, __swap(d3_102)) : word32)
-	T_4032 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-	T_4035 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-	T_4038 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-	T_4039 (in d0_108 + d1_90 : word32)
-	T_4040 (in 0<32> : word32)
-	T_4042 (in d1 : Eq_623)
-	T_4043 (in d1_171 : Eq_623)
-	T_4044 (in d3_202 : Eq_623)
-	T_4045 (in 0<32> : word32)
-	T_4053 (in 0<32> : word32)
-	T_4057 (in out d1_171 : ptr32)
-	T_4058 (in out d2_354 : ptr32)
-	T_4059 (in fn00002558(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-	T_4062 (in d6_33 : Eq_623)
-	T_4064 (in 8<32> : word32)
-	T_4065 (in __rol(dwArg0C, 8<32>) : word32)
-	T_4091 (in 8<32> : word32)
-	T_4092 (in __rol(d6_33, 8<32>) : word32)
-	T_4098 (in 8<32> : word32)
-	T_4099 (in __rol(d6_33, 8<32>) : word32)
-	T_4106 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_4109 (in d0_88 : Eq_623)
-	T_4111 (in dwArg04 >> d4_64 : word32)
-	T_4114 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-	T_4117 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-	T_4118 (in out d1_89 : ptr32)
-	T_4119 (in out d2_90 : ptr32)
-	T_4120 (in fn00002558(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-	T_4121 (in d3_75 : Eq_623)
-	T_4122 (in dwArg10 << d5_66 : word32)
-	T_4123 (in d7_104 : Eq_623)
-	T_4125 (in __swap(d0_88) : word32)
-	T_4126 (in d6_106 : Eq_623)
-	T_4128 (in __swap(d3_75) : word32)
-	T_4132 (in d2_110 : Eq_623)
-	T_4135 (in d0_88 * (word16) d3_75 : word32)
-	T_4136 (in __swap(d0_88 * (word16) d3_75) : word32)
-	T_4149 (in d2_127 : Eq_623)
-	T_4151 (in SEQ(v37_112, v40_119) : uipr32)
-	T_4152 (in __swap(SEQ(v37_112, v40_119)) : word32)
-	T_4162 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-	T_4163 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-	T_4167 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-	T_4168 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-	T_4187 (in dwArg08 - dwArg10 : word32)
-	T_4191 (in d1_211 : Eq_623)
-	T_4192 (in d2_212 : Eq_623)
-	T_4194 (in 0<i32> : int32)
-	T_4195 (in out d1_211 : ptr32)
-	T_4196 (in out d2_212 : ptr32)
-	T_4197 (in fn00002558(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-	T_4200 (in out d1_171 : ptr32)
-	T_4201 (in out d2_355 : ptr32)
-	T_4202 (in fn00002558(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-	T_4213 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_4218 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-	T_4231 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
-	T_4273 (in d0 : Eq_623)
-	T_4274 (in d1 : Eq_623)
-	T_4275 (in a1 : Eq_623)
-	T_4276 (in dwArg04 : Eq_623)
-	T_4278 (in dwArg0C : Eq_623)
+	T_4273 (in d0 : Eq_624)
+	T_4274 (in d1 : Eq_624)
+	T_4276 (in dwArg04 : Eq_624)
 	T_4280 (in Mem10[0x00003FF0<p32>:word32] : word32)
-	T_4283 (in fp + 8<i32> : word32)
-	T_4285 (in d0 : Eq_623)
-	T_4286 (in bArg07 : Eq_623)
-	T_4287 (in dwArg08 : Eq_623)
-	T_4288 (in d0_10 : Eq_623)
+	T_4285 (in d0 : Eq_624)
+	T_4287 (in dwArg08 : Eq_624)
+	T_4288 (in d0_10 : Eq_624)
 	T_4289 (in 0<32> : word32)
 	T_4293 (in Mem5[dwArg08 + 4<i32>:word32] : word32)
 	T_4296 (in Mem5[dwArg08 + 8<i32>:word32] : word32)
@@ -698,51 +364,36 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_4311 (in *((word32) dwArg08 + 4<i32>) - 1<32> : word32)
 	T_4313 (in Mem25[dwArg08 + 4<i32>:word32] : word32)
 	T_4316 (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-	T_4319 (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-	T_4324 (in d2_1090 : Eq_623)
-	T_4326 (in a2_1014 : Eq_623)
-	T_4329 (in d5_1044 : Eq_623)
+	T_4326 (in a2_1014 : Eq_624)
+	T_4329 (in d5_1044 : Eq_624)
 	T_4330 (in 0<i32> : int32)
 	T_4336 (in 0xFFFFFFFF<32> : word32)
 	T_4360 (in d0_63 & 8<32> : word32)
-	T_4386 (in d6_1133 : Eq_623)
-	T_4387 (in -1<i32> : int32)
 	T_4389 (in d0_289 & 4<32> : word32)
-	T_4409 (in 0<i32> : int32)
 	T_4411 (in d0_305 & 4<32> : word32)
-	T_4420 (in Mem316[a7_313 + 0<32>:word32] : word32)
-	T_4423 (in 10<i32> : int32)
-	T_4424 (in __swap(10<i32>) : word32)
-	T_4434 (in __swap(d6_1133) : word32)
-	T_4439 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-	T_4440 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-	T_4466 (in Mem316[a7_313 + 0<32>:word32] : word32)
 	T_4468 (in d1_340 - 0x30<32> : word32)
-	T_4470 (in d1_340 - 0x30<32> + d0_331 : word32)
 	T_4472 (in d0_354 & 4<32> : word32)
 	T_4486 (in SEQ(SLICE(d1, word24, 8), Mem361[a7_1330 + 72<i32>:byte]) : uip32)
 	T_4542 (in 2<i32> : int32)
 	T_4590 (in SEQ(SLICE(d1, word24, 8), Mem361[a3_279 + 0<32>:byte]) : uip32)
 	T_4596 (in 1<i32> : int32)
-	T_4633 (in d1_612 : Eq_623)
+	T_4633 (in d1_612 : Eq_624)
 	T_4636 (in SEQ(v147_608, v83_500 - 0x25<8>) : uip32)
-	T_4646 (in d0_540 : Eq_623)
+	T_4646 (in d0_540 : Eq_624)
 	T_4677 (in Mem535[a7_533 + 0<32>:word32] : word32)
-	T_4682 (in dwArg04 : Eq_623)
+	T_4682 (in dwArg04 : Eq_624)
 	T_4688 (in Mem535[a7_533 + 0<32>:word32] : word32)
 	T_4692 (in fn00003CCC(*a7_533, out d1_5316, out a1, out a5_5317) : word32)
-	T_4694 (in a2_1014 + 4<i32> : word32)
 	T_4704 (in Mem554[a7_552 + 0<32>:word32] : word32)
 	T_4716 (in Mem558[a7_552 + 0<32>:word32] : word32)
 	T_4718 (in SEQ(SLICE(d0, word24, 8), v96_562) : uip32)
 	T_4720 (in (uint32) (uint8) v96_562 : uint32)
 	T_4735 (in d0_591 & 8<32> : word32)
-	T_4739 (in d0_111 : Eq_623)
-	T_4765 (in d0_187 : Eq_623)
+	T_4739 (in d0_111 : Eq_624)
+	T_4765 (in d0_187 : Eq_624)
 	T_4796 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_4802 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_4806 (in fn00003CCC(*a7_180, out d1_5318, out a1, out a5_5319) : word32)
-	T_4808 (in a2_1014 + 4<i32> : word32)
 	T_4818 (in Mem201[a7_199 + 0<32>:word32] : word32)
 	T_4830 (in Mem205[a7_199 + 0<32>:word32] : word32)
 	T_4832 (in SEQ(SLICE(d0, word24, 8), v109_209) : uip32)
@@ -751,14 +402,12 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_4854 (in 0xFFFFFFFF<32> : word32)
 	T_4864 (in Mem251[a7_248 + 0<32>:word32] : word32)
 	T_4869 (in Mem254[a7_248 - 4<i32> + 0<32>:word32] : word32)
-	T_4876 (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
 	T_4879 (in Mem254[a7_248 + 0<32>:word32] : word32)
 	T_4880 (in fn00002BF8(*(a7_248 - 1<i32>), *a7_248) : word32)
 	T_4888 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_4893 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_4897 (in fn00003CCC(a7_79->t0000, out d1, out a1, out a5_5320) : word32)
 	T_4900 (in Mem94[a7_79 + 48<i32>:word32] : word32)
-	T_4902 (in a2_1014 + 4<i32> : word32)
 	T_4912 (in Mem101[a7_99 + 0<32>:word32] : word32)
 	T_4924 (in Mem105[a7_99 + 0<32>:word32] : word32)
 	T_4927 (in Mem115[a7_99 + 0<32>:word32] : word32)
@@ -769,19 +418,16 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_4964 (in 0xFFFFFFFF<32> : word32)
 	T_4974 (in Mem151[a7_148 + 0<32>:word32] : word32)
 	T_4979 (in Mem154[a7_148 - 4<i32> + 0<32>:word32] : word32)
-	T_4985 (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
 	T_4988 (in Mem154[a7_148 + 0<32>:word32] : word32)
 	T_4989 (in fn00002BF8(*(a7_148 - 1<i32>), *a7_148) : word32)
-	T_5026 (in d1_1355 : Eq_623)
+	T_5026 (in d1_1355 : Eq_624)
 	T_5029 (in SEQ(v147_608, v83_500 - 0x63<8>) : uip32)
-	T_5031 (in 0xFFFFFFFF<32> : word32)
 	T_5035 (in SEQ(v147_608, v83_500 - 0x6E<8>) : uip32)
 	T_5044 (in SEQ(v147_608, v83_500 - 0x73<8>) : uip32)
 	T_5071 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_5076 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_5080 (in fn00003CCC(a7_640->t0000, out d1, out a1, out a5_5321) : word32)
 	T_5083 (in Mem655[a7_640 + 48<i32>:word32] : word32)
-	T_5085 (in a2_1014 + 4<i32> : word32)
 	T_5095 (in Mem662[a7_660 + 0<32>:word32] : word32)
 	T_5107 (in Mem666[a7_660 + 0<32>:word32] : word32)
 	T_5110 (in Mem686[a7_660 + 0<32>:word32] : word32)
@@ -791,38 +437,29 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_5137 (in 0xFFFFFFFF<32> : word32)
 	T_5148 (in Mem738[a7_735 + 0<32>:word32] : word32)
 	T_5153 (in Mem741[a7_735 - 4<i32> + 0<32>:word32] : word32)
-	T_5159 (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
 	T_5162 (in Mem741[a7_735 + 0<32>:word32] : word32)
 	T_5163 (in fn00002BF8(*(a7_735 - 1<i32>), *a7_735) : word32)
 	T_5166 (in 0x2D<32> : word32)
 	T_5179 (in (word32) d2_1090 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_5181 (in d0 + 4<32> : word32)
 	T_5185 (in 0xFFFFFFFF<32> : word32)
 	T_5210 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5223 (in d0 + 4<32> : word32)
 	T_5224 (in 0xFFFFFFFF<32> : word32)
 	T_5238 (in d0_1765 & 8<32> : word32)
 	T_5291 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5299 (in d0 + 4<32> : word32)
 	T_5305 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_5310 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_5314 (in fn00003CCC(*a7_1807, out d1_5322, out a1, out a5_1727) : word32)
-	T_5316 (in a2_1014 + 4<i32> : word32)
 	T_5326 (in Mem1828[a7_1826 + 0<32>:word32] : word32)
 	T_5338 (in Mem1832[a7_1826 + 0<32>:word32] : word32)
 	T_5340 (in SEQ(SLICE(d0, word24, 8), v201_1836) : uip32)
 	T_5342 (in (uint32) (uint8) v201_1836 : uint32)
 	T_5347 (in 0xFFFFFFFF<32> : word32)
 	T_5359 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5368 (in d0 + 4<32> : word32)
 	T_5384 (in d0_1871 & 8<32> : word32)
 	T_5398 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5406 (in d0 + 4<32> : word32)
 	T_5412 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5421 (in d0 + 4<32> : word32)
 	T_5436 (in Mem1903[a7_1897 + 0<32>:word32] : word32)
 	T_5441 (in Mem1906[a7_1897 - 4<i32> + 0<32>:word32] : word32)
-	T_5447 (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
 	T_5450 (in Mem1906[a7_1897 + 0<32>:word32] : word32)
 	T_5451 (in fn00002BF8(*(a7_1897 - 1<i32>), *a7_1897) : word32)
 	T_5452 (in 0x2B<32> : word32)
@@ -831,7 +468,6 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_5501 (in Mem2009[a7_2007 + 0<32>:word32] : word32)
 	T_5505 (in fn00003CCC(a7_2007->t0000, out d1, out a1, out a5_5323) : word32)
 	T_5508 (in Mem2022[a7_2007 + 56<i32>:word32] : word32)
-	T_5510 (in a2_1014 + 4<i32> : word32)
 	T_5520 (in Mem2029[a7_2027 + 0<32>:word32] : word32)
 	T_5532 (in Mem2033[a7_2027 + 0<32>:word32] : word32)
 	T_5535 (in Mem2050[a7_2027 + 0<32>:word32] : word32)
@@ -840,29 +476,25 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_5548 (in Mem2062[a7_1330 + 52<i32>:word32] : word32)
 	T_5571 (in 0x30<32> : word32)
 	T_5585 (in d0_2109 & 4<32> : word32)
-	T_5592 (in d0_2155 : Eq_623)
+	T_5592 (in d0_2155 : Eq_624)
 	T_5623 (in Mem2150[a7_2148 + 0<32>:word32] : word32)
 	T_5628 (in Mem2150[a7_2148 + 0<32>:word32] : word32)
 	T_5632 (in fn00003CCC(a7_2148->t0000, out d1, out a1, out a5_5324) : word32)
 	T_5635 (in Mem2163[a7_2148 + 56<i32>:word32] : word32)
-	T_5637 (in a2_1014 + 4<i32> : word32)
 	T_5647 (in Mem2170[a7_2168 + 0<32>:word32] : word32)
 	T_5659 (in Mem2174[a7_2168 + 0<32>:word32] : word32)
 	T_5662 (in Mem2185[a7_2168 + 0<32>:word32] : word32)
 	T_5669 (in SEQ(SLICE(d0, word24, 8), v249_2178) : uip32)
 	T_5672 (in Mem2191[a7_2168 + 0<32>:word32] : word32)
 	T_5689 (in d0_2209 & 0xFF<32> : word32)
-	T_5708 (in 1<i32> : int32)
 	T_5709 (in 0x78<32> : word32)
 	T_5717 (in SEQ(SLICE(d0_2209 & 0xFF<32>, word24, 8), SLICE(d0_2209 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
 	T_5724 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5726 (in d0 + 4<32> : word32)
-	T_5764 (in d0_2253 : Eq_623)
+	T_5764 (in d0_2253 : Eq_624)
 	T_5795 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_5800 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_5804 (in fn00003CCC(a7_2246->t0000, out d1, out a1, out a5_5325) : word32)
 	T_5807 (in Mem2261[a7_2246 + 56<i32>:word32] : word32)
-	T_5809 (in a2_1014 + 4<i32> : word32)
 	T_5819 (in Mem2268[a7_2266 + 0<32>:word32] : word32)
 	T_5831 (in Mem2272[a7_2266 + 0<32>:word32] : word32)
 	T_5834 (in Mem2283[a7_2266 + 0<32>:word32] : word32)
@@ -878,18 +510,14 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_5926 (in Mem1444[a7_1425 + 0<32>:word32] : word32)
 	T_5933 (in SEQ(SLICE(d0, word24, 8), v284_1435) : uip32)
 	T_5936 (in Mem1450[a7_1425 + 0<32>:word32] : word32)
-	T_5939 (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
 	T_5942 (in Mem1456[a7_1330 + 52<i32>:word32] : word32)
 	T_5965 (in 0xFFFFFFFF<32> : word32)
-	T_5969 (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
 	T_6018 (in Mem2338[a7_2334 + 0<32>:word32] : word32)
-	T_6032 (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
 	T_6035 (in Mem2342[a7_2334 + 0<32>:word32] : word32)
 	T_6036 (in fn00002BF8(*(a7_2334 - 1<i32>), a7_2334->t0000) : word32)
 	T_6042 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_6048 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_6052 (in fn00003CCC(*a7_1512, out d1_5328, out a1, out a5_5329) : word32)
-	T_6054 (in a2_1014 + 4<i32> : word32)
 	T_6064 (in Mem1533[a7_1531 + 0<32>:word32] : word32)
 	T_6076 (in Mem1537[a7_1531 + 0<32>:word32] : word32)
 	T_6078 (in SEQ(SLICE(d0, word24, 8), v314_1541) : uip32)
@@ -897,21 +525,18 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_6085 (in 0xFFFFFFFF<32> : word32)
 	T_6114 (in Mem1591[a7_1585 + 0<32>:word32] : word32)
 	T_6119 (in Mem1594[a7_1585 - 4<i32> + 0<32>:word32] : word32)
-	T_6125 (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
 	T_6128 (in Mem1594[a7_1585 + 0<32>:word32] : word32)
 	T_6129 (in fn00002BF8(*(a7_1585 - 1<i32>), *a7_1585) : word32)
 	T_6135 (in Mem2373[a7_2368 + 0<32>:word32] : word32)
-	T_6149 (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
 	T_6152 (in Mem2377[a7_2368 + 0<32>:word32] : word32)
 	T_6153 (in fn00002BF8(*(a7_2368 - 1<i32>), a7_2368->t0000) : word32)
 	T_6176 (in d0_2124 & 0x44<32> : word32)
 	T_6187 (in 0x30<32> : word32)
-	T_6192 (in d0_2450 : Eq_623)
+	T_6192 (in d0_2450 : Eq_624)
 	T_6223 (in Mem2445[a7_2443 + 0<32>:word32] : word32)
 	T_6228 (in Mem2445[a7_2443 + 0<32>:word32] : word32)
 	T_6232 (in fn00003CCC(a7_2443->t0000, out d1, out a1, out a5_5330) : word32)
 	T_6235 (in Mem2458[a7_2443 + 56<i32>:word32] : word32)
-	T_6237 (in a2_1014 + 4<i32> : word32)
 	T_6247 (in Mem2465[a7_2463 + 0<32>:word32] : word32)
 	T_6259 (in Mem2469[a7_2463 + 0<32>:word32] : word32)
 	T_6262 (in Mem2492[a7_2463 + 0<32>:word32] : word32)
@@ -920,40 +545,28 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_6292 (in d0_2517 & 0xFF<32> : word32)
 	T_6302 (in 0x78<32> : word32)
 	T_6310 (in SEQ(SLICE(d0_2517 & 0xFF<32>, word24, 8), SLICE(d0_2517 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
-	T_6319 (in d0_2559 : Eq_623)
+	T_6319 (in d0_2559 : Eq_624)
 	T_6350 (in Mem2554[a7_2552 + 0<32>:word32] : word32)
 	T_6355 (in Mem2554[a7_2552 + 0<32>:word32] : word32)
 	T_6359 (in fn00003CCC(a7_2552->t0000, out d1, out a1, out a5_5331) : word32)
 	T_6362 (in Mem2567[a7_2552 + 56<i32>:word32] : word32)
-	T_6364 (in a2_1014 + 4<i32> : word32)
 	T_6374 (in Mem2574[a7_2572 + 0<32>:word32] : word32)
 	T_6386 (in Mem2578[a7_2572 + 0<32>:word32] : word32)
 	T_6389 (in Mem2589[a7_2572 + 0<32>:word32] : word32)
 	T_6396 (in SEQ(SLICE(d0, word24, 8), v372_2582) : uip32)
 	T_6399 (in Mem2595[a7_2572 + 0<32>:word32] : word32)
 	T_6424 (in d0_2620 & 0x44<32> : word32)
-	T_6457 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
 	T_6466 (in d0_2760 & 0x44<32> : word32)
 	T_6479 (in Mem2671[a7_2667 + 0<32>:word32] : word32)
-	T_6493 (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
 	T_6496 (in Mem2675[a7_2667 + 0<32>:word32] : word32)
 	T_6497 (in fn00002BF8(*(a7_2667 - 1<i32>), a7_2667->t0000) : word32)
 	T_6509 (in Mem2603[a7_1330 + 74<i32>:word32] : word32)
-	T_6522 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-	T_6552 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
 	T_6561 (in d0_2818 & 4<32> : word32)
-	T_6567 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-	T_6573 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-	T_6583 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
 	T_6591 (in 0x37<32> : word32)
-	T_6604 (in v419_2893 : Eq_623)
-	T_6609 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-	T_6734 (in d0_3135 : Eq_623)
-	T_6784 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_6734 (in d0_3135 : Eq_624)
 	T_6810 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6817 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6821 (in fn00003CCC(*(a7_1330 - 4<i32>), out d1_5332, out a1, out a5_5333) : word32)
-	T_6823 (in a2_1014 + 4<i32> : word32)
 	T_6831 (in Mem3149[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6841 (in (uint32) (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint32)
 	T_6845 (in Mem3153[a7_1330 - 4<i32> + 0<32>:word32] : word32)
@@ -964,98 +577,62 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_6887 (in Mem3291[a7_1330 + 110<i32>:word32] : word32)
 	T_6893 (in Mem3272[a7_3259 + 0<32>:word32] : word32)
 	T_6898 (in Mem3275[a7_3259 - 4<i32> + 0<32>:word32] : word32)
-	T_6904 (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
 	T_6907 (in Mem3275[a7_3259 + 0<32>:word32] : word32)
 	T_6908 (in fn00002BF8(*(a7_3259 - 1<i32>), *a7_3259) : word32)
 	T_6914 (in Mem2639[a7_2635 + 0<32>:word32] : word32)
-	T_6928 (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
 	T_6931 (in Mem2643[a7_2635 + 0<32>:word32] : word32)
 	T_6932 (in fn00002BF8(*(a7_2635 - 1<i32>), a7_2635->t0000) : word32)
 	T_6950 (in d0_3206 & 4<32> : word32)
 	T_6958 (in 0x37<32> : word32)
-	T_6964 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_6967 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_6969 (in d7 >> 31<i32> : word32)
-	T_6972 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-	T_6982 (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
-	T_7014 (in dwArg04 : Eq_623)
-	T_7015 (in dwArg08 : Eq_623)
-	T_7016 (in dwArg0C : Eq_623)
-	T_7017 (in dwArg10 : Eq_623)
-	T_7022 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-	T_7027 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-	T_7032 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-	T_7037 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
 	T_7076 (in Mem3303[a7_3299 + 0<32>:word32] : word32)
 	T_7081 (in Mem3306[a7_3299 - 4<i32> + 0<32>:word32] : word32)
-	T_7087 (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
 	T_7090 (in Mem3306[a7_3299 + 0<32>:word32] : word32)
 	T_7091 (in fn00002BF8(*(a7_3299 - 1<i32>), *a7_3299) : word32)
 	T_7120 (in Mem3476[a7_3474 + 0<32>:word32] : word32)
-	T_7144 (in (d0_3495 << 2<32>) + 4<32> : word32)
 	T_7151 (in Mem3485[a7_3474 + 52<i32>:word32] : word32)
 	T_7154 (in Mem3503[a0_3501 + 4<i32>:word32] : word32)
 	T_7161 (in d0_3495 << 2<32> : word32)
-	T_7180 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7183 (in Mem3508[a7_3474 + 52<i32>:word32] : word32)
 	T_7184 (in SLICE(d0, byte, 0) : byte)
 	T_7190 (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_7209 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7212 (in Mem3525[a7_3474 + 52<i32>:word32] : word32)
 	T_7213 (in SLICE(d0, word16, 0) : word16)
 	T_7219 (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_7238 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7241 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_7247 (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7255 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7258 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_7264 (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
 	T_7290 (in -v528_3348->dw0004 : word32)
 	T_7295 (in 0<32> : word32)
 	T_7297 (in -v528_3348->dw0000 - (d1 < 0<32>) : word32)
 	T_7306 (in Mem3375[a7_3364 + 0<32>:word32] : word32)
-	T_7331 (in d1_1027 : Eq_623)
+	T_7331 (in d1_1027 : Eq_624)
 	T_7334 (in Mem773[a7_1330 + 52<i32>:word32] : word32)
-	T_7349 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_7356 (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
+	T_7359 (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
 	T_7366 (in d0_3398 << 2<32> : word32)
-	T_7385 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7388 (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
 	T_7389 (in SLICE(d0, byte, 0) : byte)
 	T_7395 (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_7414 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7417 (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
 	T_7418 (in SLICE(d0, word16, 0) : word16)
 	T_7424 (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_7443 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7446 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_7452 (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7460 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7463 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_7469 (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7473 (in SLICE(d5_785, byte, 0) : byte)
-	T_7477 (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
 	T_7479 (in d1_1027 + 1<32> : word32)
 	T_7480 (in 0x20<32> : word32)
-	T_7486 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-	T_7497 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
 	T_7512 (in SEQ(SLICE(d1_1027, word24, 8), v556_834) : uip32)
 	T_7538 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_7557 (in Mem889[a0_881 + 0<32>:byte] : byte)
 	T_7559 (in (uint32) (uint8) Mem889[a0_881 + 0<32>:byte] : uint32)
-	T_7565 (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-	T_7568 (in Mem895[a0_881 + 0<32>:byte] : byte)
-	T_7577 (in Mem889[a0_900 + 0<32>:byte] : byte)
 	T_7579 (in (uint32) (uint8) Mem889[a0_900 + 0<32>:byte] : uint32)
-	T_7586 (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-	T_7589 (in Mem914[a0_900 + 0<32>:byte] : byte)
 	T_7594 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_7607 (in (d0_957 << 2<32>) + 4<32> : word32)
 	T_7608 (in d0_957 << 2<32> : word32)
 	T_7647 (in Mem987[a7_985 + 0<32>:word32] : word32)
 	T_7652 (in Mem987[a7_985 + 0<32>:word32] : word32)
-	T_7656 (in fn00003CCC(*a7_985, out d1, out a1, out a5_5334) : word32)
+	T_7656 (in fn00003CCC(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
 	T_7659 (in Mem1000[a7_985 + 48<i32>:word32] : word32)
-	T_7661 (in a2_1014 + 4<i32> : word32)
 	T_7671 (in Mem1007[a7_1005 + 0<32>:word32] : word32)
 	T_7683 (in Mem1011[a7_1005 + 0<32>:word32] : word32)
 	T_7686 (in Mem1031[a7_1005 + 0<32>:word32] : word32)
@@ -1063,23 +640,13 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_7696 (in Mem1037[a7_1005 + 0<32>:word32] : word32)
 	T_7699 (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
 	T_7711 (in 0xFFFFFFFF<32> : word32)
-	T_7717 (in a7_1330 + 78<i32> : word32)
-	T_7720 (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-	T_7725 (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-	T_7726 (in 00000008 : ptr32)
-	T_7731 (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_7736 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_7739 (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-	T_7745 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_7750 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_7755 (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn000026E4(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)):byte] : uint32)
-	T_7760 (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
 	T_7765 (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
 	T_7766 (in 0<32> : word32)
 	T_7813 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_7819 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_7823 (in fn00003CCC(*a7_1182, out d1_5335, out a1, out a5_5336) : word32)
-	T_7825 (in a2_1014 + 4<i32> : word32)
 	T_7835 (in Mem1203[a7_1201 + 0<32>:word32] : word32)
 	T_7847 (in Mem1207[a7_1201 + 0<32>:word32] : word32)
 	T_7849 (in SEQ(SLICE(d0, word24, 8), v611_1211) : uip32)
@@ -1087,55 +654,24 @@ Eq_623: (union "Eq_623" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8460) u3) ((
 	T_7856 (in 0xFFFFFFFF<32> : word32)
 	T_7872 (in Mem1308[a7_1302 + 0<32>:word32] : word32)
 	T_7877 (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
-	T_7883 (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
 	T_7886 (in Mem1311[a7_1302 + 0<32>:word32] : word32)
 	T_7887 (in fn00002BF8(*(a7_1302 - 1<i32>), *a7_1302) : word32)
-	T_7895 (in a7_1330 + 78<i32> : word32)
-	T_7898 (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-	T_7903 (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-	T_7904 (in 00000008 : ptr32)
-	T_7909 (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_7914 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_7917 (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-	T_7922 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_7927 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_7932 (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn000026E4(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)):byte] : uint32)
-	T_7937 (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
 	T_7942 (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
 	T_7943 (in 0<32> : word32)
-	T_7964 (in d0_23 : Eq_623)
-	T_7966 (in __swap(dwArg08) : word32)
-	T_7967 (in d1_25 : Eq_623)
-	T_7969 (in __swap(dwArg10) : word32)
-	T_7979 (in d2_39 : Eq_623)
-	T_7987 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-	T_7988 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-	T_7992 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-	T_7993 (in 0<32> : word32)
-	T_7995 (in d2_45 : Eq_623)
-	T_7997 (in __swap(d2_39) : word32)
-	T_8000 (in __swap(dwArg0C) : word32)
-	T_8003 (in d3_71 : Eq_623)
-	T_8007 (in __swap(dwArg08) : word32)
-	T_8012 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-	T_8013 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-	T_8016 (in __swap(dwArg04) : word32)
-	T_8019 (in d3_89 : Eq_623)
-	T_8023 (in __swap(dwArg10) : word32)
-	T_8028 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-	T_8029 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
 	T_8066 (in 0<32> : word32)
 	T_8105 (in Mem86[dwArg04 + 8<i32>:word32] : word32)
 	T_8106 (in 0<32> : word32)
 	T_8126 (in Mem135[dwArg04 + 8<i32>:word32] : word32)
 	T_8129 (in Mem137[dwArg04 + 4<i32>:word32] : word32)
-	T_8171 (in a0_153 : Eq_623)
+	T_8171 (in a0_153 : Eq_624)
 	T_8174 (in Mem149[dwArg04 + 4<i32>:word32] : word32)
 	T_8176 (in a0_153 + 1<i32> : word32)
 	T_8178 (in Mem157[dwArg04 + 4<i32>:word32] : word32)
 	T_8212 (in d0_117 + 1<i32> : word32)
 	T_8215 (in Mem131[dwArg04 + 8<i32>:word32] : word32)
-Eq_625: (fn void (Eq_623, Eq_623, Eq_623, (ptr32 Eq_630)))
+Eq_625: (fn void (Eq_624, Eq_624, (ptr32 (ptr32 byte)), (ptr32 Eq_630)))
 	T_625 (in fn00002BDC : ptr32)
 	T_626 (in signature of fn00002BDC : void)
 	T_652 (in fn00002BDC : ptr32)
@@ -1153,7 +689,7 @@ Eq_630: (struct "Eq_630" 0001 (0 uint8 b0000) (1 cu8 b0001))
 	T_7499 (in a3_1955 + 1<i32> : word32)
 	T_7510 (in a3_1955 + 1<i32> : word32)
 	T_7527 (in a3_1955 + 2<i32> : word32)
-Eq_631: (fn Eq_623 ((ptr32 byte), Eq_634, (ptr32 (ptr32 byte))))
+Eq_631: (fn Eq_624 ((ptr32 byte), Eq_634, (ptr32 (ptr32 byte))))
 	T_631 (in fn00003E04 : ptr32)
 	T_632 (in signature of fn00003E04 : void)
 	T_653 (in fn00003E04 : ptr32)
@@ -1276,7 +812,7 @@ Eq_703: (union "Eq_703" (uint32 u0) (ptr32 u1))
 	T_1875 (in Mem1478[a7_1383 + 128<i32>:word32] : word32)
 	T_2349 (in ((word32) d3_1482 + 3<i32> >> 2<32> << 2<32>) + 4<32> : word32)
 	T_2595 (in ((word32) d3_1482 + 3<i32> >> 2<32> << 2<32>) + 4<32> : word32)
-Eq_710: (struct "Eq_710" 0004 (2C Eq_8416 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8417 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+Eq_710: (struct "Eq_710" 0004 (2C Eq_8410 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8411 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 	T_710 (in a7_1968 : (ptr32 Eq_710))
 	T_713 (in fp + -112<i32> : word32)
 	T_768 (in a7_51 + 4<i32> : word32)
@@ -1330,6 +866,416 @@ Eq_751: (fn Eq_662 (int32, (ptr32 Eq_701), (ptr32 ui32), ptr32))
 	T_2041 (in fn00001E34 : ptr32)
 	T_2098 (in fn00001E34 : ptr32)
 	T_2147 (in fn00001E34 : ptr32)
+Eq_783: (union "Eq_783" ((ptr32 Eq_1355) u0) ((ptr32 Eq_8412) u1) ((ptr32 Eq_8413) u2))
+	T_783 (in d5_256 : Eq_783)
+	T_784 (in -1<i32> : int32)
+	T_795 (in d2_1005 : Eq_783)
+	T_798 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
+	T_814 (in d2_1005 | d1_123 : word32)
+	T_824 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
+	T_940 (in 0<i32> : int32)
+	T_968 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
+	T_974 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_978 (in  : word32)
+	T_979 (in 10<i32> : int32)
+	T_980 (in __swap(10<i32>) : word32)
+	T_987 (in __swap(d5_256) : word32)
+	T_992 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
+	T_993 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
+	T_1030 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_1034 (in d1_303 - 0x30<32> + d0_293 : word32)
+	T_1079 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
+	T_1087 (in 10<i32> : int32)
+	T_1088 (in __swap(10<i32>) : word32)
+	T_1095 (in __swap(d2_1005) : word32)
+	T_1100 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
+	T_1101 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
+	T_1143 (in d1_196 - 0x30<32> + d0_186 : word32)
+	T_1151 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
+	T_1250 (in 0<32> : word32)
+	T_1329 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
+	T_1378 (in 0<32> : word32)
+	T_1598 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
+	T_1735 (in dwArg04 : Eq_783)
+	T_1736 (in dwArg08 : Eq_783)
+	T_1737 (in dwArg0C : Eq_783)
+	T_1738 (in dwArg10 : Eq_783)
+	T_1742 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_1747 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_1752 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_1757 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_1819 (in dwArg04 : Eq_783)
+	T_1820 (in dwArg08 : Eq_783)
+	T_1821 (in dwArg0C : Eq_783)
+	T_1822 (in dwArg10 : Eq_783)
+	T_1823 (in d1Out : Eq_783)
+	T_1824 (in a0Out : Eq_783)
+	T_1828 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_1833 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_1838 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_1843 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_1844 (in out d1_1450 : ptr32)
+	T_1845 (in out a0_1447 : ptr32)
+	T_2409 (in 0<32> : word32)
+	T_2439 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_2443 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_2499 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
+	T_3384 (in d0 : Eq_783)
+	T_3385 (in d0_196 : Eq_783)
+	T_3386 (in d1_142 : Eq_783)
+	T_3387 (in a0_20 : Eq_783)
+	T_3388 (in d3_166 : Eq_783)
+	T_3389 (in 0<32> : word32)
+	T_3397 (in 0<32> : word32)
+	T_3403 (in d0 : Eq_783)
+	T_3404 (in d1 : Eq_783)
+	T_3405 (in d2 : Eq_783)
+	T_3406 (in d1Out : Eq_783)
+	T_3407 (in d2Out : Eq_783)
+	T_3408 (in out d1_318 : ptr32)
+	T_3409 (in out d2_319 : ptr32)
+	T_3410 (in fn00002558(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
+	T_3411 (in 0<i32> : int32)
+	T_3414 (in d6_30 : Eq_783)
+	T_3417 (in  : word32)
+	T_3418 (in  : word32)
+	T_3419 (in 8<32> : word32)
+	T_3420 (in __rol(dwArg0C, 8<32>) : word32)
+	T_3446 (in 8<32> : word32)
+	T_3447 (in __rol(d6_30, 8<32>) : word32)
+	T_3453 (in 8<32> : word32)
+	T_3454 (in __rol(d6_30, 8<32>) : word32)
+	T_3461 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_3462 (in d1_175 : Eq_783)
+	T_3463 (in d2_176 : Eq_783)
+	T_3464 (in d0_174 : Eq_783)
+	T_3466 (in 0<i32> : int32)
+	T_3467 (in out d1_175 : ptr32)
+	T_3468 (in out d2_176 : ptr32)
+	T_3469 (in fn00002558(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
+	T_3473 (in out d1_320 : ptr32)
+	T_3474 (in out d2_321 : ptr32)
+	T_3475 (in fn00002558(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
+	T_3486 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_3489 (in d0_85 : Eq_783)
+	T_3491 (in dwArg04 >> d4_61 : word32)
+	T_3494 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
+	T_3497 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
+	T_3498 (in out d1_86 : ptr32)
+	T_3499 (in out d2_322 : ptr32)
+	T_3500 (in fn00002558(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
+	T_3501 (in d3_72 : Eq_783)
+	T_3502 (in dwArg10 << d5_63 : word32)
+	T_3503 (in d5_101 : Eq_783)
+	T_3505 (in __swap(d0_85) : word32)
+	T_3506 (in d6_103 : Eq_783)
+	T_3508 (in __swap(d3_72) : word32)
+	T_3512 (in d2_107 : Eq_783)
+	T_3515 (in d0_85 * (word16) d3_72 : word32)
+	T_3516 (in __swap(d0_85 * (word16) d3_72) : word32)
+	T_3529 (in d6_82 : Eq_783)
+	T_3530 (in dwArg08 << d5_63 : word32)
+	T_3531 (in d2_124 : Eq_783)
+	T_3533 (in SEQ(v35_109, v39_116) : uipr32)
+	T_3534 (in __swap(SEQ(v35_109, v39_116)) : word32)
+	T_3542 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
+	T_3543 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
+	T_3547 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
+	T_3548 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
+	T_3570 (in d0_85 - 1<32> : word32)
+	T_3576 (in d7_13 : Eq_783)
+	T_3577 (in 0<32> : word32)
+	T_3581 (in d0 : Eq_783)
+	T_3582 (in d1 : Eq_783)
+	T_3583 (in d2 : Eq_783)
+	T_3584 (in d1Out : Eq_783)
+	T_3585 (in out d1 : ptr32)
+	T_3586 (in fn00002716(d1, d2, d2, out d1) : word32)
+	T_3587 (in d6_17 : Eq_783)
+	T_3588 (in d5_19 : Eq_783)
+	T_3589 (in 0<32> : word32)
+	T_3591 (in d2_22 : Eq_783)
+	T_3593 (in __swap(d2) : word32)
+	T_3597 (in 0<32> : word32)
+	T_3606 (in 0<32> : word32)
+	T_3608 (in d0_281 : Eq_783)
+	T_3610 (in __swap(d0) : word32)
+	T_3611 (in d1_282 : Eq_783)
+	T_3613 (in __swap(d1) : word32)
+	T_3623 (in __swap(d1_282) : word32)
+	T_3630 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
+	T_3631 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
+	T_3636 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
+	T_3642 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
+	T_3643 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
+	T_3647 (in d6_17 * 2<32> : word32)
+	T_3655 (in 0<32> : word32)
+	T_3657 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
+	T_3659 (in d7_13 * 2<32> : word32)
+	T_3660 (in 0<32> : word32)
+	T_3664 (in d3_74 : Eq_783)
+	T_3671 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
+	T_3672 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
+	T_3675 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
+	T_3676 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
+	T_3677 (in d1_104 : Eq_783)
+	T_3678 (in 0xFFFF<32> : uipr32)
+	T_3679 (in d6_98 : Eq_783)
+	T_3683 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
+	T_3684 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
+	T_3685 (in d6_133 : Eq_783)
+	T_3687 (in __swap(d1_104) : word32)
+	T_3688 (in d3_140 : Eq_783)
+	T_3690 (in __swap(d6_133) : word32)
+	T_3691 (in d4_142 : Eq_783)
+	T_3693 (in __swap(d7_13) : word32)
+	T_3697 (in d6_146 : Eq_783)
+	T_3700 (in d6_133 * (word16) d7_13 : word32)
+	T_3701 (in __swap(d6_133 * (word16) d7_13) : word32)
+	T_3717 (in d6_178 : Eq_783)
+	T_3719 (in SEQ(v56_148, v59_155) : uipr32)
+	T_3720 (in __swap(SEQ(v56_148, v59_155)) : word32)
+	T_3721 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
+	T_3722 (in d5_181 : word32)
+	T_3726 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
+	T_3727 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
+	T_3731 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
+	T_3732 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
+	T_3745 (in 0<32> : word32)
+	T_3747 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
+	T_3748 (in 0<32> : word32)
+	T_3756 (in d1_104 - 1<32> : word32)
+	T_3757 (in d4_113 : Eq_783)
+	T_3760 (in __swap(d7_13) : word32)
+	T_3763 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
+	T_3764 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
+	T_3779 (in __swap(d7_13) : word32)
+	T_3783 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
+	T_3785 (in d1_104 - 1<32> : word32)
+	T_3786 (in 0<32> : word32)
+	T_3792 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
+	T_3793 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_3794 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_3795 (in d6_220 : Eq_783)
+	T_3799 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
+	T_3800 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
+	T_3803 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
+	T_3804 (in d5_221 : Eq_783)
+	T_3806 (in __swap(d5_181) : word32)
+	T_3811 (in d5_266 : Eq_783)
+	T_3813 (in __swap(d5_181) : word32)
+	T_3814 (in d6_267 : Eq_783)
+	T_3816 (in __swap(d6_178) : word32)
+	T_3819 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
+	T_3822 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
+	T_3826 (in d2_73 : Eq_783)
+	T_3828 (in __swap(d5_19) : word32)
+	T_3830 (in __swap(d7_13) : word32)
+	T_3840 (in d5_221 >> 1<32> : word32)
+	T_3845 (in  : word32)
+	T_3851 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
+	T_3858 (in d0 : Eq_783)
+	T_3859 (in d2 : Eq_783)
+	T_3860 (in dwArg04 : Eq_783)
+	T_3861 (in dwArg08 : Eq_783)
+	T_3862 (in 0<32> : word32)
+	T_3864 (in 0<32> : word32)
+	T_3866 (in d0_36 : Eq_783)
+	T_3867 (in -dwArg04 : word32)
+	T_3868 (in 0<32> : word32)
+	T_3872 (in out d1_43 : ptr32)
+	T_3873 (in fn00002716(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_3874 (in -fn00002716(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_3877 (in -dwArg08 : word32)
+	T_3878 (in out d1_55 : ptr32)
+	T_3879 (in fn00002716(d0_36, -dwArg08, d2, out d1_55) : word32)
+	T_3882 (in out d1_88 : ptr32)
+	T_3883 (in fn00002716(dwArg04, dwArg08, d2, out d1_88) : word32)
+	T_3886 (in -dwArg08 : word32)
+	T_3887 (in out d1_89 : ptr32)
+	T_3888 (in fn00002716(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_3889 (in -fn00002716(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_3890 (in d1_22 : Eq_783)
+	T_3892 (in __swap(d1) : word32)
+	T_3897 (in d2_11 : Eq_783)
+	T_3898 (in SEQ(v11_10, v10_9) : uipr32)
+	T_3901 (in d3_18 : Eq_783)
+	T_3902 (in 16<i32> : int32)
+	T_3906 (in d0_134 : Eq_783)
+	T_3908 (in __swap(d0) : word32)
+	T_3909 (in d1_135 : Eq_783)
+	T_3911 (in __swap(d1_22) : word32)
+	T_3916 (in __swap(d2_11) : word32)
+	T_3921 (in d0_150 : Eq_783)
+	T_3923 (in __swap(d0_134) : word32)
+	T_3937 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
+	T_3938 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
+	T_3940 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
+	T_3942 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
+	T_3952 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
+	T_3957 (in 8<32> : word32)
+	T_3958 (in __rol(d1_22, 8<32>) : word32)
+	T_3959 (in 8<32> : uipr32)
+	T_3964 (in 4<32> : word32)
+	T_3965 (in __rol(d1_22, 4<32>) : word32)
+	T_3970 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
+	T_3975 (in 2<32> : word32)
+	T_3976 (in __rol(d1_22, 2<32>) : word32)
+	T_3981 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
+	T_3987 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
+	T_3988 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
+	T_3995 (in __swap(d3_18) : word32)
+	T_4001 (in d1_90 : Eq_783)
+	T_4003 (in __swap(d1_22) : word32)
+	T_4004 (in d3_102 : Eq_783)
+	T_4005 (in SEQ(v53_82, v51_79) : uipr32)
+	T_4006 (in d0_108 : Eq_783)
+	T_4016 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
+	T_4017 (in 0<32> : word32)
+	T_4020 (in 1<32> : word32)
+	T_4021 (in __rol(d1_22, 1<32>) : word32)
+	T_4026 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
+	T_4030 (in __swap(d3_102) : word32)
+	T_4031 (in __rol(d0_108, __swap(d3_102)) : word32)
+	T_4032 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
+	T_4035 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
+	T_4038 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
+	T_4039 (in d0_108 + d1_90 : word32)
+	T_4040 (in 0<32> : word32)
+	T_4042 (in d1 : Eq_783)
+	T_4043 (in d1_171 : Eq_783)
+	T_4044 (in d3_202 : Eq_783)
+	T_4045 (in 0<32> : word32)
+	T_4053 (in 0<32> : word32)
+	T_4057 (in out d1_171 : ptr32)
+	T_4058 (in out d2_354 : ptr32)
+	T_4059 (in fn00002558(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
+	T_4062 (in d6_33 : Eq_783)
+	T_4064 (in 8<32> : word32)
+	T_4065 (in __rol(dwArg0C, 8<32>) : word32)
+	T_4091 (in 8<32> : word32)
+	T_4092 (in __rol(d6_33, 8<32>) : word32)
+	T_4098 (in 8<32> : word32)
+	T_4099 (in __rol(d6_33, 8<32>) : word32)
+	T_4106 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_4109 (in d0_88 : Eq_783)
+	T_4111 (in dwArg04 >> d4_64 : word32)
+	T_4114 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
+	T_4117 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
+	T_4118 (in out d1_89 : ptr32)
+	T_4119 (in out d2_90 : ptr32)
+	T_4120 (in fn00002558(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
+	T_4121 (in d3_75 : Eq_783)
+	T_4122 (in dwArg10 << d5_66 : word32)
+	T_4123 (in d7_104 : Eq_783)
+	T_4125 (in __swap(d0_88) : word32)
+	T_4126 (in d6_106 : Eq_783)
+	T_4128 (in __swap(d3_75) : word32)
+	T_4132 (in d2_110 : Eq_783)
+	T_4135 (in d0_88 * (word16) d3_75 : word32)
+	T_4136 (in __swap(d0_88 * (word16) d3_75) : word32)
+	T_4149 (in d2_127 : Eq_783)
+	T_4151 (in SEQ(v37_112, v40_119) : uipr32)
+	T_4152 (in __swap(SEQ(v37_112, v40_119)) : word32)
+	T_4162 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
+	T_4163 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
+	T_4167 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
+	T_4168 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
+	T_4187 (in dwArg08 - dwArg10 : word32)
+	T_4191 (in d1_211 : Eq_783)
+	T_4192 (in d2_212 : Eq_783)
+	T_4194 (in 0<i32> : int32)
+	T_4195 (in out d1_211 : ptr32)
+	T_4196 (in out d2_212 : ptr32)
+	T_4197 (in fn00002558(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
+	T_4200 (in out d1_171 : ptr32)
+	T_4201 (in out d2_355 : ptr32)
+	T_4202 (in fn00002558(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
+	T_4213 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_4218 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
+	T_4231 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
+	T_4278 (in dwArg0C : Eq_783)
+	T_4283 (in fp + 8<i32> : word32)
+	T_4324 (in d2_1090 : Eq_783)
+	T_4386 (in d6_1133 : Eq_783)
+	T_4387 (in -1<i32> : int32)
+	T_4409 (in 0<i32> : int32)
+	T_4420 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_4423 (in 10<i32> : int32)
+	T_4424 (in __swap(10<i32>) : word32)
+	T_4434 (in __swap(d6_1133) : word32)
+	T_4439 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
+	T_4440 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
+	T_4466 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_4470 (in d1_340 - 0x30<32> + d0_331 : word32)
+	T_5031 (in 0xFFFFFFFF<32> : word32)
+	T_5181 (in d0 + 4<32> : word32)
+	T_5223 (in d0 + 4<32> : word32)
+	T_5299 (in d0 + 4<32> : word32)
+	T_5368 (in d0 + 4<32> : word32)
+	T_5406 (in d0 + 4<32> : word32)
+	T_5421 (in d0 + 4<32> : word32)
+	T_5708 (in 1<i32> : int32)
+	T_5726 (in d0 + 4<32> : word32)
+	T_6457 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
+	T_6522 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
+	T_6552 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
+	T_6567 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
+	T_6573 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
+	T_6583 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
+	T_6604 (in v419_2893 : Eq_783)
+	T_6609 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_6784 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_6964 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_6967 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_6969 (in d7 >> 31<i32> : word32)
+	T_6972 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
+	T_7014 (in dwArg04 : Eq_783)
+	T_7015 (in dwArg08 : Eq_783)
+	T_7016 (in dwArg0C : Eq_783)
+	T_7017 (in dwArg10 : Eq_783)
+	T_7022 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
+	T_7027 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
+	T_7032 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
+	T_7037 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
+	T_7144 (in (d0_3495 << 2<32>) + 4<32> : word32)
+	T_7180 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7209 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7238 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7255 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7349 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_7385 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7414 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7443 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7460 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7486 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
+	T_7497 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
+	T_7607 (in (d0_957 << 2<32>) + 4<32> : word32)
+	T_7745 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
+	T_7750 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
+	T_7922 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
+	T_7927 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
+	T_7964 (in d0_23 : Eq_783)
+	T_7966 (in __swap(dwArg08) : word32)
+	T_7967 (in d1_25 : Eq_783)
+	T_7969 (in __swap(dwArg10) : word32)
+	T_7979 (in d2_39 : Eq_783)
+	T_7987 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
+	T_7988 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
+	T_7992 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
+	T_7993 (in 0<32> : word32)
+	T_7995 (in d2_45 : Eq_783)
+	T_7997 (in __swap(d2_39) : word32)
+	T_8000 (in __swap(dwArg0C) : word32)
+	T_8003 (in d3_71 : Eq_783)
+	T_8007 (in __swap(dwArg08) : word32)
+	T_8012 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
+	T_8013 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
+	T_8016 (in __swap(dwArg04) : word32)
+	T_8019 (in d3_89 : Eq_783)
+	T_8023 (in __swap(dwArg10) : word32)
+	T_8028 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
+	T_8029 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
 Eq_790: (struct "Eq_790" (0 Eq_2355 t0000) (3C word32 dw003C) (40 up32 dw0040))
 	T_790 (in d7_1024 : (ptr32 Eq_790))
 	T_791 (in 0<i32> : int32)
@@ -1365,7 +1311,7 @@ Eq_946: (union "Eq_946" (uint32 u0) (ptr32 u1))
 	T_946 (in 3<32> : word32)
 Eq_947: (union "Eq_947" (uint32 u0) (ptr32 u1))
 	T_947 (in d3_1482 + 3<32> : word32)
-Eq_976: (fn Eq_623 (Eq_623))
+Eq_976: (fn Eq_783 (Eq_783))
 	T_976 (in __swap : ptr32)
 	T_977 (in signature of __swap : void)
 	T_984 (in __swap : ptr32)
@@ -1490,34 +1436,6 @@ Eq_1188: (struct "Eq_1188" (0 word32 dw0000) (4 word32 dw0004))
 	T_2426 (in Mem916[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_2448 (in Mem935[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_2486 (in Mem1000[a7_992 - 4<i32> + 0<32>:word32] : word32)
-Eq_1191: (union "Eq_1191" (ui24 u0) ((ptr32 Eq_8418) u1) (Eq_1355 u2))
-	T_1191 (in d0_1471 : Eq_1191)
-	T_1193 (in SEQ(SLICE(d0_159, word24, 8), v100_428) : uip32)
-	T_1238 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_1337 (in a2_1892 - a4_1925 : word32)
-	T_1340 (in Mem756[a7_1968 + 102<i32>:word32] : word32)
-	T_1362 (in Mem662[a7_1968 + 102<i32>:word32] : word32)
-	T_1373 (in Mem719[a7_1968 + 102<i32>:word32] : word32)
-	T_1375 (in d0_1471 + 1<32> : word32)
-	T_1486 (in Mem1516[a7_1508 + 0<32>:word32] : word32)
-	T_1496 (in Mem1531[a7_1508 + 0<32>:word32] : word32)
-	T_1499 (in Mem1537[a7_1508 + 0<32>:word32] : word32)
-	T_1500 (in d0_1541 : Eq_1191)
-	T_1503 (in Mem1537[a7_1508 + 0<32>:word32] : word32)
-	T_1532 (in Mem1546[a7_1508 + 0<32>:word32] : word32)
-	T_1612 (in d7_1371 : Eq_1191)
-	T_1615 (in Mem1367[v187_1368 + 4<i32>:word32] : word32)
-	T_1726 (in Mem1400[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1809 (in Mem1444[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1815 (in d1_1450 : Eq_1191)
-	T_1856 (in 0<32> : word32)
-	T_2334 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2396 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2464 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2543 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2555 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2568 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2580 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
 Eq_1224: (union "Eq_1224" (cu8 u0) (word32 u1))
 	T_1224 (in Mem535[a7_1968 + 44<i32>:byte] : byte)
 	T_1225 (in 0x70<8> : byte)
@@ -1547,20 +1465,8 @@ Eq_1306: (struct "Eq_1306" (0 (ptr32 Eq_1188) ptr0000) (30 byte b0030) (34 int32
 	T_1308 (in a7_1968 - 4<i32> : word32)
 Eq_1333: (union "Eq_1333" (bool u0) (int32 u1))
 	T_1333 (in d0_1181 < null : bool)
-Eq_1355: (union "Eq_1355" (ui24 u0) ((ptr32 Eq_8419) u1))
+Eq_1355: (struct "Eq_1355" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_1355 (in Mem662[a7_1968 + 102<i32>:word32] : word32)
-Eq_1356: (union "Eq_1356" (ui24 u0) ((ptr32 Eq_8420) u1) (Eq_1355 u2))
-	T_1356 (in d5_256 - a7_1968->t0066 : word32)
-	T_1357 (in 0<32> : word32)
-Eq_1361: (union "Eq_1361" (ui24 u0) ((ptr32 Eq_8421) u1) (Eq_1355 u2))
-	T_1361 (in a7_1968 + 102<i32> : word32)
-Eq_1368: (union "Eq_1368" (ui24 u0) ((ptr32 Eq_8422) u1) (Eq_1355 u2))
-	T_1368 (in d5_256 - d0_1471 : word32)
-	T_1369 (in 0<32> : word32)
-Eq_1372: (union "Eq_1372" (int32 u0) (uint32 u1) (Eq_1191 u2) (Eq_1355 u3))
-	T_1372 (in a7_1968 + 102<i32> : word32)
-Eq_1374: (union "Eq_1374" (ui24 u0) ((ptr32 Eq_8423) u1) (Eq_1355 u2))
-	T_1374 (in 1<32> : word32)
 Eq_1381: (union "Eq_1381" (uint32 u0) (ptr32 u1))
 	T_1381 (in 3<32> : word32)
 Eq_1382: (union "Eq_1382" (uint32 u0) (ptr32 u1))
@@ -1575,13 +1481,9 @@ Eq_1416: (union "Eq_1416" (uint32 u0) (ptr32 u1))
 Eq_1428: (struct "Eq_1428" (0 (ptr32 Eq_1188) ptr0000) (34 int32 dw0034))
 	T_1428 (in a7_1145 : (ptr32 Eq_1428))
 	T_1430 (in a7_1968 - 4<i32> : word32)
-Eq_1481: (struct "Eq_1481" (0 Eq_1191 t0000) (30 up32 dw0030) (34 up32 dw0034) (44 up32 dw0044))
+Eq_1481: (struct "Eq_1481" (0 (ptr32 Eq_1355) ptr0000) (30 up32 dw0030) (34 up32 dw0034) (44 up32 dw0044))
 	T_1481 (in a7_1508 : (ptr32 Eq_1481))
 	T_1483 (in a7_1465 - 4<i32> : word32)
-Eq_1498: (union "Eq_1498" (ui24 u0) ((ptr32 Eq_8424) u1) (Eq_1355 u2))
-	T_1498 (in a7_1508 + 0<32> : word32)
-Eq_1502: (union "Eq_1502" (ui24 u0) ((ptr32 Eq_8425) u1) (Eq_1355 u2))
-	T_1502 (in a7_1508 + 0<32> : word32)
 Eq_1513: (union "Eq_1513" (byte u0) (word32 u1))
 	T_1513 (in 0x10<32> : word32)
 	T_1516 (in Mem1293[a7_1020 + 44<i32>:word32] : word32)
@@ -1593,9 +1495,7 @@ Eq_1521: (union "Eq_1521" (byte u0) (ptr32 u1))
 Eq_1524: (union "Eq_1524" (byte u0) (word32 u1))
 	T_1524 (in Mem1296[a7_1020 + 44<i32>:word32] : word32)
 	T_1527 (in Mem1298[a7_1020 + 108<i32>:word32] : word32)
-Eq_1531: (union "Eq_1531" (ui24 u0) ((ptr32 Eq_8426) u1) (Eq_1355 u2))
-	T_1531 (in a7_1508 + 0<32> : word32)
-Eq_1605: (struct "Eq_1605" (0 word32 dw0000) (4 Eq_1191 t0004))
+Eq_1605: (struct "Eq_1605" (0 word32 dw0000) (4 (ptr32 Eq_1355) ptr0004))
 	T_1605 (in v187_1368 : (ptr32 Eq_1605))
 	T_1607 (in a7_1020 + 56<i32> : word32)
 Eq_1620: (union "Eq_1620" (byte u0) (word32 u1))
@@ -1619,14 +1519,14 @@ Eq_1686: (union "Eq_1686" (int32 u0) (up32 u1))
 Eq_1693: (struct "Eq_1693" (0 int32 dw0000) (34 Eq_717 t0034) (48 Eq_1180 t0048) (4C ui32 dw004C) (66 (ptr32 Eq_790) ptr0066) (6A word32 dw006A) (80 Eq_703 t0080))
 	T_1693 (in a7_1383 : (ptr32 Eq_1693))
 	T_1695 (in a7_1020 - 4<i32> : word32)
-Eq_1733: (fn int32 (Eq_623, Eq_623, Eq_623, Eq_623))
+Eq_1733: (fn int32 (Eq_783, Eq_783, Eq_783, Eq_783))
 	T_1733 (in fn0000279C : ptr32)
 	T_1734 (in signature of fn0000279C : void)
-Eq_1817: (fn word32 (Eq_623, Eq_623, Eq_623, Eq_623, Eq_623, Eq_623))
+Eq_1817: (fn word32 (Eq_783, Eq_783, Eq_783, Eq_783, Eq_783, Eq_783))
 	T_1817 (in fn00002454 : ptr32)
 	T_1818 (in signature of fn00002454 : void)
 Eq_1857: (union "Eq_1857" (bool u0) (word32 u1))
-	T_1857 (in d1_1450 < 0<32> : bool)
+	T_1857 (in d1_1450 < null : bool)
 Eq_1889: (union "Eq_1889" (int32 u0) (up32 u1))
 	T_1889 (in Mem1496[a7_1465 + 102<i32>:word32] : word32)
 Eq_1890: (union "Eq_1890" (int32 u0) (up32 u1))
@@ -1688,9 +1588,6 @@ Eq_2111: (union "Eq_2111" (int32 u0) (up32 u1))
 	T_2111 (in d2_1847 : Eq_2111)
 	T_2112 (in 0<i32> : int32)
 	T_2123 (in d2_1847 + 1<32> : word32)
-Eq_2202: (union "Eq_2202" (byte u0) (word32 u1))
-	T_2202 (in v248_1105 : Eq_2202)
-	T_2205 (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
 Eq_2206: (struct "Eq_2206" (0 (ptr32 Eq_1188) ptr0000) (34 int32 dw0034) (38 int32 dw0038))
 	T_2206 (in a7_1109 : (ptr32 Eq_2206))
 	T_2208 (in a7_1968 - 4<i32> : word32)
@@ -1701,9 +1598,6 @@ Eq_2243: (union "Eq_2243" (uint32 u0) (ptr32 u1))
 	T_2243 (in 3<32> : word32)
 Eq_2244: (union "Eq_2244" (uint32 u0) (ptr32 u1))
 	T_2244 (in d3_1482 + 3<32> : word32)
-Eq_2267: (union "Eq_2267" (word16 u0) (word32 u1))
-	T_2267 (in v262_844 : Eq_2267)
-	T_2270 (in Mem843[a7_1968 + 62<i32>:word16] : word16)
 Eq_2271: (struct "Eq_2271" (0 (ptr32 Eq_1188) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2271 (in a7_848 : (ptr32 Eq_2271))
 	T_2273 (in a7_1968 - 4<i32> : word32)
@@ -1719,8 +1613,6 @@ Eq_2329: (union "Eq_2329" (uint32 u0) (ptr32 u1))
 	T_2329 (in 3<32> : word32)
 Eq_2330: (union "Eq_2330" (uint32 u0) (ptr32 u1))
 	T_2330 (in d3_1482 + 3<32> : word32)
-Eq_2336: (union "Eq_2336" (ui24 u0) ((ptr32 Eq_8427) u1) (Eq_1355 u2))
-	T_2336 (in d0_1471 + 0<32> : word32)
 Eq_2345: (union "Eq_2345" (uint32 u0) (ptr32 u1))
 	T_2345 (in d3_1482 + 3<32> : word32)
 Eq_2355: (union "Eq_2355" (ui32 u0) (byte u1))
@@ -1737,9 +1629,6 @@ Eq_2361: (union "Eq_2361" (cu8 u0) (word32 u1) (Eq_1224 u2) (Eq_1227 u3) (Eq_130
 	T_2364 (in Mem894[a7_1968 + 44<i32>:byte] : byte)
 Eq_2363: (union "Eq_2363" (cu8 u0) (word32 u1) (Eq_1224 u2) (Eq_1227 u3) (Eq_1302 u4) (Eq_2361 u5))
 	T_2363 (in a7_1968 + 44<i32> : word32)
-Eq_2367: (union "Eq_2367" (byte u0) (word32 u1))
-	T_2367 (in v277_869 : Eq_2367)
-	T_2370 (in Mem868[a7_1968 + 63<i32>:byte] : byte)
 Eq_2371: (struct "Eq_2371" (0 (ptr32 Eq_1188) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2371 (in a7_873 : (ptr32 Eq_2371))
 	T_2373 (in a7_1968 - 4<i32> : word32)
@@ -1747,8 +1636,6 @@ Eq_2391: (union "Eq_2391" (uint32 u0) (ptr32 u1))
 	T_2391 (in 3<32> : word32)
 Eq_2392: (union "Eq_2392" (uint32 u0) (ptr32 u1))
 	T_2392 (in d3_1482 + 3<32> : word32)
-Eq_2398: (union "Eq_2398" (ui24 u0) ((ptr32 Eq_8428) u1) (Eq_1355 u2))
-	T_2398 (in d0_1471 + 0<32> : word32)
 Eq_2416: (struct "Eq_2416" (0 Eq_2355 t0000) (3C word32 dw003C) (40 up32 dw0040))
 	T_2416 (in a7_911 : (ptr32 Eq_2416))
 	T_2418 (in a7_1968 - 4<i32> : word32)
@@ -1758,8 +1645,6 @@ Eq_2459: (union "Eq_2459" (uint32 u0) (ptr32 u1))
 	T_2459 (in 3<32> : word32)
 Eq_2460: (union "Eq_2460" (uint32 u0) (ptr32 u1))
 	T_2460 (in d3_1482 + 3<32> : word32)
-Eq_2466: (union "Eq_2466" (ui24 u0) ((ptr32 Eq_8429) u1) (Eq_1355 u2))
-	T_2466 (in d0_1471 + 0<32> : word32)
 Eq_2472: (union "Eq_2472" (cu8 u0) (word32 u1) (Eq_1224 u2) (Eq_1227 u3) (Eq_1302 u4) (Eq_2361 u5))
 	T_2472 (in SLICE(d1_1068, byte, 0) : byte)
 	T_2475 (in Mem991[a7_1968 + 44<i32>:byte] : byte)
@@ -1796,34 +1681,26 @@ Eq_2538: (union "Eq_2538" (uint32 u0) (ptr32 u1))
 	T_2538 (in 3<32> : word32)
 Eq_2539: (union "Eq_2539" (uint32 u0) (ptr32 u1))
 	T_2539 (in d3_1482 + 3<32> : word32)
-Eq_2545: (union "Eq_2545" (ui24 u0) ((ptr32 Eq_8430) u1) (Eq_1355 u2))
-	T_2545 (in d0_1471 + 0<32> : word32)
 Eq_2550: (union "Eq_2550" (uint32 u0) (ptr32 u1))
 	T_2550 (in 3<32> : word32)
 Eq_2551: (union "Eq_2551" (uint32 u0) (ptr32 u1))
 	T_2551 (in d3_1482 + 3<32> : word32)
-Eq_2557: (union "Eq_2557" (ui24 u0) ((ptr32 Eq_8431) u1) (Eq_1355 u2))
-	T_2557 (in d0_1471 + 0<32> : word32)
 Eq_2563: (union "Eq_2563" (uint32 u0) (ptr32 u1))
 	T_2563 (in 3<32> : word32)
 Eq_2564: (union "Eq_2564" (uint32 u0) (ptr32 u1))
 	T_2564 (in d3_1482 + 3<32> : word32)
-Eq_2570: (union "Eq_2570" (ui24 u0) ((ptr32 Eq_8432) u1) (Eq_1355 u2))
-	T_2570 (in d0_1471 + 3<32> : word32)
 Eq_2575: (union "Eq_2575" (uint32 u0) (ptr32 u1))
 	T_2575 (in 3<32> : word32)
 Eq_2576: (union "Eq_2576" (uint32 u0) (ptr32 u1))
 	T_2576 (in d3_1482 + 3<32> : word32)
-Eq_2582: (union "Eq_2582" (ui24 u0) ((ptr32 Eq_8433) u1) (Eq_1355 u2))
-	T_2582 (in d0_1471 + 3<32> : word32)
 Eq_2587: (union "Eq_2587" (uint32 u0) (ptr32 u1))
 	T_2587 (in d3_1482 + 3<32> : word32)
 Eq_2592: (union "Eq_2592" (uint32 u0) (ptr32 u1))
 	T_2592 (in d3_1482 + 3<32> : word32)
-Eq_2596: (union "Eq_2596" (int32 u0) (uint32 u1) (Eq_1191 u2) (Eq_1355 u3) (Eq_1889 u4) (Eq_1951 u5) (Eq_1957 u6) (Eq_2025 u7) (Eq_2068 u8))
+Eq_2596: (union "Eq_2596" ((ptr32 Eq_1355) u0) ((ptr32 Eq_1355) u1) (Eq_1889 u2) (Eq_1951 u3) (Eq_1957 u4) (Eq_2025 u5) (Eq_2068 u6))
 	T_2596 (in 1<32> : word32)
 	T_2599 (in Mem525[a7_1968 + 102<i32>:word32] : word32)
-Eq_2598: (union "Eq_2598" (int32 u0) (uint32 u1) (Eq_1191 u2) (Eq_1355 u3) (Eq_1889 u4) (Eq_1951 u5) (Eq_1957 u6) (Eq_2025 u7) (Eq_2068 u8))
+Eq_2598: (union "Eq_2598" ((ptr32 Eq_1355) u0) (Eq_1889 u1) (Eq_1951 u2) (Eq_1957 u3) (Eq_2025 u4) (Eq_2068 u5))
 	T_2598 (in a7_1968 + 102<i32> : word32)
 Eq_2622: (fn Eq_634 (int32, (ptr32 Eq_701), (ptr32 ui32), ptr32, ptr32))
 	T_2622 (in fn00001E90 : ptr32)
@@ -1834,7 +1711,7 @@ Eq_2663: (fn Eq_2669 (ptr32, ptr32))
 	T_2664 (in signature of fn00002424 : void)
 	T_2839 (in fn00002424 : ptr32)
 	T_8062 (in fn00002424 : ptr32)
-Eq_2669: (union "Eq_2669" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1))
+Eq_2669: (union "Eq_2669" (byte u0) (word16 u1) ((ptr32 Eq_8456) u2) ((ptr32 Eq_8429) u3))
 	T_2669 (in fn00002424(out a1_125, out a5_127) : word32)
 	T_2842 (in fn00002424(out a1_21, out a5_23) : word32)
 	T_4683 (in d1Out : Eq_2669)
@@ -1941,7 +1818,7 @@ Eq_3340: (fn void ((ptr32 Eq_380)))
 Eq_3364: (fn void (int32, word32))
 	T_3364 (in SetSignal : ptr32)
 	T_3365 (in signature of SetSignal : void)
-Eq_3401: (fn Eq_623 (Eq_623, Eq_623, Eq_623, Eq_623, Eq_623))
+Eq_3401: (fn Eq_783 (Eq_783, Eq_783, Eq_783, Eq_783, Eq_783))
 	T_3401 (in fn00002558 : ptr32)
 	T_3402 (in signature of fn00002558 : void)
 	T_3465 (in fn00002558 : ptr32)
@@ -1951,7 +1828,7 @@ Eq_3401: (fn Eq_623 (Eq_623, Eq_623, Eq_623, Eq_623, Eq_623))
 	T_4110 (in fn00002558 : ptr32)
 	T_4193 (in fn00002558 : ptr32)
 	T_4199 (in fn00002558 : ptr32)
-Eq_3415: (fn Eq_623 (Eq_623, Eq_623))
+Eq_3415: (fn Eq_783 (Eq_783, Eq_783))
 	T_3415 (in __rol : ptr32)
 	T_3416 (in signature of __rol : void)
 	T_3445 (in __rol : ptr32)
@@ -1977,7 +1854,7 @@ Eq_3553: (union "Eq_3553" (bool u0) (word16 u1))
 	T_3553 (in v34_108 <u 0<16> : bool)
 Eq_3556: (union "Eq_3556" (bool u0) (word16 u1))
 	T_3556 (in v39_116 <u 0<16> : bool)
-Eq_3579: (fn Eq_623 (Eq_623, Eq_623, Eq_623, Eq_623))
+Eq_3579: (fn Eq_783 (Eq_783, Eq_783, Eq_783, Eq_783))
 	T_3579 (in fn00002716 : ptr32)
 	T_3580 (in signature of fn00002716 : void)
 	T_3871 (in fn00002716 : ptr32)
@@ -1995,7 +1872,7 @@ Eq_3740: (union "Eq_3740" (bool u0) (word16 u1))
 	T_3740 (in v59_155 <u 0<16> : bool)
 Eq_3746: (union "Eq_3746" (bool u0) (uint32 u1))
 	T_3746 (in d6_178 <u 0<32> : bool)
-Eq_3843: (fn Eq_623 (Eq_623, word32, bool))
+Eq_3843: (fn Eq_783 (Eq_783, word32, bool))
 	T_3843 (in __rcr : ptr32)
 	T_3844 (in signature of __rcr : void)
 Eq_4173: (union "Eq_4173" (bool u0) (word16 u1))
@@ -2008,16 +1885,16 @@ Eq_4217: (union "Eq_4217" (bool u0) (word32 u1))
 	T_4217 (in d3_135 < 0<32> : bool)
 Eq_4225: (union "Eq_4225" (bool u0) (ui32 u1))
 	T_4225 (in d6_157 < 0<32> : bool)
-Eq_4271: (fn void (Eq_623, Eq_623, Eq_623, Eq_623, (ptr32 Eq_630), Eq_623))
+Eq_4271: (fn void (Eq_624, Eq_624, (ptr32 (ptr32 byte)), Eq_624, (ptr32 Eq_630), Eq_783))
 	T_4271 (in fn00002C28 : ptr32)
 	T_4272 (in signature of fn00002C28 : void)
-Eq_4320: (union "Eq_4320" (uint8 u0) ((ptr32 Eq_8439) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_4320 (in a7_1330 : Eq_4320)
+Eq_4320: (struct "Eq_4320" 0004 (2C int32 dw002C) (30 Eq_8430 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8431 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+	T_4320 (in a7_1330 : (ptr32 Eq_4320))
 	T_4323 (in fp + -120<i32> : word32)
 	T_7130 (in a7_3474 + 4<i32> : word32)
 	T_7300 (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
 	T_7316 (in a7_3364 + 4<i32> : word32)
-Eq_4327: (union "Eq_4327" (byte u0) (word16 u1) ((ptr32 Eq_8460) u2) ((ptr32 Eq_8441) u3))
+Eq_4327: (union "Eq_4327" (byte u0) (word16 u1) ((ptr32 Eq_8456) u2) ((ptr32 Eq_8433) u3))
 	T_4327 (in d4_132 : Eq_4327)
 	T_4328 (in 0<i32> : int32)
 	T_4733 (in d4_132 + 1<32> : word32)
@@ -2046,7 +1923,7 @@ Eq_4327: (union "Eq_4327" (byte u0) (word16 u1) ((ptr32 Eq_8460) u2) ((ptr32 Eq_
 	T_6570 (in Mem2854[a7_1330 + 52<i32>:word32] : word32)
 	T_6586 (in Mem2840[a7_1330 + 52<i32>:word32] : word32)
 	T_6600 (in 0<i32> : int32)
-	T_6602 (in d5_1044 - 0x30<32> : word32)
+	T_6602 (in d5_1044 - (struct Eq_8446 *) 0x30<32> : word32)
 	T_7013 (in d4 : Eq_4327)
 	T_7065 (in d4_3243 - 1<32> : word32)
 	T_7861 (in d4_1070 - 1<32> : word32)
@@ -2153,7 +2030,7 @@ Eq_4429: (union "Eq_4429" (int32 u0) (uint32 u1))
 	T_4429 (in 10<i32> : int32)
 Eq_4459: (union "Eq_4459" (int32 u0) (uint32 u1))
 	T_4459 (in (uint32) (uint8) Mem316[a3_279 + 0<32>:byte] : uint32)
-Eq_4680: (fn Eq_623 (Eq_623, Eq_2669, (ptr32 word32), (ptr32 byte)))
+Eq_4680: (fn Eq_624 (Eq_624, Eq_2669, (ptr32 word32), (ptr32 byte)))
 	T_4680 (in fn00003CCC : ptr32)
 	T_4681 (in signature of fn00003CCC : void)
 	T_4799 (in fn00003CCC : ptr32)
@@ -2170,7 +2047,7 @@ Eq_4680: (fn Eq_623 (Eq_623, Eq_2669, (ptr32 word32), (ptr32 byte)))
 	T_6813 (in fn00003CCC : ptr32)
 	T_7649 (in fn00003CCC : ptr32)
 	T_7816 (in fn00003CCC : ptr32)
-Eq_4870: (fn Eq_623 (Eq_623, Eq_623))
+Eq_4870: (fn Eq_624 (byte, Eq_624))
 	T_4870 (in fn00002BF8 : ptr32)
 	T_4871 (in signature of fn00002BF8 : void)
 	T_4980 (in fn00002BF8 : ptr32)
@@ -2184,19 +2061,19 @@ Eq_4870: (fn Eq_623 (Eq_623, Eq_623))
 	T_6923 (in fn00002BF8 : ptr32)
 	T_7082 (in fn00002BF8 : ptr32)
 	T_7878 (in fn00002BF8 : ptr32)
-Eq_4883: (struct "Eq_4883" (0 Eq_623 t0000) (30 Eq_623 t0030))
+Eq_4883: (struct "Eq_4883" (0 Eq_624 t0000) (30 Eq_624 t0030))
 	T_4883 (in a7_79 : (ptr32 Eq_4883))
 	T_4885 (in a7_1330 - 4<i32> : word32)
-Eq_4907: (struct "Eq_4907" (0 Eq_623 t0000) (30 uint32 dw0030))
+Eq_4907: (struct "Eq_4907" (0 Eq_624 t0000) (30 uint32 dw0030))
 	T_4907 (in a7_99 : (ptr32 Eq_4907))
 	T_4909 (in a7_1330 - 4<i32> : word32)
 Eq_5017: (union "Eq_5017" (int32 u0) (byte u1))
 	T_5017 (in 0<8> : byte)
 	T_5020 (in Mem761[a7_1330 + 44<i32>:byte] : byte)
-Eq_5066: (struct "Eq_5066" (0 Eq_623 t0000) (30 Eq_623 t0030))
+Eq_5066: (struct "Eq_5066" (0 Eq_624 t0000) (30 Eq_624 t0030))
 	T_5066 (in a7_640 : (ptr32 Eq_5066))
 	T_5068 (in a7_1330 - 4<i32> : word32)
-Eq_5090: (struct "Eq_5090" (0 Eq_623 t0000) (30 uint32 dw0030))
+Eq_5090: (struct "Eq_5090" (0 Eq_624 t0000) (30 uint32 dw0030))
 	T_5090 (in a7_660 : (ptr32 Eq_5090))
 	T_5092 (in a7_1330 - 4<i32> : word32)
 Eq_5206: (union "Eq_5206" (int32 u0) (uint32 u1))
@@ -2217,10 +2094,10 @@ Eq_5422: (union "Eq_5422" (int32 u0) (uint32 u1))
 Eq_5457: (union "Eq_5457" (int32 u0) (uint32 u1))
 	T_5457 (in d6_1133 - d3_1850 : word32)
 	T_5458 (in 0<32> : word32)
-Eq_5491: (struct "Eq_5491" (0 Eq_623 t0000) (38 Eq_623 t0038))
+Eq_5491: (struct "Eq_5491" (0 Eq_624 t0000) (38 Eq_624 t0038))
 	T_5491 (in a7_2007 : (ptr32 Eq_5491))
 	T_5493 (in a7_1330 - 4<i32> : word32)
-Eq_5515: (struct "Eq_5515" (0 Eq_623 t0000) (38 uint32 dw0038))
+Eq_5515: (struct "Eq_5515" (0 Eq_624 t0000) (38 uint32 dw0038))
 	T_5515 (in a7_2027 : (ptr32 Eq_5515))
 	T_5517 (in a7_1330 - 4<i32> : word32)
 Eq_5549: (union "Eq_5549" (int32 u0) (uint32 u1))
@@ -2228,10 +2105,10 @@ Eq_5549: (union "Eq_5549" (int32 u0) (uint32 u1))
 Eq_5589: (union "Eq_5589" (int32 u0) (uint32 u1))
 	T_5589 (in d6_1133 - d3_1850 : word32)
 	T_5590 (in 0<32> : word32)
-Eq_5618: (struct "Eq_5618" (0 Eq_623 t0000) (38 Eq_623 t0038))
+Eq_5618: (struct "Eq_5618" (0 Eq_624 t0000) (38 Eq_624 t0038))
 	T_5618 (in a7_2148 : (ptr32 Eq_5618))
 	T_5620 (in a7_1330 - 4<i32> : word32)
-Eq_5642: (struct "Eq_5642" (0 Eq_623 t0000) (38 uint32 dw0038))
+Eq_5642: (struct "Eq_5642" (0 Eq_624 t0000) (38 uint32 dw0038))
 	T_5642 (in a7_2168 : (ptr32 Eq_5642))
 	T_5644 (in a7_1330 - 4<i32> : word32)
 Eq_5685: (union "Eq_5685" (int32 u0) (uint32 u1))
@@ -2246,16 +2123,16 @@ Eq_5690: (fn bool (Eq_4356, word16))
 Eq_5761: (union "Eq_5761" (int32 u0) (uint32 u1))
 	T_5761 (in d6_1133 - d3_2201 : word32)
 	T_5762 (in 0<32> : word32)
-Eq_5790: (struct "Eq_5790" (0 Eq_623 t0000) (38 Eq_623 t0038))
+Eq_5790: (struct "Eq_5790" (0 Eq_624 t0000) (38 Eq_624 t0038))
 	T_5790 (in a7_2246 : (ptr32 Eq_5790))
 	T_5792 (in a7_1330 - 4<i32> : word32)
-Eq_5814: (struct "Eq_5814" (0 Eq_623 t0000) (38 uint32 dw0038))
+Eq_5814: (struct "Eq_5814" (0 Eq_624 t0000) (38 uint32 dw0038))
 	T_5814 (in a7_2266 : (ptr32 Eq_5814))
 	T_5816 (in a7_1330 - 4<i32> : word32)
-Eq_5871: (struct "Eq_5871" (0 Eq_623 t0000) (30 int32 dw0030) (38 Eq_623 t0038))
+Eq_5871: (struct "Eq_5871" (0 Eq_624 t0000) (30 int32 dw0030) (38 Eq_624 t0038))
 	T_5871 (in a7_1400 : (ptr32 Eq_5871))
 	T_5873 (in a7_1330 - 4<i32> : word32)
-Eq_5906: (struct "Eq_5906" (0 Eq_623 t0000) (38 uint32 dw0038))
+Eq_5906: (struct "Eq_5906" (0 Eq_624 t0000) (38 uint32 dw0038))
 	T_5906 (in a7_1425 : (ptr32 Eq_5906))
 	T_5908 (in a7_1330 - 4<i32> : word32)
 Eq_5943: (union "Eq_5943" (int32 u0) (uint32 u1))
@@ -2274,7 +2151,7 @@ Eq_5961: (union "Eq_5961" (int32 u0) (uint32 u1))
 Eq_5970: (union "Eq_5970" (int32 u0) (uint32 u1))
 	T_5970 (in d6_1133 - d3_1462 : word32)
 	T_5971 (in 0<32> : word32)
-Eq_6013: (struct "Eq_6013" (0 Eq_623 t0000) (4E word32 dw004E))
+Eq_6013: (struct "Eq_6013" (0 Eq_624 t0000) (4E word32 dw004E))
 	T_6013 (in a7_2334 : (ptr32 Eq_6013))
 	T_6015 (in a7_1330 - 4<i32> : word32)
 Eq_6081: (union "Eq_6081" (int32 u0) (uint32 u1))
@@ -2284,7 +2161,7 @@ Eq_6090: (union "Eq_6090" (int32 u0) (uint32 u1))
 	T_6091 (in 0<32> : word32)
 Eq_6100: (union "Eq_6100" (int32 u0) (uint32 u1))
 	T_6100 (in 1<32> : word32)
-Eq_6130: (struct "Eq_6130" (0 Eq_623 t0000) (44 word32 dw0044))
+Eq_6130: (struct "Eq_6130" (0 Eq_624 t0000) (44 word32 dw0044))
 	T_6130 (in a7_2368 : (ptr32 Eq_6130))
 	T_6132 (in a7_1330 - 4<i32> : word32)
 Eq_6180: (union "Eq_6180" (int32 u0) (uint32 u1))
@@ -2293,10 +2170,10 @@ Eq_6180: (union "Eq_6180" (int32 u0) (uint32 u1))
 Eq_6189: (union "Eq_6189" (int32 u0) (uint32 u1))
 	T_6189 (in d6_1133 - d3_1850 : word32)
 	T_6190 (in 0<32> : word32)
-Eq_6218: (struct "Eq_6218" (0 Eq_623 t0000) (38 Eq_623 t0038))
+Eq_6218: (struct "Eq_6218" (0 Eq_624 t0000) (38 Eq_624 t0038))
 	T_6218 (in a7_2443 : (ptr32 Eq_6218))
 	T_6220 (in a7_1330 - 4<i32> : word32)
-Eq_6242: (struct "Eq_6242" (0 Eq_623 t0000) (38 uint32 dw0038))
+Eq_6242: (struct "Eq_6242" (0 Eq_624 t0000) (38 uint32 dw0038))
 	T_6242 (in a7_2463 : (ptr32 Eq_6242))
 	T_6244 (in a7_1330 - 4<i32> : word32)
 Eq_6285: (union "Eq_6285" (int32 u0) (uint32 u1))
@@ -2307,14 +2184,12 @@ Eq_6286: (union "Eq_6286" (int32 u0) (uint32 u1))
 Eq_6316: (union "Eq_6316" (int32 u0) (uint32 u1))
 	T_6316 (in d6_1133 - d3_2508 : word32)
 	T_6317 (in 0<32> : word32)
-Eq_6345: (struct "Eq_6345" (0 Eq_623 t0000) (38 Eq_623 t0038))
+Eq_6345: (struct "Eq_6345" (0 Eq_624 t0000) (38 Eq_624 t0038))
 	T_6345 (in a7_2552 : (ptr32 Eq_6345))
 	T_6347 (in a7_1330 - 4<i32> : word32)
-Eq_6369: (struct "Eq_6369" (0 Eq_623 t0000) (38 uint32 dw0038))
+Eq_6369: (struct "Eq_6369" (0 Eq_624 t0000) (38 uint32 dw0038))
 	T_6369 (in a7_2572 : (ptr32 Eq_6369))
 	T_6371 (in a7_1330 - 4<i32> : word32)
-Eq_6411: (union "Eq_6411" (uint8 u0) (word32 u1))
-	T_6411 (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
 Eq_6419: (union "Eq_6419" (int32 u0) (uint32 u1))
 	T_6419 (in 1<32> : word32)
 Eq_6461: (union "Eq_6461" (byte u0) (word32 u1))
@@ -2322,7 +2197,7 @@ Eq_6461: (union "Eq_6461" (byte u0) (word32 u1))
 	T_6464 (in Mem2801[a7_1330 + 74<i32>:byte] : byte)
 Eq_6470: (union "Eq_6470" (int32 u0) (uint32 u1))
 	T_6470 (in 1<32> : word32)
-Eq_6474: (struct "Eq_6474" (0 Eq_623 t0000) (44 word32 dw0044))
+Eq_6474: (struct "Eq_6474" (0 Eq_624 t0000) (44 word32 dw0044))
 	T_6474 (in a7_2667 : (ptr32 Eq_6474))
 	T_6476 (in a7_1330 - 4<i32> : word32)
 Eq_6503: (union "Eq_6503" (int32 u0) (uint32 u1))
@@ -2346,372 +2221,98 @@ Eq_6578: (union "Eq_6578" (int32 u0) (uint32 u1))
 Eq_6587: (union "Eq_6587" (byte u0) (word32 u1))
 	T_6587 (in SLICE(d7, byte, 0) : byte)
 	T_6590 (in Mem2843[a7_1330 + 74<i32>:byte] : byte)
-Eq_6601: (union "Eq_6601" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1))
-	T_6601 (in 0x30<32> : word32)
-Eq_6603: (union "Eq_6603" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1))
-	T_6603 (in d6_3015 : Eq_6603)
-	T_6669 (in 0<i32> : int32)
-	T_6671 (in d5_1044 - 0x37<32> : word32)
-Eq_6618: (union "Eq_6618" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1))
-	T_6618 (in d2_2977 : word32)
-	T_6622 (in d4_2510 + Mem2975[a7_1330 + 68<i32>:word32] : word32)
-	T_6625 (in Mem2980[a7_1330 + 48<i32>:word32] : word32)
-	T_6638 (in 0<32> : word32)
-Eq_6621: (union "Eq_6621" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1))
-	T_6621 (in Mem2975[a7_1330 + 68<i32>:word32] : word32)
 Eq_6639: (union "Eq_6639" (bool u0) (word32 u1))
-	T_6639 (in d2_2977 < 0<32> : bool)
-Eq_6670: (union "Eq_6670" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1))
-	T_6670 (in 0x37<32> : word32)
-Eq_6672: (union "Eq_6672" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1))
-	T_6672 (in d2_3074 : Eq_6672)
-	T_6731 (in 0<i32> : int32)
-	T_6733 (in d5_1044 - 0x57<32> : word32)
-	T_6738 (in Mem3085[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-Eq_6685: (union "Eq_6685" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1) (Eq_6621 u2))
-	T_6685 (in d2_3037 : word32)
-	T_6689 (in d6_3015 + Mem3035[a7_1330 + 48<i32>:word32] : word32)
-	T_6692 (in Mem3040[a7_1330 + 68<i32>:word32] : word32)
-	T_6705 (in 0<32> : word32)
-Eq_6691: (union "Eq_6691" ((ptr32 (ptr32 Eq_4327)) u0) (Eq_6621 u1))
+	T_6639 (in d2_2977 < null : bool)
+Eq_6691: (union "Eq_6691" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8450) u1))
 	T_6691 (in a7_1330 + 68<i32> : word32)
-Eq_6732: (union "Eq_6732" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1))
-	T_6732 (in 0x57<32> : word32)
-Eq_6747: (union "Eq_6747" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1))
-	T_6747 (in d2_3095 : word32)
-	T_6751 (in d2_3074 + Mem3093[a7_1330 + 68<i32>:word32] : word32)
-	T_6754 (in Mem3098[a7_1330 + 48<i32>:word32] : word32)
-	T_6766 (in 0<32> : word32)
-Eq_6749: (union "Eq_6749" ((ptr32 (ptr32 Eq_4327)) u0) (Eq_6621 u1) (Eq_6685 u2))
+Eq_6749: (union "Eq_6749" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8450) u1))
 	T_6749 (in a7_1330 + 68<i32> : word32)
-Eq_6750: (union "Eq_6750" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1) (Eq_6621 u2) (Eq_6685 u3))
+Eq_6750: (union "Eq_6750" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8450) u1) ((ptr32 Eq_8456) u2))
 	T_6750 (in Mem3093[a7_1330 + 68<i32>:word32] : word32)
-Eq_6753: (union "Eq_6753" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1))
+Eq_6753: (union "Eq_6753" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8456) u1))
 	T_6753 (in a7_1330 + 48<i32> : word32)
 Eq_6767: (union "Eq_6767" (bool u0) (word32 u1))
-	T_6767 (in d2_3095 < 0<32> : bool)
+	T_6767 (in d2_3095 < null : bool)
 Eq_6881: (union "Eq_6881" (int32 u0) (uint32 u1))
 	T_6881 (in 1<32> : word32)
-Eq_6909: (struct "Eq_6909" (0 Eq_623 t0000) (4E word32 dw004E))
+Eq_6909: (struct "Eq_6909" (0 Eq_624 t0000) (4E word32 dw004E))
 	T_6909 (in a7_2635 : (ptr32 Eq_6909))
 	T_6911 (in a7_1330 - 4<i32> : word32)
-Eq_6960: (struct "Eq_6960" (0 Eq_623 t0000) (1 Eq_7049 t0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
+Eq_6960: (struct "Eq_6960" (0 Eq_783 t0000) (1 ui24 n0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
 	T_6960 (in a7_2886 : (ptr32 Eq_6960))
 	T_6961 (in a7_1330 - 4<i32> : word32)
-Eq_6971: (union "Eq_6971" (ui24 u0) ((ptr32 Eq_8463) u1) (Eq_1355 u2))
-	T_6971 (in a7_2886 + 0<32> : word32)
-Eq_7011: (fn word32 (Eq_4327, Eq_623, Eq_623, Eq_623, Eq_623, ptr32))
+Eq_7011: (fn word32 (Eq_4327, Eq_783, Eq_783, Eq_783, Eq_783, ptr32))
 	T_7011 (in fn00003C4C : ptr32)
 	T_7012 (in signature of fn00003C4C : void)
-Eq_7048: (union "Eq_7048" (ui24 u0) ((ptr32 Eq_8464) u1) (Eq_1355 u2))
-	T_7048 (in a7_2886 + 1<32> : word32)
-Eq_7049: (union "Eq_7049" (ui24 u0) ((ptr32 Eq_8465) u1) (Eq_1355 u2))
-	T_7049 (in Mem2934[a7_2886 + 1<32>:word24] : word24)
 Eq_7062: (union "Eq_7062" (int32 u0) (uint32 u1))
 	T_7062 (in 1<32> : word32)
-Eq_7115: (struct "Eq_7115" (0 Eq_623 t0000) (30 word32 dw0030) (34 Eq_623 t0034) (38 byte b0038) (4C byte b004C))
+Eq_7115: (struct "Eq_7115" (0 Eq_624 t0000) (30 word32 dw0030) (34 Eq_624 t0034) (38 byte b0038) (4C byte b004C))
 	T_7115 (in a7_3474 : (ptr32 Eq_7115))
 	T_7117 (in a7_1330 - 4<i32> : word32)
-Eq_7145: (struct "Eq_7145" (0 word32 dw0000) (4 Eq_623 t0004))
+Eq_7145: (struct "Eq_7145" (0 word32 dw0000) (4 Eq_624 t0004))
 	T_7145 (in a0_3501 : (ptr32 Eq_7145))
 	T_7148 (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
-Eq_7273: (union "Eq_7273" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1) (Eq_6747 u2))
+Eq_7273: (union "Eq_7273" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8456) u1))
 	T_7273 (in a7_1330 + 48<i32> : word32)
-Eq_7274: (union "Eq_7274" (uint8 u0) ((ptr32 (ptr32 Eq_4327)) u1) ((ptr32 Eq_8460) u2) (Eq_6411 u3) (Eq_6747 u4))
+Eq_7274: (union "Eq_7274" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8456) u1) ((ptr32 Eq_8456) u2))
 	T_7274 (in Mem3324[a7_1330 + 48<i32>:word32] : word32)
 	T_7277 (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
-Eq_7276: (union "Eq_7276" (uint8 u0) (word32 u1) (Eq_6411 u2))
-	T_7276 (in a7_1330 + 56<i32> : word32)
 Eq_7284: (struct "Eq_7284" (0 int32 dw0000) (4 word32 dw0004))
 	T_7284 (in v528_3348 : (ptr32 Eq_7284))
 	T_7286 (in a7_1330 + 44<i32> : word32)
 Eq_7296: (union "Eq_7296" (bool u0) (int32 u1))
 	T_7296 (in d1 < 0<32> : bool)
-Eq_7299: (union "Eq_7299" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7299 (in a7_1330 + 0x38<32> : word32)
-Eq_7301: (union "Eq_7301" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7301 (in a7_3364 : Eq_7301)
+Eq_7301: (struct "Eq_7301" (0 Eq_624 t0000) (30 byte b0030) (38 word32 dw0038) (3C Eq_624 t003C) (4C byte b004C))
+	T_7301 (in a7_3364 : (ptr32 Eq_7301))
 	T_7303 (in a7_1330 - 4<i32> : word32)
-Eq_7302: (union "Eq_7302" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7302 (in 4<i32> : int32)
-Eq_7305: (union "Eq_7305" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7305 (in a7_3364 + 0<32> : word32)
-Eq_7308: (union "Eq_7308" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7308 (in a7_3364 + 76<i32> : word32)
-Eq_7313: (union "Eq_7313" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7313 (in a7_3364 + 48<i32> : word32)
-Eq_7315: (union "Eq_7315" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7315 (in 4<i32> : int32)
-Eq_7318: (union "Eq_7318" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7318 (in a7_3364 + 48<i32> : word32)
-Eq_7324: (union "Eq_7324" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7324 (in a7_1330 + 52<i32> : word32)
-Eq_7328: (union "Eq_7328" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7328 (in a7_1330 + 44<i32> : word32)
-Eq_7333: (union "Eq_7333" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7333 (in a7_1330 + 52<i32> : word32)
-Eq_7337: (union "Eq_7337" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7337 (in a7_1330 + 44<i32> : word32)
-Eq_7350: (struct "Eq_7350" (0 word32 dw0000) (4 word32 dw0004))
+Eq_7326: (union "Eq_7326" (int32 u0) (byte u1))
+	T_7326 (in v544_774 : Eq_7326)
+	T_7329 (in Mem773[a7_1330 + 44<i32>:byte] : byte)
+	T_7482 (in 0<8> : byte)
+	T_7489 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+Eq_7335: (union "Eq_7335" (int32 u0) (byte u1))
+	T_7335 (in 1<8> : byte)
+	T_7338 (in Mem769[a7_1330 + 44<i32>:byte] : byte)
+Eq_7350: (struct "Eq_7350" (0 word32 dw0000) (4 Eq_624 t0004))
 	T_7350 (in a0_3404 : (ptr32 Eq_7350))
 	T_7353 (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
-Eq_7355: (union "Eq_7355" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7355 (in a7_3364 + 60<i32> : word32)
-Eq_7361: (union "Eq_7361" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7361 (in a7_3364 + 56<i32> : word32)
-Eq_7369: (union "Eq_7369" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7369 (in a7_3364 + 48<i32> : word32)
-Eq_7374: (union "Eq_7374" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7374 (in a7_3364 + 48<i32> : word32)
-Eq_7387: (union "Eq_7387" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7387 (in a7_3364 + 60<i32> : word32)
-Eq_7398: (union "Eq_7398" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7398 (in a7_3364 + 48<i32> : word32)
-Eq_7403: (union "Eq_7403" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7403 (in a7_3364 + 48<i32> : word32)
-Eq_7416: (union "Eq_7416" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7416 (in a7_3364 + 60<i32> : word32)
-Eq_7427: (union "Eq_7427" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7427 (in a7_3364 + 48<i32> : word32)
-Eq_7432: (union "Eq_7432" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7432 (in a7_3364 + 48<i32> : word32)
-Eq_7445: (union "Eq_7445" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7445 (in a7_3364 + 60<i32> : word32)
-Eq_7462: (union "Eq_7462" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7462 (in a7_3364 + 60<i32> : word32)
-Eq_7474: (union "Eq_7474" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7474 (in 78<i32> : int32)
-Eq_7475: (union "Eq_7475" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7475 (in a7_1330 + 78<i32> : word32)
-Eq_7476: (union "Eq_7476" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7476 (in a7_1330 + 78<i32> + d1_1027 : word32)
-Eq_7478: (union "Eq_7478" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7478 (in 1<32> : word32)
-Eq_7485: (union "Eq_7485" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7485 (in a7_1330 + 132<i32> : word32)
-Eq_7488: (union "Eq_7488" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7488 (in a7_1330 + 44<i32> : word32)
-Eq_7492: (union "Eq_7492" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7492 (in a7_1330 + 44<i32> : word32)
-Eq_7496: (union "Eq_7496" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7496 (in a7_1330 + 132<i32> : word32)
-Eq_7501: (union "Eq_7501" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7501 (in a7_1330 + 73<i32> : word32)
-Eq_7549: (union "Eq_7549" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7549 (in a0_881 : Eq_7549)
-	T_7554 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_7550: (union "Eq_7550" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7550 (in 78<i32> : int32)
-Eq_7551: (union "Eq_7551" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7551 (in a7_1330 + 78<i32> : word32)
-Eq_7553: (union "Eq_7553" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
+Eq_7490: (union "Eq_7490" (int32 u0) (byte u1))
+	T_7490 (in v554_824 : Eq_7490)
+	T_7493 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+	T_7547 (in 0<8> : byte)
+Eq_7553: (union "Eq_7553" (int32 u0) (uint32 u1))
 	T_7553 (in d5_862 >> 3<32> : word32)
-Eq_7556: (union "Eq_7556" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7556 (in a0_881 + 0<32> : word32)
-Eq_7567: (union "Eq_7567" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7567 (in a0_881 + 0<32> : word32)
-Eq_7569: (union "Eq_7569" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7569 (in a0_900 : Eq_7569)
-	T_7574 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_7570: (union "Eq_7570" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7570 (in 78<i32> : int32)
-Eq_7571: (union "Eq_7571" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7571 (in a7_1330 + 78<i32> : word32)
-Eq_7573: (union "Eq_7573" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
+Eq_7573: (union "Eq_7573" (int32 u0) (uint32 u1))
 	T_7573 (in d5_862 >> 3<32> : word32)
-Eq_7576: (union "Eq_7576" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7576 (in a0_900 + 0<32> : word32)
-Eq_7588: (union "Eq_7588" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7588 (in a0_900 + 0<32> : word32)
-Eq_7642: (union "Eq_7642" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7642 (in a7_985 : Eq_7642)
+Eq_7642: (struct "Eq_7642" (0 Eq_624 t0000) (30 Eq_624 t0030))
+	T_7642 (in a7_985 : (ptr32 Eq_7642))
 	T_7644 (in a7_1330 - 4<i32> : word32)
-Eq_7643: (union "Eq_7643" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7643 (in 4<i32> : int32)
-Eq_7646: (union "Eq_7646" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7646 (in a7_985 + 0<32> : word32)
-Eq_7651: (union "Eq_7651" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7651 (in a7_985 + 0<32> : word32)
-Eq_7658: (union "Eq_7658" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7658 (in a7_985 + 48<i32> : word32)
-Eq_7666: (union "Eq_7666" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7666 (in a7_1005 : Eq_7666)
+Eq_7666: (struct "Eq_7666" (0 Eq_624 t0000) (30 uint32 dw0030))
+	T_7666 (in a7_1005 : (ptr32 Eq_7666))
 	T_7668 (in a7_1330 - 4<i32> : word32)
-Eq_7667: (union "Eq_7667" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7667 (in 4<i32> : int32)
-Eq_7670: (union "Eq_7670" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7670 (in a7_1005 + 0<32> : word32)
-Eq_7682: (union "Eq_7682" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7682 (in a7_1005 + 0<32> : word32)
-Eq_7685: (union "Eq_7685" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7685 (in a7_1005 + 0<32> : word32)
-Eq_7690: (union "Eq_7690" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7690 (in a7_1005 + 48<i32> : word32)
-Eq_7695: (union "Eq_7695" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7695 (in a7_1005 + 0<32> : word32)
-Eq_7698: (union "Eq_7698" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7698 (in a7_1330 + 44<i32> : word32)
 Eq_7700: (union "Eq_7700" (int32 u0) (uint32 u1))
 	T_7700 (in d3_1057 : Eq_7700)
 	T_7702 (in d3_1850 + 1<32> : word32)
 	T_7853 (in d3_1057 + 1<32> : word32)
 Eq_7701: (union "Eq_7701" (int32 u0) (uint32 u1))
 	T_7701 (in 1<32> : word32)
-Eq_7707: (union "Eq_7707" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7707 (in a7_1330 + 44<i32> : word32)
-Eq_7713: (union "Eq_7713" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7713 (in a7_1076 : Eq_7713)
+Eq_7713: (struct "Eq_7713" (0 ptr32 ptr0000) (4D byte b004D))
+	T_7713 (in a7_1076 : (ptr32 Eq_7713))
 	T_7715 (in a7_1330 - 4<i32> : word32)
-Eq_7714: (union "Eq_7714" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7714 (in 4<i32> : int32)
-Eq_7716: (union "Eq_7716" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7716 (in 78<i32> : int32)
-Eq_7719: (union "Eq_7719" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7719 (in a7_1076 + 0<32> : word32)
-Eq_7721: (union "Eq_7721" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7721 (in 4<i32> : int32)
-Eq_7722: (union "Eq_7722" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7722 (in a7_1076 - 4<i32> : word32)
-Eq_7724: (union "Eq_7724" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7724 (in a7_1076 - 4<i32> + 0<32> : word32)
-Eq_7727: (union "Eq_7727" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7727 (in 8<i32> : int32)
-Eq_7728: (union "Eq_7728" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7728 (in a7_1076 - 8<i32> : word32)
-Eq_7730: (union "Eq_7730" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7730 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_7732: (union "Eq_7732" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7732 (in 12<i32> : int32)
-Eq_7733: (union "Eq_7733" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7733 (in a7_1076 - 12<i32> : word32)
-Eq_7735: (union "Eq_7735" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7735 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_7738: (union "Eq_7738" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7738 (in a7_1076 + 0<32> : word32)
-Eq_7740: (fn int32 (Eq_623, Eq_623, Eq_623))
+Eq_7740: (fn int32 (Eq_783, Eq_783, Eq_783))
 	T_7740 (in fn000026E4 : ptr32)
 	T_7741 (in signature of fn000026E4 : void)
 	T_7918 (in fn000026E4 : ptr32)
-Eq_7742: (union "Eq_7742" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7742 (in a7_1076 - 12<i32> : word32)
-Eq_7744: (union "Eq_7744" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7744 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_7746: (union "Eq_7746" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7746 (in 8<i32> : int32)
-Eq_7747: (union "Eq_7747" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7747 (in a7_1076 - 8<i32> : word32)
-Eq_7749: (union "Eq_7749" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7749 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_7756: (union "Eq_7756" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7756 (in 4<i32> : int32)
-Eq_7757: (union "Eq_7757" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7757 (in a7_1076 - 4<i32> : word32)
-Eq_7759: (union "Eq_7759" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7759 (in a7_1076 - 4<i32> + 0<32> : word32)
 Eq_7768: (union "Eq_7768" (int32 u0) (uint32 u1))
 	T_7768 (in d6_1133 - d3_1057 : word32)
 	T_7769 (in 0<32> : word32)
-Eq_7773: (union "Eq_7773" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7773 (in a7_1076 + 77<i32> : word32)
-Eq_7808: (union "Eq_7808" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7808 (in a7_1182 : Eq_7808)
-	T_7810 (in a7_1330 - 4<i32> : word32)
-Eq_7809: (union "Eq_7809" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7809 (in 4<i32> : int32)
-Eq_7812: (union "Eq_7812" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7812 (in a7_1182 + 0<32> : word32)
-Eq_7818: (union "Eq_7818" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7818 (in a7_1182 + 0<32> : word32)
-Eq_7830: (union "Eq_7830" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7830 (in a7_1201 : Eq_7830)
-	T_7832 (in a7_1330 - 4<i32> : word32)
-Eq_7831: (union "Eq_7831" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7831 (in 4<i32> : int32)
-Eq_7834: (union "Eq_7834" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7834 (in a7_1201 + 0<32> : word32)
-Eq_7846: (union "Eq_7846" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7846 (in a7_1201 + 0<32> : word32)
 Eq_7852: (union "Eq_7852" (int32 u0) (uint32 u1))
 	T_7852 (in 1<32> : word32)
 Eq_7858: (union "Eq_7858" (int32 u0) (uint32 u1))
 	T_7858 (in 1<32> : word32)
-Eq_7863: (union "Eq_7863" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7863 (in a7_1330 + 73<i32> : word32)
-Eq_7867: (union "Eq_7867" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7867 (in a7_1302 : Eq_7867)
-	T_7869 (in a7_1330 - 4<i32> : word32)
-Eq_7868: (union "Eq_7868" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7868 (in 4<i32> : int32)
-Eq_7871: (union "Eq_7871" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7871 (in a7_1302 + 0<32> : word32)
-Eq_7873: (union "Eq_7873" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7873 (in 4<i32> : int32)
-Eq_7874: (union "Eq_7874" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7874 (in a7_1302 - 4<i32> : word32)
-Eq_7876: (union "Eq_7876" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7876 (in a7_1302 - 4<i32> + 0<32> : word32)
-Eq_7879: (union "Eq_7879" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7879 (in 1<i32> : int32)
-Eq_7880: (union "Eq_7880" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7880 (in a7_1302 - 1<i32> : word32)
-Eq_7882: (union "Eq_7882" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7882 (in a7_1302 - 1<i32> + 0<32> : word32)
-Eq_7885: (union "Eq_7885" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7885 (in a7_1302 + 0<32> : word32)
-Eq_7889: (union "Eq_7889" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7889 (in a7_1330 + 73<i32> : word32)
-Eq_7891: (union "Eq_7891" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7891 (in a7_1237 : Eq_7891)
-	T_7893 (in a7_1330 - 4<i32> : word32)
-Eq_7892: (union "Eq_7892" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7892 (in 4<i32> : int32)
-Eq_7894: (union "Eq_7894" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7894 (in 78<i32> : int32)
-Eq_7897: (union "Eq_7897" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7897 (in a7_1237 + 0<32> : word32)
-Eq_7899: (union "Eq_7899" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7899 (in 4<i32> : int32)
-Eq_7900: (union "Eq_7900" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7900 (in a7_1237 - 4<i32> : word32)
-Eq_7902: (union "Eq_7902" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7902 (in a7_1237 - 4<i32> + 0<32> : word32)
-Eq_7905: (union "Eq_7905" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7905 (in 8<i32> : int32)
-Eq_7906: (union "Eq_7906" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7906 (in a7_1237 - 8<i32> : word32)
-Eq_7908: (union "Eq_7908" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7908 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_7910: (union "Eq_7910" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7910 (in 12<i32> : int32)
-Eq_7911: (union "Eq_7911" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7911 (in a7_1237 - 12<i32> : word32)
-Eq_7913: (union "Eq_7913" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7913 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_7916: (union "Eq_7916" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7916 (in a7_1237 + 0<32> : word32)
-Eq_7919: (union "Eq_7919" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7919 (in a7_1237 - 12<i32> : word32)
-Eq_7921: (union "Eq_7921" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7921 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_7923: (union "Eq_7923" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7923 (in 8<i32> : int32)
-Eq_7924: (union "Eq_7924" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7924 (in a7_1237 - 8<i32> : word32)
-Eq_7926: (union "Eq_7926" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7926 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_7933: (union "Eq_7933" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7933 (in 4<i32> : int32)
-Eq_7934: (union "Eq_7934" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7934 (in a7_1237 - 4<i32> : word32)
-Eq_7936: (union "Eq_7936" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7936 (in a7_1237 - 4<i32> + 0<32> : word32)
 Eq_7945: (union "Eq_7945" (int32 u0) (uint32 u1))
 	T_7945 (in d6_1133 - d3_1057 : word32)
 	T_7946 (in 0<32> : word32)
-Eq_7957: (union "Eq_7957" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7957 (in a7_1330 + 60<i32> : word32)
-Eq_7961: (union "Eq_7961" (uint8 u0) ((ptr32 Eq_8486) u1) (Eq_6411 u2) (Eq_7274 u3))
-	T_7961 (in a7_1330 + 60<i32> : word32)
 Eq_8096: (fn int32 (ptr32, ptr32))
 	T_8096 (in fn00003DC8 : ptr32)
 	T_8097 (in signature of fn00003DC8 : void)
@@ -2720,25 +2321,25 @@ Eq_8133: (fn void ())
 	T_8134 (in signature of execPrivate2 : void)
 Eq_8351: (struct "Eq_8351" 0004 (0 byte b0000))
 	T_8351
-Eq_8408: (struct "Eq_8408" 0001 (0 word32 dw0000) (3 byte b0003) (4 Eq_623 t0004) (8 Eq_623 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
+Eq_8408: (struct "Eq_8408" (0 Eq_4327 t0000))
 	T_8408
-Eq_8409: (struct "Eq_8409" (0 Eq_623 t0000))
+Eq_8409: (struct "Eq_8409" 0004 (0 (ptr32 Eq_8408) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8409
-Eq_8410: (union "Eq_8410" (int32 u0) (byte u1) (Eq_623 u2))
+Eq_8410: (union "Eq_8410" (cu8 u0) (word32 u1) (Eq_1224 u2) (Eq_1227 u3) (Eq_1302 u4) (Eq_2361 u5) (Eq_2472 u6) (Eq_2513 u7))
 	T_8410
-Eq_8411: (union "Eq_8411" (byte u0) ((ptr32 (ptr32 Eq_4327)) u1) ((ptr32 Eq_8460) u2) (Eq_623 u3) (Eq_6747 u4) (Eq_7274 u5))
+Eq_8411: (union "Eq_8411" ((ptr32 Eq_1355) u0) (Eq_1889 u1) (Eq_1951 u2) (Eq_1957 u3) (Eq_2025 u4) (Eq_2068 u5) (Eq_2596 u6))
 	T_8411
-Eq_8412: (union "Eq_8412" (uint8 u0) (word32 u1) (Eq_6411 u2))
+Eq_8412: (struct "Eq_8412" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8412
-Eq_8413: (union "Eq_8413" (uint8 u0) (word32 u1) (Eq_4320 u2) (Eq_6411 u3) (Eq_7274 u4))
+Eq_8413: (struct "Eq_8413" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8413
-Eq_8414: (union "Eq_8414" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1) (Eq_6621 u2) (Eq_6685 u3) (Eq_6750 u4))
+Eq_8414: (struct "Eq_8414" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8414
-Eq_8415: (struct "Eq_8415" 0004 (FFFFFFFC (ptr32 Eq_8409) ptrFFFFFFFC) (0 (ptr32 Eq_4327) ptr0000) (2C Eq_8410 t002C) (30 Eq_8411 t0030) (34 word32 dw0034) (37 Eq_8412 t0037) (38 Eq_8413 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8414 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8415: (struct "Eq_8415" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8415
-Eq_8416: (union "Eq_8416" (cu8 u0) (word32 u1) (Eq_1224 u2) (Eq_1227 u3) (Eq_1302 u4) (Eq_2361 u5) (Eq_2472 u6) (Eq_2513 u7))
+Eq_8416: (struct "Eq_8416" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8416
-Eq_8417: (union "Eq_8417" (int32 u0) (uint32 u1) (Eq_1191 u2) (Eq_1355 u3) (Eq_1889 u4) (Eq_1951 u5) (Eq_1957 u6) (Eq_2025 u7) (Eq_2068 u8) (Eq_2596 u9))
+Eq_8417: (struct "Eq_8417" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8417
 Eq_8418: (struct "Eq_8418" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8418
@@ -2762,142 +2363,144 @@ Eq_8427: (struct "Eq_8427" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8427
 Eq_8428: (struct "Eq_8428" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8428
-Eq_8429: (struct "Eq_8429" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8429: (struct "Eq_8429" 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8429
-Eq_8430: (struct "Eq_8430" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8430: (union "Eq_8430" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8456) u1) (Eq_7274 u2))
 	T_8430
-Eq_8431: (struct "Eq_8431" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8431: (union "Eq_8431" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8450) u1) ((ptr32 Eq_8456) u2) (Eq_6750 u3))
 	T_8431
-Eq_8432: (struct "Eq_8432" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8432: (struct "Eq_8432" (0 Eq_4327 t0000))
 	T_8432
-Eq_8433: (struct "Eq_8433" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8433: (struct "Eq_8433" 0004 (0 (ptr32 Eq_8432) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8433
-Eq_8434: (union "Eq_8434" (int32 u0) (byte u1) (Eq_623 u2))
+Eq_8434: (struct "Eq_8434" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8434
-Eq_8435: (union "Eq_8435" (byte u0) ((ptr32 (ptr32 Eq_4327)) u1) ((ptr32 Eq_8460) u2) (Eq_623 u3) (Eq_6747 u4) (Eq_7274 u5))
+Eq_8435: (struct "Eq_8435" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8435
-Eq_8436: (union "Eq_8436" (uint8 u0) (word32 u1) (Eq_6411 u2))
+Eq_8436: (struct "Eq_8436" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8436
-Eq_8437: (union "Eq_8437" (uint8 u0) (word32 u1) (Eq_4320 u2) (Eq_6411 u3) (Eq_7274 u4))
+Eq_8437: (struct "Eq_8437" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8437
-Eq_8438: (union "Eq_8438" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1) (Eq_6621 u2) (Eq_6685 u3) (Eq_6750 u4))
+Eq_8438: (struct "Eq_8438" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8438
-Eq_8439: (struct "Eq_8439" 0004 (0 Eq_623 t0000) (2C Eq_8434 t002C) (30 Eq_8435 t0030) (34 word32 dw0034) (37 Eq_8436 t0037) (38 Eq_8437 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8438 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8439: (struct "Eq_8439" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8439
-Eq_8440: (struct "Eq_8440" (0 Eq_4327 t0000))
+Eq_8440: (struct "Eq_8440" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8440
-Eq_8441: (struct "Eq_8441" 0004 (0 (ptr32 Eq_8440) ptr0000))
+Eq_8441: (struct "Eq_8441" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8441
-Eq_8442: (struct "Eq_8442" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8442: (struct "Eq_8442" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8442
-Eq_8443: (struct "Eq_8443" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8443: (struct "Eq_8443" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8443
-Eq_8444: (struct "Eq_8444" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8444: (struct "Eq_8444" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8444
-Eq_8445: (struct "Eq_8445" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
-	T_8445
-Eq_8446: (struct "Eq_8446" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8446: (struct "Eq_8446" 0004 (0 (ptr32 Eq_8494) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8446
-Eq_8447: (struct "Eq_8447" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8447: (struct "Eq_8447" 0004 (0 (ptr32 Eq_8495) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8447
-Eq_8448: (struct "Eq_8448" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8448: (struct "Eq_8448" 0004 (0 (ptr32 Eq_8496) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8448
-Eq_8449: (struct "Eq_8449" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
-	T_8449
-Eq_8450: (struct "Eq_8450" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8450: (struct "Eq_8450" 0004 (0 (ptr32 Eq_8501) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8450
-Eq_8451: (struct "Eq_8451" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
-	T_8451
-Eq_8452: (struct "Eq_8452" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8452: (struct "Eq_8452" 0004 (0 (ptr32 Eq_8498) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8452
-Eq_8459: (struct "Eq_8459" (0 Eq_4327 t0000))
+Eq_8453: (struct "Eq_8453" 0004 (0 (ptr32 Eq_8499) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
+	T_8453
+Eq_8454: (struct "Eq_8454" 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
+	T_8454
+Eq_8455: (struct "Eq_8455" (0 Eq_4327 t0000))
+	T_8455
+Eq_8456: (struct "Eq_8456" 0004 (0 (ptr32 Eq_8500) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
+	T_8456
+Eq_8458: (struct "Eq_8458" 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
+	T_8458
+Eq_8459: (struct "Eq_8459" 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8459
-Eq_8460: (struct "Eq_8460" 0004 (0 (ptr32 Eq_8459) ptr0000))
+Eq_8460: (struct "Eq_8460" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8460
-Eq_8463: (struct "Eq_8463" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8461: (struct "Eq_8461" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
+	T_8461
+Eq_8462: (struct "Eq_8462" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
+	T_8462
+Eq_8463: (struct "Eq_8463" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8463
-Eq_8464: (struct "Eq_8464" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8464: (struct "Eq_8464" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8464
-Eq_8465: (struct "Eq_8465" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8465: (struct "Eq_8465" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8465
-Eq_8466: (struct "Eq_8466" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8466: (struct "Eq_8466" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8466
-Eq_8467: (struct "Eq_8467" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8467: (struct "Eq_8467" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8467
-Eq_8468: (struct "Eq_8468" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8468: (struct "Eq_8468" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8468
-Eq_8469: (struct "Eq_8469" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8469: (struct "Eq_8469" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8469
-Eq_8470: (struct "Eq_8470" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8470: (struct "Eq_8470" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8470
-Eq_8471: (struct "Eq_8471" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8471: (struct "Eq_8471" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8471
-Eq_8472: (struct "Eq_8472" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8472: (struct "Eq_8472" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8472
-Eq_8473: (struct "Eq_8473" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8473: (struct "Eq_8473" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8473
-Eq_8474: (struct "Eq_8474" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8474: (struct "Eq_8474" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8474
-Eq_8475: (struct "Eq_8475" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8475: (struct "Eq_8475" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8475
-Eq_8476: (struct "Eq_8476" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8476: (struct "Eq_8476" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8476
-Eq_8477: (struct "Eq_8477" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8477: (struct "Eq_8477" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8477
-Eq_8478: (struct "Eq_8478" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8478: (struct "Eq_8478" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8478
-Eq_8479: (struct "Eq_8479" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8479: (struct "Eq_8479" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8479
-Eq_8480: (struct "Eq_8480" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8480: (struct "Eq_8480" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8480
-Eq_8481: (union "Eq_8481" (int32 u0) (byte u1) (Eq_623 u2))
+Eq_8481: (struct "Eq_8481" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8481
-Eq_8482: (union "Eq_8482" (byte u0) ((ptr32 (ptr32 Eq_4327)) u1) ((ptr32 Eq_8460) u2) (Eq_623 u3) (Eq_6747 u4) (Eq_7274 u5))
+Eq_8482: (struct "Eq_8482" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8482
-Eq_8483: (union "Eq_8483" (uint8 u0) (word32 u1) (Eq_6411 u2))
+Eq_8483: (struct "Eq_8483" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8483
-Eq_8484: (union "Eq_8484" (uint8 u0) (word32 u1) (Eq_4320 u2) (Eq_6411 u3) (Eq_7274 u4))
+Eq_8484: (struct "Eq_8484" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8484
-Eq_8485: (union "Eq_8485" ((ptr32 (ptr32 Eq_4327)) u0) ((ptr32 Eq_8460) u1) (Eq_6621 u2) (Eq_6685 u3) (Eq_6750 u4))
+Eq_8485: (struct "Eq_8485" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8485
-Eq_8486: (struct "Eq_8486" 0004 (0 Eq_623 t0000) (2C Eq_8481 t002C) (30 Eq_8482 t0030) (34 word32 dw0034) (37 Eq_8483 t0037) (38 Eq_8484 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8485 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8486: (struct "Eq_8486" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8486
-Eq_8487: (struct "Eq_8487" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8487: (struct "Eq_8487" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8487
-Eq_8488: (struct "Eq_8488" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8488: (struct "Eq_8488" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8488
-Eq_8489: (struct "Eq_8489" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8489: (struct "Eq_8489" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8489
-Eq_8490: (struct "Eq_8490" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8490: (struct "Eq_8490" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8490
-Eq_8491: (struct "Eq_8491" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8491: (struct "Eq_8491" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8491
-Eq_8492: (struct "Eq_8492" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8492: (struct "Eq_8492" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8492
-Eq_8493: (struct "Eq_8493" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8493: (struct "Eq_8493" 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))
 	T_8493
-Eq_8494: (struct "Eq_8494" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8494: (union "Eq_8494" (Eq_4327 u0) (Eq_8455 u1))
 	T_8494
-Eq_8495: (struct "Eq_8495" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8495: (union "Eq_8495" (Eq_4327 u0) (Eq_8455 u1))
 	T_8495
-Eq_8496: (struct "Eq_8496" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8496: (union "Eq_8496" (Eq_4327 u0) (Eq_8455 u1))
 	T_8496
-Eq_8497: (struct "Eq_8497" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8497: (union "Eq_8497" (Eq_4327 u0) (Eq_8455 u1))
 	T_8497
-Eq_8498: (struct "Eq_8498" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8498: (union "Eq_8498" (Eq_4327 u0) (Eq_8455 u1))
 	T_8498
-Eq_8499: (struct "Eq_8499" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8499: (union "Eq_8499" (Eq_4327 u0) (Eq_8455 u1))
 	T_8499
-Eq_8500: (struct "Eq_8500" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8500: (union "Eq_8500" (Eq_4327 u0) (Eq_8455 u1))
 	T_8500
-Eq_8501: (struct "Eq_8501" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
+Eq_8501: (union "Eq_8501" (Eq_4327 u0) (Eq_8497 u1) (Eq_8500 u2))
 	T_8501
-Eq_8502: (struct "Eq_8502" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
-	T_8502
-Eq_8503: (struct "Eq_8503" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
-	T_8503
-Eq_8504: (struct "Eq_8504" 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))
-	T_8504
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -5387,13 +4990,13 @@ T_622: (in d0 : word32)
   Class: Eq_607
   DataType: word32
   OrigDataType: word32
-T_623: (in a1_14 : Eq_623)
+T_623: (in a1_14 : (ptr32 (ptr32 byte)))
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
-T_624: (in d1_16 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_624: (in d1_16 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_625: (in fn00002BDC : ptr32)
   Class: Eq_625
@@ -5403,17 +5006,17 @@ T_626: (in signature of fn00002BDC : void)
   Class: Eq_625
   DataType: (ptr32 Eq_625)
   OrigDataType: 
-T_627: (in d0 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_627: (in d0 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
-T_628: (in d1 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_628: (in d1 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
-T_629: (in a1 : Eq_623)
+T_629: (in a1 : (ptr32 (ptr32 byte)))
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_630: (in dwArg04 : (ptr32 Eq_630))
   Class: Eq_630
@@ -5452,8 +5055,8 @@ T_638: (in out a1_14 : ptr32)
   DataType: (ptr32 (ptr32 byte))
   OrigDataType: ptr32
 T_639: (in fn00003E04(&globals->b1438, out d1_16, out a1_14) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_640: (in 00001458 : ptr32)
   Class: Eq_630
@@ -5495,13 +5098,13 @@ T_649: (in d2_102 - dwLoc0C <= 0<32> : bool)
   Class: Eq_649
   DataType: bool
   OrigDataType: bool
-T_650: (in a1_48 : Eq_623)
+T_650: (in a1_48 : (ptr32 (ptr32 byte)))
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
-T_651: (in d1_50 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_651: (in d1_50 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_652: (in fn00002BDC : ptr32)
   Class: Eq_625
@@ -5524,8 +5127,8 @@ T_656: (in out a1_48 : ptr32)
   DataType: (ptr32 (ptr32 byte))
   OrigDataType: ptr32
 T_657: (in fn00003E04(&globals->b1410, out d1_50, out a1_48) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_658: (in 00001420 : ptr32)
   Class: Eq_630
@@ -5738,7 +5341,7 @@ T_709: (in fn000014B4(d0, *(struct Eq_701 **) 0x3FF4<u32>, dwArg04, fp + 8<i32>)
 T_710: (in a7_1968 : (ptr32 Eq_710))
   Class: Eq_710
   DataType: (ptr32 Eq_710)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1224 u2) (T_1230 u3) (T_1305 u4) (T_2364 u5) (T_2475 u6) (T_2516 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1355 u2) (T_1362 u3) (T_1373 u4) (T_1889 u5) (T_1954 u6) (T_1957 u7) (T_2025 u8) (T_2071 u9) (T_2599 u10)) u0066) (6A byte b006A)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1224 u2) (T_1230 u3) (T_1305 u4) (T_2364 u5) (T_2475 u6) (T_2516 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1355 u2) (T_1362 u3) (T_1373 u4) (T_1889 u5) (T_1954 u6) (T_1957 u7) (T_2025 u8) (T_2071 u9) (T_2599 u10)) u0066) (6A byte b006A)))
 T_711: (in fp : ptr32)
   Class: Eq_711
   DataType: ptr32
@@ -5754,7 +5357,7 @@ T_713: (in fp + -112<i32> : word32)
 T_714: (in d3_1482 : Eq_703)
   Class: Eq_703
   DataType: Eq_703
-  OrigDataType: word32
+  OrigDataType: (ptr32 Eq_1355)
 T_715: (in a5_1579 : (ptr32 Eq_701))
   Class: Eq_701
   DataType: (ptr32 Eq_701)
@@ -6025,15 +5628,15 @@ T_781: (in a7_1968 + 102<i32> : word32)
   OrigDataType: ptr32
 T_782: (in Mem91[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_779
-  DataType: Eq_8417
+  DataType: Eq_8411
   OrigDataType: word32
-T_783: (in d5_256 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: (struct "Eq_710" 0004 (2C Eq_8416 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8417 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+T_783: (in d5_256 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: (struct "Eq_710" 0004 (2C Eq_8410 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8411 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 T_784: (in -1<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_785: (in d4_376 : int32)
   Class: Eq_785
@@ -6075,10 +5678,10 @@ T_794: (in a4_1925 + 1<i32> : word32)
   Class: Eq_792
   DataType: (ptr32 uint8)
   OrigDataType: ptr32
-T_795: (in d2_1005 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: (ptr32 Eq_623)
+T_795: (in d2_1005 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: (ptr32 Eq_783)
 T_796: (in 72<i32> : int32)
   Class: Eq_796
   DataType: int32
@@ -6088,8 +5691,8 @@ T_797: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_798: (in Mem91[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_799: (in d1_103 : Eq_662)
   Class: Eq_662
@@ -6152,8 +5755,8 @@ T_813: (in Mem121[a7_99 + 0<32>:word32] : word32)
   DataType: Eq_662
   OrigDataType: word32
 T_814: (in d2_1005 | d1_123 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_815: (in 1<i32> : int32)
   Class: Eq_815
@@ -6192,8 +5795,8 @@ T_823: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_824: (in Mem143[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_825: (in 0<32> : word32)
   Class: Eq_825
@@ -6656,8 +6259,8 @@ T_939: (in (uint32) (uint8) Mem248[a0_1447 + 0<32>:byte] : uint32)
   DataType: uint32
   OrigDataType: uint32
 T_940: (in 0<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_941: (in 4<32> : word32)
   Class: Eq_941
@@ -6768,12 +6371,12 @@ T_967: (in a7_1968 + 44<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_968: (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_969: (in a7_275 : (ptr32 Eq_623))
+T_969: (in a7_275 : (ptr32 Eq_783))
   Class: Eq_969
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_783 t0000)))
 T_970: (in 4<i32> : int32)
   Class: Eq_970
@@ -6781,7 +6384,7 @@ T_970: (in 4<i32> : int32)
   OrigDataType: int32
 T_971: (in a7_1968 - 4<i32> : word32)
   Class: Eq_969
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: ptr32
 T_972: (in 0<32> : word32)
   Class: Eq_972
@@ -6792,8 +6395,8 @@ T_973: (in a7_275 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_974: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_975: (in d1_284 : uint32)
   Class: Eq_975
@@ -6808,16 +6411,16 @@ T_977: (in signature of __swap : void)
   DataType: (ptr32 Eq_976)
   OrigDataType: 
 T_978: (in  : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: 
 T_979: (in 10<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_980: (in __swap(10<i32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_981: (in SLICE(d5_256, word16, 0) : word16)
   Class: Eq_981
@@ -6844,8 +6447,8 @@ T_986: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_987 (T_783)))
 T_987: (in __swap(d5_256) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_988: (in 0xA<16> : word16)
   Class: Eq_988
@@ -6864,12 +6467,12 @@ T_991: (in SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_992: (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_993: (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_994: (in SLICE(__swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_994
@@ -7016,8 +6619,8 @@ T_1029: (in a7_275 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1030: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1031: (in 0x30<32> : word32)
   Class: Eq_1031
@@ -7032,8 +6635,8 @@ T_1033: (in d1_303 - 0x30<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1034: (in d1_303 - 0x30<32> + d0_293 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_1035: (in 4<32> : word32)
   Class: Eq_1035
@@ -7212,8 +6815,8 @@ T_1078: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1079: (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1080: (in 4<i32> : int32)
   Class: Eq_1080
@@ -7244,12 +6847,12 @@ T_1086: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_1088 (T_1087)))
 T_1087: (in 10<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_1088: (in __swap(10<i32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_1089: (in SLICE(d2_1005, word16, 0) : word16)
   Class: Eq_1089
@@ -7276,8 +6879,8 @@ T_1094: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_1095 (T_795)))
 T_1095: (in __swap(d2_1005) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_1096: (in 0xA<16> : word16)
   Class: Eq_1096
@@ -7296,12 +6899,12 @@ T_1099: (in SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_1100: (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_1101: (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1102: (in SLICE(__swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_1102
@@ -7468,8 +7071,8 @@ T_1142: (in d1_196 - 0x30<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1143: (in d1_196 - 0x30<32> + d0_186 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_1144: (in 4<32> : word32)
   Class: Eq_1144
@@ -7500,8 +7103,8 @@ T_1150: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1151: (in Mem217[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1152: (in 0x6C<32> : word32)
   Class: Eq_785
@@ -7659,17 +7262,17 @@ T_1190: (in SEQ(SLICE(d1_103, word24, 8), v100_428) : uip32)
   Class: Eq_1188
   DataType: (ptr32 Eq_1188)
   OrigDataType: uip32
-T_1191: (in d0_1471 : Eq_1191)
+T_1191: (in d0_1471 : (ptr32 Eq_1355))
   Class: Eq_1191
-  DataType: Eq_1191
-  OrigDataType: word32
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_1192: (in SLICE(d0_159, word24, 8) : word24)
   Class: Eq_1192
   DataType: word24
   OrigDataType: word24
 T_1193: (in SEQ(SLICE(d0_159, word24, 8), v100_428) : uip32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: uip32
 T_1194: (in 0x25<8> : byte)
   Class: Eq_1181
@@ -7697,7 +7300,7 @@ T_1199: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1200: (in Mem465[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1197
-  DataType: Eq_8417
+  DataType: Eq_8411
   OrigDataType: word32
 T_1201: (in 00001E08 : ptr32)
   Class: Eq_663
@@ -7849,7 +7452,7 @@ T_1237: (in 2<32> : word32)
   OrigDataType: word32
 T_1238: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: ui32
 T_1239: (in 0<32> : word32)
   Class: Eq_1239
@@ -7877,7 +7480,7 @@ T_1244: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1245: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1242
-  DataType: Eq_8417
+  DataType: Eq_8411
   OrigDataType: word32
 T_1246: (in 4<32> : word32)
   Class: Eq_1246
@@ -7896,8 +7499,8 @@ T_1249: (in a1_661 : (ptr32 byte))
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct 0001 (0 byte b0000)))
 T_1250: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_1251: (in d5_256 == 0<32> : bool)
   Class: Eq_1251
@@ -7934,7 +7537,7 @@ T_1258: (in d3_1050 : ptr32)
 T_1259: (in a7_1020 : (ptr32 Eq_710))
   Class: Eq_710
   DataType: (ptr32 Eq_710)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1224 u2) (T_1230 u3) (T_1305 u4) (T_2364 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1355 u2) (T_1362 u3) (T_1373 u4) (T_1889 u5) (T_1954 u6) (T_1957 u7) (T_2025 u8) (T_2071 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1224 u2) (T_1230 u3) (T_1305 u4) (T_2364 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1355 u2) (T_1362 u3) (T_1373 u4) (T_1889 u5) (T_1954 u6) (T_1957 u7) (T_2025 u8) (T_2071 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
 T_1260: (in SLICE(d1_1068, byte, 0) : byte)
   Class: Eq_1260
   DataType: byte
@@ -8201,7 +7804,7 @@ T_1325: (in 8<i32> : int32)
   OrigDataType: int32
 T_1326: (in a7_1174 - 8<i32> : word32)
   Class: Eq_1326
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_1329 t0000)))
 T_1327: (in 0<32> : word32)
   Class: Eq_1327
@@ -8212,8 +7815,8 @@ T_1328: (in a7_1174 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1329: (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1330: (in 4<i32> : int32)
   Class: Eq_1330
@@ -8245,7 +7848,7 @@ T_1336: (in d1_1182 - (d0_1181 < null) >= 0<32> : bool)
   OrigDataType: bool
 T_1337: (in a2_1892 - a4_1925 : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_1338: (in 102<i32> : int32)
   Class: Eq_1338
@@ -8257,8 +7860,8 @@ T_1339: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1340: (in Mem756[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1191
-  DataType: Eq_8417
-  OrigDataType: Eq_1191
+  DataType: Eq_8411
+  OrigDataType: (ptr32 Eq_1355)
 T_1341: (in 0<32> : word32)
   Class: Eq_1341
   DataType: word32
@@ -8317,17 +7920,17 @@ T_1354: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1355: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1355
-  DataType: Eq_1355
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_1356: (in d5_256 - a7_1968->t0066 : word32)
   Class: Eq_1356
-  DataType: Eq_1356
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_1357: (in 0<32> : word32)
   Class: Eq_1356
-  DataType: ui24
+  DataType: (ptr32 Eq_1355)
   OrigDataType: up32
-T_1358: (in d5_256 - a7_1968->t0066 <= 0<32> : bool)
+T_1358: (in d5_256 - a7_1968->t0066 <= null : bool)
   Class: Eq_1358
   DataType: bool
   OrigDataType: bool
@@ -8341,12 +7944,12 @@ T_1360: (in 102<i32> : int32)
   OrigDataType: int32
 T_1361: (in a7_1968 + 102<i32> : word32)
   Class: Eq_1361
-  DataType: (ptr32 Eq_1361)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2)))
+  DataType: (ptr32 (ptr32 Eq_1355))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2)))
 T_1362: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1191
-  DataType: Eq_1191
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_1363: (in 0<32> : word32)
   Class: Eq_1363
   DataType: word32
@@ -8369,13 +7972,13 @@ T_1367: (in *a1_661 != 0<8> : bool)
   OrigDataType: bool
 T_1368: (in d5_256 - d0_1471 : word32)
   Class: Eq_1368
-  DataType: Eq_1368
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_1369: (in 0<32> : word32)
   Class: Eq_1368
-  DataType: ui24
+  DataType: (ptr32 Eq_1355)
   OrigDataType: up32
-T_1370: (in d5_256 - d0_1471 <= 0<32> : bool)
+T_1370: (in d5_256 - d0_1471 <= null : bool)
   Class: Eq_1370
   DataType: bool
   OrigDataType: bool
@@ -8385,20 +7988,20 @@ T_1371: (in 102<i32> : int32)
   OrigDataType: int32
 T_1372: (in a7_1968 + 102<i32> : word32)
   Class: Eq_1372
-  DataType: (ptr32 Eq_1372)
+  DataType: (ptr32 (ptr32 Eq_1355))
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (T_1355 u2) (T_1362 u3)))
 T_1373: (in Mem719[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1191
-  DataType: Eq_8417
-  OrigDataType: Eq_1191
+  DataType: Eq_8411
+  OrigDataType: (ptr32 Eq_1355)
 T_1374: (in 1<32> : word32)
   Class: Eq_1374
-  DataType: ui24
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_1375: (in d0_1471 + 1<32> : word32)
   Class: Eq_1191
-  DataType: Eq_1191
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_1376: (in 1<i32> : int32)
   Class: Eq_1376
   DataType: int32
@@ -8408,8 +8011,8 @@ T_1377: (in a1_661 + 1<i32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_1378: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: up32
 T_1379: (in d5_256 <= 0<32> : bool)
   Class: Eq_1379
@@ -8841,7 +8444,7 @@ T_1485: (in a7_1508 + 0<32> : word32)
   OrigDataType: ptr32
 T_1486: (in Mem1516[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_1487: (in 48<i32> : int32)
   Class: Eq_1487
@@ -8881,7 +8484,7 @@ T_1495: (in a7_1508 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_1496: (in Mem1531[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_1497: (in 0<32> : word32)
   Class: Eq_1497
@@ -8889,28 +8492,28 @@ T_1497: (in 0<32> : word32)
   OrigDataType: word32
 T_1498: (in a7_1508 + 0<32> : word32)
   Class: Eq_1498
-  DataType: (ptr32 Eq_1498)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2)))
+  DataType: (ptr32 (ptr32 Eq_1355))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2)))
 T_1499: (in Mem1537[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1191
-  DataType: Eq_1191
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
-T_1500: (in d0_1541 : Eq_1191)
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
+T_1500: (in d0_1541 : (ptr32 Eq_1355))
   Class: Eq_1191
-  DataType: Eq_1191
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_1501: (in 0<32> : word32)
   Class: Eq_1501
   DataType: word32
   OrigDataType: word32
 T_1502: (in a7_1508 + 0<32> : word32)
   Class: Eq_1502
-  DataType: (ptr32 Eq_1502)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2)))
+  DataType: (ptr32 (ptr32 Eq_1355))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2)))
 T_1503: (in Mem1537[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1191
-  DataType: Eq_1191
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_1504: (in 52<i32> : int32)
   Class: Eq_1504
   DataType: int32
@@ -9021,12 +8624,12 @@ T_1530: (in 0<32> : word32)
   OrigDataType: word32
 T_1531: (in a7_1508 + 0<32> : word32)
   Class: Eq_1531
-  DataType: (ptr32 Eq_1531)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2)))
+  DataType: (ptr32 (ptr32 Eq_1355))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2)))
 T_1532: (in Mem1546[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1191
-  DataType: Eq_1191
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_1533: (in 68<i32> : int32)
   Class: Eq_1533
   DataType: int32
@@ -9288,8 +8891,8 @@ T_1597: (in a7_1020 + 68<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1598: (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1599: (in 48<i32> : int32)
   Class: Eq_1599
@@ -9343,9 +8946,9 @@ T_1611: (in Mem1367[v187_1368 + 0<32>:word32] : word32)
   Class: Eq_1608
   DataType: word32
   OrigDataType: word32
-T_1612: (in d7_1371 : Eq_1191)
+T_1612: (in d7_1371 : (ptr32 Eq_1355))
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_1613: (in 4<i32> : int32)
   Class: Eq_1613
@@ -9357,7 +8960,7 @@ T_1614: (in v187_1368 + 4<i32> : word32)
   OrigDataType: ptr32
 T_1615: (in Mem1367[v187_1368 + 4<i32>:word32] : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_1616: (in d3_1373 : word32)
   Class: Eq_1616
@@ -9789,7 +9392,7 @@ T_1722: (in 20<i32> : int32)
   OrigDataType: int32
 T_1723: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1723
-  DataType: (ptr32 Eq_1191)
+  DataType: (ptr32 (ptr32 Eq_1355))
   OrigDataType: (ptr32 (struct (0 T_1726 t0000)))
 T_1724: (in 0<32> : word32)
   Class: Eq_1724
@@ -9801,7 +9404,7 @@ T_1725: (in a7_1383 - 20<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_1726: (in Mem1400[a7_1383 - 20<i32> + 0<32>:word32] : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_1727: (in 24<i32> : int32)
   Class: Eq_1727
@@ -9835,25 +9438,25 @@ T_1734: (in signature of fn0000279C : void)
   Class: Eq_1733
   DataType: (ptr32 Eq_1733)
   OrigDataType: 
-T_1735: (in dwArg04 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_1735: (in dwArg04 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_1736: (in dwArg08 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_1736: (in dwArg08 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_1737: (in dwArg0C : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_1737: (in dwArg0C : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_1738: (in dwArg10 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_1738: (in dwArg10 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_1739: (in a7_1383 - 24<i32> : word32)
   Class: Eq_1739
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_1742 t0000)))
 T_1740: (in 0<32> : word32)
   Class: Eq_1740
@@ -9864,8 +9467,8 @@ T_1741: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1742: (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1743: (in 20<i32> : int32)
   Class: Eq_1743
@@ -9873,7 +9476,7 @@ T_1743: (in 20<i32> : int32)
   OrigDataType: int32
 T_1744: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1744
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_1747 t0000)))
 T_1745: (in 0<32> : word32)
   Class: Eq_1745
@@ -9884,8 +9487,8 @@ T_1746: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1747: (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1748: (in 16<i32> : int32)
   Class: Eq_1748
@@ -9893,7 +9496,7 @@ T_1748: (in 16<i32> : int32)
   OrigDataType: int32
 T_1749: (in a7_1383 - 16<i32> : word32)
   Class: Eq_1749
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_1752 t0000)))
 T_1750: (in 0<32> : word32)
   Class: Eq_1750
@@ -9904,8 +9507,8 @@ T_1751: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1752: (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1753: (in 12<i32> : int32)
   Class: Eq_1753
@@ -9913,7 +9516,7 @@ T_1753: (in 12<i32> : int32)
   OrigDataType: int32
 T_1754: (in a7_1383 - 12<i32> : word32)
   Class: Eq_1754
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_1757 t0000)))
 T_1755: (in 0<32> : word32)
   Class: Eq_1755
@@ -9924,8 +9527,8 @@ T_1756: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1757: (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1758: (in fn0000279C(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>)) : word32)
   Class: Eq_1732
@@ -10121,7 +9724,7 @@ T_1805: (in 20<i32> : int32)
   OrigDataType: int32
 T_1806: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1806
-  DataType: (ptr32 Eq_1191)
+  DataType: (ptr32 (ptr32 Eq_1355))
   OrigDataType: (ptr32 (struct (0 T_1809 t0000)))
 T_1807: (in 0<32> : word32)
   Class: Eq_1807
@@ -10133,7 +9736,7 @@ T_1808: (in a7_1383 - 20<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_1809: (in Mem1444[a7_1383 - 20<i32> + 0<32>:word32] : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_1810: (in 24<i32> : int32)
   Class: Eq_1810
@@ -10155,9 +9758,9 @@ T_1814: (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
   Class: Eq_1608
   DataType: word32
   OrigDataType: word32
-T_1815: (in d1_1450 : Eq_1191)
+T_1815: (in d1_1450 : (ptr32 Eq_1355))
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: up32
 T_1816: (in d0_1449 : word32)
   Class: Eq_1608
@@ -10171,33 +9774,33 @@ T_1818: (in signature of fn00002454 : void)
   Class: Eq_1817
   DataType: (ptr32 Eq_1817)
   OrigDataType: 
-T_1819: (in dwArg04 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_1819: (in dwArg04 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_1820: (in dwArg08 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_1820: (in dwArg08 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_1821: (in dwArg0C : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_1821: (in dwArg0C : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_1822: (in dwArg10 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_1822: (in dwArg10 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_1823: (in d1Out : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_1823: (in d1Out : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
-T_1824: (in a0Out : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_1824: (in a0Out : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_1825: (in a7_1383 - 24<i32> : word32)
   Class: Eq_1825
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_1828 t0000)))
 T_1826: (in 0<32> : word32)
   Class: Eq_1826
@@ -10208,8 +9811,8 @@ T_1827: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1828: (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1829: (in 20<i32> : int32)
   Class: Eq_1829
@@ -10217,7 +9820,7 @@ T_1829: (in 20<i32> : int32)
   OrigDataType: int32
 T_1830: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1830
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_1833 t0000)))
 T_1831: (in 0<32> : word32)
   Class: Eq_1831
@@ -10228,8 +9831,8 @@ T_1832: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1833: (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1834: (in 16<i32> : int32)
   Class: Eq_1834
@@ -10237,7 +9840,7 @@ T_1834: (in 16<i32> : int32)
   OrigDataType: int32
 T_1835: (in a7_1383 - 16<i32> : word32)
   Class: Eq_1835
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_1838 t0000)))
 T_1836: (in 0<32> : word32)
   Class: Eq_1836
@@ -10248,8 +9851,8 @@ T_1837: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1838: (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1839: (in 12<i32> : int32)
   Class: Eq_1839
@@ -10257,7 +9860,7 @@ T_1839: (in 12<i32> : int32)
   OrigDataType: int32
 T_1840: (in a7_1383 - 12<i32> : word32)
   Class: Eq_1840
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_1843 t0000)))
 T_1841: (in 0<32> : word32)
   Class: Eq_1841
@@ -10268,16 +9871,16 @@ T_1842: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1843: (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_1844: (in out d1_1450 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_1845: (in out a0_1447 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: (ptr32 (struct (0 T_842 t0000)))
 T_1846: (in fn00002454(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>), out d1_1450, out a0_1447) : word32)
   Class: Eq_1608
@@ -10321,13 +9924,13 @@ T_1855: (in d3_1373 + 1<32> : word32)
   OrigDataType: word32
 T_1856: (in 0<32> : word32)
   Class: Eq_1191
-  DataType: ui24
+  DataType: (ptr32 Eq_1355)
   OrigDataType: up32
-T_1857: (in d1_1450 < 0<32> : bool)
+T_1857: (in d1_1450 < null : bool)
   Class: Eq_1857
   DataType: Eq_1857
   OrigDataType: (union (bool u0) (word32 u1))
-T_1858: (in d0_1449 - (d1_1450 < 0<32>) : word32)
+T_1858: (in d0_1449 - (d1_1450 < null) : word32)
   Class: Eq_1858
   DataType: word32
   OrigDataType: word32
@@ -10335,7 +9938,7 @@ T_1859: (in 0<32> : word32)
   Class: Eq_1858
   DataType: word32
   OrigDataType: word32
-T_1860: (in d0_1449 - (d1_1450 < 0<32>) != 0<32> : bool)
+T_1860: (in d0_1449 - (d1_1450 < null) != 0<32> : bool)
   Class: Eq_1860
   DataType: bool
   OrigDataType: bool
@@ -11703,22 +11306,22 @@ T_2201: (in Mem1091[a7_1057 + 0<32>:word32] : word32)
   Class: Eq_1188
   DataType: (ptr32 Eq_1188)
   OrigDataType: int32
-T_2202: (in v248_1105 : Eq_2202)
+T_2202: (in v248_1105 : byte)
   Class: Eq_2202
-  DataType: Eq_2202
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2203: (in 55<i32> : int32)
   Class: Eq_2203
   DataType: int32
   OrigDataType: int32
 T_2204: (in a7_1968 + 55<i32> : word32)
   Class: Eq_2204
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2205: (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
   Class: Eq_2202
-  DataType: Eq_2202
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2206: (in a7_1109 : (ptr32 Eq_2206))
   Class: Eq_2206
   DataType: (ptr32 Eq_2206)
@@ -11933,8 +11536,8 @@ T_2258: (in 56<i32> : int32)
   OrigDataType: int32
 T_2259: (in a7_1968 + 56<i32> : word32)
   Class: Eq_2259
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2260: (in Mem836[a7_1968 + 56<i32>:word32] : word32)
   Class: Eq_2257
   DataType: word32
@@ -11963,22 +11566,22 @@ T_2266: (in d4_376 != 2<32> : bool)
   Class: Eq_2266
   DataType: bool
   OrigDataType: bool
-T_2267: (in v262_844 : Eq_2267)
+T_2267: (in v262_844 : word16)
   Class: Eq_2267
-  DataType: Eq_2267
-  OrigDataType: (union (word16 u0) (word32 u1))
+  DataType: word16
+  OrigDataType: word16
 T_2268: (in 62<i32> : int32)
   Class: Eq_2268
   DataType: int32
   OrigDataType: int32
 T_2269: (in a7_1968 + 62<i32> : word32)
   Class: Eq_2269
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2270: (in Mem843[a7_1968 + 62<i32>:word16] : word16)
   Class: Eq_2267
-  DataType: Eq_2267
-  OrigDataType: word32
+  DataType: word16
+  OrigDataType: word16
 T_2271: (in a7_848 : (ptr32 Eq_2271))
   Class: Eq_2271
   DataType: (ptr32 Eq_2271)
@@ -12233,7 +11836,7 @@ T_2333: (in 2<32> : word32)
   OrigDataType: word32
 T_2334: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: ui32
 T_2335: (in 0<32> : word32)
   Class: Eq_2335
@@ -12241,8 +11844,8 @@ T_2335: (in 0<32> : word32)
   OrigDataType: word32
 T_2336: (in d0_1471 + 0<32> : word32)
   Class: Eq_2336
-  DataType: Eq_2336
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_2337: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_820
   DataType: (ptr32 Eq_820)
@@ -12363,22 +11966,22 @@ T_2366: (in d0_891 == 0<32> : bool)
   Class: Eq_2366
   DataType: bool
   OrigDataType: bool
-T_2367: (in v277_869 : Eq_2367)
+T_2367: (in v277_869 : byte)
   Class: Eq_2367
-  DataType: Eq_2367
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2368: (in 63<i32> : int32)
   Class: Eq_2368
   DataType: int32
   OrigDataType: int32
 T_2369: (in a7_1968 + 63<i32> : word32)
   Class: Eq_2369
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2370: (in Mem868[a7_1968 + 63<i32>:byte] : byte)
   Class: Eq_2367
-  DataType: Eq_2367
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2371: (in a7_873 : (ptr32 Eq_2371))
   Class: Eq_2371
   DataType: (ptr32 Eq_2371)
@@ -12481,7 +12084,7 @@ T_2395: (in 2<32> : word32)
   OrigDataType: word32
 T_2396: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: ui32
 T_2397: (in 0<32> : word32)
   Class: Eq_2397
@@ -12489,8 +12092,8 @@ T_2397: (in 0<32> : word32)
   OrigDataType: word32
 T_2398: (in d0_1471 + 0<32> : word32)
   Class: Eq_2398
-  DataType: Eq_2398
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_2399: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_820
   DataType: (ptr32 Eq_820)
@@ -12532,8 +12135,8 @@ T_2408: (in (byte) d1_1068 == 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_2409: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_2410: (in d5_256 != 0<32> : bool)
   Class: Eq_2410
@@ -12641,7 +12244,7 @@ T_2435: (in 8<i32> : int32)
   OrigDataType: int32
 T_2436: (in a7_911 - 8<i32> : word32)
   Class: Eq_2436
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_2439 t0000)))
 T_2437: (in 0<32> : word32)
   Class: Eq_2437
@@ -12652,12 +12255,12 @@ T_2438: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2439: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_2440: (in a7_911 - 8<i32> : word32)
   Class: Eq_2440
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_2443 t0000)))
 T_2441: (in 0<32> : word32)
   Class: Eq_2441
@@ -12668,8 +12271,8 @@ T_2442: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2443: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_2444: (in 4<i32> : int32)
   Class: Eq_2444
@@ -12753,7 +12356,7 @@ T_2463: (in 2<32> : word32)
   OrigDataType: word32
 T_2464: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: ui32
 T_2465: (in 0<32> : word32)
   Class: Eq_2465
@@ -12761,8 +12364,8 @@ T_2465: (in 0<32> : word32)
   OrigDataType: word32
 T_2466: (in d0_1471 + 0<32> : word32)
   Class: Eq_2466
-  DataType: Eq_2466
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_2467: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_820
   DataType: (ptr32 Eq_820)
@@ -12881,7 +12484,7 @@ T_2495: (in 8<i32> : int32)
   OrigDataType: int32
 T_2496: (in a7_992 - 8<i32> : word32)
   Class: Eq_2496
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_2499 t0000)))
 T_2497: (in 0<32> : word32)
   Class: Eq_2497
@@ -12892,8 +12495,8 @@ T_2498: (in a7_992 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2499: (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_2500: (in d1_1017 : word32)
   Class: Eq_2500
@@ -13069,7 +12672,7 @@ T_2542: (in 2<32> : word32)
   OrigDataType: word32
 T_2543: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: ui32
 T_2544: (in 0<32> : word32)
   Class: Eq_2544
@@ -13077,8 +12680,8 @@ T_2544: (in 0<32> : word32)
   OrigDataType: word32
 T_2545: (in d0_1471 + 0<32> : word32)
   Class: Eq_2545
-  DataType: Eq_2545
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_2546: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_820
   DataType: (ptr32 Eq_820)
@@ -13117,7 +12720,7 @@ T_2554: (in 2<32> : word32)
   OrigDataType: word32
 T_2555: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: ui32
 T_2556: (in 0<32> : word32)
   Class: Eq_2556
@@ -13125,8 +12728,8 @@ T_2556: (in 0<32> : word32)
   OrigDataType: word32
 T_2557: (in d0_1471 + 0<32> : word32)
   Class: Eq_2557
-  DataType: Eq_2557
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_2558: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_820
   DataType: (ptr32 Eq_820)
@@ -13169,7 +12772,7 @@ T_2567: (in 2<32> : word32)
   OrigDataType: word32
 T_2568: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: ui32
 T_2569: (in 3<32> : word32)
   Class: Eq_2569
@@ -13177,8 +12780,8 @@ T_2569: (in 3<32> : word32)
   OrigDataType: word32
 T_2570: (in d0_1471 + 3<32> : word32)
   Class: Eq_2570
-  DataType: Eq_2570
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_2571: (in Mem341[d0_1471 + 3<32>:byte] : byte)
   Class: Eq_2571
   DataType: byte
@@ -13217,7 +12820,7 @@ T_2579: (in 2<32> : word32)
   OrigDataType: word32
 T_2580: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1191
-  DataType: Eq_1191
+  DataType: (ptr32 Eq_1355)
   OrigDataType: ui32
 T_2581: (in 3<32> : word32)
   Class: Eq_2581
@@ -13225,8 +12828,8 @@ T_2581: (in 3<32> : word32)
   OrigDataType: word32
 T_2582: (in d0_1471 + 3<32> : word32)
   Class: Eq_2582
-  DataType: Eq_2582
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: (ptr32 Eq_1355)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_2583: (in Mem341[d0_1471 + 3<32>:byte] : byte)
   Class: Eq_2583
   DataType: byte
@@ -13281,7 +12884,7 @@ T_2595: (in ((word32) d3_1482 + 3<i32> >> 2<32> << 2<32>) + 4<32> : word32)
   OrigDataType: ui32
 T_2596: (in 1<32> : word32)
   Class: Eq_2596
-  DataType: int32
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_2597: (in 102<i32> : int32)
   Class: Eq_2597
@@ -13293,8 +12896,8 @@ T_2598: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (Eq_1355 u2) (Eq_1191 u3) (Eq_1191 u4) (Eq_1889 u5) (Eq_1951 u6) (Eq_1957 u7) (Eq_2025 u8) (Eq_2068 u9)))
 T_2599: (in Mem525[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_2596
-  DataType: Eq_8417
-  OrigDataType: int32
+  DataType: Eq_8411
+  OrigDataType: (ptr32 Eq_1355)
 T_2600: (in 0<i32> : int32)
   Class: Eq_1180
   DataType: int32
@@ -16431,29 +16034,29 @@ T_3383: (in fn0000131C(0x14<u32>, out d1_21, out a1, out a5) : word32)
   Class: Eq_607
   DataType: word32
   OrigDataType: word32
-T_3384: (in d0 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3384: (in d0 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3385: (in d0_196 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: uint8
-T_3386: (in d1_142 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3385: (in d0_196 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: (ptr32 Eq_1355)
+T_3386: (in d1_142 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_3387: (in a0_20 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3387: (in a0_20 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
-T_3388: (in d3_166 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3388: (in d3_166 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
 T_3389: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_3390: (in dwArg0C != 0<32> : bool)
   Class: Eq_3390
@@ -16484,8 +16087,8 @@ T_3396: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_3397: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_3398: (in dwArg10 != 0<32> : bool)
   Class: Eq_3398
@@ -16507,41 +16110,41 @@ T_3402: (in signature of fn00002558 : void)
   Class: Eq_3401
   DataType: (ptr32 Eq_3401)
   OrigDataType: 
-T_3403: (in d0 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3403: (in d0 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: (union (int32 u1) (up32 u0))
-T_3404: (in d1 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3404: (in d1 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: up32
-T_3405: (in d2 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3405: (in d2 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: (union (int32 u0) (up32 u1))
-T_3406: (in d1Out : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3406: (in d1Out : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
-T_3407: (in d2Out : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3407: (in d2Out : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3408: (in out d1_318 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3409: (in out d2_319 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3410: (in fn00002558(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3411: (in 0<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_3412: (in d4_29 : int32)
   Class: Eq_3412
@@ -16551,9 +16154,9 @@ T_3413: (in 24<i32> : int32)
   Class: Eq_3412
   DataType: int32
   OrigDataType: int32
-T_3414: (in d6_30 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3414: (in d6_30 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uip32
 T_3415: (in __rol : ptr32)
   Class: Eq_3415
@@ -16564,20 +16167,20 @@ T_3416: (in signature of __rol : void)
   DataType: (ptr32 Eq_3415)
   OrigDataType: 
 T_3417: (in  : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: 
 T_3418: (in  : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: 
 T_3419: (in 8<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_3420: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3421: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3421
@@ -16680,12 +16283,12 @@ T_3445: (in __rol : ptr32)
   DataType: (ptr32 Eq_3415)
   OrigDataType: (ptr32 (fn T_3447 (T_3414, T_3446)))
 T_3446: (in 8<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_3447: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3448: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3448
@@ -16708,12 +16311,12 @@ T_3452: (in __rol : ptr32)
   DataType: (ptr32 Eq_3415)
   OrigDataType: (ptr32 (fn T_3454 (T_3414, T_3453)))
 T_3453: (in 8<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_3454: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3455: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3455
@@ -16740,40 +16343,40 @@ T_3460: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_3461: (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uip32
-T_3462: (in d1_175 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3462: (in d1_175 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3463: (in d2_176 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3463: (in d2_176 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3464: (in d0_174 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3464: (in d0_174 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3465: (in fn00002558 : ptr32)
   Class: Eq_3401
   DataType: (ptr32 Eq_3401)
   OrigDataType: (ptr32 (fn T_3469 (T_3466, T_1819, T_3388, T_3467, T_3468)))
 T_3466: (in 0<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_3467: (in out d1_175 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3468: (in out d2_176 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3469: (in fn00002558(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3470: (in d2_321 : word32)
   Class: Eq_3470
@@ -16788,16 +16391,16 @@ T_3472: (in fn00002558 : ptr32)
   DataType: (ptr32 Eq_3401)
   OrigDataType: (ptr32 (fn T_3475 (T_3462, T_1820, T_3463, T_3473, T_3474)))
 T_3473: (in out d1_320 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3474: (in out d2_321 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3475: (in fn00002558(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3476: (in 1<i32> : int32)
   Class: Eq_3476
@@ -16840,8 +16443,8 @@ T_3485: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_3486: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
 T_3487: (in d1_86 : word32)
   Class: Eq_3487
@@ -16851,17 +16454,17 @@ T_3488: (in d2_322 : word32)
   Class: Eq_3488
   DataType: word32
   OrigDataType: word32
-T_3489: (in d0_85 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3489: (in d0_85 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3490: (in fn00002558 : ptr32)
   Class: Eq_3401
   DataType: (ptr32 Eq_3401)
   OrigDataType: (ptr32 (fn T_3500 (T_3491, T_3494, T_3497, T_3498, T_3499)))
 T_3491: (in dwArg04 >> d4_61 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3492: (in dwArg04 << d5_63 : word32)
   Class: Eq_3492
@@ -16872,8 +16475,8 @@ T_3493: (in dwArg08 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3494: (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_3495: (in dwArg0C << d5_63 : word32)
   Class: Eq_3495
@@ -16884,52 +16487,52 @@ T_3496: (in dwArg10 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3497: (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_3498: (in out d1_86 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3499: (in out d2_322 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3500: (in fn00002558(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3501: (in d3_72 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3501: (in d3_72 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3502: (in dwArg10 << d5_63 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
-T_3503: (in d5_101 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3503: (in d5_101 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3504: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3505 (T_3489)))
 T_3505: (in __swap(d0_85) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3506: (in d6_103 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3506: (in d6_103 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3507: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3508 (T_3501)))
 T_3508: (in __swap(d3_72) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3509: (in d3_102 : uint32)
   Class: Eq_3509
@@ -16943,9 +16546,9 @@ T_3511: (in d3_72 * (word16) d5_101 : word32)
   Class: Eq_3509
   DataType: uint32
   OrigDataType: uint32
-T_3512: (in d2_107 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3512: (in d2_107 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3513: (in __swap : ptr32)
   Class: Eq_976
@@ -16956,12 +16559,12 @@ T_3514: (in SLICE(d3_72, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3515: (in d0_85 * (word16) d3_72 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3516: (in __swap(d0_85 * (word16) d3_72) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3517: (in v34_108 : cup16)
   Class: Eq_3517
@@ -17011,29 +16614,29 @@ T_3528: (in SLICE(SEQ(v35_109, v34_108) + d4_104, word16, 0) : word16)
   Class: Eq_3525
   DataType: cup16
   OrigDataType: word16
-T_3529: (in d6_82 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3529: (in d6_82 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3530: (in dwArg08 << d5_63 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
-T_3531: (in d2_124 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3531: (in d2_124 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3532: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3534 (T_3533)))
 T_3533: (in SEQ(v35_109, v39_116) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3534: (in __swap(SEQ(v35_109, v39_116)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3535: (in d5_105 : uint32)
   Class: Eq_3535
@@ -17064,12 +16667,12 @@ T_3541: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3542: (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3543: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3544: (in __swap : ptr32)
   Class: Eq_976
@@ -17084,12 +16687,12 @@ T_3546: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3547: (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3548: (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3549: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
   Class: Eq_3549
@@ -17176,8 +16779,8 @@ T_3569: (in 1<32> : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3570: (in d0_85 - 1<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3571: (in 0<32> : word32)
   Class: Eq_3538
@@ -17199,13 +16802,13 @@ T_3575: (in d6_82 - d2_124 >= 0<32> : bool)
   Class: Eq_3575
   DataType: bool
   OrigDataType: bool
-T_3576: (in d7_13 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3576: (in d7_13 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: (union (int32 u0) (uint32 u1))
 T_3577: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_3578: (in d2 == 0<32> : bool)
   Class: Eq_3578
@@ -17219,57 +16822,57 @@ T_3580: (in signature of fn00002716 : void)
   Class: Eq_3579
   DataType: (ptr32 Eq_3579)
   OrigDataType: 
-T_3581: (in d0 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3581: (in d0 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_3582: (in d1 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3582: (in d1 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3583: (in d2 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3583: (in d2 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3584: (in d1Out : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3584: (in d1Out : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3585: (in out d1 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3586: (in fn00002716(d1, d2, d2, out d1) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3587: (in d6_17 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3587: (in d6_17 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_3588: (in d5_19 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3588: (in d5_19 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3589: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_3590: (in d0 != 0<32> : bool)
   Class: Eq_3590
   DataType: bool
   OrigDataType: bool
-T_3591: (in d2_22 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3591: (in d2_22 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3592: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3593 (T_3405)))
 T_3593: (in __swap(d2) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3594: (in SLICE(d2_22, word16, 0) : word16)
   Class: Eq_3594
@@ -17284,8 +16887,8 @@ T_3596: (in (word16) d2_22 != 0<16> : bool)
   DataType: bool
   OrigDataType: bool
 T_3597: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_3598: (in d1 == 0<32> : bool)
   Class: Eq_3598
@@ -17320,36 +16923,36 @@ T_3605: (in 0<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_3606: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_3607: (in d2 < 0<32> : bool)
   Class: Eq_3607
   DataType: bool
   OrigDataType: bool
-T_3608: (in d0_281 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3608: (in d0_281 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3609: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3610 (T_3403)))
 T_3610: (in __swap(d0) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3611: (in d1_282 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3611: (in d1_282 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3612: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3613 (T_3404)))
 T_3613: (in __swap(d1) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3614: (in d0_285 : uint32)
   Class: Eq_3614
@@ -17388,8 +16991,8 @@ T_3622: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3623 (T_3611)))
 T_3623: (in __swap(d1_282) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3624: (in SLICE(__swap(d1_282), word16, 0) : word16)
   Class: Eq_3624
@@ -17416,12 +17019,12 @@ T_3629: (in (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3630: (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3631: (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3632: (in SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16) : word16)
   Class: Eq_3632
@@ -17440,8 +17043,8 @@ T_3635: (in (uint16) (d0_295 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3636: (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3637: (in __swap : ptr32)
   Class: Eq_976
@@ -17464,12 +17067,12 @@ T_3641: (in 0<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3642: (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3643: (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3644: (in v41_64 : word16)
   Class: Eq_3644
@@ -17484,8 +17087,8 @@ T_3646: (in 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3647: (in d6_17 * 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_3648: (in SLICE(d0_44, word16, 16) : word16)
   Class: Eq_3648
@@ -17516,28 +17119,28 @@ T_3654: (in d5_19 * 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3655: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: up32
 T_3656: (in d6_17 < 0<32> : bool)
   Class: Eq_3656
   DataType: bool
   OrigDataType: bool
 T_3657: (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_3658: (in 2<32> : word32)
   Class: Eq_3658
   DataType: ui32
   OrigDataType: ui32
 T_3659: (in d7_13 * 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_3660: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_3661: (in d7_13 > 0<32> : bool)
   Class: Eq_3661
@@ -17551,9 +17154,9 @@ T_3663: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3672 (T_3671)))
-T_3664: (in d3_74 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3664: (in d3_74 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3665: (in SLICE(d3_74, uint16, 0) : uint16)
   Class: Eq_3665
@@ -17580,12 +17183,12 @@ T_3670: (in (uint16) (d5_19 /u SLICE(d3_74, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3671: (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3672: (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3673: (in SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16) : word16)
   Class: Eq_3673
@@ -17596,24 +17199,24 @@ T_3674: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3675: (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3676: (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3677: (in d1_104 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: uint8
+T_3677: (in d1_104 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: (ptr32 Eq_1355)
 T_3678: (in 0xFFFF<32> : uipr32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: uipr32
-T_3679: (in d6_98 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3679: (in d6_98 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3680: (in __swap : ptr32)
   Class: Eq_976
@@ -17628,48 +17231,48 @@ T_3682: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3683: (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3684: (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3685: (in d6_133 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3685: (in d6_133 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3686: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3687 (T_3677)))
 T_3687: (in __swap(d1_104) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3688: (in d3_140 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3688: (in d3_140 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3689: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3690 (T_3685)))
 T_3690: (in __swap(d6_133) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3691: (in d4_142 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3691: (in d4_142 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3692: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3693 (T_3576)))
 T_3693: (in __swap(d7_13) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3694: (in d5_141 : uint32)
   Class: Eq_3694
@@ -17683,9 +17286,9 @@ T_3696: (in d7_13 * (word16) d3_140 : word32)
   Class: Eq_3694
   DataType: uint32
   OrigDataType: uint32
-T_3697: (in d6_146 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3697: (in d6_146 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3698: (in __swap : ptr32)
   Class: Eq_976
@@ -17696,12 +17299,12 @@ T_3699: (in SLICE(d7_13, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3700: (in d6_133 * (word16) d7_13 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3701: (in __swap(d6_133 * (word16) d7_13) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3702: (in v55_147 : cup16)
   Class: Eq_3702
@@ -17763,29 +17366,29 @@ T_3716: (in d3_140 * (word16) d4_142 : word32)
   Class: Eq_3714
   DataType: uint32
   OrigDataType: uint32
-T_3717: (in d6_178 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3717: (in d6_178 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3718: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3720 (T_3719)))
 T_3719: (in SEQ(v56_148, v59_155) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3720: (in __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3721: (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3722: (in d5_181 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3723: (in __swap : ptr32)
   Class: Eq_976
@@ -17800,12 +17403,12 @@ T_3725: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3726: (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3727: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3728: (in __swap : ptr32)
   Class: Eq_976
@@ -17820,12 +17423,12 @@ T_3730: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3731: (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3732: (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3733: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
   Class: Eq_3733
@@ -17876,20 +17479,20 @@ T_3744: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ
   DataType: uint32
   OrigDataType: uint32
 T_3745: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: up32
 T_3746: (in d6_178 <u 0<32> : bool)
   Class: Eq_3746
   DataType: Eq_3746
   OrigDataType: (union (bool u0) (uint32 u1))
 T_3747: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3748: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: up32
 T_3749: (in d5_181 >= 0<32> : bool)
   Class: Eq_3749
@@ -17920,12 +17523,12 @@ T_3755: (in 1<32> : word32)
   DataType: uipr32
   OrigDataType: uipr32
 T_3756: (in d1_104 - 1<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
-T_3757: (in d4_113 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3757: (in d4_113 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3758: (in __swap : ptr32)
   Class: Eq_976
@@ -17936,8 +17539,8 @@ T_3759: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3760 (T_3576)))
 T_3760: (in __swap(d7_13) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3761: (in SLICE(d1_104, word16, 0) : word16)
   Class: Eq_3761
@@ -17948,12 +17551,12 @@ T_3762: (in __swap(d7_13) * (word16) d1_104 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3763: (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3764: (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3765: (in wLoc22_442 : word16)
   Class: Eq_3765
@@ -18012,8 +17615,8 @@ T_3778: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3779 (T_3576)))
 T_3779: (in __swap(d7_13) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3780: (in SLICE(__swap(d7_13), word16, 16) : word16)
   Class: Eq_3780
@@ -18028,20 +17631,20 @@ T_3782: (in SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : uipr32)
   DataType: uipr32
   OrigDataType: uipr32
 T_3783: (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3784: (in 1<32> : word32)
   Class: Eq_3784
   DataType: uint32
   OrigDataType: uint32
 T_3785: (in d1_104 - 1<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3786: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: up32
 T_3787: (in d6_178 < 0<32> : bool)
   Class: Eq_3787
@@ -18064,20 +17667,20 @@ T_3791: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3792: (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3793: (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3794: (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_3795: (in d6_220 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3795: (in d6_220 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3796: (in __swap : ptr32)
   Class: Eq_976
@@ -18092,12 +17695,12 @@ T_3798: (in SLICE(d5_181, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3799: (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3800: (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3801: (in SLICE(dwLoc24, word16, 16) : word16)
   Class: Eq_3801
@@ -18108,20 +17711,20 @@ T_3802: (in SLICE(d1_104, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3803: (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
-T_3804: (in d5_221 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3804: (in d5_221 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3805: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3806 (T_3722)))
 T_3806: (in __swap(d5_181) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3807: (in v82_224 : word16)
   Class: Eq_3807
@@ -18139,29 +17742,29 @@ T_3810: (in v41_64 == 0<16> : bool)
   Class: Eq_3810
   DataType: bool
   OrigDataType: bool
-T_3811: (in d5_266 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3811: (in d5_266 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3812: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3813 (T_3722)))
 T_3813: (in __swap(d5_181) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3814: (in d6_267 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3814: (in d6_267 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3815: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3816 (T_3717)))
 T_3816: (in __swap(d6_178) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3817: (in SLICE(d5_266, word16, 16) : word16)
   Class: Eq_3817
@@ -18172,8 +17775,8 @@ T_3818: (in SLICE(d6_267, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3819: (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3820: (in SLICE(d6_267, word16, 16) : word16)
   Class: Eq_3820
@@ -18184,8 +17787,8 @@ T_3821: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3822: (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3823: (in true : bool)
   Class: Eq_3602
@@ -18199,25 +17802,25 @@ T_3825: (in SEQ(SLICE(d1_104, word16, 0), wLoc22_442) : word32)
   Class: Eq_3766
   DataType: word32
   OrigDataType: word32
-T_3826: (in d2_73 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3826: (in d2_73 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3827: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3828 (T_3588)))
 T_3828: (in __swap(d5_19) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3829: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3830 (T_3576)))
 T_3830: (in __swap(d7_13) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3831: (in d2_73 - d3_74 : word32)
   Class: Eq_3831
@@ -18256,8 +17859,8 @@ T_3839: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3840: (in d5_221 >> 1<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3841: (in v86_241 : word16)
   Class: Eq_3841
@@ -18276,8 +17879,8 @@ T_3844: (in signature of __rcr : void)
   DataType: (ptr32 Eq_3843)
   OrigDataType: 
 T_3845: (in  : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: 
 T_3846: (in  : word32)
   Class: Eq_3846
@@ -18300,8 +17903,8 @@ T_3850: (in SLICE(cond(d5_221), bool, 4) : bool)
   DataType: bool
   OrigDataType: bool
 T_3851: (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3852: (in SLICE(d7_230, word16, 16) : word16)
   Class: Eq_3852
@@ -18327,49 +17930,49 @@ T_3857: (in v86_241 != 0<16> : bool)
   Class: Eq_3857
   DataType: bool
   OrigDataType: bool
-T_3858: (in d0 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3858: (in d0 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3859: (in d2 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3859: (in d2 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3860: (in dwArg04 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3860: (in dwArg04 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
-T_3861: (in dwArg08 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3861: (in dwArg08 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
 T_3862: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_3863: (in dwArg04 > 0<32> : bool)
   Class: Eq_3863
   DataType: bool
   OrigDataType: bool
 T_3864: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_3865: (in dwArg08 > 0<32> : bool)
   Class: Eq_3865
   DataType: bool
   OrigDataType: bool
-T_3866: (in d0_36 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3866: (in d0_36 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
 T_3867: (in -dwArg04 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
 T_3868: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_3869: (in dwArg08 > 0<32> : bool)
   Class: Eq_3869
@@ -18384,16 +17987,16 @@ T_3871: (in fn00002716 : ptr32)
   DataType: (ptr32 Eq_3579)
   OrigDataType: (ptr32 (fn T_3873 (T_3866, T_3861, T_3859, T_3872)))
 T_3872: (in out d1_43 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3873: (in fn00002716(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3874: (in -fn00002716(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3875: (in d1_55 : word32)
   Class: Eq_3875
@@ -18404,16 +18007,16 @@ T_3876: (in fn00002716 : ptr32)
   DataType: (ptr32 Eq_3579)
   OrigDataType: (ptr32 (fn T_3879 (T_3866, T_3877, T_3859, T_3878)))
 T_3877: (in -dwArg08 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
 T_3878: (in out d1_55 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3879: (in fn00002716(d0_36, -dwArg08, d2, out d1_55) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3880: (in d1_88 : word32)
   Class: Eq_3880
@@ -18424,12 +18027,12 @@ T_3881: (in fn00002716 : ptr32)
   DataType: (ptr32 Eq_3579)
   OrigDataType: (ptr32 (fn T_3883 (T_3860, T_3861, T_3859, T_3882)))
 T_3882: (in out d1_88 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3883: (in fn00002716(dwArg04, dwArg08, d2, out d1_88) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3884: (in d1_89 : word32)
   Class: Eq_3884
@@ -18440,32 +18043,32 @@ T_3885: (in fn00002716 : ptr32)
   DataType: (ptr32 Eq_3579)
   OrigDataType: (ptr32 (fn T_3888 (T_3860, T_3886, T_3859, T_3887)))
 T_3886: (in -dwArg08 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
 T_3887: (in out d1_89 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_3888: (in fn00002716(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3889: (in -fn00002716(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3890: (in d1_22 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3890: (in d1_22 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3891: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3892 (T_3582)))
 T_3892: (in __swap(d1) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3893: (in v10_9 : word16)
   Class: Eq_3893
@@ -18483,13 +18086,13 @@ T_3896: (in SLICE(d2, word16, 16) : word16)
   Class: Eq_3895
   DataType: word16
   OrigDataType: word16
-T_3897: (in d2_11 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3897: (in d2_11 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3898: (in SEQ(v11_10, v10_9) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3899: (in 0<16> : word16)
   Class: Eq_3893
@@ -18499,13 +18102,13 @@ T_3900: (in v10_9 != 0<16> : bool)
   Class: Eq_3900
   DataType: bool
   OrigDataType: bool
-T_3901: (in d3_18 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: uint8
+T_3901: (in d3_18 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: (ptr32 Eq_1355)
 T_3902: (in 16<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_3903: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3903
@@ -18519,29 +18122,29 @@ T_3905: (in (word16) d1_22 >= 0x80<16> : bool)
   Class: Eq_3905
   DataType: bool
   OrigDataType: bool
-T_3906: (in d0_134 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3906: (in d0_134 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3907: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3908 (T_3581)))
 T_3908: (in __swap(d0) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_3909: (in d1_135 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3909: (in d1_135 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3910: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3911 (T_3890)))
 T_3911: (in __swap(d1_22) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3912: (in v14_137 : word16)
   Class: Eq_3912
@@ -18560,8 +18163,8 @@ T_3915: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3916 (T_3897)))
 T_3916: (in __swap(d2_11) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3917: (in SLICE(__swap(d2_11), word16, 16) : word16)
   Class: Eq_3917
@@ -18579,17 +18182,17 @@ T_3920: (in v14_137 == 0<16> : bool)
   Class: Eq_3920
   DataType: bool
   OrigDataType: bool
-T_3921: (in d0_150 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_3921: (in d0_150 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3922: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3923 (T_3906)))
 T_3923: (in __swap(d0_134) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3924: (in d2_154 : uint32)
   Class: Eq_3924
@@ -18644,28 +18247,28 @@ T_3936: (in (uint16) (d2_154 % SLICE(d1_135, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3937: (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_3938: (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3939: (in SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0) : word16)
   Class: Eq_3939
   DataType: word16
   OrigDataType: word16
 T_3940: (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3941: (in SLICE(d0_150, word16, 16) : word16)
   Class: Eq_3941
   DataType: word16
   OrigDataType: word16
 T_3942: (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3943: (in v17_143 : uint16)
   Class: Eq_3943
@@ -18704,8 +18307,8 @@ T_3951: (in SLICE(d0_134, word16, 16) : word16)
   DataType: word16
   OrigDataType: word16
 T_3952: (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3953: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3953
@@ -18724,16 +18327,16 @@ T_3956: (in __rol : ptr32)
   DataType: (ptr32 Eq_3415)
   OrigDataType: (ptr32 (fn T_3958 (T_3890, T_3957)))
 T_3957: (in 8<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_3958: (in __rol(d1_22, 8<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3959: (in 8<32> : uipr32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: uipr32
 T_3960: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3960
@@ -18752,12 +18355,12 @@ T_3963: (in __rol : ptr32)
   DataType: (ptr32 Eq_3415)
   OrigDataType: (ptr32 (fn T_3965 (T_3890, T_3964)))
 T_3964: (in 4<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_3965: (in __rol(d1_22, 4<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3966: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_3966
@@ -18776,8 +18379,8 @@ T_3969: (in (word16) d3_18 - 4<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3970: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3971: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3971
@@ -18796,12 +18399,12 @@ T_3974: (in __rol : ptr32)
   DataType: (ptr32 Eq_3415)
   OrigDataType: (ptr32 (fn T_3976 (T_3890, T_3975)))
 T_3975: (in 2<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_3976: (in __rol(d1_22, 2<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3977: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_3977
@@ -18820,8 +18423,8 @@ T_3980: (in (word16) d3_18 - 2<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3981: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3982: (in d0_71 : uint32)
   Class: Eq_3982
@@ -18844,12 +18447,12 @@ T_3986: (in SLICE(d0, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3987: (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_3988: (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3989: (in SLICE(__swap(SEQ(v11_10, (word16) d0)), word16, 16) : word16)
   Class: Eq_3989
@@ -18876,8 +18479,8 @@ T_3994: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_3995 (T_3901)))
 T_3995: (in __swap(d3_18) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_3996: (in SLICE(__swap(d3_18), word16, 16) : word16)
   Class: Eq_3993
@@ -18899,29 +18502,29 @@ T_4000: (in (uint16) (d0_71 /u SLICE(d1_22, uint16, 0)) : uint16)
   Class: Eq_3997
   DataType: uint16
   OrigDataType: uint16
-T_4001: (in d1_90 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4001: (in d1_90 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4002: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_4003 (T_3890)))
 T_4003: (in __swap(d1_22) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_4004: (in d3_102 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4004: (in d3_102 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_4005: (in SEQ(v53_82, v51_79) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
-T_4006: (in d0_108 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4006: (in d0_108 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4007: (in SLICE(d1_22, uint16, 0) : uint16)
   Class: Eq_4007
@@ -18960,12 +18563,12 @@ T_4015: (in SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4016: (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4017: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: up32
 T_4018: (in d0_108 >= 0<32> : bool)
   Class: Eq_4018
@@ -18976,12 +18579,12 @@ T_4019: (in __rol : ptr32)
   DataType: (ptr32 Eq_3415)
   OrigDataType: (ptr32 (fn T_4021 (T_3890, T_4020)))
 T_4020: (in 1<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_4021: (in __rol(d1_22, 1<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4022: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_4022
@@ -19000,8 +18603,8 @@ T_4025: (in (word16) d3_18 - 1<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4026: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_4027: (in __swap : ptr32)
   Class: Eq_976
@@ -19016,16 +18619,16 @@ T_4029: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_4030 (T_4004)))
 T_4030: (in __swap(d3_102) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4031: (in __rol(d0_108, __swap(d3_102)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4032: (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4033: (in SLICE(d3_102, word16, 0) : word16)
   Class: Eq_4033
@@ -19036,8 +18639,8 @@ T_4034: (in (uint16) SLICE(d3_102, word16, 0) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_4035: (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4036: (in 1<16> : word16)
   Class: Eq_4036
@@ -19048,36 +18651,36 @@ T_4037: (in v51_79 - 1<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4038: (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_4039: (in d0_108 + d1_90 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4040: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: up32
 T_4041: (in d0_108 >= 0<32> : bool)
   Class: Eq_4041
   DataType: bool
   OrigDataType: bool
-T_4042: (in d1 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4042: (in d1 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_4043: (in d1_171 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4043: (in d1_171 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_4044: (in d3_202 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4044: (in d3_202 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
 T_4045: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_4046: (in dwArg0C != 0<32> : bool)
   Class: Eq_4046
@@ -19108,8 +18711,8 @@ T_4052: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_4053: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_4054: (in dwArg10 != 0<32> : bool)
   Class: Eq_4054
@@ -19124,16 +18727,16 @@ T_4056: (in fn00002558 : ptr32)
   DataType: (ptr32 Eq_3401)
   OrigDataType: (ptr32 (fn T_4059 (T_1735, T_1736, T_1738, T_4057, T_4058)))
 T_4057: (in out d1_171 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_4058: (in out d2_354 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_4059: (in fn00002558(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4060: (in d4_32 : int32)
   Class: Eq_4060
@@ -19143,21 +18746,21 @@ T_4061: (in 24<i32> : int32)
   Class: Eq_4060
   DataType: int32
   OrigDataType: int32
-T_4062: (in d6_33 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4062: (in d6_33 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uip32
 T_4063: (in __rol : ptr32)
   Class: Eq_3415
   DataType: (ptr32 Eq_3415)
   OrigDataType: (ptr32 (fn T_4065 (T_1737, T_4064)))
 T_4064: (in 8<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_4065: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4066: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4066
@@ -19260,12 +18863,12 @@ T_4090: (in __rol : ptr32)
   DataType: (ptr32 Eq_3415)
   OrigDataType: (ptr32 (fn T_4092 (T_4062, T_4091)))
 T_4091: (in 8<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_4092: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4093: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4093
@@ -19288,12 +18891,12 @@ T_4097: (in __rol : ptr32)
   DataType: (ptr32 Eq_3415)
   OrigDataType: (ptr32 (fn T_4099 (T_4062, T_4098)))
 T_4098: (in 8<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_4099: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4100: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4100
@@ -19320,8 +18923,8 @@ T_4105: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_4106: (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uip32
 T_4107: (in d1_89 : ui32)
   Class: Eq_4107
@@ -19331,17 +18934,17 @@ T_4108: (in d2_90 : word32)
   Class: Eq_4108
   DataType: word32
   OrigDataType: word32
-T_4109: (in d0_88 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4109: (in d0_88 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4110: (in fn00002558 : ptr32)
   Class: Eq_3401
   DataType: (ptr32 Eq_3401)
   OrigDataType: (ptr32 (fn T_4120 (T_4111, T_4114, T_4117, T_4118, T_4119)))
 T_4111: (in dwArg04 >> d4_64 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4112: (in dwArg04 << d5_66 : word32)
   Class: Eq_4112
@@ -19352,8 +18955,8 @@ T_4113: (in dwArg08 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4114: (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_4115: (in dwArg0C << d5_66 : word32)
   Class: Eq_4115
@@ -19364,52 +18967,52 @@ T_4116: (in dwArg10 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4117: (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_4118: (in out d1_89 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_4119: (in out d2_90 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_4120: (in fn00002558(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_4121: (in d3_75 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4121: (in d3_75 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4122: (in dwArg10 << d5_66 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
-T_4123: (in d7_104 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4123: (in d7_104 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4124: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_4125 (T_4109)))
 T_4125: (in __swap(d0_88) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_4126: (in d6_106 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4126: (in d6_106 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4127: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_4128 (T_4121)))
 T_4128: (in __swap(d3_75) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4129: (in d3_105 : uint32)
   Class: Eq_4129
@@ -19423,9 +19026,9 @@ T_4131: (in d3_75 * (word16) d7_104 : word32)
   Class: Eq_4129
   DataType: uint32
   OrigDataType: uint32
-T_4132: (in d2_110 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4132: (in d2_110 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4133: (in __swap : ptr32)
   Class: Eq_976
@@ -19436,12 +19039,12 @@ T_4134: (in SLICE(d3_75, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4135: (in d0_88 * (word16) d3_75 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4136: (in __swap(d0_88 * (word16) d3_75) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4137: (in v36_111 : cup16)
   Class: Eq_4137
@@ -19491,21 +19094,21 @@ T_4148: (in SLICE(SEQ(v37_112, v36_111) + d4_107, word16, 0) : word16)
   Class: Eq_4145
   DataType: cup16
   OrigDataType: word16
-T_4149: (in d2_127 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4149: (in d2_127 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_4150: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_4152 (T_4151)))
 T_4151: (in SEQ(v37_112, v40_119) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_4152: (in __swap(SEQ(v37_112, v40_119)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4153: (in d7_108 : uint32)
   Class: Eq_4153
@@ -19544,12 +19147,12 @@ T_4161: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4162: (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_4163: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4164: (in __swap : ptr32)
   Class: Eq_976
@@ -19564,12 +19167,12 @@ T_4166: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4167: (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_4168: (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4169: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
   Class: Eq_4169
@@ -19644,8 +19247,8 @@ T_4186: (in dwArg0C - dwArg04 < 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_4187: (in dwArg08 - dwArg10 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4188: (in dwArg10 - dwArg08 : word32)
   Class: Eq_4188
@@ -19659,33 +19262,33 @@ T_4190: (in dwArg10 - dwArg08 > 0<32> : bool)
   Class: Eq_4190
   DataType: bool
   OrigDataType: bool
-T_4191: (in d1_211 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4191: (in d1_211 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_4192: (in d2_212 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4192: (in d2_212 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4193: (in fn00002558 : ptr32)
   Class: Eq_3401
   DataType: (ptr32 Eq_3401)
   OrigDataType: (ptr32 (fn T_4197 (T_4194, T_1735, T_4044, T_4195, T_4196)))
 T_4194: (in 0<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_4195: (in out d1_211 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_4196: (in out d2_212 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_4197: (in fn00002558(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4198: (in d2_355 : word32)
   Class: Eq_4198
@@ -19696,16 +19299,16 @@ T_4199: (in fn00002558 : ptr32)
   DataType: (ptr32 Eq_3401)
   OrigDataType: (ptr32 (fn T_4202 (T_4191, T_1736, T_4192, T_4200, T_4201)))
 T_4200: (in out d1_171 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: (union (uint32 u0) (ptr32 u1))
 T_4201: (in out d2_355 : ptr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_4202: (in fn00002558(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4203: (in 1<i32> : int32)
   Class: Eq_4203
@@ -19748,8 +19351,8 @@ T_4212: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_4213: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
 T_4214: (in d3_135 - d3_75 : word32)
   Class: Eq_4158
@@ -19768,8 +19371,8 @@ T_4217: (in d3_135 < 0<32> : bool)
   DataType: Eq_4217
   OrigDataType: (union (bool u0) (word32 u1))
 T_4218: (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4219: (in 0<32> : word32)
   Class: Eq_4180
@@ -19820,8 +19423,8 @@ T_4230: (in d6_157 >> d5_66 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4231: (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_4232: (in d6_85 - d3_135 : word32)
   Class: Eq_4232
@@ -19987,37 +19590,37 @@ T_4272: (in signature of fn00002C28 : void)
   Class: Eq_4271
   DataType: (ptr32 Eq_4271)
   OrigDataType: 
-T_4273: (in d0 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4273: (in d0 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
-T_4274: (in d1 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4274: (in d1 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
-T_4275: (in a1 : Eq_623)
+T_4275: (in a1 : (ptr32 (ptr32 byte)))
   Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: Eq_7934
-T_4276: (in dwArg04 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: (ptr32 (struct (0 T_4695 t0000)))
+T_4276: (in dwArg04 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4277: (in dwArg08 : (ptr32 Eq_630))
   Class: Eq_630
   DataType: (ptr32 Eq_630)
   OrigDataType: (ptr32 (struct (0 T_4333 t0000)))
-T_4278: (in dwArg0C : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4278: (in dwArg0C : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4279: (in 00003FF0 : ptr32)
   Class: Eq_4279
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_4280 t0000)))
 T_4280: (in Mem10[0x00003FF0<p32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4281: (in fp : ptr32)
   Class: Eq_4281
@@ -20028,32 +19631,32 @@ T_4282: (in 8<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4283: (in fp + 8<i32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
-T_4284: (in fn00002C28(d0, d1, a1, *(union Eq_623 *) 0x3FF0<u32>, dwArg04, fp + 8<i32>) : void)
+T_4284: (in fn00002C28(d0, d1, a1, *(union Eq_624 *) 0x3FF0<u32>, dwArg04, fp + 8<i32>) : void)
   Class: Eq_4284
   DataType: void
   OrigDataType: void
-T_4285: (in d0 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4285: (in d0 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
-T_4286: (in bArg07 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4286: (in bArg07 : byte)
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
-T_4287: (in dwArg08 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4287: (in dwArg08 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: (ptr32 (struct (4 T_4285 t0004) (8 T_4296 t0008) (14 T_4302 t0014)))
-T_4288: (in d0_10 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4288: (in d0_10 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: up32
 T_4289: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_4290: (in dwArg08 == 0<32> : bool)
   Class: Eq_4290
@@ -20068,8 +19671,8 @@ T_4292: (in dwArg08 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_4293: (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4294: (in 8<i32> : int32)
   Class: Eq_4294
@@ -20080,8 +19683,8 @@ T_4295: (in dwArg08 + 8<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4296: (in Mem5[dwArg08 + 8<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: up32
 T_4297: (in d0_10 - *((word32) dwArg08 + 8<i32>) : word32)
   Class: Eq_4297
@@ -20121,7 +19724,7 @@ T_4305: (in dwArg08 + 20<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_4306: (in Mem22[dwArg08 + 20<i32>:word32] : word32)
   Class: Eq_2723
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: word32
 T_4307: (in 4<i32> : int32)
   Class: Eq_4307
@@ -20132,24 +19735,24 @@ T_4308: (in dwArg08 + 4<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4309: (in Mem22[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4310: (in 1<32> : word32)
   Class: Eq_4310
   DataType: word32
   OrigDataType: word32
 T_4311: (in *((word32) dwArg08 + 4<i32>) - 1<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4312: (in dwArg08 + 4<i32> : word32)
   Class: Eq_4312
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4313: (in Mem25[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4314: (in 4<i32> : int32)
   Class: Eq_4314
@@ -20160,8 +19763,8 @@ T_4315: (in dwArg08 + 4<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4316: (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: (ptr32 (struct (0 T_4319 t0000)))
 T_4317: (in 0<32> : word32)
   Class: Eq_4317
@@ -20172,13 +19775,13 @@ T_4318: (in Mem5[dwArg08 + 4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_4319: (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: Eq_624
   OrigDataType: byte
-T_4320: (in a7_1330 : Eq_4320)
+T_4320: (in a7_1330 : (ptr32 Eq_4320))
   Class: Eq_4320
-  DataType: Eq_4320
-  OrigDataType: word32
+  DataType: (ptr32 Eq_4320)
+  OrigDataType: (ptr32 (struct 0004 (2C int32 dw002C) (30 (union ((ptr32 (ptr32 Eq_4327)) u0) (T_6688 u1) (T_6754 u2) (T_7274 u3)) u0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 (union ((ptr32 (ptr32 Eq_4327)) u0) (T_6621 u1) (T_6688 u2) (T_6692 u3) (T_6750 u4)) u0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084)))
 T_4321: (in fp : ptr32)
   Class: Eq_4321
   DataType: ptr32
@@ -20189,20 +19792,20 @@ T_4322: (in -120<i32> : int32)
   OrigDataType: int32
 T_4323: (in fp + -120<i32> : word32)
   Class: Eq_4320
-  DataType: Eq_4320
+  DataType: (ptr32 Eq_4320)
   OrigDataType: ptr32
-T_4324: (in d2_1090 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: Eq_4320
+T_4324: (in d2_1090 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: (struct "Eq_4320" 0004 (2C int32 dw002C) (30 Eq_8430 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8431 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_4325: (in a4_274 : (ptr32 Eq_630))
   Class: Eq_630
   DataType: (ptr32 Eq_630)
   OrigDataType: (ptr32 (struct 0001 (0 uint8 b0000)))
-T_4326: (in a2_1014 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: Eq_7830
+T_4326: (in a2_1014 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: (ptr32 Eq_624)
 T_4327: (in d4_132 : Eq_4327)
   Class: Eq_4327
   DataType: Eq_4327
@@ -20211,13 +19814,13 @@ T_4328: (in 0<i32> : int32)
   Class: Eq_4327
   DataType: byte
   OrigDataType: int32
-T_4329: (in d5_1044 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: Eq_4320
+T_4329: (in d5_1044 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: (struct "Eq_4320" 0004 (2C int32 dw002C) (30 Eq_8430 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8431 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_4330: (in 0<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: int32
 T_4331: (in 0<32> : word32)
   Class: Eq_4331
@@ -20240,8 +19843,8 @@ T_4335: (in dwArg08->b0000 == 0<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_4336: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_4337: (in d5_1044 != 0xFFFFFFFF<32> : bool)
   Class: Eq_4337
@@ -20336,8 +19939,8 @@ T_4359: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_4360: (in d0_63 & 8<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_4361: (in d0_63 & 8<32> : word32)
   Class: Eq_4361
@@ -20365,7 +19968,7 @@ T_4366: (in a7_1330 + 72<i32> : word32)
   OrigDataType: ptr32
 T_4367: (in Mem277[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4364
-  DataType: Eq_4320
+  DataType: byte
   OrigDataType: byte
 T_4368: (in 0<8> : byte)
   Class: Eq_4368
@@ -20381,7 +19984,7 @@ T_4370: (in a7_1330 + 73<i32> : word32)
   OrigDataType: ptr32
 T_4371: (in Mem278[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_4368
-  DataType: Eq_4320
+  DataType: byte
   OrigDataType: byte
 T_4372: (in a3_279 : (ptr32 byte))
   Class: Eq_4372
@@ -20439,21 +20042,21 @@ T_4385: (in (uint32) (uint8) Mem278[0x000028B1<p32> + (uint32) ((uint8) Mem278[a
   Class: Eq_4375
   DataType: uint32
   OrigDataType: uint32
-T_4386: (in d6_1133 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: uint8
+T_4386: (in d6_1133 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: (ptr32 Eq_1355)
 T_4387: (in -1<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_4388: (in 4<32> : word32)
   Class: Eq_4388
   DataType: ui32
   OrigDataType: ui32
 T_4389: (in d0_289 & 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_4390: (in d0_289 & 4<32> : word32)
   Class: Eq_4390
@@ -20532,16 +20135,16 @@ T_4408: (in (uint32) (uint8) Mem278[0x000028B1<p32> + (uint32) ((uint8) Mem278[a
   DataType: uint32
   OrigDataType: uint32
 T_4409: (in 0<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_4410: (in 4<32> : word32)
   Class: Eq_4410
   DataType: ui32
   OrigDataType: ui32
 T_4411: (in d0_305 & 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_4412: (in d0_305 & 4<32> : word32)
   Class: Eq_4412
@@ -20555,9 +20158,9 @@ T_4414: (in (d0_305 & 4<32>) == 0<32> : bool)
   Class: Eq_4414
   DataType: bool
   OrigDataType: bool
-T_4415: (in a7_313 : (ptr32 Eq_623))
+T_4415: (in a7_313 : (ptr32 Eq_783))
   Class: Eq_4415
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_783 t0000)))
 T_4416: (in 4<i32> : int32)
   Class: Eq_4416
@@ -20565,7 +20168,7 @@ T_4416: (in 4<i32> : int32)
   OrigDataType: int32
 T_4417: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4415
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: ptr32
 T_4418: (in 0<32> : word32)
   Class: Eq_4418
@@ -20576,8 +20179,8 @@ T_4419: (in a7_313 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4420: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4421: (in d1_322 : uint32)
   Class: Eq_4421
@@ -20588,12 +20191,12 @@ T_4422: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_4424 (T_4423)))
 T_4423: (in 10<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_4424: (in __swap(10<i32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4425: (in SLICE(d6_1133, word16, 0) : word16)
   Class: Eq_4425
@@ -20632,8 +20235,8 @@ T_4433: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_4434 (T_4386)))
 T_4434: (in __swap(d6_1133) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4435: (in 0xA<16> : word16)
   Class: Eq_4435
@@ -20652,12 +20255,12 @@ T_4438: (in SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4439: (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_4440: (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4441: (in SLICE(__swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_4441
@@ -20760,32 +20363,32 @@ T_4465: (in a7_313 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4466: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_4467: (in 0x30<32> : word32)
   Class: Eq_4467
   DataType: uint32
   OrigDataType: uint32
 T_4468: (in d1_340 - 0x30<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_4469: (in d1_340 - 0x30<32> : word32)
   Class: Eq_4469
   DataType: uint32
   OrigDataType: uint32
 T_4470: (in d1_340 - 0x30<32> + d0_331 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_4471: (in 4<32> : word32)
   Class: Eq_4471
   DataType: ui32
   OrigDataType: ui32
 T_4472: (in d0_354 & 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_4473: (in d0_354 & 4<32> : word32)
   Class: Eq_4473
@@ -20840,8 +20443,8 @@ T_4485: (in Mem361[a7_1330 + 72<i32>:byte] : byte)
   DataType: byte
   OrigDataType: byte
 T_4486: (in SEQ(SLICE(d1, word24, 8), Mem361[a7_1330 + 72<i32>:byte]) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_4487: (in 0<32> : word32)
   Class: Eq_4487
@@ -20979,7 +20582,7 @@ T_4520: (in 0x6A<8> : byte)
   Class: Eq_4519
   DataType: byte
   OrigDataType: byte
-T_4521: (in *((word32) a7_1330 + 72<i32>) != 0x6A<8> : bool)
+T_4521: (in a7_1330[18<i32>] != 0x6A<8> : bool)
   Class: Eq_4521
   DataType: bool
   OrigDataType: bool
@@ -21064,8 +20667,8 @@ T_4541: (in *a3_279 != 0x68<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_4542: (in 2<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: int32
 T_4543: (in 0<32> : word32)
   Class: Eq_4543
@@ -21221,7 +20824,7 @@ T_4580: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4581: (in Mem463[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4578
-  DataType: Eq_4320
+  DataType: byte
   OrigDataType: byte
 T_4582: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_4582
@@ -21237,7 +20840,7 @@ T_4584: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4585: (in Mem469[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_4582
-  DataType: Eq_4320
+  DataType: byte
   OrigDataType: byte
 T_4586: (in SLICE(d1, word24, 8) : word24)
   Class: Eq_4586
@@ -21256,8 +20859,8 @@ T_4589: (in Mem361[a3_279 + 0<32>:byte] : byte)
   DataType: byte
   OrigDataType: byte
 T_4590: (in SEQ(SLICE(d1, word24, 8), Mem361[a3_279 + 0<32>:byte]) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_4591: (in 0<32> : word32)
   Class: Eq_4591
@@ -21280,8 +20883,8 @@ T_4595: (in *a3_279 != 0x6C<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_4596: (in 1<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: int32
 T_4597: (in 72<i32> : int32)
   Class: Eq_4597
@@ -21299,7 +20902,7 @@ T_4600: (in 0x74<8> : byte)
   Class: Eq_4599
   DataType: byte
   OrigDataType: byte
-T_4601: (in *((word32) a7_1330 + 72<i32>) != 0x74<8> : bool)
+T_4601: (in a7_1330[18<i32>] != 0x74<8> : bool)
   Class: Eq_4601
   DataType: bool
   OrigDataType: bool
@@ -21317,7 +20920,7 @@ T_4604: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4605: (in Mem477[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4602
-  DataType: Eq_4320
+  DataType: byte
   OrigDataType: byte
 T_4606: (in 72<i32> : int32)
   Class: Eq_4606
@@ -21335,7 +20938,7 @@ T_4609: (in 0x7A<8> : byte)
   Class: Eq_4608
   DataType: byte
   OrigDataType: byte
-T_4610: (in *((word32) a7_1330 + 72<i32>) != 0x7A<8> : bool)
+T_4610: (in a7_1330[18<i32>] != 0x7A<8> : bool)
   Class: Eq_4610
   DataType: bool
   OrigDataType: bool
@@ -21353,7 +20956,7 @@ T_4613: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4614: (in Mem485[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4611
-  DataType: Eq_4320
+  DataType: byte
   OrigDataType: byte
 T_4615: (in v83_500 : byte)
   Class: Eq_4615
@@ -21417,7 +21020,7 @@ T_4629: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4630: (in Mem493[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4627
-  DataType: Eq_4320
+  DataType: byte
   OrigDataType: byte
 T_4631: (in v147_608 : word24)
   Class: Eq_4631
@@ -21427,9 +21030,9 @@ T_4632: (in SLICE(d1, word24, 8) : word24)
   Class: Eq_4631
   DataType: word24
   OrigDataType: word24
-T_4633: (in d1_612 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4633: (in d1_612 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_4634: (in 0x25<8> : byte)
   Class: Eq_4615
@@ -21440,8 +21043,8 @@ T_4635: (in v83_500 - 0x25<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_4636: (in SEQ(v147_608, v83_500 - 0x25<8>) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_4637: (in v83_500 == 0x25<8> : bool)
   Class: Eq_4637
@@ -21479,9 +21082,9 @@ T_4645: (in v83_500 == 0x5B<8> : bool)
   Class: Eq_4645
   DataType: bool
   OrigDataType: bool
-T_4646: (in d0_540 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4646: (in d0_540 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_4647: (in a0_523 : (ptr32 ui32))
   Class: Eq_4647
@@ -21583,9 +21186,9 @@ T_4671: (in v90_528 < 0<32> : bool)
   Class: Eq_4671
   DataType: bool
   OrigDataType: bool
-T_4672: (in a7_533 : (ptr32 Eq_623))
+T_4672: (in a7_533 : (ptr32 Eq_624))
   Class: Eq_4672
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_4276 t0000)))
 T_4673: (in 4<i32> : int32)
   Class: Eq_4673
@@ -21593,7 +21196,7 @@ T_4673: (in 4<i32> : int32)
   OrigDataType: int32
 T_4674: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4672
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_4675: (in 0<32> : word32)
   Class: Eq_4675
@@ -21604,8 +21207,8 @@ T_4676: (in a7_533 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4677: (in Mem535[a7_533 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4678: (in d1_5316 : word32)
   Class: Eq_4678
@@ -21623,9 +21226,9 @@ T_4681: (in signature of fn00003CCC : void)
   Class: Eq_4680
   DataType: (ptr32 Eq_4680)
   OrigDataType: 
-T_4682: (in dwArg04 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4682: (in dwArg04 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: (ptr32 (struct (0 T_8132 t0000) (4 T_8105 t0004) (8 T_8105 t0008) (14 T_8083 t0014) (18 T_8070 t0018) (1C T_8093 t001C)))
 T_4683: (in d1Out : Eq_2669)
   Class: Eq_2669
@@ -21648,8 +21251,8 @@ T_4687: (in a7_533 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4688: (in Mem535[a7_533 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4689: (in out d1_5316 : ptr32)
   Class: Eq_2669
@@ -21664,8 +21267,8 @@ T_4691: (in out a5_5317 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_4692: (in fn00003CCC(*a7_533, out d1_5316, out a1, out a5_5317) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4693: (in 4<i32> : int32)
   Class: Eq_4693
@@ -21673,7 +21276,7 @@ T_4693: (in 4<i32> : int32)
   OrigDataType: int32
 T_4694: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_4695: (in a0_551 : (ptr32 byte))
   Class: Eq_4695
@@ -21691,9 +21294,9 @@ T_4698: (in Mem529[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
   DataType: (ptr32 byte)
   OrigDataType: word32
-T_4699: (in a7_552 : (ptr32 Eq_623))
+T_4699: (in a7_552 : (ptr32 Eq_624))
   Class: Eq_4699
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_4276 t0000)))
 T_4700: (in 4<i32> : int32)
   Class: Eq_4700
@@ -21701,7 +21304,7 @@ T_4700: (in 4<i32> : int32)
   OrigDataType: int32
 T_4701: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4699
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_4702: (in 0<32> : word32)
   Class: Eq_4702
@@ -21712,8 +21315,8 @@ T_4703: (in a7_552 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4704: (in Mem554[a7_552 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4705: (in 1<i32> : int32)
   Class: Eq_4705
@@ -21733,8 +21336,8 @@ T_4708: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_4709: (in Mem558[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: word32
 T_4710: (in v96_562 : byte)
   Class: Eq_4710
   DataType: byte
@@ -21760,24 +21363,24 @@ T_4715: (in a7_552 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4716: (in Mem558[a7_552 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4717: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_4717
   DataType: word24
   OrigDataType: word24
 T_4718: (in SEQ(SLICE(d0, word24, 8), v96_562) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_4719: (in (uint8) v96_562 : uint8)
   Class: Eq_4719
   DataType: uint8
   OrigDataType: uint8
 T_4720: (in (uint32) (uint8) v96_562 : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_4721: (in d0_591 : uint32)
   Class: Eq_4721
@@ -21836,8 +21439,8 @@ T_4734: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_4735: (in d0_591 & 8<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_4736: (in d0_591 & 8<32> : word32)
   Class: Eq_4736
@@ -21851,9 +21454,9 @@ T_4738: (in (d0_591 & 8<32>) != 0<32> : bool)
   Class: Eq_4738
   DataType: bool
   OrigDataType: bool
-T_4739: (in d0_111 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4739: (in d0_111 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_4740: (in a0_70 : (ptr32 ui32))
   Class: Eq_4740
@@ -21955,9 +21558,9 @@ T_4764: (in v126_74 < 0<32> : bool)
   Class: Eq_4764
   DataType: bool
   OrigDataType: bool
-T_4765: (in d0_187 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_4765: (in d0_187 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_4766: (in a0_170 : (ptr32 ui32))
   Class: Eq_4766
@@ -22059,9 +21662,9 @@ T_4790: (in v105_175 < 0<32> : bool)
   Class: Eq_4790
   DataType: bool
   OrigDataType: bool
-T_4791: (in a7_180 : (ptr32 Eq_623))
+T_4791: (in a7_180 : (ptr32 Eq_624))
   Class: Eq_4791
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_4276 t0000)))
 T_4792: (in 4<i32> : int32)
   Class: Eq_4792
@@ -22069,7 +21672,7 @@ T_4792: (in 4<i32> : int32)
   OrigDataType: int32
 T_4793: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4791
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_4794: (in 0<32> : word32)
   Class: Eq_4794
@@ -22080,8 +21683,8 @@ T_4795: (in a7_180 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4796: (in Mem182[a7_180 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4797: (in d1_5318 : word32)
   Class: Eq_4797
@@ -22104,8 +21707,8 @@ T_4801: (in a7_180 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4802: (in Mem182[a7_180 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4803: (in out d1_5318 : ptr32)
   Class: Eq_2669
@@ -22120,8 +21723,8 @@ T_4805: (in out a5_5319 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_4806: (in fn00003CCC(*a7_180, out d1_5318, out a1, out a5_5319) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4807: (in 4<i32> : int32)
   Class: Eq_4807
@@ -22129,7 +21732,7 @@ T_4807: (in 4<i32> : int32)
   OrigDataType: int32
 T_4808: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_4809: (in a0_198 : (ptr32 byte))
   Class: Eq_4695
@@ -22147,9 +21750,9 @@ T_4812: (in Mem176[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
-T_4813: (in a7_199 : (ptr32 Eq_623))
+T_4813: (in a7_199 : (ptr32 Eq_624))
   Class: Eq_4813
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_4276 t0000)))
 T_4814: (in 4<i32> : int32)
   Class: Eq_4814
@@ -22157,7 +21760,7 @@ T_4814: (in 4<i32> : int32)
   OrigDataType: int32
 T_4815: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4813
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_4816: (in 0<32> : word32)
   Class: Eq_4816
@@ -22168,8 +21771,8 @@ T_4817: (in a7_199 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4818: (in Mem201[a7_199 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4819: (in 1<i32> : int32)
   Class: Eq_4819
@@ -22189,8 +21792,8 @@ T_4822: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_4823: (in Mem205[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_4824: (in v109_209 : byte)
   Class: Eq_4710
   DataType: byte
@@ -22216,24 +21819,24 @@ T_4829: (in a7_199 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4830: (in Mem205[a7_199 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4831: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_4831
   DataType: word24
   OrigDataType: word24
 T_4832: (in SEQ(SLICE(d0, word24, 8), v109_209) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_4833: (in (uint8) v109_209 : uint8)
   Class: Eq_4833
   DataType: uint8
   OrigDataType: uint8
 T_4834: (in (uint32) (uint8) v109_209 : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_4835: (in d0_238 : uint32)
   Class: Eq_4835
@@ -22292,8 +21895,8 @@ T_4848: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_4849: (in d0_238 & 8<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_4850: (in d0_238 & 8<32> : word32)
   Class: Eq_4850
@@ -22312,8 +21915,8 @@ T_4853: (in 1<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4854: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_4855: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_4855
@@ -22331,9 +21934,9 @@ T_4858: (in 1<i32> : int32)
   Class: Eq_4338
   DataType: int32
   OrigDataType: int32
-T_4859: (in a7_248 : (ptr32 Eq_623))
+T_4859: (in a7_248 : (ptr32 Eq_624))
   Class: Eq_4859
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_4276 t0000)))
 T_4860: (in 4<i32> : int32)
   Class: Eq_4860
@@ -22341,7 +21944,7 @@ T_4860: (in 4<i32> : int32)
   OrigDataType: int32
 T_4861: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4859
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_4862: (in 0<32> : word32)
   Class: Eq_4862
@@ -22352,8 +21955,8 @@ T_4863: (in a7_248 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4864: (in Mem251[a7_248 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4865: (in 4<i32> : int32)
   Class: Eq_4865
@@ -22361,7 +21964,7 @@ T_4865: (in 4<i32> : int32)
   OrigDataType: int32
 T_4866: (in a7_248 - 4<i32> : word32)
   Class: Eq_4866
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_4869 t0000)))
 T_4867: (in 0<32> : word32)
   Class: Eq_4867
@@ -22372,8 +21975,8 @@ T_4868: (in a7_248 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4869: (in Mem254[a7_248 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4870: (in fn00002BF8 : ptr32)
   Class: Eq_4870
@@ -22389,7 +21992,7 @@ T_4872: (in 1<i32> : int32)
   OrigDataType: int32
 T_4873: (in a7_248 - 1<i32> : word32)
   Class: Eq_4873
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4876 t0000)))
 T_4874: (in 0<32> : word32)
   Class: Eq_4874
@@ -22400,8 +22003,8 @@ T_4875: (in a7_248 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4876: (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_4877: (in 0<32> : word32)
   Class: Eq_4877
@@ -22412,12 +22015,12 @@ T_4878: (in a7_248 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4879: (in Mem254[a7_248 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4880: (in fn00002BF8(*(a7_248 - 1<i32>), *a7_248) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4881: (in 1<i32> : int32)
   Class: Eq_4881
@@ -22448,8 +22051,8 @@ T_4887: (in a7_79 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4888: (in Mem81[a7_79 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4889: (in a5_5320 : word32)
   Class: Eq_4889
@@ -22468,13 +22071,13 @@ T_4892: (in a7_79 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4893: (in Mem81[a7_79 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4894: (in out d1 : ptr32)
   Class: Eq_2669
   DataType: Eq_2669
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_4895: (in out a1 : ptr32)
   Class: Eq_4684
   DataType: (ptr32 word32)
@@ -22484,8 +22087,8 @@ T_4896: (in out a5_5320 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_4897: (in fn00003CCC(a7_79->t0000, out d1, out a1, out a5_5320) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4898: (in 48<i32> : int32)
   Class: Eq_4898
@@ -22496,8 +22099,8 @@ T_4899: (in a7_79 + 48<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4900: (in Mem94[a7_79 + 48<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4901: (in 4<i32> : int32)
   Class: Eq_4901
@@ -22505,7 +22108,7 @@ T_4901: (in 4<i32> : int32)
   OrigDataType: int32
 T_4902: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_4903: (in a0_98 : (ptr32 byte))
   Class: Eq_4695
@@ -22544,8 +22147,8 @@ T_4911: (in a7_99 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4912: (in Mem101[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4913: (in 1<i32> : int32)
   Class: Eq_4913
@@ -22565,8 +22168,8 @@ T_4916: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_4917: (in Mem105[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_4918: (in v130_109 : byte)
   Class: Eq_4710
   DataType: byte
@@ -22592,8 +22195,8 @@ T_4923: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4924: (in Mem105[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4925: (in 0<32> : word32)
   Class: Eq_4925
@@ -22604,8 +22207,8 @@ T_4926: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4927: (in Mem115[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4928: (in (uint8) v130_109 : uint8)
   Class: Eq_4928
@@ -22636,8 +22239,8 @@ T_4934: (in SLICE(d0_63 & 8<32>, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_4935: (in SEQ(SLICE(d0_63 & 8<32>, word24, 8), v130_109) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_4936: (in 0<32> : word32)
   Class: Eq_4936
@@ -22648,8 +22251,8 @@ T_4937: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4938: (in Mem121[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4939: (in SLICE(d0_111, word24, 8) : word24)
   Class: Eq_4939
@@ -22680,8 +22283,8 @@ T_4945: (in (int16) (int8) SEQ(SLICE(d0_111, word24, 8), Mem127[a4_274 + 0<32>:b
   DataType: int16
   OrigDataType: int16
 T_4946: (in (int32) (int16) (int8) SEQ(SLICE(d0_111, word24, 8), Mem127[a4_274 + 0<32>:byte]) : int32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: int32
 T_4947: (in 44<i32> : int32)
   Class: Eq_4947
@@ -22692,8 +22295,8 @@ T_4948: (in a7_1330 + 44<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4949: (in Mem127[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4950: (in 1<32> : word32)
   Class: Eq_4338
@@ -22719,7 +22322,7 @@ T_4955: (in Mem127[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_4955
   DataType: int32
   OrigDataType: int32
-T_4956: (in d0 - *((word32) a7_1330 + 44<i32>) : word32)
+T_4956: (in d0 - a7_1330[11<i32>] : word32)
   Class: Eq_4956
   DataType: int32
   OrigDataType: int32
@@ -22727,7 +22330,7 @@ T_4957: (in 0<32> : word32)
   Class: Eq_4956
   DataType: int32
   OrigDataType: word32
-T_4958: (in d0 - *((word32) a7_1330 + 44<i32>) == 0<32> : bool)
+T_4958: (in d0 - a7_1330[11<i32>] == 0<32> : bool)
   Class: Eq_4958
   DataType: bool
   OrigDataType: bool
@@ -22752,8 +22355,8 @@ T_4963: (in a4_274->b0000 != 0<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_4964: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_4965: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_4965
@@ -22771,9 +22374,9 @@ T_4968: (in d4_132 - 1<32> : word32)
   Class: Eq_4327
   DataType: Eq_4327
   OrigDataType: int32
-T_4969: (in a7_148 : (ptr32 Eq_623))
+T_4969: (in a7_148 : (ptr32 Eq_624))
   Class: Eq_4969
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_4970: (in 4<i32> : int32)
   Class: Eq_4970
@@ -22781,7 +22384,7 @@ T_4970: (in 4<i32> : int32)
   OrigDataType: int32
 T_4971: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4969
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_4972: (in 0<32> : word32)
   Class: Eq_4972
@@ -22792,8 +22395,8 @@ T_4973: (in a7_148 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4974: (in Mem151[a7_148 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4975: (in 4<i32> : int32)
   Class: Eq_4975
@@ -22801,7 +22404,7 @@ T_4975: (in 4<i32> : int32)
   OrigDataType: int32
 T_4976: (in a7_148 - 4<i32> : word32)
   Class: Eq_4976
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_4979 t0000)))
 T_4977: (in 0<32> : word32)
   Class: Eq_4977
@@ -22812,8 +22415,8 @@ T_4978: (in a7_148 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4979: (in Mem154[a7_148 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4980: (in fn00002BF8 : ptr32)
   Class: Eq_4870
@@ -22825,7 +22428,7 @@ T_4981: (in 1<i32> : int32)
   OrigDataType: int32
 T_4982: (in a7_148 - 1<i32> : word32)
   Class: Eq_4982
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4985 t0000)))
 T_4983: (in 0<32> : word32)
   Class: Eq_4983
@@ -22836,8 +22439,8 @@ T_4984: (in a7_148 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4985: (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_4986: (in 0<32> : word32)
   Class: Eq_4986
@@ -22848,12 +22451,12 @@ T_4987: (in a7_148 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4988: (in Mem154[a7_148 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4989: (in fn00002BF8(*(a7_148 - 1<i32>), *a7_148) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_4990: (in a0_628 : (ptr32 ui32))
   Class: Eq_4990
@@ -22977,8 +22580,8 @@ T_5019: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5020: (in Mem761[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_5017
-  DataType: Eq_4320
-  OrigDataType: byte
+  DataType: Eq_5017
+  OrigDataType: int32
 T_5021: (in 0<32> : word32)
   Class: Eq_5021
   DataType: word32
@@ -22999,9 +22602,9 @@ T_5025: (in a3_1955->b0000 != 0x5E<8> : bool)
   Class: Eq_5025
   DataType: bool
   OrigDataType: bool
-T_5026: (in d1_1355 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_5026: (in d1_1355 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5027: (in 0x63<8> : byte)
   Class: Eq_4615
@@ -23012,16 +22615,16 @@ T_5028: (in v83_500 - 0x63<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_5029: (in SEQ(v147_608, v83_500 - 0x63<8>) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5030: (in v83_500 == 0x63<8> : bool)
   Class: Eq_5030
   DataType: bool
   OrigDataType: bool
 T_5031: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: word32
 T_5032: (in d6_1133 != 0xFFFFFFFF<32> : bool)
   Class: Eq_5032
@@ -23036,8 +22639,8 @@ T_5034: (in v83_500 - 0x6E<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_5035: (in SEQ(v147_608, v83_500 - 0x6E<8>) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5036: (in v83_500 == 0x6E<8> : bool)
   Class: Eq_5036
@@ -23059,7 +22662,7 @@ T_5040: (in 0<8> : byte)
   Class: Eq_5039
   DataType: byte
   OrigDataType: byte
-T_5041: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5041: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5041
   DataType: bool
   OrigDataType: bool
@@ -23072,8 +22675,8 @@ T_5043: (in v83_500 - 0x73<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_5044: (in SEQ(v147_608, v83_500 - 0x73<8>) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5045: (in v83_500 == 0x73<8> : bool)
   Class: Eq_5045
@@ -23099,7 +22702,7 @@ T_5050: (in 0<8> : byte)
   Class: Eq_5049
   DataType: byte
   OrigDataType: byte
-T_5051: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5051: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5051
   DataType: bool
   OrigDataType: bool
@@ -23117,7 +22720,7 @@ T_5054: (in a7_1330 + 48<i32> : word32)
   OrigDataType: ptr32
 T_5055: (in Mem1948[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_5052
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
 T_5056: (in 0<32> : word32)
   Class: Eq_5056
@@ -23133,7 +22736,7 @@ T_5058: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5059: (in Mem1949[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_5056
-  DataType: Eq_4320
+  DataType: int32
   OrigDataType: int32
 T_5060: (in 0<32> : word32)
   Class: Eq_5060
@@ -23149,7 +22752,7 @@ T_5062: (in a7_1330 + 110<i32> : word32)
   OrigDataType: ptr32
 T_5063: (in Mem1950[a7_1330 + 110<i32>:word32] : word32)
   Class: Eq_5060
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
 T_5064: (in 0<8> : byte)
   Class: Eq_4615
@@ -23180,8 +22783,8 @@ T_5070: (in a7_640 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5071: (in Mem642[a7_640 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5072: (in a5_5321 : word32)
   Class: Eq_5072
@@ -23200,13 +22803,13 @@ T_5075: (in a7_640 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5076: (in Mem642[a7_640 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5077: (in out d1 : ptr32)
   Class: Eq_2669
   DataType: Eq_2669
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_5078: (in out a1 : ptr32)
   Class: Eq_4684
   DataType: (ptr32 word32)
@@ -23216,8 +22819,8 @@ T_5079: (in out a5_5321 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5080: (in fn00003CCC(a7_640->t0000, out d1, out a1, out a5_5321) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5081: (in 48<i32> : int32)
   Class: Eq_5081
@@ -23228,8 +22831,8 @@ T_5082: (in a7_640 + 48<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5083: (in Mem655[a7_640 + 48<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5084: (in 4<i32> : int32)
   Class: Eq_5084
@@ -23237,7 +22840,7 @@ T_5084: (in 4<i32> : int32)
   OrigDataType: int32
 T_5085: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5086: (in a0_659 : (ptr32 byte))
   Class: Eq_4695
@@ -23276,8 +22879,8 @@ T_5094: (in a7_660 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5095: (in Mem662[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5096: (in 1<i32> : int32)
   Class: Eq_5096
@@ -23297,8 +22900,8 @@ T_5099: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_5100: (in Mem666[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_5101: (in v163_670 : byte)
   Class: Eq_4710
   DataType: byte
@@ -23324,8 +22927,8 @@ T_5106: (in a7_660 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5107: (in Mem666[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5108: (in 0<32> : word32)
   Class: Eq_5108
@@ -23336,8 +22939,8 @@ T_5109: (in a7_660 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5110: (in Mem686[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5111: (in (uint8) v163_670 : uint8)
   Class: Eq_5111
@@ -23364,8 +22967,8 @@ T_5116: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5117: (in SEQ(SLICE(d0, word24, 8), v163_670) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5118: (in 0<32> : word32)
   Class: Eq_5118
@@ -23376,8 +22979,8 @@ T_5119: (in a7_660 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5120: (in Mem692[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5121: (in 44<i32> : int32)
   Class: Eq_5121
@@ -23388,8 +22991,8 @@ T_5122: (in a7_1330 + 44<i32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_5123: (in Mem698[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: int32
 T_5124: (in 1<32> : word32)
   Class: Eq_5124
@@ -23423,7 +23026,7 @@ T_5131: (in 0x25<32> : word32)
   Class: Eq_5130
   DataType: int32
   OrigDataType: word32
-T_5132: (in *((word32) a7_1330 + 44<i32>) == 0x25<32> : bool)
+T_5132: (in a7_1330[11<i32>] == 0x25<32> : bool)
   Class: Eq_5132
   DataType: bool
   OrigDataType: bool
@@ -23444,8 +23047,8 @@ T_5136: (in a3_1955 - 1<i32> : word32)
   DataType: (ptr32 Eq_630)
   OrigDataType: ptr32
 T_5137: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_5138: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5138
@@ -23467,9 +23070,9 @@ T_5142: (in d4_132 - 1<32> : word32)
   Class: Eq_4327
   DataType: Eq_4327
   OrigDataType: int32
-T_5143: (in a7_735 : (ptr32 Eq_623))
+T_5143: (in a7_735 : (ptr32 Eq_624))
   Class: Eq_5143
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_5144: (in 4<i32> : int32)
   Class: Eq_5144
@@ -23477,7 +23080,7 @@ T_5144: (in 4<i32> : int32)
   OrigDataType: int32
 T_5145: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5143
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_5146: (in 0<32> : word32)
   Class: Eq_5146
@@ -23488,8 +23091,8 @@ T_5147: (in a7_735 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5148: (in Mem738[a7_735 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5149: (in 4<i32> : int32)
   Class: Eq_5149
@@ -23497,7 +23100,7 @@ T_5149: (in 4<i32> : int32)
   OrigDataType: int32
 T_5150: (in a7_735 - 4<i32> : word32)
   Class: Eq_5150
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_5153 t0000)))
 T_5151: (in 0<32> : word32)
   Class: Eq_5151
@@ -23508,8 +23111,8 @@ T_5152: (in a7_735 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5153: (in Mem741[a7_735 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5154: (in fn00002BF8 : ptr32)
   Class: Eq_4870
@@ -23521,7 +23124,7 @@ T_5155: (in 1<i32> : int32)
   OrigDataType: int32
 T_5156: (in a7_735 - 1<i32> : word32)
   Class: Eq_5156
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5159 t0000)))
 T_5157: (in 0<32> : word32)
   Class: Eq_5157
@@ -23532,8 +23135,8 @@ T_5158: (in a7_735 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5159: (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_5160: (in 0<32> : word32)
   Class: Eq_5160
@@ -23544,12 +23147,12 @@ T_5161: (in a7_735 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5162: (in Mem741[a7_735 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5163: (in fn00002BF8(*(a7_735 - 1<i32>), *a7_735) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5164: (in 0<32> : word32)
   Class: Eq_4338
@@ -23560,8 +23163,8 @@ T_5165: (in d3_130 == 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_5166: (in 0x2D<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_5167: (in d5_1044 != 0x2D<32> : bool)
   Class: Eq_5167
@@ -23581,7 +23184,7 @@ T_5170: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5171: (in Mem1962[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_5168
-  DataType: Eq_4320
+  DataType: byte
   OrigDataType: byte
 T_5172: (in 120<i32> : int32)
   Class: Eq_4476
@@ -23612,16 +23215,16 @@ T_5178: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5179: (in (word32) d2_1090 + 3<i32> >> 2<32> << 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5180: (in 4<32> : word32)
   Class: Eq_5180
   DataType: word32
   OrigDataType: word32
 T_5181: (in d0 + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
 T_5182: (in 0<32> : word32)
   Class: Eq_5182
@@ -23636,8 +23239,8 @@ T_5184: (in Mem629[d0 + 0<32>:word32] : word32)
   DataType: (ptr32 byte)
   OrigDataType: word32
 T_5185: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_5186: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5186
@@ -23669,7 +23272,7 @@ T_5192: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5193: (in Mem1716[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_5191
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
 T_5194: (in 1<i32> : int32)
   Class: Eq_4338
@@ -23691,7 +23294,7 @@ T_5198: (in 1<8> : byte)
   Class: Eq_5197
   DataType: byte
   OrigDataType: byte
-T_5199: (in *((word32) a7_1330 + 72<i32>) != 1<8> : bool)
+T_5199: (in a7_1330[18<i32>] != 1<8> : bool)
   Class: Eq_5199
   DataType: bool
   OrigDataType: bool
@@ -23711,14 +23314,14 @@ T_5203: (in 0x6C<8> : byte)
   Class: Eq_5202
   DataType: byte
   OrigDataType: byte
-T_5204: (in *((word32) a7_1330 + 72<i32>) != 0x6C<8> : bool)
+T_5204: (in a7_1330[18<i32>] != 0x6C<8> : bool)
   Class: Eq_5204
   DataType: bool
   OrigDataType: bool
 T_5205: (in 3<32> : word32)
   Class: Eq_5205
-  DataType: (ptr32 Eq_8442)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8434)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5206: (in d2_1090 + 3<32> : word32)
   Class: Eq_5206
   DataType: Eq_5206
@@ -23736,8 +23339,8 @@ T_5209: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5210: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5211: (in a0_1704 : (ptr32 Eq_5211))
   Class: Eq_5211
@@ -23788,12 +23391,12 @@ T_5222: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5223: (in d0 + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_5224: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_5225: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5225
@@ -23848,8 +23451,8 @@ T_5237: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5238: (in d0_1765 & 8<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5239: (in d0_1765 & 8<32> : word32)
   Class: Eq_5239
@@ -24035,18 +23638,18 @@ T_5284: (in 0x68<8> : byte)
   Class: Eq_5283
   DataType: byte
   OrigDataType: byte
-T_5285: (in *((word32) a7_1330 + 72<i32>) != 0x68<8> : bool)
+T_5285: (in a7_1330[18<i32>] != 0x68<8> : bool)
   Class: Eq_5285
   DataType: bool
   OrigDataType: bool
 T_5286: (in 3<32> : word32)
   Class: Eq_5286
-  DataType: (ptr32 Eq_8443)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8435)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5287: (in d2_1090 + 3<32> : word32)
   Class: Eq_5287
-  DataType: (ptr32 Eq_8444)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8436)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5288: (in 2<32> : word32)
   Class: Eq_5288
   DataType: word32
@@ -24060,8 +23663,8 @@ T_5290: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5291: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5292: (in 0<32> : word32)
   Class: Eq_5292
@@ -24085,19 +23688,19 @@ T_5296: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_5297: (in Mem1694[Mem629[d0 + 0<32>:word32] + 0<32>:word32] : word32)
   Class: Eq_4327
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: Eq_4327
 T_5298: (in 4<32> : word32)
   Class: Eq_5298
   DataType: int32
   OrigDataType: int32
 T_5299: (in d0 + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
-T_5300: (in a7_1807 : (ptr32 Eq_623))
+T_5300: (in a7_1807 : (ptr32 Eq_624))
   Class: Eq_5300
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_5301: (in 4<i32> : int32)
   Class: Eq_5301
@@ -24105,7 +23708,7 @@ T_5301: (in 4<i32> : int32)
   OrigDataType: int32
 T_5302: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5300
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_5303: (in 0<32> : word32)
   Class: Eq_5303
@@ -24116,8 +23719,8 @@ T_5304: (in a7_1807 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5305: (in Mem1809[a7_1807 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5306: (in d1_5322 : word32)
   Class: Eq_5306
@@ -24136,8 +23739,8 @@ T_5309: (in a7_1807 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5310: (in Mem1809[a7_1807 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5311: (in out d1_5322 : ptr32)
   Class: Eq_2669
@@ -24152,8 +23755,8 @@ T_5313: (in out a5_1727 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct 0001 (0 byte b0000)))
 T_5314: (in fn00003CCC(*a7_1807, out d1_5322, out a1, out a5_1727) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5315: (in 4<i32> : int32)
   Class: Eq_5315
@@ -24161,7 +23764,7 @@ T_5315: (in 4<i32> : int32)
   OrigDataType: int32
 T_5316: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5317: (in a0_1825 : (ptr32 byte))
   Class: Eq_4695
@@ -24179,9 +23782,9 @@ T_5320: (in Mem1802[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
-T_5321: (in a7_1826 : (ptr32 Eq_623))
+T_5321: (in a7_1826 : (ptr32 Eq_624))
   Class: Eq_5321
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_5322: (in 4<i32> : int32)
   Class: Eq_5322
@@ -24189,7 +23792,7 @@ T_5322: (in 4<i32> : int32)
   OrigDataType: int32
 T_5323: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5321
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_5324: (in 0<32> : word32)
   Class: Eq_5324
@@ -24200,8 +23803,8 @@ T_5325: (in a7_1826 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5326: (in Mem1828[a7_1826 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5327: (in 1<i32> : int32)
   Class: Eq_5327
@@ -24221,8 +23824,8 @@ T_5330: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_5331: (in Mem1832[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_5332: (in v201_1836 : byte)
   Class: Eq_4710
   DataType: byte
@@ -24248,24 +23851,24 @@ T_5337: (in a7_1826 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5338: (in Mem1832[a7_1826 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5339: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_5339
   DataType: word24
   OrigDataType: word24
 T_5340: (in SEQ(SLICE(d0, word24, 8), v201_1836) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5341: (in (uint8) v201_1836 : uint8)
   Class: Eq_5341
   DataType: uint8
   OrigDataType: uint8
 T_5342: (in (uint32) (uint8) v201_1836 : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_5343: (in 1<32> : word32)
   Class: Eq_5343
@@ -24284,8 +23887,8 @@ T_5346: (in d4_132 + 1<32> : word32)
   DataType: Eq_4327
   OrigDataType: int32
 T_5347: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_5348: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5348
@@ -24307,18 +23910,18 @@ T_5352: (in 2<8> : byte)
   Class: Eq_5351
   DataType: byte
   OrigDataType: byte
-T_5353: (in *((word32) a7_1330 + 72<i32>) != 2<8> : bool)
+T_5353: (in a7_1330[18<i32>] != 2<8> : bool)
   Class: Eq_5353
   DataType: bool
   OrigDataType: bool
 T_5354: (in 3<32> : word32)
   Class: Eq_5354
-  DataType: (ptr32 Eq_8445)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8437)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5355: (in d2_1090 + 3<32> : word32)
   Class: Eq_5355
-  DataType: (ptr32 Eq_8446)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8438)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5356: (in 2<32> : word32)
   Class: Eq_5356
   DataType: word32
@@ -24332,8 +23935,8 @@ T_5358: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5359: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5360: (in SLICE(d4_132, word16, 0) : word16)
   Class: Eq_4327
@@ -24361,15 +23964,15 @@ T_5365: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_5366: (in Mem1682[Mem629[d0 + 0<32>:word32] + 0<32>:word16] : word16)
   Class: Eq_4327
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: Eq_4327
 T_5367: (in 4<32> : word32)
   Class: Eq_5367
   DataType: int32
   OrigDataType: int32
 T_5368: (in d0 + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_5369: (in 73<i32> : int32)
   Class: Eq_5369
@@ -24381,7 +23984,7 @@ T_5370: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5371: (in Mem1889[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_5245
-  DataType: Eq_4320
+  DataType: byte
   OrigDataType: byte
 T_5372: (in d0_1871 : uint32)
   Class: Eq_5372
@@ -24432,8 +24035,8 @@ T_5383: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5384: (in d0_1871 & 8<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5385: (in d0_1871 & 8<32> : word32)
   Class: Eq_5385
@@ -24469,12 +24072,12 @@ T_5392: (in v190_1777 != 0<8> : bool)
   OrigDataType: bool
 T_5393: (in 3<32> : word32)
   Class: Eq_5393
-  DataType: (ptr32 Eq_8447)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8439)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5394: (in d2_1090 + 3<32> : word32)
   Class: Eq_5394
-  DataType: (ptr32 Eq_8448)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8440)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5395: (in 2<32> : word32)
   Class: Eq_5395
   DataType: word32
@@ -24488,8 +24091,8 @@ T_5397: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5398: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5399: (in 0<32> : word32)
   Class: Eq_5399
@@ -24513,24 +24116,24 @@ T_5403: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: (ptr32 int32)
 T_5404: (in Mem1658[Mem629[d0 + 0<32>:word32] + 0<32>:word32] : word32)
   Class: Eq_4327
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: Eq_4327
 T_5405: (in 4<32> : word32)
   Class: Eq_5405
   DataType: int32
   OrigDataType: int32
 T_5406: (in d0 + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_5407: (in 3<32> : word32)
   Class: Eq_5407
-  DataType: (ptr32 Eq_8449)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8441)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5408: (in d2_1090 + 3<32> : word32)
   Class: Eq_5408
-  DataType: (ptr32 Eq_8450)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8442)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5409: (in 2<32> : word32)
   Class: Eq_5409
   DataType: word32
@@ -24544,8 +24147,8 @@ T_5411: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5412: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5413: (in SLICE(d4_132, byte, 0) : byte)
   Class: Eq_4327
@@ -24573,15 +24176,15 @@ T_5418: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: (ptr32 int32)
 T_5419: (in Mem1670[Mem629[d0 + 0<32>:word32] + 0<32>:byte] : byte)
   Class: Eq_4327
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: Eq_4327
 T_5420: (in 4<32> : word32)
   Class: Eq_5420
   DataType: int32
   OrigDataType: int32
 T_5421: (in d0 + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_5422: (in 1<32> : word32)
   Class: Eq_5422
@@ -24615,13 +24218,13 @@ T_5429: (in 0<8> : byte)
   Class: Eq_5428
   DataType: byte
   OrigDataType: byte
-T_5430: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5430: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5430
   DataType: bool
   OrigDataType: bool
-T_5431: (in a7_1897 : (ptr32 Eq_623))
+T_5431: (in a7_1897 : (ptr32 Eq_624))
   Class: Eq_5431
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_5432: (in 4<i32> : int32)
   Class: Eq_5432
@@ -24629,7 +24232,7 @@ T_5432: (in 4<i32> : int32)
   OrigDataType: int32
 T_5433: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5431
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_5434: (in 0<32> : word32)
   Class: Eq_5434
@@ -24640,8 +24243,8 @@ T_5435: (in a7_1897 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5436: (in Mem1903[a7_1897 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5437: (in 4<i32> : int32)
   Class: Eq_5437
@@ -24649,7 +24252,7 @@ T_5437: (in 4<i32> : int32)
   OrigDataType: int32
 T_5438: (in a7_1897 - 4<i32> : word32)
   Class: Eq_5438
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_5441 t0000)))
 T_5439: (in 0<32> : word32)
   Class: Eq_5439
@@ -24660,8 +24263,8 @@ T_5440: (in a7_1897 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5441: (in Mem1906[a7_1897 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5442: (in fn00002BF8 : ptr32)
   Class: Eq_4870
@@ -24673,7 +24276,7 @@ T_5443: (in 1<i32> : int32)
   OrigDataType: int32
 T_5444: (in a7_1897 - 1<i32> : word32)
   Class: Eq_5444
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5447 t0000)))
 T_5445: (in 0<32> : word32)
   Class: Eq_5445
@@ -24684,8 +24287,8 @@ T_5446: (in a7_1897 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5447: (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_5448: (in 0<32> : word32)
   Class: Eq_5448
@@ -24696,16 +24299,16 @@ T_5449: (in a7_1897 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5450: (in Mem1906[a7_1897 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5451: (in fn00002BF8(*(a7_1897 - 1<i32>), *a7_1897) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5452: (in 0x2B<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_5453: (in d5_1044 != 0x2B<32> : bool)
   Class: Eq_5453
@@ -24756,9 +24359,9 @@ T_5464: (in a7_1330 + 110<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5465: (in Mem1994[a7_1330 + 110<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_4320
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_5466: (in a0_1999 : (ptr32 ui32))
   Class: Eq_5466
   DataType: (ptr32 ui32)
@@ -24880,8 +24483,8 @@ T_5495: (in a7_2007 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5496: (in Mem2009[a7_2007 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5497: (in a5_5323 : word32)
   Class: Eq_5497
@@ -24900,13 +24503,13 @@ T_5500: (in a7_2007 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5501: (in Mem2009[a7_2007 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5502: (in out d1 : ptr32)
   Class: Eq_2669
   DataType: Eq_2669
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_5503: (in out a1 : ptr32)
   Class: Eq_4684
   DataType: (ptr32 word32)
@@ -24916,8 +24519,8 @@ T_5504: (in out a5_5323 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5505: (in fn00003CCC(a7_2007->t0000, out d1, out a1, out a5_5323) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5506: (in 56<i32> : int32)
   Class: Eq_5506
@@ -24928,8 +24531,8 @@ T_5507: (in a7_2007 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5508: (in Mem2022[a7_2007 + 56<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5509: (in 4<i32> : int32)
   Class: Eq_5509
@@ -24937,7 +24540,7 @@ T_5509: (in 4<i32> : int32)
   OrigDataType: int32
 T_5510: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5511: (in a0_2026 : (ptr32 byte))
   Class: Eq_4695
@@ -24976,8 +24579,8 @@ T_5519: (in a7_2027 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5520: (in Mem2029[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5521: (in 1<i32> : int32)
   Class: Eq_5521
@@ -24997,8 +24600,8 @@ T_5524: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_5525: (in Mem2033[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_5526: (in v231_2037 : byte)
   Class: Eq_4710
   DataType: byte
@@ -25024,8 +24627,8 @@ T_5531: (in a7_2027 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5532: (in Mem2033[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5533: (in 0<32> : word32)
   Class: Eq_5533
@@ -25036,8 +24639,8 @@ T_5534: (in a7_2027 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5535: (in Mem2050[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5536: (in (uint8) v231_2037 : uint8)
   Class: Eq_5536
@@ -25064,8 +24667,8 @@ T_5541: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5542: (in SEQ(SLICE(d0, word24, 8), v231_2037) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5543: (in 0<32> : word32)
   Class: Eq_5543
@@ -25076,8 +24679,8 @@ T_5544: (in a7_2027 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5545: (in Mem2056[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5546: (in 52<i32> : int32)
   Class: Eq_5546
@@ -25088,8 +24691,8 @@ T_5547: (in a7_1330 + 52<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5548: (in Mem2062[a7_1330 + 52<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5549: (in 1<32> : word32)
   Class: Eq_5549
@@ -25157,7 +24760,7 @@ T_5564: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5565: (in Mem1946[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_5563
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
 T_5566: (in d4_2510 : Eq_4327)
   Class: Eq_4327
@@ -25180,8 +24783,8 @@ T_5570: (in (byte) d7 != 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_5571: (in 0x30<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_5572: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_5572
@@ -25236,8 +24839,8 @@ T_5584: (in 4<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5585: (in d0_2109 & 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5586: (in d0_2109 & 4<32> : word32)
   Class: Eq_5586
@@ -25263,9 +24866,9 @@ T_5591: (in d6_1133 - d3_1850 < 0<32> : bool)
   Class: Eq_5591
   DataType: bool
   OrigDataType: bool
-T_5592: (in d0_2155 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_5592: (in d0_2155 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5593: (in a0_2139 : (ptr32 ui32))
   Class: Eq_5593
@@ -25388,8 +24991,8 @@ T_5622: (in a7_2148 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5623: (in Mem2150[a7_2148 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5624: (in a5_5324 : word32)
   Class: Eq_5624
@@ -25408,13 +25011,13 @@ T_5627: (in a7_2148 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5628: (in Mem2150[a7_2148 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5629: (in out d1 : ptr32)
   Class: Eq_2669
   DataType: Eq_2669
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_5630: (in out a1 : ptr32)
   Class: Eq_4684
   DataType: (ptr32 word32)
@@ -25424,8 +25027,8 @@ T_5631: (in out a5_5324 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5632: (in fn00003CCC(a7_2148->t0000, out d1, out a1, out a5_5324) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5633: (in 56<i32> : int32)
   Class: Eq_5633
@@ -25436,8 +25039,8 @@ T_5634: (in a7_2148 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5635: (in Mem2163[a7_2148 + 56<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5636: (in 4<i32> : int32)
   Class: Eq_5636
@@ -25445,7 +25048,7 @@ T_5636: (in 4<i32> : int32)
   OrigDataType: int32
 T_5637: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5638: (in a0_2167 : (ptr32 byte))
   Class: Eq_4695
@@ -25484,8 +25087,8 @@ T_5646: (in a7_2168 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5647: (in Mem2170[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5648: (in 1<i32> : int32)
   Class: Eq_5648
@@ -25505,8 +25108,8 @@ T_5651: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_5652: (in Mem2174[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_5653: (in v249_2178 : byte)
   Class: Eq_4710
   DataType: byte
@@ -25532,8 +25135,8 @@ T_5658: (in a7_2168 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5659: (in Mem2174[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5660: (in 0<32> : word32)
   Class: Eq_5660
@@ -25544,8 +25147,8 @@ T_5661: (in a7_2168 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5662: (in Mem2185[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5663: (in (uint8) v249_2178 : uint8)
   Class: Eq_5663
@@ -25572,8 +25175,8 @@ T_5668: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5669: (in SEQ(SLICE(d0, word24, 8), v249_2178) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5670: (in 0<32> : word32)
   Class: Eq_5670
@@ -25584,8 +25187,8 @@ T_5671: (in a7_2168 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5672: (in Mem2191[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5673: (in 52<i32> : int32)
   Class: Eq_5673
@@ -25625,12 +25228,12 @@ T_5681: (in 55<i32> : int32)
   OrigDataType: int32
 T_5682: (in a7_1330 + 55<i32> : word32)
   Class: Eq_5682
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_5683: (in Mem2199[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_5683
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_5684: (in SEQ(SLICE(d0_2155, word24, 8), Mem2199[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_5679
   DataType: ui32
@@ -25652,8 +25255,8 @@ T_5688: (in 0xFF<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5689: (in d0_2209 & 0xFF<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5690: (in __btst : ptr32)
   Class: Eq_5690
@@ -25723,17 +25326,17 @@ T_5706: (in 0<8> : byte)
   Class: Eq_5705
   DataType: byte
   OrigDataType: byte
-T_5707: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5707: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5707
   DataType: bool
   OrigDataType: bool
 T_5708: (in 1<i32> : int32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: int32
 T_5709: (in 0x78<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_5710: (in d0 != 0x78<32> : bool)
   Class: Eq_5710
@@ -25764,8 +25367,8 @@ T_5716: (in (byte) (d0_2209 & 0xFF<32>) | 0x20<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_5717: (in SEQ(SLICE(d0_2209 & 0xFF<32>, word24, 8), SLICE(d0_2209 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5718: (in 0<32> : word32)
   Class: Eq_5702
@@ -25773,12 +25376,12 @@ T_5718: (in 0<32> : word32)
   OrigDataType: word32
 T_5719: (in 3<32> : word32)
   Class: Eq_5719
-  DataType: (ptr32 Eq_8451)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8443)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5720: (in d2_1090 + 3<32> : word32)
   Class: Eq_5720
-  DataType: (ptr32 Eq_8452)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8444)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5721: (in 2<32> : word32)
   Class: Eq_5721
   DataType: word32
@@ -25792,16 +25395,16 @@ T_5723: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5724: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5725: (in 4<32> : word32)
   Class: Eq_5725
   DataType: int32
   OrigDataType: int32
 T_5726: (in d0 + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ptr32
 T_5727: (in 0<32> : word32)
   Class: Eq_5727
@@ -25913,8 +25516,8 @@ T_5753: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5754: (in Mem1393[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_5702
-  DataType: Eq_4320
-  OrigDataType: (ptr32 Eq_4327)
+  DataType: (ptr32 Eq_4327)
+  OrigDataType: int32
 T_5755: (in 0<32> : word32)
   Class: Eq_5755
   DataType: word32
@@ -25951,9 +25554,9 @@ T_5763: (in d6_1133 - d3_2201 < 0<32> : bool)
   Class: Eq_5763
   DataType: bool
   OrigDataType: bool
-T_5764: (in d0_2253 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_5764: (in d0_2253 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5765: (in a0_2236 : (ptr32 ui32))
   Class: Eq_5765
@@ -26076,8 +25679,8 @@ T_5794: (in a7_2246 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5795: (in Mem2248[a7_2246 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5796: (in a5_5325 : word32)
   Class: Eq_5796
@@ -26096,13 +25699,13 @@ T_5799: (in a7_2246 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5800: (in Mem2248[a7_2246 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5801: (in out d1 : ptr32)
   Class: Eq_2669
   DataType: Eq_2669
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_5802: (in out a1 : ptr32)
   Class: Eq_4684
   DataType: (ptr32 word32)
@@ -26112,8 +25715,8 @@ T_5803: (in out a5_5325 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5804: (in fn00003CCC(a7_2246->t0000, out d1, out a1, out a5_5325) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5805: (in 56<i32> : int32)
   Class: Eq_5805
@@ -26124,8 +25727,8 @@ T_5806: (in a7_2246 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5807: (in Mem2261[a7_2246 + 56<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5808: (in 4<i32> : int32)
   Class: Eq_5808
@@ -26133,7 +25736,7 @@ T_5808: (in 4<i32> : int32)
   OrigDataType: int32
 T_5809: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_5810: (in a0_2265 : (ptr32 byte))
   Class: Eq_4695
@@ -26172,8 +25775,8 @@ T_5818: (in a7_2266 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5819: (in Mem2268[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5820: (in 1<i32> : int32)
   Class: Eq_5820
@@ -26193,8 +25796,8 @@ T_5823: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_5824: (in Mem2272[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_5825: (in v271_2276 : byte)
   Class: Eq_4710
   DataType: byte
@@ -26220,8 +25823,8 @@ T_5830: (in a7_2266 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5831: (in Mem2272[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5832: (in 0<32> : word32)
   Class: Eq_5832
@@ -26232,8 +25835,8 @@ T_5833: (in a7_2266 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5834: (in Mem2283[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5835: (in (uint8) v271_2276 : uint8)
   Class: Eq_5835
@@ -26260,8 +25863,8 @@ T_5840: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5841: (in SEQ(SLICE(d0, word24, 8), v271_2276) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5842: (in 0<32> : word32)
   Class: Eq_5842
@@ -26272,8 +25875,8 @@ T_5843: (in a7_2266 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5844: (in Mem2289[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5845: (in 52<i32> : int32)
   Class: Eq_5845
@@ -26348,8 +25951,8 @@ T_5862: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5863: (in d0_2317 & 0x44<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_5864: (in d0_2317 & 0x44<32> : word32)
   Class: Eq_5864
@@ -26400,8 +26003,8 @@ T_5875: (in a7_1400 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5876: (in Mem1402[a7_1400 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5877: (in 48<i32> : int32)
   Class: Eq_5877
@@ -26436,13 +26039,13 @@ T_5884: (in a7_1400 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5885: (in Mem1404[a7_1400 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5886: (in out d1 : ptr32)
   Class: Eq_2669
   DataType: Eq_2669
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_5887: (in out a1_5326 : ptr32)
   Class: Eq_4684
   DataType: (ptr32 word32)
@@ -26452,8 +26055,8 @@ T_5888: (in out a5_5327 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5889: (in fn00003CCC(a7_1400->t0000, out d1, out a1_5326, out a5_5327) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5890: (in 56<i32> : int32)
   Class: Eq_5890
@@ -26464,8 +26067,8 @@ T_5891: (in a7_1400 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5892: (in Mem1417[a7_1400 + 56<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5893: (in 48<i32> : int32)
   Class: Eq_5893
@@ -26540,8 +26143,8 @@ T_5910: (in a7_1425 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5911: (in Mem1427[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5912: (in 1<i32> : int32)
   Class: Eq_5912
@@ -26588,8 +26191,8 @@ T_5922: (in a7_1425 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5923: (in Mem1431[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5924: (in 0<32> : word32)
   Class: Eq_5924
@@ -26600,8 +26203,8 @@ T_5925: (in a7_1425 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5926: (in Mem1444[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5927: (in (uint8) v284_1435 : uint8)
   Class: Eq_5927
@@ -26628,8 +26231,8 @@ T_5932: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5933: (in SEQ(SLICE(d0, word24, 8), v284_1435) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_5934: (in 0<32> : word32)
   Class: Eq_5934
@@ -26640,8 +26243,8 @@ T_5935: (in a7_1425 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5936: (in Mem1450[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5937: (in 44<i32> : int32)
   Class: Eq_5937
@@ -26653,7 +26256,7 @@ T_5938: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5939: (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: int32
 T_5940: (in 52<i32> : int32)
   Class: Eq_5940
@@ -26664,8 +26267,8 @@ T_5941: (in a7_1330 + 52<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5942: (in Mem1456[a7_1330 + 52<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_5943: (in d3_1462 : Eq_5943)
   Class: Eq_5943
@@ -26707,7 +26310,7 @@ T_5952: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_5951
   DataType: word32
   OrigDataType: word32
-T_5953: (in *((word32) a7_1330 + 52<i32>) == 0xFFFFFFFF<32> : bool)
+T_5953: (in a7_1330[13<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_5953
   DataType: bool
   OrigDataType: bool
@@ -26727,7 +26330,7 @@ T_5957: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_5956
   DataType: word32
   OrigDataType: word32
-T_5958: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_5958: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_5958
   DataType: bool
   OrigDataType: bool
@@ -26756,8 +26359,8 @@ T_5964: (in 120<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5965: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_5966: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5966
@@ -26773,8 +26376,8 @@ T_5968: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5969: (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_623
-  DataType: Eq_4320
-  OrigDataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: int32
 T_5970: (in d6_1133 - d3_1462 : word32)
   Class: Eq_5970
   DataType: Eq_5970
@@ -26968,8 +26571,8 @@ T_6017: (in a7_2334 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6018: (in Mem2338[a7_2334 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6019: (in 78<i32> : int32)
   Class: Eq_6019
@@ -27013,7 +26616,7 @@ T_6028: (in 1<i32> : int32)
   OrigDataType: int32
 T_6029: (in a7_2334 - 1<i32> : word32)
   Class: Eq_6029
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6032 t0000)))
 T_6030: (in 0<32> : word32)
   Class: Eq_6030
@@ -27024,8 +26627,8 @@ T_6031: (in a7_2334 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6032: (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_6033: (in 0<32> : word32)
   Class: Eq_6033
@@ -27036,16 +26639,16 @@ T_6034: (in a7_2334 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6035: (in Mem2342[a7_2334 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6036: (in fn00002BF8(*(a7_2334 - 1<i32>), a7_2334->t0000) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
-T_6037: (in a7_1512 : (ptr32 Eq_623))
+T_6037: (in a7_1512 : (ptr32 Eq_624))
   Class: Eq_6037
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_6038: (in 4<i32> : int32)
   Class: Eq_6038
@@ -27053,7 +26656,7 @@ T_6038: (in 4<i32> : int32)
   OrigDataType: int32
 T_6039: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6037
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_6040: (in 0<32> : word32)
   Class: Eq_6040
@@ -27064,8 +26667,8 @@ T_6041: (in a7_1512 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6042: (in Mem1514[a7_1512 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6043: (in d1_5328 : word32)
   Class: Eq_6043
@@ -27088,8 +26691,8 @@ T_6047: (in a7_1512 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6048: (in Mem1514[a7_1512 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6049: (in out d1_5328 : ptr32)
   Class: Eq_2669
@@ -27104,8 +26707,8 @@ T_6051: (in out a5_5329 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_6052: (in fn00003CCC(*a7_1512, out d1_5328, out a1, out a5_5329) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6053: (in 4<i32> : int32)
   Class: Eq_6053
@@ -27113,7 +26716,7 @@ T_6053: (in 4<i32> : int32)
   OrigDataType: int32
 T_6054: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6055: (in a0_1530 : (ptr32 byte))
   Class: Eq_4695
@@ -27131,9 +26734,9 @@ T_6058: (in Mem1507[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
-T_6059: (in a7_1531 : (ptr32 Eq_623))
+T_6059: (in a7_1531 : (ptr32 Eq_624))
   Class: Eq_6059
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_6060: (in 4<i32> : int32)
   Class: Eq_6060
@@ -27141,7 +26744,7 @@ T_6060: (in 4<i32> : int32)
   OrigDataType: int32
 T_6061: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6059
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_6062: (in 0<32> : word32)
   Class: Eq_6062
@@ -27152,8 +26755,8 @@ T_6063: (in a7_1531 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6064: (in Mem1533[a7_1531 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6065: (in 1<i32> : int32)
   Class: Eq_6065
@@ -27173,8 +26776,8 @@ T_6068: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_6069: (in Mem1537[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_6070: (in v314_1541 : byte)
   Class: Eq_4710
   DataType: byte
@@ -27200,24 +26803,24 @@ T_6075: (in a7_1531 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6076: (in Mem1537[a7_1531 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6077: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_6077
   DataType: word24
   OrigDataType: word24
 T_6078: (in SEQ(SLICE(d0, word24, 8), v314_1541) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_6079: (in (uint8) v314_1541 : uint8)
   Class: Eq_6079
   DataType: uint8
   OrigDataType: uint8
 T_6080: (in (uint32) (uint8) v314_1541 : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_6081: (in 1<32> : word32)
   Class: Eq_6081
@@ -27236,8 +26839,8 @@ T_6084: (in d4_1466 + 1<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_6085: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_6086: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6086
@@ -27253,7 +26856,7 @@ T_6088: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_6089: (in Mem1577[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_5973
-  DataType: Eq_4320
+  DataType: byte
   OrigDataType: byte
 T_6090: (in d6_1133 - d3_1462 : word32)
   Class: Eq_6090
@@ -27291,7 +26894,7 @@ T_6098: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6097
   DataType: word32
   OrigDataType: word32
-T_6099: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_6099: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6099
   DataType: bool
   OrigDataType: bool
@@ -27327,13 +26930,13 @@ T_6107: (in 0<8> : byte)
   Class: Eq_6106
   DataType: byte
   OrigDataType: byte
-T_6108: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_6108: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_6108
   DataType: bool
   OrigDataType: bool
-T_6109: (in a7_1585 : (ptr32 Eq_623))
+T_6109: (in a7_1585 : (ptr32 Eq_624))
   Class: Eq_6109
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_6110: (in 4<i32> : int32)
   Class: Eq_6110
@@ -27341,7 +26944,7 @@ T_6110: (in 4<i32> : int32)
   OrigDataType: int32
 T_6111: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6109
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_6112: (in 0<32> : word32)
   Class: Eq_6112
@@ -27352,8 +26955,8 @@ T_6113: (in a7_1585 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6114: (in Mem1591[a7_1585 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6115: (in 4<i32> : int32)
   Class: Eq_6115
@@ -27361,7 +26964,7 @@ T_6115: (in 4<i32> : int32)
   OrigDataType: int32
 T_6116: (in a7_1585 - 4<i32> : word32)
   Class: Eq_6116
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_6119 t0000)))
 T_6117: (in 0<32> : word32)
   Class: Eq_6117
@@ -27372,8 +26975,8 @@ T_6118: (in a7_1585 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6119: (in Mem1594[a7_1585 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6120: (in fn00002BF8 : ptr32)
   Class: Eq_4870
@@ -27385,7 +26988,7 @@ T_6121: (in 1<i32> : int32)
   OrigDataType: int32
 T_6122: (in a7_1585 - 1<i32> : word32)
   Class: Eq_6122
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6125 t0000)))
 T_6123: (in 0<32> : word32)
   Class: Eq_6123
@@ -27396,8 +26999,8 @@ T_6124: (in a7_1585 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6125: (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_6126: (in 0<32> : word32)
   Class: Eq_6126
@@ -27408,12 +27011,12 @@ T_6127: (in a7_1585 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6128: (in Mem1594[a7_1585 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6129: (in fn00002BF8(*(a7_1585 - 1<i32>), *a7_1585) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6130: (in a7_2368 : (ptr32 Eq_6130))
   Class: Eq_6130
@@ -27436,8 +27039,8 @@ T_6134: (in a7_2368 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6135: (in Mem2373[a7_2368 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6136: (in 68<i32> : int32)
   Class: Eq_6136
@@ -27481,7 +27084,7 @@ T_6145: (in 1<i32> : int32)
   OrigDataType: int32
 T_6146: (in a7_2368 - 1<i32> : word32)
   Class: Eq_6146
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6149 t0000)))
 T_6147: (in 0<32> : word32)
   Class: Eq_6147
@@ -27492,8 +27095,8 @@ T_6148: (in a7_2368 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6149: (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_6150: (in 0<32> : word32)
   Class: Eq_6150
@@ -27504,12 +27107,12 @@ T_6151: (in a7_2368 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6152: (in Mem2377[a7_2368 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6153: (in fn00002BF8(*(a7_2368 - 1<i32>), a7_2368->t0000) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6154: (in 0<32> : word32)
   Class: Eq_4338
@@ -27545,7 +27148,7 @@ T_6161: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6162: (in Mem1625[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_6160
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
 T_6163: (in d0_2124 : uint32)
   Class: Eq_6163
@@ -27600,8 +27203,8 @@ T_6175: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6176: (in d0_2124 & 0x44<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_6177: (in d0_2124 & 0x44<32> : word32)
   Class: Eq_6177
@@ -27644,8 +27247,8 @@ T_6186: (in (byte) d7 == 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_6187: (in 0x30<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_6188: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_6188
@@ -27663,9 +27266,9 @@ T_6191: (in d6_1133 - d3_1850 < 0<32> : bool)
   Class: Eq_6191
   DataType: bool
   OrigDataType: bool
-T_6192: (in d0_2450 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_6192: (in d0_2450 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_6193: (in a0_2430 : (ptr32 ui32))
   Class: Eq_6193
@@ -27788,8 +27391,8 @@ T_6222: (in a7_2443 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6223: (in Mem2445[a7_2443 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6224: (in a5_5330 : word32)
   Class: Eq_6224
@@ -27808,13 +27411,13 @@ T_6227: (in a7_2443 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6228: (in Mem2445[a7_2443 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6229: (in out d1 : ptr32)
   Class: Eq_2669
   DataType: Eq_2669
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_6230: (in out a1 : ptr32)
   Class: Eq_4684
   DataType: (ptr32 word32)
@@ -27824,8 +27427,8 @@ T_6231: (in out a5_5330 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_6232: (in fn00003CCC(a7_2443->t0000, out d1, out a1, out a5_5330) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6233: (in 56<i32> : int32)
   Class: Eq_6233
@@ -27836,8 +27439,8 @@ T_6234: (in a7_2443 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6235: (in Mem2458[a7_2443 + 56<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6236: (in 4<i32> : int32)
   Class: Eq_6236
@@ -27845,7 +27448,7 @@ T_6236: (in 4<i32> : int32)
   OrigDataType: int32
 T_6237: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6238: (in a0_2462 : (ptr32 byte))
   Class: Eq_4695
@@ -27884,8 +27487,8 @@ T_6246: (in a7_2463 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6247: (in Mem2465[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6248: (in 1<i32> : int32)
   Class: Eq_6248
@@ -27905,8 +27508,8 @@ T_6251: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_6252: (in Mem2469[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_6253: (in v351_2473 : byte)
   Class: Eq_4710
   DataType: byte
@@ -27932,8 +27535,8 @@ T_6258: (in a7_2463 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6259: (in Mem2469[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6260: (in 0<32> : word32)
   Class: Eq_6260
@@ -27944,8 +27547,8 @@ T_6261: (in a7_2463 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6262: (in Mem2492[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6263: (in (uint8) v351_2473 : uint8)
   Class: Eq_6263
@@ -27972,8 +27575,8 @@ T_6268: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_6269: (in SEQ(SLICE(d0, word24, 8), v351_2473) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_6270: (in 0<32> : word32)
   Class: Eq_6270
@@ -27984,8 +27587,8 @@ T_6271: (in a7_2463 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6272: (in Mem2498[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6273: (in 52<i32> : int32)
   Class: Eq_6273
@@ -28025,12 +27628,12 @@ T_6281: (in 55<i32> : int32)
   OrigDataType: int32
 T_6282: (in a7_1330 + 55<i32> : word32)
   Class: Eq_6282
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_6283: (in Mem2506[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_6283
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_6284: (in SEQ(SLICE(d0_2450, word24, 8), Mem2506[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_6279
   DataType: ui32
@@ -28064,8 +27667,8 @@ T_6291: (in 0xFF<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6292: (in d0_2517 & 0xFF<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_6293: (in __btst : ptr32)
   Class: Eq_5690
@@ -28104,8 +27707,8 @@ T_6301: (in __btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[(int3
   DataType: bool
   OrigDataType: bool
 T_6302: (in 0x78<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_6303: (in d0 != 0x78<32> : bool)
   Class: Eq_6303
@@ -28136,8 +27739,8 @@ T_6309: (in (byte) (d0_2517 & 0xFF<32>) | 0x20<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_6310: (in SEQ(SLICE(d0_2517 & 0xFF<32>, word24, 8), SLICE(d0_2517 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_6311: (in 64<i32> : int32)
   Class: Eq_6311
@@ -28155,7 +27758,7 @@ T_6314: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6313
   DataType: word32
   OrigDataType: word32
-T_6315: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_6315: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6315
   DataType: bool
   OrigDataType: bool
@@ -28171,9 +27774,9 @@ T_6318: (in d6_1133 - d3_2508 < 0<32> : bool)
   Class: Eq_6318
   DataType: bool
   OrigDataType: bool
-T_6319: (in d0_2559 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_6319: (in d0_2559 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_6320: (in a0_2542 : (ptr32 ui32))
   Class: Eq_6320
@@ -28296,8 +27899,8 @@ T_6349: (in a7_2552 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6350: (in Mem2554[a7_2552 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6351: (in a5_5331 : word32)
   Class: Eq_6351
@@ -28316,13 +27919,13 @@ T_6354: (in a7_2552 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6355: (in Mem2554[a7_2552 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6356: (in out d1 : ptr32)
   Class: Eq_2669
   DataType: Eq_2669
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_6357: (in out a1 : ptr32)
   Class: Eq_4684
   DataType: (ptr32 word32)
@@ -28332,8 +27935,8 @@ T_6358: (in out a5_5331 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_6359: (in fn00003CCC(a7_2552->t0000, out d1, out a1, out a5_5331) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6360: (in 56<i32> : int32)
   Class: Eq_6360
@@ -28344,8 +27947,8 @@ T_6361: (in a7_2552 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6362: (in Mem2567[a7_2552 + 56<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6363: (in 4<i32> : int32)
   Class: Eq_6363
@@ -28353,7 +27956,7 @@ T_6363: (in 4<i32> : int32)
   OrigDataType: int32
 T_6364: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6365: (in a0_2571 : (ptr32 byte))
   Class: Eq_4695
@@ -28392,8 +27995,8 @@ T_6373: (in a7_2572 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6374: (in Mem2574[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6375: (in 1<i32> : int32)
   Class: Eq_6375
@@ -28413,8 +28016,8 @@ T_6378: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_6379: (in Mem2578[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_6380: (in v372_2582 : byte)
   Class: Eq_4710
   DataType: byte
@@ -28440,8 +28043,8 @@ T_6385: (in a7_2572 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6386: (in Mem2578[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6387: (in 0<32> : word32)
   Class: Eq_6387
@@ -28452,8 +28055,8 @@ T_6388: (in a7_2572 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6389: (in Mem2589[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6390: (in (uint8) v372_2582 : uint8)
   Class: Eq_6390
@@ -28480,8 +28083,8 @@ T_6395: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_6396: (in SEQ(SLICE(d0, word24, 8), v372_2582) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_6397: (in 0<32> : word32)
   Class: Eq_6397
@@ -28492,8 +28095,8 @@ T_6398: (in a7_2572 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6399: (in Mem2595[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6400: (in 52<i32> : int32)
   Class: Eq_6400
@@ -28537,12 +28140,12 @@ T_6409: (in 55<i32> : int32)
   OrigDataType: int32
 T_6410: (in a7_1330 + 55<i32> : word32)
   Class: Eq_6410
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_6411: (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_6411
-  DataType: Eq_6411
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_6411 u2))
+  DataType: uint8
+  OrigDataType: uint8
 T_6412: (in SEQ(SLICE(d0_2559, word24, 8), Mem2603[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_6412
   DataType: ui32
@@ -28551,7 +28154,7 @@ T_6413: (in 0xFF<32> : word32)
   Class: Eq_6413
   DataType: ui32
   OrigDataType: ui32
-T_6414: (in SEQ(SLICE(d0_2559, word24, 8), *((word32) a7_1330 + 55<i32>)) & 0xFF<32> : word32)
+T_6414: (in SEQ(SLICE(d0_2559, word24, 8), a7_1330->b0037) & 0xFF<32> : word32)
   Class: Eq_6414
   DataType: int32
   OrigDataType: int32
@@ -28592,8 +28195,8 @@ T_6423: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6424: (in d0_2620 & 0x44<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_6425: (in d0_2620 & 0x44<32> : word32)
   Class: Eq_6425
@@ -28621,7 +28224,7 @@ T_6430: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6431: (in Mem2726[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_6428
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
 T_6432: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6432
@@ -28724,9 +28327,9 @@ T_6456: (in a7_1330 + 132<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6457: (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_4320
-  OrigDataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: word32
 T_6458: (in 52<i32> : int32)
   Class: Eq_6458
   DataType: int32
@@ -28737,8 +28340,8 @@ T_6459: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6460: (in Mem2796[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4327
-  DataType: Eq_4320
-  OrigDataType: Eq_4327
+  DataType: Eq_4327
+  OrigDataType: word32
 T_6461: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6461
   DataType: Eq_6461
@@ -28753,15 +28356,15 @@ T_6463: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6464: (in Mem2801[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6461
-  DataType: Eq_4320
-  OrigDataType: Eq_6461
+  DataType: Eq_6461
+  OrigDataType: word32
 T_6465: (in 0x44<32> : word32)
   Class: Eq_6465
   DataType: ui32
   OrigDataType: ui32
 T_6466: (in d0_2760 & 0x44<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_6467: (in d0_2760 & 0x44<32> : word32)
   Class: Eq_6467
@@ -28812,8 +28415,8 @@ T_6478: (in a7_2667 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6479: (in Mem2671[a7_2667 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6480: (in 68<i32> : int32)
   Class: Eq_6480
@@ -28857,7 +28460,7 @@ T_6489: (in 1<i32> : int32)
   OrigDataType: int32
 T_6490: (in a7_2667 - 1<i32> : word32)
   Class: Eq_6490
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6493 t0000)))
 T_6491: (in 0<32> : word32)
   Class: Eq_6491
@@ -28868,8 +28471,8 @@ T_6492: (in a7_2667 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6493: (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_6494: (in 0<32> : word32)
   Class: Eq_6494
@@ -28880,12 +28483,12 @@ T_6495: (in a7_2667 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6496: (in Mem2675[a7_2667 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6497: (in fn00002BF8(*(a7_2667 - 1<i32>), a7_2667->t0000) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6498: (in 74<i32> : int32)
   Class: Eq_6498
@@ -28903,7 +28506,7 @@ T_6501: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6500
   DataType: word32
   OrigDataType: word32
-T_6502: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_6502: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_6502
   DataType: bool
   OrigDataType: bool
@@ -28932,8 +28535,8 @@ T_6508: (in a7_1330 + 74<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6509: (in Mem2603[a7_1330 + 74<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6510: (in v476_3238 : Eq_6510)
   Class: Eq_6510
@@ -28984,8 +28587,8 @@ T_6521: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6522: (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_6523: (in 110<i32> : int32)
   Class: Eq_6523
@@ -29003,7 +28606,7 @@ T_6526: (in 0<32> : word32)
   Class: Eq_6525
   DataType: word32
   OrigDataType: word32
-T_6527: (in *((word32) a7_1330 + 110<i32>) == 0<32> : bool)
+T_6527: (in a7_1330->dw006E == 0<32> : bool)
   Class: Eq_6527
   DataType: bool
   OrigDataType: bool
@@ -29023,7 +28626,7 @@ T_6531: (in 0xA<32> : word32)
   Class: Eq_6530
   DataType: word32
   OrigDataType: word32
-T_6532: (in *((word32) a7_1330 + 114<i32>) != 0xA<32> : bool)
+T_6532: (in a7_1330->dw0072 != 0xA<32> : bool)
   Class: Eq_6532
   DataType: bool
   OrigDataType: bool
@@ -29043,7 +28646,7 @@ T_6536: (in 8<32> : word32)
   Class: Eq_6535
   DataType: word32
   OrigDataType: word32
-T_6537: (in *((word32) a7_1330 + 114<i32>) != 8<32> : bool)
+T_6537: (in a7_1330->dw0072 != 8<32> : bool)
   Class: Eq_6537
   DataType: bool
   OrigDataType: bool
@@ -29104,9 +28707,9 @@ T_6551: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6552: (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_4320
-  OrigDataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: word32
 T_6553: (in 52<i32> : int32)
   Class: Eq_6553
   DataType: int32
@@ -29117,8 +28720,8 @@ T_6554: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6555: (in Mem2823[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4327
-  DataType: Eq_4320
-  OrigDataType: Eq_4327
+  DataType: Eq_4327
+  OrigDataType: word32
 T_6556: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6556
   DataType: Eq_6556
@@ -29133,15 +28736,15 @@ T_6558: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6559: (in Mem2825[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6556
-  DataType: Eq_4320
-  OrigDataType: Eq_6556
+  DataType: Eq_6556
+  OrigDataType: word32
 T_6560: (in 4<32> : word32)
   Class: Eq_6560
   DataType: ui32
   OrigDataType: ui32
 T_6561: (in d0_2818 & 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_6562: (in d0_2818 & 4<32> : word32)
   Class: Eq_6562
@@ -29164,9 +28767,9 @@ T_6566: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6567: (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_4320
-  OrigDataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: word32
 T_6568: (in 52<i32> : int32)
   Class: Eq_6568
   DataType: int32
@@ -29177,8 +28780,8 @@ T_6569: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6570: (in Mem2854[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4327
-  DataType: Eq_4320
-  OrigDataType: Eq_4327
+  DataType: Eq_4327
+  OrigDataType: word32
 T_6571: (in 64<i32> : int32)
   Class: Eq_6571
   DataType: int32
@@ -29188,9 +28791,9 @@ T_6572: (in a7_1330 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6573: (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_4320
-  OrigDataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: word32
 T_6574: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6574
   DataType: Eq_6574
@@ -29205,8 +28808,8 @@ T_6576: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6577: (in Mem2869[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6574
-  DataType: Eq_4320
-  OrigDataType: Eq_6574
+  DataType: Eq_6574
+  OrigDataType: word32
 T_6578: (in d6_1133 - d3_2423 : word32)
   Class: Eq_6578
   DataType: Eq_6578
@@ -29228,9 +28831,9 @@ T_6582: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6583: (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_4320
-  OrigDataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: word32
 T_6584: (in 52<i32> : int32)
   Class: Eq_6584
   DataType: int32
@@ -29241,8 +28844,8 @@ T_6585: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6586: (in Mem2840[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4327
-  DataType: Eq_4320
-  OrigDataType: Eq_4327
+  DataType: Eq_4327
+  OrigDataType: word32
 T_6587: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6587
   DataType: Eq_6587
@@ -29257,11 +28860,11 @@ T_6589: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6590: (in Mem2843[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6587
-  DataType: Eq_4320
-  OrigDataType: Eq_6587
+  DataType: Eq_6587
+  OrigDataType: word32
 T_6591: (in 0x37<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: int32
 T_6592: (in d5_1044 > 0x37<32> : bool)
   Class: Eq_6592
@@ -29301,19 +28904,19 @@ T_6600: (in 0<i32> : int32)
   OrigDataType: int32
 T_6601: (in 0x30<32> : word32)
   Class: Eq_6601
-  DataType: (ptr32 (ptr32 Eq_4327))
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
-T_6602: (in d5_1044 - 0x30<32> : word32)
+  DataType: (ptr32 Eq_8446)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
+T_6602: (in d5_1044 - (struct Eq_8446 *) 0x30<32> : word32)
   Class: Eq_4327
   DataType: Eq_4327
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
-T_6603: (in d6_3015 : Eq_6603)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
+T_6603: (in d6_3015 : (ptr32 Eq_8447))
   Class: Eq_6603
-  DataType: Eq_6603
-  OrigDataType: (ptr32 (ptr32 Eq_4327))
-T_6604: (in v419_2893 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 Eq_8447)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
+T_6604: (in v419_2893 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_6605: (in 4<i32> : int32)
   Class: Eq_6605
@@ -29321,7 +28924,7 @@ T_6605: (in 4<i32> : int32)
   OrigDataType: int32
 T_6606: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6606
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_6609 t0000)))
 T_6607: (in 0<32> : word32)
   Class: Eq_6607
@@ -29332,8 +28935,8 @@ T_6608: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6609: (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_6610: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6610
@@ -29369,8 +28972,8 @@ T_6617: (in Mem2975[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_6618: (in d2_2977 : word32)
   Class: Eq_6618
-  DataType: Eq_6618
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  DataType: (ptr32 Eq_8448)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_6619: (in 68<i32> : int32)
   Class: Eq_6619
   DataType: int32
@@ -29381,12 +28984,12 @@ T_6620: (in a7_1330 + 68<i32> : word32)
   OrigDataType: ptr32
 T_6621: (in Mem2975[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_6621
-  DataType: Eq_6621
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  DataType: (ptr32 Eq_8450)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_6622: (in d4_2510 + Mem2975[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_6618
-  DataType: Eq_6618
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  DataType: (ptr32 Eq_8448)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_6623: (in 48<i32> : int32)
   Class: Eq_6623
   DataType: int32
@@ -29397,8 +29000,8 @@ T_6624: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6625: (in Mem2980[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6618
-  DataType: Eq_4320
-  OrigDataType: Eq_6618
+  DataType: (ptr32 Eq_8448)
+  OrigDataType: word32
 T_6626: (in 8<i32> : int32)
   Class: Eq_6626
   DataType: int32
@@ -29449,9 +29052,9 @@ T_6637: (in Mem2986[a7_1330 + 64<i32>:word32] + d0_2969 : word32)
   OrigDataType: word32
 T_6638: (in 0<32> : word32)
   Class: Eq_6618
-  DataType: (ptr32 (ptr32 Eq_4327))
+  DataType: (ptr32 Eq_8448)
   OrigDataType: up32
-T_6639: (in d2_2977 < 0<32> : bool)
+T_6639: (in d2_2977 < null : bool)
   Class: Eq_6639
   DataType: Eq_6639
   OrigDataType: (union (bool u0) (word32 u1))
@@ -29469,8 +29072,8 @@ T_6642: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_6643: (in Mem2992[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_6640
-  DataType: Eq_4320
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_6644: (in v441_2993 : word32)
   Class: Eq_6644
   DataType: word32
@@ -29573,20 +29176,20 @@ T_6668: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t
   OrigDataType: bool
 T_6669: (in 0<i32> : int32)
   Class: Eq_6603
-  DataType: (ptr32 (ptr32 Eq_4327))
+  DataType: (ptr32 Eq_8447)
   OrigDataType: int32
 T_6670: (in 0x37<32> : word32)
   Class: Eq_6670
-  DataType: (ptr32 (ptr32 Eq_4327))
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
-T_6671: (in d5_1044 - 0x37<32> : word32)
+  DataType: (ptr32 Eq_8452)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
+T_6671: (in d5_1044 - (struct Eq_8452 *) 0x37<32> : word32)
   Class: Eq_6603
-  DataType: Eq_6603
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
-T_6672: (in d2_3074 : Eq_6672)
+  DataType: (ptr32 Eq_8447)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
+T_6672: (in d2_3074 : (ptr32 Eq_8453))
   Class: Eq_6672
-  DataType: Eq_6672
-  OrigDataType: (ptr32 (ptr32 Eq_4327))
+  DataType: (ptr32 Eq_8453)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_6673: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6673
   DataType: (ptr32 word32)
@@ -29637,8 +29240,8 @@ T_6684: (in Mem3035[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_6685: (in d2_3037 : word32)
   Class: Eq_6685
-  DataType: Eq_6685
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  DataType: (ptr32 Eq_8450)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_6686: (in 48<i32> : int32)
   Class: Eq_6686
   DataType: int32
@@ -29649,12 +29252,12 @@ T_6687: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6688: (in Mem3035[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6688
-  DataType: (ptr32 Eq_8460)
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  DataType: (ptr32 Eq_8456)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_6689: (in d6_3015 + Mem3035[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6685
-  DataType: Eq_6685
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  DataType: (ptr32 Eq_8450)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_6690: (in 68<i32> : int32)
   Class: Eq_6690
   DataType: int32
@@ -29665,8 +29268,8 @@ T_6691: (in a7_1330 + 68<i32> : word32)
   OrigDataType: (ptr32 (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4327)) u1) (T_6621 u3)))
 T_6692: (in Mem3040[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_6685
-  DataType: Eq_4320
-  OrigDataType: Eq_6685
+  DataType: (ptr32 Eq_8450)
+  OrigDataType: (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4327)) u1) (T_6621 u3))
 T_6693: (in 8<i32> : int32)
   Class: Eq_6693
   DataType: int32
@@ -29717,13 +29320,13 @@ T_6704: (in Mem3045[a7_1330 + 44<i32>:word32] + d0_3029 : word32)
   OrigDataType: int32
 T_6705: (in 0<32> : word32)
   Class: Eq_6685
-  DataType: (ptr32 (ptr32 Eq_4327))
+  DataType: (ptr32 Eq_8450)
   OrigDataType: up32
-T_6706: (in d2_3037 < 0<32> : bool)
+T_6706: (in d2_3037 < null : bool)
   Class: Eq_6706
   DataType: bool
   OrigDataType: bool
-T_6707: (in (word32) *((word32) a7_1330 + 44<i32>) + d0_3029 + (d2_3037 < 0<32>) : word32)
+T_6707: (in (word32) a7_1330[11<i32>] + d0_3029 + (d2_3037 < null) : word32)
   Class: Eq_6707
   DataType: int32
   OrigDataType: int32
@@ -29737,8 +29340,8 @@ T_6709: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6710: (in Mem3051[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_6707
-  DataType: Eq_4320
-  OrigDataType: int32
+  DataType: int32
+  OrigDataType: word32
 T_6711: (in v453_3052 : word32)
   Class: Eq_6711
   DataType: word32
@@ -29821,23 +29424,23 @@ T_6730: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t
   OrigDataType: bool
 T_6731: (in 0<i32> : int32)
   Class: Eq_6672
-  DataType: (ptr32 (ptr32 Eq_4327))
+  DataType: (ptr32 Eq_8453)
   OrigDataType: int32
 T_6732: (in 0x57<32> : word32)
   Class: Eq_6732
-  DataType: (ptr32 (ptr32 Eq_4327))
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
-T_6733: (in d5_1044 - 0x57<32> : word32)
+  DataType: (ptr32 Eq_8456)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
+T_6733: (in d5_1044 - (struct Eq_8456 *) 0x57<32> : word32)
   Class: Eq_6672
-  DataType: Eq_6672
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
-T_6734: (in d0_3135 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 Eq_8453)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
+T_6734: (in d0_3135 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_6735: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6735
-  DataType: (ptr32 Eq_6672)
+  DataType: (ptr32 (ptr32 Eq_8453))
   OrigDataType: (ptr32 (struct (0 T_6738 t0000)))
 T_6736: (in 0<32> : word32)
   Class: Eq_6736
@@ -29849,7 +29452,7 @@ T_6737: (in a7_1330 - 4<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_6738: (in Mem3085[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_6672
-  DataType: Eq_6672
+  DataType: (ptr32 Eq_8453)
   OrigDataType: word32
 T_6739: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6739
@@ -29885,8 +29488,8 @@ T_6746: (in Mem3093[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_6747: (in d2_3095 : word32)
   Class: Eq_6747
-  DataType: Eq_6747
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  DataType: (ptr32 Eq_8456)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_6748: (in 68<i32> : int32)
   Class: Eq_6748
   DataType: int32
@@ -29901,8 +29504,8 @@ T_6750: (in Mem3093[a7_1330 + 68<i32>:word32] : word32)
   OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u0) (T_6621 u1) (T_6688 u2) (T_6692 u3))
 T_6751: (in d2_3074 + Mem3093[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_6747
-  DataType: Eq_6747
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  DataType: (ptr32 Eq_8456)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_6752: (in 48<i32> : int32)
   Class: Eq_6752
   DataType: int32
@@ -29913,8 +29516,8 @@ T_6753: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4327)) u1) (T_6688 u3)))
 T_6754: (in Mem3098[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6747
-  DataType: Eq_4320
-  OrigDataType: Eq_6747
+  DataType: (ptr32 Eq_8456)
+  OrigDataType: (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_4327)) u1) (T_6688 u3))
 T_6755: (in 8<i32> : int32)
   Class: Eq_6755
   DataType: int32
@@ -29961,9 +29564,9 @@ T_6765: (in Mem3103[a7_1330 + 64<i32>:word32] + (d2_3074 >> 31<i32>) : word32)
   OrigDataType: word32
 T_6766: (in 0<32> : word32)
   Class: Eq_6747
-  DataType: (ptr32 (ptr32 Eq_4327))
+  DataType: (ptr32 Eq_8456)
   OrigDataType: up32
-T_6767: (in d2_3095 < 0<32> : bool)
+T_6767: (in d2_3095 < null : bool)
   Class: Eq_6767
   DataType: Eq_6767
   OrigDataType: (union (bool u0) (word32 u1))
@@ -29981,8 +29584,8 @@ T_6770: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_6771: (in Mem3108[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_6768
-  DataType: Eq_4320
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_6772: (in a0_3119 : (ptr32 ui32))
   Class: Eq_6772
   DataType: (ptr32 ui32)
@@ -30021,7 +29624,7 @@ T_6780: (in Mem3108[a7_1330 - 8<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_6781: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6781
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_6784 t0000)))
 T_6782: (in 0<32> : word32)
   Class: Eq_6782
@@ -30032,8 +29635,8 @@ T_6783: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6784: (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_6785: (in 0<32> : word32)
   Class: Eq_6785
@@ -30125,7 +29728,7 @@ T_6806: (in v468_3124 < 0<32> : bool)
   OrigDataType: bool
 T_6807: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6807
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_6810 t0000)))
 T_6808: (in 0<32> : word32)
   Class: Eq_6808
@@ -30136,8 +29739,8 @@ T_6809: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6810: (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6811: (in d1_5332 : word32)
   Class: Eq_6811
@@ -30153,7 +29756,7 @@ T_6813: (in fn00003CCC : ptr32)
   OrigDataType: (ptr32 (fn T_6821 (T_6817, T_6818, T_6819, T_6820)))
 T_6814: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6814
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_6817 t0000)))
 T_6815: (in 0<32> : word32)
   Class: Eq_6815
@@ -30164,8 +29767,8 @@ T_6816: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6817: (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6818: (in out d1_5332 : ptr32)
   Class: Eq_2669
@@ -30180,8 +29783,8 @@ T_6820: (in out a5_5333 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_6821: (in fn00003CCC(*(a7_1330 - 4<i32>), out d1_5332, out a1, out a5_5333) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6822: (in 4<i32> : int32)
   Class: Eq_6822
@@ -30189,7 +29792,7 @@ T_6822: (in 4<i32> : int32)
   OrigDataType: int32
 T_6823: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6824: (in a0_3146 : (ptr32 byte))
   Class: Eq_4695
@@ -30209,7 +29812,7 @@ T_6827: (in Mem3125[a1 + 0<32>:word32] : word32)
   OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_6828: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6828
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_6831 t0000)))
 T_6829: (in 0<32> : word32)
   Class: Eq_6829
@@ -30220,8 +29823,8 @@ T_6830: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6831: (in Mem3149[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6832: (in 1<i32> : int32)
   Class: Eq_6832
@@ -30241,8 +29844,8 @@ T_6835: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_6836: (in Mem3153[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_6837: (in 0<32> : word32)
   Class: Eq_6837
   DataType: word32
@@ -30260,12 +29863,12 @@ T_6840: (in (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_6841: (in (uint32) (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_6842: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6842
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_6845 t0000)))
 T_6843: (in 0<32> : word32)
   Class: Eq_6843
@@ -30276,8 +29879,8 @@ T_6844: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6845: (in Mem3153[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6846: (in SLICE(d0_3135, byte, 0) : byte)
   Class: Eq_6846
@@ -30288,8 +29891,8 @@ T_6847: (in (uint8) SLICE(d0_3135, byte, 0) : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_6848: (in (uint32) (uint8) SLICE(d0_3135, byte, 0) : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_6849: (in 52<i32> : int32)
   Class: Eq_6849
@@ -30321,7 +29924,7 @@ T_6855: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6856: (in Mem3172[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_6853
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
 T_6857: (in d0_3184 : uint32)
   Class: Eq_6857
@@ -30380,8 +29983,8 @@ T_6870: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6871: (in d0_3184 & 0x44<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_6872: (in d0_3184 & 0x44<32> : word32)
   Class: Eq_6872
@@ -30396,8 +29999,8 @@ T_6874: (in (d0_3184 & 0x44<32>) == 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_6875: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_6876: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6876
@@ -30412,8 +30015,8 @@ T_6878: (in d3_2423 != 2<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_6879: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_6880: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6880
@@ -30444,12 +30047,12 @@ T_6886: (in a7_1330 + 110<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6887: (in Mem3291[a7_1330 + 110<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
-T_6888: (in a7_3259 : (ptr32 Eq_623))
+T_6888: (in a7_3259 : (ptr32 Eq_624))
   Class: Eq_6888
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_6889: (in 4<i32> : int32)
   Class: Eq_6889
@@ -30457,7 +30060,7 @@ T_6889: (in 4<i32> : int32)
   OrigDataType: int32
 T_6890: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6888
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_6891: (in 0<32> : word32)
   Class: Eq_6891
@@ -30468,8 +30071,8 @@ T_6892: (in a7_3259 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6893: (in Mem3272[a7_3259 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6894: (in 4<i32> : int32)
   Class: Eq_6894
@@ -30477,7 +30080,7 @@ T_6894: (in 4<i32> : int32)
   OrigDataType: int32
 T_6895: (in a7_3259 - 4<i32> : word32)
   Class: Eq_6895
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_6898 t0000)))
 T_6896: (in 0<32> : word32)
   Class: Eq_6896
@@ -30488,8 +30091,8 @@ T_6897: (in a7_3259 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6898: (in Mem3275[a7_3259 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6899: (in fn00002BF8 : ptr32)
   Class: Eq_4870
@@ -30501,7 +30104,7 @@ T_6900: (in 1<i32> : int32)
   OrigDataType: int32
 T_6901: (in a7_3259 - 1<i32> : word32)
   Class: Eq_6901
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6904 t0000)))
 T_6902: (in 0<32> : word32)
   Class: Eq_6902
@@ -30512,8 +30115,8 @@ T_6903: (in a7_3259 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6904: (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_6905: (in 0<32> : word32)
   Class: Eq_6905
@@ -30524,12 +30127,12 @@ T_6906: (in a7_3259 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6907: (in Mem3275[a7_3259 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6908: (in fn00002BF8(*(a7_3259 - 1<i32>), *a7_3259) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6909: (in a7_2635 : (ptr32 Eq_6909))
   Class: Eq_6909
@@ -30552,8 +30155,8 @@ T_6913: (in a7_2635 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6914: (in Mem2639[a7_2635 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6915: (in 78<i32> : int32)
   Class: Eq_6915
@@ -30597,7 +30200,7 @@ T_6924: (in 1<i32> : int32)
   OrigDataType: int32
 T_6925: (in a7_2635 - 1<i32> : word32)
   Class: Eq_6925
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6928 t0000)))
 T_6926: (in 0<32> : word32)
   Class: Eq_6926
@@ -30608,8 +30211,8 @@ T_6927: (in a7_2635 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6928: (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_6929: (in 0<32> : word32)
   Class: Eq_6929
@@ -30620,12 +30223,12 @@ T_6930: (in a7_2635 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6931: (in Mem2643[a7_2635 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6932: (in fn00002BF8(*(a7_2635 - 1<i32>), a7_2635->t0000) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_6933: (in 0xA<32> : word32)
   Class: Eq_4476
@@ -30696,8 +30299,8 @@ T_6949: (in 4<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6950: (in d0_3206 & 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_6951: (in d0_3206 & 4<32> : word32)
   Class: Eq_6951
@@ -30728,8 +30331,8 @@ T_6957: (in a4_2881 - (v465_3109 + 1<32>) >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_6958: (in 0x37<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: int32
 T_6959: (in d1 > 0x37<32> : bool)
   Class: Eq_6959
@@ -30752,8 +30355,8 @@ T_6963: (in a7_2886 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6964: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_6965: (in 0<32> : word32)
   Class: Eq_6965
@@ -30764,16 +30367,16 @@ T_6966: (in a7_2886 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6967: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_6968: (in 31<i32> : int32)
   Class: Eq_6968
   DataType: int32
   OrigDataType: int32
 T_6969: (in d7 >> 31<i32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: int32
 T_6970: (in 0<32> : word32)
   Class: Eq_6970
@@ -30781,12 +30384,12 @@ T_6970: (in 0<32> : word32)
   OrigDataType: word32
 T_6971: (in a7_2886 + 0<32> : word32)
   Class: Eq_6971
-  DataType: (ptr32 Eq_6971)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2)))
+  DataType: (ptr32 (ptr32 Eq_1355))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2)))
 T_6972: (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1355 u2))
 T_6973: (in 4<i32> : int32)
   Class: Eq_6973
   DataType: int32
@@ -30813,7 +30416,7 @@ T_6978: (in 8<i32> : int32)
   OrigDataType: int32
 T_6979: (in a7_2886 - 8<i32> : word32)
   Class: Eq_6979
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
   OrigDataType: (ptr32 (struct (0 T_6982 t0000)))
 T_6980: (in 0<32> : word32)
   Class: Eq_6980
@@ -30825,7 +30428,7 @@ T_6981: (in a7_2886 - 8<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_6982: (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_6983: (in 52<i32> : int32)
   Class: Eq_6983
@@ -30951,21 +30554,21 @@ T_7013: (in d4 : Eq_4327)
   Class: Eq_4327
   DataType: Eq_4327
   OrigDataType: word32
-T_7014: (in dwArg04 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_7014: (in dwArg04 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_7015: (in dwArg08 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_7015: (in dwArg08 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_7016: (in dwArg0C : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_7016: (in dwArg0C : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
-T_7017: (in dwArg10 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_7017: (in dwArg10 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_7018: (in d1Out : ptr32)
   Class: Eq_7018
@@ -30973,7 +30576,7 @@ T_7018: (in d1Out : ptr32)
   OrigDataType: ptr32
 T_7019: (in a7_2886 - 24<i32> : word32)
   Class: Eq_7019
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_7022 t0000)))
 T_7020: (in 0<32> : word32)
   Class: Eq_7020
@@ -30984,8 +30587,8 @@ T_7021: (in a7_2886 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7022: (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7023: (in 20<i32> : int32)
   Class: Eq_7023
@@ -30993,7 +30596,7 @@ T_7023: (in 20<i32> : int32)
   OrigDataType: int32
 T_7024: (in a7_2886 - 20<i32> : word32)
   Class: Eq_7024
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_7027 t0000)))
 T_7025: (in 0<32> : word32)
   Class: Eq_7025
@@ -31004,8 +30607,8 @@ T_7026: (in a7_2886 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7027: (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7028: (in 16<i32> : int32)
   Class: Eq_7028
@@ -31013,7 +30616,7 @@ T_7028: (in 16<i32> : int32)
   OrigDataType: int32
 T_7029: (in a7_2886 - 16<i32> : word32)
   Class: Eq_7029
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_7032 t0000)))
 T_7030: (in 0<32> : word32)
   Class: Eq_7030
@@ -31024,8 +30627,8 @@ T_7031: (in a7_2886 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7032: (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7033: (in 12<i32> : int32)
   Class: Eq_7033
@@ -31033,7 +30636,7 @@ T_7033: (in 12<i32> : int32)
   OrigDataType: int32
 T_7034: (in a7_2886 - 12<i32> : word32)
   Class: Eq_7034
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_783)
   OrigDataType: (ptr32 (struct (0 T_7037 t0000)))
 T_7035: (in 0<32> : word32)
   Class: Eq_7035
@@ -31044,8 +30647,8 @@ T_7036: (in a7_2886 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7037: (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7038: (in out d1_2921 : ptr32)
   Class: Eq_7018
@@ -31089,12 +30692,12 @@ T_7047: (in 1<32> : word32)
   OrigDataType: word32
 T_7048: (in a7_2886 + 1<32> : word32)
   Class: Eq_7048
-  DataType: (ptr32 Eq_7048)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2)))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7049: (in Mem2934[a7_2886 + 1<32>:word24] : word24)
   Class: Eq_7049
-  DataType: Eq_7049
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1355 u2))
+  DataType: ui24
+  OrigDataType: ui24
 T_7050: (in SLICE(d5_1044, byte, 0) : byte)
   Class: Eq_7050
   DataType: uint8
@@ -31107,7 +30710,7 @@ T_7052: (in 0xFF<32> : word32)
   Class: Eq_7052
   DataType: ui32
   OrigDataType: ui32
-T_7053: (in SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32> : word32)
+T_7053: (in SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32> : word32)
   Class: Eq_7053
   DataType: int32
   OrigDataType: int32
@@ -31131,7 +30734,7 @@ T_7058: (in 4<32> : word32)
   Class: Eq_7058
   DataType: ui32
   OrigDataType: ui32
-T_7059: (in (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32> : word32)
+T_7059: (in (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32> : word32)
   Class: Eq_7059
   DataType: ui32
   OrigDataType: ui32
@@ -31139,7 +30742,7 @@ T_7060: (in 0<32> : word32)
   Class: Eq_7059
   DataType: ui32
   OrigDataType: word32
-T_7061: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32>) == 0<32> : bool)
+T_7061: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32>) == 0<32> : bool)
   Class: Eq_7061
   DataType: bool
   OrigDataType: bool
@@ -31175,13 +30778,13 @@ T_7069: (in 0<8> : byte)
   Class: Eq_7068
   DataType: byte
   OrigDataType: byte
-T_7070: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7070: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7070
   DataType: bool
   OrigDataType: bool
-T_7071: (in a7_3299 : (ptr32 Eq_623))
+T_7071: (in a7_3299 : (ptr32 Eq_624))
   Class: Eq_7071
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_7072: (in 4<i32> : int32)
   Class: Eq_7072
@@ -31189,7 +30792,7 @@ T_7072: (in 4<i32> : int32)
   OrigDataType: int32
 T_7073: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7071
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: ptr32
 T_7074: (in 0<32> : word32)
   Class: Eq_7074
@@ -31200,8 +30803,8 @@ T_7075: (in a7_3299 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7076: (in Mem3303[a7_3299 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7077: (in 4<i32> : int32)
   Class: Eq_7077
@@ -31209,7 +30812,7 @@ T_7077: (in 4<i32> : int32)
   OrigDataType: int32
 T_7078: (in a7_3299 - 4<i32> : word32)
   Class: Eq_7078
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_7081 t0000)))
 T_7079: (in 0<32> : word32)
   Class: Eq_7079
@@ -31220,8 +30823,8 @@ T_7080: (in a7_3299 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7081: (in Mem3306[a7_3299 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7082: (in fn00002BF8 : ptr32)
   Class: Eq_4870
@@ -31233,7 +30836,7 @@ T_7083: (in 1<i32> : int32)
   OrigDataType: int32
 T_7084: (in a7_3299 - 1<i32> : word32)
   Class: Eq_7084
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7087 t0000)))
 T_7085: (in 0<32> : word32)
   Class: Eq_7085
@@ -31244,8 +30847,8 @@ T_7086: (in a7_3299 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7087: (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_7088: (in 0<32> : word32)
   Class: Eq_7088
@@ -31256,12 +30859,12 @@ T_7089: (in a7_3299 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7090: (in Mem3306[a7_3299 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7091: (in fn00002BF8(*(a7_3299 - 1<i32>), *a7_3299) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7092: (in 0xA<32> : word32)
   Class: Eq_7092
@@ -31277,7 +30880,7 @@ T_7094: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7095: (in Mem2714[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7092
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
 T_7096: (in 8<32> : word32)
   Class: Eq_7096
@@ -31293,7 +30896,7 @@ T_7098: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7099: (in Mem2717[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7096
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
 T_7100: (in 52<i32> : int32)
   Class: Eq_7100
@@ -31351,7 +30954,7 @@ T_7113: (in 0x2D<32> : word32)
   Class: Eq_7112
   DataType: word32
   OrigDataType: word32
-T_7114: (in *((word32) a7_1330 + 110<i32>) != 0x2D<32> : bool)
+T_7114: (in a7_1330->dw006E != 0x2D<32> : bool)
   Class: Eq_7114
   DataType: bool
   OrigDataType: bool
@@ -31376,8 +30979,8 @@ T_7119: (in a7_3474 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7120: (in Mem3476[a7_3474 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7121: (in 76<i32> : int32)
   Class: Eq_7121
@@ -31417,7 +31020,7 @@ T_7129: (in 4<i32> : int32)
   OrigDataType: int32
 T_7130: (in a7_3474 + 4<i32> : word32)
   Class: Eq_4320
-  DataType: Eq_4320
+  DataType: (ptr32 Eq_4320)
   OrigDataType: ptr32
 T_7131: (in 56<i32> : int32)
   Class: Eq_7131
@@ -31445,12 +31048,12 @@ T_7136: (in d0_3495 : word32)
   OrigDataType: uint32
 T_7137: (in 3<32> : word32)
   Class: Eq_7137
-  DataType: (ptr32 Eq_8466)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8461)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7138: (in d2_1090 + 3<32> : word32)
   Class: Eq_7138
-  DataType: (ptr32 Eq_8467)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8462)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7139: (in 2<32> : word32)
   Class: Eq_7139
   DataType: word32
@@ -31472,8 +31075,8 @@ T_7143: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7144: (in (d0_3495 << 2<32>) + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_7145: (in a0_3501 : (ptr32 Eq_7145))
   Class: Eq_7145
@@ -31485,8 +31088,8 @@ T_7146: (in -4<i32> : int32)
   OrigDataType: int32
 T_7147: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7147
-  DataType: (ptr32 Eq_8468)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8463)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7148: (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7145
   DataType: (ptr32 Eq_7145)
@@ -31500,8 +31103,8 @@ T_7150: (in a7_3474 + 52<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7151: (in Mem3485[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7152: (in 4<i32> : int32)
   Class: Eq_7152
@@ -31512,8 +31115,8 @@ T_7153: (in a0_3501 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7154: (in Mem3503[a0_3501 + 4<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7155: (in 48<i32> : int32)
   Class: Eq_7155
@@ -31540,8 +31143,8 @@ T_7160: (in Mem3505[a0_3501 + 0<32>:word32] : word32)
   DataType: word32
   OrigDataType: word32
 T_7161: (in d0_3495 << 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_7162: (in v517_3507 : byte)
   Class: Eq_7125
@@ -31589,12 +31192,12 @@ T_7172: (in v517_3507 == 0<8> : bool)
   OrigDataType: bool
 T_7173: (in 3<32> : word32)
   Class: Eq_7173
-  DataType: (ptr32 Eq_8469)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8464)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7174: (in d2_1090 + 3<32> : word32)
   Class: Eq_7174
-  DataType: (ptr32 Eq_8470)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8465)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7175: (in 2<32> : word32)
   Class: Eq_7175
   DataType: word32
@@ -31616,8 +31219,8 @@ T_7179: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7180: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_7181: (in 52<i32> : int32)
   Class: Eq_7181
@@ -31628,12 +31231,12 @@ T_7182: (in a7_3474 + 52<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7183: (in Mem3508[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7184: (in SLICE(d0, byte, 0) : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: byte
 T_7185: (in -4<i32> : int32)
   Class: Eq_7185
@@ -31641,11 +31244,11 @@ T_7185: (in -4<i32> : int32)
   OrigDataType: int32
 T_7186: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7186
-  DataType: (ptr32 Eq_8471)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8466)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7187: (in Mem3508[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7187
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_7190 t0000)))
 T_7188: (in 0<32> : word32)
   Class: Eq_7188
@@ -31656,9 +31259,9 @@ T_7189: (in Mem3508[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7190: (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: byte
+  Class: Eq_624
+  DataType: Eq_783
+  OrigDataType: Eq_624
 T_7191: (in v518_3524 : byte)
   Class: Eq_7125
   DataType: byte
@@ -31705,12 +31308,12 @@ T_7201: (in v518_3524 == 0<8> : bool)
   OrigDataType: bool
 T_7202: (in 3<32> : word32)
   Class: Eq_7202
-  DataType: (ptr32 Eq_8472)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8467)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7203: (in d2_1090 + 3<32> : word32)
   Class: Eq_7203
-  DataType: (ptr32 Eq_8473)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8468)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7204: (in 2<32> : word32)
   Class: Eq_7204
   DataType: word32
@@ -31732,8 +31335,8 @@ T_7208: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7209: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_7210: (in 52<i32> : int32)
   Class: Eq_7210
@@ -31744,12 +31347,12 @@ T_7211: (in a7_3474 + 52<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7212: (in Mem3525[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7213: (in SLICE(d0, word16, 0) : word16)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word16
 T_7214: (in -4<i32> : int32)
   Class: Eq_7214
@@ -31757,11 +31360,11 @@ T_7214: (in -4<i32> : int32)
   OrigDataType: int32
 T_7215: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7215
-  DataType: (ptr32 Eq_8474)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8469)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7216: (in Mem3525[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7216
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_7219 t0000)))
 T_7217: (in 0<32> : word32)
   Class: Eq_7217
@@ -31772,9 +31375,9 @@ T_7218: (in Mem3525[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7219: (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: word16
+  Class: Eq_624
+  DataType: Eq_783
+  OrigDataType: Eq_624
 T_7220: (in v519_3541 : byte)
   Class: Eq_7125
   DataType: byte
@@ -31821,12 +31424,12 @@ T_7230: (in v519_3541 == 0<8> : bool)
   OrigDataType: bool
 T_7231: (in 3<32> : word32)
   Class: Eq_7231
-  DataType: (ptr32 Eq_8475)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8470)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7232: (in d2_1090 + 3<32> : word32)
   Class: Eq_7232
-  DataType: (ptr32 Eq_8476)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8471)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7233: (in 2<32> : word32)
   Class: Eq_7233
   DataType: word32
@@ -31848,8 +31451,8 @@ T_7237: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7238: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_7239: (in 52<i32> : int32)
   Class: Eq_7239
@@ -31860,8 +31463,8 @@ T_7240: (in a7_3474 + 52<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7241: (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7242: (in -4<i32> : int32)
   Class: Eq_7242
@@ -31869,11 +31472,11 @@ T_7242: (in -4<i32> : int32)
   OrigDataType: int32
 T_7243: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7243
-  DataType: (ptr32 Eq_8477)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8472)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7244: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7244
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_7247 t0000)))
 T_7245: (in 0<32> : word32)
   Class: Eq_7245
@@ -31884,17 +31487,17 @@ T_7246: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7247: (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: word32
+  Class: Eq_624
+  DataType: Eq_783
+  OrigDataType: Eq_624
 T_7248: (in 3<32> : word32)
   Class: Eq_7248
-  DataType: (ptr32 Eq_8478)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8473)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7249: (in d2_1090 + 3<32> : word32)
   Class: Eq_7249
-  DataType: (ptr32 Eq_8479)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8474)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7250: (in 2<32> : word32)
   Class: Eq_7250
   DataType: word32
@@ -31916,8 +31519,8 @@ T_7254: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7255: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_7256: (in 52<i32> : int32)
   Class: Eq_7256
@@ -31928,8 +31531,8 @@ T_7257: (in a7_3474 + 52<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7258: (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7259: (in -4<i32> : int32)
   Class: Eq_7259
@@ -31937,11 +31540,11 @@ T_7259: (in -4<i32> : int32)
   OrigDataType: int32
 T_7260: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7260
-  DataType: (ptr32 Eq_8480)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8475)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7261: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7261
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_7264 t0000)))
 T_7262: (in 0<32> : word32)
   Class: Eq_7262
@@ -31952,9 +31555,9 @@ T_7263: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7264: (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: word32
+  Class: Eq_624
+  DataType: Eq_783
+  OrigDataType: Eq_624
 T_7265: (in 60<i32> : int32)
   Class: Eq_7265
   DataType: int32
@@ -31981,7 +31584,7 @@ T_7270: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7271: (in Mem3574[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_7269
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
 T_7272: (in 48<i32> : int32)
   Class: Eq_7272
@@ -32001,12 +31604,12 @@ T_7275: (in 56<i32> : int32)
   OrigDataType: int32
 T_7276: (in a7_1330 + 56<i32> : word32)
   Class: Eq_7276
-  DataType: (ptr32 Eq_7276)
-  OrigDataType: (ptr32 (union (uint8 u0) (word32 u1) (T_6411 u2)))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7277: (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
   Class: Eq_7274
   DataType: Eq_7274
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_6411 u2))
+  OrigDataType: word32
 T_7278: (in 44<i32> : int32)
   Class: Eq_7278
   DataType: int32
@@ -32056,8 +31659,8 @@ T_7289: (in Mem3324[v528_3348 + 4<i32>:word32] : word32)
   DataType: word32
   OrigDataType: word32
 T_7290: (in -v528_3348->dw0004 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7291: (in 0<32> : word32)
   Class: Eq_7291
@@ -32076,16 +31679,16 @@ T_7294: (in -v528_3348->dw0000 : word32)
   DataType: int32
   OrigDataType: int32
 T_7295: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: up32
 T_7296: (in d1 < 0<32> : bool)
   Class: Eq_7296
   DataType: Eq_7296
   OrigDataType: (union (bool u0) (int32 u1))
 T_7297: (in -v528_3348->dw0000 - (d1 < 0<32>) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: int32
 T_7298: (in 0x38<32> : word32)
   Class: Eq_7298
@@ -32093,44 +31696,44 @@ T_7298: (in 0x38<32> : word32)
   OrigDataType: word32
 T_7299: (in a7_1330 + 0x38<32> : word32)
   Class: Eq_7299
-  DataType: (ptr32 Eq_7299)
-  OrigDataType: (ptr32 (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3)))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7300: (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
   Class: Eq_4320
-  DataType: Eq_4320
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
-T_7301: (in a7_3364 : Eq_7301)
+  DataType: (ptr32 Eq_4320)
+  OrigDataType: word32
+T_7301: (in a7_3364 : (ptr32 Eq_7301))
   Class: Eq_7301
-  DataType: Eq_7301
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_7301)
+  OrigDataType: (ptr32 (struct (0 T_7306 t0000) (30 T_7311 t0030) (38 T_7362 t0038) (3C T_624 t003C) (4C T_7309 t004C)))
 T_7302: (in 4<i32> : int32)
   Class: Eq_7302
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7303: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7301
-  DataType: Eq_7301
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_7301)
+  OrigDataType: ptr32
 T_7304: (in 0<32> : word32)
   Class: Eq_7304
   DataType: word32
   OrigDataType: word32
 T_7305: (in a7_3364 + 0<32> : word32)
   Class: Eq_7305
-  DataType: Eq_7305
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7306: (in Mem3375[a7_3364 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7301
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_7307: (in 76<i32> : int32)
   Class: Eq_7307
   DataType: int32
   OrigDataType: int32
 T_7308: (in a7_3364 + 76<i32> : word32)
   Class: Eq_7308
-  DataType: Eq_7308
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7309: (in Mem3375[a7_3364 + 76<i32>:byte] : byte)
   Class: Eq_7309
   DataType: byte
@@ -32139,7 +31742,7 @@ T_7310: (in 1<8> : byte)
   Class: Eq_7310
   DataType: byte
   OrigDataType: byte
-T_7311: (in *((word32) a7_3364 + 76<i32>) - 1<8> : byte)
+T_7311: (in a7_3364->b004C - 1<8> : byte)
   Class: Eq_7311
   DataType: byte
   OrigDataType: byte
@@ -32149,37 +31752,37 @@ T_7312: (in 48<i32> : int32)
   OrigDataType: int32
 T_7313: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7313
-  DataType: Eq_7313
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7314: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
   Class: Eq_7311
-  DataType: Eq_7301
+  DataType: byte
   OrigDataType: byte
 T_7315: (in 4<i32> : int32)
   Class: Eq_7315
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7316: (in a7_3364 + 4<i32> : word32)
   Class: Eq_4320
-  DataType: Eq_4320
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_4320)
+  OrigDataType: ptr32
 T_7317: (in 48<i32> : int32)
   Class: Eq_7317
   DataType: int32
   OrigDataType: int32
 T_7318: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7318
-  DataType: Eq_7318
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7319: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7319
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7320: (in 0<8> : byte)
-  Class: Eq_7319
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
-T_7321: (in *((word32) a7_3364 + 48<i32>) == 0<8> : bool)
+T_7321: (in a7_3364->b0030 == 0<8> : bool)
   Class: Eq_7321
   DataType: bool
   OrigDataType: bool
@@ -32193,35 +31796,35 @@ T_7323: (in 52<i32> : int32)
   OrigDataType: int32
 T_7324: (in a7_1330 + 52<i32> : word32)
   Class: Eq_7324
-  DataType: Eq_7324
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7325: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7322
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
-T_7326: (in v544_774 : byte)
+T_7326: (in v544_774 : Eq_7326)
   Class: Eq_7326
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7326
+  OrigDataType: (union (int32 u0) (byte u1))
 T_7327: (in 44<i32> : int32)
   Class: Eq_7327
   DataType: int32
   OrigDataType: int32
 T_7328: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7328
-  DataType: Eq_7328
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7329: (in Mem773[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7326
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7326
+  OrigDataType: int32
 T_7330: (in SEQ(v84_506, v544_774) : uip32)
   Class: Eq_4476
   DataType: int32
   OrigDataType: uip32
-T_7331: (in d1_1027 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_7331: (in d1_1027 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_7332: (in 52<i32> : int32)
   Class: Eq_7332
@@ -32229,11 +31832,11 @@ T_7332: (in 52<i32> : int32)
   OrigDataType: int32
 T_7333: (in a7_1330 + 52<i32> : word32)
   Class: Eq_7333
-  DataType: Eq_7333
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7334: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7335: (in 1<8> : byte)
   Class: Eq_7335
@@ -32245,12 +31848,12 @@ T_7336: (in 44<i32> : int32)
   OrigDataType: int32
 T_7337: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7337
-  DataType: Eq_7337
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7338: (in Mem769[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7335
-  DataType: Eq_4320
-  OrigDataType: byte
+  DataType: Eq_7335
+  OrigDataType: int32
 T_7339: (in 1<i32> : int32)
   Class: Eq_7339
   DataType: int32
@@ -32265,12 +31868,12 @@ T_7341: (in d0_3398 : word32)
   OrigDataType: uint32
 T_7342: (in 3<32> : word32)
   Class: Eq_7342
-  DataType: (ptr32 Eq_8487)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8476)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7343: (in d2_1090 + 3<32> : word32)
   Class: Eq_7343
-  DataType: (ptr32 Eq_8488)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8477)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7344: (in 2<32> : word32)
   Class: Eq_7344
   DataType: word32
@@ -32292,8 +31895,8 @@ T_7348: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7349: (in (d0_3398 << 2<32>) + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_7350: (in a0_3404 : (ptr32 Eq_7350))
   Class: Eq_7350
@@ -32305,8 +31908,8 @@ T_7351: (in -4<i32> : int32)
   OrigDataType: int32
 T_7352: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7352
-  DataType: (ptr32 Eq_8489)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8478)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7353: (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7350
   DataType: (ptr32 Eq_7350)
@@ -32317,11 +31920,11 @@ T_7354: (in 60<i32> : int32)
   OrigDataType: int32
 T_7355: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7355
-  DataType: Eq_7355
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7356: (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_7356
-  DataType: word32
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7357: (in 4<i32> : int32)
   Class: Eq_7357
@@ -32332,8 +31935,8 @@ T_7358: (in a0_3404 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7359: (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
-  Class: Eq_7356
-  DataType: word32
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7360: (in 56<i32> : int32)
   Class: Eq_7360
@@ -32341,8 +31944,8 @@ T_7360: (in 56<i32> : int32)
   OrigDataType: int32
 T_7361: (in a7_3364 + 56<i32> : word32)
   Class: Eq_7361
-  DataType: Eq_7361
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7362: (in Mem3406[a7_3364 + 56<i32>:word32] : word32)
   Class: Eq_7362
   DataType: word32
@@ -32360,11 +31963,11 @@ T_7365: (in Mem3408[a0_3404 + 0<32>:word32] : word32)
   DataType: word32
   OrigDataType: word32
 T_7366: (in d0_3398 << 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_7367: (in v540_3410 : byte)
-  Class: Eq_7367
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7368: (in 48<i32> : int32)
@@ -32373,18 +31976,18 @@ T_7368: (in 48<i32> : int32)
   OrigDataType: int32
 T_7369: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7369
-  DataType: Eq_7369
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7370: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7370
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7371: (in 1<8> : byte)
   Class: Eq_7371
   DataType: byte
   OrigDataType: byte
-T_7372: (in *((word32) a7_3364 + 48<i32>) - 1<8> : byte)
-  Class: Eq_7367
+T_7372: (in a7_3364->b0030 - 1<8> : byte)
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7373: (in 48<i32> : int32)
@@ -32393,14 +31996,14 @@ T_7373: (in 48<i32> : int32)
   OrigDataType: int32
 T_7374: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7374
-  DataType: Eq_7374
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7375: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7367
-  DataType: Eq_7301
+  Class: Eq_7311
+  DataType: byte
   OrigDataType: byte
 T_7376: (in 0<8> : byte)
-  Class: Eq_7367
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7377: (in v540_3410 == 0<8> : bool)
@@ -32409,12 +32012,12 @@ T_7377: (in v540_3410 == 0<8> : bool)
   OrigDataType: bool
 T_7378: (in 3<32> : word32)
   Class: Eq_7378
-  DataType: (ptr32 Eq_8490)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8479)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7379: (in d2_1090 + 3<32> : word32)
   Class: Eq_7379
-  DataType: (ptr32 Eq_8491)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8480)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7380: (in 2<32> : word32)
   Class: Eq_7380
   DataType: word32
@@ -32436,8 +32039,8 @@ T_7384: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7385: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_7386: (in 60<i32> : int32)
   Class: Eq_7386
@@ -32445,15 +32048,15 @@ T_7386: (in 60<i32> : int32)
   OrigDataType: int32
 T_7387: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7387
-  DataType: Eq_7387
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7388: (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7389: (in SLICE(d0, byte, 0) : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: byte
 T_7390: (in -4<i32> : int32)
   Class: Eq_7390
@@ -32461,11 +32064,11 @@ T_7390: (in -4<i32> : int32)
   OrigDataType: int32
 T_7391: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7391
-  DataType: (ptr32 Eq_8492)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8481)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7392: (in Mem3411[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7392
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_7395 t0000)))
 T_7393: (in 0<32> : word32)
   Class: Eq_7393
@@ -32476,11 +32079,11 @@ T_7394: (in Mem3411[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7395: (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: byte
+  Class: Eq_624
+  DataType: Eq_783
+  OrigDataType: Eq_624
 T_7396: (in v541_3427 : byte)
-  Class: Eq_7396
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7397: (in 48<i32> : int32)
@@ -32489,18 +32092,18 @@ T_7397: (in 48<i32> : int32)
   OrigDataType: int32
 T_7398: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7398
-  DataType: Eq_7398
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7399: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7399
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7400: (in 0x66<8> : byte)
   Class: Eq_7400
   DataType: byte
   OrigDataType: byte
-T_7401: (in *((word32) a7_3364 + 48<i32>) - 0x66<8> : byte)
-  Class: Eq_7396
+T_7401: (in a7_3364->b0030 - 0x66<8> : byte)
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7402: (in 48<i32> : int32)
@@ -32509,14 +32112,14 @@ T_7402: (in 48<i32> : int32)
   OrigDataType: int32
 T_7403: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7403
-  DataType: Eq_7403
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7404: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7396
-  DataType: Eq_7301
+  Class: Eq_7311
+  DataType: byte
   OrigDataType: byte
 T_7405: (in 0<8> : byte)
-  Class: Eq_7396
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7406: (in v541_3427 == 0<8> : bool)
@@ -32525,12 +32128,12 @@ T_7406: (in v541_3427 == 0<8> : bool)
   OrigDataType: bool
 T_7407: (in 3<32> : word32)
   Class: Eq_7407
-  DataType: (ptr32 Eq_8493)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8482)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7408: (in d2_1090 + 3<32> : word32)
   Class: Eq_7408
-  DataType: (ptr32 Eq_8494)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8483)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7409: (in 2<32> : word32)
   Class: Eq_7409
   DataType: word32
@@ -32552,8 +32155,8 @@ T_7413: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7414: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_7415: (in 60<i32> : int32)
   Class: Eq_7415
@@ -32561,15 +32164,15 @@ T_7415: (in 60<i32> : int32)
   OrigDataType: int32
 T_7416: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7416
-  DataType: Eq_7416
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7417: (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7418: (in SLICE(d0, word16, 0) : word16)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word16
 T_7419: (in -4<i32> : int32)
   Class: Eq_7419
@@ -32577,11 +32180,11 @@ T_7419: (in -4<i32> : int32)
   OrigDataType: int32
 T_7420: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7420
-  DataType: (ptr32 Eq_8495)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8484)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7421: (in Mem3428[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7421
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_7424 t0000)))
 T_7422: (in 0<32> : word32)
   Class: Eq_7422
@@ -32592,11 +32195,11 @@ T_7423: (in Mem3428[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7424: (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: word16
+  Class: Eq_624
+  DataType: Eq_783
+  OrigDataType: Eq_624
 T_7425: (in v542_3444 : byte)
-  Class: Eq_7425
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7426: (in 48<i32> : int32)
@@ -32605,18 +32208,18 @@ T_7426: (in 48<i32> : int32)
   OrigDataType: int32
 T_7427: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7427
-  DataType: Eq_7427
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7428: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7428
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7429: (in 4<8> : byte)
   Class: Eq_7429
   DataType: byte
   OrigDataType: byte
-T_7430: (in *((word32) a7_3364 + 48<i32>) - 4<8> : byte)
-  Class: Eq_7425
+T_7430: (in a7_3364->b0030 - 4<8> : byte)
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7431: (in 48<i32> : int32)
@@ -32625,14 +32228,14 @@ T_7431: (in 48<i32> : int32)
   OrigDataType: int32
 T_7432: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7432
-  DataType: Eq_7432
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7433: (in Mem3445[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7425
-  DataType: Eq_7301
+  Class: Eq_7311
+  DataType: byte
   OrigDataType: byte
 T_7434: (in 0<8> : byte)
-  Class: Eq_7425
+  Class: Eq_7311
   DataType: byte
   OrigDataType: byte
 T_7435: (in v542_3444 == 0<8> : bool)
@@ -32641,12 +32244,12 @@ T_7435: (in v542_3444 == 0<8> : bool)
   OrigDataType: bool
 T_7436: (in 3<32> : word32)
   Class: Eq_7436
-  DataType: (ptr32 Eq_8496)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8485)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7437: (in d2_1090 + 3<32> : word32)
   Class: Eq_7437
-  DataType: (ptr32 Eq_8497)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8486)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7438: (in 2<32> : word32)
   Class: Eq_7438
   DataType: word32
@@ -32668,8 +32271,8 @@ T_7442: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7443: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_7444: (in 60<i32> : int32)
   Class: Eq_7444
@@ -32677,11 +32280,11 @@ T_7444: (in 60<i32> : int32)
   OrigDataType: int32
 T_7445: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7445
-  DataType: Eq_7445
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7446: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7447: (in -4<i32> : int32)
   Class: Eq_7447
@@ -32689,11 +32292,11 @@ T_7447: (in -4<i32> : int32)
   OrigDataType: int32
 T_7448: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7448
-  DataType: (ptr32 Eq_8498)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8487)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7449: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7449
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_7452 t0000)))
 T_7450: (in 0<32> : word32)
   Class: Eq_7450
@@ -32704,17 +32307,17 @@ T_7451: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7452: (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: word32
+  Class: Eq_624
+  DataType: Eq_783
+  OrigDataType: Eq_624
 T_7453: (in 3<32> : word32)
   Class: Eq_7453
-  DataType: (ptr32 Eq_8499)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8488)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7454: (in d2_1090 + 3<32> : word32)
   Class: Eq_7454
-  DataType: (ptr32 Eq_8500)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8489)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7455: (in 2<32> : word32)
   Class: Eq_7455
   DataType: word32
@@ -32736,8 +32339,8 @@ T_7459: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7460: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_7461: (in 60<i32> : int32)
   Class: Eq_7461
@@ -32745,11 +32348,11 @@ T_7461: (in 60<i32> : int32)
   OrigDataType: int32
 T_7462: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7462
-  DataType: Eq_7462
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7463: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7464: (in -4<i32> : int32)
   Class: Eq_7464
@@ -32757,11 +32360,11 @@ T_7464: (in -4<i32> : int32)
   OrigDataType: int32
 T_7465: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7465
-  DataType: (ptr32 Eq_8501)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8490)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7466: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7466
-  DataType: (ptr32 Eq_623)
+  DataType: (ptr32 Eq_624)
   OrigDataType: (ptr32 (struct (0 T_7469 t0000)))
 T_7467: (in 0<32> : word32)
   Class: Eq_7467
@@ -32772,9 +32375,9 @@ T_7468: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7469: (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: word32
+  Class: Eq_624
+  DataType: Eq_783
+  OrigDataType: Eq_624
 T_7470: (in 0<i32> : int32)
   Class: Eq_7470
   DataType: int32
@@ -32788,36 +32391,36 @@ T_7472: (in 0xFF<32> : word32)
   DataType: int32
   OrigDataType: word32
 T_7473: (in SLICE(d5_785, byte, 0) : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_7473
+  DataType: byte
   OrigDataType: byte
 T_7474: (in 78<i32> : int32)
   Class: Eq_7474
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7475: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7475
-  DataType: Eq_7475
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7476: (in a7_1330 + 78<i32> + d1_1027 : word32)
   Class: Eq_7476
-  DataType: Eq_7476
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7477 t0000)))
 T_7477: (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_7473
+  DataType: byte
   OrigDataType: byte
 T_7478: (in 1<32> : word32)
   Class: Eq_7478
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: word32
+  OrigDataType: word32
 T_7479: (in d1_1027 + 1<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: int32
 T_7480: (in 0x20<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: up32
 T_7481: (in d1_1027 < 0x20<32> : bool)
   Class: Eq_7481
@@ -32837,40 +32440,40 @@ T_7484: (in 132<i32> : int32)
   OrigDataType: int32
 T_7485: (in a7_1330 + 132<i32> : word32)
   Class: Eq_7485
-  DataType: Eq_7485
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7486: (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_4320
-  OrigDataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
+  OrigDataType: word32
 T_7487: (in 44<i32> : int32)
   Class: Eq_7487
   DataType: int32
   OrigDataType: int32
 T_7488: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7488
-  DataType: Eq_7488
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7489: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7326
-  DataType: Eq_4320
-  OrigDataType: byte
-T_7490: (in v554_824 : byte)
+  DataType: Eq_7326
+  OrigDataType: int32
+T_7490: (in v554_824 : Eq_7490)
   Class: Eq_7490
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7490
+  OrigDataType: (union (int32 u1) (byte u0))
 T_7491: (in 44<i32> : int32)
   Class: Eq_7491
   DataType: int32
   OrigDataType: int32
 T_7492: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7492
-  DataType: Eq_7492
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7493: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7490
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7490
+  OrigDataType: int32
 T_7494: (in a6_1164 : (ptr32 byte))
   Class: Eq_7494
   DataType: (ptr32 byte)
@@ -32881,11 +32484,11 @@ T_7495: (in 132<i32> : int32)
   OrigDataType: int32
 T_7496: (in a7_1330 + 132<i32> : word32)
   Class: Eq_7496
-  DataType: Eq_7496
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7497: (in Mem946[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7498: (in 1<i32> : int32)
   Class: Eq_7498
@@ -32901,8 +32504,8 @@ T_7500: (in 73<i32> : int32)
   OrigDataType: int32
 T_7501: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7501
-  DataType: Eq_7501
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7502: (in Mem946[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7502
   DataType: byte
@@ -32911,7 +32514,7 @@ T_7503: (in 0<8> : byte)
   Class: Eq_7502
   DataType: byte
   OrigDataType: byte
-T_7504: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7504: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7504
   DataType: bool
   OrigDataType: bool
@@ -32944,8 +32547,8 @@ T_7511: (in SLICE(d1_1027, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_7512: (in SEQ(SLICE(d1_1027, word24, 8), v556_834) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_7513: (in 0<32> : word32)
   Class: Eq_7513
@@ -33048,8 +32651,8 @@ T_7537: (in (uint8) SLICE(d7, byte, 0) : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_7538: (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_7539: (in d0 - d5_862 : word32)
   Class: Eq_7539
@@ -33091,18 +32694,18 @@ T_7548: (in v554_824 == 0<8> : bool)
   Class: Eq_7548
   DataType: bool
   OrigDataType: bool
-T_7549: (in a0_881 : Eq_7549)
+T_7549: (in a0_881 : word32)
   Class: Eq_7549
-  DataType: Eq_7549
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7557 t0000)))
 T_7550: (in 78<i32> : int32)
   Class: Eq_7550
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7551: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7551
-  DataType: Eq_7551
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7552: (in 3<32> : word32)
   Class: Eq_7552
   DataType: word32
@@ -33110,30 +32713,30 @@ T_7552: (in 3<32> : word32)
 T_7553: (in d5_862 >> 3<32> : word32)
   Class: Eq_7553
   DataType: Eq_7553
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_7554: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_7549
-  DataType: Eq_7549
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_7555: (in 0<32> : word32)
   Class: Eq_7555
   DataType: word32
   OrigDataType: word32
 T_7556: (in a0_881 + 0<32> : word32)
   Class: Eq_7556
-  DataType: Eq_7556
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7557: (in Mem889[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_7557
+  DataType: byte
   OrigDataType: byte
 T_7558: (in (uint8) Mem889[a0_881 + 0<32>:byte] : uint8)
   Class: Eq_7558
   DataType: uint8
   OrigDataType: uint8
 T_7559: (in (uint32) (uint8) Mem889[a0_881 + 0<32>:byte] : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_7560: (in 1<i32> : int32)
   Class: Eq_7560
@@ -33156,8 +32759,8 @@ T_7564: (in 1<i32> << (d5_862 & 7<i32>) | d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7565: (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_7557
+  DataType: byte
   OrigDataType: byte
 T_7566: (in 0<32> : word32)
   Class: Eq_7566
@@ -33165,24 +32768,24 @@ T_7566: (in 0<32> : word32)
   OrigDataType: word32
 T_7567: (in a0_881 + 0<32> : word32)
   Class: Eq_7567
-  DataType: Eq_7567
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7568: (in Mem895[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_7549
-  OrigDataType: Eq_623
-T_7569: (in a0_900 : Eq_7569)
+  Class: Eq_7557
+  DataType: byte
+  OrigDataType: byte
+T_7569: (in a0_900 : word32)
   Class: Eq_7569
-  DataType: Eq_7569
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7577 t0000)))
 T_7570: (in 78<i32> : int32)
   Class: Eq_7570
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7571: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7571
-  DataType: Eq_7571
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7572: (in 3<32> : word32)
   Class: Eq_7572
   DataType: word32
@@ -33190,30 +32793,30 @@ T_7572: (in 3<32> : word32)
 T_7573: (in d5_862 >> 3<32> : word32)
   Class: Eq_7573
   DataType: Eq_7573
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_7574: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_7569
-  DataType: Eq_7569
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_7575: (in 0<32> : word32)
   Class: Eq_7575
   DataType: word32
   OrigDataType: word32
 T_7576: (in a0_900 + 0<32> : word32)
   Class: Eq_7576
-  DataType: Eq_7576
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7577: (in Mem889[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_7577
+  DataType: byte
   OrigDataType: byte
 T_7578: (in (uint8) Mem889[a0_900 + 0<32>:byte] : uint8)
   Class: Eq_7578
   DataType: uint8
   OrigDataType: uint8
 T_7579: (in (uint32) (uint8) Mem889[a0_900 + 0<32>:byte] : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_7580: (in 1<i32> : int32)
   Class: Eq_7580
@@ -33240,8 +32843,8 @@ T_7585: (in ~(1<i32> << (d5_862 & 7<i32>)) & d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7586: (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_7577
+  DataType: byte
   OrigDataType: byte
 T_7587: (in 0<32> : word32)
   Class: Eq_7587
@@ -33249,12 +32852,12 @@ T_7587: (in 0<32> : word32)
   OrigDataType: word32
 T_7588: (in a0_900 + 0<32> : word32)
   Class: Eq_7588
-  DataType: Eq_7588
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7589: (in Mem914[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_7569
-  OrigDataType: Eq_623
+  Class: Eq_7577
+  DataType: byte
+  OrigDataType: byte
 T_7590: (in 1<32> : word32)
   Class: Eq_7590
   DataType: word32
@@ -33272,8 +32875,8 @@ T_7593: (in (uint8) SLICE(d7, byte, 0) : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_7594: (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_7595: (in d0 - d5_862 : word32)
   Class: Eq_7595
@@ -33297,12 +32900,12 @@ T_7599: (in d0_957 : word32)
   OrigDataType: uint32
 T_7600: (in 3<32> : word32)
   Class: Eq_7600
-  DataType: (ptr32 Eq_8502)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8491)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7601: (in d2_1090 + 3<32> : word32)
   Class: Eq_7601
-  DataType: (ptr32 Eq_8503)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8492)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7602: (in 2<32> : word32)
   Class: Eq_7602
   DataType: word32
@@ -33324,12 +32927,12 @@ T_7606: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7607: (in (d0_957 << 2<32>) + 4<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: ui32
 T_7608: (in d0_957 << 2<32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_7609: (in -4<i32> : int32)
   Class: Eq_7609
@@ -33337,8 +32940,8 @@ T_7609: (in -4<i32> : int32)
   OrigDataType: int32
 T_7610: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7610
-  DataType: (ptr32 Eq_8504)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_623) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8493)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_624) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7611: (in Mem946[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7494
   DataType: (ptr32 byte)
@@ -33463,30 +33066,30 @@ T_7641: (in a3_1955->b0000 == 0<8> : bool)
   Class: Eq_7641
   DataType: bool
   OrigDataType: bool
-T_7642: (in a7_985 : Eq_7642)
+T_7642: (in a7_985 : (ptr32 Eq_7642))
   Class: Eq_7642
-  DataType: Eq_7642
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_7642)
+  OrigDataType: (ptr32 (struct (0 T_624 t0000) (30 T_7659 t0030)))
 T_7643: (in 4<i32> : int32)
   Class: Eq_7643
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7644: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7642
-  DataType: Eq_7642
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_7642)
+  OrigDataType: ptr32
 T_7645: (in 0<32> : word32)
   Class: Eq_7645
   DataType: word32
   OrigDataType: word32
 T_7646: (in a7_985 + 0<32> : word32)
   Class: Eq_7646
-  DataType: Eq_7646
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7647: (in Mem987[a7_985 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7642
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_7648: (in a5_5334 : word32)
   Class: Eq_7648
   DataType: word32
@@ -33501,16 +33104,16 @@ T_7650: (in 0<32> : word32)
   OrigDataType: word32
 T_7651: (in a7_985 + 0<32> : word32)
   Class: Eq_7651
-  DataType: Eq_7651
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7652: (in Mem987[a7_985 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7653: (in out d1 : ptr32)
   Class: Eq_2669
   DataType: Eq_2669
-  OrigDataType: (union ((ptr32 (ptr32 Eq_4327)) u1) (uint32 u0) (ptr32 u2) (Eq_6688 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4327) ptr0000) (4 Eq_624 t0004) (8 Eq_624 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_6688 u3))
 T_7654: (in out a1 : ptr32)
   Class: Eq_4684
   DataType: (ptr32 word32)
@@ -33519,9 +33122,9 @@ T_7655: (in out a5_5334 : ptr32)
   Class: Eq_4685
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_7656: (in fn00003CCC(*a7_985, out d1, out a1, out a5_5334) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+T_7656: (in fn00003CCC(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7657: (in 48<i32> : int32)
   Class: Eq_7657
@@ -33529,19 +33132,19 @@ T_7657: (in 48<i32> : int32)
   OrigDataType: int32
 T_7658: (in a7_985 + 48<i32> : word32)
   Class: Eq_7658
-  DataType: Eq_7658
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7659: (in Mem1000[a7_985 + 48<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7642
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_7660: (in 4<i32> : int32)
   Class: Eq_7660
   DataType: int32
   OrigDataType: int32
 T_7661: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_7662: (in a0_1004 : (ptr32 byte))
   Class: Eq_4695
@@ -33559,30 +33162,30 @@ T_7665: (in Mem981[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
-T_7666: (in a7_1005 : Eq_7666)
+T_7666: (in a7_1005 : (ptr32 Eq_7666))
   Class: Eq_7666
-  DataType: Eq_7666
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_7666)
+  OrigDataType: (ptr32 (struct (0 T_624 t0000) (30 T_7691 t0030)))
 T_7667: (in 4<i32> : int32)
   Class: Eq_7667
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7668: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7666
-  DataType: Eq_7666
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_7666)
+  OrigDataType: ptr32
 T_7669: (in 0<32> : word32)
   Class: Eq_7669
   DataType: word32
   OrigDataType: word32
 T_7670: (in a7_1005 + 0<32> : word32)
   Class: Eq_7670
-  DataType: Eq_7670
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7671: (in Mem1007[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7666
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_7672: (in 1<i32> : int32)
   Class: Eq_7672
   DataType: int32
@@ -33601,8 +33204,8 @@ T_7675: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_7676: (in Mem1011[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_7677: (in v585_1015 : byte)
   Class: Eq_4710
   DataType: byte
@@ -33625,11 +33228,11 @@ T_7681: (in 0<32> : word32)
   OrigDataType: word32
 T_7682: (in a7_1005 + 0<32> : word32)
   Class: Eq_7682
-  DataType: Eq_7682
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7683: (in Mem1011[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7684: (in 0<32> : word32)
   Class: Eq_7684
@@ -33637,12 +33240,12 @@ T_7684: (in 0<32> : word32)
   OrigDataType: word32
 T_7685: (in a7_1005 + 0<32> : word32)
   Class: Eq_7685
-  DataType: Eq_7685
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7686: (in Mem1031[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7666
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_7687: (in (uint8) v585_1015 : uint8)
   Class: Eq_7687
   DataType: uint8
@@ -33657,19 +33260,19 @@ T_7689: (in 48<i32> : int32)
   OrigDataType: int32
 T_7690: (in a7_1005 + 48<i32> : word32)
   Class: Eq_7690
-  DataType: Eq_7690
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7691: (in Mem1037[a7_1005 + 48<i32>:word32] : word32)
   Class: Eq_7688
-  DataType: Eq_7666
-  OrigDataType: uint32
+  DataType: uint32
+  OrigDataType: word32
 T_7692: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_7692
   DataType: word24
   OrigDataType: word24
 T_7693: (in SEQ(SLICE(d0, word24, 8), v585_1015) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_7694: (in 0<32> : word32)
   Class: Eq_7694
@@ -33677,11 +33280,11 @@ T_7694: (in 0<32> : word32)
   OrigDataType: word32
 T_7695: (in a7_1005 + 0<32> : word32)
   Class: Eq_7695
-  DataType: Eq_7695
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7696: (in Mem1037[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7697: (in 44<i32> : int32)
   Class: Eq_7697
@@ -33689,12 +33292,12 @@ T_7697: (in 44<i32> : int32)
   OrigDataType: int32
 T_7698: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7698
-  DataType: Eq_7698
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7699: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: word32
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: int32
 T_7700: (in d3_1057 : Eq_7700)
   Class: Eq_7700
   DataType: Eq_7700
@@ -33725,135 +33328,135 @@ T_7706: (in 44<i32> : int32)
   OrigDataType: int32
 T_7707: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7707
-  DataType: Eq_7707
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7708: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_7708
-  DataType: word32
-  OrigDataType: word32
+  DataType: int32
+  OrigDataType: int32
 T_7709: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_7708
-  DataType: word32
+  DataType: int32
   OrigDataType: word32
-T_7710: (in *((word32) a7_1330 + 44<i32>) == 0xFFFFFFFF<32> : bool)
+T_7710: (in a7_1330[11<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_7710
   DataType: bool
   OrigDataType: bool
 T_7711: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_7712: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_7712
   DataType: bool
   OrigDataType: bool
-T_7713: (in a7_1076 : Eq_7713)
+T_7713: (in a7_1076 : (ptr32 Eq_7713))
   Class: Eq_7713
-  DataType: Eq_7713
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_7713)
+  OrigDataType: (ptr32 (struct (0 T_7717 t0000) (4D T_7774 t004D)))
 T_7714: (in 4<i32> : int32)
   Class: Eq_7714
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7715: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7713
-  DataType: Eq_7713
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_7713)
+  OrigDataType: ptr32
 T_7716: (in 78<i32> : int32)
   Class: Eq_7716
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7717: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  Class: Eq_7717
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7718: (in 0<32> : word32)
   Class: Eq_7718
   DataType: word32
   OrigDataType: word32
 T_7719: (in a7_1076 + 0<32> : word32)
   Class: Eq_7719
-  DataType: Eq_7719
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7720: (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7713
+  Class: Eq_7717
+  DataType: ptr32
   OrigDataType: word32
 T_7721: (in 4<i32> : int32)
   Class: Eq_7721
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7722: (in a7_1076 - 4<i32> : word32)
   Class: Eq_7722
-  DataType: Eq_7722
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_7725 t0000)))
 T_7723: (in 0<32> : word32)
   Class: Eq_7723
   DataType: word32
   OrigDataType: word32
 T_7724: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_7724
-  DataType: Eq_7724
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7725: (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_623
-  DataType: Eq_7722
-  OrigDataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: word32
 T_7726: (in 00000008 : ptr32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_7726
+  DataType: ptr32
   OrigDataType: ptr32
 T_7727: (in 8<i32> : int32)
   Class: Eq_7727
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7728: (in a7_1076 - 8<i32> : word32)
   Class: Eq_7728
-  DataType: Eq_7728
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7731 t0000)))
 T_7729: (in 0<32> : word32)
   Class: Eq_7729
   DataType: word32
   OrigDataType: word32
 T_7730: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_7730
-  DataType: Eq_7730
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7731: (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7728
-  OrigDataType: uint8
+  Class: Eq_7726
+  DataType: ptr32
+  OrigDataType: word32
 T_7732: (in 12<i32> : int32)
   Class: Eq_7732
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7733: (in a7_1076 - 12<i32> : word32)
   Class: Eq_7733
-  DataType: Eq_7733
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_624)
+  OrigDataType: (ptr32 (struct (0 T_7736 t0000)))
 T_7734: (in 0<32> : word32)
   Class: Eq_7734
   DataType: word32
   OrigDataType: word32
 T_7735: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_7735
-  DataType: Eq_7735
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7736: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7733
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_7737: (in 0<32> : word32)
   Class: Eq_7737
   DataType: word32
   OrigDataType: word32
 T_7738: (in a7_1076 + 0<32> : word32)
   Class: Eq_7738
-  DataType: Eq_7738
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7739: (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_7717
+  DataType: ptr32
   OrigDataType: ptr32
 T_7740: (in fn000026E4 : ptr32)
   Class: Eq_7740
@@ -33865,45 +33468,45 @@ T_7741: (in signature of fn000026E4 : void)
   OrigDataType: 
 T_7742: (in a7_1076 - 12<i32> : word32)
   Class: Eq_7742
-  DataType: Eq_7742
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_783)
+  OrigDataType: (ptr32 (struct (0 T_7745 t0000)))
 T_7743: (in 0<32> : word32)
   Class: Eq_7743
   DataType: word32
   OrigDataType: word32
 T_7744: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_7744
-  DataType: Eq_7744
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7745: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7746: (in 8<i32> : int32)
   Class: Eq_7746
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7747: (in a7_1076 - 8<i32> : word32)
   Class: Eq_7747
-  DataType: Eq_7747
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_783)
+  OrigDataType: (ptr32 (struct (0 T_7750 t0000)))
 T_7748: (in 0<32> : word32)
   Class: Eq_7748
   DataType: word32
   OrigDataType: word32
 T_7749: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_7749
-  DataType: Eq_7749
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7750: (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7751: (in fn000026E4(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_7751
   DataType: int32
   OrigDataType: int32
-T_7752: (in Mem1087[a7_1076 + 0<32>:word32] + fn000026E4(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
+T_7752: (in a7_1076->ptr0000 + fn000026E4(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_7752
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7753 t0000)))
@@ -33916,28 +33519,28 @@ T_7754: (in (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn000026E4(d2_1090
   DataType: uint8
   OrigDataType: uint8
 T_7755: (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn000026E4(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)):byte] : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_7756: (in 4<i32> : int32)
   Class: Eq_7756
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7757: (in a7_1076 - 4<i32> : word32)
   Class: Eq_7757
-  DataType: Eq_7757
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_7760 t0000)))
 T_7758: (in 0<32> : word32)
   Class: Eq_7758
   DataType: word32
   OrigDataType: word32
 T_7759: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_7759
-  DataType: Eq_7759
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7760: (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_7761: (in 1<i32> : int32)
   Class: Eq_7761
@@ -33956,12 +33559,12 @@ T_7764: (in 1<i32> << (d5_1044 & 7<i32>) : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7765: (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_7766: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_7767: (in d0 == 0<32> : bool)
   Class: Eq_7767
@@ -33989,8 +33592,8 @@ T_7772: (in 77<i32> : int32)
   OrigDataType: int32
 T_7773: (in a7_1076 + 77<i32> : word32)
   Class: Eq_7773
-  DataType: Eq_7773
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7774: (in Mem1087[a7_1076 + 77<i32>:byte] : byte)
   Class: Eq_7771
   DataType: byte
@@ -34127,30 +33730,30 @@ T_7807: (in a6_1164 + 1<i32> : word32)
   Class: Eq_7494
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_7808: (in a7_1182 : Eq_7808)
+T_7808: (in a7_1182 : (ptr32 Eq_624))
   Class: Eq_7808
-  DataType: Eq_7808
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_624)
+  OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_7809: (in 4<i32> : int32)
   Class: Eq_7809
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7810: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7808
-  DataType: Eq_7808
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_624)
+  OrigDataType: ptr32
 T_7811: (in 0<32> : word32)
   Class: Eq_7811
   DataType: word32
   OrigDataType: word32
 T_7812: (in a7_1182 + 0<32> : word32)
   Class: Eq_7812
-  DataType: Eq_7812
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7813: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7808
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_7814: (in d1_5335 : word32)
   Class: Eq_7814
   DataType: word32
@@ -34169,11 +33772,11 @@ T_7817: (in 0<32> : word32)
   OrigDataType: word32
 T_7818: (in a7_1182 + 0<32> : word32)
   Class: Eq_7818
-  DataType: Eq_7818
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7819: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7820: (in out d1_5335 : ptr32)
   Class: Eq_2669
@@ -34188,8 +33791,8 @@ T_7822: (in out a5_5336 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_7823: (in fn00003CCC(*a7_1182, out d1_5335, out a1, out a5_5336) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7824: (in 4<i32> : int32)
   Class: Eq_7824
@@ -34197,7 +33800,7 @@ T_7824: (in 4<i32> : int32)
   OrigDataType: int32
 T_7825: (in a2_1014 + 4<i32> : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_7826: (in a0_1200 : (ptr32 byte))
   Class: Eq_4695
@@ -34215,30 +33818,30 @@ T_7829: (in Mem1177[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
-T_7830: (in a7_1201 : Eq_7830)
+T_7830: (in a7_1201 : (ptr32 Eq_624))
   Class: Eq_7830
-  DataType: Eq_7830
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_624)
+  OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_7831: (in 4<i32> : int32)
   Class: Eq_7831
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7832: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7830
-  DataType: Eq_7830
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_624)
+  OrigDataType: ptr32
 T_7833: (in 0<32> : word32)
   Class: Eq_7833
   DataType: word32
   OrigDataType: word32
 T_7834: (in a7_1201 + 0<32> : word32)
   Class: Eq_7834
-  DataType: Eq_7834
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7835: (in Mem1203[a7_1201 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7830
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_7836: (in 1<i32> : int32)
   Class: Eq_7836
   DataType: int32
@@ -34257,8 +33860,8 @@ T_7839: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4713 t0000))))
 T_7840: (in Mem1207[a1 + 0<32>:word32] : word32)
   Class: Eq_4695
-  DataType: Eq_623
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4713 t0000)))
 T_7841: (in v611_1211 : byte)
   Class: Eq_4710
   DataType: byte
@@ -34281,27 +33884,27 @@ T_7845: (in 0<32> : word32)
   OrigDataType: word32
 T_7846: (in a7_1201 + 0<32> : word32)
   Class: Eq_7846
-  DataType: Eq_7846
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7847: (in Mem1207[a7_1201 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7848: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_7848
   DataType: word24
   OrigDataType: word24
 T_7849: (in SEQ(SLICE(d0, word24, 8), v611_1211) : uip32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uip32
 T_7850: (in (uint8) v611_1211 : uint8)
   Class: Eq_7850
   DataType: uint8
   OrigDataType: uint8
 T_7851: (in (uint32) (uint8) v611_1211 : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_7852: (in 1<32> : word32)
   Class: Eq_7852
@@ -34320,8 +33923,8 @@ T_7855: (in d4_1070 + 1<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_7856: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_7857: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_7857
@@ -34349,8 +33952,8 @@ T_7862: (in 73<i32> : int32)
   OrigDataType: int32
 T_7863: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7863
-  DataType: Eq_7863
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7864: (in Mem1331[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7864
   DataType: byte
@@ -34359,77 +33962,77 @@ T_7865: (in 0<8> : byte)
   Class: Eq_7864
   DataType: byte
   OrigDataType: byte
-T_7866: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7866: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7866
   DataType: bool
   OrigDataType: bool
-T_7867: (in a7_1302 : Eq_7867)
+T_7867: (in a7_1302 : (ptr32 Eq_624))
   Class: Eq_7867
-  DataType: Eq_7867
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_624)
+  OrigDataType: (ptr32 (struct (0 T_624 t0000)))
 T_7868: (in 4<i32> : int32)
   Class: Eq_7868
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7869: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7867
-  DataType: Eq_7867
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_624)
+  OrigDataType: ptr32
 T_7870: (in 0<32> : word32)
   Class: Eq_7870
   DataType: word32
   OrigDataType: word32
 T_7871: (in a7_1302 + 0<32> : word32)
   Class: Eq_7871
-  DataType: Eq_7871
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7872: (in Mem1308[a7_1302 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7867
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_7873: (in 4<i32> : int32)
   Class: Eq_7873
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7874: (in a7_1302 - 4<i32> : word32)
   Class: Eq_7874
-  DataType: Eq_7874
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_624)
+  OrigDataType: (ptr32 (struct (0 T_7877 t0000)))
 T_7875: (in 0<32> : word32)
   Class: Eq_7875
   DataType: word32
   OrigDataType: word32
 T_7876: (in a7_1302 - 4<i32> + 0<32> : word32)
   Class: Eq_7876
-  DataType: Eq_7876
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7877: (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7874
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_7878: (in fn00002BF8 : ptr32)
   Class: Eq_4870
   DataType: (ptr32 Eq_4870)
   OrigDataType: (ptr32 (fn T_7887 (T_7883, T_7886)))
 T_7879: (in 1<i32> : int32)
   Class: Eq_7879
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7880: (in a7_1302 - 1<i32> : word32)
   Class: Eq_7880
-  DataType: Eq_7880
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7883 t0000)))
 T_7881: (in 0<32> : word32)
   Class: Eq_7881
   DataType: word32
   OrigDataType: word32
 T_7882: (in a7_1302 - 1<i32> + 0<32> : word32)
   Class: Eq_7882
-  DataType: Eq_7882
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7883: (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_4286
+  DataType: byte
   OrigDataType: byte
 T_7884: (in 0<32> : word32)
   Class: Eq_7884
@@ -34437,15 +34040,15 @@ T_7884: (in 0<32> : word32)
   OrigDataType: word32
 T_7885: (in a7_1302 + 0<32> : word32)
   Class: Eq_7885
-  DataType: Eq_7885
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7886: (in Mem1311[a7_1302 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7887: (in fn00002BF8(*(a7_1302 - 1<i32>), *a7_1302) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_7888: (in 73<i32> : int32)
   Class: Eq_7888
@@ -34453,119 +34056,119 @@ T_7888: (in 73<i32> : int32)
   OrigDataType: int32
 T_7889: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7889
-  DataType: Eq_7889
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7890: (in Mem1294[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7771
-  DataType: Eq_4320
+  DataType: byte
   OrigDataType: byte
-T_7891: (in a7_1237 : Eq_7891)
+T_7891: (in a7_1237 : (ptr32 ptr32))
   Class: Eq_7891
-  DataType: Eq_7891
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7895 t0000)))
 T_7892: (in 4<i32> : int32)
   Class: Eq_7892
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7893: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7891
-  DataType: Eq_7891
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
 T_7894: (in 78<i32> : int32)
   Class: Eq_7894
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7895: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  Class: Eq_7895
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7896: (in 0<32> : word32)
   Class: Eq_7896
   DataType: word32
   OrigDataType: word32
 T_7897: (in a7_1237 + 0<32> : word32)
   Class: Eq_7897
-  DataType: Eq_7897
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7898: (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7891
+  Class: Eq_7895
+  DataType: ptr32
   OrigDataType: word32
 T_7899: (in 4<i32> : int32)
   Class: Eq_7899
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7900: (in a7_1237 - 4<i32> : word32)
   Class: Eq_7900
-  DataType: Eq_7900
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_7903 t0000)))
 T_7901: (in 0<32> : word32)
   Class: Eq_7901
   DataType: word32
   OrigDataType: word32
 T_7902: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_7902
-  DataType: Eq_7902
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7903: (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_623
-  DataType: Eq_7900
-  OrigDataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: word32
 T_7904: (in 00000008 : ptr32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_7904
+  DataType: ptr32
   OrigDataType: ptr32
 T_7905: (in 8<i32> : int32)
   Class: Eq_7905
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7906: (in a7_1237 - 8<i32> : word32)
   Class: Eq_7906
-  DataType: Eq_7906
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7909 t0000)))
 T_7907: (in 0<32> : word32)
   Class: Eq_7907
   DataType: word32
   OrigDataType: word32
 T_7908: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_7908
-  DataType: Eq_7908
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7909: (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7906
-  OrigDataType: uint8
+  Class: Eq_7904
+  DataType: ptr32
+  OrigDataType: word32
 T_7910: (in 12<i32> : int32)
   Class: Eq_7910
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7911: (in a7_1237 - 12<i32> : word32)
   Class: Eq_7911
-  DataType: Eq_7911
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_624)
+  OrigDataType: (ptr32 (struct (0 T_7914 t0000)))
 T_7912: (in 0<32> : word32)
   Class: Eq_7912
   DataType: word32
   OrigDataType: word32
 T_7913: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_7913
-  DataType: Eq_7913
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7914: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_7911
-  OrigDataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
+  OrigDataType: word32
 T_7915: (in 0<32> : word32)
   Class: Eq_7915
   DataType: word32
   OrigDataType: word32
 T_7916: (in a7_1237 + 0<32> : word32)
   Class: Eq_7916
-  DataType: Eq_7916
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7917: (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_7895
+  DataType: ptr32
   OrigDataType: ptr32
 T_7918: (in fn000026E4 : ptr32)
   Class: Eq_7740
@@ -34573,45 +34176,45 @@ T_7918: (in fn000026E4 : ptr32)
   OrigDataType: (ptr32 (fn T_7928 (T_4324, T_7922, T_7927)))
 T_7919: (in a7_1237 - 12<i32> : word32)
   Class: Eq_7919
-  DataType: Eq_7919
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_783)
+  OrigDataType: (ptr32 (struct (0 T_7922 t0000)))
 T_7920: (in 0<32> : word32)
   Class: Eq_7920
   DataType: word32
   OrigDataType: word32
 T_7921: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_7921
-  DataType: Eq_7921
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7922: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7923: (in 8<i32> : int32)
   Class: Eq_7923
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7924: (in a7_1237 - 8<i32> : word32)
   Class: Eq_7924
-  DataType: Eq_7924
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 Eq_783)
+  OrigDataType: (ptr32 (struct (0 T_7927 t0000)))
 T_7925: (in 0<32> : word32)
   Class: Eq_7925
   DataType: word32
   OrigDataType: word32
 T_7926: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_7926
-  DataType: Eq_7926
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7927: (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7928: (in fn000026E4(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_7751
   DataType: int32
   OrigDataType: int32
-T_7929: (in Mem1248[a7_1237 + 0<32>:word32] + fn000026E4(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
+T_7929: (in *a7_1237 + fn000026E4(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_7929
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7930 t0000)))
@@ -34624,28 +34227,28 @@ T_7931: (in (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn000026E4(d2_1090
   DataType: uint8
   OrigDataType: uint8
 T_7932: (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn000026E4(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)):byte] : uint32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: uint32
 T_7933: (in 4<i32> : int32)
   Class: Eq_7933
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7934: (in a7_1237 - 4<i32> : word32)
   Class: Eq_7934
-  DataType: Eq_7934
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_7937 t0000)))
 T_7935: (in 0<32> : word32)
   Class: Eq_7935
   DataType: word32
   OrigDataType: word32
 T_7936: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_7936
-  DataType: Eq_7936
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7937: (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_623
-  DataType: Eq_623
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_7938: (in 1<i32> : int32)
   Class: Eq_7938
@@ -34664,12 +34267,12 @@ T_7941: (in 1<i32> << (d1 & 7<i32>) : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7942: (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: ui32
 T_7943: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_7944: (in d0 == 0<32> : bool)
   Class: Eq_7944
@@ -34725,8 +34328,8 @@ T_7956: (in 60<i32> : int32)
   OrigDataType: int32
 T_7957: (in a7_1330 + 60<i32> : word32)
   Class: Eq_7957
-  DataType: Eq_7957
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7958: (in Mem1348[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_7958
   DataType: word32
@@ -34741,39 +34344,39 @@ T_7960: (in Mem1348[a7_1330 + 60<i32>:word32] + 1<32> : word32)
   OrigDataType: word32
 T_7961: (in a7_1330 + 60<i32> : word32)
   Class: Eq_7961
-  DataType: Eq_7961
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8486) u1) (T_6411 u2) (T_7277 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7962: (in Mem1351[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_7960
-  DataType: Eq_4320
+  DataType: word32
   OrigDataType: word32
 T_7963: (in d0 : uint32)
   Class: Eq_7963
   DataType: uint32
   OrigDataType: word32
-T_7964: (in d0_23 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_7964: (in d0_23 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7965: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_7966 (T_7015)))
 T_7966: (in __swap(dwArg08) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
-T_7967: (in d1_25 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_7967: (in d1_25 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_7968: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_7969 (T_7017)))
 T_7969: (in __swap(dwArg10) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7970: (in d4_29 : uint32)
   Class: Eq_7970
@@ -34811,9 +34414,9 @@ T_7978: (in d1_25 * (word16) d0_23 : word32)
   Class: Eq_7976
   DataType: uint32
   OrigDataType: uint32
-T_7979: (in d2_39 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_7979: (in d2_39 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_7980: (in SLICE(d1_25, word16, 0) : word16)
   Class: Eq_7980
@@ -34844,12 +34447,12 @@ T_7986: (in (word16) d4_29 ^ (word16) d4_29 : word16)
   DataType: ui16
   OrigDataType: ui16
 T_7987: (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_7988: (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7989: (in dwArg08 *u SLICE(d1_25, word16, 0) + __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
   Class: Eq_7989
@@ -34864,28 +34467,28 @@ T_7991: (in dwArg10 * (word16) d0_23 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_7992: (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_7993: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_783
+  DataType: (ptr32 Eq_1355)
   OrigDataType: up32
 T_7994: (in d2_39 >= 0<32> : bool)
   Class: Eq_7994
   DataType: bool
   OrigDataType: bool
-T_7995: (in d2_45 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_7995: (in d2_45 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7996: (in __swap : ptr32)
   Class: Eq_976
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_7997 (T_7979)))
 T_7997: (in __swap(d2_39) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_7998: (in d3_65 : uint32)
   Class: Eq_7998
@@ -34896,8 +34499,8 @@ T_7999: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_8000 (T_7016)))
 T_8000: (in __swap(dwArg0C) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_8001: (in SLICE(dwArg08, word16, 0) : word16)
   Class: Eq_8001
@@ -34907,9 +34510,9 @@ T_8002: (in __swap(dwArg0C) * (word16) dwArg08 : word32)
   Class: Eq_7998
   DataType: uint32
   OrigDataType: uint32
-T_8003: (in d3_71 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_8003: (in d3_71 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_8004: (in __swap : ptr32)
   Class: Eq_976
@@ -34924,8 +34527,8 @@ T_8006: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_8007 (T_7015)))
 T_8007: (in __swap(dwArg08) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_8008: (in SLICE(dwArg0C, word16, 0) : word16)
   Class: Eq_8008
@@ -34944,12 +34547,12 @@ T_8011: (in SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_8012: (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_8013: (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_8014: (in d3_83 : uint32)
   Class: Eq_8014
@@ -34960,8 +34563,8 @@ T_8015: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_8016 (T_7014)))
 T_8016: (in __swap(dwArg04) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_8017: (in SLICE(dwArg10, word16, 0) : word16)
   Class: Eq_8017
@@ -34971,9 +34574,9 @@ T_8018: (in __swap(dwArg04) * (word16) dwArg10 : word32)
   Class: Eq_8014
   DataType: uint32
   OrigDataType: uint32
-T_8019: (in d3_89 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_8019: (in d3_89 : Eq_783)
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_8020: (in __swap : ptr32)
   Class: Eq_976
@@ -34988,8 +34591,8 @@ T_8022: (in __swap : ptr32)
   DataType: (ptr32 Eq_976)
   OrigDataType: (ptr32 (fn T_8023 (T_7017)))
 T_8023: (in __swap(dwArg10) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uint32
 T_8024: (in SLICE(dwArg04, word16, 0) : word16)
   Class: Eq_8024
@@ -35008,12 +34611,12 @@ T_8027: (in SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_8028: (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: uipr32
 T_8029: (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_783
+  DataType: Eq_783
   OrigDataType: word32
 T_8030: (in SLICE(d2_45, word16, 16) : word16)
   Class: Eq_8030
@@ -35142,7 +34745,7 @@ T_8060: (in a1_116 : (ptr32 word32))
 T_8061: (in d1_118 : Eq_2669)
   Class: Eq_2669
   DataType: Eq_2669
-  OrigDataType: Eq_623
+  OrigDataType: Eq_624
 T_8062: (in fn00002424 : ptr32)
   Class: Eq_2663
   DataType: (ptr32 Eq_2663)
@@ -35160,8 +34763,8 @@ T_8065: (in fn00002424(out a1_116, out a5_279) : word32)
   DataType: Eq_2669
   OrigDataType: word32
 T_8066: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_8067: (in dwArg04 != 0<32> : bool)
   Class: Eq_8067
@@ -35225,7 +34828,7 @@ T_8081: (in dwArg04 + 24<i32> : word32)
   OrigDataType: (ptr32 ui32)
 T_8082: (in Mem49[dwArg04 + 24<i32>:word32] : word32)
   Class: Eq_8070
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: ui32
 T_8083: (in d0_125 : int32)
   Class: Eq_2723
@@ -35316,12 +34919,12 @@ T_8104: (in dwArg04 + 8<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_8105: (in Mem86[dwArg04 + 8<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_8106: (in 0<32> : word32)
-  Class: Eq_623
-  DataType: uint8
+  Class: Eq_624
+  DataType: byte
   OrigDataType: word32
 T_8107: (in *((word32) dwArg04 + 8<i32>) != 0<32> : bool)
   Class: Eq_8107
@@ -35369,7 +34972,7 @@ T_8117: (in dwArg04 + 28<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_8118: (in Mem79[dwArg04 + 28<i32>:word32] : word32)
   Class: Eq_8093
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: int32
 T_8119: (in 1<i32> : int32)
   Class: Eq_8093
@@ -35385,7 +34988,7 @@ T_8121: (in dwArg04 + 28<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_8122: (in Mem83[dwArg04 + 28<i32>:word32] : word32)
   Class: Eq_8093
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: int32
 T_8123: (in 1<i32> : int32)
   Class: Eq_2723
@@ -35400,8 +35003,8 @@ T_8125: (in dwArg04 + 8<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8126: (in Mem135[dwArg04 + 8<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_8127: (in 4<i32> : int32)
   Class: Eq_8127
@@ -35412,8 +35015,8 @@ T_8128: (in dwArg04 + 4<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_8129: (in Mem137[dwArg04 + 4<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_8130: (in 0<32> : word32)
   Class: Eq_8130
@@ -35449,7 +35052,7 @@ T_8137: (in dwArg04 + 20<i32> : word32)
   OrigDataType: ptr32
 T_8138: (in Mem147[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2723
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: int32
 T_8139: (in v26_148 : int32)
   Class: Eq_2723
@@ -35477,7 +35080,7 @@ T_8144: (in dwArg04 + 20<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_8145: (in Mem149[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2723
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: int32
 T_8146: (in 0<32> : word32)
   Class: Eq_2723
@@ -35579,9 +35182,9 @@ T_8170: (in d0_117 != 0<32> : bool)
   Class: Eq_8170
   DataType: bool
   OrigDataType: bool
-T_8171: (in a0_153 : Eq_623)
-  Class: Eq_623
-  DataType: Eq_623
+T_8171: (in a0_153 : Eq_624)
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: (ptr32 (struct (0 T_8183 t0000)))
 T_8172: (in 4<i32> : int32)
   Class: Eq_8172
@@ -35592,24 +35195,24 @@ T_8173: (in dwArg04 + 4<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8174: (in Mem149[dwArg04 + 4<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_8175: (in 1<i32> : int32)
   Class: Eq_8175
   DataType: int32
   OrigDataType: int32
 T_8176: (in a0_153 + 1<i32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_8177: (in dwArg04 + 4<i32> : word32)
   Class: Eq_8177
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8178: (in Mem157[dwArg04 + 4<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_8179: (in dwArg04 + 4<i32> : word32)
   Class: Eq_4684
@@ -35689,7 +35292,7 @@ T_8197: (in dwArg04 + 24<i32> : word32)
   OrigDataType: (ptr32 ui32)
 T_8198: (in Mem172[dwArg04 + 24<i32>:word32] : word32)
   Class: Eq_8070
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: ui32
 T_8199: (in 24<i32> : int32)
   Class: Eq_8199
@@ -35717,7 +35320,7 @@ T_8204: (in dwArg04 + 24<i32> : word32)
   OrigDataType: (ptr32 ui32)
 T_8205: (in Mem179[dwArg04 + 24<i32>:word32] : word32)
   Class: Eq_8070
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: ui32
 T_8206: (in 0<32> : word32)
   Class: Eq_2723
@@ -35733,7 +35336,7 @@ T_8208: (in dwArg04 + 20<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_8209: (in Mem184[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2723
-  DataType: Eq_623
+  DataType: Eq_624
   OrigDataType: int32
 T_8210: (in -1<i32> : int32)
   Class: Eq_8057
@@ -35744,8 +35347,8 @@ T_8211: (in 1<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_8212: (in d0_117 + 1<i32> : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_8213: (in 8<i32> : int32)
   Class: Eq_8213
@@ -35756,8 +35359,8 @@ T_8214: (in dwArg04 + 8<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8215: (in Mem131[dwArg04 + 8<i32>:word32] : word32)
-  Class: Eq_623
-  DataType: Eq_623
+  Class: Eq_624
+  DataType: Eq_624
   OrigDataType: word32
 T_8216: (in d0_117 + 1<i32> : word32)
   Class: Eq_4684
@@ -36677,7 +36280,7 @@ T_8444:
   OrigDataType: 
 T_8445:
   Class: Eq_8445
-  DataType: Eq_8445
+  DataType: Eq_4327
   OrigDataType: 
 T_8446:
   Class: Eq_8446
@@ -36693,7 +36296,7 @@ T_8448:
   OrigDataType: 
 T_8449:
   Class: Eq_8449
-  DataType: Eq_8449
+  DataType: Eq_4327
   OrigDataType: 
 T_8450:
   Class: Eq_8450
@@ -36701,7 +36304,7 @@ T_8450:
   OrigDataType: 
 T_8451:
   Class: Eq_8451
-  DataType: Eq_8451
+  DataType: Eq_4327
   OrigDataType: 
 T_8452:
   Class: Eq_8452
@@ -36709,19 +36312,19 @@ T_8452:
   OrigDataType: 
 T_8453:
   Class: Eq_8453
-  DataType: Eq_4327
+  DataType: Eq_8453
   OrigDataType: 
 T_8454:
   Class: Eq_8454
-  DataType: (ptr32 Eq_4327)
+  DataType: Eq_8454
   OrigDataType: 
 T_8455:
   Class: Eq_8455
-  DataType: Eq_4327
+  DataType: Eq_8455
   OrigDataType: 
 T_8456:
   Class: Eq_8456
-  DataType: (ptr32 Eq_4327)
+  DataType: Eq_8456
   OrigDataType: 
 T_8457:
   Class: Eq_8457
@@ -36729,7 +36332,7 @@ T_8457:
   OrigDataType: 
 T_8458:
   Class: Eq_8458
-  DataType: (ptr32 Eq_4327)
+  DataType: Eq_8458
   OrigDataType: 
 T_8459:
   Class: Eq_8459
@@ -36741,11 +36344,11 @@ T_8460:
   OrigDataType: 
 T_8461:
   Class: Eq_8461
-  DataType: Eq_4327
+  DataType: Eq_8461
   OrigDataType: 
 T_8462:
   Class: Eq_8462
-  DataType: (ptr32 Eq_4327)
+  DataType: Eq_8462
   OrigDataType: 
 T_8463:
   Class: Eq_8463
@@ -36903,18 +36506,6 @@ T_8501:
   Class: Eq_8501
   DataType: Eq_8501
   OrigDataType: 
-T_8502:
-  Class: Eq_8502
-  DataType: Eq_8502
-  OrigDataType: 
-T_8503:
-  Class: Eq_8503
-  DataType: Eq_8503
-  OrigDataType: 
-T_8504:
-  Class: Eq_8504
-  DataType: Eq_8504
-  OrigDataType: 
 */
 typedef struct Eq_630;
 struct Globals {
@@ -36949,7 +36540,7 @@ struct Globals {
 	Eq_552 t3FDC;	// 3FDC
 	word32 dw3FE0;	// 3FE0
 	struct Eq_569 * ptr3FEC;	// 3FEC
-	Eq_623 t3FF0;	// 3FF0
+	Eq_624 t3FF0;	// 3FF0
 	struct Eq_701 * ptr3FF4;	// 3FF4
 	struct Eq_701 * ptr3FFC;	// 3FFC
 	Eq_4 t4000;	// 4000
@@ -37099,26 +36690,21 @@ typedef word32 (Eq_599)(Eq_378, ptr32, ptr32, ptr32);
 
 typedef Eq_378 (Eq_601)();
 
-typedef union Eq_623 {
-	uint8 u0;
-	ui24 u1;
-	word16 u2;
-	struct Eq_8460 * u3;
-	struct Eq_8408 * u4;
-	struct Eq_8415 * u5;
-	Eq_1355 u6;
-	Eq_6411 u7;
-	Eq_7274 u8;
-} Eq_623;
+typedef union Eq_624 {
+	byte u0;
+	word16 u1;
+	struct Eq_8456 * u2;
+	struct Eq_8409 * u3;
+} Eq_624;
 
-typedef void (Eq_625)(Eq_623, Eq_623, Eq_623, Eq_630 *);
+typedef void (Eq_625)(Eq_624, Eq_624, byte * *, Eq_630 *);
 
 typedef struct Eq_630 {	// size: 1 1
 	uint8 b0000;	// 0
 	cu8 b0001;	// 1
 } Eq_630;
 
-typedef Eq_623 (Eq_631)(byte *, Eq_634, byte * *);
+typedef Eq_624 (Eq_631)(byte *, Eq_634, byte * *);
 
 typedef union Eq_634 {
 	int32 u0;
@@ -37153,19 +36739,19 @@ typedef union Eq_703 {
 } Eq_703;
 
 typedef struct Eq_710 {	// size: 4 4
-	Eq_8416 t002C;	// 2C
+	Eq_8410 t002C;	// 2C
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
-	word32 dw0037;	// 37
+	byte b0037;	// 37
 	word32 dw0038;	// 38
 	word32 dw003C;	// 3C
-	word32 dw003E;	// 3E
-	word32 dw003F;	// 3F
+	word16 w003E;	// 3E
+	byte b003F;	// 3F
 	word32 dw0040;	// 40
 	word32 dw0044;	// 44
 	ui32 dw0048;	// 48
 	word32 dw0062;	// 62
-	Eq_8417 t0066;	// 66
+	Eq_8411 t0066;	// 66
 	byte b006A;	// 6A
 	word32 dw006C;	// 6C
 	word32 dw007C;	// 7C
@@ -37178,6 +36764,12 @@ typedef union Eq_717 {
 } Eq_717;
 
 typedef Eq_662 (Eq_751)(int32, Eq_701 *, ui32 *, ptr32);
+
+typedef union Eq_783 {
+	struct Eq_1355 * u0;
+	struct Eq_8412 * u1;
+	struct Eq_8413 * u2;
+} Eq_783;
 
 typedef struct Eq_790 {
 	Eq_2355 t0000;	// 0
@@ -37210,7 +36802,7 @@ typedef union Eq_947 {
 	ptr32 u1;
 } Eq_947;
 
-typedef Eq_623 (Eq_976)(Eq_623);
+typedef Eq_783 (Eq_976)(Eq_783);
 
 typedef union Eq_999 {
 	int32 u0;
@@ -37237,12 +36829,6 @@ typedef struct Eq_1188 {
 	word32 dw0000;	// 0
 	word32 dw0004;	// 4
 } Eq_1188;
-
-typedef union Eq_1191 {
-	ui24 u0;
-	struct Eq_8418 * u1;
-	Eq_1355 u2;
-} Eq_1191;
 
 typedef union Eq_1224 {
 	cu8 u0;
@@ -37313,41 +36899,10 @@ typedef union Eq_1333 {
 	int32 u1;
 } Eq_1333;
 
-typedef union Eq_1355 {
-	ui24 u0;
-	struct Eq_8419 * u1;
+typedef struct Eq_1355 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_1355;
-
-typedef union Eq_1356 {
-	ui24 u0;
-	struct Eq_8420 * u1;
-	Eq_1355 u2;
-} Eq_1356;
-
-typedef union Eq_1361 {
-	ui24 u0;
-	struct Eq_8421 * u1;
-	Eq_1355 u2;
-} Eq_1361;
-
-typedef union Eq_1368 {
-	ui24 u0;
-	struct Eq_8422 * u1;
-	Eq_1355 u2;
-} Eq_1368;
-
-typedef union Eq_1372 {
-	int32 u0;
-	uint32 u1;
-	Eq_1191 u2;
-	Eq_1355 u3;
-} Eq_1372;
-
-typedef union Eq_1374 {
-	ui24 u0;
-	struct Eq_8423 * u1;
-	Eq_1355 u2;
-} Eq_1374;
 
 typedef union Eq_1381 {
 	uint32 u0;
@@ -37382,23 +36937,11 @@ typedef struct Eq_1428 {
 } Eq_1428;
 
 typedef struct Eq_1481 {
-	Eq_1191 t0000;	// 0
+	struct Eq_1355 * ptr0000;	// 0
 	up32 dw0030;	// 30
 	up32 dw0034;	// 34
 	up32 dw0044;	// 44
 } Eq_1481;
-
-typedef union Eq_1498 {
-	ui24 u0;
-	struct Eq_8424 * u1;
-	Eq_1355 u2;
-} Eq_1498;
-
-typedef union Eq_1502 {
-	ui24 u0;
-	struct Eq_8425 * u1;
-	Eq_1355 u2;
-} Eq_1502;
 
 typedef union Eq_1513 {
 	byte u0;
@@ -37415,15 +36958,9 @@ typedef union Eq_1524 {
 	word32 u1;
 } Eq_1524;
 
-typedef union Eq_1531 {
-	ui24 u0;
-	struct Eq_8426 * u1;
-	Eq_1355 u2;
-} Eq_1531;
-
 typedef struct Eq_1605 {
 	word32 dw0000;	// 0
-	Eq_1191 t0004;	// 4
+	struct Eq_1355 * ptr0004;	// 4
 } Eq_1605;
 
 typedef union Eq_1620 {
@@ -37461,9 +36998,9 @@ typedef struct Eq_1693 {
 	Eq_703 t0080;	// 80
 } Eq_1693;
 
-typedef int32 (Eq_1733)(Eq_623, Eq_623, Eq_623, Eq_623);
+typedef int32 (Eq_1733)(Eq_783, Eq_783, Eq_783, Eq_783);
 
-typedef word32 (Eq_1817)(Eq_623, Eq_623, Eq_623, Eq_623, Eq_623, Eq_623);
+typedef word32 (Eq_1817)(Eq_783, Eq_783, Eq_783, Eq_783, Eq_783, Eq_783);
 
 typedef union Eq_1857 {
 	bool u0;
@@ -37606,11 +37143,6 @@ typedef union Eq_2111 {
 	up32 u1;
 } Eq_2111;
 
-typedef union Eq_2202 {
-	byte u0;
-	word32 u1;
-} Eq_2202;
-
 typedef struct Eq_2206 {
 	struct Eq_1188 * ptr0000;	// 0
 	int32 dw0034;	// 34
@@ -37631,11 +37163,6 @@ typedef union Eq_2244 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2244;
-
-typedef union Eq_2267 {
-	word16 u0;
-	word32 u1;
-} Eq_2267;
 
 typedef struct Eq_2271 {
 	struct Eq_1188 * ptr0000;	// 0
@@ -37673,12 +37200,6 @@ typedef union Eq_2330 {
 	ptr32 u1;
 } Eq_2330;
 
-typedef union Eq_2336 {
-	ui24 u0;
-	struct Eq_8427 * u1;
-	Eq_1355 u2;
-} Eq_2336;
-
 typedef union Eq_2345 {
 	uint32 u0;
 	ptr32 u1;
@@ -37706,11 +37227,6 @@ typedef union Eq_2363 {
 	Eq_2361 u5;
 } Eq_2363;
 
-typedef union Eq_2367 {
-	byte u0;
-	word32 u1;
-} Eq_2367;
-
 typedef struct Eq_2371 {
 	struct Eq_1188 * ptr0000;	// 0
 	word32 dw003C;	// 3C
@@ -37726,12 +37242,6 @@ typedef union Eq_2392 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2392;
-
-typedef union Eq_2398 {
-	ui24 u0;
-	struct Eq_8428 * u1;
-	Eq_1355 u2;
-} Eq_2398;
 
 typedef struct Eq_2416 {
 	Eq_2355 t0000;	// 0
@@ -37753,12 +37263,6 @@ typedef union Eq_2460 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2460;
-
-typedef union Eq_2466 {
-	ui24 u0;
-	struct Eq_8429 * u1;
-	Eq_1355 u2;
-} Eq_2466;
 
 typedef union Eq_2472 {
 	cu8 u0;
@@ -37872,12 +37376,6 @@ typedef union Eq_2539 {
 	ptr32 u1;
 } Eq_2539;
 
-typedef union Eq_2545 {
-	ui24 u0;
-	struct Eq_8430 * u1;
-	Eq_1355 u2;
-} Eq_2545;
-
 typedef union Eq_2550 {
 	uint32 u0;
 	ptr32 u1;
@@ -37887,12 +37385,6 @@ typedef union Eq_2551 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2551;
-
-typedef union Eq_2557 {
-	ui24 u0;
-	struct Eq_8431 * u1;
-	Eq_1355 u2;
-} Eq_2557;
 
 typedef union Eq_2563 {
 	uint32 u0;
@@ -37904,12 +37396,6 @@ typedef union Eq_2564 {
 	ptr32 u1;
 } Eq_2564;
 
-typedef union Eq_2570 {
-	ui24 u0;
-	struct Eq_8432 * u1;
-	Eq_1355 u2;
-} Eq_2570;
-
 typedef union Eq_2575 {
 	uint32 u0;
 	ptr32 u1;
@@ -37919,12 +37405,6 @@ typedef union Eq_2576 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2576;
-
-typedef union Eq_2582 {
-	ui24 u0;
-	struct Eq_8433 * u1;
-	Eq_1355 u2;
-} Eq_2582;
 
 typedef union Eq_2587 {
 	uint32 u0;
@@ -37937,27 +37417,22 @@ typedef union Eq_2592 {
 } Eq_2592;
 
 typedef union Eq_2596 {
-	int32 u0;
-	uint32 u1;
-	Eq_1191 u2;
-	Eq_1355 u3;
-	Eq_1889 u4;
-	Eq_1951 u5;
-	Eq_1957 u6;
-	Eq_2025 u7;
-	Eq_2068 u8;
+	struct Eq_1355 * u0;
+	struct Eq_1355 * u1;
+	Eq_1889 u2;
+	Eq_1951 u3;
+	Eq_1957 u4;
+	Eq_2025 u5;
+	Eq_2068 u6;
 } Eq_2596;
 
 typedef union Eq_2598 {
-	int32 u0;
-	uint32 u1;
-	Eq_1191 u2;
-	Eq_1355 u3;
-	Eq_1889 u4;
-	Eq_1951 u5;
-	Eq_1957 u6;
-	Eq_2025 u7;
-	Eq_2068 u8;
+	struct Eq_1355 * u0;
+	Eq_1889 u1;
+	Eq_1951 u2;
+	Eq_1957 u3;
+	Eq_2025 u4;
+	Eq_2068 u5;
 } Eq_2598;
 
 typedef Eq_634 (Eq_2622)(int32, Eq_701 *, ui32 *, ptr32, ptr32);
@@ -37965,8 +37440,10 @@ typedef Eq_634 (Eq_2622)(int32, Eq_701 *, ui32 *, ptr32, ptr32);
 typedef Eq_2669 (Eq_2663)(ptr32, ptr32);
 
 typedef union Eq_2669 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
+	byte u0;
+	word16 u1;
+	struct Eq_8456 * u2;
+	struct Eq_8429 * u3;
 } Eq_2669;
 
 typedef int32 (Eq_2724)(int32, ptr32, ptr32, int32 *);
@@ -38018,9 +37495,9 @@ typedef void (Eq_3340)(Eq_380 *);
 
 typedef void (Eq_3364)(int32, word32);
 
-typedef Eq_623 (Eq_3401)(Eq_623, Eq_623, Eq_623, Eq_623, Eq_623);
+typedef Eq_783 (Eq_3401)(Eq_783, Eq_783, Eq_783, Eq_783, Eq_783);
 
-typedef Eq_623 (Eq_3415)(Eq_623, Eq_623);
+typedef Eq_783 (Eq_3415)(Eq_783, Eq_783);
 
 typedef struct Eq_3436 {	// size: 1 1
 	Eq_3436 a0000[];	// 0
@@ -38041,7 +37518,7 @@ typedef union Eq_3556 {
 	word16 u1;
 } Eq_3556;
 
-typedef Eq_623 (Eq_3579)(Eq_623, Eq_623, Eq_623, Eq_623);
+typedef Eq_783 (Eq_3579)(Eq_783, Eq_783, Eq_783, Eq_783);
 
 typedef union Eq_3602 {
 	bool u0;
@@ -38063,7 +37540,7 @@ typedef union Eq_3746 {
 	uint32 u1;
 } Eq_3746;
 
-typedef Eq_623 (Eq_3843)(Eq_623, word32, bool);
+typedef Eq_783 (Eq_3843)(Eq_783, word32, bool);
 
 typedef union Eq_4173 {
 	bool u0;
@@ -38090,20 +37567,30 @@ typedef union Eq_4225 {
 	ui32 u1;
 } Eq_4225;
 
-typedef void (Eq_4271)(Eq_623, Eq_623, Eq_623, Eq_623, Eq_630 *, Eq_623);
+typedef void (Eq_4271)(Eq_624, Eq_624, byte * *, Eq_624, Eq_630 *, Eq_783);
 
-typedef union Eq_4320 {
-	uint8 u0;
-	struct Eq_8439 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
+typedef struct Eq_4320 {	// size: 4 4
+	int32 dw002C;	// 2C
+	Eq_8430 t0030;	// 30
+	word32 dw0034;	// 34
+	uint8 b0037;	// 37
+	word32 dw0038;	// 38
+	word32 dw003C;	// 3C
+	word32 dw0040;	// 40
+	Eq_8431 t0044;	// 44
+	byte b0048;	// 48
+	byte b0049;	// 49
+	word32 dw004A;	// 4A
+	word32 dw006E;	// 6E
+	word32 dw0072;	// 72
+	word32 dw0084;	// 84
 } Eq_4320;
 
 typedef union Eq_4327 {
 	byte u0;
 	word16 u1;
-	struct Eq_8460 * u2;
-	struct Eq_8441 * u3;
+	struct Eq_8456 * u2;
+	struct Eq_8433 * u3;
 } Eq_4327;
 
 typedef union Eq_4338 {
@@ -38140,17 +37627,17 @@ typedef union Eq_4459 {
 	uint32 u1;
 } Eq_4459;
 
-typedef Eq_623 (Eq_4680)(Eq_623, Eq_2669, word32 *, byte *);
+typedef Eq_624 (Eq_4680)(Eq_624, Eq_2669, word32 *, byte *);
 
-typedef Eq_623 (Eq_4870)(Eq_623, Eq_623);
+typedef Eq_624 (Eq_4870)(byte, Eq_624);
 
 typedef struct Eq_4883 {
-	Eq_623 t0000;	// 0
-	Eq_623 t0030;	// 30
+	Eq_624 t0000;	// 0
+	Eq_624 t0030;	// 30
 } Eq_4883;
 
 typedef struct Eq_4907 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	uint32 dw0030;	// 30
 } Eq_4907;
 
@@ -38160,12 +37647,12 @@ typedef union Eq_5017 {
 } Eq_5017;
 
 typedef struct Eq_5066 {
-	Eq_623 t0000;	// 0
-	Eq_623 t0030;	// 30
+	Eq_624 t0000;	// 0
+	Eq_624 t0030;	// 30
 } Eq_5066;
 
 typedef struct Eq_5090 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	uint32 dw0030;	// 30
 } Eq_5090;
 
@@ -38205,12 +37692,12 @@ typedef union Eq_5457 {
 } Eq_5457;
 
 typedef struct Eq_5491 {
-	Eq_623 t0000;	// 0
-	Eq_623 t0038;	// 38
+	Eq_624 t0000;	// 0
+	Eq_624 t0038;	// 38
 } Eq_5491;
 
 typedef struct Eq_5515 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5515;
 
@@ -38225,12 +37712,12 @@ typedef union Eq_5589 {
 } Eq_5589;
 
 typedef struct Eq_5618 {
-	Eq_623 t0000;	// 0
-	Eq_623 t0038;	// 38
+	Eq_624 t0000;	// 0
+	Eq_624 t0038;	// 38
 } Eq_5618;
 
 typedef struct Eq_5642 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5642;
 
@@ -38252,23 +37739,23 @@ typedef union Eq_5761 {
 } Eq_5761;
 
 typedef struct Eq_5790 {
-	Eq_623 t0000;	// 0
-	Eq_623 t0038;	// 38
+	Eq_624 t0000;	// 0
+	Eq_624 t0038;	// 38
 } Eq_5790;
 
 typedef struct Eq_5814 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5814;
 
 typedef struct Eq_5871 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	int32 dw0030;	// 30
-	Eq_623 t0038;	// 38
+	Eq_624 t0038;	// 38
 } Eq_5871;
 
 typedef struct Eq_5906 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5906;
 
@@ -38303,7 +37790,7 @@ typedef union Eq_5970 {
 } Eq_5970;
 
 typedef struct Eq_6013 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	word32 dw004E;	// 4E
 } Eq_6013;
 
@@ -38323,7 +37810,7 @@ typedef union Eq_6100 {
 } Eq_6100;
 
 typedef struct Eq_6130 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	word32 dw0044;	// 44
 } Eq_6130;
 
@@ -38338,12 +37825,12 @@ typedef union Eq_6189 {
 } Eq_6189;
 
 typedef struct Eq_6218 {
-	Eq_623 t0000;	// 0
-	Eq_623 t0038;	// 38
+	Eq_624 t0000;	// 0
+	Eq_624 t0038;	// 38
 } Eq_6218;
 
 typedef struct Eq_6242 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_6242;
 
@@ -38363,19 +37850,14 @@ typedef union Eq_6316 {
 } Eq_6316;
 
 typedef struct Eq_6345 {
-	Eq_623 t0000;	// 0
-	Eq_623 t0038;	// 38
+	Eq_624 t0000;	// 0
+	Eq_624 t0038;	// 38
 } Eq_6345;
 
 typedef struct Eq_6369 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_6369;
-
-typedef union Eq_6411 {
-	uint8 u0;
-	word32 u1;
-} Eq_6411;
 
 typedef union Eq_6419 {
 	int32 u0;
@@ -38393,7 +37875,7 @@ typedef union Eq_6470 {
 } Eq_6470;
 
 typedef struct Eq_6474 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	word32 dw0044;	// 44
 } Eq_6474;
 
@@ -38432,78 +37914,30 @@ typedef union Eq_6587 {
 	word32 u1;
 } Eq_6587;
 
-typedef union Eq_6601 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-} Eq_6601;
-
-typedef union Eq_6603 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-} Eq_6603;
-
-typedef union Eq_6618 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-} Eq_6618;
-
-typedef union Eq_6621 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-} Eq_6621;
-
 typedef union Eq_6639 {
 	bool u0;
 	word32 u1;
 } Eq_6639;
 
-typedef union Eq_6670 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-} Eq_6670;
-
-typedef union Eq_6672 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-} Eq_6672;
-
-typedef union Eq_6685 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-	Eq_6621 u2;
-} Eq_6685;
-
 typedef union Eq_6691 {
 	union Eq_4327 ** u0;
-	Eq_6621 u1;
+	struct Eq_8450 * u1;
 } Eq_6691;
-
-typedef union Eq_6732 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-} Eq_6732;
-
-typedef union Eq_6747 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-} Eq_6747;
 
 typedef union Eq_6749 {
 	union Eq_4327 ** u0;
-	Eq_6621 u1;
-	Eq_6685 u2;
+	struct Eq_8450 * u1;
 } Eq_6749;
 
 typedef union Eq_6750 {
 	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-	Eq_6621 u2;
-	Eq_6685 u3;
+	struct Eq_8450 * u1;
+	struct Eq_8456 * u2;
 } Eq_6750;
 
 typedef union Eq_6753 {
 	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
+	struct Eq_8456 * u1;
 } Eq_6753;
 
 typedef union Eq_6767 {
@@ -38517,38 +37951,20 @@ typedef union Eq_6881 {
 } Eq_6881;
 
 typedef struct Eq_6909 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	word32 dw004E;	// 4E
 } Eq_6909;
 
 typedef struct Eq_6960 {
-	Eq_623 t0000;	// 0
-	Eq_7049 t0001;	// 1
+	Eq_783 t0000;	// 0
+	ui24 n0001;	// 1
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
 	word32 dw0044;	// 44
 	word32 dw0048;	// 48
 } Eq_6960;
 
-typedef union Eq_6971 {
-	ui24 u0;
-	struct Eq_8463 * u1;
-	Eq_1355 u2;
-} Eq_6971;
-
-typedef word32 (Eq_7011)(Eq_4327, Eq_623, Eq_623, Eq_623, Eq_623, ptr32);
-
-typedef union Eq_7048 {
-	ui24 u0;
-	struct Eq_8464 * u1;
-	Eq_1355 u2;
-} Eq_7048;
-
-typedef union Eq_7049 {
-	ui24 u0;
-	struct Eq_8465 * u1;
-	Eq_1355 u2;
-} Eq_7049;
+typedef word32 (Eq_7011)(Eq_4327, Eq_783, Eq_783, Eq_783, Eq_783, ptr32);
 
 typedef union Eq_7062 {
 	int32 u0;
@@ -38556,37 +37972,28 @@ typedef union Eq_7062 {
 } Eq_7062;
 
 typedef struct Eq_7115 {
-	Eq_623 t0000;	// 0
+	Eq_624 t0000;	// 0
 	word32 dw0030;	// 30
-	Eq_623 t0034;	// 34
+	Eq_624 t0034;	// 34
 	byte b0038;	// 38
 	byte b004C;	// 4C
 } Eq_7115;
 
 typedef struct Eq_7145 {
 	word32 dw0000;	// 0
-	Eq_623 t0004;	// 4
+	Eq_624 t0004;	// 4
 } Eq_7145;
 
 typedef union Eq_7273 {
 	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-	Eq_6747 u2;
+	struct Eq_8456 * u1;
 } Eq_7273;
 
 typedef union Eq_7274 {
-	uint8 u0;
-	union Eq_4327 ** u1;
-	struct Eq_8460 * u2;
-	Eq_6411 u3;
-	Eq_6747 u4;
+	union Eq_4327 ** u0;
+	struct Eq_8456 * u1;
+	struct Eq_8456 * u2;
 } Eq_7274;
-
-typedef union Eq_7276 {
-	uint8 u0;
-	word32 u1;
-	Eq_6411 u2;
-} Eq_7276;
 
 typedef struct Eq_7284 {
 	int32 dw0000;	// 0
@@ -38598,416 +38005,53 @@ typedef union Eq_7296 {
 	int32 u1;
 } Eq_7296;
 
-typedef union Eq_7299 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7299;
-
-typedef union Eq_7301 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
+typedef struct Eq_7301 {
+	Eq_624 t0000;	// 0
+	byte b0030;	// 30
+	word32 dw0038;	// 38
+	Eq_624 t003C;	// 3C
+	byte b004C;	// 4C
 } Eq_7301;
 
-typedef union Eq_7302 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7302;
+typedef union Eq_7326 {
+	int32 u0;
+	byte u1;
+} Eq_7326;
 
-typedef union Eq_7305 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7305;
-
-typedef union Eq_7308 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7308;
-
-typedef union Eq_7313 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7313;
-
-typedef union Eq_7315 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7315;
-
-typedef union Eq_7318 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7318;
-
-typedef union Eq_7324 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7324;
-
-typedef union Eq_7328 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7328;
-
-typedef union Eq_7333 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7333;
-
-typedef union Eq_7337 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7337;
+typedef union Eq_7335 {
+	int32 u0;
+	byte u1;
+} Eq_7335;
 
 typedef struct Eq_7350 {
 	word32 dw0000;	// 0
-	word32 dw0004;	// 4
+	Eq_624 t0004;	// 4
 } Eq_7350;
 
-typedef union Eq_7355 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7355;
-
-typedef union Eq_7361 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7361;
-
-typedef union Eq_7369 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7369;
-
-typedef union Eq_7374 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7374;
-
-typedef union Eq_7387 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7387;
-
-typedef union Eq_7398 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7398;
-
-typedef union Eq_7403 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7403;
-
-typedef union Eq_7416 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7416;
-
-typedef union Eq_7427 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7427;
-
-typedef union Eq_7432 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7432;
-
-typedef union Eq_7445 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7445;
-
-typedef union Eq_7462 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7462;
-
-typedef union Eq_7474 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7474;
-
-typedef union Eq_7475 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7475;
-
-typedef union Eq_7476 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7476;
-
-typedef union Eq_7478 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7478;
-
-typedef union Eq_7485 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7485;
-
-typedef union Eq_7488 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7488;
-
-typedef union Eq_7492 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7492;
-
-typedef union Eq_7496 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7496;
-
-typedef union Eq_7501 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7501;
-
-typedef union Eq_7549 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7549;
-
-typedef union Eq_7550 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7550;
-
-typedef union Eq_7551 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7551;
+typedef union Eq_7490 {
+	int32 u0;
+	byte u1;
+} Eq_7490;
 
 typedef union Eq_7553 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_7553;
 
-typedef union Eq_7556 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7556;
-
-typedef union Eq_7567 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7567;
-
-typedef union Eq_7569 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7569;
-
-typedef union Eq_7570 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7570;
-
-typedef union Eq_7571 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7571;
-
 typedef union Eq_7573 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_7573;
 
-typedef union Eq_7576 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7576;
-
-typedef union Eq_7588 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7588;
-
-typedef union Eq_7642 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
+typedef struct Eq_7642 {
+	Eq_624 t0000;	// 0
+	Eq_624 t0030;	// 30
 } Eq_7642;
 
-typedef union Eq_7643 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7643;
-
-typedef union Eq_7646 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7646;
-
-typedef union Eq_7651 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7651;
-
-typedef union Eq_7658 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7658;
-
-typedef union Eq_7666 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
+typedef struct Eq_7666 {
+	Eq_624 t0000;	// 0
+	uint32 dw0030;	// 30
 } Eq_7666;
-
-typedef union Eq_7667 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7667;
-
-typedef union Eq_7670 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7670;
-
-typedef union Eq_7682 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7682;
-
-typedef union Eq_7685 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7685;
-
-typedef union Eq_7690 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7690;
-
-typedef union Eq_7695 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7695;
-
-typedef union Eq_7698 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7698;
 
 typedef union Eq_7700 {
 	int32 u0;
@@ -39019,236 +38063,17 @@ typedef union Eq_7701 {
 	uint32 u1;
 } Eq_7701;
 
-typedef union Eq_7707 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7707;
-
-typedef union Eq_7713 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
+typedef struct Eq_7713 {
+	ptr32 ptr0000;	// 0
+	byte b004D;	// 4D
 } Eq_7713;
 
-typedef union Eq_7714 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7714;
-
-typedef union Eq_7716 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7716;
-
-typedef union Eq_7719 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7719;
-
-typedef union Eq_7721 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7721;
-
-typedef union Eq_7722 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7722;
-
-typedef union Eq_7724 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7724;
-
-typedef union Eq_7727 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7727;
-
-typedef union Eq_7728 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7728;
-
-typedef union Eq_7730 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7730;
-
-typedef union Eq_7732 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7732;
-
-typedef union Eq_7733 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7733;
-
-typedef union Eq_7735 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7735;
-
-typedef union Eq_7738 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7738;
-
-typedef int32 (Eq_7740)(Eq_623, Eq_623, Eq_623);
-
-typedef union Eq_7742 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7742;
-
-typedef union Eq_7744 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7744;
-
-typedef union Eq_7746 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7746;
-
-typedef union Eq_7747 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7747;
-
-typedef union Eq_7749 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7749;
-
-typedef union Eq_7756 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7756;
-
-typedef union Eq_7757 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7757;
-
-typedef union Eq_7759 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7759;
+typedef int32 (Eq_7740)(Eq_783, Eq_783, Eq_783);
 
 typedef union Eq_7768 {
 	int32 u0;
 	uint32 u1;
 } Eq_7768;
-
-typedef union Eq_7773 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7773;
-
-typedef union Eq_7808 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7808;
-
-typedef union Eq_7809 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7809;
-
-typedef union Eq_7812 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7812;
-
-typedef union Eq_7818 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7818;
-
-typedef union Eq_7830 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7830;
-
-typedef union Eq_7831 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7831;
-
-typedef union Eq_7834 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7834;
-
-typedef union Eq_7846 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7846;
 
 typedef union Eq_7852 {
 	int32 u0;
@@ -39260,262 +38085,10 @@ typedef union Eq_7858 {
 	uint32 u1;
 } Eq_7858;
 
-typedef union Eq_7863 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7863;
-
-typedef union Eq_7867 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7867;
-
-typedef union Eq_7868 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7868;
-
-typedef union Eq_7871 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7871;
-
-typedef union Eq_7873 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7873;
-
-typedef union Eq_7874 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7874;
-
-typedef union Eq_7876 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7876;
-
-typedef union Eq_7879 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7879;
-
-typedef union Eq_7880 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7880;
-
-typedef union Eq_7882 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7882;
-
-typedef union Eq_7885 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7885;
-
-typedef union Eq_7889 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7889;
-
-typedef union Eq_7891 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7891;
-
-typedef union Eq_7892 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7892;
-
-typedef union Eq_7894 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7894;
-
-typedef union Eq_7897 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7897;
-
-typedef union Eq_7899 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7899;
-
-typedef union Eq_7900 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7900;
-
-typedef union Eq_7902 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7902;
-
-typedef union Eq_7905 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7905;
-
-typedef union Eq_7906 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7906;
-
-typedef union Eq_7908 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7908;
-
-typedef union Eq_7910 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7910;
-
-typedef union Eq_7911 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7911;
-
-typedef union Eq_7913 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7913;
-
-typedef union Eq_7916 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7916;
-
-typedef union Eq_7919 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7919;
-
-typedef union Eq_7921 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7921;
-
-typedef union Eq_7923 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7923;
-
-typedef union Eq_7924 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7924;
-
-typedef union Eq_7926 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7926;
-
-typedef union Eq_7933 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7933;
-
-typedef union Eq_7934 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7934;
-
-typedef union Eq_7936 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7936;
-
 typedef union Eq_7945 {
 	int32 u0;
 	uint32 u1;
 } Eq_7945;
-
-typedef union Eq_7957 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7957;
-
-typedef union Eq_7961 {
-	uint8 u0;
-	struct Eq_8486 * u1;
-	Eq_6411 u2;
-	Eq_7274 u3;
-} Eq_7961;
 
 typedef int32 (Eq_8096)(ptr32, ptr32);
 
@@ -39525,79 +38098,20 @@ typedef struct Eq_8351 {	// size: 4 4
 	byte b0000;	// 0
 } Eq_8351;
 
-typedef struct Eq_8408 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
-	Eq_623 t0004;	// 4
-	Eq_623 t0008;	// 8
+typedef struct Eq_8408 {
+	Eq_4327 t0000;	// 0
+} Eq_8408;
+
+typedef struct Eq_8409 {	// size: 4 4
+	struct Eq_8408 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
 	int32 dw0014;	// 14
 	ui32 dw0018;	// 18
 	int32 dw001C;	// 1C
-} Eq_8408;
-
-typedef struct Eq_8409 {
-	Eq_623 t0000;	// 0
 } Eq_8409;
 
 typedef union Eq_8410 {
-	int32 u0;
-	byte u1;
-	Eq_623 u2;
-} Eq_8410;
-
-typedef union Eq_8411 {
-	byte u0;
-	union Eq_4327 ** u1;
-	struct Eq_8460 * u2;
-	Eq_623 u3;
-	Eq_6747 u4;
-	Eq_7274 u5;
-} Eq_8411;
-
-typedef union Eq_8412 {
-	uint8 u0;
-	word32 u1;
-	Eq_6411 u2;
-} Eq_8412;
-
-typedef union Eq_8413 {
-	uint8 u0;
-	word32 u1;
-	Eq_4320 u2;
-	Eq_6411 u3;
-	Eq_7274 u4;
-} Eq_8413;
-
-typedef union Eq_8414 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-	Eq_6621 u2;
-	Eq_6685 u3;
-	Eq_6750 u4;
-} Eq_8414;
-
-typedef struct Eq_8415 {	// size: 4 4
-	struct Eq_8409 * ptrFFFFFFFC;	// FFFFFFFC
-	union Eq_4327 * ptr0000;	// 0
-	Eq_8410 t002C;	// 2C
-	Eq_8411 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8412 t0037;	// 37
-	Eq_8413 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8414 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
-} Eq_8415;
-
-typedef union Eq_8416 {
 	cu8 u0;
 	word32 u1;
 	Eq_1224 u2;
@@ -39606,19 +38120,45 @@ typedef union Eq_8416 {
 	Eq_2361 u5;
 	Eq_2472 u6;
 	Eq_2513 u7;
+} Eq_8410;
+
+typedef union Eq_8411 {
+	struct Eq_1355 * u0;
+	Eq_1889 u1;
+	Eq_1951 u2;
+	Eq_1957 u3;
+	Eq_2025 u4;
+	Eq_2068 u5;
+	Eq_2596 u6;
+} Eq_8411;
+
+typedef struct Eq_8412 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8412;
+
+typedef struct Eq_8413 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8413;
+
+typedef struct Eq_8414 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8414;
+
+typedef struct Eq_8415 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8415;
+
+typedef struct Eq_8416 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_8416;
 
-typedef union Eq_8417 {
-	int32 u0;
-	uint32 u1;
-	Eq_1191 u2;
-	Eq_1355 u3;
-	Eq_1889 u4;
-	Eq_1951 u5;
-	Eq_1957 u6;
-	Eq_2025 u7;
-	Eq_2068 u8;
-	Eq_2596 u9;
+typedef struct Eq_8417 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_8417;
 
 typedef struct Eq_8418 {	// size: 1 1
@@ -39676,349 +38216,354 @@ typedef struct Eq_8428 {	// size: 1 1
 	byte b0003;	// 3
 } Eq_8428;
 
-typedef struct Eq_8429 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8429 {	// size: 4 4
+	union Eq_4327 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8429;
 
-typedef struct Eq_8430 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef union Eq_8430 {
+	union Eq_4327 ** u0;
+	struct Eq_8456 * u1;
+	Eq_7274 u2;
 } Eq_8430;
 
-typedef struct Eq_8431 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef union Eq_8431 {
+	union Eq_4327 ** u0;
+	struct Eq_8450 * u1;
+	struct Eq_8456 * u2;
+	Eq_6750 u3;
 } Eq_8431;
 
-typedef struct Eq_8432 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8432 {
+	Eq_4327 t0000;	// 0
 } Eq_8432;
 
-typedef struct Eq_8433 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8433 {	// size: 4 4
+	struct Eq_8432 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8433;
 
-typedef union Eq_8434 {
-	int32 u0;
-	byte u1;
-	Eq_623 u2;
+typedef struct Eq_8434 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8434;
 
-typedef union Eq_8435 {
-	byte u0;
-	union Eq_4327 ** u1;
-	struct Eq_8460 * u2;
-	Eq_623 u3;
-	Eq_6747 u4;
-	Eq_7274 u5;
+typedef struct Eq_8435 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8435;
 
-typedef union Eq_8436 {
-	uint8 u0;
-	word32 u1;
-	Eq_6411 u2;
+typedef struct Eq_8436 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8436;
 
-typedef union Eq_8437 {
-	uint8 u0;
-	word32 u1;
-	Eq_4320 u2;
-	Eq_6411 u3;
-	Eq_7274 u4;
+typedef struct Eq_8437 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8437;
 
-typedef union Eq_8438 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-	Eq_6621 u2;
-	Eq_6685 u3;
-	Eq_6750 u4;
+typedef struct Eq_8438 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8438;
 
 typedef struct Eq_8439 {	// size: 4 4
-	Eq_623 t0000;	// 0
-	Eq_8434 t002C;	// 2C
-	Eq_8435 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8436 t0037;	// 37
-	Eq_8437 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8438 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8439;
 
-typedef struct Eq_8440 {
-	Eq_4327 t0000;	// 0
+typedef struct Eq_8440 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8440;
 
 typedef struct Eq_8441 {	// size: 4 4
-	struct Eq_8440 * ptr0000;	// 0
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8441;
 
 typedef struct Eq_8442 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8442;
 
 typedef struct Eq_8443 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8443;
 
 typedef struct Eq_8444 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8444;
 
-typedef struct Eq_8445 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8445;
-
 typedef struct Eq_8446 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8494 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8446;
 
 typedef struct Eq_8447 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8495 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8447;
 
 typedef struct Eq_8448 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8496 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8448;
 
-typedef struct Eq_8449 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8449;
-
 typedef struct Eq_8450 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8501 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8450;
 
-typedef struct Eq_8451 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8451;
-
 typedef struct Eq_8452 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8498 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8452;
 
-typedef struct Eq_8459 {
+typedef struct Eq_8453 {	// size: 4 4
+	union Eq_8499 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
+} Eq_8453;
+
+typedef struct Eq_8454 {	// size: 4 4
+	union Eq_4327 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
+} Eq_8454;
+
+typedef struct Eq_8455 {
 	Eq_4327 t0000;	// 0
+} Eq_8455;
+
+typedef struct Eq_8456 {	// size: 4 4
+	union Eq_8500 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
+} Eq_8456;
+
+typedef struct Eq_8458 {	// size: 4 4
+	union Eq_4327 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
+} Eq_8458;
+
+typedef struct Eq_8459 {	// size: 4 4
+	union Eq_4327 * ptr0000;	// 0
+	Eq_624 t0004;	// 4
+	Eq_624 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8459;
 
-typedef struct Eq_8460 {	// size: 4 4
-	struct Eq_8459 * ptr0000;	// 0
+typedef struct Eq_8460 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_8460;
 
-typedef struct Eq_8463 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8461 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8461;
+
+typedef struct Eq_8462 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8462;
+
+typedef struct Eq_8463 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8463;
 
-typedef struct Eq_8464 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8464 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8464;
 
-typedef struct Eq_8465 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8465 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8465;
 
 typedef struct Eq_8466 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8466;
 
 typedef struct Eq_8467 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8467;
 
 typedef struct Eq_8468 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8468;
 
 typedef struct Eq_8469 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8469;
 
 typedef struct Eq_8470 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8470;
 
 typedef struct Eq_8471 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8471;
 
 typedef struct Eq_8472 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8472;
 
 typedef struct Eq_8473 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8473;
 
 typedef struct Eq_8474 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8474;
 
 typedef struct Eq_8475 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8475;
 
 typedef struct Eq_8476 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8476;
 
 typedef struct Eq_8477 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8477;
 
 typedef struct Eq_8478 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8478;
 
 typedef struct Eq_8479 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8479;
 
 typedef struct Eq_8480 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8480;
 
-typedef union Eq_8481 {
-	int32 u0;
-	byte u1;
-	Eq_623 u2;
+typedef struct Eq_8481 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8481;
 
-typedef union Eq_8482 {
-	byte u0;
-	union Eq_4327 ** u1;
-	struct Eq_8460 * u2;
-	Eq_623 u3;
-	Eq_6747 u4;
-	Eq_7274 u5;
+typedef struct Eq_8482 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8482;
 
-typedef union Eq_8483 {
-	uint8 u0;
-	word32 u1;
-	Eq_6411 u2;
+typedef struct Eq_8483 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8483;
 
-typedef union Eq_8484 {
-	uint8 u0;
-	word32 u1;
-	Eq_4320 u2;
-	Eq_6411 u3;
-	Eq_7274 u4;
+typedef struct Eq_8484 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8484;
 
-typedef union Eq_8485 {
-	union Eq_4327 ** u0;
-	struct Eq_8460 * u1;
-	Eq_6621 u2;
-	Eq_6685 u3;
-	Eq_6750 u4;
+typedef struct Eq_8485 {	// size: 4 4
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8485;
 
 typedef struct Eq_8486 {	// size: 4 4
-	Eq_623 t0000;	// 0
-	Eq_8481 t002C;	// 2C
-	Eq_8482 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8483 t0037;	// 37
-	Eq_8484 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8485 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8486;
 
 typedef struct Eq_8487 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8487;
 
 typedef struct Eq_8488 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8488;
 
 typedef struct Eq_8489 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8489;
 
 typedef struct Eq_8490 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8490;
 
 typedef struct Eq_8491 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8491;
 
 typedef struct Eq_8492 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8492;
 
 typedef struct Eq_8493 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_624 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8493;
 
-typedef struct Eq_8494 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8494 {
+	Eq_4327 u0;
+	Eq_8455 u1;
 } Eq_8494;
 
-typedef struct Eq_8495 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8495 {
+	Eq_4327 u0;
+	Eq_8455 u1;
 } Eq_8495;
 
-typedef struct Eq_8496 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8496 {
+	Eq_4327 u0;
+	Eq_8455 u1;
 } Eq_8496;
 
-typedef struct Eq_8497 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8497 {
+	Eq_4327 u0;
+	Eq_8455 u1;
 } Eq_8497;
 
-typedef struct Eq_8498 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8498 {
+	Eq_4327 u0;
+	Eq_8455 u1;
 } Eq_8498;
 
-typedef struct Eq_8499 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8499 {
+	Eq_4327 u0;
+	Eq_8455 u1;
 } Eq_8499;
 
-typedef struct Eq_8500 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8500 {
+	Eq_4327 u0;
+	Eq_8455 u1;
 } Eq_8500;
 
-typedef struct Eq_8501 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
+typedef union Eq_8501 {
+	Eq_4327 u0;
+	Eq_8497 u1;
+	Eq_8500 u2;
 } Eq_8501;
-
-typedef struct Eq_8502 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8502;
-
-typedef struct Eq_8503 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8503;
-
-typedef struct Eq_8504 {	// size: 4 4
-	union Eq_623 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8504;
 

--- a/subjects/Hunk-m68k/FIBO.reko/FIBO_code.c
+++ b/subjects/Hunk-m68k/FIBO.reko/FIBO_code.c
@@ -332,14 +332,14 @@ void fn00001354(int32 dwArg04, struct Eq_n * dwArg08)
 // 00001390: Register word32 fn00001390()
 word32 fn00001390()
 {
-	Eq_n a1_n;
+	byte ** a1_n;
 	Eq_n d1_n;
 	fn00002BDC(fn00003E04(&globals->b1438, out d1_n, out a1_n), d1_n, a1_n, &globals->t1458);
 	Eq_n dwLoc1C_n = 0x1438;
 	int32 d2_n = 1;
 	while (d2_n - dwLoc0C <= 0x00)
 	{
-		Eq_n a1_n;
+		byte ** a1_n;
 		Eq_n d1_n;
 		fn00002BDC(fn00003E04(&globals->b1410, out d1_n, out a1_n), d1_n, a1_n, &globals->t1420);
 		fn00001498(fn0000145C(dwLoc08), &globals->b1424);
@@ -478,7 +478,7 @@ void fn000014B4(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 					{
 						a0_n = 10417 + (SEQ(SLICE(d0_n, word24, 8), *a2_n) & 0xFF);
 						uint32 d0_n = (uint32) (uint8) a0_n->t0000;
-						d5_n.u0 = 0;
+						&d5_n.u0->dw0000 = 0;
 						d0_n = d0_n & 0x04;
 						if ((d0_n & 0x04) != 0x00)
 						{
@@ -527,7 +527,7 @@ void fn000014B4(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 				Eq_n v100_n = *a2_n;
 				byte * a2_n = a2_n + 1;
 				struct Eq_n * d1_n = SEQ(SLICE(d1_n, word24, 8), v100_n);
-				Eq_n d0_n = SEQ(SLICE(d0_n, word24, 8), v100_n);
+				struct Eq_n * d0_n = SEQ(SLICE(d0_n, word24, 8), v100_n);
 				if (v100_n != 0x25)
 				{
 					if (v100_n != 88)
@@ -549,7 +549,7 @@ void fn000014B4(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 									if (v100_n == 0x00)
 										a2_n -= (byte *) 1;
 									d0_n = a2_n - a4_n;
-									a7_n->t0066.u2 = d0_n;
+									a7_n->t0066 = d0_n;
 									a7_n[16] = (struct Eq_n) 0x00;
 									a3_n = a4_n;
 									d5_n.u0 = 0;
@@ -557,20 +557,20 @@ void fn000014B4(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 								else
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a3_n = (byte *) *d0_n;
+									a3_n = d0_n->dw0000;
 									a7_n->t0066 = 0x00;
-									d3_n = (word32) d0_n + 4;
-									a0_n = (word32) d0_n + 4;
+									d3_n = d0_n + 4;
+									a0_n = (struct Eq_n *) (d0_n + 4);
 									byte * a1_n = a3_n;
-									if ((d5_n == 0x00 || d5_n - a7_n->t0066 > 0x00) && *a3_n != 0x00)
+									if ((d5_n == 0x00 || d5_n - a7_n->t0066 > null) && *a3_n != 0x00)
 									{
-										d0_n = a7_n->t0066;
+										d0_n = (struct Eq_n *) a7_n->t0066;
 										do
 										{
-											d0_n = (word32) d0_n + 1;
+											++d0_n;
 											++a1_n;
-										} while ((d5_n <= 0x00 || d5_n - d0_n > 0x00) && *a1_n != 0x00);
-										a7_n->t0066.u2 = d0_n;
+										} while ((d5_n <= 0x00 || d5_n - d0_n > null) && *a1_n != 0x00);
+										a7_n->t0066 = d0_n;
 									}
 									d5_n.u0 = 0;
 								}
@@ -580,32 +580,32 @@ void fn000014B4(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 								if (d4_n == 0x01)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0004 = d6_n;
 									a0_n->t0000.u0 = 0x00;
 								}
 								else if (d4_n == 0x6C)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = d6_n;
 								}
 								else if (d4_n == 0x68)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = (word16) d6_n;
 								}
 								else if (d4_n == 0x02)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = (byte) d6_n;
 								}
 								else
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = d6_n;
 								}
 								d3_n = ((word32) d3_n + 3 >> 0x02 << 0x02) + 0x04;
@@ -618,16 +618,16 @@ void fn000014B4(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 							if (d4_n == 0x6C)
 							{
 								d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-								*a3_n = (byte) *((word32) d0_n + 3);
+								*a3_n = (byte) d0_n[3];
 							}
 							else
 							{
 								d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-								*a3_n = (byte) *((word32) d0_n + 3);
+								*a3_n = (byte) d0_n[3];
 							}
 							a0_n = ((word32) d3_n + 3 >> 0x02 << 0x02) + 0x04;
 							d3_n = ((word32) d3_n + 3 >> 0x02 << 0x02) + 0x04;
-							a7_n->t0066.u0 = 0x01;
+							a7_n->t0066 = 0x01;
 							d5_n.u0 = 0;
 						}
 						goto l00001C20;
@@ -666,7 +666,7 @@ l00001732:
 						}
 						if (d4_n == 0x68)
 						{
-							Eq_n v262_n = a7_n->dw003E;
+							word16 v262_n = a7_n->w003E;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1_n;
 							a7_n->dw0040 = (uint32) (uint16) v262_n;
@@ -675,7 +675,7 @@ l00001732:
 						}
 						if (d4_n == 0x02)
 						{
-							Eq_n v277_n = a7_n->dw003F;
+							byte v277_n = a7_n->b003F;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1_n;
 							a7_n->dw0040 = (uint32) (uint8) v277_n;
@@ -786,7 +786,7 @@ l0000198E:
 							}
 							if (d4_n == 0x02)
 							{
-								Eq_n v248_n = a7_n->dw0037;
+								byte v248_n = a7_n->b0037;
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->ptr0000 = d1_n;
 								int32 d1_n = (int32) (int16) (int8) SEQ(SLICE(d1_n, word24, 8), v248_n);
@@ -855,7 +855,7 @@ l000019D0:
 					a7_n->dw0062 = d7_n;
 					struct Eq_n * v187_n = a7_n + 0x0E;
 					word32 d6_n = v187_n->dw0000;
-					Eq_n d7_n = v187_n->t0004;
+					struct Eq_n * d7_n = v187_n->ptr0004;
 					word32 d3_n = a7_n->t0066;
 					Eq_n a1_n = a7_n[11];
 					do
@@ -867,7 +867,7 @@ l000019D0:
 						*(a7_n - 8) = (union Eq_n *) a1_n;
 						*(a7_n - 0x0C) = d1_n;
 						*(a7_n - 16) = d1_n >> 31;
-						*(a7_n - 20) = (union Eq_n *) d7_n;
+						*(a7_n - 20) = (struct Eq_n **) d7_n;
 						*(a7_n - 24) = d6_n;
 						int32 d1_n = fn0000279C(*(a7_n - 24), *(a7_n - 20), *(a7_n - 16), *(a7_n - 0x0C));
 						ptr32 v191_n = *(a7_n - 8);
@@ -880,9 +880,9 @@ l000019D0:
 						*(a7_n - 8) = v191_n;
 						*(a7_n - 0x0C) = d1_n;
 						*(a7_n - 16) = d0_n;
-						*(a7_n - 20) = (union Eq_n *) d7_n;
+						*(a7_n - 20) = (struct Eq_n **) d7_n;
 						*(a7_n - 24) = d6_n;
-						Eq_n d1_n;
+						struct Eq_n * d1_n;
 						word32 d0_n = fn00002454(*(a7_n - 24), *(a7_n - 20), *(a7_n - 16), *(a7_n - 0x0C), out d1_n, out a0_n);
 						a1_n = *(a7_n - 8);
 						d6_n = d0_n;
@@ -890,7 +890,7 @@ l000019D0:
 						a7_n = (struct Eq_n *) (&a7_n->dw0000 + 1);
 						++d3_n;
 						d0_n = d1_n;
-					} while (d0_n - (d1_n < 0x00) != 0x00);
+					} while (d0_n - (d1_n < null) != 0x00);
 					a7_n->dw006A = d3_n;
 					d7_n = a7_n->ptr0066;
 					d6_n = a7_n->t0034;
@@ -913,15 +913,15 @@ l00001C20:
 				else
 					a7_n[11] = (struct Eq_n) d5_n;
 				struct Eq_n * a7_n = a7_n - 4;
-				a7_n->t0000 = d0_n;
+				a7_n->ptr0000 = d0_n;
 				a7_n->dw0034 = d7_n + a7_n->dw0030 / 0x0044;
-				a7_n->t0000 = a7_n->t0000;
-				Eq_n d0_n = a7_n->t0000;
+				a7_n->ptr0000 = a7_n->ptr0000;
+				struct Eq_n * d0_n = a7_n->ptr0000;
 				if (a7_n->dw0034 - a7_n->dw0044 >= 0x00)
 					a7_n->dw0030 = 0x00;
 				else
 				{
-					a7_n->t0000 = d0_n;
+					a7_n->ptr0000 = d0_n;
 					a7_n->dw0030 = a7_n->dw0044 - a7_n->dw0034;
 				}
 				a7_n[0x0C] = a7_n[11];
@@ -1541,7 +1541,7 @@ l00002552:
 		word32 d1_n;
 		d1_n = fn00002558(dwArg04, dwArg08, dwArg10, out d1_n, out d2_n);
 l00002550:
-		d0_n.u0 = 0;
+		&d0_n.u0->dw0000 = 0;
 		goto l00002552;
 	}
 }
@@ -1599,7 +1599,7 @@ l00002572:
 					Eq_n d2_n = __swap(d5_n);
 					Eq_n d3_n = __swap(d7_n);
 					if ((word16) (d2_n - d3_n) == 0x00)
-						d1_n.u0 = 0xFFFF;
+						&d1_n.u0->dw0000 = 0xFFFF;
 					else
 						d1_n = __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_n % (uint16) d3_n), (uint16) (d5_n /u (uint16) d3_n))), word16, 16), 0x00));
 					Eq_n d6_n = __swap(SEQ(SLICE(d6_n, word16, 16), 0x00));
@@ -1711,7 +1711,7 @@ Eq_n fn00002716(Eq_n d0, Eq_n d1, Eq_n d2, union Eq_n & d1Out)
 		if ((word16) d1_n < 0x80)
 		{
 			d1_n = __rol(d1_n, 0x08);
-			d3_n.u0 = 0x08;
+			&d3_n.u0->dw0000 = 0x08;
 		}
 		if ((word16) d1_n < 0x0800)
 		{
@@ -1872,31 +1872,31 @@ void fn00002B98(struct Eq_n * dwArg04)
 	}
 }
 
-// 00002BDC: void fn00002BDC(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack (ptr32 Eq_n) dwArg04)
-void fn00002BDC(Eq_n d0, Eq_n d1, Eq_n a1, struct Eq_n * dwArg04)
+// 00002BDC: void fn00002BDC(Register Eq_n d0, Register Eq_n d1, Register (ptr32 (ptr32 byte)) a1, Stack (ptr32 Eq_n) dwArg04)
+void fn00002BDC(Eq_n d0, Eq_n d1, byte ** a1, struct Eq_n * dwArg04)
 {
 	fn00002C28(d0, d1, a1, *(union Eq_n *) 0x3FF0, dwArg04, fp + 8);
 }
 
-// 00002BF8: Register Eq_n fn00002BF8(Stack Eq_n bArg07, Stack Eq_n dwArg08)
-Eq_n fn00002BF8(Eq_n bArg07, Eq_n dwArg08)
+// 00002BF8: Register Eq_n fn00002BF8(Stack byte bArg07, Stack Eq_n dwArg08)
+Eq_n fn00002BF8(byte bArg07, Eq_n dwArg08)
 {
 	Eq_n d0_n = dwArg08;
 	if (dwArg08 != 0x00)
 	{
 		d0_n = *((word32) dwArg08 + 4);
 		if (d0_n - *((word32) dwArg08 + 8) < 0x00)
-			**((word32) dwArg08 + 4) = bArg07;
+			(*((word32) dwArg08 + 4))->u0 = bArg07;
 		*((word32) dwArg08 + 20) = (word32) *((word32) dwArg08 + 20) + 1;
 		--*((word32) dwArg08 + 4);
 	}
 	return d0_n;
 }
 
-// 00002C28: void fn00002C28(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
-void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
+// 00002C28: void fn00002C28(Register Eq_n d0, Register Eq_n d1, Register (ptr32 (ptr32 byte)) a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
+void fn00002C28(Eq_n d0, Eq_n d1, byte ** a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
 {
-	Eq_n a7_n = fp + -0x0078;
+	struct Eq_n * a7_n = fp + -0x0078;
 	Eq_n d2_n = dwArg0C;
 	struct Eq_n * a4_n = dwArg08;
 	Eq_n a2_n = dwArg04;
@@ -1910,8 +1910,8 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 			Eq_n d3_n = 0;
 			if (a4_n->b0000 == 0x25)
 			{
-				*((word32) a7_n + 72) = 0x69;
-				*((word32) a7_n + 73) = 0x00;
+				a7_n[18] = (struct Eq_n) 0x69;
+				a7_n->b0049 = 0x00;
 				byte * a3_n = a4_n + 1;
 				uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 				Eq_n d6_n = -1;
@@ -1919,7 +1919,7 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				if ((d0_n & 0x04) != 0x00)
 				{
 					uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-					d6_n.u0 = 0;
+					&d6_n.u0->dw0000 = 0;
 					d0 = d0_n & 0x04;
 					if ((d0_n & 0x04) != 0x00)
 					{
@@ -1941,8 +1941,8 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				}
 				if (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))))
 				{
-					d7 = SEQ(SLICE(d7, word24, 8), *((word32) a7_n + 73));
-					d1 = SEQ(SLICE(d1, word24, 8), *((word32) a7_n + 72));
+					d7 = SEQ(SLICE(d7, word24, 8), a7_n->b0049);
+					d1 = SEQ(SLICE(d1, word24, 8), a7_n[18]);
 					do
 					{
 						if (*a3_n == 0x2A)
@@ -1955,15 +1955,15 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 							d1 = SEQ(SLICE(d1, word24, 8), *a3_n);
 						++a3_n;
 					} while (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))));
-					*((word32) a7_n + 72) = (byte) d1;
-					*((word32) a7_n + 73) = (byte) d7;
+					a7_n[18] = (struct Eq_n) (byte) d1;
+					a7_n->b0049 = (byte) d7;
 				}
-				if (*((word32) a7_n + 72) == 0x6A)
-					*((word32) a7_n + 72) = 0x01;
-				if (*((word32) a7_n + 72) == 116)
-					*((word32) a7_n + 72) = 0x69;
-				if (*((word32) a7_n + 72) == 122)
-					*((word32) a7_n + 72) = 0x6C;
+				if (a7_n[18] == 0x6A)
+					a7_n[18] = (struct Eq_n) 0x01;
+				if (a7_n[18] == 116)
+					a7_n[18] = (struct Eq_n) 0x69;
+				if (a7_n[18] == 122)
+					a7_n[18] = (struct Eq_n) 0x6C;
 				byte v83_n = *a3_n;
 				word24 v84_n = SLICE(d7, word24, 8);
 				struct Eq_n * a3_n = a3_n + 1;
@@ -1984,7 +1984,7 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 							byte * a0_n = *a1;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							*a1 = (byte **) (a0_n + 1);
 							byte v96_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v96_n);
@@ -2021,19 +2021,19 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 								d1 = SEQ(v147_n, v83_n - 115);
 								if (v83_n != 115)
 								{
-									*((word32) a7_n + 48) = 0x00;
-									*((word32) a7_n + 44) = 0x00;
-									*((word32) a7_n + 110) = 0x00;
+									a7_n[0x0C] = (struct Eq_n) 0x00;
+									a7_n[11] = (struct Eq_n) 0x00;
+									a7_n->dw006E = 0x00;
 									if (v83_n == 0x00)
 										--a3_n;
 									if (v83_n == 0x70)
 									{
-										*((word32) a7_n + 72) = 0x6C;
+										a7_n[18] = (struct Eq_n) 0x6C;
 										d7 = 0x0078;
 									}
 									if ((d5_n == 0x2D && (byte) d7 != 117 || d5_n == 0x2B) && d6_n - d3_n >= 0x00)
 									{
-										*((word32) a7_n + 110) = d5_n;
+										a7_n->dw006E = (word32) d5_n;
 										ui32 * a0_n = (word32) a2_n + 24;
 										*a0_n |= 0x01;
 										int32 * a0_n = (word32) a2_n + 20;
@@ -2045,7 +2045,7 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											byte * a0_n = *a1;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v231_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -2061,7 +2061,7 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0 = fn00003CCC(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0;
 										}
-										d5_n = *((word32) a7_n + 52);
+										d5_n = a7_n[0x0D];
 										d3_n = (word32) d3_n + 1;
 										d4_n = (word32) d4_n + 1;
 									}
@@ -2081,7 +2081,7 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												byte * a0_n = *a1;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												*a1 = (byte **) (a0_n + 1);
 												byte v249_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -2097,8 +2097,8 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00003CCC(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 64) = *((word32) a7_n + 52);
-											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+											a7_n[16] = a7_n[0x0D];
+											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 											Eq_n d3_n = (word32) d3_n + 1;
 											d0 = d0_n & 0xFF;
 											if (!__btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[(int32) (int16) (d0_n & 0xFF)].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0], 0x00))
@@ -2117,7 +2117,7 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 													byte * a0_n = *a1;
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
-													*a1 = a0_n + 1;
+													*a1 = (byte **) (a0_n + 1);
 													byte v271_n = *a0_n;
 													a2_n = a7_n->t0000;
 													a7_n->t0000 = d1;
@@ -2133,12 +2133,12 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 													d0_n = fn00003CCC(a7_n->t0000, out d1, out a1, out a5_n);
 													a7_n->t0038 = d0_n;
 												}
-												*((word32) a7_n + 74) = *((word32) a7_n + 52);
+												a7_n->dw004A = (word32) a7_n[0x0D];
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x44;
 												if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 													d7 = 0x0078;
-												if (*((word32) a7_n + 74) != ~0x00)
+												if (a7_n->dw004A != ~0x00)
 												{
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
@@ -2148,7 +2148,7 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											}
 											else
 												d7 = 111;
-											if (*((word32) a7_n + 64) != ~0x00)
+											if (a7_n[16] != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -2185,7 +2185,7 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											byte * a0_n = *a1;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v351_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -2201,8 +2201,8 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0_n = fn00003CCC(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0_n;
 										}
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
-										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+										a7_n[16] = a7_n[0x0D];
+										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 										Eq_n d3_n = (word32) d3_n + 1;
 										int32 d4_n = (word32) d4_n + 1;
 										d0 = d0_n & 0xFF;
@@ -2222,7 +2222,7 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												byte * a0_n = *a1;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												*a1 = (byte **) (a0_n + 1);
 												byte v372_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -2238,17 +2238,17 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00003CCC(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 74) = *((word32) a7_n + 52);
-											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55)) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
+											a7_n->dw004A = (word32) a7_n[0x0D];
+											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(SLICE(d0_n, word24, 8), a7_n->b0037) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 											d3_n = (word32) d3_n + 1;
 											d4_n = d4_n + 0x01;
 											d0 = d0_n & 0x44;
 											if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 											{
-												d5_n = *((word32) a7_n + 74);
+												d5_n = a7_n->dw004A;
 												goto l00003692;
 											}
-											if (*((word32) a7_n + 74) != ~0x00)
+											if (a7_n->dw004A != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -2256,7 +2256,7 @@ void fn00002C28(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0 = fn00002BF8(*(a7_n - 1), a7_n->t0000);
 											}
 										}
-										if (*((word32) a7_n + 64) != ~0x00)
+										if (a7_n[16] != ~0x00)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
@@ -2270,52 +2270,52 @@ l00003692:
 									if ((byte) d7 != 0x78 && (byte) d7 != 88)
 									{
 										if ((byte) d7 == 111)
-											*((word32) a7_n + 52) = 0x08;
+											a7_n[0x0D] = (struct Eq_n) 0x08;
 										else
-											*((word32) a7_n + 52) = 0x0A;
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
+											a7_n[0x0D] = (struct Eq_n) 0x0A;
+										a7_n[16] = a7_n[0x0D];
 									}
 									else
-										*((word32) a7_n + 64) = 0x10;
-									*((word32) a7_n + 114) = *((word32) a7_n + 64);
+										a7_n[16] = (struct Eq_n) 0x10;
+									a7_n->dw0072 = (word32) a7_n[16];
 									uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(SLICE(d0, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-									*((word32) a7_n + 0x0084) = d2_n;
-									*((word32) a7_n + 52) = d4_n;
-									*((word32) a7_n + 74) = (byte) d7;
+									a7_n[33] = (struct Eq_n) d2_n;
+									a7_n[0x0D] = (struct Eq_n) d4_n;
+									a7_n->dw004A = (word32) (byte) d7;
 									d0 = d0_n & 0x44;
 									if ((d0_n & 0x44) != 0x00)
 									{
-										if (*((word32) a7_n + 114) == 0x0A)
+										if (a7_n->dw0072 == 0x0A)
 										{
 											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(SLICE(d0_n & 0x44, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											d0 = d0_n & 0x04;
 											if ((d0_n & 0x04) != 0x00)
 												goto l0000372E;
 											goto l0000392E;
 										}
 l0000372E:
-										if (*((word32) a7_n + 114) == 0x08)
+										if (a7_n->dw0072 == 0x08)
 										{
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d5_n <= 55)
 												goto l0000374E;
 										}
 										else
 										{
 l0000374E:
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 64) = d6_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n[16] = (struct Eq_n) d6_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d6_n - d3_n >= 0x00)
 											{
-												d7 = (int32) *((word32) a7_n + 114);
-												up32 a4_n = *((word32) a7_n + 64);
+												d7 = a7_n->dw0072;
+												up32 a4_n = a7_n[16];
 												do
 												{
 													struct Eq_n * a7_n = a7_n - 4;
@@ -2323,7 +2323,7 @@ l0000374E:
 													Eq_n v419_n = a7_n->t0000;
 													a7_n->t0000 = d7 >> 31;
 													*(a7_n - 4) = d7;
-													*(a7_n - 8) = (union Eq_n *) a1;
+													*(a7_n - 8) = (byte ***) a1;
 													*(a7_n - 0x0C) = a7_n->dw0034;
 													*(a7_n - 16) = a7_n->dw0030;
 													*(a7_n - 20) = d7;
@@ -2331,44 +2331,44 @@ l0000374E:
 													word32 d1_n;
 													a7_n->dw0044 = fn00003C4C(d4_n, *(a7_n - 24), *(a7_n - 20), *(a7_n - 16), *(a7_n - 0x0C), out d1_n);
 													a7_n->dw0048 = d1_n;
-													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(a7_n->t0001, (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x04) != 0x00)
-														d4_n = d5_n - 0x30;
+													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(a7_n->n0001, (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x04) != 0x00)
+														d4_n = d5_n - (struct Eq_n *) 0x30;
 													else
 														d4_n.u0 = 0;
-													Eq_n d6_n;
+													struct Eq_n * d6_n;
 													*(a7_n - 4) = (union Eq_n *) v419_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d4_n + Mem2975[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = (union Eq_n *) d3_n;
 													int32 d0_n = d4_n >> 31;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + d0_n);
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < null) + ((word32) a7_n[16] + d0_n));
 													word32 v441_n = *(a7_n - 8);
 													word32 v442_n = *(a7_n - 4);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x01) != 0x00)
-														d6_n = d5_n - 55;
+														d6_n = d5_n - (struct Eq_n *) 55;
 													else
-														d6_n.u0 = 0;
-													Eq_n d2_n;
+														d6_n = null;
+													struct Eq_n * d2_n;
 													*(a7_n - 4) = v442_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d6_n + Mem3035[a7_n + 48:word32];
-													*((word32) a7_n + 0x0044) = d2_n;
+													a7_n[0x0011] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v441_n;
 													int32 d0_n = d6_n >> 31;
-													*((word32) a7_n + 64) = (word32) *((word32) a7_n + 44) + d0_n + (d2_n < 0x00);
+													a7_n[16] = (struct Eq_n) ((word32) a7_n[11] + d0_n + (d2_n < null));
 													word32 v453_n = *(a7_n - 8);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x02) != 0x00)
-														d2_n = d5_n - 0x57;
+														d2_n = d5_n - (struct Eq_n *) 0x57;
 													else
-														d2_n.u0 = 0;
+														d2_n = null;
 													Eq_n d0_n;
-													*(a7_n - 4) = (union Eq_n *) d2_n;
+													*(a7_n - 4) = (struct Eq_n **) d2_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d2_n + Mem3093[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v453_n;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + (d2_n >> 31));
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < null) + ((word32) a7_n[16] + (d2_n >> 31)));
 													ui32 * a0_n = (word32) a2_n + 24;
 													up32 v465_n = *(a7_n - 8);
 													d2_n = *(a7_n - 4);
@@ -2381,7 +2381,7 @@ l0000374E:
 														a1 = (word32) a2_n + 4;
 														byte * a0_n = *a1;
 														*(a7_n - 4) = (union Eq_n *) a2_n;
-														*a1 = a0_n + 1;
+														*a1 = (byte **) (a0_n + 1);
 														d0_n = (uint32) (uint8) *a0_n;
 														a2_n = *(a7_n - 4);
 														d1 = (uint32) (uint8) (byte) d0_n;
@@ -2394,7 +2394,7 @@ l0000374E:
 														d0_n = fn00003CCC(*(a7_n - 4), out d1_n, out a1, out a5_n);
 														d1 = d0_n;
 													}
-													*((word32) a7_n + 52) = (word32) *((word32) a7_n + 52) + 1;
+													a7_n[0x0D] = (struct Eq_n) ((word32) a7_n[0x0D] + 1);
 													uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(SLICE(d0_n, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 													d5_n = d1;
 													d3_n = v465_n + 0x01;
@@ -2413,11 +2413,11 @@ l0000374E:
 										}
 									}
 l0000392E:
-									Eq_n v476_n = *((word32) a7_n + 74);
+									Eq_n v476_n = a7_n->dw004A;
 									d7 = SEQ(SLICE(d7, word24, 8), v476_n);
-									word32 d4_n = *((word32) a7_n + 52);
-									d2_n = *((word32) a7_n + 0x0084);
-									if (*((word32) a7_n + 110) != 0x00 && d3_n == 0x02)
+									word32 d4_n = a7_n[0x0D];
+									d2_n = a7_n[33];
+									if (a7_n->dw006E != 0x00 && d3_n == 0x02)
 									{
 										if (d5_n != ~0x00)
 										{
@@ -2428,7 +2428,7 @@ l0000392E:
 										}
 										--d3_n;
 										--d4_n;
-										d5_n = *((word32) a7_n + 110);
+										d5_n = a7_n->dw006E;
 									}
 									if (d5_n != ~0x00)
 									{
@@ -2439,14 +2439,14 @@ l0000392E:
 									}
 									d3_n = d3_n - 0x01;
 									d4_n = d4_n - 0x01;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										if (v476_n == 117)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = d0;
 											a7_n->b0038 = a7_n->b004C - 0x01;
-											a7_n = (char *) &a7_n->t0000 + 4;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
 											if (a7_n->b0038 != 0x00)
 											{
 												byte v517_n = a7_n->b0038 - 0x01;
@@ -2498,58 +2498,58 @@ l0000392E:
 										}
 										else
 										{
-											if (*((word32) a7_n + 110) == 0x2D)
+											if (a7_n->dw006E == 0x2D)
 											{
-												struct Eq_n * v528_n = (word32) a7_n + 44;
+												struct Eq_n * v528_n = a7_n + 11;
 												d1 = -v528_n->dw0004;
 												d0 = -v528_n->dw0000 - (d1 < 0x00);
-												a7_n = *((word32) a7_n + 56);
+												a7_n = (struct Eq_n *) a7_n[0x0E];
 											}
 											else
 											{
-												*((word32) a7_n + 56) = *((word32) a7_n + 48);
-												*((word32) a7_n + 52) = *((word32) a7_n + 44);
+												a7_n[0x0E] = a7_n[0x0C];
+												a7_n[0x0D] = a7_n[11];
 											}
-											Eq_n a7_n = a7_n - 4;
-											*a7_n = d0;
-											*((word32) a7_n + 48) = *((word32) a7_n + 76) - 0x01;
-											a7_n = (word32) a7_n + 4;
-											if (*((word32) a7_n + 48) != 0x00)
+											struct Eq_n * a7_n = a7_n - 4;
+											a7_n->t0000 = d0;
+											a7_n->b0030 = a7_n->b004C - 0x01;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
+											if (a7_n->b0030 != 0x00)
 											{
-												byte v540_n = *((word32) a7_n + 48) - 0x01;
-												*((word32) a7_n + 48) = v540_n;
+												byte v540_n = a7_n->b0030 - 0x01;
+												a7_n->b0030 = v540_n;
 												if (v540_n != 0x00)
 												{
-													byte v541_n = *((word32) a7_n + 48) - 0x66;
-													*((word32) a7_n + 48) = v541_n;
+													byte v541_n = a7_n->b0030 - 0x66;
+													a7_n->b0030 = v541_n;
 													if (v541_n != 0x00)
 													{
-														byte v542_n = *((word32) a7_n + 48) - 0x04;
-														*((word32) a7_n + 48) = v542_n;
+														byte v542_n = a7_n->b0030 - 0x04;
+														a7_n->b0030 = v542_n;
 														if (v542_n != 0x00)
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 														else
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 													}
 													else
 													{
 														d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-														d0 = *((word32) a7_n + 60);
+														d0 = a7_n->t003C;
 														**((word32) d2_n - 4) = (word16) d0;
 													}
 												}
 												else
 												{
 													d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-													d0 = *((word32) a7_n + 60);
+													d0 = a7_n->t003C;
 													**((word32) d2_n - 4) = (byte) d0;
 												}
 											}
@@ -2558,18 +2558,18 @@ l0000392E:
 												word32 d0_n = d2_n + 0x03 >>u 0x02;
 												d2_n = (d0_n << 0x02) + 0x04;
 												struct Eq_n * a0_n = *((word32) d2_n - 4);
-												a0_n->dw0004 = (word32) *((word32) a7_n + 60);
-												a0_n->dw0000 = (word32) *((word32) a7_n + 56);
+												a0_n->t0004 = a7_n->t003C;
+												a0_n->dw0000 = a7_n->dw0038;
 												d0 = d0_n << 0x02;
 											}
 										}
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 								else
 								{
 									byte * a5_n;
-									if (*((word32) a7_n + 73) == 0x00)
+									if (a7_n->b0049 == 0x00)
 									{
 										d0 = (word32) d2_n + 3 >> 0x02 << 0x02;
 										d2_n = (word32) d0 + 4;
@@ -2583,7 +2583,7 @@ l0000392E:
 										d0 = d0_n & 0x08;
 										if ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00)
 										{
-											byte v190_n = *((word32) a7_n + 73);
+											byte v190_n = a7_n->b0049;
 											d7 = SEQ(v84_n, v190_n);
 											do
 											{
@@ -2603,7 +2603,7 @@ l0000392E:
 													byte * a0_n = *a1;
 													union Eq_n * a7_n = a7_n - 4;
 													*a7_n = (union Eq_n *) a2_n;
-													*a1 = a0_n + 1;
+													*a1 = (byte **) (a0_n + 1);
 													byte v201_n = *a0_n;
 													a2_n = *a7_n;
 													d0 = SEQ(SLICE(d0, word24, 8), v201_n);
@@ -2625,7 +2625,7 @@ l0000392E:
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t28B1)[SEQ(SLICE(d0, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x08;
 											} while ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00);
-											*((word32) a7_n + 73) = v190_n;
+											a7_n->b0049 = v190_n;
 										}
 									}
 									if (d5_n != ~0x00)
@@ -2637,18 +2637,18 @@ l0000392E:
 									}
 									d3_n = d3_n - 0x01;
 									--d4_n;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										*a5_n = 0x00;
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 							}
 							else
 							{
-								if (*((word32) a7_n + 73) == 0x00)
+								if (a7_n->b0049 == 0x00)
 								{
-									if (*((word32) a7_n + 72) == 0x01)
+									if (a7_n[18] == 0x01)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										struct Eq_n * a0_n = *d0;
@@ -2656,19 +2656,19 @@ l0000392E:
 										a0_n->dw0000 = 0x00;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x6C)
+									else if (a7_n[18] == 0x6C)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x68)
+									else if (a7_n[18] == 0x68)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (word16) d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x02)
+									else if (a7_n[18] == 0x02)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (byte) d4_n;
@@ -2681,16 +2681,16 @@ l0000392E:
 										d2_n = (word32) d0 + 4;
 									}
 								}
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 								d3_n.u0 = 1;
 							}
 						}
 						else
 						{
 							if (d6_n == ~0x00)
-								d6_n.u0 = 1;
+								&d6_n.u0->dw0000 = 1;
 							union Eq_n * a1_n;
-							if (*((word32) a7_n + 73) == 0x00)
+							if (a7_n->b0049 == 0x00)
 							{
 								d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 								d2_n = (word32) d0 + 4;
@@ -2702,7 +2702,7 @@ l0000392E:
 							*a0_n |= 0x01;
 							int32 * a0_n = (word32) a2_n + 20;
 							--*a0_n;
-							*((word32) a7_n + 44) = a1_n;
+							a7_n[11] = (struct Eq_n) a1_n;
 							if (*a0_n >= 0x00)
 							{
 								byte ** a1_n = (word32) a2_n + 4;
@@ -2719,7 +2719,7 @@ l0000392E:
 							}
 							else
 							{
-								int32 a1_n = *((word32) a7_n + 44);
+								int32 a1_n = a7_n[11];
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->t0000 = a2_n;
 								a7_n->dw0030 = a1_n;
@@ -2729,18 +2729,18 @@ l0000392E:
 								a7_n->t0038 = d0;
 								a7_n->dw0030 = a7_n->dw0030;
 							}
-							a1 = *((word32) a7_n + 44);
-							d5_n = *((word32) a7_n + 52);
+							a1 = (byte **) a7_n[11];
+							d5_n = a7_n[0x0D];
 							Eq_n d3_n = (word32) d3_n + 1;
 							int32 d4_n = (word32) d4_n + 1;
-							if (*((word32) a7_n + 52) != ~0x00)
+							if (a7_n[0x0D] != ~0x00)
 							{
-								*((word32) a7_n + 44) = a1;
+								a7_n[11] = (struct Eq_n) a1;
 								if (d6_n - d3_n >= 0x00)
 								{
-									byte v302_n = *((word32) a7_n + 73);
+									byte v302_n = a7_n->b0049;
 									d7 = SEQ(v84_n, v302_n);
-									byte * a4_n = *((word32) a7_n + 44);
+									byte * a4_n = a7_n[11];
 									do
 									{
 										if (v302_n == 0x00)
@@ -2759,7 +2759,7 @@ l0000392E:
 											byte * a0_n = *a1;
 											union Eq_n * a7_n = a7_n - 4;
 											*a7_n = (union Eq_n *) a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v314_n = *a0_n;
 											a2_n = *a7_n;
 											d0 = SEQ(SLICE(d0, word24, 8), v314_n);
@@ -2778,7 +2778,7 @@ l0000392E:
 										d3_n = (word32) d3_n + 1;
 										++d4_n;
 									} while (d1 != ~0x00 && d6_n - d3_n >= 0x00);
-									*((word32) a7_n + 73) = v302_n;
+									a7_n->b0049 = v302_n;
 								}
 							}
 							if (d5_n != ~0x00)
@@ -2790,22 +2790,22 @@ l0000392E:
 							}
 							d3_n = d3_n - 0x01;
 							d4_n = d4_n - 0x01;
-							if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							if (a7_n->b0049 == 0x00 && d3_n != 0x00)
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 					else
 					{
-						*((word32) a7_n + 44) = 0x00;
+						a7_n[11] = (struct Eq_n) 0x00;
 						if (a3_n->b0000 == 0x5E)
 						{
-							*((word32) a7_n + 44) = 0x01;
+							a7_n[11] = (struct Eq_n) 0x01;
 							++a3_n;
 						}
-						*((word32) a7_n + 52) = 0x00;
-						byte v544_n = *((word32) a7_n + 44);
+						a7_n[0x0D] = (struct Eq_n) 0x00;
+						Eq_n v544_n = a7_n[11];
 						d7 = SEQ(v84_n, v544_n);
-						Eq_n d1_n = *((word32) a7_n + 52);
+						Eq_n d1_n = a7_n[0x0D];
 						do
 						{
 							int32 d5_n;
@@ -2813,12 +2813,12 @@ l0000392E:
 								d5_n = 0xFF;
 							else
 								d5_n = 0;
-							*((word32) d1_n + ((word32) a7_n + 78)) = (byte) d5_n;
+							Mem796[a7_n + 78 + d1_n:byte] = SLICE(d5_n, byte, 0);
 							d1_n = (word32) d1_n + 1;
 						} while (d1_n < 0x20);
-						*((word32) a7_n + 0x0084) = d2_n;
-						*((word32) a7_n + 44) = v544_n;
-						byte v554_n = *((word32) a7_n + 44);
+						a7_n[33] = (struct Eq_n) d2_n;
+						a7_n[11] = (struct Eq_n) v544_n;
+						Eq_n v554_n = a7_n[11];
 						while (a3_n->b0000 != 0x00)
 						{
 							cu8 v556_n = a3_n->b0000;
@@ -2837,13 +2837,13 @@ l0000392E:
 							{
 								if (v554_n != 0x00)
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (~(1 << (d5_n & 7)) & d1_n);
 								}
 								else
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (1 << (d5_n & 7) | d1_n);
 								}
@@ -2854,9 +2854,9 @@ l0000392E:
 								break;
 						}
 						byte * a6_n;
-						d2_n = *((word32) a7_n + 0x0084);
+						d2_n = a7_n[33];
 						++a3_n;
-						if (*((word32) a7_n + 73) == 0x00)
+						if (a7_n->b0049 == 0x00)
 						{
 							word32 d0_n = d2_n + 0x03 >>u 0x02;
 							d2_n = (d0_n << 0x02) + 0x04;
@@ -2874,40 +2874,40 @@ l0000392E:
 						{
 							a1 = (word32) a2_n + 4;
 							byte * a0_n = *a1;
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*a1 = a0_n + 1;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
+							*a1 = (byte **) (a0_n + 1);
 							byte v585_n = *a0_n;
-							a2_n = *a7_n;
-							*a7_n = d1_n;
-							*((word32) a7_n + 48) = (uint32) (uint8) v585_n;
+							a2_n = a7_n->t0000;
+							a7_n->t0000 = d1_n;
+							a7_n->dw0030 = (uint32) (uint8) v585_n;
 							d0 = SEQ(SLICE(d0, word24, 8), v585_n);
-							d1 = *a7_n;
+							d1 = a7_n->t0000;
 						}
 						else
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
 							word32 a5_n;
-							d0 = fn00003CCC(*a7_n, out d1, out a1, out a5_n);
-							*((word32) a7_n + 48) = d0;
+							d0 = fn00003CCC(a7_n->t0000, out d1, out a1, out a5_n);
+							a7_n->t0030 = d0;
 						}
-						d5_n = *((word32) a7_n + 44);
+						d5_n = a7_n[11];
 						Eq_n d3_n = (word32) d3_n + 1;
 						int32 d4_n = (word32) d4_n + 1;
-						if (*((word32) a7_n + 44) != ~0x00)
+						if (a7_n[11] != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = (word32) a7_n + 78;
-							*(a7_n - 4) = a1;
-							(a7_n - 8)->u0 = 0x08;
-							*(a7_n - 0x0C) = d5_n;
-							d1 = (uint32) (uint8) *((word32) *a7_n + fn000026E4(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-							a1 = *(a7_n - 4);
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->ptr0000 = &a7_n->dw004A + 1;
+							*(a7_n - 4) = (byte ***) a1;
+							*(a7_n - 8) = 0x08;
+							*(a7_n - 0x0C) = (union Eq_n *) d5_n;
+							d1 = (uint32) (uint8) (a7_n->ptr0000 + fn000026E4(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+							a1 = (byte **) *(a7_n - 4);
 							d0 = 1 << (d5_n & 7) & d1;
 							if (d0 != 0x00 && d6_n - d3_n >= 0x00)
 							{
-								byte v601_n = *((word32) a7_n + 77);
+								byte v601_n = a7_n->b004D;
 								d7 = SEQ(SLICE(d7, word24, 8), v601_n);
 								do
 								{
@@ -2925,9 +2925,9 @@ l0000392E:
 									{
 										a1 = (word32) a2_n + 4;
 										byte * a0_n = *a1;
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
-										*a1 = a0_n + 1;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
+										*a1 = (byte **) (a0_n + 1);
 										byte v611_n = *a0_n;
 										a2_n = *a7_n;
 										d0 = SEQ(SLICE(d0, word24, 8), v611_n);
@@ -2935,8 +2935,8 @@ l0000392E:
 									}
 									else
 									{
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
 										word32 d1_n;
 										word32 a5_n;
 										d0 = fn00003CCC(*a7_n, out d1_n, out a1, out a5_n);
@@ -2947,31 +2947,31 @@ l0000392E:
 									++d4_n;
 									if (d1 == ~0x00)
 										break;
-									Eq_n a7_n = a7_n - 4;
-									*a7_n = (word32) a7_n + 78;
-									*(a7_n - 4) = a1;
-									(a7_n - 8)->u0 = 0x08;
-									*(a7_n - 0x0C) = d1;
-									d1 = (uint32) (uint8) *((word32) *a7_n + fn000026E4(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-									a1 = *(a7_n - 4);
+									ptr32 * a7_n = a7_n - 4;
+									*a7_n = &a7_n->dw004A + 1;
+									*(a7_n - 4) = (byte ***) a1;
+									*(a7_n - 8) = 0x08;
+									*(a7_n - 0x0C) = (union Eq_n *) d1;
+									d1 = (uint32) (uint8) (*a7_n + fn000026E4(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+									a1 = (byte **) *(a7_n - 4);
 									d0 = 1 << (d1 & 7) & d1;
 								} while (d0 != 0x00 && d6_n - d3_n >= 0x00);
-								*((word32) a7_n + 73) = v601_n;
+								a7_n->b0049 = v601_n;
 							}
 						}
 						if (d5_n != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*(a7_n - 4) = d5_n;
+							union Eq_n * a7_n = a7_n - 4;
+							*a7_n = (union Eq_n *) a2_n;
+							*(a7_n - 4) = (union Eq_n *) d5_n;
 							d0 = fn00002BF8(*(a7_n - 1), *a7_n);
 						}
 						d3_n = d3_n - 0x01;
 						d4_n = d4_n - 0x01;
-						if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+						if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 						{
 							*a6_n = 0x00;
-							*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 				}
@@ -2988,7 +2988,7 @@ l0000392E:
 						byte * a0_n = *a1;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						*a1 = (byte **) (a0_n + 1);
 						byte v163_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1_n;
@@ -3004,10 +3004,10 @@ l0000392E:
 						d0 = fn00003CCC(a7_n->t0000, out d1, out a1, out a5_n);
 						a7_n->t0030 = d0;
 					}
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n = (word32) d3_n.u0 + 1;
 					d4_n = (word32) d4_n + 1;
-					if (*((word32) a7_n + 44) != 0x25)
+					if (a7_n[11] != 0x25)
 					{
 						if (d5_n != ~0x00)
 						{
@@ -3042,7 +3042,7 @@ l0000392E:
 							byte * a0_n = *a1;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							*a1 = (byte **) (a0_n + 1);
 							byte v109_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v109_n);
@@ -3086,7 +3086,7 @@ l0000392E:
 						byte * a0_n = *a1;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						*a1 = (byte **) (a0_n + 1);
 						byte v130_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1;
@@ -3103,10 +3103,10 @@ l0000392E:
 						a7_n->t0030 = d0_n;
 					}
 					d0 = (int32) (int16) (int8) SEQ(SLICE(d0_n, word24, 8), a4_n->b0000);
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n.u0 = 0x01;
 					d4_n = (word32) d4_n + 1;
-					if (d0 - *((word32) a7_n + 44) != 0x00)
+					if (d0 - a7_n[11] != 0x00)
 					{
 						if (d5_n != ~0x00)
 						{

--- a/subjects/Hunk-m68k/MAX.reko/MAX.h
+++ b/subjects/Hunk-m68k/MAX.reko/MAX.h
@@ -320,15 +320,13 @@ Eq_553: (struct "Eq_553" (0 (ptr32 Eq_553) ptr0000) (4 (ptr32 code) ptr0004))
 Eq_561: (fn word32 (ptr32, ptr32, ptr32))
 	T_561 (in fn000012D0 : ptr32)
 	T_562 (in signature of fn000012D0 : void)
-Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8282) u3) ((ptr32 Eq_8294) u4) (Eq_2791 u5) (Eq_3068 u6) (Eq_3654 u7))
+Eq_576: (union "Eq_576" (byte u0) (word16 u1) ((ptr32 Eq_8313) u2) ((ptr32 Eq_8283) u3))
 	T_576 (in d0_10 : Eq_576)
 	T_577 (in 0x3ECC<32> : word32)
 	T_587 (in d0 : Eq_576)
-	T_606 (in a1_8 : Eq_576)
 	T_607 (in d1_10 : Eq_576)
 	T_610 (in d0 : Eq_576)
 	T_611 (in d1 : Eq_576)
-	T_612 (in a1 : Eq_576)
 	T_616 (in d0 : Eq_576)
 	T_623 (in fn00002F18(d0, 0x13DC<u32>, out d1_10, out a1_8) : word32)
 	T_626 (in d0_34 : Eq_576)
@@ -342,13 +340,9 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_645 (in d0_17 : Eq_576)
 	T_651 (in d0 : Eq_576)
 	T_652 (in d1 : Eq_576)
-	T_653 (in a1 : Eq_576)
 	T_654 (in dwArg04 : Eq_576)
-	T_656 (in dwArg0C : Eq_576)
 	T_658 (in Mem10[0x00003EF4<p32>:word32] : word32)
-	T_661 (in fp + 8<i32> : word32)
 	T_663 (in d0 : Eq_576)
-	T_664 (in bArg07 : Eq_576)
 	T_665 (in dwArg08 : Eq_576)
 	T_666 (in d0_10 : Eq_576)
 	T_667 (in 0<32> : word32)
@@ -358,28 +352,14 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_689 (in *((word32) dwArg08 + 4<i32>) - 1<32> : word32)
 	T_691 (in Mem25[dwArg08 + 4<i32>:word32] : word32)
 	T_694 (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-	T_697 (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-	T_702 (in d2_1090 : Eq_576)
 	T_704 (in a2_1014 : Eq_576)
 	T_707 (in d5_1044 : Eq_576)
 	T_708 (in 0<i32> : int32)
 	T_714 (in 0xFFFFFFFF<32> : word32)
 	T_738 (in d0_63 & 8<32> : word32)
-	T_764 (in d6_1133 : Eq_576)
-	T_765 (in -1<i32> : int32)
 	T_767 (in d0_289 & 4<32> : word32)
-	T_787 (in 0<i32> : int32)
 	T_789 (in d0_305 & 4<32> : word32)
-	T_798 (in Mem316[a7_313 + 0<32>:word32] : word32)
-	T_802 (in  : word32)
-	T_803 (in 10<i32> : int32)
-	T_804 (in __swap(10<i32>) : word32)
-	T_814 (in __swap(d6_1133) : word32)
-	T_819 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-	T_820 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-	T_846 (in Mem316[a7_313 + 0<32>:word32] : word32)
 	T_848 (in d1_340 - 0x30<32> : word32)
-	T_850 (in d1_340 - 0x30<32> + d0_331 : word32)
 	T_852 (in d0_354 & 4<32> : word32)
 	T_866 (in SEQ(SLICE(d1, word24, 8), Mem361[a7_1330 + 72<i32>:byte]) : uip32)
 	T_922 (in 2<i32> : int32)
@@ -392,7 +372,6 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_1062 (in dwArg04 : Eq_576)
 	T_1068 (in Mem535[a7_533 + 0<32>:word32] : word32)
 	T_1072 (in fn00002604(*a7_533, out d1_5316, out a1, out a5_5317) : word32)
-	T_1074 (in a2_1014 + 4<i32> : word32)
 	T_1084 (in Mem554[a7_552 + 0<32>:word32] : word32)
 	T_1096 (in Mem558[a7_552 + 0<32>:word32] : word32)
 	T_1098 (in SEQ(SLICE(d0, word24, 8), v96_562) : uip32)
@@ -403,7 +382,6 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_1176 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_1182 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_1186 (in fn00002604(*a7_180, out d1_5318, out a1, out a5_5319) : word32)
-	T_1188 (in a2_1014 + 4<i32> : word32)
 	T_1198 (in Mem201[a7_199 + 0<32>:word32] : word32)
 	T_1210 (in Mem205[a7_199 + 0<32>:word32] : word32)
 	T_1212 (in SEQ(SLICE(d0, word24, 8), v109_209) : uip32)
@@ -412,14 +390,12 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_1234 (in 0xFFFFFFFF<32> : word32)
 	T_1244 (in Mem251[a7_248 + 0<32>:word32] : word32)
 	T_1249 (in Mem254[a7_248 - 4<i32> + 0<32>:word32] : word32)
-	T_1256 (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
 	T_1259 (in Mem254[a7_248 + 0<32>:word32] : word32)
 	T_1260 (in fn00001438(*(a7_248 - 1<i32>), *a7_248) : word32)
 	T_1268 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_1273 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_1277 (in fn00002604(a7_79->t0000, out d1, out a1, out a5_5320) : word32)
 	T_1280 (in Mem94[a7_79 + 48<i32>:word32] : word32)
-	T_1282 (in a2_1014 + 4<i32> : word32)
 	T_1292 (in Mem101[a7_99 + 0<32>:word32] : word32)
 	T_1304 (in Mem105[a7_99 + 0<32>:word32] : word32)
 	T_1307 (in Mem115[a7_99 + 0<32>:word32] : word32)
@@ -430,19 +406,16 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_1344 (in 0xFFFFFFFF<32> : word32)
 	T_1354 (in Mem151[a7_148 + 0<32>:word32] : word32)
 	T_1359 (in Mem154[a7_148 - 4<i32> + 0<32>:word32] : word32)
-	T_1365 (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
 	T_1368 (in Mem154[a7_148 + 0<32>:word32] : word32)
 	T_1369 (in fn00001438(*(a7_148 - 1<i32>), *a7_148) : word32)
 	T_1406 (in d1_1355 : Eq_576)
 	T_1409 (in SEQ(v147_608, v83_500 - 0x63<8>) : uip32)
-	T_1411 (in 0xFFFFFFFF<32> : word32)
 	T_1415 (in SEQ(v147_608, v83_500 - 0x6E<8>) : uip32)
 	T_1424 (in SEQ(v147_608, v83_500 - 0x73<8>) : uip32)
 	T_1451 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_1456 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_1460 (in fn00002604(a7_640->t0000, out d1, out a1, out a5_5321) : word32)
 	T_1463 (in Mem655[a7_640 + 48<i32>:word32] : word32)
-	T_1465 (in a2_1014 + 4<i32> : word32)
 	T_1475 (in Mem662[a7_660 + 0<32>:word32] : word32)
 	T_1487 (in Mem666[a7_660 + 0<32>:word32] : word32)
 	T_1490 (in Mem686[a7_660 + 0<32>:word32] : word32)
@@ -452,38 +425,29 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_1517 (in 0xFFFFFFFF<32> : word32)
 	T_1528 (in Mem738[a7_735 + 0<32>:word32] : word32)
 	T_1533 (in Mem741[a7_735 - 4<i32> + 0<32>:word32] : word32)
-	T_1539 (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
 	T_1542 (in Mem741[a7_735 + 0<32>:word32] : word32)
 	T_1543 (in fn00001438(*(a7_735 - 1<i32>), *a7_735) : word32)
 	T_1546 (in 0x2D<32> : word32)
 	T_1559 (in (word32) d2_1090 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_1561 (in d0 + 4<32> : word32)
 	T_1565 (in 0xFFFFFFFF<32> : word32)
 	T_1590 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_1603 (in d0 + 4<32> : word32)
 	T_1604 (in 0xFFFFFFFF<32> : word32)
 	T_1618 (in d0_1765 & 8<32> : word32)
 	T_1671 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_1679 (in d0 + 4<32> : word32)
 	T_1685 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_1690 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_1694 (in fn00002604(*a7_1807, out d1_5322, out a1, out a5_1727) : word32)
-	T_1696 (in a2_1014 + 4<i32> : word32)
 	T_1706 (in Mem1828[a7_1826 + 0<32>:word32] : word32)
 	T_1718 (in Mem1832[a7_1826 + 0<32>:word32] : word32)
 	T_1720 (in SEQ(SLICE(d0, word24, 8), v201_1836) : uip32)
 	T_1722 (in (uint32) (uint8) v201_1836 : uint32)
 	T_1727 (in 0xFFFFFFFF<32> : word32)
 	T_1739 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_1748 (in d0 + 4<32> : word32)
 	T_1764 (in d0_1871 & 8<32> : word32)
 	T_1778 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_1786 (in d0 + 4<32> : word32)
 	T_1792 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_1801 (in d0 + 4<32> : word32)
 	T_1816 (in Mem1903[a7_1897 + 0<32>:word32] : word32)
 	T_1821 (in Mem1906[a7_1897 - 4<i32> + 0<32>:word32] : word32)
-	T_1827 (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
 	T_1830 (in Mem1906[a7_1897 + 0<32>:word32] : word32)
 	T_1831 (in fn00001438(*(a7_1897 - 1<i32>), *a7_1897) : word32)
 	T_1832 (in 0x2B<32> : word32)
@@ -492,7 +456,6 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_1881 (in Mem2009[a7_2007 + 0<32>:word32] : word32)
 	T_1885 (in fn00002604(a7_2007->t0000, out d1, out a1, out a5_5323) : word32)
 	T_1888 (in Mem2022[a7_2007 + 56<i32>:word32] : word32)
-	T_1890 (in a2_1014 + 4<i32> : word32)
 	T_1900 (in Mem2029[a7_2027 + 0<32>:word32] : word32)
 	T_1912 (in Mem2033[a7_2027 + 0<32>:word32] : word32)
 	T_1915 (in Mem2050[a7_2027 + 0<32>:word32] : word32)
@@ -506,24 +469,20 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_2008 (in Mem2150[a7_2148 + 0<32>:word32] : word32)
 	T_2012 (in fn00002604(a7_2148->t0000, out d1, out a1, out a5_5324) : word32)
 	T_2015 (in Mem2163[a7_2148 + 56<i32>:word32] : word32)
-	T_2017 (in a2_1014 + 4<i32> : word32)
 	T_2027 (in Mem2170[a7_2168 + 0<32>:word32] : word32)
 	T_2039 (in Mem2174[a7_2168 + 0<32>:word32] : word32)
 	T_2042 (in Mem2185[a7_2168 + 0<32>:word32] : word32)
 	T_2049 (in SEQ(SLICE(d0, word24, 8), v249_2178) : uip32)
 	T_2052 (in Mem2191[a7_2168 + 0<32>:word32] : word32)
 	T_2069 (in d0_2209 & 0xFF<32> : word32)
-	T_2088 (in 1<i32> : int32)
 	T_2089 (in 0x78<32> : word32)
 	T_2097 (in SEQ(SLICE(d0_2209 & 0xFF<32>, word24, 8), SLICE(d0_2209 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
 	T_2104 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_2106 (in d0 + 4<32> : word32)
 	T_2144 (in d0_2253 : Eq_576)
 	T_2175 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_2180 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_2184 (in fn00002604(a7_2246->t0000, out d1, out a1, out a5_5325) : word32)
 	T_2187 (in Mem2261[a7_2246 + 56<i32>:word32] : word32)
-	T_2189 (in a2_1014 + 4<i32> : word32)
 	T_2199 (in Mem2268[a7_2266 + 0<32>:word32] : word32)
 	T_2211 (in Mem2272[a7_2266 + 0<32>:word32] : word32)
 	T_2214 (in Mem2283[a7_2266 + 0<32>:word32] : word32)
@@ -539,18 +498,14 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_2306 (in Mem1444[a7_1425 + 0<32>:word32] : word32)
 	T_2313 (in SEQ(SLICE(d0, word24, 8), v284_1435) : uip32)
 	T_2316 (in Mem1450[a7_1425 + 0<32>:word32] : word32)
-	T_2319 (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
 	T_2322 (in Mem1456[a7_1330 + 52<i32>:word32] : word32)
 	T_2345 (in 0xFFFFFFFF<32> : word32)
-	T_2349 (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
 	T_2398 (in Mem2338[a7_2334 + 0<32>:word32] : word32)
-	T_2412 (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
 	T_2415 (in Mem2342[a7_2334 + 0<32>:word32] : word32)
 	T_2416 (in fn00001438(*(a7_2334 - 1<i32>), a7_2334->t0000) : word32)
 	T_2422 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_2428 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_2432 (in fn00002604(*a7_1512, out d1_5328, out a1, out a5_5329) : word32)
-	T_2434 (in a2_1014 + 4<i32> : word32)
 	T_2444 (in Mem1533[a7_1531 + 0<32>:word32] : word32)
 	T_2456 (in Mem1537[a7_1531 + 0<32>:word32] : word32)
 	T_2458 (in SEQ(SLICE(d0, word24, 8), v314_1541) : uip32)
@@ -558,11 +513,9 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_2465 (in 0xFFFFFFFF<32> : word32)
 	T_2494 (in Mem1591[a7_1585 + 0<32>:word32] : word32)
 	T_2499 (in Mem1594[a7_1585 - 4<i32> + 0<32>:word32] : word32)
-	T_2505 (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
 	T_2508 (in Mem1594[a7_1585 + 0<32>:word32] : word32)
 	T_2509 (in fn00001438(*(a7_1585 - 1<i32>), *a7_1585) : word32)
 	T_2515 (in Mem2373[a7_2368 + 0<32>:word32] : word32)
-	T_2529 (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
 	T_2532 (in Mem2377[a7_2368 + 0<32>:word32] : word32)
 	T_2533 (in fn00001438(*(a7_2368 - 1<i32>), a7_2368->t0000) : word32)
 	T_2556 (in d0_2124 & 0x44<32> : word32)
@@ -572,7 +525,6 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_2608 (in Mem2445[a7_2443 + 0<32>:word32] : word32)
 	T_2612 (in fn00002604(a7_2443->t0000, out d1, out a1, out a5_5330) : word32)
 	T_2615 (in Mem2458[a7_2443 + 56<i32>:word32] : word32)
-	T_2617 (in a2_1014 + 4<i32> : word32)
 	T_2627 (in Mem2465[a7_2463 + 0<32>:word32] : word32)
 	T_2639 (in Mem2469[a7_2463 + 0<32>:word32] : word32)
 	T_2642 (in Mem2492[a7_2463 + 0<32>:word32] : word32)
@@ -586,35 +538,23 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_2735 (in Mem2554[a7_2552 + 0<32>:word32] : word32)
 	T_2739 (in fn00002604(a7_2552->t0000, out d1, out a1, out a5_5331) : word32)
 	T_2742 (in Mem2567[a7_2552 + 56<i32>:word32] : word32)
-	T_2744 (in a2_1014 + 4<i32> : word32)
 	T_2754 (in Mem2574[a7_2572 + 0<32>:word32] : word32)
 	T_2766 (in Mem2578[a7_2572 + 0<32>:word32] : word32)
 	T_2769 (in Mem2589[a7_2572 + 0<32>:word32] : word32)
 	T_2776 (in SEQ(SLICE(d0, word24, 8), v372_2582) : uip32)
 	T_2779 (in Mem2595[a7_2572 + 0<32>:word32] : word32)
 	T_2804 (in d0_2620 & 0x44<32> : word32)
-	T_2837 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
 	T_2846 (in d0_2760 & 0x44<32> : word32)
 	T_2859 (in Mem2671[a7_2667 + 0<32>:word32] : word32)
-	T_2873 (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
 	T_2876 (in Mem2675[a7_2667 + 0<32>:word32] : word32)
 	T_2877 (in fn00001438(*(a7_2667 - 1<i32>), a7_2667->t0000) : word32)
 	T_2889 (in Mem2603[a7_1330 + 74<i32>:word32] : word32)
-	T_2902 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-	T_2932 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
 	T_2941 (in d0_2818 & 4<32> : word32)
-	T_2947 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-	T_2953 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-	T_2963 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
 	T_2971 (in 0x37<32> : word32)
-	T_2984 (in v419_2893 : Eq_576)
-	T_2989 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_3114 (in d0_3135 : Eq_576)
-	T_3164 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_3190 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_3197 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_3201 (in fn00002604(*(a7_1330 - 4<i32>), out d1_5332, out a1, out a5_5333) : word32)
-	T_3203 (in a2_1014 + 4<i32> : word32)
 	T_3211 (in Mem3149[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_3221 (in (uint32) (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint32)
 	T_3225 (in Mem3153[a7_1330 - 4<i32> + 0<32>:word32] : word32)
@@ -625,50 +565,29 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_3267 (in Mem3291[a7_1330 + 110<i32>:word32] : word32)
 	T_3273 (in Mem3272[a7_3259 + 0<32>:word32] : word32)
 	T_3278 (in Mem3275[a7_3259 - 4<i32> + 0<32>:word32] : word32)
-	T_3284 (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
 	T_3287 (in Mem3275[a7_3259 + 0<32>:word32] : word32)
 	T_3288 (in fn00001438(*(a7_3259 - 1<i32>), *a7_3259) : word32)
 	T_3294 (in Mem2639[a7_2635 + 0<32>:word32] : word32)
-	T_3308 (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
 	T_3311 (in Mem2643[a7_2635 + 0<32>:word32] : word32)
 	T_3312 (in fn00001438(*(a7_2635 - 1<i32>), a7_2635->t0000) : word32)
 	T_3330 (in d0_3206 & 4<32> : word32)
 	T_3338 (in 0x37<32> : word32)
-	T_3344 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_3347 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_3349 (in d7 >> 31<i32> : word32)
-	T_3352 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-	T_3362 (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
-	T_3394 (in dwArg04 : Eq_576)
-	T_3395 (in dwArg08 : Eq_576)
-	T_3396 (in dwArg0C : Eq_576)
-	T_3397 (in dwArg10 : Eq_576)
-	T_3402 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-	T_3407 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-	T_3412 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-	T_3417 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
 	T_3456 (in Mem3303[a7_3299 + 0<32>:word32] : word32)
 	T_3461 (in Mem3306[a7_3299 - 4<i32> + 0<32>:word32] : word32)
-	T_3467 (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
 	T_3470 (in Mem3306[a7_3299 + 0<32>:word32] : word32)
 	T_3471 (in fn00001438(*(a7_3299 - 1<i32>), *a7_3299) : word32)
 	T_3500 (in Mem3476[a7_3474 + 0<32>:word32] : word32)
-	T_3524 (in (d0_3495 << 2<32>) + 4<32> : word32)
 	T_3531 (in Mem3485[a7_3474 + 52<i32>:word32] : word32)
 	T_3534 (in Mem3503[a0_3501 + 4<i32>:word32] : word32)
 	T_3541 (in d0_3495 << 2<32> : word32)
-	T_3560 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_3563 (in Mem3508[a7_3474 + 52<i32>:word32] : word32)
 	T_3564 (in SLICE(d0, byte, 0) : byte)
 	T_3570 (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_3589 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_3592 (in Mem3525[a7_3474 + 52<i32>:word32] : word32)
 	T_3593 (in SLICE(d0, word16, 0) : word16)
 	T_3599 (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_3618 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_3621 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_3627 (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_3635 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_3638 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_3644 (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
 	T_3670 (in -v528_3348->dw0004 : word32)
@@ -677,46 +596,31 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_3686 (in Mem3375[a7_3364 + 0<32>:word32] : word32)
 	T_3711 (in d1_1027 : Eq_576)
 	T_3714 (in Mem773[a7_1330 + 52<i32>:word32] : word32)
-	T_3729 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_3736 (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
+	T_3739 (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
 	T_3746 (in d0_3398 << 2<32> : word32)
-	T_3765 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_3768 (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
 	T_3769 (in SLICE(d0, byte, 0) : byte)
 	T_3775 (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_3794 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_3797 (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
 	T_3798 (in SLICE(d0, word16, 0) : word16)
 	T_3804 (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_3823 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_3826 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_3832 (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_3840 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_3843 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_3849 (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_3853 (in SLICE(d5_785, byte, 0) : byte)
-	T_3857 (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
 	T_3859 (in d1_1027 + 1<32> : word32)
 	T_3860 (in 0x20<32> : word32)
-	T_3866 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-	T_3877 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
 	T_3892 (in SEQ(SLICE(d1_1027, word24, 8), v556_834) : uip32)
 	T_3918 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_3937 (in Mem889[a0_881 + 0<32>:byte] : byte)
 	T_3939 (in (uint32) (uint8) Mem889[a0_881 + 0<32>:byte] : uint32)
-	T_3945 (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-	T_3948 (in Mem895[a0_881 + 0<32>:byte] : byte)
-	T_3957 (in Mem889[a0_900 + 0<32>:byte] : byte)
 	T_3959 (in (uint32) (uint8) Mem889[a0_900 + 0<32>:byte] : uint32)
-	T_3966 (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-	T_3969 (in Mem914[a0_900 + 0<32>:byte] : byte)
 	T_3974 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_3987 (in (d0_957 << 2<32>) + 4<32> : word32)
 	T_3988 (in d0_957 << 2<32> : word32)
 	T_4027 (in Mem987[a7_985 + 0<32>:word32] : word32)
 	T_4032 (in Mem987[a7_985 + 0<32>:word32] : word32)
-	T_4036 (in fn00002604(*a7_985, out d1, out a1, out a5_5334) : word32)
+	T_4036 (in fn00002604(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
 	T_4039 (in Mem1000[a7_985 + 48<i32>:word32] : word32)
-	T_4041 (in a2_1014 + 4<i32> : word32)
 	T_4051 (in Mem1007[a7_1005 + 0<32>:word32] : word32)
 	T_4063 (in Mem1011[a7_1005 + 0<32>:word32] : word32)
 	T_4066 (in Mem1031[a7_1005 + 0<32>:word32] : word32)
@@ -724,26 +628,13 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_4076 (in Mem1037[a7_1005 + 0<32>:word32] : word32)
 	T_4079 (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
 	T_4091 (in 0xFFFFFFFF<32> : word32)
-	T_4097 (in a7_1330 + 78<i32> : word32)
-	T_4100 (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-	T_4105 (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-	T_4106 (in 00000008 : ptr32)
-	T_4111 (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_4116 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_4119 (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-	T_4122 (in d2 : Eq_576)
-	T_4123 (in dwArg04 : Eq_576)
-	T_4124 (in dwArg08 : Eq_576)
-	T_4128 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_4133 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_4138 (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn0000254C(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)):byte] : uint32)
-	T_4143 (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
 	T_4148 (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
 	T_4149 (in 0<32> : word32)
 	T_4196 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_4202 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_4206 (in fn00002604(*a7_1182, out d1_5335, out a1, out a5_5336) : word32)
-	T_4208 (in a2_1014 + 4<i32> : word32)
 	T_4218 (in Mem1203[a7_1201 + 0<32>:word32] : word32)
 	T_4230 (in Mem1207[a7_1201 + 0<32>:word32] : word32)
 	T_4232 (in SEQ(SLICE(d0, word24, 8), v611_1211) : uip32)
@@ -751,114 +642,12 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_4239 (in 0xFFFFFFFF<32> : word32)
 	T_4255 (in Mem1308[a7_1302 + 0<32>:word32] : word32)
 	T_4260 (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
-	T_4266 (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
 	T_4269 (in Mem1311[a7_1302 + 0<32>:word32] : word32)
 	T_4270 (in fn00001438(*(a7_1302 - 1<i32>), *a7_1302) : word32)
-	T_4278 (in a7_1330 + 78<i32> : word32)
-	T_4281 (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-	T_4286 (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-	T_4287 (in 00000008 : ptr32)
-	T_4292 (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_4297 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_4300 (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-	T_4305 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_4310 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_4315 (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn0000254C(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)):byte] : uint32)
-	T_4320 (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
 	T_4325 (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
 	T_4326 (in 0<32> : word32)
-	T_4347 (in d0_23 : Eq_576)
-	T_4349 (in __swap(dwArg08) : word32)
-	T_4350 (in d1_25 : Eq_576)
-	T_4352 (in __swap(dwArg10) : word32)
-	T_4362 (in d2_39 : Eq_576)
-	T_4370 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-	T_4371 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-	T_4375 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-	T_4376 (in 0<32> : word32)
-	T_4378 (in d2_45 : Eq_576)
-	T_4380 (in __swap(d2_39) : word32)
-	T_4383 (in __swap(dwArg0C) : word32)
-	T_4386 (in d3_71 : Eq_576)
-	T_4390 (in __swap(dwArg08) : word32)
-	T_4395 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-	T_4396 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-	T_4399 (in __swap(dwArg04) : word32)
-	T_4402 (in d3_89 : Eq_576)
-	T_4406 (in __swap(dwArg10) : word32)
-	T_4411 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-	T_4412 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
-	T_4440 (in d0 : Eq_576)
-	T_4441 (in 0<32> : word32)
-	T_4443 (in 0<32> : word32)
-	T_4445 (in d0_36 : Eq_576)
-	T_4446 (in -dwArg04 : word32)
-	T_4447 (in 0<32> : word32)
-	T_4452 (in d0 : Eq_576)
-	T_4453 (in d1 : Eq_576)
-	T_4454 (in d2 : Eq_576)
-	T_4455 (in d1Out : Eq_576)
-	T_4456 (in out d1_43 : ptr32)
-	T_4457 (in fn0000257E(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_4458 (in -fn0000257E(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_4461 (in -dwArg08 : word32)
-	T_4462 (in out d1_55 : ptr32)
-	T_4463 (in fn0000257E(d0_36, -dwArg08, d2, out d1_55) : word32)
-	T_4466 (in out d1_88 : ptr32)
-	T_4467 (in fn0000257E(dwArg04, dwArg08, d2, out d1_88) : word32)
-	T_4470 (in -dwArg08 : word32)
-	T_4471 (in out d1_89 : ptr32)
-	T_4472 (in fn0000257E(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_4473 (in -fn0000257E(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_4474 (in d1_22 : Eq_576)
-	T_4476 (in __swap(d1) : word32)
-	T_4481 (in d2_11 : Eq_576)
-	T_4482 (in SEQ(v11_10, v10_9) : uipr32)
-	T_4485 (in d3_18 : Eq_576)
-	T_4486 (in 16<i32> : int32)
-	T_4490 (in d0_134 : Eq_576)
-	T_4492 (in __swap(d0) : word32)
-	T_4493 (in d1_135 : Eq_576)
-	T_4495 (in __swap(d1_22) : word32)
-	T_4500 (in __swap(d2_11) : word32)
-	T_4505 (in d0_150 : Eq_576)
-	T_4507 (in __swap(d0_134) : word32)
-	T_4521 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-	T_4522 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-	T_4524 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-	T_4526 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-	T_4536 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-	T_4542 (in  : word32)
-	T_4543 (in  : word32)
-	T_4544 (in 8<32> : word32)
-	T_4545 (in __rol(d1_22, 8<32>) : word32)
-	T_4546 (in 8<32> : uipr32)
-	T_4551 (in 4<32> : word32)
-	T_4552 (in __rol(d1_22, 4<32>) : word32)
-	T_4557 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-	T_4562 (in 2<32> : word32)
-	T_4563 (in __rol(d1_22, 2<32>) : word32)
-	T_4568 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-	T_4574 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-	T_4575 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-	T_4582 (in __swap(d3_18) : word32)
-	T_4588 (in d1_90 : Eq_576)
-	T_4590 (in __swap(d1_22) : word32)
-	T_4591 (in d3_102 : Eq_576)
-	T_4592 (in SEQ(v53_82, v51_79) : uipr32)
-	T_4593 (in d0_108 : Eq_576)
-	T_4603 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-	T_4604 (in 0<32> : word32)
-	T_4607 (in 1<32> : word32)
-	T_4608 (in __rol(d1_22, 1<32>) : word32)
-	T_4613 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-	T_4617 (in __swap(d3_102) : word32)
-	T_4618 (in __rol(d0_108, __swap(d3_102)) : word32)
-	T_4619 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-	T_4622 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-	T_4625 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-	T_4626 (in d0_108 + d1_90 : word32)
-	T_4627 (in 0<32> : word32)
 	T_4641 (in 0<32> : word32)
 	T_4680 (in Mem86[dwArg04 + 8<i32>:word32] : word32)
 	T_4681 (in 0<32> : word32)
@@ -878,10 +667,6 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_5448 (in 0<i32> : int32)
 	T_5502 (in fn000038B4(*(a7_51 - 4<i32>), *a7_51, out d1, out a0_66, out a1, out a5_1579) : word32)
 	T_5505 (in 0xFFFFFFFF<32> : word32)
-	T_5519 (in d5_256 : Eq_576)
-	T_5520 (in -1<i32> : int32)
-	T_5531 (in d2_1005 : Eq_576)
-	T_5534 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
 	T_5535 (in d1_103 : Eq_576)
 	T_5537 (in d1_103 + 1<32> : word32)
 	T_5538 (in 5<32> : word32)
@@ -889,68 +674,24 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_5544 (in d1_123 : Eq_576)
 	T_5546 (in 1<i32> << d1_103 : word32)
 	T_5549 (in Mem121[a7_99 + 0<32>:word32] : word32)
-	T_5550 (in d2_1005 | d1_123 : word32)
 	T_5553 (in 5<32> : word32)
 	T_5555 (in 0<i32> : int32)
-	T_5560 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
 	T_5578 (in Mem143[a0_1447 + 0<32>:byte] : byte)
 	T_5635 (in Mem102[a7_99 + 0<32>:word32] : word32)
 	T_5638 (in Mem102[a7_99 + 0<32>:word32] : word32)
 	T_5673 (in Mem248[a0_1447 + 0<32>:byte] : byte)
-	T_5676 (in 0<i32> : int32)
-	T_5704 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-	T_5710 (in Mem278[a7_275 + 0<32>:word32] : word32)
-	T_5713 (in 10<i32> : int32)
-	T_5714 (in __swap(10<i32>) : word32)
-	T_5721 (in __swap(d5_256) : word32)
-	T_5726 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-	T_5727 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
 	T_5759 (in Mem278[a0_1447 + 0<32>:byte] : byte)
-	T_5764 (in Mem278[a7_275 + 0<32>:word32] : word32)
 	T_5766 (in d1_303 - 0x30<32> : word32)
-	T_5768 (in d1_303 - 0x30<32> + d0_293 : word32)
-	T_5813 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-	T_5821 (in 10<i32> : int32)
-	T_5822 (in __swap(10<i32>) : word32)
-	T_5829 (in __swap(d2_1005) : word32)
-	T_5834 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-	T_5835 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
 	T_5867 (in Mem171[a0_1447 + 0<32>:byte] : byte)
 	T_5875 (in d1_196 - 0x30<32> : word32)
-	T_5877 (in d1_196 - 0x30<32> + d0_186 : word32)
-	T_5885 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
 	T_5913 (in d6_1480 + 1<32> : word32)
-	T_5982 (in 0<32> : word32)
-	T_6061 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-	T_6110 (in 0<32> : word32)
 	T_6285 (in d0_1566 : Eq_576)
 	T_6290 (in a7_1465[18<i32>] & 2<i32> : word32)
 	T_6291 (in 0<32> : word32)
-	T_6330 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
 	T_6333 (in Mem1359[a7_1020 + 48<i32>:word32] : word32)
 	T_6412 (in fn000038B4(*(a7_1578 - 4<i32>), a7_1578->ptr0000, out d1, out a0_1447, out a1, out a5_1579) : word32)
 	T_6413 (in 0xFFFFFFFF<32> : word32)
 	T_6418 (in d6_1480 + 1<32> : word32)
-	T_6468 (in dwArg04 : Eq_576)
-	T_6469 (in dwArg08 : Eq_576)
-	T_6470 (in dwArg0C : Eq_576)
-	T_6471 (in dwArg10 : Eq_576)
-	T_6475 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_6480 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_6485 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_6490 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_6552 (in dwArg04 : Eq_576)
-	T_6553 (in dwArg08 : Eq_576)
-	T_6554 (in dwArg0C : Eq_576)
-	T_6555 (in dwArg10 : Eq_576)
-	T_6556 (in d1Out : Eq_576)
-	T_6557 (in a0Out : Eq_576)
-	T_6561 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_6566 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_6571 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_6576 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_6577 (in out d1_1450 : ptr32)
-	T_6578 (in out a0_1447 : ptr32)
 	T_6602 (in Mem1478[a7_1383 + 52<i32>:word32] : word32)
 	T_6626 (in d0_1691 : Eq_576)
 	T_6631 (in a7_1465[18<i32>] & 2<i32> : word32)
@@ -976,218 +717,14 @@ Eq_576: (union "Eq_576" (uint8 u0) (word16 u1) ((ptr32 Eq_6087) u2) ((ptr32 Eq_8
 	T_7084 (in 0<32> : word32)
 	T_7087 (in Mem624[a0_1447 + 0<32>:word32] : word32)
 	T_7145 (in Mem611[a0_1447 + 0<32>:word32] : word32)
-	T_7152 (in 0<32> : word32)
-	T_7182 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-	T_7186 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
 	T_7211 (in SLICE(d6_1480, word16, 0) : word16)
 	T_7214 (in Mem599[a0_1447 + 0<32>:word16] : word16)
-	T_7242 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
 	T_7292 (in Mem575[a0_1447 + 0<32>:word32] : word32)
 	T_7302 (in SLICE(d6_1480, byte, 0) : byte)
 	T_7305 (in Mem587[a0_1447 + 0<32>:byte] : byte)
 	T_7386 (in SLICE(dwArg04, byte, 0) : byte)
 	T_7389 (in Mem66[a0_104 + 0<32>:byte] : byte)
 	T_7393 (in Mem66[a0_104 + 0<32>:byte] : byte)
-	T_7565 (in d0 : Eq_576)
-	T_7566 (in d0_196 : Eq_576)
-	T_7567 (in d1_142 : Eq_576)
-	T_7568 (in a0_20 : Eq_576)
-	T_7569 (in d3_166 : Eq_576)
-	T_7570 (in 0<32> : word32)
-	T_7578 (in 0<32> : word32)
-	T_7584 (in d0 : Eq_576)
-	T_7585 (in d1 : Eq_576)
-	T_7586 (in d2 : Eq_576)
-	T_7587 (in d1Out : Eq_576)
-	T_7588 (in d2Out : Eq_576)
-	T_7589 (in out d1_318 : ptr32)
-	T_7590 (in out d2_319 : ptr32)
-	T_7591 (in fn00003B28(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-	T_7592 (in 0<i32> : int32)
-	T_7595 (in d6_30 : Eq_576)
-	T_7597 (in 8<32> : word32)
-	T_7598 (in __rol(dwArg0C, 8<32>) : word32)
-	T_7624 (in 8<32> : word32)
-	T_7625 (in __rol(d6_30, 8<32>) : word32)
-	T_7631 (in 8<32> : word32)
-	T_7632 (in __rol(d6_30, 8<32>) : word32)
-	T_7639 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_7640 (in d1_175 : Eq_576)
-	T_7641 (in d2_176 : Eq_576)
-	T_7642 (in d0_174 : Eq_576)
-	T_7644 (in 0<i32> : int32)
-	T_7645 (in out d1_175 : ptr32)
-	T_7646 (in out d2_176 : ptr32)
-	T_7647 (in fn00003B28(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-	T_7651 (in out d1_320 : ptr32)
-	T_7652 (in out d2_321 : ptr32)
-	T_7653 (in fn00003B28(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-	T_7664 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_7667 (in d0_85 : Eq_576)
-	T_7669 (in dwArg04 >> d4_61 : word32)
-	T_7672 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-	T_7675 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-	T_7676 (in out d1_86 : ptr32)
-	T_7677 (in out d2_322 : ptr32)
-	T_7678 (in fn00003B28(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-	T_7679 (in d3_72 : Eq_576)
-	T_7680 (in dwArg10 << d5_63 : word32)
-	T_7681 (in d5_101 : Eq_576)
-	T_7683 (in __swap(d0_85) : word32)
-	T_7684 (in d6_103 : Eq_576)
-	T_7686 (in __swap(d3_72) : word32)
-	T_7690 (in d2_107 : Eq_576)
-	T_7693 (in d0_85 * (word16) d3_72 : word32)
-	T_7694 (in __swap(d0_85 * (word16) d3_72) : word32)
-	T_7707 (in d6_82 : Eq_576)
-	T_7708 (in dwArg08 << d5_63 : word32)
-	T_7709 (in d2_124 : Eq_576)
-	T_7711 (in SEQ(v35_109, v39_116) : uipr32)
-	T_7712 (in __swap(SEQ(v35_109, v39_116)) : word32)
-	T_7720 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-	T_7721 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-	T_7725 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-	T_7726 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-	T_7748 (in d0_85 - 1<32> : word32)
-	T_7754 (in d7_13 : Eq_576)
-	T_7755 (in 0<32> : word32)
-	T_7758 (in out d1 : ptr32)
-	T_7759 (in fn0000257E(d1, d2, d2, out d1) : word32)
-	T_7760 (in d6_17 : Eq_576)
-	T_7761 (in d5_19 : Eq_576)
-	T_7762 (in 0<32> : word32)
-	T_7764 (in d2_22 : Eq_576)
-	T_7766 (in __swap(d2) : word32)
-	T_7770 (in 0<32> : word32)
-	T_7779 (in 0<32> : word32)
-	T_7781 (in d0_281 : Eq_576)
-	T_7783 (in __swap(d0) : word32)
-	T_7784 (in d1_282 : Eq_576)
-	T_7786 (in __swap(d1) : word32)
-	T_7796 (in __swap(d1_282) : word32)
-	T_7803 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-	T_7804 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-	T_7809 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-	T_7815 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-	T_7816 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-	T_7820 (in d6_17 * 2<32> : word32)
-	T_7828 (in 0<32> : word32)
-	T_7830 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-	T_7832 (in d7_13 * 2<32> : word32)
-	T_7833 (in 0<32> : word32)
-	T_7837 (in d3_74 : Eq_576)
-	T_7844 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-	T_7845 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-	T_7848 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-	T_7849 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-	T_7850 (in d1_104 : Eq_576)
-	T_7851 (in 0xFFFF<32> : uipr32)
-	T_7852 (in d6_98 : Eq_576)
-	T_7856 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-	T_7857 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-	T_7858 (in d6_133 : Eq_576)
-	T_7860 (in __swap(d1_104) : word32)
-	T_7861 (in d3_140 : Eq_576)
-	T_7863 (in __swap(d6_133) : word32)
-	T_7864 (in d4_142 : Eq_576)
-	T_7866 (in __swap(d7_13) : word32)
-	T_7870 (in d6_146 : Eq_576)
-	T_7873 (in d6_133 * (word16) d7_13 : word32)
-	T_7874 (in __swap(d6_133 * (word16) d7_13) : word32)
-	T_7890 (in d6_178 : Eq_576)
-	T_7892 (in SEQ(v56_148, v59_155) : uipr32)
-	T_7893 (in __swap(SEQ(v56_148, v59_155)) : word32)
-	T_7894 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-	T_7895 (in d5_181 : word32)
-	T_7899 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-	T_7900 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-	T_7904 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-	T_7905 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-	T_7918 (in 0<32> : word32)
-	T_7920 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-	T_7921 (in 0<32> : word32)
-	T_7929 (in d1_104 - 1<32> : word32)
-	T_7930 (in d4_113 : Eq_576)
-	T_7933 (in __swap(d7_13) : word32)
-	T_7936 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-	T_7937 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-	T_7952 (in __swap(d7_13) : word32)
-	T_7956 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-	T_7958 (in d1_104 - 1<32> : word32)
-	T_7959 (in 0<32> : word32)
-	T_7965 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-	T_7966 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_7967 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_7968 (in d6_220 : Eq_576)
-	T_7972 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-	T_7973 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-	T_7976 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-	T_7977 (in d5_221 : Eq_576)
-	T_7979 (in __swap(d5_181) : word32)
-	T_7984 (in d5_266 : Eq_576)
-	T_7986 (in __swap(d5_181) : word32)
-	T_7987 (in d6_267 : Eq_576)
-	T_7989 (in __swap(d6_178) : word32)
-	T_7992 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-	T_7995 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-	T_7999 (in d2_73 : Eq_576)
-	T_8001 (in __swap(d5_19) : word32)
-	T_8003 (in __swap(d7_13) : word32)
-	T_8013 (in d5_221 >> 1<32> : word32)
-	T_8018 (in  : word32)
-	T_8024 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-	T_8031 (in d1 : Eq_576)
-	T_8032 (in d1_171 : Eq_576)
-	T_8033 (in d3_202 : Eq_576)
-	T_8034 (in 0<32> : word32)
-	T_8042 (in 0<32> : word32)
-	T_8046 (in out d1_171 : ptr32)
-	T_8047 (in out d2_354 : ptr32)
-	T_8048 (in fn00003B28(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-	T_8051 (in d6_33 : Eq_576)
-	T_8053 (in 8<32> : word32)
-	T_8054 (in __rol(dwArg0C, 8<32>) : word32)
-	T_8080 (in 8<32> : word32)
-	T_8081 (in __rol(d6_33, 8<32>) : word32)
-	T_8087 (in 8<32> : word32)
-	T_8088 (in __rol(d6_33, 8<32>) : word32)
-	T_8095 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_8098 (in d0_88 : Eq_576)
-	T_8100 (in dwArg04 >> d4_64 : word32)
-	T_8103 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-	T_8106 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-	T_8107 (in out d1_89 : ptr32)
-	T_8108 (in out d2_90 : ptr32)
-	T_8109 (in fn00003B28(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-	T_8110 (in d3_75 : Eq_576)
-	T_8111 (in dwArg10 << d5_66 : word32)
-	T_8112 (in d7_104 : Eq_576)
-	T_8114 (in __swap(d0_88) : word32)
-	T_8115 (in d6_106 : Eq_576)
-	T_8117 (in __swap(d3_75) : word32)
-	T_8121 (in d2_110 : Eq_576)
-	T_8124 (in d0_88 * (word16) d3_75 : word32)
-	T_8125 (in __swap(d0_88 * (word16) d3_75) : word32)
-	T_8138 (in d2_127 : Eq_576)
-	T_8140 (in SEQ(v37_112, v40_119) : uipr32)
-	T_8141 (in __swap(SEQ(v37_112, v40_119)) : word32)
-	T_8151 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-	T_8152 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-	T_8156 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-	T_8157 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-	T_8176 (in dwArg08 - dwArg10 : word32)
-	T_8180 (in d1_211 : Eq_576)
-	T_8181 (in d2_212 : Eq_576)
-	T_8183 (in 0<i32> : int32)
-	T_8184 (in out d1_211 : ptr32)
-	T_8185 (in out d2_212 : ptr32)
-	T_8186 (in fn00003B28(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-	T_8189 (in out d1_171 : ptr32)
-	T_8190 (in out d2_355 : ptr32)
-	T_8191 (in fn00003B28(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-	T_8202 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_8207 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-	T_8220 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
 Eq_583: (fn word32 (ptr32, ptr32, ptr32))
 	T_583 (in fn0000131C : ptr32)
 	T_584 (in signature of fn0000131C : void)
@@ -1195,7 +732,7 @@ Eq_583: (fn word32 (ptr32, ptr32, ptr32))
 Eq_585: (fn ptr32 (Eq_576))
 	T_585 (in fn00001390 : ptr32)
 	T_586 (in signature of fn00001390 : void)
-Eq_608: (fn void (Eq_576, Eq_576, Eq_576, (ptr32 Eq_613)))
+Eq_608: (fn void (Eq_576, Eq_576, (ptr32 (ptr32 byte)), (ptr32 Eq_613)))
 	T_608 (in fn0000141C : ptr32)
 	T_609 (in signature of fn0000141C : void)
 Eq_613: (struct "Eq_613" 0001 (0 uint8 b0000) (1 cu8 b0001))
@@ -1241,16 +778,426 @@ Eq_617: (union "Eq_617" (byte u0) ((ptr32 byte) u1))
 Eq_635: (fn Eq_576 (Eq_576, Eq_576))
 	T_635 (in fn00001408 : ptr32)
 	T_636 (in signature of fn00001408 : void)
-Eq_649: (fn void (Eq_576, Eq_576, Eq_576, Eq_576, (ptr32 Eq_613), Eq_576))
+Eq_649: (fn void (Eq_576, Eq_576, (ptr32 (ptr32 byte)), Eq_576, (ptr32 Eq_613), Eq_656))
 	T_649 (in fn00001468 : ptr32)
 	T_650 (in signature of fn00001468 : void)
-Eq_698: (union "Eq_698" (uint8 u0) ((ptr32 Eq_8302) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_698 (in a7_1330 : Eq_698)
+Eq_656: (union "Eq_656" ((ptr32 Eq_6087) u0) ((ptr32 Eq_8284) u1) ((ptr32 Eq_8285) u2))
+	T_656 (in dwArg0C : Eq_656)
+	T_661 (in fp + 8<i32> : word32)
+	T_702 (in d2_1090 : Eq_656)
+	T_764 (in d6_1133 : Eq_656)
+	T_765 (in -1<i32> : int32)
+	T_787 (in 0<i32> : int32)
+	T_798 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_802 (in  : word32)
+	T_803 (in 10<i32> : int32)
+	T_804 (in __swap(10<i32>) : word32)
+	T_814 (in __swap(d6_1133) : word32)
+	T_819 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
+	T_820 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
+	T_846 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_850 (in d1_340 - 0x30<32> + d0_331 : word32)
+	T_1411 (in 0xFFFFFFFF<32> : word32)
+	T_1561 (in d0 + 4<32> : word32)
+	T_1603 (in d0 + 4<32> : word32)
+	T_1679 (in d0 + 4<32> : word32)
+	T_1748 (in d0 + 4<32> : word32)
+	T_1786 (in d0 + 4<32> : word32)
+	T_1801 (in d0 + 4<32> : word32)
+	T_2088 (in 1<i32> : int32)
+	T_2106 (in d0 + 4<32> : word32)
+	T_2837 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
+	T_2902 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
+	T_2932 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
+	T_2947 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
+	T_2953 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
+	T_2963 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
+	T_2984 (in v419_2893 : Eq_656)
+	T_2989 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_3164 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_3344 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_3347 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_3349 (in d7 >> 31<i32> : word32)
+	T_3352 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
+	T_3394 (in dwArg04 : Eq_656)
+	T_3395 (in dwArg08 : Eq_656)
+	T_3396 (in dwArg0C : Eq_656)
+	T_3397 (in dwArg10 : Eq_656)
+	T_3402 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
+	T_3407 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
+	T_3412 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
+	T_3417 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
+	T_3524 (in (d0_3495 << 2<32>) + 4<32> : word32)
+	T_3560 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_3589 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_3618 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_3635 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_3729 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_3765 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_3794 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_3823 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_3840 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_3866 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
+	T_3877 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
+	T_3987 (in (d0_957 << 2<32>) + 4<32> : word32)
+	T_4122 (in d2 : Eq_656)
+	T_4123 (in dwArg04 : Eq_656)
+	T_4124 (in dwArg08 : Eq_656)
+	T_4128 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
+	T_4133 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
+	T_4305 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
+	T_4310 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
+	T_4347 (in d0_23 : Eq_656)
+	T_4349 (in __swap(dwArg08) : word32)
+	T_4350 (in d1_25 : Eq_656)
+	T_4352 (in __swap(dwArg10) : word32)
+	T_4362 (in d2_39 : Eq_656)
+	T_4370 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
+	T_4371 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
+	T_4375 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
+	T_4376 (in 0<32> : word32)
+	T_4378 (in d2_45 : Eq_656)
+	T_4380 (in __swap(d2_39) : word32)
+	T_4383 (in __swap(dwArg0C) : word32)
+	T_4386 (in d3_71 : Eq_656)
+	T_4390 (in __swap(dwArg08) : word32)
+	T_4395 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
+	T_4396 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
+	T_4399 (in __swap(dwArg04) : word32)
+	T_4402 (in d3_89 : Eq_656)
+	T_4406 (in __swap(dwArg10) : word32)
+	T_4411 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
+	T_4412 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
+	T_4440 (in d0 : Eq_656)
+	T_4441 (in 0<32> : word32)
+	T_4443 (in 0<32> : word32)
+	T_4445 (in d0_36 : Eq_656)
+	T_4446 (in -dwArg04 : word32)
+	T_4447 (in 0<32> : word32)
+	T_4452 (in d0 : Eq_656)
+	T_4453 (in d1 : Eq_656)
+	T_4454 (in d2 : Eq_656)
+	T_4455 (in d1Out : Eq_656)
+	T_4456 (in out d1_43 : ptr32)
+	T_4457 (in fn0000257E(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_4458 (in -fn0000257E(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_4461 (in -dwArg08 : word32)
+	T_4462 (in out d1_55 : ptr32)
+	T_4463 (in fn0000257E(d0_36, -dwArg08, d2, out d1_55) : word32)
+	T_4466 (in out d1_88 : ptr32)
+	T_4467 (in fn0000257E(dwArg04, dwArg08, d2, out d1_88) : word32)
+	T_4470 (in -dwArg08 : word32)
+	T_4471 (in out d1_89 : ptr32)
+	T_4472 (in fn0000257E(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_4473 (in -fn0000257E(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_4474 (in d1_22 : Eq_656)
+	T_4476 (in __swap(d1) : word32)
+	T_4481 (in d2_11 : Eq_656)
+	T_4482 (in SEQ(v11_10, v10_9) : uipr32)
+	T_4485 (in d3_18 : Eq_656)
+	T_4486 (in 16<i32> : int32)
+	T_4490 (in d0_134 : Eq_656)
+	T_4492 (in __swap(d0) : word32)
+	T_4493 (in d1_135 : Eq_656)
+	T_4495 (in __swap(d1_22) : word32)
+	T_4500 (in __swap(d2_11) : word32)
+	T_4505 (in d0_150 : Eq_656)
+	T_4507 (in __swap(d0_134) : word32)
+	T_4521 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
+	T_4522 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
+	T_4524 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
+	T_4526 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
+	T_4536 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
+	T_4542 (in  : word32)
+	T_4543 (in  : word32)
+	T_4544 (in 8<32> : word32)
+	T_4545 (in __rol(d1_22, 8<32>) : word32)
+	T_4546 (in 8<32> : uipr32)
+	T_4551 (in 4<32> : word32)
+	T_4552 (in __rol(d1_22, 4<32>) : word32)
+	T_4557 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
+	T_4562 (in 2<32> : word32)
+	T_4563 (in __rol(d1_22, 2<32>) : word32)
+	T_4568 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
+	T_4574 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
+	T_4575 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
+	T_4582 (in __swap(d3_18) : word32)
+	T_4588 (in d1_90 : Eq_656)
+	T_4590 (in __swap(d1_22) : word32)
+	T_4591 (in d3_102 : Eq_656)
+	T_4592 (in SEQ(v53_82, v51_79) : uipr32)
+	T_4593 (in d0_108 : Eq_656)
+	T_4603 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
+	T_4604 (in 0<32> : word32)
+	T_4607 (in 1<32> : word32)
+	T_4608 (in __rol(d1_22, 1<32>) : word32)
+	T_4613 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
+	T_4617 (in __swap(d3_102) : word32)
+	T_4618 (in __rol(d0_108, __swap(d3_102)) : word32)
+	T_4619 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
+	T_4622 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
+	T_4625 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
+	T_4626 (in d0_108 + d1_90 : word32)
+	T_4627 (in 0<32> : word32)
+	T_5519 (in d5_256 : Eq_656)
+	T_5520 (in -1<i32> : int32)
+	T_5531 (in d2_1005 : Eq_656)
+	T_5534 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
+	T_5550 (in d2_1005 | d1_123 : word32)
+	T_5560 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
+	T_5676 (in 0<i32> : int32)
+	T_5704 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
+	T_5710 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_5713 (in 10<i32> : int32)
+	T_5714 (in __swap(10<i32>) : word32)
+	T_5721 (in __swap(d5_256) : word32)
+	T_5726 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
+	T_5727 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
+	T_5764 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_5768 (in d1_303 - 0x30<32> + d0_293 : word32)
+	T_5813 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
+	T_5821 (in 10<i32> : int32)
+	T_5822 (in __swap(10<i32>) : word32)
+	T_5829 (in __swap(d2_1005) : word32)
+	T_5834 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
+	T_5835 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
+	T_5877 (in d1_196 - 0x30<32> + d0_186 : word32)
+	T_5885 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
+	T_5982 (in 0<32> : word32)
+	T_6061 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
+	T_6110 (in 0<32> : word32)
+	T_6330 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
+	T_6468 (in dwArg04 : Eq_656)
+	T_6469 (in dwArg08 : Eq_656)
+	T_6470 (in dwArg0C : Eq_656)
+	T_6471 (in dwArg10 : Eq_656)
+	T_6475 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_6480 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_6485 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_6490 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_6552 (in dwArg04 : Eq_656)
+	T_6553 (in dwArg08 : Eq_656)
+	T_6554 (in dwArg0C : Eq_656)
+	T_6555 (in dwArg10 : Eq_656)
+	T_6556 (in d1Out : Eq_656)
+	T_6557 (in a0Out : Eq_656)
+	T_6561 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_6566 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_6571 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_6576 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_6577 (in out d1_1450 : ptr32)
+	T_6578 (in out a0_1447 : ptr32)
+	T_7152 (in 0<32> : word32)
+	T_7182 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_7186 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_7242 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
+	T_7565 (in d0 : Eq_656)
+	T_7566 (in d0_196 : Eq_656)
+	T_7567 (in d1_142 : Eq_656)
+	T_7568 (in a0_20 : Eq_656)
+	T_7569 (in d3_166 : Eq_656)
+	T_7570 (in 0<32> : word32)
+	T_7578 (in 0<32> : word32)
+	T_7584 (in d0 : Eq_656)
+	T_7585 (in d1 : Eq_656)
+	T_7586 (in d2 : Eq_656)
+	T_7587 (in d1Out : Eq_656)
+	T_7588 (in d2Out : Eq_656)
+	T_7589 (in out d1_318 : ptr32)
+	T_7590 (in out d2_319 : ptr32)
+	T_7591 (in fn00003B28(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
+	T_7592 (in 0<i32> : int32)
+	T_7595 (in d6_30 : Eq_656)
+	T_7597 (in 8<32> : word32)
+	T_7598 (in __rol(dwArg0C, 8<32>) : word32)
+	T_7624 (in 8<32> : word32)
+	T_7625 (in __rol(d6_30, 8<32>) : word32)
+	T_7631 (in 8<32> : word32)
+	T_7632 (in __rol(d6_30, 8<32>) : word32)
+	T_7639 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_7640 (in d1_175 : Eq_656)
+	T_7641 (in d2_176 : Eq_656)
+	T_7642 (in d0_174 : Eq_656)
+	T_7644 (in 0<i32> : int32)
+	T_7645 (in out d1_175 : ptr32)
+	T_7646 (in out d2_176 : ptr32)
+	T_7647 (in fn00003B28(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
+	T_7651 (in out d1_320 : ptr32)
+	T_7652 (in out d2_321 : ptr32)
+	T_7653 (in fn00003B28(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
+	T_7664 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_7667 (in d0_85 : Eq_656)
+	T_7669 (in dwArg04 >> d4_61 : word32)
+	T_7672 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
+	T_7675 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
+	T_7676 (in out d1_86 : ptr32)
+	T_7677 (in out d2_322 : ptr32)
+	T_7678 (in fn00003B28(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
+	T_7679 (in d3_72 : Eq_656)
+	T_7680 (in dwArg10 << d5_63 : word32)
+	T_7681 (in d5_101 : Eq_656)
+	T_7683 (in __swap(d0_85) : word32)
+	T_7684 (in d6_103 : Eq_656)
+	T_7686 (in __swap(d3_72) : word32)
+	T_7690 (in d2_107 : Eq_656)
+	T_7693 (in d0_85 * (word16) d3_72 : word32)
+	T_7694 (in __swap(d0_85 * (word16) d3_72) : word32)
+	T_7707 (in d6_82 : Eq_656)
+	T_7708 (in dwArg08 << d5_63 : word32)
+	T_7709 (in d2_124 : Eq_656)
+	T_7711 (in SEQ(v35_109, v39_116) : uipr32)
+	T_7712 (in __swap(SEQ(v35_109, v39_116)) : word32)
+	T_7720 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
+	T_7721 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
+	T_7725 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
+	T_7726 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
+	T_7748 (in d0_85 - 1<32> : word32)
+	T_7754 (in d7_13 : Eq_656)
+	T_7755 (in 0<32> : word32)
+	T_7758 (in out d1 : ptr32)
+	T_7759 (in fn0000257E(d1, d2, d2, out d1) : word32)
+	T_7760 (in d6_17 : Eq_656)
+	T_7761 (in d5_19 : Eq_656)
+	T_7762 (in 0<32> : word32)
+	T_7764 (in d2_22 : Eq_656)
+	T_7766 (in __swap(d2) : word32)
+	T_7770 (in 0<32> : word32)
+	T_7779 (in 0<32> : word32)
+	T_7781 (in d0_281 : Eq_656)
+	T_7783 (in __swap(d0) : word32)
+	T_7784 (in d1_282 : Eq_656)
+	T_7786 (in __swap(d1) : word32)
+	T_7796 (in __swap(d1_282) : word32)
+	T_7803 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
+	T_7804 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
+	T_7809 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
+	T_7815 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
+	T_7816 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
+	T_7820 (in d6_17 * 2<32> : word32)
+	T_7828 (in 0<32> : word32)
+	T_7830 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
+	T_7832 (in d7_13 * 2<32> : word32)
+	T_7833 (in 0<32> : word32)
+	T_7837 (in d3_74 : Eq_656)
+	T_7844 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
+	T_7845 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
+	T_7848 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
+	T_7849 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
+	T_7850 (in d1_104 : Eq_656)
+	T_7851 (in 0xFFFF<32> : uipr32)
+	T_7852 (in d6_98 : Eq_656)
+	T_7856 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
+	T_7857 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
+	T_7858 (in d6_133 : Eq_656)
+	T_7860 (in __swap(d1_104) : word32)
+	T_7861 (in d3_140 : Eq_656)
+	T_7863 (in __swap(d6_133) : word32)
+	T_7864 (in d4_142 : Eq_656)
+	T_7866 (in __swap(d7_13) : word32)
+	T_7870 (in d6_146 : Eq_656)
+	T_7873 (in d6_133 * (word16) d7_13 : word32)
+	T_7874 (in __swap(d6_133 * (word16) d7_13) : word32)
+	T_7890 (in d6_178 : Eq_656)
+	T_7892 (in SEQ(v56_148, v59_155) : uipr32)
+	T_7893 (in __swap(SEQ(v56_148, v59_155)) : word32)
+	T_7894 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
+	T_7895 (in d5_181 : word32)
+	T_7899 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
+	T_7900 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
+	T_7904 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
+	T_7905 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
+	T_7918 (in 0<32> : word32)
+	T_7920 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
+	T_7921 (in 0<32> : word32)
+	T_7929 (in d1_104 - 1<32> : word32)
+	T_7930 (in d4_113 : Eq_656)
+	T_7933 (in __swap(d7_13) : word32)
+	T_7936 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
+	T_7937 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
+	T_7952 (in __swap(d7_13) : word32)
+	T_7956 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
+	T_7958 (in d1_104 - 1<32> : word32)
+	T_7959 (in 0<32> : word32)
+	T_7965 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
+	T_7966 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_7967 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_7968 (in d6_220 : Eq_656)
+	T_7972 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
+	T_7973 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
+	T_7976 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
+	T_7977 (in d5_221 : Eq_656)
+	T_7979 (in __swap(d5_181) : word32)
+	T_7984 (in d5_266 : Eq_656)
+	T_7986 (in __swap(d5_181) : word32)
+	T_7987 (in d6_267 : Eq_656)
+	T_7989 (in __swap(d6_178) : word32)
+	T_7992 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
+	T_7995 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
+	T_7999 (in d2_73 : Eq_656)
+	T_8001 (in __swap(d5_19) : word32)
+	T_8003 (in __swap(d7_13) : word32)
+	T_8013 (in d5_221 >> 1<32> : word32)
+	T_8018 (in  : word32)
+	T_8024 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
+	T_8031 (in d1 : Eq_656)
+	T_8032 (in d1_171 : Eq_656)
+	T_8033 (in d3_202 : Eq_656)
+	T_8034 (in 0<32> : word32)
+	T_8042 (in 0<32> : word32)
+	T_8046 (in out d1_171 : ptr32)
+	T_8047 (in out d2_354 : ptr32)
+	T_8048 (in fn00003B28(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
+	T_8051 (in d6_33 : Eq_656)
+	T_8053 (in 8<32> : word32)
+	T_8054 (in __rol(dwArg0C, 8<32>) : word32)
+	T_8080 (in 8<32> : word32)
+	T_8081 (in __rol(d6_33, 8<32>) : word32)
+	T_8087 (in 8<32> : word32)
+	T_8088 (in __rol(d6_33, 8<32>) : word32)
+	T_8095 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_8098 (in d0_88 : Eq_656)
+	T_8100 (in dwArg04 >> d4_64 : word32)
+	T_8103 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
+	T_8106 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
+	T_8107 (in out d1_89 : ptr32)
+	T_8108 (in out d2_90 : ptr32)
+	T_8109 (in fn00003B28(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
+	T_8110 (in d3_75 : Eq_656)
+	T_8111 (in dwArg10 << d5_66 : word32)
+	T_8112 (in d7_104 : Eq_656)
+	T_8114 (in __swap(d0_88) : word32)
+	T_8115 (in d6_106 : Eq_656)
+	T_8117 (in __swap(d3_75) : word32)
+	T_8121 (in d2_110 : Eq_656)
+	T_8124 (in d0_88 * (word16) d3_75 : word32)
+	T_8125 (in __swap(d0_88 * (word16) d3_75) : word32)
+	T_8138 (in d2_127 : Eq_656)
+	T_8140 (in SEQ(v37_112, v40_119) : uipr32)
+	T_8141 (in __swap(SEQ(v37_112, v40_119)) : word32)
+	T_8151 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
+	T_8152 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
+	T_8156 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
+	T_8157 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
+	T_8176 (in dwArg08 - dwArg10 : word32)
+	T_8180 (in d1_211 : Eq_656)
+	T_8181 (in d2_212 : Eq_656)
+	T_8183 (in 0<i32> : int32)
+	T_8184 (in out d1_211 : ptr32)
+	T_8185 (in out d2_212 : ptr32)
+	T_8186 (in fn00003B28(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
+	T_8189 (in out d1_171 : ptr32)
+	T_8190 (in out d2_355 : ptr32)
+	T_8191 (in fn00003B28(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
+	T_8202 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_8207 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
+	T_8220 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
+Eq_698: (struct "Eq_698" 0004 (2C int32 dw002C) (30 Eq_8286 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8287 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+	T_698 (in a7_1330 : (ptr32 Eq_698))
 	T_701 (in fp + -120<i32> : word32)
 	T_3510 (in a7_3474 + 4<i32> : word32)
 	T_3680 (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
 	T_3696 (in a7_3364 + 4<i32> : word32)
-Eq_705: (union "Eq_705" (byte u0) (word16 u1) ((ptr32 Eq_8304) u2) (Eq_3068 u3))
+Eq_705: (union "Eq_705" (byte u0) (word16 u1) ((ptr32 Eq_8313) u2) ((ptr32 Eq_8289) u3))
 	T_705 (in d4_132 : Eq_705)
 	T_706 (in 0<i32> : int32)
 	T_1113 (in d4_132 + 1<32> : word32)
@@ -1279,7 +1226,7 @@ Eq_705: (union "Eq_705" (byte u0) (word16 u1) ((ptr32 Eq_8304) u2) (Eq_3068 u3))
 	T_2950 (in Mem2854[a7_1330 + 52<i32>:word32] : word32)
 	T_2966 (in Mem2840[a7_1330 + 52<i32>:word32] : word32)
 	T_2980 (in 0<i32> : int32)
-	T_2982 (in d5_1044 - 0x30<32> : word32)
+	T_2982 (in d5_1044 - (struct Eq_8303 *) 0x30<32> : word32)
 	T_3393 (in d4 : Eq_705)
 	T_3445 (in d4_3243 - 1<32> : word32)
 	T_4244 (in d4_1070 - 1<32> : word32)
@@ -1382,7 +1329,7 @@ Eq_759: (union "Eq_759" (int32 u0) (uint32 u1))
 	T_759 (in (uint32) (uint8) Mem278[a3_279 + 0<32>:byte] : uint32)
 Eq_782: (union "Eq_782" (int32 u0) (uint32 u1))
 	T_782 (in (uint32) (uint8) Mem278[a3_279 + 0<32>:byte] : uint32)
-Eq_800: (fn Eq_576 (Eq_576))
+Eq_800: (fn Eq_656 (Eq_656))
 	T_800 (in __swap : ptr32)
 	T_801 (in signature of __swap : void)
 	T_811 (in __swap : ptr32)
@@ -1473,7 +1420,7 @@ Eq_1060: (fn Eq_576 (Eq_576, Eq_1063, (ptr32 word32), (ptr32 byte)))
 	T_3193 (in fn00002604 : ptr32)
 	T_4029 (in fn00002604 : ptr32)
 	T_4199 (in fn00002604 : ptr32)
-Eq_1063: (union "Eq_1063" (byte u0) ((ptr32 Eq_8305) u1) (Eq_3068 u2))
+Eq_1063: (union "Eq_1063" (byte u0) (word16 u1) ((ptr32 Eq_8313) u2) ((ptr32 Eq_8290) u3))
 	T_1063 (in d1Out : Eq_1063)
 	T_1069 (in out d1_5316 : ptr32)
 	T_1183 (in out d1_5318 : ptr32)
@@ -1495,7 +1442,7 @@ Eq_1063: (union "Eq_1063" (byte u0) ((ptr32 Eq_8305) u1) (Eq_3068 u2))
 	T_4707 (in Mem137[dwArg04 + 0<32>:word32] : word32)
 	T_5275 (in fn00002BBC(out a1_21, out a5_23) : word32)
 	T_7410 (in fn00002BBC(out a1_125, out a5_127) : word32)
-Eq_1250: (fn Eq_576 (Eq_576, Eq_576))
+Eq_1250: (fn Eq_576 (byte, Eq_576))
 	T_1250 (in fn00001438 : ptr32)
 	T_1251 (in signature of fn00001438 : void)
 	T_1360 (in fn00001438 : ptr32)
@@ -1638,8 +1585,6 @@ Eq_2725: (struct "Eq_2725" (0 Eq_576 t0000) (38 Eq_576 t0038))
 Eq_2749: (struct "Eq_2749" (0 Eq_576 t0000) (38 uint32 dw0038))
 	T_2749 (in a7_2572 : (ptr32 Eq_2749))
 	T_2751 (in a7_1330 - 4<i32> : word32)
-Eq_2791: (union "Eq_2791" (uint8 u0) (word32 u1))
-	T_2791 (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
 Eq_2799: (union "Eq_2799" (int32 u0) (uint32 u1))
 	T_2799 (in 1<32> : word32)
 Eq_2841: (union "Eq_2841" (byte u0) (word32 u1))
@@ -1671,65 +1616,29 @@ Eq_2958: (union "Eq_2958" (int32 u0) (uint32 u1))
 Eq_2967: (union "Eq_2967" (byte u0) (word32 u1))
 	T_2967 (in SLICE(d7, byte, 0) : byte)
 	T_2970 (in Mem2843[a7_1330 + 74<i32>:byte] : byte)
-Eq_2981: (union "Eq_2981" (byte u0) ((ptr32 Eq_8318) u1) (Eq_3068 u2))
-	T_2981 (in 0x30<32> : word32)
-Eq_2983: (union "Eq_2983" (byte u0) ((ptr32 Eq_8319) u1) (Eq_3068 u2))
-	T_2983 (in d6_3015 : Eq_2983)
-	T_3049 (in 0<i32> : int32)
-	T_3051 (in d5_1044 - 0x37<32> : word32)
-Eq_2998: (union "Eq_2998" (byte u0) ((ptr32 Eq_8320) u1) (Eq_3068 u2))
-	T_2998 (in d2_2977 : word32)
-	T_3002 (in d4_2510 + Mem2975[a7_1330 + 68<i32>:word32] : word32)
-	T_3005 (in Mem2980[a7_1330 + 48<i32>:word32] : word32)
-	T_3018 (in 0<32> : word32)
-Eq_3001: (union "Eq_3001" (byte u0) ((ptr32 Eq_8322) u1) (Eq_3068 u2))
-	T_3001 (in Mem2975[a7_1330 + 68<i32>:word32] : word32)
 Eq_3019: (union "Eq_3019" (bool u0) (word32 u1))
-	T_3019 (in d2_2977 < 0<32> : bool)
-Eq_3050: (union "Eq_3050" (byte u0) ((ptr32 Eq_8324) u1) (Eq_3068 u2))
-	T_3050 (in 0x37<32> : word32)
-Eq_3052: (union "Eq_3052" (byte u0) ((ptr32 Eq_8325) u1) (Eq_3068 u2))
-	T_3052 (in d2_3074 : Eq_3052)
-	T_3111 (in 0<i32> : int32)
-	T_3113 (in d5_1044 - 0x57<32> : word32)
-	T_3118 (in Mem3085[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-Eq_3065: (union "Eq_3065" (byte u0) ((ptr32 Eq_8327) u1) (Eq_3001 u2) (Eq_3068 u3))
-	T_3065 (in d2_3037 : word32)
-	T_3069 (in d6_3015 + Mem3035[a7_1330 + 48<i32>:word32] : word32)
-	T_3072 (in Mem3040[a7_1330 + 68<i32>:word32] : word32)
-	T_3085 (in 0<32> : word32)
-Eq_3068: (union "Eq_3068" (byte u0) ((ptr32 Eq_8329) u1))
-	T_3068 (in Mem3035[a7_1330 + 48<i32>:word32] : word32)
-Eq_3071: (union "Eq_3071" ((ptr32 (ptr32 Eq_705)) u0) (Eq_3001 u1))
+	T_3019 (in d2_2977 < null : bool)
+Eq_3071: (union "Eq_3071" ((ptr32 (ptr32 Eq_705)) u0) ((ptr32 Eq_8307) u1))
 	T_3071 (in a7_1330 + 68<i32> : word32)
-Eq_3112: (union "Eq_3112" (byte u0) ((ptr32 Eq_8331) u1) (Eq_3068 u2))
-	T_3112 (in 0x57<32> : word32)
-Eq_3127: (union "Eq_3127" (byte u0) ((ptr32 Eq_8333) u1) (Eq_3068 u2))
-	T_3127 (in d2_3095 : word32)
-	T_3131 (in d2_3074 + Mem3093[a7_1330 + 68<i32>:word32] : word32)
-	T_3134 (in Mem3098[a7_1330 + 48<i32>:word32] : word32)
-	T_3146 (in 0<32> : word32)
-Eq_3129: (union "Eq_3129" ((ptr32 (ptr32 Eq_705)) u0) (Eq_3001 u1) (Eq_3065 u2))
+Eq_3129: (union "Eq_3129" ((ptr32 (ptr32 Eq_705)) u0) ((ptr32 Eq_8307) u1))
 	T_3129 (in a7_1330 + 68<i32> : word32)
-Eq_3130: (union "Eq_3130" ((ptr32 Eq_8335) u0) (Eq_3001 u1) (Eq_3065 u2) (Eq_3068 u3))
+Eq_3130: (union "Eq_3130" ((ptr32 (ptr32 Eq_705)) u0) ((ptr32 Eq_8307) u1) ((ptr32 Eq_8313) u2))
 	T_3130 (in Mem3093[a7_1330 + 68<i32>:word32] : word32)
-Eq_3133: (union "Eq_3133" ((ptr32 (ptr32 Eq_705)) u0) (Eq_3068 u1))
+Eq_3133: (union "Eq_3133" ((ptr32 (ptr32 Eq_705)) u0) ((ptr32 Eq_8313) u1))
 	T_3133 (in a7_1330 + 48<i32> : word32)
 Eq_3147: (union "Eq_3147" (bool u0) (word32 u1))
-	T_3147 (in d2_3095 < 0<32> : bool)
+	T_3147 (in d2_3095 < null : bool)
 Eq_3261: (union "Eq_3261" (int32 u0) (uint32 u1))
 	T_3261 (in 1<32> : word32)
 Eq_3289: (struct "Eq_3289" (0 Eq_576 t0000) (4E word32 dw004E))
 	T_3289 (in a7_2635 : (ptr32 Eq_3289))
 	T_3291 (in a7_1330 - 4<i32> : word32)
-Eq_3340: (struct "Eq_3340" (0 Eq_576 t0000) (1 Eq_3429 t0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
+Eq_3340: (struct "Eq_3340" (0 Eq_656 t0000) (1 ui24 n0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
 	T_3340 (in a7_2886 : (ptr32 Eq_3340))
 	T_3341 (in a7_1330 - 4<i32> : word32)
-Eq_3391: (fn word32 (Eq_705, Eq_576, Eq_576, Eq_576, Eq_576, ptr32))
+Eq_3391: (fn word32 (Eq_705, Eq_656, Eq_656, Eq_656, Eq_656, ptr32))
 	T_3391 (in fn0000248C : ptr32)
 	T_3392 (in signature of fn0000248C : void)
-Eq_3429: (union "Eq_3429" (ui24 u0) (word32 u1))
-	T_3429 (in Mem2934[a7_2886 + 1<32>:word24] : word24)
 Eq_3442: (union "Eq_3442" (int32 u0) (uint32 u1))
 	T_3442 (in 1<32> : word32)
 Eq_3495: (struct "Eq_3495" (0 Eq_576 t0000) (30 word32 dw0030) (34 Eq_576 t0034) (38 byte b0038) (4C byte b004C))
@@ -1738,311 +1647,75 @@ Eq_3495: (struct "Eq_3495" (0 Eq_576 t0000) (30 word32 dw0030) (34 Eq_576 t0034)
 Eq_3525: (struct "Eq_3525" (0 word32 dw0000) (4 Eq_576 t0004))
 	T_3525 (in a0_3501 : (ptr32 Eq_3525))
 	T_3528 (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
-Eq_3653: (union "Eq_3653" ((ptr32 (ptr32 Eq_705)) u0) (Eq_3068 u1) (Eq_3127 u2))
+Eq_3653: (union "Eq_3653" ((ptr32 (ptr32 Eq_705)) u0) ((ptr32 Eq_8313) u1))
 	T_3653 (in a7_1330 + 48<i32> : word32)
-Eq_3654: (union "Eq_3654" (uint8 u0) ((ptr32 Eq_8352) u1) (Eq_2791 u2) (Eq_3068 u3) (Eq_3127 u4))
+Eq_3654: (union "Eq_3654" ((ptr32 (ptr32 Eq_705)) u0) ((ptr32 Eq_8313) u1) ((ptr32 Eq_8313) u2))
 	T_3654 (in Mem3324[a7_1330 + 48<i32>:word32] : word32)
 	T_3657 (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
-Eq_3656: (union "Eq_3656" (uint8 u0) (word32 u1) (Eq_2791 u2))
-	T_3656 (in a7_1330 + 56<i32> : word32)
 Eq_3664: (struct "Eq_3664" (0 int32 dw0000) (4 word32 dw0004))
 	T_3664 (in v528_3348 : (ptr32 Eq_3664))
 	T_3666 (in a7_1330 + 44<i32> : word32)
 Eq_3676: (union "Eq_3676" (bool u0) (int32 u1))
 	T_3676 (in d1 < 0<32> : bool)
-Eq_3679: (union "Eq_3679" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3679 (in a7_1330 + 0x38<32> : word32)
-Eq_3681: (union "Eq_3681" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3681 (in a7_3364 : Eq_3681)
+Eq_3681: (struct "Eq_3681" (0 Eq_576 t0000) (30 byte b0030) (38 word32 dw0038) (3C Eq_576 t003C) (4C byte b004C))
+	T_3681 (in a7_3364 : (ptr32 Eq_3681))
 	T_3683 (in a7_1330 - 4<i32> : word32)
-Eq_3682: (union "Eq_3682" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3682 (in 4<i32> : int32)
-Eq_3685: (union "Eq_3685" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3685 (in a7_3364 + 0<32> : word32)
-Eq_3688: (union "Eq_3688" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3688 (in a7_3364 + 76<i32> : word32)
-Eq_3693: (union "Eq_3693" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3693 (in a7_3364 + 48<i32> : word32)
-Eq_3695: (union "Eq_3695" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3695 (in 4<i32> : int32)
-Eq_3698: (union "Eq_3698" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3698 (in a7_3364 + 48<i32> : word32)
-Eq_3704: (union "Eq_3704" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3704 (in a7_1330 + 52<i32> : word32)
-Eq_3708: (union "Eq_3708" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3708 (in a7_1330 + 44<i32> : word32)
-Eq_3713: (union "Eq_3713" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3713 (in a7_1330 + 52<i32> : word32)
-Eq_3717: (union "Eq_3717" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3717 (in a7_1330 + 44<i32> : word32)
-Eq_3730: (struct "Eq_3730" (0 word32 dw0000) (4 word32 dw0004))
+Eq_3706: (union "Eq_3706" (int32 u0) (byte u1))
+	T_3706 (in v544_774 : Eq_3706)
+	T_3709 (in Mem773[a7_1330 + 44<i32>:byte] : byte)
+	T_3862 (in 0<8> : byte)
+	T_3869 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+Eq_3715: (union "Eq_3715" (int32 u0) (byte u1))
+	T_3715 (in 1<8> : byte)
+	T_3718 (in Mem769[a7_1330 + 44<i32>:byte] : byte)
+Eq_3730: (struct "Eq_3730" (0 word32 dw0000) (4 Eq_576 t0004))
 	T_3730 (in a0_3404 : (ptr32 Eq_3730))
 	T_3733 (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
-Eq_3735: (union "Eq_3735" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3735 (in a7_3364 + 60<i32> : word32)
-Eq_3741: (union "Eq_3741" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3741 (in a7_3364 + 56<i32> : word32)
-Eq_3749: (union "Eq_3749" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3749 (in a7_3364 + 48<i32> : word32)
-Eq_3754: (union "Eq_3754" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3754 (in a7_3364 + 48<i32> : word32)
-Eq_3767: (union "Eq_3767" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3767 (in a7_3364 + 60<i32> : word32)
-Eq_3778: (union "Eq_3778" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3778 (in a7_3364 + 48<i32> : word32)
-Eq_3783: (union "Eq_3783" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3783 (in a7_3364 + 48<i32> : word32)
-Eq_3796: (union "Eq_3796" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3796 (in a7_3364 + 60<i32> : word32)
-Eq_3807: (union "Eq_3807" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3807 (in a7_3364 + 48<i32> : word32)
-Eq_3812: (union "Eq_3812" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3812 (in a7_3364 + 48<i32> : word32)
-Eq_3825: (union "Eq_3825" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3825 (in a7_3364 + 60<i32> : word32)
-Eq_3842: (union "Eq_3842" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3842 (in a7_3364 + 60<i32> : word32)
-Eq_3854: (union "Eq_3854" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3854 (in 78<i32> : int32)
-Eq_3855: (union "Eq_3855" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3855 (in a7_1330 + 78<i32> : word32)
-Eq_3856: (union "Eq_3856" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3856 (in a7_1330 + 78<i32> + d1_1027 : word32)
-Eq_3858: (union "Eq_3858" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3858 (in 1<32> : word32)
-Eq_3865: (union "Eq_3865" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3865 (in a7_1330 + 132<i32> : word32)
-Eq_3868: (union "Eq_3868" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3868 (in a7_1330 + 44<i32> : word32)
-Eq_3872: (union "Eq_3872" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3872 (in a7_1330 + 44<i32> : word32)
-Eq_3876: (union "Eq_3876" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3876 (in a7_1330 + 132<i32> : word32)
-Eq_3881: (union "Eq_3881" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3881 (in a7_1330 + 73<i32> : word32)
-Eq_3929: (union "Eq_3929" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3929 (in a0_881 : Eq_3929)
-	T_3934 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_3930: (union "Eq_3930" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3930 (in 78<i32> : int32)
-Eq_3931: (union "Eq_3931" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3931 (in a7_1330 + 78<i32> : word32)
-Eq_3933: (union "Eq_3933" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
+Eq_3870: (union "Eq_3870" (int32 u0) (byte u1))
+	T_3870 (in v554_824 : Eq_3870)
+	T_3873 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+	T_3927 (in 0<8> : byte)
+Eq_3933: (union "Eq_3933" (int32 u0) (uint32 u1))
 	T_3933 (in d5_862 >> 3<32> : word32)
-Eq_3936: (union "Eq_3936" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3936 (in a0_881 + 0<32> : word32)
-Eq_3947: (union "Eq_3947" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3947 (in a0_881 + 0<32> : word32)
-Eq_3949: (union "Eq_3949" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3949 (in a0_900 : Eq_3949)
-	T_3954 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_3950: (union "Eq_3950" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3950 (in 78<i32> : int32)
-Eq_3951: (union "Eq_3951" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3951 (in a7_1330 + 78<i32> : word32)
-Eq_3953: (union "Eq_3953" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
+Eq_3953: (union "Eq_3953" (int32 u0) (uint32 u1))
 	T_3953 (in d5_862 >> 3<32> : word32)
-Eq_3956: (union "Eq_3956" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3956 (in a0_900 + 0<32> : word32)
-Eq_3968: (union "Eq_3968" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_3968 (in a0_900 + 0<32> : word32)
-Eq_4022: (union "Eq_4022" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4022 (in a7_985 : Eq_4022)
+Eq_4022: (struct "Eq_4022" (0 Eq_576 t0000) (30 Eq_576 t0030))
+	T_4022 (in a7_985 : (ptr32 Eq_4022))
 	T_4024 (in a7_1330 - 4<i32> : word32)
-Eq_4023: (union "Eq_4023" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4023 (in 4<i32> : int32)
-Eq_4026: (union "Eq_4026" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4026 (in a7_985 + 0<32> : word32)
-Eq_4031: (union "Eq_4031" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4031 (in a7_985 + 0<32> : word32)
-Eq_4038: (union "Eq_4038" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4038 (in a7_985 + 48<i32> : word32)
-Eq_4046: (union "Eq_4046" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4046 (in a7_1005 : Eq_4046)
+Eq_4046: (struct "Eq_4046" (0 Eq_576 t0000) (30 uint32 dw0030))
+	T_4046 (in a7_1005 : (ptr32 Eq_4046))
 	T_4048 (in a7_1330 - 4<i32> : word32)
-Eq_4047: (union "Eq_4047" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4047 (in 4<i32> : int32)
-Eq_4050: (union "Eq_4050" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4050 (in a7_1005 + 0<32> : word32)
-Eq_4062: (union "Eq_4062" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4062 (in a7_1005 + 0<32> : word32)
-Eq_4065: (union "Eq_4065" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4065 (in a7_1005 + 0<32> : word32)
-Eq_4070: (union "Eq_4070" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4070 (in a7_1005 + 48<i32> : word32)
-Eq_4075: (union "Eq_4075" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4075 (in a7_1005 + 0<32> : word32)
-Eq_4078: (union "Eq_4078" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4078 (in a7_1330 + 44<i32> : word32)
 Eq_4080: (union "Eq_4080" (int32 u0) (uint32 u1))
 	T_4080 (in d3_1057 : Eq_4080)
 	T_4082 (in d3_1850 + 1<32> : word32)
 	T_4236 (in d3_1057 + 1<32> : word32)
 Eq_4081: (union "Eq_4081" (int32 u0) (uint32 u1))
 	T_4081 (in 1<32> : word32)
-Eq_4087: (union "Eq_4087" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4087 (in a7_1330 + 44<i32> : word32)
-Eq_4093: (union "Eq_4093" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4093 (in a7_1076 : Eq_4093)
+Eq_4093: (struct "Eq_4093" (0 ptr32 ptr0000) (4D byte b004D))
+	T_4093 (in a7_1076 : (ptr32 Eq_4093))
 	T_4095 (in a7_1330 - 4<i32> : word32)
-Eq_4094: (union "Eq_4094" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4094 (in 4<i32> : int32)
-Eq_4096: (union "Eq_4096" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4096 (in 78<i32> : int32)
-Eq_4099: (union "Eq_4099" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4099 (in a7_1076 + 0<32> : word32)
-Eq_4101: (union "Eq_4101" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4101 (in 4<i32> : int32)
-Eq_4102: (union "Eq_4102" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4102 (in a7_1076 - 4<i32> : word32)
-Eq_4104: (union "Eq_4104" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4104 (in a7_1076 - 4<i32> + 0<32> : word32)
-Eq_4107: (union "Eq_4107" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4107 (in 8<i32> : int32)
-Eq_4108: (union "Eq_4108" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4108 (in a7_1076 - 8<i32> : word32)
-Eq_4110: (union "Eq_4110" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4110 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_4112: (union "Eq_4112" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4112 (in 12<i32> : int32)
-Eq_4113: (union "Eq_4113" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4113 (in a7_1076 - 12<i32> : word32)
-Eq_4115: (union "Eq_4115" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4115 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_4118: (union "Eq_4118" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4118 (in a7_1076 + 0<32> : word32)
-Eq_4120: (fn int32 (Eq_576, Eq_576, Eq_576))
+Eq_4120: (fn int32 (Eq_656, Eq_656, Eq_656))
 	T_4120 (in fn0000254C : ptr32)
 	T_4121 (in signature of fn0000254C : void)
 	T_4301 (in fn0000254C : ptr32)
-Eq_4125: (union "Eq_4125" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4125 (in a7_1076 - 12<i32> : word32)
-Eq_4127: (union "Eq_4127" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4127 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_4129: (union "Eq_4129" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4129 (in 8<i32> : int32)
-Eq_4130: (union "Eq_4130" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4130 (in a7_1076 - 8<i32> : word32)
-Eq_4132: (union "Eq_4132" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4132 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_4139: (union "Eq_4139" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4139 (in 4<i32> : int32)
-Eq_4140: (union "Eq_4140" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4140 (in a7_1076 - 4<i32> : word32)
-Eq_4142: (union "Eq_4142" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4142 (in a7_1076 - 4<i32> + 0<32> : word32)
 Eq_4151: (union "Eq_4151" (int32 u0) (uint32 u1))
 	T_4151 (in d6_1133 - d3_1057 : word32)
 	T_4152 (in 0<32> : word32)
-Eq_4156: (union "Eq_4156" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4156 (in a7_1076 + 77<i32> : word32)
-Eq_4191: (union "Eq_4191" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4191 (in a7_1182 : Eq_4191)
-	T_4193 (in a7_1330 - 4<i32> : word32)
-Eq_4192: (union "Eq_4192" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4192 (in 4<i32> : int32)
-Eq_4195: (union "Eq_4195" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4195 (in a7_1182 + 0<32> : word32)
-Eq_4201: (union "Eq_4201" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4201 (in a7_1182 + 0<32> : word32)
-Eq_4213: (union "Eq_4213" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4213 (in a7_1201 : Eq_4213)
-	T_4215 (in a7_1330 - 4<i32> : word32)
-Eq_4214: (union "Eq_4214" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4214 (in 4<i32> : int32)
-Eq_4217: (union "Eq_4217" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4217 (in a7_1201 + 0<32> : word32)
-Eq_4229: (union "Eq_4229" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4229 (in a7_1201 + 0<32> : word32)
 Eq_4235: (union "Eq_4235" (int32 u0) (uint32 u1))
 	T_4235 (in 1<32> : word32)
 Eq_4241: (union "Eq_4241" (int32 u0) (uint32 u1))
 	T_4241 (in 1<32> : word32)
-Eq_4246: (union "Eq_4246" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4246 (in a7_1330 + 73<i32> : word32)
-Eq_4250: (union "Eq_4250" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4250 (in a7_1302 : Eq_4250)
-	T_4252 (in a7_1330 - 4<i32> : word32)
-Eq_4251: (union "Eq_4251" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4251 (in 4<i32> : int32)
-Eq_4254: (union "Eq_4254" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4254 (in a7_1302 + 0<32> : word32)
-Eq_4256: (union "Eq_4256" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4256 (in 4<i32> : int32)
-Eq_4257: (union "Eq_4257" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4257 (in a7_1302 - 4<i32> : word32)
-Eq_4259: (union "Eq_4259" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4259 (in a7_1302 - 4<i32> + 0<32> : word32)
-Eq_4262: (union "Eq_4262" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4262 (in 1<i32> : int32)
-Eq_4263: (union "Eq_4263" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4263 (in a7_1302 - 1<i32> : word32)
-Eq_4265: (union "Eq_4265" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4265 (in a7_1302 - 1<i32> + 0<32> : word32)
-Eq_4268: (union "Eq_4268" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4268 (in a7_1302 + 0<32> : word32)
-Eq_4272: (union "Eq_4272" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4272 (in a7_1330 + 73<i32> : word32)
-Eq_4274: (union "Eq_4274" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4274 (in a7_1237 : Eq_4274)
-	T_4276 (in a7_1330 - 4<i32> : word32)
-Eq_4275: (union "Eq_4275" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4275 (in 4<i32> : int32)
-Eq_4277: (union "Eq_4277" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4277 (in 78<i32> : int32)
-Eq_4280: (union "Eq_4280" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4280 (in a7_1237 + 0<32> : word32)
-Eq_4282: (union "Eq_4282" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4282 (in 4<i32> : int32)
-Eq_4283: (union "Eq_4283" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4283 (in a7_1237 - 4<i32> : word32)
-Eq_4285: (union "Eq_4285" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4285 (in a7_1237 - 4<i32> + 0<32> : word32)
-Eq_4288: (union "Eq_4288" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4288 (in 8<i32> : int32)
-Eq_4289: (union "Eq_4289" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4289 (in a7_1237 - 8<i32> : word32)
-Eq_4291: (union "Eq_4291" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4291 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_4293: (union "Eq_4293" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4293 (in 12<i32> : int32)
-Eq_4294: (union "Eq_4294" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4294 (in a7_1237 - 12<i32> : word32)
-Eq_4296: (union "Eq_4296" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4296 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_4299: (union "Eq_4299" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4299 (in a7_1237 + 0<32> : word32)
-Eq_4302: (union "Eq_4302" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4302 (in a7_1237 - 12<i32> : word32)
-Eq_4304: (union "Eq_4304" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4304 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_4306: (union "Eq_4306" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4306 (in 8<i32> : int32)
-Eq_4307: (union "Eq_4307" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4307 (in a7_1237 - 8<i32> : word32)
-Eq_4309: (union "Eq_4309" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4309 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_4316: (union "Eq_4316" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4316 (in 4<i32> : int32)
-Eq_4317: (union "Eq_4317" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4317 (in a7_1237 - 4<i32> : word32)
-Eq_4319: (union "Eq_4319" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4319 (in a7_1237 - 4<i32> + 0<32> : word32)
 Eq_4328: (union "Eq_4328" (int32 u0) (uint32 u1))
 	T_4328 (in d6_1133 - d3_1057 : word32)
 	T_4329 (in 0<32> : word32)
-Eq_4340: (union "Eq_4340" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4340 (in a7_1330 + 60<i32> : word32)
-Eq_4344: (union "Eq_4344" (uint8 u0) ((ptr32 Eq_8360) u1) (Eq_2791 u2) (Eq_3654 u3))
-	T_4344 (in a7_1330 + 60<i32> : word32)
-Eq_4450: (fn Eq_576 (Eq_576, Eq_576, Eq_576, Eq_576))
+Eq_4450: (fn Eq_656 (Eq_656, Eq_656, Eq_656, Eq_656))
 	T_4450 (in fn0000257E : ptr32)
 	T_4451 (in signature of fn0000257E : void)
 	T_4460 (in fn0000257E : ptr32)
 	T_4465 (in fn0000257E : ptr32)
 	T_4469 (in fn0000257E : ptr32)
 	T_7757 (in fn0000257E : ptr32)
-Eq_4540: (fn Eq_576 (Eq_576, Eq_576))
+Eq_4540: (fn Eq_656 (Eq_656, Eq_656))
 	T_4540 (in __rol : ptr32)
 	T_4541 (in signature of __rol : void)
 	T_4550 (in __rol : ptr32)
@@ -2235,7 +1908,7 @@ Eq_5429: (struct "Eq_5429" (0 word32 dw0000) (4 word32 dw0004))
 	T_7169 (in Mem916[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_7191 (in Mem935[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_7229 (in Mem1000[a7_992 - 4<i32> + 0<32>:word32] : word32)
-Eq_5440: (struct "Eq_5440" 0004 (2C Eq_8379 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8380 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+Eq_5440: (struct "Eq_5440" 0004 (2C Eq_8350 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8351 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 	T_5440 (in a7_1968 : (ptr32 Eq_5440))
 	T_5443 (in fp + -112<i32> : word32)
 	T_5504 (in a7_51 + 4<i32> : word32)
@@ -2423,10 +2096,10 @@ Eq_6419: (union "Eq_6419" (int32 u0) (up32 u1))
 Eq_6426: (struct "Eq_6426" (0 int32 dw0000) (34 Eq_576 t0034) (48 Eq_5914 t0048) (4C ui32 dw004C) (66 (ptr32 Eq_5526) ptr0066) (6A word32 dw006A) (80 Eq_5428 t0080))
 	T_6426 (in a7_1383 : (ptr32 Eq_6426))
 	T_6428 (in a7_1020 - 4<i32> : word32)
-Eq_6466: (fn int32 (Eq_576, Eq_576, Eq_576, Eq_576))
+Eq_6466: (fn int32 (Eq_656, Eq_656, Eq_656, Eq_656))
 	T_6466 (in fn00003C74 : ptr32)
 	T_6467 (in signature of fn00003C74 : void)
-Eq_6550: (fn word32 (Eq_576, Eq_576, Eq_576, Eq_576, Eq_576, Eq_576))
+Eq_6550: (fn word32 (Eq_656, Eq_656, Eq_656, Eq_656, Eq_656, Eq_656))
 	T_6550 (in fn00003A24 : ptr32)
 	T_6551 (in signature of fn00003A24 : void)
 Eq_6590: (union "Eq_6590" (bool u0) (word32 u1))
@@ -2492,9 +2165,6 @@ Eq_6852: (union "Eq_6852" (int32 u0) (up32 u1))
 	T_6852 (in d2_1847 : Eq_6852)
 	T_6853 (in 0<i32> : int32)
 	T_6864 (in d2_1847 + 1<32> : word32)
-Eq_6945: (union "Eq_6945" (byte u0) (word32 u1))
-	T_6945 (in v248_1105 : Eq_6945)
-	T_6948 (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
 Eq_6949: (struct "Eq_6949" (0 (ptr32 Eq_5429) ptr0000) (34 int32 dw0034) (38 int32 dw0038))
 	T_6949 (in a7_1109 : (ptr32 Eq_6949))
 	T_6951 (in a7_1968 - 4<i32> : word32)
@@ -2505,9 +2175,6 @@ Eq_6986: (union "Eq_6986" (uint32 u0) (ptr32 u1))
 	T_6986 (in 3<32> : word32)
 Eq_6987: (union "Eq_6987" (uint32 u0) (ptr32 u1))
 	T_6987 (in d3_1482 + 3<32> : word32)
-Eq_7010: (union "Eq_7010" (word16 u0) (word32 u1))
-	T_7010 (in v262_844 : Eq_7010)
-	T_7013 (in Mem843[a7_1968 + 62<i32>:word16] : word16)
 Eq_7014: (struct "Eq_7014" (0 (ptr32 Eq_5429) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_7014 (in a7_848 : (ptr32 Eq_7014))
 	T_7016 (in a7_1968 - 4<i32> : word32)
@@ -2539,9 +2206,6 @@ Eq_7104: (union "Eq_7104" (cu8 u0) (word32 u1) (Eq_5957 u2) (Eq_5960 u3) (Eq_603
 	T_7107 (in Mem894[a7_1968 + 44<i32>:byte] : byte)
 Eq_7106: (union "Eq_7106" (cu8 u0) (word32 u1) (Eq_5957 u2) (Eq_5960 u3) (Eq_6034 u4) (Eq_7104 u5))
 	T_7106 (in a7_1968 + 44<i32> : word32)
-Eq_7110: (union "Eq_7110" (byte u0) (word32 u1))
-	T_7110 (in v277_869 : Eq_7110)
-	T_7113 (in Mem868[a7_1968 + 63<i32>:byte] : byte)
 Eq_7114: (struct "Eq_7114" (0 (ptr32 Eq_5429) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_7114 (in a7_873 : (ptr32 Eq_7114))
 	T_7116 (in a7_1968 - 4<i32> : word32)
@@ -2618,7 +2282,7 @@ Eq_7341: (union "Eq_7341" ((ptr32 Eq_6087) u0) (Eq_6622 u1) (Eq_6686 u2) (Eq_669
 Eq_7365: (fn Eq_5485 (int32, (ptr32 Eq_5231), (ptr32 ui32), ptr32, ptr32))
 	T_7365 (in fn00003910 : ptr32)
 	T_7366 (in signature of fn00003910 : void)
-Eq_7582: (fn Eq_576 (Eq_576, Eq_576, Eq_576, Eq_576, Eq_576))
+Eq_7582: (fn Eq_656 (Eq_656, Eq_656, Eq_656, Eq_656, Eq_656))
 	T_7582 (in fn00003B28 : ptr32)
 	T_7583 (in signature of fn00003B28 : void)
 	T_7643 (in fn00003B28 : ptr32)
@@ -2652,7 +2316,7 @@ Eq_7913: (union "Eq_7913" (bool u0) (word16 u1))
 	T_7913 (in v59_155 <u 0<16> : bool)
 Eq_7919: (union "Eq_7919" (bool u0) (uint32 u1))
 	T_7919 (in d6_178 <u 0<32> : bool)
-Eq_8016: (fn Eq_576 (Eq_576, word32, bool))
+Eq_8016: (fn Eq_656 (Eq_656, word32, bool))
 	T_8016 (in __rcr : ptr32)
 	T_8017 (in signature of __rcr : void)
 Eq_8162: (union "Eq_8162" (bool u0) (word16 u1))
@@ -2667,107 +2331,105 @@ Eq_8214: (union "Eq_8214" (bool u0) (ui32 u1))
 	T_8214 (in d6_157 < 0<32> : bool)
 Eq_8225: (struct "Eq_8225" 0004 (0 byte b0000))
 	T_8225
-Eq_8282: (struct "Eq_8282" 0001 (0 word32 dw0000))
+Eq_8282: (struct "Eq_8282" (0 Eq_705 t0000))
 	T_8282
-Eq_8283: (struct "Eq_8283" (0 Eq_576 t0000))
+Eq_8283: (struct "Eq_8283" 0004 (0 (ptr32 Eq_8282) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8283
-Eq_8284: (struct "Eq_8284" (0 Eq_705 t0000))
+Eq_8284: (struct "Eq_8284" 0001 (0 word32 dw0000))
 	T_8284
-Eq_8285: (union "Eq_8285" (int32 u0) (byte u1) (Eq_576 u2))
+Eq_8285: (struct "Eq_8285" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8285
-Eq_8286: (struct "Eq_8286" (0 Eq_705 t0000))
+Eq_8286: (union "Eq_8286" ((ptr32 (ptr32 Eq_705)) u0) ((ptr32 Eq_8313) u1) (Eq_3654 u2))
 	T_8286
-Eq_8287: (struct "Eq_8287" 0004 (0 (ptr32 Eq_8286) ptr0000))
+Eq_8287: (union "Eq_8287" ((ptr32 (ptr32 Eq_705)) u0) ((ptr32 Eq_8307) u1) ((ptr32 Eq_8313) u2) (Eq_3130 u3))
 	T_8287
-Eq_8288: (union "Eq_8288" (byte u0) ((ptr32 Eq_8287) u1) (Eq_576 u2) (Eq_3068 u3) (Eq_3127 u4) (Eq_3654 u5))
+Eq_8288: (struct "Eq_8288" (0 Eq_705 t0000))
 	T_8288
-Eq_8289: (union "Eq_8289" (uint8 u0) (word32 u1) (Eq_2791 u2))
+Eq_8289: (struct "Eq_8289" 0004 (0 (ptr32 Eq_8288) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8289
-Eq_8290: (union "Eq_8290" (uint8 u0) (word32 u1) (Eq_698 u2) (Eq_2791 u3) (Eq_3654 u4))
+Eq_8290: (struct "Eq_8290" 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8290
-Eq_8291: (struct "Eq_8291" (0 Eq_705 t0000))
+Eq_8291: (struct "Eq_8291" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8291
-Eq_8292: (struct "Eq_8292" 0004 (0 (ptr32 Eq_8291) ptr0000))
+Eq_8292: (struct "Eq_8292" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8292
-Eq_8293: (union "Eq_8293" ((ptr32 Eq_8292) u0) (Eq_3001 u1) (Eq_3065 u2) (Eq_3068 u3) (Eq_3130 u4))
+Eq_8293: (struct "Eq_8293" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8293
-Eq_8294: (struct "Eq_8294" 0004 (FFFFFFFC (ptr32 Eq_8283) ptrFFFFFFFC) (0 (ptr32 Eq_8284) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C) (2C Eq_8285 t002C) (30 Eq_8288 t0030) (34 word32 dw0034) (37 Eq_8289 t0037) (38 Eq_8290 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8293 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8294: (struct "Eq_8294" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8294
-Eq_8295: (union "Eq_8295" (int32 u0) (byte u1) (Eq_576 u2))
+Eq_8295: (struct "Eq_8295" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8295
-Eq_8296: (struct "Eq_8296" (0 Eq_705 t0000))
+Eq_8296: (struct "Eq_8296" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8296
-Eq_8297: (struct "Eq_8297" 0004 (0 (ptr32 Eq_8296) ptr0000))
+Eq_8297: (struct "Eq_8297" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8297
-Eq_8298: (union "Eq_8298" (byte u0) ((ptr32 Eq_8297) u1) (Eq_576 u2) (Eq_3068 u3) (Eq_3127 u4) (Eq_3654 u5))
+Eq_8298: (struct "Eq_8298" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8298
-Eq_8299: (union "Eq_8299" (uint8 u0) (word32 u1) (Eq_2791 u2))
+Eq_8299: (struct "Eq_8299" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8299
-Eq_8300: (union "Eq_8300" (uint8 u0) (word32 u1) (Eq_698 u2) (Eq_2791 u3) (Eq_3654 u4))
+Eq_8300: (struct "Eq_8300" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8300
-Eq_8301: (union "Eq_8301" ((ptr32 Eq_8292) u0) (Eq_3001 u1) (Eq_3065 u2) (Eq_3068 u3) (Eq_3130 u4))
+Eq_8301: (struct "Eq_8301" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8301
-Eq_8302: (struct "Eq_8302" 0004 (0 Eq_576 t0000) (2C Eq_8295 t002C) (30 Eq_8298 t0030) (34 word32 dw0034) (37 Eq_8299 t0037) (38 Eq_8300 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8301 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
-	T_8302
-Eq_8303: (struct "Eq_8303" (0 Eq_705 t0000))
+Eq_8303: (struct "Eq_8303" 0004 (0 (ptr32 Eq_8367) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8303
-Eq_8304: (struct "Eq_8304" 0004 (0 (ptr32 Eq_8303) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8304: (struct "Eq_8304" 0004 (0 (ptr32 Eq_8368) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8304
-Eq_8305: (struct "Eq_8305" 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8305: (struct "Eq_8305" 0004 (0 (ptr32 Eq_8369) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8305
-Eq_8306: (struct "Eq_8306" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
-	T_8306
-Eq_8307: (struct "Eq_8307" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8307: (struct "Eq_8307" 0004 (0 (ptr32 Eq_8374) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8307
-Eq_8308: (struct "Eq_8308" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
-	T_8308
-Eq_8309: (struct "Eq_8309" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8309: (struct "Eq_8309" 0004 (0 (ptr32 Eq_8371) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8309
-Eq_8310: (struct "Eq_8310" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8310: (struct "Eq_8310" 0004 (0 (ptr32 Eq_8372) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8310
-Eq_8311: (struct "Eq_8311" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8311: (struct "Eq_8311" 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8311
-Eq_8312: (struct "Eq_8312" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8312: (struct "Eq_8312" (0 Eq_705 t0000))
 	T_8312
-Eq_8313: (struct "Eq_8313" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8313: (struct "Eq_8313" 0004 (0 (ptr32 Eq_8373) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8313
-Eq_8314: (struct "Eq_8314" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
-	T_8314
-Eq_8315: (struct "Eq_8315" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8315: (struct "Eq_8315" 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8315
-Eq_8316: (struct "Eq_8316" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8316: (struct "Eq_8316" 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8316
-Eq_8318: (struct "Eq_8318" 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8317: (struct "Eq_8317" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+	T_8317
+Eq_8318: (struct "Eq_8318" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8318
-Eq_8319: (struct "Eq_8319" 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8319: (struct "Eq_8319" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8319
-Eq_8320: (struct "Eq_8320" 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8320: (struct "Eq_8320" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8320
-Eq_8321: (struct "Eq_8321" (0 Eq_705 t0000))
+Eq_8321: (struct "Eq_8321" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8321
-Eq_8322: (struct "Eq_8322" 0004 (0 (ptr32 Eq_8321) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8322: (struct "Eq_8322" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8322
-Eq_8324: (struct "Eq_8324" 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8323: (struct "Eq_8323" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+	T_8323
+Eq_8324: (struct "Eq_8324" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8324
-Eq_8325: (struct "Eq_8325" 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8325: (struct "Eq_8325" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8325
-Eq_8326: (struct "Eq_8326" (0 Eq_705 t0000))
+Eq_8326: (struct "Eq_8326" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8326
-Eq_8327: (struct "Eq_8327" 0004 (0 (ptr32 Eq_8326) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8327: (struct "Eq_8327" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8327
-Eq_8328: (struct "Eq_8328" (0 Eq_705 t0000))
+Eq_8328: (struct "Eq_8328" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8328
-Eq_8329: (struct "Eq_8329" 0004 (0 (ptr32 Eq_8328) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8329: (struct "Eq_8329" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8329
-Eq_8331: (struct "Eq_8331" 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8330: (struct "Eq_8330" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+	T_8330
+Eq_8331: (struct "Eq_8331" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8331
-Eq_8332: (struct "Eq_8332" (0 Eq_705 t0000))
+Eq_8332: (struct "Eq_8332" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8332
-Eq_8333: (struct "Eq_8333" 0004 (0 (ptr32 Eq_8332) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))
+Eq_8333: (struct "Eq_8333" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8333
-Eq_8334: (struct "Eq_8334" (0 Eq_705 t0000))
+Eq_8334: (struct "Eq_8334" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8334
-Eq_8335: (struct "Eq_8335" 0004 (0 (ptr32 Eq_8334) ptr0000))
+Eq_8335: (struct "Eq_8335" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8335
 Eq_8336: (struct "Eq_8336" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8336
@@ -2797,94 +2459,56 @@ Eq_8348: (struct "Eq_8348" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8348
 Eq_8349: (struct "Eq_8349" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
 	T_8349
-Eq_8350: (struct "Eq_8350" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8350: (union "Eq_8350" (cu8 u0) (word32 u1) (Eq_5957 u2) (Eq_5960 u3) (Eq_6034 u4) (Eq_7104 u5) (Eq_7215 u6) (Eq_7256 u7))
 	T_8350
-Eq_8351: (struct "Eq_8351" (0 Eq_705 t0000))
+Eq_8351: (union "Eq_8351" ((ptr32 Eq_6087) u0) (Eq_6622 u1) (Eq_6686 u2) (Eq_6692 u3) (Eq_6762 u4) (Eq_6807 u5) (Eq_7339 u6))
 	T_8351
-Eq_8352: (struct "Eq_8352" 0004 (0 (ptr32 Eq_8351) ptr0000))
+Eq_8352: (struct "Eq_8352" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8352
-Eq_8353: (union "Eq_8353" (int32 u0) (byte u1) (Eq_576 u2))
+Eq_8353: (struct "Eq_8353" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8353
-Eq_8356: (union "Eq_8356" (byte u0) ((ptr32 (ptr32 Eq_705)) u1) (Eq_576 u2) (Eq_3068 u3) (Eq_3127 u4) (Eq_3654 u5))
+Eq_8354: (struct "Eq_8354" 0001 (0 word32 dw0000) (3 byte b0003))
+	T_8354
+Eq_8355: (struct "Eq_8355" 0001 (0 word32 dw0000) (3 byte b0003))
+	T_8355
+Eq_8356: (struct "Eq_8356" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8356
-Eq_8357: (union "Eq_8357" (uint8 u0) (word32 u1) (Eq_2791 u2))
+Eq_8357: (struct "Eq_8357" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8357
-Eq_8358: (union "Eq_8358" (uint8 u0) (word32 u1) (Eq_698 u2) (Eq_2791 u3) (Eq_3654 u4))
+Eq_8358: (struct "Eq_8358" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8358
-Eq_8359: (union "Eq_8359" ((ptr32 Eq_8292) u0) (Eq_3001 u1) (Eq_3065 u2) (Eq_3068 u3) (Eq_3130 u4))
+Eq_8359: (struct "Eq_8359" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8359
-Eq_8360: (struct "Eq_8360" 0004 (0 Eq_576 t0000) (2C Eq_8353 t002C) (30 Eq_8356 t0030) (34 word32 dw0034) (37 Eq_8357 t0037) (38 Eq_8358 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8359 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8360: (struct "Eq_8360" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8360
-Eq_8361: (struct "Eq_8361" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8361: (struct "Eq_8361" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8361
-Eq_8362: (struct "Eq_8362" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8362: (struct "Eq_8362" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8362
-Eq_8363: (struct "Eq_8363" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8363: (struct "Eq_8363" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8363
-Eq_8364: (struct "Eq_8364" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8364: (struct "Eq_8364" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8364
-Eq_8365: (struct "Eq_8365" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8365: (struct "Eq_8365" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8365
-Eq_8366: (struct "Eq_8366" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8366: (struct "Eq_8366" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8366
-Eq_8367: (struct "Eq_8367" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8367: (union "Eq_8367" (Eq_705 u0) (Eq_8312 u1))
 	T_8367
-Eq_8368: (struct "Eq_8368" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8368: (union "Eq_8368" (Eq_705 u0) (Eq_8312 u1))
 	T_8368
-Eq_8369: (struct "Eq_8369" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8369: (union "Eq_8369" (Eq_705 u0) (Eq_8312 u1))
 	T_8369
-Eq_8370: (struct "Eq_8370" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8370: (union "Eq_8370" (Eq_705 u0) (Eq_8312 u1))
 	T_8370
-Eq_8371: (struct "Eq_8371" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8371: (union "Eq_8371" (Eq_705 u0) (Eq_8312 u1))
 	T_8371
-Eq_8372: (struct "Eq_8372" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8372: (union "Eq_8372" (Eq_705 u0) (Eq_8312 u1))
 	T_8372
-Eq_8373: (struct "Eq_8373" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8373: (union "Eq_8373" (Eq_705 u0) (Eq_8312 u1))
 	T_8373
-Eq_8374: (struct "Eq_8374" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
+Eq_8374: (union "Eq_8374" (Eq_705 u0) (Eq_8370 u1) (Eq_8373 u2))
 	T_8374
-Eq_8375: (struct "Eq_8375" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
-	T_8375
-Eq_8376: (struct "Eq_8376" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
-	T_8376
-Eq_8377: (struct "Eq_8377" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
-	T_8377
-Eq_8378: (struct "Eq_8378" 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))
-	T_8378
-Eq_8379: (union "Eq_8379" (cu8 u0) (word32 u1) (Eq_5957 u2) (Eq_5960 u3) (Eq_6034 u4) (Eq_7104 u5) (Eq_7215 u6) (Eq_7256 u7))
-	T_8379
-Eq_8380: (union "Eq_8380" ((ptr32 Eq_6087) u0) (Eq_6622 u1) (Eq_6686 u2) (Eq_6692 u3) (Eq_6762 u4) (Eq_6807 u5) (Eq_7339 u6))
-	T_8380
-Eq_8381: (struct "Eq_8381" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8381
-Eq_8382: (struct "Eq_8382" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8382
-Eq_8383: (struct "Eq_8383" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8383
-Eq_8384: (struct "Eq_8384" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8384
-Eq_8385: (struct "Eq_8385" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8385
-Eq_8386: (struct "Eq_8386" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8386
-Eq_8387: (struct "Eq_8387" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8387
-Eq_8388: (struct "Eq_8388" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8388
-Eq_8389: (struct "Eq_8389" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8389
-Eq_8390: (struct "Eq_8390" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8390
-Eq_8391: (struct "Eq_8391" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8391
-Eq_8392: (struct "Eq_8392" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8392
-Eq_8393: (struct "Eq_8393" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8393
-Eq_8394: (struct "Eq_8394" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8394
-Eq_8395: (struct "Eq_8395" 0001 (0 word32 dw0000) (3 byte b0003))
-	T_8395
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -5192,7 +4816,7 @@ T_576: (in d0_10 : Eq_576)
   OrigDataType: word32
 T_577: (in 0x3ECC<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_578: (in 0x3ECC<32> : word32)
   Class: Eq_578
@@ -5306,9 +4930,9 @@ T_605: (in *a3_17 != null : bool)
   Class: Eq_605
   DataType: bool
   OrigDataType: bool
-T_606: (in a1_8 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_606: (in a1_8 : (ptr32 (ptr32 byte)))
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_607: (in d1_10 : Eq_576)
   Class: Eq_576
@@ -5330,9 +4954,9 @@ T_611: (in d1 : Eq_576)
   Class: Eq_576
   DataType: Eq_576
   OrigDataType: word32
-T_612: (in a1 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_612: (in a1 : (ptr32 (ptr32 byte)))
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_613: (in dwArg04 : (ptr32 Eq_613))
   Class: Eq_613
@@ -5494,10 +5118,10 @@ T_652: (in d1 : Eq_576)
   Class: Eq_576
   DataType: Eq_576
   OrigDataType: uint32
-T_653: (in a1 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: Eq_4317
+T_653: (in a1 : (ptr32 (ptr32 byte)))
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: (ptr32 (struct (0 T_1075 t0000)))
 T_654: (in dwArg04 : Eq_576)
   Class: Eq_576
   DataType: Eq_576
@@ -5506,9 +5130,9 @@ T_655: (in dwArg08 : (ptr32 Eq_613))
   Class: Eq_613
   DataType: (ptr32 Eq_613)
   OrigDataType: (ptr32 (struct (0 T_711 t0000)))
-T_656: (in dwArg0C : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_656: (in dwArg0C : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_657: (in 00003EF4 : ptr32)
   Class: Eq_657
@@ -5527,8 +5151,8 @@ T_660: (in 8<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_661: (in fp + 8<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_662: (in fn00001468(d0, d1, a1, *(union Eq_576 *) 0x3EF4<u32>, dwArg04, fp + 8<i32>) : void)
   Class: Eq_662
@@ -5538,9 +5162,9 @@ T_663: (in d0 : Eq_576)
   Class: Eq_576
   DataType: Eq_576
   OrigDataType: word32
-T_664: (in bArg07 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_664: (in bArg07 : byte)
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_665: (in dwArg08 : Eq_576)
   Class: Eq_576
@@ -5552,7 +5176,7 @@ T_666: (in d0_10 : Eq_576)
   OrigDataType: up32
 T_667: (in 0<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_668: (in dwArg08 == 0<32> : bool)
   Class: Eq_668
@@ -5671,13 +5295,13 @@ T_696: (in Mem5[dwArg08 + 4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_697: (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_576
+  Class: Eq_664
   DataType: Eq_576
   OrigDataType: byte
-T_698: (in a7_1330 : Eq_698)
+T_698: (in a7_1330 : (ptr32 Eq_698))
   Class: Eq_698
-  DataType: Eq_698
-  OrigDataType: word32
+  DataType: (ptr32 Eq_698)
+  OrigDataType: (ptr32 (struct 0004 (2C int32 dw002C) (30 (union ((ptr32 (ptr32 Eq_705)) u0) (T_3068 u1) (T_3134 u2) (T_3654 u3)) u0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 (union ((ptr32 (ptr32 Eq_705)) u0) (T_3001 u1) (T_3068 u2) (T_3072 u3) (T_3130 u4)) u0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084)))
 T_699: (in fp : ptr32)
   Class: Eq_699
   DataType: ptr32
@@ -5688,12 +5312,12 @@ T_700: (in -120<i32> : int32)
   OrigDataType: int32
 T_701: (in fp + -120<i32> : word32)
   Class: Eq_698
-  DataType: Eq_698
+  DataType: (ptr32 Eq_698)
   OrigDataType: ptr32
-T_702: (in d2_1090 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: Eq_698
+T_702: (in d2_1090 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: (struct "Eq_698" 0004 (2C int32 dw002C) (30 Eq_8286 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8287 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_703: (in a4_274 : (ptr32 Eq_613))
   Class: Eq_613
   DataType: (ptr32 Eq_613)
@@ -5701,7 +5325,7 @@ T_703: (in a4_274 : (ptr32 Eq_613))
 T_704: (in a2_1014 : Eq_576)
   Class: Eq_576
   DataType: Eq_576
-  OrigDataType: Eq_4213
+  OrigDataType: (ptr32 Eq_576)
 T_705: (in d4_132 : Eq_705)
   Class: Eq_705
   DataType: Eq_705
@@ -5713,10 +5337,10 @@ T_706: (in 0<i32> : int32)
 T_707: (in d5_1044 : Eq_576)
   Class: Eq_576
   DataType: Eq_576
-  OrigDataType: Eq_698
+  OrigDataType: (struct "Eq_698" 0004 (2C int32 dw002C) (30 Eq_8286 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8287 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_708: (in 0<i32> : int32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_709: (in 0<32> : word32)
   Class: Eq_709
@@ -5740,7 +5364,7 @@ T_713: (in dwArg08->b0000 == 0<8> : bool)
   OrigDataType: bool
 T_714: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_715: (in d5_1044 != 0xFFFFFFFF<32> : bool)
   Class: Eq_715
@@ -5864,7 +5488,7 @@ T_744: (in a7_1330 + 72<i32> : word32)
   OrigDataType: ptr32
 T_745: (in Mem277[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_742
-  DataType: Eq_698
+  DataType: byte
   OrigDataType: byte
 T_746: (in 0<8> : byte)
   Class: Eq_746
@@ -5880,7 +5504,7 @@ T_748: (in a7_1330 + 73<i32> : word32)
   OrigDataType: ptr32
 T_749: (in Mem278[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_746
-  DataType: Eq_698
+  DataType: byte
   OrigDataType: byte
 T_750: (in a3_279 : (ptr32 byte))
   Class: Eq_750
@@ -5938,13 +5562,13 @@ T_763: (in (uint32) (uint8) Mem278[0x00002BED<p32> + (uint32) ((uint8) Mem278[a3
   Class: Eq_753
   DataType: uint32
   OrigDataType: uint32
-T_764: (in d6_1133 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: uint8
+T_764: (in d6_1133 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: (ptr32 Eq_6087)
 T_765: (in -1<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_766: (in 4<32> : word32)
   Class: Eq_766
@@ -6031,8 +5655,8 @@ T_786: (in (uint32) (uint8) Mem278[0x00002BED<p32> + (uint32) ((uint8) Mem278[a3
   DataType: uint32
   OrigDataType: uint32
 T_787: (in 0<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_788: (in 4<32> : word32)
   Class: Eq_788
@@ -6054,9 +5678,9 @@ T_792: (in (d0_305 & 4<32>) == 0<32> : bool)
   Class: Eq_792
   DataType: bool
   OrigDataType: bool
-T_793: (in a7_313 : (ptr32 Eq_576))
+T_793: (in a7_313 : (ptr32 Eq_656))
   Class: Eq_793
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_656 t0000)))
 T_794: (in 4<i32> : int32)
   Class: Eq_794
@@ -6064,7 +5688,7 @@ T_794: (in 4<i32> : int32)
   OrigDataType: int32
 T_795: (in a7_1330 - 4<i32> : word32)
   Class: Eq_793
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: ptr32
 T_796: (in 0<32> : word32)
   Class: Eq_796
@@ -6075,8 +5699,8 @@ T_797: (in a7_313 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_798: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_799: (in d1_322 : uint32)
   Class: Eq_799
@@ -6091,16 +5715,16 @@ T_801: (in signature of __swap : void)
   DataType: (ptr32 Eq_800)
   OrigDataType: 
 T_802: (in  : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: 
 T_803: (in 10<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_804: (in __swap(10<i32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_805: (in SLICE(d6_1133, word16, 0) : word16)
   Class: Eq_805
@@ -6139,8 +5763,8 @@ T_813: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_814 (T_764)))
 T_814: (in __swap(d6_1133) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_815: (in 0xA<16> : word16)
   Class: Eq_815
@@ -6159,12 +5783,12 @@ T_818: (in SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_819: (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_820: (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_821: (in SLICE(__swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_821
@@ -6267,8 +5891,8 @@ T_845: (in a7_313 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_846: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_847: (in 0x30<32> : word32)
   Class: Eq_847
@@ -6283,8 +5907,8 @@ T_849: (in d1_340 - 0x30<32> : word32)
   DataType: uint32
   OrigDataType: uint32
 T_850: (in d1_340 - 0x30<32> + d0_331 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_851: (in 4<32> : word32)
   Class: Eq_851
@@ -6486,7 +6110,7 @@ T_900: (in 0x6A<8> : byte)
   Class: Eq_899
   DataType: byte
   OrigDataType: byte
-T_901: (in *((word32) a7_1330 + 72<i32>) != 0x6A<8> : bool)
+T_901: (in a7_1330[18<i32>] != 0x6A<8> : bool)
   Class: Eq_901
   DataType: bool
   OrigDataType: bool
@@ -6572,7 +6196,7 @@ T_921: (in *a3_279 != 0x68<8> : bool)
   OrigDataType: bool
 T_922: (in 2<i32> : int32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_923: (in 0<32> : word32)
   Class: Eq_923
@@ -6728,7 +6352,7 @@ T_960: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_961: (in Mem463[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_958
-  DataType: Eq_698
+  DataType: byte
   OrigDataType: byte
 T_962: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_962
@@ -6744,7 +6368,7 @@ T_964: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_965: (in Mem469[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_962
-  DataType: Eq_698
+  DataType: byte
   OrigDataType: byte
 T_966: (in SLICE(d1, word24, 8) : word24)
   Class: Eq_966
@@ -6788,7 +6412,7 @@ T_975: (in *a3_279 != 0x6C<8> : bool)
   OrigDataType: bool
 T_976: (in 1<i32> : int32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_977: (in 72<i32> : int32)
   Class: Eq_977
@@ -6806,7 +6430,7 @@ T_980: (in 0x74<8> : byte)
   Class: Eq_979
   DataType: byte
   OrigDataType: byte
-T_981: (in *((word32) a7_1330 + 72<i32>) != 0x74<8> : bool)
+T_981: (in a7_1330[18<i32>] != 0x74<8> : bool)
   Class: Eq_981
   DataType: bool
   OrigDataType: bool
@@ -6824,7 +6448,7 @@ T_984: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_985: (in Mem477[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_982
-  DataType: Eq_698
+  DataType: byte
   OrigDataType: byte
 T_986: (in 72<i32> : int32)
   Class: Eq_986
@@ -6842,7 +6466,7 @@ T_989: (in 0x7A<8> : byte)
   Class: Eq_988
   DataType: byte
   OrigDataType: byte
-T_990: (in *((word32) a7_1330 + 72<i32>) != 0x7A<8> : bool)
+T_990: (in a7_1330[18<i32>] != 0x7A<8> : bool)
   Class: Eq_990
   DataType: bool
   OrigDataType: bool
@@ -6860,7 +6484,7 @@ T_993: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_994: (in Mem485[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_991
-  DataType: Eq_698
+  DataType: byte
   OrigDataType: byte
 T_995: (in v83_500 : byte)
   Class: Eq_995
@@ -6924,7 +6548,7 @@ T_1009: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_1010: (in Mem493[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_1007
-  DataType: Eq_698
+  DataType: byte
   OrigDataType: byte
 T_1011: (in v147_608 : word24)
   Class: Eq_1011
@@ -7179,8 +6803,8 @@ T_1073: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_1074: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_1075: (in a0_551 : (ptr32 byte))
   Class: Eq_1075
@@ -7240,8 +6864,8 @@ T_1088: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_1089: (in Mem558[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: word32
 T_1090: (in v96_562 : byte)
   Class: Eq_1090
   DataType: byte
@@ -7635,8 +7259,8 @@ T_1187: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_1188: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_1189: (in a0_198 : (ptr32 byte))
   Class: Eq_1075
@@ -7696,8 +7320,8 @@ T_1202: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_1203: (in Mem205[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_1204: (in v109_209 : byte)
   Class: Eq_1090
   DataType: byte
@@ -7820,7 +7444,7 @@ T_1233: (in 1<i32> : int32)
   OrigDataType: int32
 T_1234: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_1235: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_1235
@@ -7896,7 +7520,7 @@ T_1252: (in 1<i32> : int32)
   OrigDataType: int32
 T_1253: (in a7_248 - 1<i32> : word32)
   Class: Eq_1253
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_1256 t0000)))
 T_1254: (in 0<32> : word32)
   Class: Eq_1254
@@ -7907,8 +7531,8 @@ T_1255: (in a7_248 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1256: (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_1257: (in 0<32> : word32)
   Class: Eq_1257
@@ -7981,7 +7605,7 @@ T_1273: (in Mem81[a7_79 + 0<32>:word32] : word32)
 T_1274: (in out d1 : ptr32)
   Class: Eq_1063
   DataType: Eq_1063
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_1275: (in out a1 : ptr32)
   Class: Eq_1064
   DataType: (ptr32 word32)
@@ -8011,8 +7635,8 @@ T_1281: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_1282: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_1283: (in a0_98 : (ptr32 byte))
   Class: Eq_1075
@@ -8072,8 +7696,8 @@ T_1296: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_1297: (in Mem105[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_1298: (in v130_109 : byte)
   Class: Eq_1090
   DataType: byte
@@ -8226,7 +7850,7 @@ T_1335: (in Mem127[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_1335
   DataType: int32
   OrigDataType: int32
-T_1336: (in d0 - *((word32) a7_1330 + 44<i32>) : word32)
+T_1336: (in d0 - a7_1330[11<i32>] : word32)
   Class: Eq_1336
   DataType: int32
   OrigDataType: int32
@@ -8234,7 +7858,7 @@ T_1337: (in 0<32> : word32)
   Class: Eq_1336
   DataType: int32
   OrigDataType: word32
-T_1338: (in d0 - *((word32) a7_1330 + 44<i32>) == 0<32> : bool)
+T_1338: (in d0 - a7_1330[11<i32>] == 0<32> : bool)
   Class: Eq_1338
   DataType: bool
   OrigDataType: bool
@@ -8260,7 +7884,7 @@ T_1343: (in a4_274->b0000 != 0<8> : bool)
   OrigDataType: bool
 T_1344: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_1345: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_1345
@@ -8332,7 +7956,7 @@ T_1361: (in 1<i32> : int32)
   OrigDataType: int32
 T_1362: (in a7_148 - 1<i32> : word32)
   Class: Eq_1362
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_1365 t0000)))
 T_1363: (in 0<32> : word32)
   Class: Eq_1363
@@ -8343,8 +7967,8 @@ T_1364: (in a7_148 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1365: (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_1366: (in 0<32> : word32)
   Class: Eq_1366
@@ -8484,8 +8108,8 @@ T_1399: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_1400: (in Mem761[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_1397
-  DataType: Eq_698
-  OrigDataType: byte
+  DataType: Eq_1397
+  OrigDataType: int32
 T_1401: (in 0<32> : word32)
   Class: Eq_1401
   DataType: word32
@@ -8527,8 +8151,8 @@ T_1410: (in v83_500 == 0x63<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_1411: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_1412: (in d6_1133 != 0xFFFFFFFF<32> : bool)
   Class: Eq_1412
@@ -8566,7 +8190,7 @@ T_1420: (in 0<8> : byte)
   Class: Eq_1419
   DataType: byte
   OrigDataType: byte
-T_1421: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_1421: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_1421
   DataType: bool
   OrigDataType: bool
@@ -8606,7 +8230,7 @@ T_1430: (in 0<8> : byte)
   Class: Eq_1429
   DataType: byte
   OrigDataType: byte
-T_1431: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_1431: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_1431
   DataType: bool
   OrigDataType: bool
@@ -8624,7 +8248,7 @@ T_1434: (in a7_1330 + 48<i32> : word32)
   OrigDataType: ptr32
 T_1435: (in Mem1948[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_1432
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
 T_1436: (in 0<32> : word32)
   Class: Eq_1436
@@ -8640,7 +8264,7 @@ T_1438: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_1439: (in Mem1949[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_1436
-  DataType: Eq_698
+  DataType: int32
   OrigDataType: int32
 T_1440: (in 0<32> : word32)
   Class: Eq_1440
@@ -8656,7 +8280,7 @@ T_1442: (in a7_1330 + 110<i32> : word32)
   OrigDataType: ptr32
 T_1443: (in Mem1950[a7_1330 + 110<i32>:word32] : word32)
   Class: Eq_1440
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
 T_1444: (in 0<8> : byte)
   Class: Eq_995
@@ -8713,7 +8337,7 @@ T_1456: (in Mem642[a7_640 + 0<32>:word32] : word32)
 T_1457: (in out d1 : ptr32)
   Class: Eq_1063
   DataType: Eq_1063
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_1458: (in out a1 : ptr32)
   Class: Eq_1064
   DataType: (ptr32 word32)
@@ -8743,8 +8367,8 @@ T_1464: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_1465: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_1466: (in a0_659 : (ptr32 byte))
   Class: Eq_1075
@@ -8804,8 +8428,8 @@ T_1479: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_1480: (in Mem666[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_1481: (in v163_670 : byte)
   Class: Eq_1090
   DataType: byte
@@ -8930,7 +8554,7 @@ T_1511: (in 0x25<32> : word32)
   Class: Eq_1510
   DataType: int32
   OrigDataType: word32
-T_1512: (in *((word32) a7_1330 + 44<i32>) == 0x25<32> : bool)
+T_1512: (in a7_1330[11<i32>] == 0x25<32> : bool)
   Class: Eq_1512
   DataType: bool
   OrigDataType: bool
@@ -8952,7 +8576,7 @@ T_1516: (in a3_1955 - 1<i32> : word32)
   OrigDataType: ptr32
 T_1517: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_1518: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_1518
@@ -9028,7 +8652,7 @@ T_1535: (in 1<i32> : int32)
   OrigDataType: int32
 T_1536: (in a7_735 - 1<i32> : word32)
   Class: Eq_1536
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_1539 t0000)))
 T_1537: (in 0<32> : word32)
   Class: Eq_1537
@@ -9039,8 +8663,8 @@ T_1538: (in a7_735 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1539: (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_1540: (in 0<32> : word32)
   Class: Eq_1540
@@ -9068,7 +8692,7 @@ T_1545: (in d3_130 == 0<32> : bool)
   OrigDataType: bool
 T_1546: (in 0x2D<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_1547: (in d5_1044 != 0x2D<32> : bool)
   Class: Eq_1547
@@ -9088,7 +8712,7 @@ T_1550: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_1551: (in Mem1962[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_1548
-  DataType: Eq_698
+  DataType: byte
   OrigDataType: byte
 T_1552: (in 120<i32> : int32)
   Class: Eq_856
@@ -9127,8 +8751,8 @@ T_1560: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_1561: (in d0 + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
 T_1562: (in 0<32> : word32)
   Class: Eq_1562
@@ -9144,7 +8768,7 @@ T_1564: (in Mem629[d0 + 0<32>:word32] : word32)
   OrigDataType: word32
 T_1565: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_1566: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_1566
@@ -9176,7 +8800,7 @@ T_1572: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1573: (in Mem1716[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_1571
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
 T_1574: (in 1<i32> : int32)
   Class: Eq_716
@@ -9198,7 +8822,7 @@ T_1578: (in 1<8> : byte)
   Class: Eq_1577
   DataType: byte
   OrigDataType: byte
-T_1579: (in *((word32) a7_1330 + 72<i32>) != 1<8> : bool)
+T_1579: (in a7_1330[18<i32>] != 1<8> : bool)
   Class: Eq_1579
   DataType: bool
   OrigDataType: bool
@@ -9218,13 +8842,13 @@ T_1583: (in 0x6C<8> : byte)
   Class: Eq_1582
   DataType: byte
   OrigDataType: byte
-T_1584: (in *((word32) a7_1330 + 72<i32>) != 0x6C<8> : bool)
+T_1584: (in a7_1330[18<i32>] != 0x6C<8> : bool)
   Class: Eq_1584
   DataType: bool
   OrigDataType: bool
 T_1585: (in 3<32> : word32)
   Class: Eq_1585
-  DataType: (ptr32 Eq_8306)
+  DataType: (ptr32 Eq_8291)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_1586: (in d2_1090 + 3<32> : word32)
   Class: Eq_1586
@@ -9295,12 +8919,12 @@ T_1602: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1603: (in d0 + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_1604: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_1605: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_1605
@@ -9542,17 +9166,17 @@ T_1664: (in 0x68<8> : byte)
   Class: Eq_1663
   DataType: byte
   OrigDataType: byte
-T_1665: (in *((word32) a7_1330 + 72<i32>) != 0x68<8> : bool)
+T_1665: (in a7_1330[18<i32>] != 0x68<8> : bool)
   Class: Eq_1665
   DataType: bool
   OrigDataType: bool
 T_1666: (in 3<32> : word32)
   Class: Eq_1666
-  DataType: (ptr32 Eq_8307)
+  DataType: (ptr32 Eq_8292)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_1667: (in d2_1090 + 3<32> : word32)
   Class: Eq_1667
-  DataType: (ptr32 Eq_8308)
+  DataType: (ptr32 Eq_8293)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_1668: (in 2<32> : word32)
   Class: Eq_1668
@@ -9599,8 +9223,8 @@ T_1678: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1679: (in d0 + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_1680: (in a7_1807 : (ptr32 Eq_576))
   Class: Eq_1680
@@ -9667,8 +9291,8 @@ T_1695: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_1696: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_1697: (in a0_1825 : (ptr32 byte))
   Class: Eq_1075
@@ -9728,8 +9352,8 @@ T_1710: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_1711: (in Mem1832[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_1712: (in v201_1836 : byte)
   Class: Eq_1090
   DataType: byte
@@ -9792,7 +9416,7 @@ T_1726: (in d4_132 + 1<32> : word32)
   OrigDataType: int32
 T_1727: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_1728: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_1728
@@ -9814,17 +9438,17 @@ T_1732: (in 2<8> : byte)
   Class: Eq_1731
   DataType: byte
   OrigDataType: byte
-T_1733: (in *((word32) a7_1330 + 72<i32>) != 2<8> : bool)
+T_1733: (in a7_1330[18<i32>] != 2<8> : bool)
   Class: Eq_1733
   DataType: bool
   OrigDataType: bool
 T_1734: (in 3<32> : word32)
   Class: Eq_1734
-  DataType: (ptr32 Eq_8309)
+  DataType: (ptr32 Eq_8294)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_1735: (in d2_1090 + 3<32> : word32)
   Class: Eq_1735
-  DataType: (ptr32 Eq_8310)
+  DataType: (ptr32 Eq_8295)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_1736: (in 2<32> : word32)
   Class: Eq_1736
@@ -9875,8 +9499,8 @@ T_1747: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1748: (in d0 + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_1749: (in 73<i32> : int32)
   Class: Eq_1749
@@ -9888,7 +9512,7 @@ T_1750: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_1751: (in Mem1889[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_1625
-  DataType: Eq_698
+  DataType: byte
   OrigDataType: byte
 T_1752: (in d0_1871 : uint32)
   Class: Eq_1752
@@ -9976,11 +9600,11 @@ T_1772: (in v190_1777 != 0<8> : bool)
   OrigDataType: bool
 T_1773: (in 3<32> : word32)
   Class: Eq_1773
-  DataType: (ptr32 Eq_8311)
+  DataType: (ptr32 Eq_8296)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_1774: (in d2_1090 + 3<32> : word32)
   Class: Eq_1774
-  DataType: (ptr32 Eq_8312)
+  DataType: (ptr32 Eq_8297)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_1775: (in 2<32> : word32)
   Class: Eq_1775
@@ -10027,16 +9651,16 @@ T_1785: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1786: (in d0 + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_1787: (in 3<32> : word32)
   Class: Eq_1787
-  DataType: (ptr32 Eq_8313)
+  DataType: (ptr32 Eq_8298)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_1788: (in d2_1090 + 3<32> : word32)
   Class: Eq_1788
-  DataType: (ptr32 Eq_8314)
+  DataType: (ptr32 Eq_8299)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_1789: (in 2<32> : word32)
   Class: Eq_1789
@@ -10087,8 +9711,8 @@ T_1800: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1801: (in d0 + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_1802: (in 1<32> : word32)
   Class: Eq_1802
@@ -10122,7 +9746,7 @@ T_1809: (in 0<8> : byte)
   Class: Eq_1808
   DataType: byte
   OrigDataType: byte
-T_1810: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_1810: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_1810
   DataType: bool
   OrigDataType: bool
@@ -10180,7 +9804,7 @@ T_1823: (in 1<i32> : int32)
   OrigDataType: int32
 T_1824: (in a7_1897 - 1<i32> : word32)
   Class: Eq_1824
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_1827 t0000)))
 T_1825: (in 0<32> : word32)
   Class: Eq_1825
@@ -10191,8 +9815,8 @@ T_1826: (in a7_1897 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1827: (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_1828: (in 0<32> : word32)
   Class: Eq_1828
@@ -10212,7 +9836,7 @@ T_1831: (in fn00001438(*(a7_1897 - 1<i32>), *a7_1897) : word32)
   OrigDataType: word32
 T_1832: (in 0x2B<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_1833: (in d5_1044 != 0x2B<32> : bool)
   Class: Eq_1833
@@ -10264,8 +9888,8 @@ T_1844: (in a7_1330 + 110<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1845: (in Mem1994[a7_1330 + 110<i32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_698
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_1846: (in a0_1999 : (ptr32 ui32))
   Class: Eq_1846
   DataType: (ptr32 ui32)
@@ -10413,7 +10037,7 @@ T_1881: (in Mem2009[a7_2007 + 0<32>:word32] : word32)
 T_1882: (in out d1 : ptr32)
   Class: Eq_1063
   DataType: Eq_1063
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_1883: (in out a1 : ptr32)
   Class: Eq_1064
   DataType: (ptr32 word32)
@@ -10443,8 +10067,8 @@ T_1889: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_1890: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_1891: (in a0_2026 : (ptr32 byte))
   Class: Eq_1075
@@ -10504,8 +10128,8 @@ T_1904: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_1905: (in Mem2033[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_1906: (in v231_2037 : byte)
   Class: Eq_1090
   DataType: byte
@@ -10664,7 +10288,7 @@ T_1944: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1945: (in Mem1946[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_1943
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
 T_1946: (in d4_2510 : Eq_705)
   Class: Eq_705
@@ -10688,7 +10312,7 @@ T_1950: (in (byte) d7 != 0x78<8> : bool)
   OrigDataType: bool
 T_1951: (in 0x30<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_1952: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_1952
@@ -10921,7 +10545,7 @@ T_2008: (in Mem2150[a7_2148 + 0<32>:word32] : word32)
 T_2009: (in out d1 : ptr32)
   Class: Eq_1063
   DataType: Eq_1063
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_2010: (in out a1 : ptr32)
   Class: Eq_1064
   DataType: (ptr32 word32)
@@ -10951,8 +10575,8 @@ T_2016: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_2017: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_2018: (in a0_2167 : (ptr32 byte))
   Class: Eq_1075
@@ -11012,8 +10636,8 @@ T_2031: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_2032: (in Mem2174[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_2033: (in v249_2178 : byte)
   Class: Eq_1090
   DataType: byte
@@ -11132,12 +10756,12 @@ T_2061: (in 55<i32> : int32)
   OrigDataType: int32
 T_2062: (in a7_1330 + 55<i32> : word32)
   Class: Eq_2062
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2063: (in Mem2199[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_2063
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2064: (in SEQ(SLICE(d0_2155, word24, 8), Mem2199[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_2059
   DataType: ui32
@@ -11230,17 +10854,17 @@ T_2086: (in 0<8> : byte)
   Class: Eq_2085
   DataType: byte
   OrigDataType: byte
-T_2087: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_2087: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_2087
   DataType: bool
   OrigDataType: bool
 T_2088: (in 1<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_2089: (in 0x78<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2090: (in d0 != 0x78<32> : bool)
   Class: Eq_2090
@@ -11280,11 +10904,11 @@ T_2098: (in 0<32> : word32)
   OrigDataType: word32
 T_2099: (in 3<32> : word32)
   Class: Eq_2099
-  DataType: (ptr32 Eq_8315)
+  DataType: (ptr32 Eq_8300)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_2100: (in d2_1090 + 3<32> : word32)
   Class: Eq_2100
-  DataType: (ptr32 Eq_8316)
+  DataType: (ptr32 Eq_8301)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_2101: (in 2<32> : word32)
   Class: Eq_2101
@@ -11307,8 +10931,8 @@ T_2105: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_2106: (in d0 + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_2107: (in 0<32> : word32)
   Class: Eq_2107
@@ -11420,8 +11044,8 @@ T_2133: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_2134: (in Mem1393[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_2082
-  DataType: Eq_698
-  OrigDataType: (ptr32 Eq_705)
+  DataType: (ptr32 Eq_705)
+  OrigDataType: int32
 T_2135: (in 0<32> : word32)
   Class: Eq_2135
   DataType: word32
@@ -11609,7 +11233,7 @@ T_2180: (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 T_2181: (in out d1 : ptr32)
   Class: Eq_1063
   DataType: Eq_1063
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_2182: (in out a1 : ptr32)
   Class: Eq_1064
   DataType: (ptr32 word32)
@@ -11639,8 +11263,8 @@ T_2188: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_2189: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_2190: (in a0_2265 : (ptr32 byte))
   Class: Eq_1075
@@ -11700,8 +11324,8 @@ T_2203: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_2204: (in Mem2272[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_2205: (in v271_2276 : byte)
   Class: Eq_1090
   DataType: byte
@@ -11949,7 +11573,7 @@ T_2265: (in Mem1404[a7_1400 + 0<32>:word32] : word32)
 T_2266: (in out d1 : ptr32)
   Class: Eq_1063
   DataType: Eq_1063
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_2267: (in out a1_5326 : ptr32)
   Class: Eq_1064
   DataType: (ptr32 word32)
@@ -12159,8 +11783,8 @@ T_2318: (in a7_1330 + 44<i32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_2319: (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: int32
 T_2320: (in 52<i32> : int32)
   Class: Eq_2320
@@ -12214,7 +11838,7 @@ T_2332: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_2331
   DataType: word32
   OrigDataType: word32
-T_2333: (in *((word32) a7_1330 + 52<i32>) == 0xFFFFFFFF<32> : bool)
+T_2333: (in a7_1330[13<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_2333
   DataType: bool
   OrigDataType: bool
@@ -12234,7 +11858,7 @@ T_2337: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_2336
   DataType: word32
   OrigDataType: word32
-T_2338: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_2338: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_2338
   DataType: bool
   OrigDataType: bool
@@ -12264,7 +11888,7 @@ T_2344: (in 120<i32> : int32)
   OrigDataType: int32
 T_2345: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2346: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_2346
@@ -12279,9 +11903,9 @@ T_2348: (in a7_1330 + 44<i32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_2349: (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_698
-  OrigDataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: int32
 T_2350: (in d6_1133 - d3_1462 : word32)
   Class: Eq_2350
   DataType: Eq_2350
@@ -12520,7 +12144,7 @@ T_2408: (in 1<i32> : int32)
   OrigDataType: int32
 T_2409: (in a7_2334 - 1<i32> : word32)
   Class: Eq_2409
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_2412 t0000)))
 T_2410: (in 0<32> : word32)
   Class: Eq_2410
@@ -12531,8 +12155,8 @@ T_2411: (in a7_2334 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2412: (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_2413: (in 0<32> : word32)
   Class: Eq_2413
@@ -12619,8 +12243,8 @@ T_2433: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_2434: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_2435: (in a0_1530 : (ptr32 byte))
   Class: Eq_1075
@@ -12680,8 +12304,8 @@ T_2448: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_2449: (in Mem1537[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_2450: (in v314_1541 : byte)
   Class: Eq_1090
   DataType: byte
@@ -12744,7 +12368,7 @@ T_2464: (in d4_1466 + 1<32> : word32)
   OrigDataType: int32
 T_2465: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2466: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_2466
@@ -12760,7 +12384,7 @@ T_2468: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_2469: (in Mem1577[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_2353
-  DataType: Eq_698
+  DataType: byte
   OrigDataType: byte
 T_2470: (in d6_1133 - d3_1462 : word32)
   Class: Eq_2470
@@ -12798,7 +12422,7 @@ T_2478: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_2477
   DataType: word32
   OrigDataType: word32
-T_2479: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_2479: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_2479
   DataType: bool
   OrigDataType: bool
@@ -12834,7 +12458,7 @@ T_2487: (in 0<8> : byte)
   Class: Eq_2486
   DataType: byte
   OrigDataType: byte
-T_2488: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_2488: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_2488
   DataType: bool
   OrigDataType: bool
@@ -12892,7 +12516,7 @@ T_2501: (in 1<i32> : int32)
   OrigDataType: int32
 T_2502: (in a7_1585 - 1<i32> : word32)
   Class: Eq_2502
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_2505 t0000)))
 T_2503: (in 0<32> : word32)
   Class: Eq_2503
@@ -12903,8 +12527,8 @@ T_2504: (in a7_1585 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2505: (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_2506: (in 0<32> : word32)
   Class: Eq_2506
@@ -12988,7 +12612,7 @@ T_2525: (in 1<i32> : int32)
   OrigDataType: int32
 T_2526: (in a7_2368 - 1<i32> : word32)
   Class: Eq_2526
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_2529 t0000)))
 T_2527: (in 0<32> : word32)
   Class: Eq_2527
@@ -12999,8 +12623,8 @@ T_2528: (in a7_2368 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2529: (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_2530: (in 0<32> : word32)
   Class: Eq_2530
@@ -13052,7 +12676,7 @@ T_2541: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_2542: (in Mem1625[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_2540
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
 T_2543: (in d0_2124 : uint32)
   Class: Eq_2543
@@ -13152,7 +12776,7 @@ T_2566: (in (byte) d7 == 0x78<8> : bool)
   OrigDataType: bool
 T_2567: (in 0x30<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2568: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_2568
@@ -13321,7 +12945,7 @@ T_2608: (in Mem2445[a7_2443 + 0<32>:word32] : word32)
 T_2609: (in out d1 : ptr32)
   Class: Eq_1063
   DataType: Eq_1063
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_2610: (in out a1 : ptr32)
   Class: Eq_1064
   DataType: (ptr32 word32)
@@ -13351,8 +12975,8 @@ T_2616: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_2617: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_2618: (in a0_2462 : (ptr32 byte))
   Class: Eq_1075
@@ -13412,8 +13036,8 @@ T_2631: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_2632: (in Mem2469[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_2633: (in v351_2473 : byte)
   Class: Eq_1090
   DataType: byte
@@ -13532,12 +13156,12 @@ T_2661: (in 55<i32> : int32)
   OrigDataType: int32
 T_2662: (in a7_1330 + 55<i32> : word32)
   Class: Eq_2662
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_2663: (in Mem2506[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_2663
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2664: (in SEQ(SLICE(d0_2450, word24, 8), Mem2506[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_2659
   DataType: ui32
@@ -13612,7 +13236,7 @@ T_2681: (in __btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[(int3
   OrigDataType: bool
 T_2682: (in 0x78<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_2683: (in d0 != 0x78<32> : bool)
   Class: Eq_2683
@@ -13662,7 +13286,7 @@ T_2694: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_2693
   DataType: word32
   OrigDataType: word32
-T_2695: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_2695: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_2695
   DataType: bool
   OrigDataType: bool
@@ -13829,7 +13453,7 @@ T_2735: (in Mem2554[a7_2552 + 0<32>:word32] : word32)
 T_2736: (in out d1 : ptr32)
   Class: Eq_1063
   DataType: Eq_1063
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_2737: (in out a1 : ptr32)
   Class: Eq_1064
   DataType: (ptr32 word32)
@@ -13859,8 +13483,8 @@ T_2743: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_2744: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_2745: (in a0_2571 : (ptr32 byte))
   Class: Eq_1075
@@ -13920,8 +13544,8 @@ T_2758: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_2759: (in Mem2578[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_2760: (in v372_2582 : byte)
   Class: Eq_1090
   DataType: byte
@@ -14044,12 +13668,12 @@ T_2789: (in 55<i32> : int32)
   OrigDataType: int32
 T_2790: (in a7_1330 + 55<i32> : word32)
   Class: Eq_2790
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_2791: (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_2791
-  DataType: Eq_2791
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_2791 u2))
+  DataType: uint8
+  OrigDataType: uint8
 T_2792: (in SEQ(SLICE(d0_2559, word24, 8), Mem2603[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_2792
   DataType: ui32
@@ -14058,7 +13682,7 @@ T_2793: (in 0xFF<32> : word32)
   Class: Eq_2793
   DataType: ui32
   OrigDataType: ui32
-T_2794: (in SEQ(SLICE(d0_2559, word24, 8), *((word32) a7_1330 + 55<i32>)) & 0xFF<32> : word32)
+T_2794: (in SEQ(SLICE(d0_2559, word24, 8), a7_1330->b0037) & 0xFF<32> : word32)
   Class: Eq_2794
   DataType: int32
   OrigDataType: int32
@@ -14128,7 +13752,7 @@ T_2810: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_2811: (in Mem2726[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_2808
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
 T_2812: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_2812
@@ -14231,9 +13855,9 @@ T_2836: (in a7_1330 + 132<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2837: (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_698
-  OrigDataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: word32
 T_2838: (in 52<i32> : int32)
   Class: Eq_2838
   DataType: int32
@@ -14244,8 +13868,8 @@ T_2839: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_2840: (in Mem2796[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_705
-  DataType: Eq_698
-  OrigDataType: Eq_705
+  DataType: Eq_705
+  OrigDataType: word32
 T_2841: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_2841
   DataType: Eq_2841
@@ -14260,8 +13884,8 @@ T_2843: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_2844: (in Mem2801[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_2841
-  DataType: Eq_698
-  OrigDataType: Eq_2841
+  DataType: Eq_2841
+  OrigDataType: word32
 T_2845: (in 0x44<32> : word32)
   Class: Eq_2845
   DataType: ui32
@@ -14364,7 +13988,7 @@ T_2869: (in 1<i32> : int32)
   OrigDataType: int32
 T_2870: (in a7_2667 - 1<i32> : word32)
   Class: Eq_2870
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_2873 t0000)))
 T_2871: (in 0<32> : word32)
   Class: Eq_2871
@@ -14375,8 +13999,8 @@ T_2872: (in a7_2667 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2873: (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_2874: (in 0<32> : word32)
   Class: Eq_2874
@@ -14410,7 +14034,7 @@ T_2881: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_2880
   DataType: word32
   OrigDataType: word32
-T_2882: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_2882: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_2882
   DataType: bool
   OrigDataType: bool
@@ -14491,8 +14115,8 @@ T_2901: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_2902: (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_2903: (in 110<i32> : int32)
   Class: Eq_2903
@@ -14510,7 +14134,7 @@ T_2906: (in 0<32> : word32)
   Class: Eq_2905
   DataType: word32
   OrigDataType: word32
-T_2907: (in *((word32) a7_1330 + 110<i32>) == 0<32> : bool)
+T_2907: (in a7_1330->dw006E == 0<32> : bool)
   Class: Eq_2907
   DataType: bool
   OrigDataType: bool
@@ -14530,7 +14154,7 @@ T_2911: (in 0xA<32> : word32)
   Class: Eq_2910
   DataType: word32
   OrigDataType: word32
-T_2912: (in *((word32) a7_1330 + 114<i32>) != 0xA<32> : bool)
+T_2912: (in a7_1330->dw0072 != 0xA<32> : bool)
   Class: Eq_2912
   DataType: bool
   OrigDataType: bool
@@ -14550,7 +14174,7 @@ T_2916: (in 8<32> : word32)
   Class: Eq_2915
   DataType: word32
   OrigDataType: word32
-T_2917: (in *((word32) a7_1330 + 114<i32>) != 8<32> : bool)
+T_2917: (in a7_1330->dw0072 != 8<32> : bool)
   Class: Eq_2917
   DataType: bool
   OrigDataType: bool
@@ -14611,9 +14235,9 @@ T_2931: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_2932: (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_698
-  OrigDataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: word32
 T_2933: (in 52<i32> : int32)
   Class: Eq_2933
   DataType: int32
@@ -14624,8 +14248,8 @@ T_2934: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_2935: (in Mem2823[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_705
-  DataType: Eq_698
-  OrigDataType: Eq_705
+  DataType: Eq_705
+  OrigDataType: word32
 T_2936: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_2936
   DataType: Eq_2936
@@ -14640,8 +14264,8 @@ T_2938: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_2939: (in Mem2825[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_2936
-  DataType: Eq_698
-  OrigDataType: Eq_2936
+  DataType: Eq_2936
+  OrigDataType: word32
 T_2940: (in 4<32> : word32)
   Class: Eq_2940
   DataType: ui32
@@ -14671,9 +14295,9 @@ T_2946: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_2947: (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_698
-  OrigDataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: word32
 T_2948: (in 52<i32> : int32)
   Class: Eq_2948
   DataType: int32
@@ -14684,8 +14308,8 @@ T_2949: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_2950: (in Mem2854[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_705
-  DataType: Eq_698
-  OrigDataType: Eq_705
+  DataType: Eq_705
+  OrigDataType: word32
 T_2951: (in 64<i32> : int32)
   Class: Eq_2951
   DataType: int32
@@ -14695,9 +14319,9 @@ T_2952: (in a7_1330 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_2953: (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_698
-  OrigDataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: word32
 T_2954: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_2954
   DataType: Eq_2954
@@ -14712,8 +14336,8 @@ T_2956: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_2957: (in Mem2869[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_2954
-  DataType: Eq_698
-  OrigDataType: Eq_2954
+  DataType: Eq_2954
+  OrigDataType: word32
 T_2958: (in d6_1133 - d3_2423 : word32)
   Class: Eq_2958
   DataType: Eq_2958
@@ -14735,9 +14359,9 @@ T_2962: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_2963: (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_698
-  OrigDataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: word32
 T_2964: (in 52<i32> : int32)
   Class: Eq_2964
   DataType: int32
@@ -14748,8 +14372,8 @@ T_2965: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_2966: (in Mem2840[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_705
-  DataType: Eq_698
-  OrigDataType: Eq_705
+  DataType: Eq_705
+  OrigDataType: word32
 T_2967: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_2967
   DataType: Eq_2967
@@ -14764,11 +14388,11 @@ T_2969: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_2970: (in Mem2843[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_2967
-  DataType: Eq_698
-  OrigDataType: Eq_2967
+  DataType: Eq_2967
+  OrigDataType: word32
 T_2971: (in 0x37<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_2972: (in d5_1044 > 0x37<32> : bool)
   Class: Eq_2972
@@ -14808,19 +14432,19 @@ T_2980: (in 0<i32> : int32)
   OrigDataType: int32
 T_2981: (in 0x30<32> : word32)
   Class: Eq_2981
-  DataType: byte
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
-T_2982: (in d5_1044 - 0x30<32> : word32)
+  DataType: (ptr32 Eq_8303)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
+T_2982: (in d5_1044 - (struct Eq_8303 *) 0x30<32> : word32)
   Class: Eq_705
   DataType: Eq_705
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
-T_2983: (in d6_3015 : Eq_2983)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
+T_2983: (in d6_3015 : (ptr32 Eq_8304))
   Class: Eq_2983
-  DataType: Eq_2983
-  OrigDataType: byte
-T_2984: (in v419_2893 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+  DataType: (ptr32 Eq_8304)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
+T_2984: (in v419_2893 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_2985: (in 4<i32> : int32)
   Class: Eq_2985
@@ -14828,7 +14452,7 @@ T_2985: (in 4<i32> : int32)
   OrigDataType: int32
 T_2986: (in a7_1330 - 4<i32> : word32)
   Class: Eq_2986
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_2989 t0000)))
 T_2987: (in 0<32> : word32)
   Class: Eq_2987
@@ -14839,8 +14463,8 @@ T_2988: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2989: (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_2990: (in a7_1330 - 4<i32> : word32)
   Class: Eq_2990
@@ -14876,8 +14500,8 @@ T_2997: (in Mem2975[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_2998: (in d2_2977 : word32)
   Class: Eq_2998
-  DataType: Eq_2998
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  DataType: (ptr32 Eq_8305)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_2999: (in 68<i32> : int32)
   Class: Eq_2999
   DataType: int32
@@ -14888,12 +14512,12 @@ T_3000: (in a7_1330 + 68<i32> : word32)
   OrigDataType: ptr32
 T_3001: (in Mem2975[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_3001
-  DataType: Eq_3001
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  DataType: (ptr32 Eq_8307)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_3002: (in d4_2510 + Mem2975[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_2998
-  DataType: Eq_2998
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  DataType: (ptr32 Eq_8305)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_3003: (in 48<i32> : int32)
   Class: Eq_3003
   DataType: int32
@@ -14904,8 +14528,8 @@ T_3004: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_3005: (in Mem2980[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_2998
-  DataType: Eq_698
-  OrigDataType: Eq_2998
+  DataType: (ptr32 Eq_8305)
+  OrigDataType: word32
 T_3006: (in 8<i32> : int32)
   Class: Eq_3006
   DataType: int32
@@ -14956,9 +14580,9 @@ T_3017: (in Mem2986[a7_1330 + 64<i32>:word32] + d0_2969 : word32)
   OrigDataType: word32
 T_3018: (in 0<32> : word32)
   Class: Eq_2998
-  DataType: byte
+  DataType: (ptr32 Eq_8305)
   OrigDataType: up32
-T_3019: (in d2_2977 < 0<32> : bool)
+T_3019: (in d2_2977 < null : bool)
   Class: Eq_3019
   DataType: Eq_3019
   OrigDataType: (union (bool u0) (word32 u1))
@@ -14976,8 +14600,8 @@ T_3022: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_3023: (in Mem2992[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_3020
-  DataType: Eq_698
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_3024: (in v441_2993 : word32)
   Class: Eq_3024
   DataType: word32
@@ -15080,20 +14704,20 @@ T_3048: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t
   OrigDataType: bool
 T_3049: (in 0<i32> : int32)
   Class: Eq_2983
-  DataType: byte
+  DataType: (ptr32 Eq_8304)
   OrigDataType: int32
 T_3050: (in 0x37<32> : word32)
   Class: Eq_3050
-  DataType: byte
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
-T_3051: (in d5_1044 - 0x37<32> : word32)
+  DataType: (ptr32 Eq_8309)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
+T_3051: (in d5_1044 - (struct Eq_8309 *) 0x37<32> : word32)
   Class: Eq_2983
-  DataType: Eq_2983
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
-T_3052: (in d2_3074 : Eq_3052)
+  DataType: (ptr32 Eq_8304)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
+T_3052: (in d2_3074 : (ptr32 Eq_8310))
   Class: Eq_3052
-  DataType: Eq_3052
-  OrigDataType: byte
+  DataType: (ptr32 Eq_8310)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_3053: (in a7_1330 - 4<i32> : word32)
   Class: Eq_3053
   DataType: (ptr32 word32)
@@ -15144,8 +14768,8 @@ T_3064: (in Mem3035[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_3065: (in d2_3037 : word32)
   Class: Eq_3065
-  DataType: Eq_3065
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  DataType: (ptr32 Eq_8307)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_3066: (in 48<i32> : int32)
   Class: Eq_3066
   DataType: int32
@@ -15156,12 +14780,12 @@ T_3067: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_3068: (in Mem3035[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_3068
-  DataType: Eq_3068
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  DataType: (ptr32 Eq_8313)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_3069: (in d6_3015 + Mem3035[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_3065
-  DataType: Eq_3065
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  DataType: (ptr32 Eq_8307)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_3070: (in 68<i32> : int32)
   Class: Eq_3070
   DataType: int32
@@ -15172,8 +14796,8 @@ T_3071: (in a7_1330 + 68<i32> : word32)
   OrigDataType: (ptr32 (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_705)) u1) (T_3001 u3)))
 T_3072: (in Mem3040[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_3065
-  DataType: Eq_698
-  OrigDataType: Eq_3065
+  DataType: (ptr32 Eq_8307)
+  OrigDataType: (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_705)) u1) (T_3001 u3))
 T_3073: (in 8<i32> : int32)
   Class: Eq_3073
   DataType: int32
@@ -15224,13 +14848,13 @@ T_3084: (in Mem3045[a7_1330 + 44<i32>:word32] + d0_3029 : word32)
   OrigDataType: int32
 T_3085: (in 0<32> : word32)
   Class: Eq_3065
-  DataType: byte
+  DataType: (ptr32 Eq_8307)
   OrigDataType: up32
-T_3086: (in d2_3037 < 0<32> : bool)
+T_3086: (in d2_3037 < null : bool)
   Class: Eq_3086
   DataType: bool
   OrigDataType: bool
-T_3087: (in (word32) *((word32) a7_1330 + 44<i32>) + d0_3029 + (d2_3037 < 0<32>) : word32)
+T_3087: (in (word32) a7_1330[11<i32>] + d0_3029 + (d2_3037 < null) : word32)
   Class: Eq_3087
   DataType: int32
   OrigDataType: int32
@@ -15244,8 +14868,8 @@ T_3089: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_3090: (in Mem3051[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_3087
-  DataType: Eq_698
-  OrigDataType: int32
+  DataType: int32
+  OrigDataType: word32
 T_3091: (in v453_3052 : word32)
   Class: Eq_3091
   DataType: word32
@@ -15328,23 +14952,23 @@ T_3110: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t
   OrigDataType: bool
 T_3111: (in 0<i32> : int32)
   Class: Eq_3052
-  DataType: byte
+  DataType: (ptr32 Eq_8310)
   OrigDataType: int32
 T_3112: (in 0x57<32> : word32)
   Class: Eq_3112
-  DataType: byte
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
-T_3113: (in d5_1044 - 0x57<32> : word32)
+  DataType: (ptr32 Eq_8313)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
+T_3113: (in d5_1044 - (struct Eq_8313 *) 0x57<32> : word32)
   Class: Eq_3052
-  DataType: Eq_3052
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  DataType: (ptr32 Eq_8310)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_3114: (in d0_3135 : Eq_576)
   Class: Eq_576
   DataType: Eq_576
   OrigDataType: uint32
 T_3115: (in a7_1330 - 4<i32> : word32)
   Class: Eq_3115
-  DataType: (ptr32 Eq_3052)
+  DataType: (ptr32 (ptr32 Eq_8310))
   OrigDataType: (ptr32 (struct (0 T_3118 t0000)))
 T_3116: (in 0<32> : word32)
   Class: Eq_3116
@@ -15356,7 +14980,7 @@ T_3117: (in a7_1330 - 4<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_3118: (in Mem3085[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_3052
-  DataType: Eq_3052
+  DataType: (ptr32 Eq_8310)
   OrigDataType: word32
 T_3119: (in a7_1330 - 4<i32> : word32)
   Class: Eq_3119
@@ -15392,8 +15016,8 @@ T_3126: (in Mem3093[a7_1330 - 4<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_3127: (in d2_3095 : word32)
   Class: Eq_3127
-  DataType: Eq_3127
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  DataType: (ptr32 Eq_8313)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_3128: (in 68<i32> : int32)
   Class: Eq_3128
   DataType: int32
@@ -15405,11 +15029,11 @@ T_3129: (in a7_1330 + 68<i32> : word32)
 T_3130: (in Mem3093[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_3130
   DataType: Eq_3130
-  OrigDataType: (union ((ptr32 Eq_8335) u0) (T_3001 u1) (T_3068 u2) (T_3072 u3))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_705)) u0) (T_3001 u1) (T_3068 u2) (T_3072 u3))
 T_3131: (in d2_3074 + Mem3093[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_3127
-  DataType: Eq_3127
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  DataType: (ptr32 Eq_8313)
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_3132: (in 48<i32> : int32)
   Class: Eq_3132
   DataType: int32
@@ -15420,8 +15044,8 @@ T_3133: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_705)) u1) (T_3068 u3)))
 T_3134: (in Mem3098[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_3127
-  DataType: Eq_698
-  OrigDataType: Eq_3127
+  DataType: (ptr32 Eq_8313)
+  OrigDataType: (union (uint32 u0) (ptr32 u2) ((ptr32 (ptr32 Eq_705)) u1) (T_3068 u3))
 T_3135: (in 8<i32> : int32)
   Class: Eq_3135
   DataType: int32
@@ -15468,9 +15092,9 @@ T_3145: (in Mem3103[a7_1330 + 64<i32>:word32] + (d2_3074 >> 31<i32>) : word32)
   OrigDataType: word32
 T_3146: (in 0<32> : word32)
   Class: Eq_3127
-  DataType: byte
+  DataType: (ptr32 Eq_8313)
   OrigDataType: up32
-T_3147: (in d2_3095 < 0<32> : bool)
+T_3147: (in d2_3095 < null : bool)
   Class: Eq_3147
   DataType: Eq_3147
   OrigDataType: (union (bool u0) (word32 u1))
@@ -15488,8 +15112,8 @@ T_3150: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_3151: (in Mem3108[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_3148
-  DataType: Eq_698
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_3152: (in a0_3119 : (ptr32 ui32))
   Class: Eq_3152
   DataType: (ptr32 ui32)
@@ -15528,7 +15152,7 @@ T_3160: (in Mem3108[a7_1330 - 8<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_3161: (in a7_1330 - 4<i32> : word32)
   Class: Eq_3161
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_3164 t0000)))
 T_3162: (in 0<32> : word32)
   Class: Eq_3162
@@ -15539,8 +15163,8 @@ T_3163: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3164: (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_3165: (in 0<32> : word32)
   Class: Eq_3165
@@ -15695,8 +15319,8 @@ T_3202: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_3203: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_3204: (in a0_3146 : (ptr32 byte))
   Class: Eq_1075
@@ -15748,8 +15372,8 @@ T_3215: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_3216: (in Mem3153[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_3217: (in 0<32> : word32)
   Class: Eq_3217
   DataType: word32
@@ -15828,7 +15452,7 @@ T_3235: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_3236: (in Mem3172[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_3233
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
 T_3237: (in d0_3184 : uint32)
   Class: Eq_3237
@@ -15904,7 +15528,7 @@ T_3254: (in (d0_3184 & 0x44<32>) == 0<32> : bool)
   OrigDataType: bool
 T_3255: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_3256: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_3256
@@ -15920,7 +15544,7 @@ T_3258: (in d3_2423 != 2<32> : bool)
   OrigDataType: bool
 T_3259: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_3260: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_3260
@@ -16008,7 +15632,7 @@ T_3280: (in 1<i32> : int32)
   OrigDataType: int32
 T_3281: (in a7_3259 - 1<i32> : word32)
   Class: Eq_3281
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_3284 t0000)))
 T_3282: (in 0<32> : word32)
   Class: Eq_3282
@@ -16019,8 +15643,8 @@ T_3283: (in a7_3259 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3284: (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_3285: (in 0<32> : word32)
   Class: Eq_3285
@@ -16104,7 +15728,7 @@ T_3304: (in 1<i32> : int32)
   OrigDataType: int32
 T_3305: (in a7_2635 - 1<i32> : word32)
   Class: Eq_3305
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_3308 t0000)))
 T_3306: (in 0<32> : word32)
   Class: Eq_3306
@@ -16115,8 +15739,8 @@ T_3307: (in a7_2635 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3308: (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_3309: (in 0<32> : word32)
   Class: Eq_3309
@@ -16236,7 +15860,7 @@ T_3337: (in a4_2881 - (v465_3109 + 1<32>) >= 0<32> : bool)
   OrigDataType: bool
 T_3338: (in 0x37<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_3339: (in d1 > 0x37<32> : bool)
   Class: Eq_3339
@@ -16259,8 +15883,8 @@ T_3343: (in a7_2886 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3344: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_3345: (in 0<32> : word32)
   Class: Eq_3345
@@ -16271,16 +15895,16 @@ T_3346: (in a7_2886 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_3347: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_3348: (in 31<i32> : int32)
   Class: Eq_3348
   DataType: int32
   OrigDataType: int32
 T_3349: (in d7 >> 31<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
 T_3350: (in 0<32> : word32)
   Class: Eq_3350
@@ -16291,8 +15915,8 @@ T_3351: (in a7_2886 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_3352: (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_3353: (in 4<i32> : int32)
   Class: Eq_3353
@@ -16320,7 +15944,7 @@ T_3358: (in 8<i32> : int32)
   OrigDataType: int32
 T_3359: (in a7_2886 - 8<i32> : word32)
   Class: Eq_3359
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
   OrigDataType: (ptr32 (struct (0 T_3362 t0000)))
 T_3360: (in 0<32> : word32)
   Class: Eq_3360
@@ -16331,8 +15955,8 @@ T_3361: (in a7_2886 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3362: (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_3363: (in 52<i32> : int32)
   Class: Eq_3363
@@ -16458,21 +16082,21 @@ T_3393: (in d4 : Eq_705)
   Class: Eq_705
   DataType: Eq_705
   OrigDataType: word32
-T_3394: (in dwArg04 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_3394: (in dwArg04 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_3395: (in dwArg08 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_3395: (in dwArg08 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_3396: (in dwArg0C : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_3396: (in dwArg0C : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_3397: (in dwArg10 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_3397: (in dwArg10 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_3398: (in d1Out : ptr32)
   Class: Eq_3398
@@ -16480,7 +16104,7 @@ T_3398: (in d1Out : ptr32)
   OrigDataType: ptr32
 T_3399: (in a7_2886 - 24<i32> : word32)
   Class: Eq_3399
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_3402 t0000)))
 T_3400: (in 0<32> : word32)
   Class: Eq_3400
@@ -16491,8 +16115,8 @@ T_3401: (in a7_2886 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3402: (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_3403: (in 20<i32> : int32)
   Class: Eq_3403
@@ -16500,7 +16124,7 @@ T_3403: (in 20<i32> : int32)
   OrigDataType: int32
 T_3404: (in a7_2886 - 20<i32> : word32)
   Class: Eq_3404
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_3407 t0000)))
 T_3405: (in 0<32> : word32)
   Class: Eq_3405
@@ -16511,8 +16135,8 @@ T_3406: (in a7_2886 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3407: (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_3408: (in 16<i32> : int32)
   Class: Eq_3408
@@ -16520,7 +16144,7 @@ T_3408: (in 16<i32> : int32)
   OrigDataType: int32
 T_3409: (in a7_2886 - 16<i32> : word32)
   Class: Eq_3409
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_3412 t0000)))
 T_3410: (in 0<32> : word32)
   Class: Eq_3410
@@ -16531,8 +16155,8 @@ T_3411: (in a7_2886 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3412: (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_3413: (in 12<i32> : int32)
   Class: Eq_3413
@@ -16540,7 +16164,7 @@ T_3413: (in 12<i32> : int32)
   OrigDataType: int32
 T_3414: (in a7_2886 - 12<i32> : word32)
   Class: Eq_3414
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_3417 t0000)))
 T_3415: (in 0<32> : word32)
   Class: Eq_3415
@@ -16551,8 +16175,8 @@ T_3416: (in a7_2886 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3417: (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_3418: (in out d1_2921 : ptr32)
   Class: Eq_3398
@@ -16596,12 +16220,12 @@ T_3427: (in 1<32> : word32)
   OrigDataType: word32
 T_3428: (in a7_2886 + 1<32> : word32)
   Class: Eq_3428
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3429: (in Mem2934[a7_2886 + 1<32>:word24] : word24)
   Class: Eq_3429
-  DataType: Eq_3429
-  OrigDataType: (union (ui24 u0) (word32 u1))
+  DataType: ui24
+  OrigDataType: ui24
 T_3430: (in SLICE(d5_1044, byte, 0) : byte)
   Class: Eq_3430
   DataType: uint8
@@ -16614,7 +16238,7 @@ T_3432: (in 0xFF<32> : word32)
   Class: Eq_3432
   DataType: ui32
   OrigDataType: ui32
-T_3433: (in SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32> : word32)
+T_3433: (in SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32> : word32)
   Class: Eq_3433
   DataType: int32
   OrigDataType: int32
@@ -16638,7 +16262,7 @@ T_3438: (in 4<32> : word32)
   Class: Eq_3438
   DataType: ui32
   OrigDataType: ui32
-T_3439: (in (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32> : word32)
+T_3439: (in (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32> : word32)
   Class: Eq_3439
   DataType: ui32
   OrigDataType: ui32
@@ -16646,7 +16270,7 @@ T_3440: (in 0<32> : word32)
   Class: Eq_3439
   DataType: ui32
   OrigDataType: word32
-T_3441: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32>) == 0<32> : bool)
+T_3441: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32>) == 0<32> : bool)
   Class: Eq_3441
   DataType: bool
   OrigDataType: bool
@@ -16682,7 +16306,7 @@ T_3449: (in 0<8> : byte)
   Class: Eq_3448
   DataType: byte
   OrigDataType: byte
-T_3450: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_3450: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_3450
   DataType: bool
   OrigDataType: bool
@@ -16740,7 +16364,7 @@ T_3463: (in 1<i32> : int32)
   OrigDataType: int32
 T_3464: (in a7_3299 - 1<i32> : word32)
   Class: Eq_3464
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_3467 t0000)))
 T_3465: (in 0<32> : word32)
   Class: Eq_3465
@@ -16751,8 +16375,8 @@ T_3466: (in a7_3299 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3467: (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_3468: (in 0<32> : word32)
   Class: Eq_3468
@@ -16784,7 +16408,7 @@ T_3474: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_3475: (in Mem2714[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_3472
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
 T_3476: (in 8<32> : word32)
   Class: Eq_3476
@@ -16800,7 +16424,7 @@ T_3478: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_3479: (in Mem2717[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_3476
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
 T_3480: (in 52<i32> : int32)
   Class: Eq_3480
@@ -16858,7 +16482,7 @@ T_3493: (in 0x2D<32> : word32)
   Class: Eq_3492
   DataType: word32
   OrigDataType: word32
-T_3494: (in *((word32) a7_1330 + 110<i32>) != 0x2D<32> : bool)
+T_3494: (in a7_1330->dw006E != 0x2D<32> : bool)
   Class: Eq_3494
   DataType: bool
   OrigDataType: bool
@@ -16924,7 +16548,7 @@ T_3509: (in 4<i32> : int32)
   OrigDataType: int32
 T_3510: (in a7_3474 + 4<i32> : word32)
   Class: Eq_698
-  DataType: Eq_698
+  DataType: (ptr32 Eq_698)
   OrigDataType: ptr32
 T_3511: (in 56<i32> : int32)
   Class: Eq_3511
@@ -16952,11 +16576,11 @@ T_3516: (in d0_3495 : word32)
   OrigDataType: uint32
 T_3517: (in 3<32> : word32)
   Class: Eq_3517
-  DataType: (ptr32 Eq_8336)
+  DataType: (ptr32 Eq_8317)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3518: (in d2_1090 + 3<32> : word32)
   Class: Eq_3518
-  DataType: (ptr32 Eq_8337)
+  DataType: (ptr32 Eq_8318)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3519: (in 2<32> : word32)
   Class: Eq_3519
@@ -16979,8 +16603,8 @@ T_3523: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3524: (in (d0_3495 << 2<32>) + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_3525: (in a0_3501 : (ptr32 Eq_3525))
   Class: Eq_3525
@@ -16992,7 +16616,7 @@ T_3526: (in -4<i32> : int32)
   OrigDataType: int32
 T_3527: (in d2_1090 + -4<i32> : word32)
   Class: Eq_3527
-  DataType: (ptr32 Eq_8338)
+  DataType: (ptr32 Eq_8319)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3528: (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_3525
@@ -17096,11 +16720,11 @@ T_3552: (in v517_3507 == 0<8> : bool)
   OrigDataType: bool
 T_3553: (in 3<32> : word32)
   Class: Eq_3553
-  DataType: (ptr32 Eq_8339)
+  DataType: (ptr32 Eq_8320)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3554: (in d2_1090 + 3<32> : word32)
   Class: Eq_3554
-  DataType: (ptr32 Eq_8340)
+  DataType: (ptr32 Eq_8321)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3555: (in 2<32> : word32)
   Class: Eq_3555
@@ -17123,8 +16747,8 @@ T_3559: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3560: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_3561: (in 52<i32> : int32)
   Class: Eq_3561
@@ -17148,7 +16772,7 @@ T_3565: (in -4<i32> : int32)
   OrigDataType: int32
 T_3566: (in d2_1090 + -4<i32> : word32)
   Class: Eq_3566
-  DataType: (ptr32 Eq_8341)
+  DataType: (ptr32 Eq_8322)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3567: (in Mem3508[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_3567
@@ -17164,8 +16788,8 @@ T_3569: (in Mem3508[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_3570: (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
   Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: byte
+  DataType: Eq_656
+  OrigDataType: Eq_576
 T_3571: (in v518_3524 : byte)
   Class: Eq_3505
   DataType: byte
@@ -17212,11 +16836,11 @@ T_3581: (in v518_3524 == 0<8> : bool)
   OrigDataType: bool
 T_3582: (in 3<32> : word32)
   Class: Eq_3582
-  DataType: (ptr32 Eq_8342)
+  DataType: (ptr32 Eq_8323)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3583: (in d2_1090 + 3<32> : word32)
   Class: Eq_3583
-  DataType: (ptr32 Eq_8343)
+  DataType: (ptr32 Eq_8324)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3584: (in 2<32> : word32)
   Class: Eq_3584
@@ -17239,8 +16863,8 @@ T_3588: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3589: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_3590: (in 52<i32> : int32)
   Class: Eq_3590
@@ -17264,7 +16888,7 @@ T_3594: (in -4<i32> : int32)
   OrigDataType: int32
 T_3595: (in d2_1090 + -4<i32> : word32)
   Class: Eq_3595
-  DataType: (ptr32 Eq_8344)
+  DataType: (ptr32 Eq_8325)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3596: (in Mem3525[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_3596
@@ -17280,8 +16904,8 @@ T_3598: (in Mem3525[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_3599: (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
   Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: word16
+  DataType: Eq_656
+  OrigDataType: Eq_576
 T_3600: (in v519_3541 : byte)
   Class: Eq_3505
   DataType: byte
@@ -17328,11 +16952,11 @@ T_3610: (in v519_3541 == 0<8> : bool)
   OrigDataType: bool
 T_3611: (in 3<32> : word32)
   Class: Eq_3611
-  DataType: (ptr32 Eq_8345)
+  DataType: (ptr32 Eq_8326)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3612: (in d2_1090 + 3<32> : word32)
   Class: Eq_3612
-  DataType: (ptr32 Eq_8346)
+  DataType: (ptr32 Eq_8327)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3613: (in 2<32> : word32)
   Class: Eq_3613
@@ -17355,8 +16979,8 @@ T_3617: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3618: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_3619: (in 52<i32> : int32)
   Class: Eq_3619
@@ -17376,7 +17000,7 @@ T_3622: (in -4<i32> : int32)
   OrigDataType: int32
 T_3623: (in d2_1090 + -4<i32> : word32)
   Class: Eq_3623
-  DataType: (ptr32 Eq_8347)
+  DataType: (ptr32 Eq_8328)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3624: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_3624
@@ -17392,15 +17016,15 @@ T_3626: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_3627: (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: word32
+  DataType: Eq_656
+  OrigDataType: Eq_576
 T_3628: (in 3<32> : word32)
   Class: Eq_3628
-  DataType: (ptr32 Eq_8348)
+  DataType: (ptr32 Eq_8329)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3629: (in d2_1090 + 3<32> : word32)
   Class: Eq_3629
-  DataType: (ptr32 Eq_8349)
+  DataType: (ptr32 Eq_8330)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3630: (in 2<32> : word32)
   Class: Eq_3630
@@ -17423,8 +17047,8 @@ T_3634: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3635: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_3636: (in 52<i32> : int32)
   Class: Eq_3636
@@ -17444,7 +17068,7 @@ T_3639: (in -4<i32> : int32)
   OrigDataType: int32
 T_3640: (in d2_1090 + -4<i32> : word32)
   Class: Eq_3640
-  DataType: (ptr32 Eq_8350)
+  DataType: (ptr32 Eq_8331)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3641: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_3641
@@ -17460,8 +17084,8 @@ T_3643: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_3644: (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: word32
+  DataType: Eq_656
+  OrigDataType: Eq_576
 T_3645: (in 60<i32> : int32)
   Class: Eq_3645
   DataType: int32
@@ -17488,7 +17112,7 @@ T_3650: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_3651: (in Mem3574[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_3649
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
 T_3652: (in 48<i32> : int32)
   Class: Eq_3652
@@ -17508,12 +17132,12 @@ T_3655: (in 56<i32> : int32)
   OrigDataType: int32
 T_3656: (in a7_1330 + 56<i32> : word32)
   Class: Eq_3656
-  DataType: (ptr32 Eq_3656)
-  OrigDataType: (ptr32 (union (uint8 u0) (word32 u1) (T_2791 u2)))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3657: (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
   Class: Eq_3654
   DataType: Eq_3654
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_2791 u2))
+  OrigDataType: word32
 T_3658: (in 44<i32> : int32)
   Class: Eq_3658
   DataType: int32
@@ -17584,7 +17208,7 @@ T_3674: (in -v528_3348->dw0000 : word32)
   OrigDataType: int32
 T_3675: (in 0<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: up32
 T_3676: (in d1 < 0<32> : bool)
   Class: Eq_3676
@@ -17600,44 +17224,44 @@ T_3678: (in 0x38<32> : word32)
   OrigDataType: word32
 T_3679: (in a7_1330 + 0x38<32> : word32)
   Class: Eq_3679
-  DataType: (ptr32 Eq_3679)
-  OrigDataType: (ptr32 (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3)))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_3680: (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
   Class: Eq_698
-  DataType: Eq_698
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
-T_3681: (in a7_3364 : Eq_3681)
+  DataType: (ptr32 Eq_698)
+  OrigDataType: word32
+T_3681: (in a7_3364 : (ptr32 Eq_3681))
   Class: Eq_3681
-  DataType: Eq_3681
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_3681)
+  OrigDataType: (ptr32 (struct (0 T_3686 t0000) (30 T_3691 t0030) (38 T_3742 t0038) (3C T_607 t003C) (4C T_3689 t004C)))
 T_3682: (in 4<i32> : int32)
   Class: Eq_3682
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_3683: (in a7_1330 - 4<i32> : word32)
   Class: Eq_3681
-  DataType: Eq_3681
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_3681)
+  OrigDataType: ptr32
 T_3684: (in 0<32> : word32)
   Class: Eq_3684
   DataType: word32
   OrigDataType: word32
 T_3685: (in a7_3364 + 0<32> : word32)
   Class: Eq_3685
-  DataType: Eq_3685
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3686: (in Mem3375[a7_3364 + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_3681
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_3687: (in 76<i32> : int32)
   Class: Eq_3687
   DataType: int32
   OrigDataType: int32
 T_3688: (in a7_3364 + 76<i32> : word32)
   Class: Eq_3688
-  DataType: Eq_3688
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3689: (in Mem3375[a7_3364 + 76<i32>:byte] : byte)
   Class: Eq_3689
   DataType: byte
@@ -17646,7 +17270,7 @@ T_3690: (in 1<8> : byte)
   Class: Eq_3690
   DataType: byte
   OrigDataType: byte
-T_3691: (in *((word32) a7_3364 + 76<i32>) - 1<8> : byte)
+T_3691: (in a7_3364->b004C - 1<8> : byte)
   Class: Eq_3691
   DataType: byte
   OrigDataType: byte
@@ -17656,37 +17280,37 @@ T_3692: (in 48<i32> : int32)
   OrigDataType: int32
 T_3693: (in a7_3364 + 48<i32> : word32)
   Class: Eq_3693
-  DataType: Eq_3693
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3694: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
   Class: Eq_3691
-  DataType: Eq_3681
+  DataType: byte
   OrigDataType: byte
 T_3695: (in 4<i32> : int32)
   Class: Eq_3695
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_3696: (in a7_3364 + 4<i32> : word32)
   Class: Eq_698
-  DataType: Eq_698
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_698)
+  OrigDataType: ptr32
 T_3697: (in 48<i32> : int32)
   Class: Eq_3697
   DataType: int32
   OrigDataType: int32
 T_3698: (in a7_3364 + 48<i32> : word32)
   Class: Eq_3698
-  DataType: Eq_3698
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_3699: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_3699
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3700: (in 0<8> : byte)
-  Class: Eq_3699
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
-T_3701: (in *((word32) a7_3364 + 48<i32>) == 0<8> : bool)
+T_3701: (in a7_3364->b0030 == 0<8> : bool)
   Class: Eq_3701
   DataType: bool
   OrigDataType: bool
@@ -17700,28 +17324,28 @@ T_3703: (in 52<i32> : int32)
   OrigDataType: int32
 T_3704: (in a7_1330 + 52<i32> : word32)
   Class: Eq_3704
-  DataType: Eq_3704
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_3705: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_3702
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
-T_3706: (in v544_774 : byte)
+T_3706: (in v544_774 : Eq_3706)
   Class: Eq_3706
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_3706
+  OrigDataType: (union (int32 u0) (byte u1))
 T_3707: (in 44<i32> : int32)
   Class: Eq_3707
   DataType: int32
   OrigDataType: int32
 T_3708: (in a7_1330 + 44<i32> : word32)
   Class: Eq_3708
-  DataType: Eq_3708
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_3709: (in Mem773[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_3706
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_3706
+  OrigDataType: int32
 T_3710: (in SEQ(v84_506, v544_774) : uip32)
   Class: Eq_856
   DataType: int32
@@ -17736,8 +17360,8 @@ T_3712: (in 52<i32> : int32)
   OrigDataType: int32
 T_3713: (in a7_1330 + 52<i32> : word32)
   Class: Eq_3713
-  DataType: Eq_3713
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_3714: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
@@ -17752,12 +17376,12 @@ T_3716: (in 44<i32> : int32)
   OrigDataType: int32
 T_3717: (in a7_1330 + 44<i32> : word32)
   Class: Eq_3717
-  DataType: Eq_3717
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_3718: (in Mem769[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_3715
-  DataType: Eq_698
-  OrigDataType: byte
+  DataType: Eq_3715
+  OrigDataType: int32
 T_3719: (in 1<i32> : int32)
   Class: Eq_3719
   DataType: int32
@@ -17772,11 +17396,11 @@ T_3721: (in d0_3398 : word32)
   OrigDataType: uint32
 T_3722: (in 3<32> : word32)
   Class: Eq_3722
-  DataType: (ptr32 Eq_8361)
+  DataType: (ptr32 Eq_8332)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3723: (in d2_1090 + 3<32> : word32)
   Class: Eq_3723
-  DataType: (ptr32 Eq_8362)
+  DataType: (ptr32 Eq_8333)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3724: (in 2<32> : word32)
   Class: Eq_3724
@@ -17799,8 +17423,8 @@ T_3728: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3729: (in (d0_3398 << 2<32>) + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_3730: (in a0_3404 : (ptr32 Eq_3730))
   Class: Eq_3730
@@ -17812,7 +17436,7 @@ T_3731: (in -4<i32> : int32)
   OrigDataType: int32
 T_3732: (in d2_1090 + -4<i32> : word32)
   Class: Eq_3732
-  DataType: (ptr32 Eq_8363)
+  DataType: (ptr32 Eq_8334)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3733: (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_3730
@@ -17824,11 +17448,11 @@ T_3734: (in 60<i32> : int32)
   OrigDataType: int32
 T_3735: (in a7_3364 + 60<i32> : word32)
   Class: Eq_3735
-  DataType: Eq_3735
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3736: (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_3736
-  DataType: word32
+  Class: Eq_576
+  DataType: Eq_576
   OrigDataType: word32
 T_3737: (in 4<i32> : int32)
   Class: Eq_3737
@@ -17839,8 +17463,8 @@ T_3738: (in a0_3404 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3739: (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
-  Class: Eq_3736
-  DataType: word32
+  Class: Eq_576
+  DataType: Eq_576
   OrigDataType: word32
 T_3740: (in 56<i32> : int32)
   Class: Eq_3740
@@ -17848,8 +17472,8 @@ T_3740: (in 56<i32> : int32)
   OrigDataType: int32
 T_3741: (in a7_3364 + 56<i32> : word32)
   Class: Eq_3741
-  DataType: Eq_3741
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3742: (in Mem3406[a7_3364 + 56<i32>:word32] : word32)
   Class: Eq_3742
   DataType: word32
@@ -17871,7 +17495,7 @@ T_3746: (in d0_3398 << 2<32> : word32)
   DataType: Eq_576
   OrigDataType: ui32
 T_3747: (in v540_3410 : byte)
-  Class: Eq_3747
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3748: (in 48<i32> : int32)
@@ -17880,18 +17504,18 @@ T_3748: (in 48<i32> : int32)
   OrigDataType: int32
 T_3749: (in a7_3364 + 48<i32> : word32)
   Class: Eq_3749
-  DataType: Eq_3749
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_3750: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_3750
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3751: (in 1<8> : byte)
   Class: Eq_3751
   DataType: byte
   OrigDataType: byte
-T_3752: (in *((word32) a7_3364 + 48<i32>) - 1<8> : byte)
-  Class: Eq_3747
+T_3752: (in a7_3364->b0030 - 1<8> : byte)
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3753: (in 48<i32> : int32)
@@ -17900,14 +17524,14 @@ T_3753: (in 48<i32> : int32)
   OrigDataType: int32
 T_3754: (in a7_3364 + 48<i32> : word32)
   Class: Eq_3754
-  DataType: Eq_3754
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_3755: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_3747
-  DataType: Eq_3681
+  Class: Eq_3691
+  DataType: byte
   OrigDataType: byte
 T_3756: (in 0<8> : byte)
-  Class: Eq_3747
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3757: (in v540_3410 == 0<8> : bool)
@@ -17916,11 +17540,11 @@ T_3757: (in v540_3410 == 0<8> : bool)
   OrigDataType: bool
 T_3758: (in 3<32> : word32)
   Class: Eq_3758
-  DataType: (ptr32 Eq_8364)
+  DataType: (ptr32 Eq_8335)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3759: (in d2_1090 + 3<32> : word32)
   Class: Eq_3759
-  DataType: (ptr32 Eq_8365)
+  DataType: (ptr32 Eq_8336)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3760: (in 2<32> : word32)
   Class: Eq_3760
@@ -17943,8 +17567,8 @@ T_3764: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3765: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_3766: (in 60<i32> : int32)
   Class: Eq_3766
@@ -17952,8 +17576,8 @@ T_3766: (in 60<i32> : int32)
   OrigDataType: int32
 T_3767: (in a7_3364 + 60<i32> : word32)
   Class: Eq_3767
-  DataType: Eq_3767
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_3768: (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
@@ -17968,7 +17592,7 @@ T_3770: (in -4<i32> : int32)
   OrigDataType: int32
 T_3771: (in d2_1090 + -4<i32> : word32)
   Class: Eq_3771
-  DataType: (ptr32 Eq_8366)
+  DataType: (ptr32 Eq_8337)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3772: (in Mem3411[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_3772
@@ -17984,10 +17608,10 @@ T_3774: (in Mem3411[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_3775: (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
   Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: byte
+  DataType: Eq_656
+  OrigDataType: Eq_576
 T_3776: (in v541_3427 : byte)
-  Class: Eq_3776
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3777: (in 48<i32> : int32)
@@ -17996,18 +17620,18 @@ T_3777: (in 48<i32> : int32)
   OrigDataType: int32
 T_3778: (in a7_3364 + 48<i32> : word32)
   Class: Eq_3778
-  DataType: Eq_3778
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_3779: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_3779
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3780: (in 0x66<8> : byte)
   Class: Eq_3780
   DataType: byte
   OrigDataType: byte
-T_3781: (in *((word32) a7_3364 + 48<i32>) - 0x66<8> : byte)
-  Class: Eq_3776
+T_3781: (in a7_3364->b0030 - 0x66<8> : byte)
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3782: (in 48<i32> : int32)
@@ -18016,14 +17640,14 @@ T_3782: (in 48<i32> : int32)
   OrigDataType: int32
 T_3783: (in a7_3364 + 48<i32> : word32)
   Class: Eq_3783
-  DataType: Eq_3783
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_3784: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_3776
-  DataType: Eq_3681
+  Class: Eq_3691
+  DataType: byte
   OrigDataType: byte
 T_3785: (in 0<8> : byte)
-  Class: Eq_3776
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3786: (in v541_3427 == 0<8> : bool)
@@ -18032,11 +17656,11 @@ T_3786: (in v541_3427 == 0<8> : bool)
   OrigDataType: bool
 T_3787: (in 3<32> : word32)
   Class: Eq_3787
-  DataType: (ptr32 Eq_8367)
+  DataType: (ptr32 Eq_8338)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3788: (in d2_1090 + 3<32> : word32)
   Class: Eq_3788
-  DataType: (ptr32 Eq_8368)
+  DataType: (ptr32 Eq_8339)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3789: (in 2<32> : word32)
   Class: Eq_3789
@@ -18059,8 +17683,8 @@ T_3793: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3794: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_3795: (in 60<i32> : int32)
   Class: Eq_3795
@@ -18068,8 +17692,8 @@ T_3795: (in 60<i32> : int32)
   OrigDataType: int32
 T_3796: (in a7_3364 + 60<i32> : word32)
   Class: Eq_3796
-  DataType: Eq_3796
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_3797: (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
@@ -18084,7 +17708,7 @@ T_3799: (in -4<i32> : int32)
   OrigDataType: int32
 T_3800: (in d2_1090 + -4<i32> : word32)
   Class: Eq_3800
-  DataType: (ptr32 Eq_8369)
+  DataType: (ptr32 Eq_8340)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3801: (in Mem3428[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_3801
@@ -18100,10 +17724,10 @@ T_3803: (in Mem3428[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_3804: (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
   Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: word16
+  DataType: Eq_656
+  OrigDataType: Eq_576
 T_3805: (in v542_3444 : byte)
-  Class: Eq_3805
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3806: (in 48<i32> : int32)
@@ -18112,18 +17736,18 @@ T_3806: (in 48<i32> : int32)
   OrigDataType: int32
 T_3807: (in a7_3364 + 48<i32> : word32)
   Class: Eq_3807
-  DataType: Eq_3807
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_3808: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_3808
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3809: (in 4<8> : byte)
   Class: Eq_3809
   DataType: byte
   OrigDataType: byte
-T_3810: (in *((word32) a7_3364 + 48<i32>) - 4<8> : byte)
-  Class: Eq_3805
+T_3810: (in a7_3364->b0030 - 4<8> : byte)
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3811: (in 48<i32> : int32)
@@ -18132,14 +17756,14 @@ T_3811: (in 48<i32> : int32)
   OrigDataType: int32
 T_3812: (in a7_3364 + 48<i32> : word32)
   Class: Eq_3812
-  DataType: Eq_3812
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_3813: (in Mem3445[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_3805
-  DataType: Eq_3681
+  Class: Eq_3691
+  DataType: byte
   OrigDataType: byte
 T_3814: (in 0<8> : byte)
-  Class: Eq_3805
+  Class: Eq_3691
   DataType: byte
   OrigDataType: byte
 T_3815: (in v542_3444 == 0<8> : bool)
@@ -18148,11 +17772,11 @@ T_3815: (in v542_3444 == 0<8> : bool)
   OrigDataType: bool
 T_3816: (in 3<32> : word32)
   Class: Eq_3816
-  DataType: (ptr32 Eq_8370)
+  DataType: (ptr32 Eq_8341)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3817: (in d2_1090 + 3<32> : word32)
   Class: Eq_3817
-  DataType: (ptr32 Eq_8371)
+  DataType: (ptr32 Eq_8342)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3818: (in 2<32> : word32)
   Class: Eq_3818
@@ -18175,8 +17799,8 @@ T_3822: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3823: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_3824: (in 60<i32> : int32)
   Class: Eq_3824
@@ -18184,8 +17808,8 @@ T_3824: (in 60<i32> : int32)
   OrigDataType: int32
 T_3825: (in a7_3364 + 60<i32> : word32)
   Class: Eq_3825
-  DataType: Eq_3825
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_3826: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
@@ -18196,7 +17820,7 @@ T_3827: (in -4<i32> : int32)
   OrigDataType: int32
 T_3828: (in d2_1090 + -4<i32> : word32)
   Class: Eq_3828
-  DataType: (ptr32 Eq_8372)
+  DataType: (ptr32 Eq_8343)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3829: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_3829
@@ -18212,15 +17836,15 @@ T_3831: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_3832: (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: word32
+  DataType: Eq_656
+  OrigDataType: Eq_576
 T_3833: (in 3<32> : word32)
   Class: Eq_3833
-  DataType: (ptr32 Eq_8373)
+  DataType: (ptr32 Eq_8344)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3834: (in d2_1090 + 3<32> : word32)
   Class: Eq_3834
-  DataType: (ptr32 Eq_8374)
+  DataType: (ptr32 Eq_8345)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3835: (in 2<32> : word32)
   Class: Eq_3835
@@ -18243,8 +17867,8 @@ T_3839: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3840: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_3841: (in 60<i32> : int32)
   Class: Eq_3841
@@ -18252,8 +17876,8 @@ T_3841: (in 60<i32> : int32)
   OrigDataType: int32
 T_3842: (in a7_3364 + 60<i32> : word32)
   Class: Eq_3842
-  DataType: Eq_3842
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_3843: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
@@ -18264,7 +17888,7 @@ T_3844: (in -4<i32> : int32)
   OrigDataType: int32
 T_3845: (in d2_1090 + -4<i32> : word32)
   Class: Eq_3845
-  DataType: (ptr32 Eq_8375)
+  DataType: (ptr32 Eq_8346)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3846: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_3846
@@ -18280,8 +17904,8 @@ T_3848: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_3849: (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: word32
+  DataType: Eq_656
+  OrigDataType: Eq_576
 T_3850: (in 0<i32> : int32)
   Class: Eq_3850
   DataType: int32
@@ -18295,36 +17919,36 @@ T_3852: (in 0xFF<32> : word32)
   DataType: int32
   OrigDataType: word32
 T_3853: (in SLICE(d5_785, byte, 0) : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_3853
+  DataType: byte
   OrigDataType: byte
 T_3854: (in 78<i32> : int32)
   Class: Eq_3854
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_3855: (in a7_1330 + 78<i32> : word32)
   Class: Eq_3855
-  DataType: Eq_3855
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3856: (in a7_1330 + 78<i32> + d1_1027 : word32)
   Class: Eq_3856
-  DataType: Eq_3856
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_3857 t0000)))
 T_3857: (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_3853
+  DataType: byte
   OrigDataType: byte
 T_3858: (in 1<32> : word32)
   Class: Eq_3858
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: word32
+  OrigDataType: word32
 T_3859: (in d1_1027 + 1<32> : word32)
   Class: Eq_576
   DataType: Eq_576
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  OrigDataType: int32
 T_3860: (in 0x20<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: up32
 T_3861: (in d1_1027 < 0x20<32> : bool)
   Class: Eq_3861
@@ -18344,40 +17968,40 @@ T_3864: (in 132<i32> : int32)
   OrigDataType: int32
 T_3865: (in a7_1330 + 132<i32> : word32)
   Class: Eq_3865
-  DataType: Eq_3865
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_3866: (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_698
-  OrigDataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: word32
 T_3867: (in 44<i32> : int32)
   Class: Eq_3867
   DataType: int32
   OrigDataType: int32
 T_3868: (in a7_1330 + 44<i32> : word32)
   Class: Eq_3868
-  DataType: Eq_3868
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_3869: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_3706
-  DataType: Eq_698
-  OrigDataType: byte
-T_3870: (in v554_824 : byte)
+  DataType: Eq_3706
+  OrigDataType: int32
+T_3870: (in v554_824 : Eq_3870)
   Class: Eq_3870
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_3870
+  OrigDataType: (union (int32 u1) (byte u0))
 T_3871: (in 44<i32> : int32)
   Class: Eq_3871
   DataType: int32
   OrigDataType: int32
 T_3872: (in a7_1330 + 44<i32> : word32)
   Class: Eq_3872
-  DataType: Eq_3872
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_3873: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_3870
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_3870
+  OrigDataType: int32
 T_3874: (in a6_1164 : (ptr32 byte))
   Class: Eq_3874
   DataType: (ptr32 byte)
@@ -18388,11 +18012,11 @@ T_3875: (in 132<i32> : int32)
   OrigDataType: int32
 T_3876: (in a7_1330 + 132<i32> : word32)
   Class: Eq_3876
-  DataType: Eq_3876
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_3877: (in Mem946[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_3878: (in 1<i32> : int32)
   Class: Eq_3878
@@ -18408,8 +18032,8 @@ T_3880: (in 73<i32> : int32)
   OrigDataType: int32
 T_3881: (in a7_1330 + 73<i32> : word32)
   Class: Eq_3881
-  DataType: Eq_3881
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_3882: (in Mem946[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_3882
   DataType: byte
@@ -18418,7 +18042,7 @@ T_3883: (in 0<8> : byte)
   Class: Eq_3882
   DataType: byte
   OrigDataType: byte
-T_3884: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_3884: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_3884
   DataType: bool
   OrigDataType: bool
@@ -18598,18 +18222,18 @@ T_3928: (in v554_824 == 0<8> : bool)
   Class: Eq_3928
   DataType: bool
   OrigDataType: bool
-T_3929: (in a0_881 : Eq_3929)
+T_3929: (in a0_881 : word32)
   Class: Eq_3929
-  DataType: Eq_3929
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_3937 t0000)))
 T_3930: (in 78<i32> : int32)
   Class: Eq_3930
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_3931: (in a7_1330 + 78<i32> : word32)
   Class: Eq_3931
-  DataType: Eq_3931
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3932: (in 3<32> : word32)
   Class: Eq_3932
   DataType: word32
@@ -18617,22 +18241,22 @@ T_3932: (in 3<32> : word32)
 T_3933: (in d5_862 >> 3<32> : word32)
   Class: Eq_3933
   DataType: Eq_3933
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_3934: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_3929
-  DataType: Eq_3929
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_3935: (in 0<32> : word32)
   Class: Eq_3935
   DataType: word32
   OrigDataType: word32
 T_3936: (in a0_881 + 0<32> : word32)
   Class: Eq_3936
-  DataType: Eq_3936
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3937: (in Mem889[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_3937
+  DataType: byte
   OrigDataType: byte
 T_3938: (in (uint8) Mem889[a0_881 + 0<32>:byte] : uint8)
   Class: Eq_3938
@@ -18663,8 +18287,8 @@ T_3944: (in 1<i32> << (d5_862 & 7<i32>) | d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3945: (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_3937
+  DataType: byte
   OrigDataType: byte
 T_3946: (in 0<32> : word32)
   Class: Eq_3946
@@ -18672,24 +18296,24 @@ T_3946: (in 0<32> : word32)
   OrigDataType: word32
 T_3947: (in a0_881 + 0<32> : word32)
   Class: Eq_3947
-  DataType: Eq_3947
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_3948: (in Mem895[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_3929
-  OrigDataType: Eq_576
-T_3949: (in a0_900 : Eq_3949)
+  Class: Eq_3937
+  DataType: byte
+  OrigDataType: byte
+T_3949: (in a0_900 : word32)
   Class: Eq_3949
-  DataType: Eq_3949
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_3957 t0000)))
 T_3950: (in 78<i32> : int32)
   Class: Eq_3950
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_3951: (in a7_1330 + 78<i32> : word32)
   Class: Eq_3951
-  DataType: Eq_3951
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3952: (in 3<32> : word32)
   Class: Eq_3952
   DataType: word32
@@ -18697,22 +18321,22 @@ T_3952: (in 3<32> : word32)
 T_3953: (in d5_862 >> 3<32> : word32)
   Class: Eq_3953
   DataType: Eq_3953
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_3954: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_3949
-  DataType: Eq_3949
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_3955: (in 0<32> : word32)
   Class: Eq_3955
   DataType: word32
   OrigDataType: word32
 T_3956: (in a0_900 + 0<32> : word32)
   Class: Eq_3956
-  DataType: Eq_3956
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3957: (in Mem889[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_3957
+  DataType: byte
   OrigDataType: byte
 T_3958: (in (uint8) Mem889[a0_900 + 0<32>:byte] : uint8)
   Class: Eq_3958
@@ -18747,8 +18371,8 @@ T_3965: (in ~(1<i32> << (d5_862 & 7<i32>)) & d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3966: (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_3957
+  DataType: byte
   OrigDataType: byte
 T_3967: (in 0<32> : word32)
   Class: Eq_3967
@@ -18756,12 +18380,12 @@ T_3967: (in 0<32> : word32)
   OrigDataType: word32
 T_3968: (in a0_900 + 0<32> : word32)
   Class: Eq_3968
-  DataType: Eq_3968
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_3969: (in Mem914[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_3949
-  OrigDataType: Eq_576
+  Class: Eq_3957
+  DataType: byte
+  OrigDataType: byte
 T_3970: (in 1<32> : word32)
   Class: Eq_3970
   DataType: word32
@@ -18804,11 +18428,11 @@ T_3979: (in d0_957 : word32)
   OrigDataType: uint32
 T_3980: (in 3<32> : word32)
   Class: Eq_3980
-  DataType: (ptr32 Eq_8376)
+  DataType: (ptr32 Eq_8347)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3981: (in d2_1090 + 3<32> : word32)
   Class: Eq_3981
-  DataType: (ptr32 Eq_8377)
+  DataType: (ptr32 Eq_8348)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3982: (in 2<32> : word32)
   Class: Eq_3982
@@ -18831,8 +18455,8 @@ T_3986: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3987: (in (d0_957 << 2<32>) + 4<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_3988: (in d0_957 << 2<32> : word32)
   Class: Eq_576
@@ -18844,7 +18468,7 @@ T_3989: (in -4<i32> : int32)
   OrigDataType: int32
 T_3990: (in d2_1090 + -4<i32> : word32)
   Class: Eq_3990
-  DataType: (ptr32 Eq_8378)
+  DataType: (ptr32 Eq_8349)
   OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_576) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_3991: (in Mem946[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_3874
@@ -18970,30 +18594,30 @@ T_4021: (in a3_1955->b0000 == 0<8> : bool)
   Class: Eq_4021
   DataType: bool
   OrigDataType: bool
-T_4022: (in a7_985 : Eq_4022)
+T_4022: (in a7_985 : (ptr32 Eq_4022))
   Class: Eq_4022
-  DataType: Eq_4022
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_4022)
+  OrigDataType: (ptr32 (struct (0 T_607 t0000) (30 T_4039 t0030)))
 T_4023: (in 4<i32> : int32)
   Class: Eq_4023
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4024: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4022
-  DataType: Eq_4022
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_4022)
+  OrigDataType: ptr32
 T_4025: (in 0<32> : word32)
   Class: Eq_4025
   DataType: word32
   OrigDataType: word32
 T_4026: (in a7_985 + 0<32> : word32)
   Class: Eq_4026
-  DataType: Eq_4026
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4027: (in Mem987[a7_985 + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_4022
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_4028: (in a5_5334 : word32)
   Class: Eq_4028
   DataType: word32
@@ -19008,8 +18632,8 @@ T_4030: (in 0<32> : word32)
   OrigDataType: word32
 T_4031: (in a7_985 + 0<32> : word32)
   Class: Eq_4031
-  DataType: Eq_4031
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_4032: (in Mem987[a7_985 + 0<32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
@@ -19017,7 +18641,7 @@ T_4032: (in Mem987[a7_985 + 0<32>:word32] : word32)
 T_4033: (in out d1 : ptr32)
   Class: Eq_1063
   DataType: Eq_1063
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014))) u1) (uint32 u0) (byte u4) (ptr32 u2) (Eq_3068 u3))
+  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_705) ptr0000) (4 Eq_576 t0004) (8 Eq_576 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))) u1) (uint32 u0) (byte u4) (ptr32 u2) (word16 u5) (Eq_3068 u3))
 T_4034: (in out a1 : ptr32)
   Class: Eq_1064
   DataType: (ptr32 word32)
@@ -19026,7 +18650,7 @@ T_4035: (in out a5_5334 : ptr32)
   Class: Eq_1065
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_4036: (in fn00002604(*a7_985, out d1, out a1, out a5_5334) : word32)
+T_4036: (in fn00002604(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
   Class: Eq_576
   DataType: Eq_576
   OrigDataType: word32
@@ -19036,19 +18660,19 @@ T_4037: (in 48<i32> : int32)
   OrigDataType: int32
 T_4038: (in a7_985 + 48<i32> : word32)
   Class: Eq_4038
-  DataType: Eq_4038
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4039: (in Mem1000[a7_985 + 48<i32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_4022
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_4040: (in 4<i32> : int32)
   Class: Eq_4040
   DataType: int32
   OrigDataType: int32
 T_4041: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_4042: (in a0_1004 : (ptr32 byte))
   Class: Eq_1075
@@ -19066,30 +18690,30 @@ T_4045: (in Mem981[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
-T_4046: (in a7_1005 : Eq_4046)
+T_4046: (in a7_1005 : (ptr32 Eq_4046))
   Class: Eq_4046
-  DataType: Eq_4046
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_4046)
+  OrigDataType: (ptr32 (struct (0 T_607 t0000) (30 T_4071 t0030)))
 T_4047: (in 4<i32> : int32)
   Class: Eq_4047
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4048: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4046
-  DataType: Eq_4046
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_4046)
+  OrigDataType: ptr32
 T_4049: (in 0<32> : word32)
   Class: Eq_4049
   DataType: word32
   OrigDataType: word32
 T_4050: (in a7_1005 + 0<32> : word32)
   Class: Eq_4050
-  DataType: Eq_4050
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4051: (in Mem1007[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_4046
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_4052: (in 1<i32> : int32)
   Class: Eq_4052
   DataType: int32
@@ -19108,8 +18732,8 @@ T_4055: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_4056: (in Mem1011[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_4057: (in v585_1015 : byte)
   Class: Eq_1090
   DataType: byte
@@ -19132,8 +18756,8 @@ T_4061: (in 0<32> : word32)
   OrigDataType: word32
 T_4062: (in a7_1005 + 0<32> : word32)
   Class: Eq_4062
-  DataType: Eq_4062
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_4063: (in Mem1011[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
@@ -19144,12 +18768,12 @@ T_4064: (in 0<32> : word32)
   OrigDataType: word32
 T_4065: (in a7_1005 + 0<32> : word32)
   Class: Eq_4065
-  DataType: Eq_4065
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_4066: (in Mem1031[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_4046
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_4067: (in (uint8) v585_1015 : uint8)
   Class: Eq_4067
   DataType: uint8
@@ -19164,12 +18788,12 @@ T_4069: (in 48<i32> : int32)
   OrigDataType: int32
 T_4070: (in a7_1005 + 48<i32> : word32)
   Class: Eq_4070
-  DataType: Eq_4070
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4071: (in Mem1037[a7_1005 + 48<i32>:word32] : word32)
   Class: Eq_4068
-  DataType: Eq_4046
-  OrigDataType: uint32
+  DataType: uint32
+  OrigDataType: word32
 T_4072: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_4072
   DataType: word24
@@ -19184,8 +18808,8 @@ T_4074: (in 0<32> : word32)
   OrigDataType: word32
 T_4075: (in a7_1005 + 0<32> : word32)
   Class: Eq_4075
-  DataType: Eq_4075
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_4076: (in Mem1037[a7_1005 + 0<32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
@@ -19196,12 +18820,12 @@ T_4077: (in 44<i32> : int32)
   OrigDataType: int32
 T_4078: (in a7_1330 + 44<i32> : word32)
   Class: Eq_4078
-  DataType: Eq_4078
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_4079: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
-  OrigDataType: word32
+  OrigDataType: int32
 T_4080: (in d3_1057 : Eq_4080)
   Class: Eq_4080
   DataType: Eq_4080
@@ -19232,135 +18856,135 @@ T_4086: (in 44<i32> : int32)
   OrigDataType: int32
 T_4087: (in a7_1330 + 44<i32> : word32)
   Class: Eq_4087
-  DataType: Eq_4087
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_4088: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_4088
-  DataType: word32
-  OrigDataType: word32
+  DataType: int32
+  OrigDataType: int32
 T_4089: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_4088
-  DataType: word32
+  DataType: int32
   OrigDataType: word32
-T_4090: (in *((word32) a7_1330 + 44<i32>) == 0xFFFFFFFF<32> : bool)
+T_4090: (in a7_1330[11<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_4090
   DataType: bool
   OrigDataType: bool
 T_4091: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4092: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_4092
   DataType: bool
   OrigDataType: bool
-T_4093: (in a7_1076 : Eq_4093)
+T_4093: (in a7_1076 : (ptr32 Eq_4093))
   Class: Eq_4093
-  DataType: Eq_4093
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_4093)
+  OrigDataType: (ptr32 (struct (0 T_4097 t0000) (4D T_4157 t004D)))
 T_4094: (in 4<i32> : int32)
   Class: Eq_4094
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4095: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4093
-  DataType: Eq_4093
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_4093)
+  OrigDataType: ptr32
 T_4096: (in 78<i32> : int32)
   Class: Eq_4096
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4097: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  Class: Eq_4097
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4098: (in 0<32> : word32)
   Class: Eq_4098
   DataType: word32
   OrigDataType: word32
 T_4099: (in a7_1076 + 0<32> : word32)
   Class: Eq_4099
-  DataType: Eq_4099
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4100: (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_4093
+  Class: Eq_4097
+  DataType: ptr32
   OrigDataType: word32
 T_4101: (in 4<i32> : int32)
   Class: Eq_4101
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4102: (in a7_1076 - 4<i32> : word32)
   Class: Eq_4102
-  DataType: Eq_4102
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_4105 t0000)))
 T_4103: (in 0<32> : word32)
   Class: Eq_4103
   DataType: word32
   OrigDataType: word32
 T_4104: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_4104
-  DataType: Eq_4104
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4105: (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_4102
-  OrigDataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: word32
 T_4106: (in 00000008 : ptr32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_4106
+  DataType: ptr32
   OrigDataType: ptr32
 T_4107: (in 8<i32> : int32)
   Class: Eq_4107
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4108: (in a7_1076 - 8<i32> : word32)
   Class: Eq_4108
-  DataType: Eq_4108
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_4111 t0000)))
 T_4109: (in 0<32> : word32)
   Class: Eq_4109
   DataType: word32
   OrigDataType: word32
 T_4110: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_4110
-  DataType: Eq_4110
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4111: (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_4108
-  OrigDataType: uint8
+  Class: Eq_4106
+  DataType: ptr32
+  OrigDataType: word32
 T_4112: (in 12<i32> : int32)
   Class: Eq_4112
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4113: (in a7_1076 - 12<i32> : word32)
   Class: Eq_4113
-  DataType: Eq_4113
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_576)
+  OrigDataType: (ptr32 (struct (0 T_4116 t0000)))
 T_4114: (in 0<32> : word32)
   Class: Eq_4114
   DataType: word32
   OrigDataType: word32
 T_4115: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_4115
-  DataType: Eq_4115
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4116: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_4113
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_4117: (in 0<32> : word32)
   Class: Eq_4117
   DataType: word32
   OrigDataType: word32
 T_4118: (in a7_1076 + 0<32> : word32)
   Class: Eq_4118
-  DataType: Eq_4118
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_4119: (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_4097
+  DataType: ptr32
   OrigDataType: ptr32
 T_4120: (in fn0000254C : ptr32)
   Class: Eq_4120
@@ -19370,59 +18994,59 @@ T_4121: (in signature of fn0000254C : void)
   Class: Eq_4120
   DataType: (ptr32 Eq_4120)
   OrigDataType: 
-T_4122: (in d2 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4122: (in d2 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_4123: (in dwArg04 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4123: (in dwArg04 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
-T_4124: (in dwArg08 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4124: (in dwArg08 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
 T_4125: (in a7_1076 - 12<i32> : word32)
   Class: Eq_4125
-  DataType: Eq_4125
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_656)
+  OrigDataType: (ptr32 (struct (0 T_4128 t0000)))
 T_4126: (in 0<32> : word32)
   Class: Eq_4126
   DataType: word32
   OrigDataType: word32
 T_4127: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_4127
-  DataType: Eq_4127
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4128: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4129: (in 8<i32> : int32)
   Class: Eq_4129
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4130: (in a7_1076 - 8<i32> : word32)
   Class: Eq_4130
-  DataType: Eq_4130
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_656)
+  OrigDataType: (ptr32 (struct (0 T_4133 t0000)))
 T_4131: (in 0<32> : word32)
   Class: Eq_4131
   DataType: word32
   OrigDataType: word32
 T_4132: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_4132
-  DataType: Eq_4132
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4133: (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4134: (in fn0000254C(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_4134
   DataType: int32
   OrigDataType: int32
-T_4135: (in Mem1087[a7_1076 + 0<32>:word32] + fn0000254C(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
+T_4135: (in a7_1076->ptr0000 + fn0000254C(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_4135
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4136 t0000)))
@@ -19440,23 +19064,23 @@ T_4138: (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn0000254
   OrigDataType: uint32
 T_4139: (in 4<i32> : int32)
   Class: Eq_4139
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4140: (in a7_1076 - 4<i32> : word32)
   Class: Eq_4140
-  DataType: Eq_4140
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_4143 t0000)))
 T_4141: (in 0<32> : word32)
   Class: Eq_4141
   DataType: word32
   OrigDataType: word32
 T_4142: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_4142
-  DataType: Eq_4142
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4143: (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_4144: (in 1<i32> : int32)
   Class: Eq_4144
@@ -19480,7 +19104,7 @@ T_4148: (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
   OrigDataType: ui32
 T_4149: (in 0<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4150: (in d0 == 0<32> : bool)
   Class: Eq_4150
@@ -19508,8 +19132,8 @@ T_4155: (in 77<i32> : int32)
   OrigDataType: int32
 T_4156: (in a7_1076 + 77<i32> : word32)
   Class: Eq_4156
-  DataType: Eq_4156
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4157: (in Mem1087[a7_1076 + 77<i32>:byte] : byte)
   Class: Eq_4154
   DataType: byte
@@ -19646,30 +19270,30 @@ T_4190: (in a6_1164 + 1<i32> : word32)
   Class: Eq_3874
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_4191: (in a7_1182 : Eq_4191)
+T_4191: (in a7_1182 : (ptr32 Eq_576))
   Class: Eq_4191
-  DataType: Eq_4191
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_576)
+  OrigDataType: (ptr32 (struct (0 T_607 t0000)))
 T_4192: (in 4<i32> : int32)
   Class: Eq_4192
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4193: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4191
-  DataType: Eq_4191
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_576)
+  OrigDataType: ptr32
 T_4194: (in 0<32> : word32)
   Class: Eq_4194
   DataType: word32
   OrigDataType: word32
 T_4195: (in a7_1182 + 0<32> : word32)
   Class: Eq_4195
-  DataType: Eq_4195
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4196: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_4191
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_4197: (in d1_5335 : word32)
   Class: Eq_4197
   DataType: word32
@@ -19688,8 +19312,8 @@ T_4200: (in 0<32> : word32)
   OrigDataType: word32
 T_4201: (in a7_1182 + 0<32> : word32)
   Class: Eq_4201
-  DataType: Eq_4201
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_4202: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
@@ -19715,8 +19339,8 @@ T_4207: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4208: (in a2_1014 + 4<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_4209: (in a0_1200 : (ptr32 byte))
   Class: Eq_1075
@@ -19734,30 +19358,30 @@ T_4212: (in Mem1177[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
-T_4213: (in a7_1201 : Eq_4213)
+T_4213: (in a7_1201 : (ptr32 Eq_576))
   Class: Eq_4213
-  DataType: Eq_4213
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_576)
+  OrigDataType: (ptr32 (struct (0 T_607 t0000)))
 T_4214: (in 4<i32> : int32)
   Class: Eq_4214
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4215: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4213
-  DataType: Eq_4213
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_576)
+  OrigDataType: ptr32
 T_4216: (in 0<32> : word32)
   Class: Eq_4216
   DataType: word32
   OrigDataType: word32
 T_4217: (in a7_1201 + 0<32> : word32)
   Class: Eq_4217
-  DataType: Eq_4217
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4218: (in Mem1203[a7_1201 + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_4213
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_4219: (in 1<i32> : int32)
   Class: Eq_4219
   DataType: int32
@@ -19776,8 +19400,8 @@ T_4222: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_1093 t0000))))
 T_4223: (in Mem1207[a1 + 0<32>:word32] : word32)
   Class: Eq_1075
-  DataType: Eq_576
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_1093 t0000)))
 T_4224: (in v611_1211 : byte)
   Class: Eq_1090
   DataType: byte
@@ -19800,8 +19424,8 @@ T_4228: (in 0<32> : word32)
   OrigDataType: word32
 T_4229: (in a7_1201 + 0<32> : word32)
   Class: Eq_4229
-  DataType: Eq_4229
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_4230: (in Mem1207[a7_1201 + 0<32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
@@ -19840,7 +19464,7 @@ T_4238: (in d4_1070 + 1<32> : word32)
   OrigDataType: int32
 T_4239: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4240: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_4240
@@ -19868,8 +19492,8 @@ T_4245: (in 73<i32> : int32)
   OrigDataType: int32
 T_4246: (in a7_1330 + 73<i32> : word32)
   Class: Eq_4246
-  DataType: Eq_4246
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_4247: (in Mem1331[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_4247
   DataType: byte
@@ -19878,77 +19502,77 @@ T_4248: (in 0<8> : byte)
   Class: Eq_4247
   DataType: byte
   OrigDataType: byte
-T_4249: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_4249: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_4249
   DataType: bool
   OrigDataType: bool
-T_4250: (in a7_1302 : Eq_4250)
+T_4250: (in a7_1302 : (ptr32 Eq_576))
   Class: Eq_4250
-  DataType: Eq_4250
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_576)
+  OrigDataType: (ptr32 (struct (0 T_607 t0000)))
 T_4251: (in 4<i32> : int32)
   Class: Eq_4251
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4252: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4250
-  DataType: Eq_4250
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_576)
+  OrigDataType: ptr32
 T_4253: (in 0<32> : word32)
   Class: Eq_4253
   DataType: word32
   OrigDataType: word32
 T_4254: (in a7_1302 + 0<32> : word32)
   Class: Eq_4254
-  DataType: Eq_4254
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4255: (in Mem1308[a7_1302 + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_4250
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_4256: (in 4<i32> : int32)
   Class: Eq_4256
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4257: (in a7_1302 - 4<i32> : word32)
   Class: Eq_4257
-  DataType: Eq_4257
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_576)
+  OrigDataType: (ptr32 (struct (0 T_4260 t0000)))
 T_4258: (in 0<32> : word32)
   Class: Eq_4258
   DataType: word32
   OrigDataType: word32
 T_4259: (in a7_1302 - 4<i32> + 0<32> : word32)
   Class: Eq_4259
-  DataType: Eq_4259
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4260: (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_4257
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_4261: (in fn00001438 : ptr32)
   Class: Eq_1250
   DataType: (ptr32 Eq_1250)
   OrigDataType: (ptr32 (fn T_4270 (T_4266, T_4269)))
 T_4262: (in 1<i32> : int32)
   Class: Eq_4262
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4263: (in a7_1302 - 1<i32> : word32)
   Class: Eq_4263
-  DataType: Eq_4263
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4266 t0000)))
 T_4264: (in 0<32> : word32)
   Class: Eq_4264
   DataType: word32
   OrigDataType: word32
 T_4265: (in a7_1302 - 1<i32> + 0<32> : word32)
   Class: Eq_4265
-  DataType: Eq_4265
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4266: (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_664
+  DataType: byte
   OrigDataType: byte
 T_4267: (in 0<32> : word32)
   Class: Eq_4267
@@ -19956,8 +19580,8 @@ T_4267: (in 0<32> : word32)
   OrigDataType: word32
 T_4268: (in a7_1302 + 0<32> : word32)
   Class: Eq_4268
-  DataType: Eq_4268
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_4269: (in Mem1311[a7_1302 + 0<32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
@@ -19972,119 +19596,119 @@ T_4271: (in 73<i32> : int32)
   OrigDataType: int32
 T_4272: (in a7_1330 + 73<i32> : word32)
   Class: Eq_4272
-  DataType: Eq_4272
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_4273: (in Mem1294[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_4154
-  DataType: Eq_698
+  DataType: byte
   OrigDataType: byte
-T_4274: (in a7_1237 : Eq_4274)
+T_4274: (in a7_1237 : (ptr32 ptr32))
   Class: Eq_4274
-  DataType: Eq_4274
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_4278 t0000)))
 T_4275: (in 4<i32> : int32)
   Class: Eq_4275
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4276: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4274
-  DataType: Eq_4274
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
 T_4277: (in 78<i32> : int32)
   Class: Eq_4277
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4278: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  Class: Eq_4278
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4279: (in 0<32> : word32)
   Class: Eq_4279
   DataType: word32
   OrigDataType: word32
 T_4280: (in a7_1237 + 0<32> : word32)
   Class: Eq_4280
-  DataType: Eq_4280
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4281: (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_4274
+  Class: Eq_4278
+  DataType: ptr32
   OrigDataType: word32
 T_4282: (in 4<i32> : int32)
   Class: Eq_4282
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4283: (in a7_1237 - 4<i32> : word32)
   Class: Eq_4283
-  DataType: Eq_4283
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_4286 t0000)))
 T_4284: (in 0<32> : word32)
   Class: Eq_4284
   DataType: word32
   OrigDataType: word32
 T_4285: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_4285
-  DataType: Eq_4285
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4286: (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_4283
-  OrigDataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
+  OrigDataType: word32
 T_4287: (in 00000008 : ptr32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_4287
+  DataType: ptr32
   OrigDataType: ptr32
 T_4288: (in 8<i32> : int32)
   Class: Eq_4288
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4289: (in a7_1237 - 8<i32> : word32)
   Class: Eq_4289
-  DataType: Eq_4289
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_4292 t0000)))
 T_4290: (in 0<32> : word32)
   Class: Eq_4290
   DataType: word32
   OrigDataType: word32
 T_4291: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_4291
-  DataType: Eq_4291
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4292: (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_4289
-  OrigDataType: uint8
+  Class: Eq_4287
+  DataType: ptr32
+  OrigDataType: word32
 T_4293: (in 12<i32> : int32)
   Class: Eq_4293
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4294: (in a7_1237 - 12<i32> : word32)
   Class: Eq_4294
-  DataType: Eq_4294
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_576)
+  OrigDataType: (ptr32 (struct (0 T_4297 t0000)))
 T_4295: (in 0<32> : word32)
   Class: Eq_4295
   DataType: word32
   OrigDataType: word32
 T_4296: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_4296
-  DataType: Eq_4296
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4297: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
   Class: Eq_576
-  DataType: Eq_4294
-  OrigDataType: Eq_576
+  DataType: Eq_576
+  OrigDataType: word32
 T_4298: (in 0<32> : word32)
   Class: Eq_4298
   DataType: word32
   OrigDataType: word32
 T_4299: (in a7_1237 + 0<32> : word32)
   Class: Eq_4299
-  DataType: Eq_4299
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_4300: (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_4278
+  DataType: ptr32
   OrigDataType: ptr32
 T_4301: (in fn0000254C : ptr32)
   Class: Eq_4120
@@ -20092,45 +19716,45 @@ T_4301: (in fn0000254C : ptr32)
   OrigDataType: (ptr32 (fn T_4311 (T_702, T_4305, T_4310)))
 T_4302: (in a7_1237 - 12<i32> : word32)
   Class: Eq_4302
-  DataType: Eq_4302
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_656)
+  OrigDataType: (ptr32 (struct (0 T_4305 t0000)))
 T_4303: (in 0<32> : word32)
   Class: Eq_4303
   DataType: word32
   OrigDataType: word32
 T_4304: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_4304
-  DataType: Eq_4304
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4305: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4306: (in 8<i32> : int32)
   Class: Eq_4306
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4307: (in a7_1237 - 8<i32> : word32)
   Class: Eq_4307
-  DataType: Eq_4307
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 Eq_656)
+  OrigDataType: (ptr32 (struct (0 T_4310 t0000)))
 T_4308: (in 0<32> : word32)
   Class: Eq_4308
   DataType: word32
   OrigDataType: word32
 T_4309: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_4309
-  DataType: Eq_4309
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4310: (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4311: (in fn0000254C(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_4134
   DataType: int32
   OrigDataType: int32
-T_4312: (in Mem1248[a7_1237 + 0<32>:word32] + fn0000254C(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
+T_4312: (in *a7_1237 + fn0000254C(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_4312
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4313 t0000)))
@@ -20148,23 +19772,23 @@ T_4315: (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn0000254
   OrigDataType: uint32
 T_4316: (in 4<i32> : int32)
   Class: Eq_4316
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: int32
+  OrigDataType: int32
 T_4317: (in a7_1237 - 4<i32> : word32)
   Class: Eq_4317
-  DataType: Eq_4317
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 (ptr32 (ptr32 byte)))
+  OrigDataType: (ptr32 (struct (0 T_4320 t0000)))
 T_4318: (in 0<32> : word32)
   Class: Eq_4318
   DataType: word32
   OrigDataType: word32
 T_4319: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_4319
-  DataType: Eq_4319
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_4320: (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_606
+  DataType: (ptr32 (ptr32 byte))
   OrigDataType: word32
 T_4321: (in 1<i32> : int32)
   Class: Eq_4321
@@ -20188,7 +19812,7 @@ T_4325: (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
   OrigDataType: ui32
 T_4326: (in 0<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4327: (in d0 == 0<32> : bool)
   Class: Eq_4327
@@ -20244,8 +19868,8 @@ T_4339: (in 60<i32> : int32)
   OrigDataType: int32
 T_4340: (in a7_1330 + 60<i32> : word32)
   Class: Eq_4340
-  DataType: Eq_4340
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_4341: (in Mem1348[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_4341
   DataType: word32
@@ -20260,39 +19884,39 @@ T_4343: (in Mem1348[a7_1330 + 60<i32>:word32] + 1<32> : word32)
   OrigDataType: word32
 T_4344: (in a7_1330 + 60<i32> : word32)
   Class: Eq_4344
-  DataType: Eq_4344
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8360) u1) (T_2791 u2) (T_3657 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_4345: (in Mem1351[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_4343
-  DataType: Eq_698
+  DataType: word32
   OrigDataType: word32
 T_4346: (in d0 : uint32)
   Class: Eq_4346
   DataType: uint32
   OrigDataType: word32
-T_4347: (in d0_23 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4347: (in d0_23 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4348: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4349 (T_3395)))
 T_4349: (in __swap(dwArg08) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_4350: (in d1_25 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4350: (in d1_25 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4351: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4352 (T_3397)))
 T_4352: (in __swap(dwArg10) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4353: (in d4_29 : uint32)
   Class: Eq_4353
@@ -20330,9 +19954,9 @@ T_4361: (in d1_25 * (word16) d0_23 : word32)
   Class: Eq_4359
   DataType: uint32
   OrigDataType: uint32
-T_4362: (in d2_39 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4362: (in d2_39 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4363: (in SLICE(d1_25, word16, 0) : word16)
   Class: Eq_4363
@@ -20363,12 +19987,12 @@ T_4369: (in (word16) d4_29 ^ (word16) d4_29 : word16)
   DataType: ui16
   OrigDataType: ui16
 T_4370: (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4371: (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4372: (in dwArg08 *u SLICE(d1_25, word16, 0) + __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
   Class: Eq_4372
@@ -20383,28 +20007,28 @@ T_4374: (in dwArg10 * (word16) d0_23 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4375: (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4376: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: up32
 T_4377: (in d2_39 >= 0<32> : bool)
   Class: Eq_4377
   DataType: bool
   OrigDataType: bool
-T_4378: (in d2_45 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4378: (in d2_45 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4379: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4380 (T_4362)))
 T_4380: (in __swap(d2_39) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4381: (in d3_65 : uint32)
   Class: Eq_4381
@@ -20415,8 +20039,8 @@ T_4382: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4383 (T_3396)))
 T_4383: (in __swap(dwArg0C) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4384: (in SLICE(dwArg08, word16, 0) : word16)
   Class: Eq_4384
@@ -20426,9 +20050,9 @@ T_4385: (in __swap(dwArg0C) * (word16) dwArg08 : word32)
   Class: Eq_4381
   DataType: uint32
   OrigDataType: uint32
-T_4386: (in d3_71 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4386: (in d3_71 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4387: (in __swap : ptr32)
   Class: Eq_800
@@ -20443,8 +20067,8 @@ T_4389: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4390 (T_3395)))
 T_4390: (in __swap(dwArg08) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4391: (in SLICE(dwArg0C, word16, 0) : word16)
   Class: Eq_4391
@@ -20463,12 +20087,12 @@ T_4394: (in SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_4395: (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4396: (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4397: (in d3_83 : uint32)
   Class: Eq_4397
@@ -20479,8 +20103,8 @@ T_4398: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4399 (T_3394)))
 T_4399: (in __swap(dwArg04) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4400: (in SLICE(dwArg10, word16, 0) : word16)
   Class: Eq_4400
@@ -20490,9 +20114,9 @@ T_4401: (in __swap(dwArg04) * (word16) dwArg10 : word32)
   Class: Eq_4397
   DataType: uint32
   OrigDataType: uint32
-T_4402: (in d3_89 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4402: (in d3_89 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4403: (in __swap : ptr32)
   Class: Eq_800
@@ -20507,8 +20131,8 @@ T_4405: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4406 (T_3397)))
 T_4406: (in __swap(dwArg10) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4407: (in SLICE(dwArg04, word16, 0) : word16)
   Class: Eq_4407
@@ -20527,12 +20151,12 @@ T_4410: (in SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_4411: (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4412: (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4413: (in SLICE(d2_45, word16, 16) : word16)
   Class: Eq_4413
@@ -20642,37 +20266,37 @@ T_4439: (in d1_32 + 0x10000<32> : word32)
   Class: Eq_4359
   DataType: uint32
   OrigDataType: uint32
-T_4440: (in d0 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4440: (in d0 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4441: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_4442: (in dwArg04 > 0<32> : bool)
   Class: Eq_4442
   DataType: bool
   OrigDataType: bool
 T_4443: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_4444: (in dwArg08 > 0<32> : bool)
   Class: Eq_4444
   DataType: bool
   OrigDataType: bool
-T_4445: (in d0_36 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4445: (in d0_36 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
 T_4446: (in -dwArg04 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
 T_4447: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_4448: (in dwArg08 > 0<32> : bool)
   Class: Eq_4448
@@ -20690,33 +20314,33 @@ T_4451: (in signature of fn0000257E : void)
   Class: Eq_4450
   DataType: (ptr32 Eq_4450)
   OrigDataType: 
-T_4452: (in d0 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4452: (in d0 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_4453: (in d1 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4453: (in d1 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_4454: (in d2 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4454: (in d2 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_4455: (in d1Out : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4455: (in d1Out : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_4456: (in out d1_43 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_4457: (in fn0000257E(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4458: (in -fn0000257E(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4459: (in d1_55 : word32)
   Class: Eq_4459
@@ -20727,16 +20351,16 @@ T_4460: (in fn0000257E : ptr32)
   DataType: (ptr32 Eq_4450)
   OrigDataType: (ptr32 (fn T_4463 (T_4445, T_4461, T_4122, T_4462)))
 T_4461: (in -dwArg08 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
 T_4462: (in out d1_55 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_4463: (in fn0000257E(d0_36, -dwArg08, d2, out d1_55) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4464: (in d1_88 : word32)
   Class: Eq_4464
@@ -20747,12 +20371,12 @@ T_4465: (in fn0000257E : ptr32)
   DataType: (ptr32 Eq_4450)
   OrigDataType: (ptr32 (fn T_4467 (T_4123, T_4124, T_4122, T_4466)))
 T_4466: (in out d1_88 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_4467: (in fn0000257E(dwArg04, dwArg08, d2, out d1_88) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4468: (in d1_89 : word32)
   Class: Eq_4468
@@ -20763,32 +20387,32 @@ T_4469: (in fn0000257E : ptr32)
   DataType: (ptr32 Eq_4450)
   OrigDataType: (ptr32 (fn T_4472 (T_4123, T_4470, T_4122, T_4471)))
 T_4470: (in -dwArg08 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
 T_4471: (in out d1_89 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_4472: (in fn0000257E(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4473: (in -fn0000257E(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_4474: (in d1_22 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4474: (in d1_22 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4475: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4476 (T_4453)))
 T_4476: (in __swap(d1) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4477: (in v10_9 : word16)
   Class: Eq_4477
@@ -20806,13 +20430,13 @@ T_4480: (in SLICE(d2, word16, 16) : word16)
   Class: Eq_4479
   DataType: word16
   OrigDataType: word16
-T_4481: (in d2_11 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4481: (in d2_11 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4482: (in SEQ(v11_10, v10_9) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4483: (in 0<16> : word16)
   Class: Eq_4477
@@ -20822,13 +20446,13 @@ T_4484: (in v10_9 != 0<16> : bool)
   Class: Eq_4484
   DataType: bool
   OrigDataType: bool
-T_4485: (in d3_18 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: uint8
+T_4485: (in d3_18 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: (ptr32 Eq_6087)
 T_4486: (in 16<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_4487: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_4487
@@ -20842,29 +20466,29 @@ T_4489: (in (word16) d1_22 >= 0x80<16> : bool)
   Class: Eq_4489
   DataType: bool
   OrigDataType: bool
-T_4490: (in d0_134 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4490: (in d0_134 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4491: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4492 (T_4452)))
 T_4492: (in __swap(d0) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_4493: (in d1_135 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4493: (in d1_135 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4494: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4495 (T_4474)))
 T_4495: (in __swap(d1_22) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4496: (in v14_137 : word16)
   Class: Eq_4496
@@ -20883,8 +20507,8 @@ T_4499: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4500 (T_4481)))
 T_4500: (in __swap(d2_11) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4501: (in SLICE(__swap(d2_11), word16, 16) : word16)
   Class: Eq_4501
@@ -20902,17 +20526,17 @@ T_4504: (in v14_137 == 0<16> : bool)
   Class: Eq_4504
   DataType: bool
   OrigDataType: bool
-T_4505: (in d0_150 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4505: (in d0_150 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4506: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4507 (T_4490)))
 T_4507: (in __swap(d0_134) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4508: (in d2_154 : uint32)
   Class: Eq_4508
@@ -20967,28 +20591,28 @@ T_4520: (in (uint16) (d2_154 % SLICE(d1_135, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_4521: (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4522: (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4523: (in SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0) : word16)
   Class: Eq_4523
   DataType: word16
   OrigDataType: word16
 T_4524: (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4525: (in SLICE(d0_150, word16, 16) : word16)
   Class: Eq_4525
   DataType: word16
   OrigDataType: word16
 T_4526: (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4527: (in v17_143 : uint16)
   Class: Eq_4527
@@ -21027,8 +20651,8 @@ T_4535: (in SLICE(d0_134, word16, 16) : word16)
   DataType: word16
   OrigDataType: word16
 T_4536: (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4537: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_4537
@@ -21051,24 +20675,24 @@ T_4541: (in signature of __rol : void)
   DataType: (ptr32 Eq_4540)
   OrigDataType: 
 T_4542: (in  : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: 
 T_4543: (in  : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: 
 T_4544: (in 8<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_4545: (in __rol(d1_22, 8<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4546: (in 8<32> : uipr32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: uipr32
 T_4547: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_4547
@@ -21087,12 +20711,12 @@ T_4550: (in __rol : ptr32)
   DataType: (ptr32 Eq_4540)
   OrigDataType: (ptr32 (fn T_4552 (T_4474, T_4551)))
 T_4551: (in 4<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_4552: (in __rol(d1_22, 4<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4553: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_4553
@@ -21111,8 +20735,8 @@ T_4556: (in (word16) d3_18 - 4<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4557: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4558: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_4558
@@ -21131,12 +20755,12 @@ T_4561: (in __rol : ptr32)
   DataType: (ptr32 Eq_4540)
   OrigDataType: (ptr32 (fn T_4563 (T_4474, T_4562)))
 T_4562: (in 2<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_4563: (in __rol(d1_22, 2<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4564: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_4564
@@ -21155,8 +20779,8 @@ T_4567: (in (word16) d3_18 - 2<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4568: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4569: (in d0_71 : uint32)
   Class: Eq_4569
@@ -21179,12 +20803,12 @@ T_4573: (in SLICE(d0, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4574: (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4575: (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4576: (in SLICE(__swap(SEQ(v11_10, (word16) d0)), word16, 16) : word16)
   Class: Eq_4576
@@ -21211,8 +20835,8 @@ T_4581: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4582 (T_4485)))
 T_4582: (in __swap(d3_18) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4583: (in SLICE(__swap(d3_18), word16, 16) : word16)
   Class: Eq_4580
@@ -21234,29 +20858,29 @@ T_4587: (in (uint16) (d0_71 /u SLICE(d1_22, uint16, 0)) : uint16)
   Class: Eq_4584
   DataType: uint16
   OrigDataType: uint16
-T_4588: (in d1_90 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4588: (in d1_90 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4589: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4590 (T_4474)))
 T_4590: (in __swap(d1_22) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_4591: (in d3_102 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4591: (in d3_102 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4592: (in SEQ(v53_82, v51_79) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
-T_4593: (in d0_108 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_4593: (in d0_108 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4594: (in SLICE(d1_22, uint16, 0) : uint16)
   Class: Eq_4594
@@ -21295,12 +20919,12 @@ T_4602: (in SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4603: (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4604: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: up32
 T_4605: (in d0_108 >= 0<32> : bool)
   Class: Eq_4605
@@ -21311,12 +20935,12 @@ T_4606: (in __rol : ptr32)
   DataType: (ptr32 Eq_4540)
   OrigDataType: (ptr32 (fn T_4608 (T_4474, T_4607)))
 T_4607: (in 1<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_4608: (in __rol(d1_22, 1<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4609: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_4609
@@ -21335,8 +20959,8 @@ T_4612: (in (word16) d3_18 - 1<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4613: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4614: (in __swap : ptr32)
   Class: Eq_800
@@ -21351,16 +20975,16 @@ T_4616: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_4617 (T_4591)))
 T_4617: (in __swap(d3_102) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4618: (in __rol(d0_108, __swap(d3_102)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4619: (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_4620: (in SLICE(d3_102, word16, 0) : word16)
   Class: Eq_4620
@@ -21371,8 +20995,8 @@ T_4621: (in (uint16) SLICE(d3_102, word16, 0) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_4622: (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4623: (in 1<16> : word16)
   Class: Eq_4623
@@ -21383,16 +21007,16 @@ T_4624: (in v51_79 - 1<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4625: (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_4626: (in d0_108 + d1_90 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_4627: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: up32
 T_4628: (in d0_108 >= 0<32> : bool)
   Class: Eq_4628
@@ -21448,7 +21072,7 @@ T_4640: (in fn00002BBC(out a1_116, out a5_279) : word32)
   OrigDataType: word32
 T_4641: (in 0<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4642: (in dwArg04 != 0<32> : bool)
   Class: Eq_4642
@@ -21608,7 +21232,7 @@ T_4680: (in Mem86[dwArg04 + 8<i32>:word32] : word32)
   OrigDataType: word32
 T_4681: (in 0<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_4682: (in *((word32) dwArg04 + 8<i32>) != 0<32> : bool)
   Class: Eq_4682
@@ -24645,7 +24269,7 @@ T_5439: (in d0_1952 : Eq_576)
 T_5440: (in a7_1968 : (ptr32 Eq_5440))
   Class: Eq_5440
   DataType: (ptr32 Eq_5440)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_5957 u2) (T_5963 u3) (T_6037 u4) (T_7107 u5) (T_7218 u6) (T_7259 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_6087 u2) (T_6094 u3) (T_6105 u4) (T_6622 u5) (T_6689 u6) (T_6692 u7) (T_6762 u8) (T_6810 u9) (T_7342 u10)) u0066) (6A byte b006A)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_5957 u2) (T_5963 u3) (T_6037 u4) (T_7107 u5) (T_7218 u6) (T_7259 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_6087 u2) (T_6094 u3) (T_6105 u4) (T_6622 u5) (T_6689 u6) (T_6692 u7) (T_6762 u8) (T_6810 u9) (T_7342 u10)) u0066) (6A byte b006A)))
 T_5441: (in fp : ptr32)
   Class: Eq_5441
   DataType: ptr32
@@ -24676,7 +24300,7 @@ T_5447: (in d6_1480 : Eq_576)
   OrigDataType: word32
 T_5448: (in 0<i32> : int32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_5449: (in 0<32> : word32)
   Class: Eq_5449
@@ -24904,7 +24528,7 @@ T_5504: (in a7_51 + 4<i32> : word32)
   OrigDataType: ptr32
 T_5505: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_5506: (in d0 != 0xFFFFFFFF<32> : bool)
   Class: Eq_5506
@@ -24956,15 +24580,15 @@ T_5517: (in a7_1968 + 102<i32> : word32)
   OrigDataType: ptr32
 T_5518: (in Mem91[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_5515
-  DataType: Eq_8380
+  DataType: Eq_8351
   OrigDataType: word32
-T_5519: (in d5_256 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: (struct "Eq_5440" 0004 (2C Eq_8379 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8380 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+T_5519: (in d5_256 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: (struct "Eq_5440" 0004 (2C Eq_8350 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8351 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 T_5520: (in -1<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_5521: (in d4_376 : int32)
   Class: Eq_5521
@@ -25006,10 +24630,10 @@ T_5530: (in a4_1925 + 1<i32> : word32)
   Class: Eq_5528
   DataType: (ptr32 uint8)
   OrigDataType: ptr32
-T_5531: (in d2_1005 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: (ptr32 Eq_576)
+T_5531: (in d2_1005 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: (ptr32 Eq_656)
 T_5532: (in 72<i32> : int32)
   Class: Eq_5532
   DataType: int32
@@ -25019,8 +24643,8 @@ T_5533: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5534: (in Mem91[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_5535: (in d1_103 : Eq_576)
   Class: Eq_576
@@ -25036,7 +24660,7 @@ T_5537: (in d1_103 + 1<32> : word32)
   OrigDataType: word32
 T_5538: (in 5<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: up32
 T_5539: (in d1_103 < 5<32> : bool)
   Class: Eq_5539
@@ -25083,8 +24707,8 @@ T_5549: (in Mem121[a7_99 + 0<32>:word32] : word32)
   DataType: Eq_576
   OrigDataType: word32
 T_5550: (in d2_1005 | d1_123 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_5551: (in 1<i32> : int32)
   Class: Eq_5551
@@ -25096,7 +24720,7 @@ T_5552: (in a2_135 + 1<i32> : word32)
   OrigDataType: ptr32
 T_5553: (in 5<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: up32
 T_5554: (in d1_103 < 5<32> : bool)
   Class: Eq_5554
@@ -25104,7 +24728,7 @@ T_5554: (in d1_103 < 5<32> : bool)
   OrigDataType: bool
 T_5555: (in 0<i32> : int32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: int32
 T_5556: (in a0_1447 : (ptr32 Eq_5556))
   Class: Eq_5556
@@ -25123,8 +24747,8 @@ T_5559: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5560: (in Mem143[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_5561: (in 0<32> : word32)
   Class: Eq_5561
@@ -25587,8 +25211,8 @@ T_5675: (in (uint32) (uint8) Mem248[a0_1447 + 0<32>:byte] : uint32)
   DataType: uint32
   OrigDataType: uint32
 T_5676: (in 0<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_5677: (in 4<32> : word32)
   Class: Eq_5677
@@ -25699,20 +25323,20 @@ T_5703: (in a7_1968 + 44<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5704: (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_5705: (in a7_275 : (ptr32 Eq_576))
+T_5705: (in a7_275 : (ptr32 Eq_656))
   Class: Eq_5705
-  DataType: (ptr32 Eq_576)
-  OrigDataType: (ptr32 (struct (0 T_606 t0000)))
+  DataType: (ptr32 Eq_656)
+  OrigDataType: (ptr32 (struct (0 T_656 t0000)))
 T_5706: (in 4<i32> : int32)
   Class: Eq_5706
   DataType: int32
   OrigDataType: int32
 T_5707: (in a7_1968 - 4<i32> : word32)
   Class: Eq_5705
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: ptr32
 T_5708: (in 0<32> : word32)
   Class: Eq_5708
@@ -25723,8 +25347,8 @@ T_5709: (in a7_275 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5710: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_5711: (in d1_284 : uint32)
   Class: Eq_5711
@@ -25735,12 +25359,12 @@ T_5712: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_5714 (T_5713)))
 T_5713: (in 10<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_5714: (in __swap(10<i32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_5715: (in SLICE(d5_256, word16, 0) : word16)
   Class: Eq_5715
@@ -25767,8 +25391,8 @@ T_5720: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_5721 (T_5519)))
 T_5721: (in __swap(d5_256) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_5722: (in 0xA<16> : word16)
   Class: Eq_5722
@@ -25787,12 +25411,12 @@ T_5725: (in SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_5726: (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_5727: (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_5728: (in SLICE(__swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_5728
@@ -25939,8 +25563,8 @@ T_5763: (in a7_275 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5764: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_5765: (in 0x30<32> : word32)
   Class: Eq_5765
@@ -25955,8 +25579,8 @@ T_5767: (in d1_303 - 0x30<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5768: (in d1_303 - 0x30<32> + d0_293 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_5769: (in 4<32> : word32)
   Class: Eq_5769
@@ -26135,8 +25759,8 @@ T_5812: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5813: (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_5814: (in 4<i32> : int32)
   Class: Eq_5814
@@ -26167,12 +25791,12 @@ T_5820: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_5822 (T_5821)))
 T_5821: (in 10<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_5822: (in __swap(10<i32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_5823: (in SLICE(d2_1005, word16, 0) : word16)
   Class: Eq_5823
@@ -26199,8 +25823,8 @@ T_5828: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_5829 (T_5531)))
 T_5829: (in __swap(d2_1005) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_5830: (in 0xA<16> : word16)
   Class: Eq_5830
@@ -26219,12 +25843,12 @@ T_5833: (in SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_5834: (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_5835: (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_5836: (in SLICE(__swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_5836
@@ -26391,8 +26015,8 @@ T_5876: (in d1_196 - 0x30<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5877: (in d1_196 - 0x30<32> + d0_186 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_5878: (in 4<32> : word32)
   Class: Eq_5878
@@ -26423,8 +26047,8 @@ T_5884: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5885: (in Mem217[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_5886: (in 0x6C<32> : word32)
   Class: Eq_5521
@@ -26616,7 +26240,7 @@ T_5932: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5933: (in Mem465[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_5930
-  DataType: Eq_8380
+  DataType: Eq_8351
   OrigDataType: word32
 T_5934: (in 00003888 : ptr32)
   Class: Eq_617
@@ -26796,7 +26420,7 @@ T_5977: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5978: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_5975
-  DataType: Eq_8380
+  DataType: Eq_8351
   OrigDataType: word32
 T_5979: (in 4<32> : word32)
   Class: Eq_5979
@@ -26811,8 +26435,8 @@ T_5981: (in d0_1471 + 4<32> : word32)
   DataType: (ptr32 Eq_5556)
   OrigDataType: ptr32
 T_5982: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_5983: (in d5_256 == 0<32> : bool)
   Class: Eq_5983
@@ -26849,7 +26473,7 @@ T_5990: (in d3_1050 : ptr32)
 T_5991: (in a7_1020 : (ptr32 Eq_5440))
   Class: Eq_5440
   DataType: (ptr32 Eq_5440)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_5957 u2) (T_5963 u3) (T_6037 u4) (T_7107 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_6087 u2) (T_6094 u3) (T_6105 u4) (T_6622 u5) (T_6689 u6) (T_6692 u7) (T_6762 u8) (T_6810 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_5957 u2) (T_5963 u3) (T_6037 u4) (T_7107 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_6087 u2) (T_6094 u3) (T_6105 u4) (T_6622 u5) (T_6689 u6) (T_6692 u7) (T_6762 u8) (T_6810 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
 T_5992: (in SLICE(d1, byte, 0) : byte)
   Class: Eq_5992
   DataType: byte
@@ -27116,7 +26740,7 @@ T_6057: (in 8<i32> : int32)
   OrigDataType: int32
 T_6058: (in a7_1174 - 8<i32> : word32)
   Class: Eq_6058
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_6061 t0000)))
 T_6059: (in 0<32> : word32)
   Class: Eq_6059
@@ -27127,8 +26751,8 @@ T_6060: (in a7_1174 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6061: (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_6062: (in 4<i32> : int32)
   Class: Eq_6062
@@ -27172,7 +26796,7 @@ T_6071: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6072: (in Mem756[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_5924
-  DataType: Eq_8380
+  DataType: Eq_8351
   OrigDataType: (ptr32 Eq_6087)
 T_6073: (in 0<32> : word32)
   Class: Eq_6073
@@ -27304,7 +26928,7 @@ T_6104: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (T_6087 u2) (T_6094 u3)))
 T_6105: (in Mem719[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_5924
-  DataType: Eq_8380
+  DataType: Eq_8351
   OrigDataType: (ptr32 Eq_6087)
 T_6106: (in 1<32> : word32)
   Class: Eq_6106
@@ -27323,8 +26947,8 @@ T_6109: (in a1 + 1<i32> : word32)
   DataType: Eq_617
   OrigDataType: ptr32
 T_6110: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: up32
 T_6111: (in d5_256 <= 0<32> : bool)
   Class: Eq_6111
@@ -28048,7 +27672,7 @@ T_6290: (in a7_1465[18<i32>] & 2<i32> : word32)
   OrigDataType: ui32
 T_6291: (in 0<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6292: (in d0_1566 == 0<32> : bool)
   Class: Eq_6292
@@ -28203,8 +27827,8 @@ T_6329: (in a7_1020 + 68<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6330: (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_6331: (in 48<i32> : int32)
   Class: Eq_6331
@@ -28536,7 +28160,7 @@ T_6412: (in fn000038B4(*(a7_1578 - 4<i32>), a7_1578->ptr0000, out d1, out a0_144
   OrigDataType: word32
 T_6413: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6414: (in d0_1566 != 0xFFFFFFFF<32> : bool)
   Class: Eq_6414
@@ -28754,25 +28378,25 @@ T_6467: (in signature of fn00003C74 : void)
   Class: Eq_6466
   DataType: (ptr32 Eq_6466)
   OrigDataType: 
-T_6468: (in dwArg04 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_6468: (in dwArg04 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_6469: (in dwArg08 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_6469: (in dwArg08 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_6470: (in dwArg0C : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_6470: (in dwArg0C : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_6471: (in dwArg10 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_6471: (in dwArg10 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_6472: (in a7_1383 - 24<i32> : word32)
   Class: Eq_6472
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_6475 t0000)))
 T_6473: (in 0<32> : word32)
   Class: Eq_6473
@@ -28783,8 +28407,8 @@ T_6474: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6475: (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_6476: (in 20<i32> : int32)
   Class: Eq_6476
@@ -28792,7 +28416,7 @@ T_6476: (in 20<i32> : int32)
   OrigDataType: int32
 T_6477: (in a7_1383 - 20<i32> : word32)
   Class: Eq_6477
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_6480 t0000)))
 T_6478: (in 0<32> : word32)
   Class: Eq_6478
@@ -28803,8 +28427,8 @@ T_6479: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6480: (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_6481: (in 16<i32> : int32)
   Class: Eq_6481
@@ -28812,7 +28436,7 @@ T_6481: (in 16<i32> : int32)
   OrigDataType: int32
 T_6482: (in a7_1383 - 16<i32> : word32)
   Class: Eq_6482
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_6485 t0000)))
 T_6483: (in 0<32> : word32)
   Class: Eq_6483
@@ -28823,8 +28447,8 @@ T_6484: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6485: (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_6486: (in 12<i32> : int32)
   Class: Eq_6486
@@ -28832,7 +28456,7 @@ T_6486: (in 12<i32> : int32)
   OrigDataType: int32
 T_6487: (in a7_1383 - 12<i32> : word32)
   Class: Eq_6487
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_6490 t0000)))
 T_6488: (in 0<32> : word32)
   Class: Eq_6488
@@ -28843,8 +28467,8 @@ T_6489: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6490: (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_6491: (in fn00003C74(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>)) : word32)
   Class: Eq_6465
@@ -29090,33 +28714,33 @@ T_6551: (in signature of fn00003A24 : void)
   Class: Eq_6550
   DataType: (ptr32 Eq_6550)
   OrigDataType: 
-T_6552: (in dwArg04 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_6552: (in dwArg04 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_6553: (in dwArg08 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_6553: (in dwArg08 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_6554: (in dwArg0C : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_6554: (in dwArg0C : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_6555: (in dwArg10 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_6555: (in dwArg10 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_6556: (in d1Out : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_6556: (in d1Out : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
-T_6557: (in a0Out : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_6557: (in a0Out : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_6558: (in a7_1383 - 24<i32> : word32)
   Class: Eq_6558
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_6561 t0000)))
 T_6559: (in 0<32> : word32)
   Class: Eq_6559
@@ -29127,8 +28751,8 @@ T_6560: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6561: (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_6562: (in 20<i32> : int32)
   Class: Eq_6562
@@ -29136,7 +28760,7 @@ T_6562: (in 20<i32> : int32)
   OrigDataType: int32
 T_6563: (in a7_1383 - 20<i32> : word32)
   Class: Eq_6563
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_6566 t0000)))
 T_6564: (in 0<32> : word32)
   Class: Eq_6564
@@ -29147,8 +28771,8 @@ T_6565: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6566: (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_6567: (in 16<i32> : int32)
   Class: Eq_6567
@@ -29156,7 +28780,7 @@ T_6567: (in 16<i32> : int32)
   OrigDataType: int32
 T_6568: (in a7_1383 - 16<i32> : word32)
   Class: Eq_6568
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_6571 t0000)))
 T_6569: (in 0<32> : word32)
   Class: Eq_6569
@@ -29167,8 +28791,8 @@ T_6570: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6571: (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_6572: (in 12<i32> : int32)
   Class: Eq_6572
@@ -29176,7 +28800,7 @@ T_6572: (in 12<i32> : int32)
   OrigDataType: int32
 T_6573: (in a7_1383 - 12<i32> : word32)
   Class: Eq_6573
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_6576 t0000)))
 T_6574: (in 0<32> : word32)
   Class: Eq_6574
@@ -29187,16 +28811,16 @@ T_6575: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6576: (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_6577: (in out d1_1450 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_6578: (in out a0_1447 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: (ptr32 (struct (0 T_5578 t0000)))
 T_6579: (in fn00003A24(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>), out d1_1450, out a0_1447) : word32)
   Class: Eq_6340
@@ -29412,7 +29036,7 @@ T_6631: (in a7_1465[18<i32>] & 2<i32> : word32)
   OrigDataType: ui32
 T_6632: (in 0<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6633: (in d0_1691 != 0<32> : bool)
   Class: Eq_6633
@@ -29592,7 +29216,7 @@ T_6676: (in fn000038B4(*(a7_1465 - 8<i32>), *(a7_1465 - 4<i32>), out d1, out a0_
   OrigDataType: word32
 T_6677: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6678: (in fn000038B4(*(a7_1465 - 8<i32>), *(a7_1465 - 4<i32>), out d1, out a0_1447, out a1, out a5_1579) != 0xFFFFFFFF<32> : bool)
   Class: Eq_6678
@@ -29820,7 +29444,7 @@ T_6733: (in fn000038B4(*(a7_1706 - 4<i32>), a7_1706->ptr0000, out d1, out a0_292
   OrigDataType: word32
 T_6734: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6735: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_6735
@@ -30048,7 +29672,7 @@ T_6790: (in fn000038B4(*(a7_1761 - 4<i32>), *a7_1761, out d1, out a0_2921, out a
   OrigDataType: word32
 T_6791: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6792: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_6792
@@ -30104,7 +29728,7 @@ T_6804: (in a7_1465[18<i32>] & 4<i32> : word32)
   OrigDataType: ui32
 T_6805: (in 0<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6806: (in d0 == 0<32> : bool)
   Class: Eq_6806
@@ -30284,7 +29908,7 @@ T_6849: (in fn000038B4(*(a7_1800 - 4<i32>), *a7_1800, out d1, out a0_2922, out a
   OrigDataType: word32
 T_6850: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6851: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_6851
@@ -30488,7 +30112,7 @@ T_6900: (in fn000038B4(*(a7_1854 - 4<i32>), *a7_1854, out d1, out a0_2923, out a
   OrigDataType: word32
 T_6901: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_6902: (in d0 != 0xFFFFFFFF<32> : bool)
   Class: Eq_6902
@@ -30662,22 +30286,22 @@ T_6944: (in Mem1091[a7_1057 + 0<32>:word32] : word32)
   Class: Eq_5429
   DataType: (ptr32 Eq_5429)
   OrigDataType: ptr32
-T_6945: (in v248_1105 : Eq_6945)
+T_6945: (in v248_1105 : byte)
   Class: Eq_6945
-  DataType: Eq_6945
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_6946: (in 55<i32> : int32)
   Class: Eq_6946
   DataType: int32
   OrigDataType: int32
 T_6947: (in a7_1968 + 55<i32> : word32)
   Class: Eq_6947
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_6948: (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
   Class: Eq_6945
-  DataType: Eq_6945
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_6949: (in a7_1109 : (ptr32 Eq_6949))
   Class: Eq_6949
   DataType: (ptr32 Eq_6949)
@@ -30892,8 +30516,8 @@ T_7001: (in 56<i32> : int32)
   OrigDataType: int32
 T_7002: (in a7_1968 + 56<i32> : word32)
   Class: Eq_7002
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7003: (in Mem836[a7_1968 + 56<i32>:word32] : word32)
   Class: Eq_7000
   DataType: word32
@@ -30922,22 +30546,22 @@ T_7009: (in d4_376 != 2<32> : bool)
   Class: Eq_7009
   DataType: bool
   OrigDataType: bool
-T_7010: (in v262_844 : Eq_7010)
+T_7010: (in v262_844 : word16)
   Class: Eq_7010
-  DataType: Eq_7010
-  OrigDataType: (union (word16 u0) (word32 u1))
+  DataType: word16
+  OrigDataType: word16
 T_7011: (in 62<i32> : int32)
   Class: Eq_7011
   DataType: int32
   OrigDataType: int32
 T_7012: (in a7_1968 + 62<i32> : word32)
   Class: Eq_7012
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7013: (in Mem843[a7_1968 + 62<i32>:word16] : word16)
   Class: Eq_7010
-  DataType: Eq_7010
-  OrigDataType: word32
+  DataType: word16
+  OrigDataType: word16
 T_7014: (in a7_848 : (ptr32 Eq_7014))
   Class: Eq_7014
   DataType: (ptr32 Eq_7014)
@@ -31220,7 +30844,7 @@ T_7083: (in Mem623[a0_1447 + 4<i32>:word32] : word32)
   OrigDataType: word32
 T_7084: (in 0<32> : word32)
   Class: Eq_576
-  DataType: uint8
+  DataType: byte
   OrigDataType: word32
 T_7085: (in 0<32> : word32)
   Class: Eq_7085
@@ -31233,7 +30857,7 @@ T_7086: (in a0_1447 + 0<32> : word32)
 T_7087: (in Mem624[a0_1447 + 0<32>:word32] : word32)
   Class: Eq_576
   DataType: Eq_576
-  OrigDataType: uint8
+  OrigDataType: byte
 T_7088: (in d3_1482 + 3<32> : word32)
   Class: Eq_7088
   DataType: Eq_7088
@@ -31322,22 +30946,22 @@ T_7109: (in d0_891 == 0<32> : bool)
   Class: Eq_7109
   DataType: bool
   OrigDataType: bool
-T_7110: (in v277_869 : Eq_7110)
+T_7110: (in v277_869 : byte)
   Class: Eq_7110
-  DataType: Eq_7110
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_7111: (in 63<i32> : int32)
   Class: Eq_7111
   DataType: int32
   OrigDataType: int32
 T_7112: (in a7_1968 + 63<i32> : word32)
   Class: Eq_7112
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7113: (in Mem868[a7_1968 + 63<i32>:byte] : byte)
   Class: Eq_7110
-  DataType: Eq_7110
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_7114: (in a7_873 : (ptr32 Eq_7114))
   Class: Eq_7114
   DataType: (ptr32 Eq_7114)
@@ -31491,8 +31115,8 @@ T_7151: (in (byte) d1 == 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_7152: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_7153: (in d5_256 != 0<32> : bool)
   Class: Eq_7153
@@ -31600,7 +31224,7 @@ T_7178: (in 8<i32> : int32)
   OrigDataType: int32
 T_7179: (in a7_911 - 8<i32> : word32)
   Class: Eq_7179
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_7182 t0000)))
 T_7180: (in 0<32> : word32)
   Class: Eq_7180
@@ -31611,12 +31235,12 @@ T_7181: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7182: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7183: (in a7_911 - 8<i32> : word32)
   Class: Eq_7183
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_7186 t0000)))
 T_7184: (in 0<32> : word32)
   Class: Eq_7184
@@ -31627,8 +31251,8 @@ T_7185: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7186: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7187: (in 4<i32> : int32)
   Class: Eq_7187
@@ -31840,7 +31464,7 @@ T_7238: (in 8<i32> : int32)
   OrigDataType: int32
 T_7239: (in a7_992 - 8<i32> : word32)
   Class: Eq_7239
-  DataType: (ptr32 Eq_576)
+  DataType: (ptr32 Eq_656)
   OrigDataType: (ptr32 (struct (0 T_7242 t0000)))
 T_7240: (in 0<32> : word32)
   Class: Eq_7240
@@ -31851,8 +31475,8 @@ T_7241: (in a7_992 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7242: (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7243: (in d1_1017 : word32)
   Class: Eq_7243
@@ -32252,7 +31876,7 @@ T_7341: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (Eq_6087 u2) (Eq_5924 u3) (Eq_5924 u4) (Eq_6622 u5) (Eq_6686 u6) (Eq_6692 u7) (Eq_6762 u8) (Eq_6807 u9)))
 T_7342: (in Mem525[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_7339
-  DataType: Eq_8380
+  DataType: Eq_8351
   OrigDataType: (ptr32 Eq_6087)
 T_7343: (in 0<i32> : int32)
   Class: Eq_5914
@@ -33142,29 +32766,29 @@ T_7564: (in -1<i32> : int32)
   Class: Eq_5267
   DataType: int32
   OrigDataType: int32
-T_7565: (in d0 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7565: (in d0 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7566: (in d0_196 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: uint8
-T_7567: (in d1_142 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7566: (in d0_196 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: (ptr32 Eq_6087)
+T_7567: (in d1_142 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_7568: (in a0_20 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7568: (in a0_20 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
-T_7569: (in d3_166 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7569: (in d3_166 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
 T_7570: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_7571: (in dwArg0C != 0<32> : bool)
   Class: Eq_7571
@@ -33195,8 +32819,8 @@ T_7577: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_7578: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_7579: (in dwArg10 != 0<32> : bool)
   Class: Eq_7579
@@ -33218,41 +32842,41 @@ T_7583: (in signature of fn00003B28 : void)
   Class: Eq_7582
   DataType: (ptr32 Eq_7582)
   OrigDataType: 
-T_7584: (in d0 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7584: (in d0 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: (union (int32 u1) (up32 u0))
-T_7585: (in d1 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7585: (in d1 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: up32
-T_7586: (in d2 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7586: (in d2 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: (union (int32 u0) (up32 u1))
-T_7587: (in d1Out : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7587: (in d1Out : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
-T_7588: (in d2Out : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7588: (in d2Out : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_7589: (in out d1_318 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_7590: (in out d2_319 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_7591: (in fn00003B28(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7592: (in 0<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_7593: (in d4_29 : int32)
   Class: Eq_7593
@@ -33262,21 +32886,21 @@ T_7594: (in 24<i32> : int32)
   Class: Eq_7593
   DataType: int32
   OrigDataType: int32
-T_7595: (in d6_30 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7595: (in d6_30 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uip32
 T_7596: (in __rol : ptr32)
   Class: Eq_4540
   DataType: (ptr32 Eq_4540)
   OrigDataType: (ptr32 (fn T_7598 (T_6554, T_7597)))
 T_7597: (in 8<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_7598: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7599: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_7599
@@ -33379,12 +33003,12 @@ T_7623: (in __rol : ptr32)
   DataType: (ptr32 Eq_4540)
   OrigDataType: (ptr32 (fn T_7625 (T_7595, T_7624)))
 T_7624: (in 8<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_7625: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7626: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_7626
@@ -33407,12 +33031,12 @@ T_7630: (in __rol : ptr32)
   DataType: (ptr32 Eq_4540)
   OrigDataType: (ptr32 (fn T_7632 (T_7595, T_7631)))
 T_7631: (in 8<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_7632: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7633: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_7633
@@ -33439,40 +33063,40 @@ T_7638: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_7639: (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uip32
-T_7640: (in d1_175 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7640: (in d1_175 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7641: (in d2_176 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7641: (in d2_176 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7642: (in d0_174 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7642: (in d0_174 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7643: (in fn00003B28 : ptr32)
   Class: Eq_7582
   DataType: (ptr32 Eq_7582)
   OrigDataType: (ptr32 (fn T_7647 (T_7644, T_6552, T_7569, T_7645, T_7646)))
 T_7644: (in 0<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_7645: (in out d1_175 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_7646: (in out d2_176 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_7647: (in fn00003B28(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7648: (in d2_321 : word32)
   Class: Eq_7648
@@ -33487,16 +33111,16 @@ T_7650: (in fn00003B28 : ptr32)
   DataType: (ptr32 Eq_7582)
   OrigDataType: (ptr32 (fn T_7653 (T_7640, T_6553, T_7641, T_7651, T_7652)))
 T_7651: (in out d1_320 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_7652: (in out d2_321 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_7653: (in fn00003B28(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7654: (in 1<i32> : int32)
   Class: Eq_7654
@@ -33539,8 +33163,8 @@ T_7663: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_7664: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
 T_7665: (in d1_86 : word32)
   Class: Eq_7665
@@ -33550,17 +33174,17 @@ T_7666: (in d2_322 : word32)
   Class: Eq_7666
   DataType: word32
   OrigDataType: word32
-T_7667: (in d0_85 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7667: (in d0_85 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7668: (in fn00003B28 : ptr32)
   Class: Eq_7582
   DataType: (ptr32 Eq_7582)
   OrigDataType: (ptr32 (fn T_7678 (T_7669, T_7672, T_7675, T_7676, T_7677)))
 T_7669: (in dwArg04 >> d4_61 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7670: (in dwArg04 << d5_63 : word32)
   Class: Eq_7670
@@ -33571,8 +33195,8 @@ T_7671: (in dwArg08 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_7672: (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_7673: (in dwArg0C << d5_63 : word32)
   Class: Eq_7673
@@ -33583,52 +33207,52 @@ T_7674: (in dwArg10 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_7675: (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_7676: (in out d1_86 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_7677: (in out d2_322 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_7678: (in fn00003B28(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7679: (in d3_72 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7679: (in d3_72 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7680: (in dwArg10 << d5_63 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
-T_7681: (in d5_101 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7681: (in d5_101 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7682: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7683 (T_7667)))
 T_7683: (in __swap(d0_85) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7684: (in d6_103 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7684: (in d6_103 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7685: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7686 (T_7679)))
 T_7686: (in __swap(d3_72) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7687: (in d3_102 : uint32)
   Class: Eq_7687
@@ -33642,9 +33266,9 @@ T_7689: (in d3_72 * (word16) d5_101 : word32)
   Class: Eq_7687
   DataType: uint32
   OrigDataType: uint32
-T_7690: (in d2_107 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7690: (in d2_107 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7691: (in __swap : ptr32)
   Class: Eq_800
@@ -33655,12 +33279,12 @@ T_7692: (in SLICE(d3_72, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_7693: (in d0_85 * (word16) d3_72 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7694: (in __swap(d0_85 * (word16) d3_72) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7695: (in v34_108 : cup16)
   Class: Eq_7695
@@ -33710,29 +33334,29 @@ T_7706: (in SLICE(SEQ(v35_109, v34_108) + d4_104, word16, 0) : word16)
   Class: Eq_7703
   DataType: cup16
   OrigDataType: word16
-T_7707: (in d6_82 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7707: (in d6_82 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7708: (in dwArg08 << d5_63 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
-T_7709: (in d2_124 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7709: (in d2_124 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7710: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7712 (T_7711)))
 T_7711: (in SEQ(v35_109, v39_116) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7712: (in __swap(SEQ(v35_109, v39_116)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7713: (in d5_105 : uint32)
   Class: Eq_7713
@@ -33763,12 +33387,12 @@ T_7719: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_7720: (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7721: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7722: (in __swap : ptr32)
   Class: Eq_800
@@ -33783,12 +33407,12 @@ T_7724: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_7725: (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7726: (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7727: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
   Class: Eq_7727
@@ -33875,8 +33499,8 @@ T_7747: (in 1<32> : word32)
   DataType: uint32
   OrigDataType: uint32
 T_7748: (in d0_85 - 1<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7749: (in 0<32> : word32)
   Class: Eq_7716
@@ -33898,13 +33522,13 @@ T_7753: (in d6_82 - d2_124 >= 0<32> : bool)
   Class: Eq_7753
   DataType: bool
   OrigDataType: bool
-T_7754: (in d7_13 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7754: (in d7_13 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: (union (int32 u0) (uint32 u1))
 T_7755: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_7756: (in d2 == 0<32> : bool)
   Class: Eq_7756
@@ -33915,40 +33539,40 @@ T_7757: (in fn0000257E : ptr32)
   DataType: (ptr32 Eq_4450)
   OrigDataType: (ptr32 (fn T_7759 (T_7585, T_7586, T_7586, T_7758)))
 T_7758: (in out d1 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_7759: (in fn0000257E(d1, d2, d2, out d1) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7760: (in d6_17 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7760: (in d6_17 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_7761: (in d5_19 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7761: (in d5_19 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7762: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_7763: (in d0 != 0<32> : bool)
   Class: Eq_7763
   DataType: bool
   OrigDataType: bool
-T_7764: (in d2_22 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7764: (in d2_22 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7765: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7766 (T_7586)))
 T_7766: (in __swap(d2) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7767: (in SLICE(d2_22, word16, 0) : word16)
   Class: Eq_7767
@@ -33963,8 +33587,8 @@ T_7769: (in (word16) d2_22 != 0<16> : bool)
   DataType: bool
   OrigDataType: bool
 T_7770: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_7771: (in d1 == 0<32> : bool)
   Class: Eq_7771
@@ -33999,36 +33623,36 @@ T_7778: (in 0<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_7779: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_7780: (in d2 < 0<32> : bool)
   Class: Eq_7780
   DataType: bool
   OrigDataType: bool
-T_7781: (in d0_281 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7781: (in d0_281 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7782: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7783 (T_7584)))
 T_7783: (in __swap(d0) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7784: (in d1_282 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7784: (in d1_282 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7785: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7786 (T_7585)))
 T_7786: (in __swap(d1) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7787: (in d0_285 : uint32)
   Class: Eq_7787
@@ -34067,8 +33691,8 @@ T_7795: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7796 (T_7784)))
 T_7796: (in __swap(d1_282) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7797: (in SLICE(__swap(d1_282), word16, 0) : word16)
   Class: Eq_7797
@@ -34095,12 +33719,12 @@ T_7802: (in (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_7803: (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7804: (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7805: (in SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16) : word16)
   Class: Eq_7805
@@ -34119,8 +33743,8 @@ T_7808: (in (uint16) (d0_295 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_7809: (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7810: (in __swap : ptr32)
   Class: Eq_800
@@ -34143,12 +33767,12 @@ T_7814: (in 0<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_7815: (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7816: (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7817: (in v41_64 : word16)
   Class: Eq_7817
@@ -34163,8 +33787,8 @@ T_7819: (in 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7820: (in d6_17 * 2<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_7821: (in SLICE(d0_44, word16, 16) : word16)
   Class: Eq_7821
@@ -34195,28 +33819,28 @@ T_7827: (in d5_19 * 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7828: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: up32
 T_7829: (in d6_17 < 0<32> : bool)
   Class: Eq_7829
   DataType: bool
   OrigDataType: bool
 T_7830: (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_7831: (in 2<32> : word32)
   Class: Eq_7831
   DataType: ui32
   OrigDataType: ui32
 T_7832: (in d7_13 * 2<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_7833: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_7834: (in d7_13 > 0<32> : bool)
   Class: Eq_7834
@@ -34230,9 +33854,9 @@ T_7836: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7845 (T_7844)))
-T_7837: (in d3_74 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7837: (in d3_74 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7838: (in SLICE(d3_74, uint16, 0) : uint16)
   Class: Eq_7838
@@ -34259,12 +33883,12 @@ T_7843: (in (uint16) (d5_19 /u SLICE(d3_74, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_7844: (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7845: (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7846: (in SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16) : word16)
   Class: Eq_7846
@@ -34275,24 +33899,24 @@ T_7847: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_7848: (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7849: (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7850: (in d1_104 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
-  OrigDataType: uint8
+T_7850: (in d1_104 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
+  OrigDataType: (ptr32 Eq_6087)
 T_7851: (in 0xFFFF<32> : uipr32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: uipr32
-T_7852: (in d6_98 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7852: (in d6_98 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7853: (in __swap : ptr32)
   Class: Eq_800
@@ -34307,48 +33931,48 @@ T_7855: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_7856: (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7857: (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7858: (in d6_133 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7858: (in d6_133 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7859: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7860 (T_7850)))
 T_7860: (in __swap(d1_104) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7861: (in d3_140 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7861: (in d3_140 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7862: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7863 (T_7858)))
 T_7863: (in __swap(d6_133) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7864: (in d4_142 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7864: (in d4_142 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7865: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7866 (T_7754)))
 T_7866: (in __swap(d7_13) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7867: (in d5_141 : uint32)
   Class: Eq_7867
@@ -34362,9 +33986,9 @@ T_7869: (in d7_13 * (word16) d3_140 : word32)
   Class: Eq_7867
   DataType: uint32
   OrigDataType: uint32
-T_7870: (in d6_146 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7870: (in d6_146 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7871: (in __swap : ptr32)
   Class: Eq_800
@@ -34375,12 +33999,12 @@ T_7872: (in SLICE(d7_13, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_7873: (in d6_133 * (word16) d7_13 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7874: (in __swap(d6_133 * (word16) d7_13) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7875: (in v55_147 : cup16)
   Class: Eq_7875
@@ -34442,29 +34066,29 @@ T_7889: (in d3_140 * (word16) d4_142 : word32)
   Class: Eq_7887
   DataType: uint32
   OrigDataType: uint32
-T_7890: (in d6_178 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7890: (in d6_178 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7891: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7893 (T_7892)))
 T_7892: (in SEQ(v56_148, v59_155) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7893: (in __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7894: (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7895: (in d5_181 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7896: (in __swap : ptr32)
   Class: Eq_800
@@ -34479,12 +34103,12 @@ T_7898: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_7899: (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7900: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7901: (in __swap : ptr32)
   Class: Eq_800
@@ -34499,12 +34123,12 @@ T_7903: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_7904: (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7905: (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7906: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
   Class: Eq_7906
@@ -34555,20 +34179,20 @@ T_7917: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ
   DataType: uint32
   OrigDataType: uint32
 T_7918: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: up32
 T_7919: (in d6_178 <u 0<32> : bool)
   Class: Eq_7919
   DataType: Eq_7919
   OrigDataType: (union (bool u0) (uint32 u1))
 T_7920: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7921: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: up32
 T_7922: (in d5_181 >= 0<32> : bool)
   Class: Eq_7922
@@ -34599,12 +34223,12 @@ T_7928: (in 1<32> : word32)
   DataType: uipr32
   OrigDataType: uipr32
 T_7929: (in d1_104 - 1<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
-T_7930: (in d4_113 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7930: (in d4_113 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7931: (in __swap : ptr32)
   Class: Eq_800
@@ -34615,8 +34239,8 @@ T_7932: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7933 (T_7754)))
 T_7933: (in __swap(d7_13) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7934: (in SLICE(d1_104, word16, 0) : word16)
   Class: Eq_7934
@@ -34627,12 +34251,12 @@ T_7935: (in __swap(d7_13) * (word16) d1_104 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_7936: (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7937: (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7938: (in wLoc22_442 : word16)
   Class: Eq_7938
@@ -34691,8 +34315,8 @@ T_7951: (in __swap : ptr32)
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7952 (T_7754)))
 T_7952: (in __swap(d7_13) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7953: (in SLICE(__swap(d7_13), word16, 16) : word16)
   Class: Eq_7953
@@ -34707,20 +34331,20 @@ T_7955: (in SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : uipr32)
   DataType: uipr32
   OrigDataType: uipr32
 T_7956: (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7957: (in 1<32> : word32)
   Class: Eq_7957
   DataType: uint32
   OrigDataType: uint32
 T_7958: (in d1_104 - 1<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7959: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: up32
 T_7960: (in d6_178 < 0<32> : bool)
   Class: Eq_7960
@@ -34743,20 +34367,20 @@ T_7964: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_7965: (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7966: (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7967: (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_7968: (in d6_220 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7968: (in d6_220 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7969: (in __swap : ptr32)
   Class: Eq_800
@@ -34771,12 +34395,12 @@ T_7971: (in SLICE(d5_181, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_7972: (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7973: (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7974: (in SLICE(dwLoc24, word16, 16) : word16)
   Class: Eq_7974
@@ -34787,20 +34411,20 @@ T_7975: (in SLICE(d1_104, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_7976: (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
-T_7977: (in d5_221 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7977: (in d5_221 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_7978: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7979 (T_7895)))
 T_7979: (in __swap(d5_181) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7980: (in v82_224 : word16)
   Class: Eq_7980
@@ -34818,29 +34442,29 @@ T_7983: (in v41_64 == 0<16> : bool)
   Class: Eq_7983
   DataType: bool
   OrigDataType: bool
-T_7984: (in d5_266 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7984: (in d5_266 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7985: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7986 (T_7895)))
 T_7986: (in __swap(d5_181) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_7987: (in d6_267 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7987: (in d6_267 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7988: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_7989 (T_7890)))
 T_7989: (in __swap(d6_178) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_7990: (in SLICE(d5_266, word16, 16) : word16)
   Class: Eq_7990
@@ -34851,8 +34475,8 @@ T_7991: (in SLICE(d6_267, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_7992: (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7993: (in SLICE(d6_267, word16, 16) : word16)
   Class: Eq_7993
@@ -34863,8 +34487,8 @@ T_7994: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_7995: (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_7996: (in true : bool)
   Class: Eq_7775
@@ -34878,25 +34502,25 @@ T_7998: (in SEQ(SLICE(d1_104, word16, 0), wLoc22_442) : word32)
   Class: Eq_7939
   DataType: word32
   OrigDataType: word32
-T_7999: (in d2_73 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_7999: (in d2_73 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8000: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_8001 (T_7761)))
 T_8001: (in __swap(d5_19) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8002: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_8003 (T_7754)))
 T_8003: (in __swap(d7_13) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8004: (in d2_73 - d3_74 : word32)
   Class: Eq_8004
@@ -34935,8 +34559,8 @@ T_8012: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_8013: (in d5_221 >> 1<32> : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_8014: (in v86_241 : word16)
   Class: Eq_8014
@@ -34955,8 +34579,8 @@ T_8017: (in signature of __rcr : void)
   DataType: (ptr32 Eq_8016)
   OrigDataType: 
 T_8018: (in  : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: 
 T_8019: (in  : word32)
   Class: Eq_8019
@@ -34979,8 +34603,8 @@ T_8023: (in SLICE(cond(d5_221), bool, 4) : bool)
   DataType: bool
   OrigDataType: bool
 T_8024: (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8025: (in SLICE(d7_230, word16, 16) : word16)
   Class: Eq_8025
@@ -35006,21 +34630,21 @@ T_8030: (in v86_241 != 0<16> : bool)
   Class: Eq_8030
   DataType: bool
   OrigDataType: bool
-T_8031: (in d1 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8031: (in d1 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_8032: (in d1_171 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8032: (in d1_171 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
-T_8033: (in d3_202 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8033: (in d3_202 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
 T_8034: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_8035: (in dwArg0C != 0<32> : bool)
   Class: Eq_8035
@@ -35051,8 +34675,8 @@ T_8041: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_8042: (in 0<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_8043: (in dwArg10 != 0<32> : bool)
   Class: Eq_8043
@@ -35067,16 +34691,16 @@ T_8045: (in fn00003B28 : ptr32)
   DataType: (ptr32 Eq_7582)
   OrigDataType: (ptr32 (fn T_8048 (T_6468, T_6469, T_6471, T_8046, T_8047)))
 T_8046: (in out d1_171 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_8047: (in out d2_354 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_8048: (in fn00003B28(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8049: (in d4_32 : int32)
   Class: Eq_8049
@@ -35086,21 +34710,21 @@ T_8050: (in 24<i32> : int32)
   Class: Eq_8049
   DataType: int32
   OrigDataType: int32
-T_8051: (in d6_33 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8051: (in d6_33 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uip32
 T_8052: (in __rol : ptr32)
   Class: Eq_4540
   DataType: (ptr32 Eq_4540)
   OrigDataType: (ptr32 (fn T_8054 (T_6470, T_8053)))
 T_8053: (in 8<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_8054: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8055: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_8055
@@ -35203,12 +34827,12 @@ T_8079: (in __rol : ptr32)
   DataType: (ptr32 Eq_4540)
   OrigDataType: (ptr32 (fn T_8081 (T_8051, T_8080)))
 T_8080: (in 8<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_8081: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8082: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_8082
@@ -35231,12 +34855,12 @@ T_8086: (in __rol : ptr32)
   DataType: (ptr32 Eq_4540)
   OrigDataType: (ptr32 (fn T_8088 (T_8051, T_8087)))
 T_8087: (in 8<32> : word32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: word32
 T_8088: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8089: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_8089
@@ -35263,8 +34887,8 @@ T_8094: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_8095: (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uip32
 T_8096: (in d1_89 : ui32)
   Class: Eq_8096
@@ -35274,17 +34898,17 @@ T_8097: (in d2_90 : word32)
   Class: Eq_8097
   DataType: word32
   OrigDataType: word32
-T_8098: (in d0_88 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8098: (in d0_88 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_8099: (in fn00003B28 : ptr32)
   Class: Eq_7582
   DataType: (ptr32 Eq_7582)
   OrigDataType: (ptr32 (fn T_8109 (T_8100, T_8103, T_8106, T_8107, T_8108)))
 T_8100: (in dwArg04 >> d4_64 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_8101: (in dwArg04 << d5_66 : word32)
   Class: Eq_8101
@@ -35295,8 +34919,8 @@ T_8102: (in dwArg08 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_8103: (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_8104: (in dwArg0C << d5_66 : word32)
   Class: Eq_8104
@@ -35307,52 +34931,52 @@ T_8105: (in dwArg10 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_8106: (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_8107: (in out d1_89 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_8108: (in out d2_90 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_8109: (in fn00003B28(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_8110: (in d3_75 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8110: (in d3_75 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_8111: (in dwArg10 << d5_66 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
-T_8112: (in d7_104 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8112: (in d7_104 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_8113: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_8114 (T_8098)))
 T_8114: (in __swap(d0_88) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_8115: (in d6_106 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8115: (in d6_106 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8116: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_8117 (T_8110)))
 T_8117: (in __swap(d3_75) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8118: (in d3_105 : uint32)
   Class: Eq_8118
@@ -35366,9 +34990,9 @@ T_8120: (in d3_75 * (word16) d7_104 : word32)
   Class: Eq_8118
   DataType: uint32
   OrigDataType: uint32
-T_8121: (in d2_110 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8121: (in d2_110 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8122: (in __swap : ptr32)
   Class: Eq_800
@@ -35379,12 +35003,12 @@ T_8123: (in SLICE(d3_75, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_8124: (in d0_88 * (word16) d3_75 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_8125: (in __swap(d0_88 * (word16) d3_75) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8126: (in v36_111 : cup16)
   Class: Eq_8126
@@ -35434,21 +35058,21 @@ T_8137: (in SLICE(SEQ(v37_112, v36_111) + d4_107, word16, 0) : word16)
   Class: Eq_8134
   DataType: cup16
   OrigDataType: word16
-T_8138: (in d2_127 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8138: (in d2_127 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_8139: (in __swap : ptr32)
   Class: Eq_800
   DataType: (ptr32 Eq_800)
   OrigDataType: (ptr32 (fn T_8141 (T_8140)))
 T_8140: (in SEQ(v37_112, v40_119) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_8141: (in __swap(SEQ(v37_112, v40_119)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8142: (in d7_108 : uint32)
   Class: Eq_8142
@@ -35487,12 +35111,12 @@ T_8150: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_8151: (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_8152: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8153: (in __swap : ptr32)
   Class: Eq_800
@@ -35507,12 +35131,12 @@ T_8155: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_8156: (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uipr32
 T_8157: (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8158: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
   Class: Eq_8158
@@ -35587,8 +35211,8 @@ T_8175: (in dwArg0C - dwArg04 < 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_8176: (in dwArg08 - dwArg10 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: uint32
 T_8177: (in dwArg10 - dwArg08 : word32)
   Class: Eq_8177
@@ -35602,33 +35226,33 @@ T_8179: (in dwArg10 - dwArg08 > 0<32> : bool)
   Class: Eq_8179
   DataType: bool
   OrigDataType: bool
-T_8180: (in d1_211 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8180: (in d1_211 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
-T_8181: (in d2_212 : Eq_576)
-  Class: Eq_576
-  DataType: Eq_576
+T_8181: (in d2_212 : Eq_656)
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8182: (in fn00003B28 : ptr32)
   Class: Eq_7582
   DataType: (ptr32 Eq_7582)
   OrigDataType: (ptr32 (fn T_8186 (T_8183, T_6468, T_8033, T_8184, T_8185)))
 T_8183: (in 0<i32> : int32)
-  Class: Eq_576
-  DataType: uint8
+  Class: Eq_656
+  DataType: (ptr32 Eq_6087)
   OrigDataType: int32
 T_8184: (in out d1_211 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_8185: (in out d2_212 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_8186: (in fn00003B28(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8187: (in d2_355 : word32)
   Class: Eq_8187
@@ -35639,16 +35263,16 @@ T_8188: (in fn00003B28 : ptr32)
   DataType: (ptr32 Eq_7582)
   OrigDataType: (ptr32 (fn T_8191 (T_8180, T_6469, T_8181, T_8189, T_8190)))
 T_8189: (in out d1_171 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: (union (uint32 u0) (ptr32 u1))
 T_8190: (in out d2_355 : ptr32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ptr32
 T_8191: (in fn00003B28(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8192: (in 1<i32> : int32)
   Class: Eq_8192
@@ -35691,8 +35315,8 @@ T_8201: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_8202: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: int32
 T_8203: (in d3_135 - d3_75 : word32)
   Class: Eq_8147
@@ -35711,8 +35335,8 @@ T_8206: (in d3_135 < 0<32> : bool)
   DataType: Eq_8206
   OrigDataType: (union (bool u0) (word32 u1))
 T_8207: (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: word32
 T_8208: (in 0<32> : word32)
   Class: Eq_8169
@@ -35763,8 +35387,8 @@ T_8219: (in d6_157 >> d5_66 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_8220: (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
-  Class: Eq_576
-  DataType: Eq_576
+  Class: Eq_656
+  DataType: Eq_656
   OrigDataType: ui32
 T_8221: (in d6_85 - d3_135 : word32)
   Class: Eq_8221
@@ -36092,7 +35716,7 @@ T_8301:
   OrigDataType: 
 T_8302:
   Class: Eq_8302
-  DataType: Eq_8302
+  DataType: Eq_705
   OrigDataType: 
 T_8303:
   Class: Eq_8303
@@ -36108,7 +35732,7 @@ T_8305:
   OrigDataType: 
 T_8306:
   Class: Eq_8306
-  DataType: Eq_8306
+  DataType: Eq_705
   OrigDataType: 
 T_8307:
   Class: Eq_8307
@@ -36116,7 +35740,7 @@ T_8307:
   OrigDataType: 
 T_8308:
   Class: Eq_8308
-  DataType: Eq_8308
+  DataType: Eq_705
   OrigDataType: 
 T_8309:
   Class: Eq_8309
@@ -36140,7 +35764,7 @@ T_8313:
   OrigDataType: 
 T_8314:
   Class: Eq_8314
-  DataType: Eq_8314
+  DataType: Eq_705
   OrigDataType: 
 T_8315:
   Class: Eq_8315
@@ -36152,7 +35776,7 @@ T_8316:
   OrigDataType: 
 T_8317:
   Class: Eq_8317
-  DataType: Eq_705
+  DataType: Eq_8317
   OrigDataType: 
 T_8318:
   Class: Eq_8318
@@ -36176,7 +35800,7 @@ T_8322:
   OrigDataType: 
 T_8323:
   Class: Eq_8323
-  DataType: Eq_705
+  DataType: Eq_8323
   OrigDataType: 
 T_8324:
   Class: Eq_8324
@@ -36204,7 +35828,7 @@ T_8329:
   OrigDataType: 
 T_8330:
   Class: Eq_8330
-  DataType: Eq_705
+  DataType: Eq_8330
   OrigDataType: 
 T_8331:
   Class: Eq_8331
@@ -36300,11 +35924,11 @@ T_8353:
   OrigDataType: 
 T_8354:
   Class: Eq_8354
-  DataType: Eq_705
+  DataType: Eq_8354
   OrigDataType: 
 T_8355:
   Class: Eq_8355
-  DataType: (ptr32 Eq_705)
+  DataType: Eq_8355
   OrigDataType: 
 T_8356:
   Class: Eq_8356
@@ -36381,90 +36005,6 @@ T_8373:
 T_8374:
   Class: Eq_8374
   DataType: Eq_8374
-  OrigDataType: 
-T_8375:
-  Class: Eq_8375
-  DataType: Eq_8375
-  OrigDataType: 
-T_8376:
-  Class: Eq_8376
-  DataType: Eq_8376
-  OrigDataType: 
-T_8377:
-  Class: Eq_8377
-  DataType: Eq_8377
-  OrigDataType: 
-T_8378:
-  Class: Eq_8378
-  DataType: Eq_8378
-  OrigDataType: 
-T_8379:
-  Class: Eq_8379
-  DataType: Eq_8379
-  OrigDataType: 
-T_8380:
-  Class: Eq_8380
-  DataType: Eq_8380
-  OrigDataType: 
-T_8381:
-  Class: Eq_8381
-  DataType: Eq_8381
-  OrigDataType: 
-T_8382:
-  Class: Eq_8382
-  DataType: Eq_8382
-  OrigDataType: 
-T_8383:
-  Class: Eq_8383
-  DataType: Eq_8383
-  OrigDataType: 
-T_8384:
-  Class: Eq_8384
-  DataType: Eq_8384
-  OrigDataType: 
-T_8385:
-  Class: Eq_8385
-  DataType: Eq_8385
-  OrigDataType: 
-T_8386:
-  Class: Eq_8386
-  DataType: Eq_8386
-  OrigDataType: 
-T_8387:
-  Class: Eq_8387
-  DataType: Eq_8387
-  OrigDataType: 
-T_8388:
-  Class: Eq_8388
-  DataType: Eq_8388
-  OrigDataType: 
-T_8389:
-  Class: Eq_8389
-  DataType: Eq_8389
-  OrigDataType: 
-T_8390:
-  Class: Eq_8390
-  DataType: Eq_8390
-  OrigDataType: 
-T_8391:
-  Class: Eq_8391
-  DataType: Eq_8391
-  OrigDataType: 
-T_8392:
-  Class: Eq_8392
-  DataType: Eq_8392
-  OrigDataType: 
-T_8393:
-  Class: Eq_8393
-  DataType: Eq_8393
-  OrigDataType: 
-T_8394:
-  Class: Eq_8394
-  DataType: Eq_8394
-  OrigDataType: 
-T_8395:
-  Class: Eq_8395
-  DataType: Eq_8395
   OrigDataType: 
 */
 typedef struct Eq_613;
@@ -36636,21 +36176,17 @@ typedef struct Eq_553 {
 typedef word32 (Eq_561)(ptr32, ptr32, ptr32);
 
 typedef union Eq_576 {
-	uint8 u0;
+	byte u0;
 	word16 u1;
-	struct Eq_6087 * u2;
-	struct Eq_8282 * u3;
-	struct Eq_8294 * u4;
-	Eq_2791 u5;
-	Eq_3068 u6;
-	Eq_3654 u7;
+	struct Eq_8313 * u2;
+	struct Eq_8283 * u3;
 } Eq_576;
 
 typedef word32 (Eq_583)(ptr32, ptr32, ptr32);
 
 typedef ptr32 (Eq_585)(Eq_576);
 
-typedef void (Eq_608)(Eq_576, Eq_576, Eq_576, Eq_613 *);
+typedef void (Eq_608)(Eq_576, Eq_576, byte * *, Eq_613 *);
 
 typedef struct Eq_613 {	// size: 1 1
 	uint8 b0000;	// 0
@@ -36666,20 +36202,36 @@ typedef union Eq_617 {
 
 typedef Eq_576 (Eq_635)(Eq_576, Eq_576);
 
-typedef void (Eq_649)(Eq_576, Eq_576, Eq_576, Eq_576, Eq_613 *, Eq_576);
+typedef void (Eq_649)(Eq_576, Eq_576, byte * *, Eq_576, Eq_613 *, Eq_656);
 
-typedef union Eq_698 {
-	uint8 u0;
-	struct Eq_8302 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
+typedef union Eq_656 {
+	struct Eq_6087 * u0;
+	struct Eq_8284 * u1;
+	struct Eq_8285 * u2;
+} Eq_656;
+
+typedef struct Eq_698 {	// size: 4 4
+	int32 dw002C;	// 2C
+	Eq_8286 t0030;	// 30
+	word32 dw0034;	// 34
+	uint8 b0037;	// 37
+	word32 dw0038;	// 38
+	word32 dw003C;	// 3C
+	word32 dw0040;	// 40
+	Eq_8287 t0044;	// 44
+	byte b0048;	// 48
+	byte b0049;	// 49
+	word32 dw004A;	// 4A
+	word32 dw006E;	// 6E
+	word32 dw0072;	// 72
+	word32 dw0084;	// 84
 } Eq_698;
 
 typedef union Eq_705 {
 	byte u0;
 	word16 u1;
-	struct Eq_8304 * u2;
-	Eq_3068 u3;
+	struct Eq_8313 * u2;
+	struct Eq_8289 * u3;
 } Eq_705;
 
 typedef union Eq_716 {
@@ -36706,7 +36258,7 @@ typedef union Eq_782 {
 	uint32 u1;
 } Eq_782;
 
-typedef Eq_576 (Eq_800)(Eq_576);
+typedef Eq_656 (Eq_800)(Eq_656);
 
 typedef union Eq_809 {
 	int32 u0;
@@ -36722,11 +36274,12 @@ typedef Eq_576 (Eq_1060)(Eq_576, Eq_1063, word32 *, byte *);
 
 typedef union Eq_1063 {
 	byte u0;
-	struct Eq_8305 * u1;
-	Eq_3068 u2;
+	word16 u1;
+	struct Eq_8313 * u2;
+	struct Eq_8290 * u3;
 } Eq_1063;
 
-typedef Eq_576 (Eq_1250)(Eq_576, Eq_576);
+typedef Eq_576 (Eq_1250)(byte, Eq_576);
 
 typedef struct Eq_1263 {
 	Eq_576 t0000;	// 0
@@ -36956,11 +36509,6 @@ typedef struct Eq_2749 {
 	uint32 dw0038;	// 38
 } Eq_2749;
 
-typedef union Eq_2791 {
-	uint8 u0;
-	word32 u1;
-} Eq_2791;
-
 typedef union Eq_2799 {
 	int32 u0;
 	uint32 u1;
@@ -37016,92 +36564,30 @@ typedef union Eq_2967 {
 	word32 u1;
 } Eq_2967;
 
-typedef union Eq_2981 {
-	byte u0;
-	struct Eq_8318 * u1;
-	Eq_3068 u2;
-} Eq_2981;
-
-typedef union Eq_2983 {
-	byte u0;
-	struct Eq_8319 * u1;
-	Eq_3068 u2;
-} Eq_2983;
-
-typedef union Eq_2998 {
-	byte u0;
-	struct Eq_8320 * u1;
-	Eq_3068 u2;
-} Eq_2998;
-
-typedef union Eq_3001 {
-	byte u0;
-	struct Eq_8322 * u1;
-	Eq_3068 u2;
-} Eq_3001;
-
 typedef union Eq_3019 {
 	bool u0;
 	word32 u1;
 } Eq_3019;
 
-typedef union Eq_3050 {
-	byte u0;
-	struct Eq_8324 * u1;
-	Eq_3068 u2;
-} Eq_3050;
-
-typedef union Eq_3052 {
-	byte u0;
-	struct Eq_8325 * u1;
-	Eq_3068 u2;
-} Eq_3052;
-
-typedef union Eq_3065 {
-	byte u0;
-	struct Eq_8327 * u1;
-	Eq_3001 u2;
-	Eq_3068 u3;
-} Eq_3065;
-
-typedef union Eq_3068 {
-	byte u0;
-	struct Eq_8329 * u1;
-} Eq_3068;
-
 typedef union Eq_3071 {
 	union Eq_705 ** u0;
-	Eq_3001 u1;
+	struct Eq_8307 * u1;
 } Eq_3071;
-
-typedef union Eq_3112 {
-	byte u0;
-	struct Eq_8331 * u1;
-	Eq_3068 u2;
-} Eq_3112;
-
-typedef union Eq_3127 {
-	byte u0;
-	struct Eq_8333 * u1;
-	Eq_3068 u2;
-} Eq_3127;
 
 typedef union Eq_3129 {
 	union Eq_705 ** u0;
-	Eq_3001 u1;
-	Eq_3065 u2;
+	struct Eq_8307 * u1;
 } Eq_3129;
 
 typedef union Eq_3130 {
-	struct Eq_8335 * u0;
-	Eq_3001 u1;
-	Eq_3065 u2;
-	Eq_3068 u3;
+	union Eq_705 ** u0;
+	struct Eq_8307 * u1;
+	struct Eq_8313 * u2;
 } Eq_3130;
 
 typedef union Eq_3133 {
 	union Eq_705 ** u0;
-	Eq_3068 u1;
+	struct Eq_8313 * u1;
 } Eq_3133;
 
 typedef union Eq_3147 {
@@ -37120,20 +36606,15 @@ typedef struct Eq_3289 {
 } Eq_3289;
 
 typedef struct Eq_3340 {
-	Eq_576 t0000;	// 0
-	Eq_3429 t0001;	// 1
+	Eq_656 t0000;	// 0
+	ui24 n0001;	// 1
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
 	word32 dw0044;	// 44
 	word32 dw0048;	// 48
 } Eq_3340;
 
-typedef word32 (Eq_3391)(Eq_705, Eq_576, Eq_576, Eq_576, Eq_576, ptr32);
-
-typedef union Eq_3429 {
-	ui24 u0;
-	word32 u1;
-} Eq_3429;
+typedef word32 (Eq_3391)(Eq_705, Eq_656, Eq_656, Eq_656, Eq_656, ptr32);
 
 typedef union Eq_3442 {
 	int32 u0;
@@ -37155,23 +36636,14 @@ typedef struct Eq_3525 {
 
 typedef union Eq_3653 {
 	union Eq_705 ** u0;
-	Eq_3068 u1;
-	Eq_3127 u2;
+	struct Eq_8313 * u1;
 } Eq_3653;
 
 typedef union Eq_3654 {
-	uint8 u0;
-	struct Eq_8352 * u1;
-	Eq_2791 u2;
-	Eq_3068 u3;
-	Eq_3127 u4;
+	union Eq_705 ** u0;
+	struct Eq_8313 * u1;
+	struct Eq_8313 * u2;
 } Eq_3654;
-
-typedef union Eq_3656 {
-	uint8 u0;
-	word32 u1;
-	Eq_2791 u2;
-} Eq_3656;
 
 typedef struct Eq_3664 {
 	int32 dw0000;	// 0
@@ -37183,416 +36655,53 @@ typedef union Eq_3676 {
 	int32 u1;
 } Eq_3676;
 
-typedef union Eq_3679 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3679;
-
-typedef union Eq_3681 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
+typedef struct Eq_3681 {
+	Eq_576 t0000;	// 0
+	byte b0030;	// 30
+	word32 dw0038;	// 38
+	Eq_576 t003C;	// 3C
+	byte b004C;	// 4C
 } Eq_3681;
 
-typedef union Eq_3682 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3682;
+typedef union Eq_3706 {
+	int32 u0;
+	byte u1;
+} Eq_3706;
 
-typedef union Eq_3685 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3685;
-
-typedef union Eq_3688 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3688;
-
-typedef union Eq_3693 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3693;
-
-typedef union Eq_3695 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3695;
-
-typedef union Eq_3698 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3698;
-
-typedef union Eq_3704 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3704;
-
-typedef union Eq_3708 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3708;
-
-typedef union Eq_3713 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3713;
-
-typedef union Eq_3717 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3717;
+typedef union Eq_3715 {
+	int32 u0;
+	byte u1;
+} Eq_3715;
 
 typedef struct Eq_3730 {
 	word32 dw0000;	// 0
-	word32 dw0004;	// 4
+	Eq_576 t0004;	// 4
 } Eq_3730;
 
-typedef union Eq_3735 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3735;
-
-typedef union Eq_3741 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3741;
-
-typedef union Eq_3749 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3749;
-
-typedef union Eq_3754 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3754;
-
-typedef union Eq_3767 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3767;
-
-typedef union Eq_3778 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3778;
-
-typedef union Eq_3783 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3783;
-
-typedef union Eq_3796 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3796;
-
-typedef union Eq_3807 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3807;
-
-typedef union Eq_3812 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3812;
-
-typedef union Eq_3825 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3825;
-
-typedef union Eq_3842 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3842;
-
-typedef union Eq_3854 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3854;
-
-typedef union Eq_3855 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3855;
-
-typedef union Eq_3856 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3856;
-
-typedef union Eq_3858 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3858;
-
-typedef union Eq_3865 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3865;
-
-typedef union Eq_3868 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3868;
-
-typedef union Eq_3872 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3872;
-
-typedef union Eq_3876 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3876;
-
-typedef union Eq_3881 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3881;
-
-typedef union Eq_3929 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3929;
-
-typedef union Eq_3930 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3930;
-
-typedef union Eq_3931 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3931;
+typedef union Eq_3870 {
+	int32 u0;
+	byte u1;
+} Eq_3870;
 
 typedef union Eq_3933 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_3933;
 
-typedef union Eq_3936 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3936;
-
-typedef union Eq_3947 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3947;
-
-typedef union Eq_3949 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3949;
-
-typedef union Eq_3950 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3950;
-
-typedef union Eq_3951 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3951;
-
 typedef union Eq_3953 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_3953;
 
-typedef union Eq_3956 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3956;
-
-typedef union Eq_3968 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_3968;
-
-typedef union Eq_4022 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
+typedef struct Eq_4022 {
+	Eq_576 t0000;	// 0
+	Eq_576 t0030;	// 30
 } Eq_4022;
 
-typedef union Eq_4023 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4023;
-
-typedef union Eq_4026 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4026;
-
-typedef union Eq_4031 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4031;
-
-typedef union Eq_4038 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4038;
-
-typedef union Eq_4046 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
+typedef struct Eq_4046 {
+	Eq_576 t0000;	// 0
+	uint32 dw0030;	// 30
 } Eq_4046;
-
-typedef union Eq_4047 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4047;
-
-typedef union Eq_4050 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4050;
-
-typedef union Eq_4062 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4062;
-
-typedef union Eq_4065 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4065;
-
-typedef union Eq_4070 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4070;
-
-typedef union Eq_4075 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4075;
-
-typedef union Eq_4078 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4078;
 
 typedef union Eq_4080 {
 	int32 u0;
@@ -37604,236 +36713,17 @@ typedef union Eq_4081 {
 	uint32 u1;
 } Eq_4081;
 
-typedef union Eq_4087 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4087;
-
-typedef union Eq_4093 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
+typedef struct Eq_4093 {
+	ptr32 ptr0000;	// 0
+	byte b004D;	// 4D
 } Eq_4093;
 
-typedef union Eq_4094 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4094;
-
-typedef union Eq_4096 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4096;
-
-typedef union Eq_4099 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4099;
-
-typedef union Eq_4101 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4101;
-
-typedef union Eq_4102 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4102;
-
-typedef union Eq_4104 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4104;
-
-typedef union Eq_4107 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4107;
-
-typedef union Eq_4108 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4108;
-
-typedef union Eq_4110 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4110;
-
-typedef union Eq_4112 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4112;
-
-typedef union Eq_4113 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4113;
-
-typedef union Eq_4115 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4115;
-
-typedef union Eq_4118 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4118;
-
-typedef int32 (Eq_4120)(Eq_576, Eq_576, Eq_576);
-
-typedef union Eq_4125 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4125;
-
-typedef union Eq_4127 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4127;
-
-typedef union Eq_4129 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4129;
-
-typedef union Eq_4130 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4130;
-
-typedef union Eq_4132 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4132;
-
-typedef union Eq_4139 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4139;
-
-typedef union Eq_4140 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4140;
-
-typedef union Eq_4142 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4142;
+typedef int32 (Eq_4120)(Eq_656, Eq_656, Eq_656);
 
 typedef union Eq_4151 {
 	int32 u0;
 	uint32 u1;
 } Eq_4151;
-
-typedef union Eq_4156 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4156;
-
-typedef union Eq_4191 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4191;
-
-typedef union Eq_4192 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4192;
-
-typedef union Eq_4195 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4195;
-
-typedef union Eq_4201 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4201;
-
-typedef union Eq_4213 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4213;
-
-typedef union Eq_4214 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4214;
-
-typedef union Eq_4217 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4217;
-
-typedef union Eq_4229 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4229;
 
 typedef union Eq_4235 {
 	int32 u0;
@@ -37845,266 +36735,14 @@ typedef union Eq_4241 {
 	uint32 u1;
 } Eq_4241;
 
-typedef union Eq_4246 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4246;
-
-typedef union Eq_4250 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4250;
-
-typedef union Eq_4251 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4251;
-
-typedef union Eq_4254 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4254;
-
-typedef union Eq_4256 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4256;
-
-typedef union Eq_4257 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4257;
-
-typedef union Eq_4259 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4259;
-
-typedef union Eq_4262 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4262;
-
-typedef union Eq_4263 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4263;
-
-typedef union Eq_4265 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4265;
-
-typedef union Eq_4268 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4268;
-
-typedef union Eq_4272 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4272;
-
-typedef union Eq_4274 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4274;
-
-typedef union Eq_4275 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4275;
-
-typedef union Eq_4277 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4277;
-
-typedef union Eq_4280 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4280;
-
-typedef union Eq_4282 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4282;
-
-typedef union Eq_4283 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4283;
-
-typedef union Eq_4285 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4285;
-
-typedef union Eq_4288 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4288;
-
-typedef union Eq_4289 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4289;
-
-typedef union Eq_4291 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4291;
-
-typedef union Eq_4293 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4293;
-
-typedef union Eq_4294 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4294;
-
-typedef union Eq_4296 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4296;
-
-typedef union Eq_4299 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4299;
-
-typedef union Eq_4302 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4302;
-
-typedef union Eq_4304 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4304;
-
-typedef union Eq_4306 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4306;
-
-typedef union Eq_4307 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4307;
-
-typedef union Eq_4309 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4309;
-
-typedef union Eq_4316 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4316;
-
-typedef union Eq_4317 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4317;
-
-typedef union Eq_4319 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4319;
-
 typedef union Eq_4328 {
 	int32 u0;
 	uint32 u1;
 } Eq_4328;
 
-typedef union Eq_4340 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4340;
+typedef Eq_656 (Eq_4450)(Eq_656, Eq_656, Eq_656, Eq_656);
 
-typedef union Eq_4344 {
-	uint8 u0;
-	struct Eq_8360 * u1;
-	Eq_2791 u2;
-	Eq_3654 u3;
-} Eq_4344;
-
-typedef Eq_576 (Eq_4450)(Eq_576, Eq_576, Eq_576, Eq_576);
-
-typedef Eq_576 (Eq_4540)(Eq_576, Eq_576);
+typedef Eq_656 (Eq_4540)(Eq_656, Eq_656);
 
 typedef Eq_1063 (Eq_4634)(ptr32, ptr32);
 
@@ -38184,19 +36822,19 @@ typedef struct Eq_5429 {
 } Eq_5429;
 
 typedef struct Eq_5440 {	// size: 4 4
-	Eq_8379 t002C;	// 2C
+	Eq_8350 t002C;	// 2C
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
-	word32 dw0037;	// 37
+	byte b0037;	// 37
 	word32 dw0038;	// 38
 	word32 dw003C;	// 3C
-	word32 dw003E;	// 3E
-	word32 dw003F;	// 3F
+	word16 w003E;	// 3E
+	byte b003F;	// 3F
 	word32 dw0040;	// 40
 	word32 dw0044;	// 44
 	ui32 dw0048;	// 48
 	word32 dw0062;	// 62
-	Eq_8380 t0066;	// 66
+	Eq_8351 t0066;	// 66
 	byte b006A;	// 6A
 	word32 dw006C;	// 6C
 	word32 dw007C;	// 7C
@@ -38431,9 +37069,9 @@ typedef struct Eq_6426 {
 	Eq_5428 t0080;	// 80
 } Eq_6426;
 
-typedef int32 (Eq_6466)(Eq_576, Eq_576, Eq_576, Eq_576);
+typedef int32 (Eq_6466)(Eq_656, Eq_656, Eq_656, Eq_656);
 
-typedef word32 (Eq_6550)(Eq_576, Eq_576, Eq_576, Eq_576, Eq_576, Eq_576);
+typedef word32 (Eq_6550)(Eq_656, Eq_656, Eq_656, Eq_656, Eq_656, Eq_656);
 
 typedef union Eq_6590 {
 	bool u0;
@@ -38576,11 +37214,6 @@ typedef union Eq_6852 {
 	up32 u1;
 } Eq_6852;
 
-typedef union Eq_6945 {
-	byte u0;
-	word32 u1;
-} Eq_6945;
-
 typedef struct Eq_6949 {
 	struct Eq_5429 * ptr0000;	// 0
 	int32 dw0034;	// 34
@@ -38601,11 +37234,6 @@ typedef union Eq_6987 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_6987;
-
-typedef union Eq_7010 {
-	word16 u0;
-	word32 u1;
-} Eq_7010;
 
 typedef struct Eq_7014 {
 	struct Eq_5429 * ptr0000;	// 0
@@ -38669,11 +37297,6 @@ typedef union Eq_7106 {
 	Eq_6034 u4;
 	Eq_7104 u5;
 } Eq_7106;
-
-typedef union Eq_7110 {
-	byte u0;
-	word32 u1;
-} Eq_7110;
 
 typedef struct Eq_7114 {
 	struct Eq_5429 * ptr0000;	// 0
@@ -38885,7 +37508,7 @@ typedef union Eq_7341 {
 
 typedef Eq_5485 (Eq_7365)(int32, Eq_5231 *, ui32 *, ptr32, ptr32);
 
-typedef Eq_576 (Eq_7582)(Eq_576, Eq_576, Eq_576, Eq_576, Eq_576);
+typedef Eq_656 (Eq_7582)(Eq_656, Eq_656, Eq_656, Eq_656, Eq_656);
 
 typedef struct Eq_7614 {	// size: 1 1
 	Eq_7614 a0000[];	// 0
@@ -38926,7 +37549,7 @@ typedef union Eq_7919 {
 	uint32 u1;
 } Eq_7919;
 
-typedef Eq_576 (Eq_8016)(Eq_576, word32, bool);
+typedef Eq_656 (Eq_8016)(Eq_656, word32, bool);
 
 typedef union Eq_8162 {
 	bool u0;
@@ -38957,316 +37580,274 @@ typedef struct Eq_8225 {	// size: 4 4
 	byte b0000;	// 0
 } Eq_8225;
 
-typedef struct Eq_8282 {	// size: 1 1
-	word32 dw0000;	// 0
+typedef struct Eq_8282 {
+	Eq_705 t0000;	// 0
 } Eq_8282;
 
-typedef struct Eq_8283 {
-	Eq_576 t0000;	// 0
-} Eq_8283;
-
-typedef struct Eq_8284 {
-	Eq_705 t0000;	// 0
-} Eq_8284;
-
-typedef union Eq_8285 {
-	int32 u0;
-	byte u1;
-	Eq_576 u2;
-} Eq_8285;
-
-typedef struct Eq_8286 {
-	Eq_705 t0000;	// 0
-} Eq_8286;
-
-typedef struct Eq_8287 {	// size: 4 4
-	struct Eq_8286 * ptr0000;	// 0
-} Eq_8287;
-
-typedef union Eq_8288 {
-	byte u0;
-	struct Eq_8287 * u1;
-	Eq_576 u2;
-	Eq_3068 u3;
-	Eq_3127 u4;
-	Eq_3654 u5;
-} Eq_8288;
-
-typedef union Eq_8289 {
-	uint8 u0;
-	word32 u1;
-	Eq_2791 u2;
-} Eq_8289;
-
-typedef union Eq_8290 {
-	uint8 u0;
-	word32 u1;
-	Eq_698 u2;
-	Eq_2791 u3;
-	Eq_3654 u4;
-} Eq_8290;
-
-typedef struct Eq_8291 {
-	Eq_705 t0000;	// 0
-} Eq_8291;
-
-typedef struct Eq_8292 {	// size: 4 4
-	struct Eq_8291 * ptr0000;	// 0
-} Eq_8292;
-
-typedef union Eq_8293 {
-	struct Eq_8292 * u0;
-	Eq_3001 u1;
-	Eq_3065 u2;
-	Eq_3068 u3;
-	Eq_3130 u4;
-} Eq_8293;
-
-typedef struct Eq_8294 {	// size: 4 4
-	struct Eq_8283 * ptrFFFFFFFC;	// FFFFFFFC
-	struct Eq_8284 * ptr0000;	// 0
+typedef struct Eq_8283 {	// size: 4 4
+	struct Eq_8282 * ptr0000;	// 0
 	Eq_576 t0004;	// 4
 	Eq_576 t0008;	// 8
 	int32 dw0014;	// 14
 	ui32 dw0018;	// 18
 	int32 dw001C;	// 1C
-	Eq_8285 t002C;	// 2C
-	Eq_8288 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8289 t0037;	// 37
-	Eq_8290 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8293 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
+} Eq_8283;
+
+typedef struct Eq_8284 {	// size: 1 1
+	word32 dw0000;	// 0
+} Eq_8284;
+
+typedef struct Eq_8285 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8285;
+
+typedef union Eq_8286 {
+	union Eq_705 ** u0;
+	struct Eq_8313 * u1;
+	Eq_3654 u2;
+} Eq_8286;
+
+typedef union Eq_8287 {
+	union Eq_705 ** u0;
+	struct Eq_8307 * u1;
+	struct Eq_8313 * u2;
+	Eq_3130 u3;
+} Eq_8287;
+
+typedef struct Eq_8288 {
+	Eq_705 t0000;	// 0
+} Eq_8288;
+
+typedef struct Eq_8289 {	// size: 4 4
+	struct Eq_8288 * ptr0000;	// 0
+	Eq_576 t0004;	// 4
+	Eq_576 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
+} Eq_8289;
+
+typedef struct Eq_8290 {	// size: 4 4
+	union Eq_705 * ptr0000;	// 0
+	Eq_576 t0004;	// 4
+	Eq_576 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
+} Eq_8290;
+
+typedef struct Eq_8291 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8291;
+
+typedef struct Eq_8292 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8292;
+
+typedef struct Eq_8293 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8293;
+
+typedef struct Eq_8294 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8294;
 
-typedef union Eq_8295 {
-	int32 u0;
-	byte u1;
-	Eq_576 u2;
+typedef struct Eq_8295 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8295;
 
-typedef struct Eq_8296 {
-	Eq_705 t0000;	// 0
+typedef struct Eq_8296 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8296;
 
 typedef struct Eq_8297 {	// size: 4 4
-	struct Eq_8296 * ptr0000;	// 0
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8297;
 
-typedef union Eq_8298 {
-	byte u0;
-	struct Eq_8297 * u1;
-	Eq_576 u2;
-	Eq_3068 u3;
-	Eq_3127 u4;
-	Eq_3654 u5;
+typedef struct Eq_8298 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8298;
 
-typedef union Eq_8299 {
-	uint8 u0;
-	word32 u1;
-	Eq_2791 u2;
+typedef struct Eq_8299 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8299;
 
-typedef union Eq_8300 {
-	uint8 u0;
-	word32 u1;
-	Eq_698 u2;
-	Eq_2791 u3;
-	Eq_3654 u4;
+typedef struct Eq_8300 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8300;
 
-typedef union Eq_8301 {
-	struct Eq_8292 * u0;
-	Eq_3001 u1;
-	Eq_3065 u2;
-	Eq_3068 u3;
-	Eq_3130 u4;
+typedef struct Eq_8301 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8301;
 
-typedef struct Eq_8302 {	// size: 4 4
-	Eq_576 t0000;	// 0
-	Eq_8295 t002C;	// 2C
-	Eq_8298 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8299 t0037;	// 37
-	Eq_8300 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8301 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
-} Eq_8302;
-
-typedef struct Eq_8303 {
-	Eq_705 t0000;	// 0
+typedef struct Eq_8303 {	// size: 4 4
+	union Eq_8367 * ptr0000;	// 0
+	Eq_576 t0004;	// 4
+	Eq_576 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8303;
 
 typedef struct Eq_8304 {	// size: 4 4
-	struct Eq_8303 * ptr0000;	// 0
+	union Eq_8368 * ptr0000;	// 0
 	Eq_576 t0004;	// 4
 	Eq_576 t0008;	// 8
 	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8304;
 
 typedef struct Eq_8305 {	// size: 4 4
-	union Eq_705 * ptr0000;	// 0
+	union Eq_8369 * ptr0000;	// 0
 	Eq_576 t0004;	// 4
 	Eq_576 t0008;	// 8
 	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8305;
 
-typedef struct Eq_8306 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8306;
-
 typedef struct Eq_8307 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8374 * ptr0000;	// 0
+	Eq_576 t0004;	// 4
+	Eq_576 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8307;
 
-typedef struct Eq_8308 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8308;
-
 typedef struct Eq_8309 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8371 * ptr0000;	// 0
+	Eq_576 t0004;	// 4
+	Eq_576 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8309;
 
 typedef struct Eq_8310 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8372 * ptr0000;	// 0
+	Eq_576 t0004;	// 4
+	Eq_576 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8310;
 
 typedef struct Eq_8311 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_705 * ptr0000;	// 0
+	Eq_576 t0004;	// 4
+	Eq_576 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8311;
 
-typedef struct Eq_8312 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+typedef struct Eq_8312 {
+	Eq_705 t0000;	// 0
 } Eq_8312;
 
 typedef struct Eq_8313 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_8373 * ptr0000;	// 0
+	Eq_576 t0004;	// 4
+	Eq_576 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8313;
 
-typedef struct Eq_8314 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8314;
-
 typedef struct Eq_8315 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_705 * ptr0000;	// 0
+	Eq_576 t0004;	// 4
+	Eq_576 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8315;
 
 typedef struct Eq_8316 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8316;
-
-typedef struct Eq_8318 {	// size: 4 4
 	union Eq_705 * ptr0000;	// 0
 	Eq_576 t0004;	// 4
 	Eq_576 t0008;	// 8
 	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
+} Eq_8316;
+
+typedef struct Eq_8317 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8317;
+
+typedef struct Eq_8318 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8318;
 
 typedef struct Eq_8319 {	// size: 4 4
-	union Eq_705 * ptr0000;	// 0
-	Eq_576 t0004;	// 4
-	Eq_576 t0008;	// 8
-	int32 dw0014;	// 14
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8319;
 
 typedef struct Eq_8320 {	// size: 4 4
-	union Eq_705 * ptr0000;	// 0
-	Eq_576 t0004;	// 4
-	Eq_576 t0008;	// 8
-	int32 dw0014;	// 14
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8320;
 
-typedef struct Eq_8321 {
-	Eq_705 t0000;	// 0
+typedef struct Eq_8321 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8321;
 
 typedef struct Eq_8322 {	// size: 4 4
-	struct Eq_8321 * ptr0000;	// 0
-	Eq_576 t0004;	// 4
-	Eq_576 t0008;	// 8
-	int32 dw0014;	// 14
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8322;
 
+typedef struct Eq_8323 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8323;
+
 typedef struct Eq_8324 {	// size: 4 4
-	union Eq_705 * ptr0000;	// 0
-	Eq_576 t0004;	// 4
-	Eq_576 t0008;	// 8
-	int32 dw0014;	// 14
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8324;
 
 typedef struct Eq_8325 {	// size: 4 4
-	union Eq_705 * ptr0000;	// 0
-	Eq_576 t0004;	// 4
-	Eq_576 t0008;	// 8
-	int32 dw0014;	// 14
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8325;
 
-typedef struct Eq_8326 {
-	Eq_705 t0000;	// 0
+typedef struct Eq_8326 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8326;
 
 typedef struct Eq_8327 {	// size: 4 4
-	struct Eq_8326 * ptr0000;	// 0
-	Eq_576 t0004;	// 4
-	Eq_576 t0008;	// 8
-	int32 dw0014;	// 14
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8327;
 
-typedef struct Eq_8328 {
-	Eq_705 t0000;	// 0
+typedef struct Eq_8328 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8328;
 
 typedef struct Eq_8329 {	// size: 4 4
-	struct Eq_8328 * ptr0000;	// 0
-	Eq_576 t0004;	// 4
-	Eq_576 t0008;	// 8
-	int32 dw0014;	// 14
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8329;
 
+typedef struct Eq_8330 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8330;
+
 typedef struct Eq_8331 {	// size: 4 4
-	union Eq_705 * ptr0000;	// 0
-	Eq_576 t0004;	// 4
-	Eq_576 t0008;	// 8
-	int32 dw0014;	// 14
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8331;
 
-typedef struct Eq_8332 {
-	Eq_705 t0000;	// 0
+typedef struct Eq_8332 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8332;
 
 typedef struct Eq_8333 {	// size: 4 4
-	struct Eq_8332 * ptr0000;	// 0
-	Eq_576 t0004;	// 4
-	Eq_576 t0008;	// 8
-	int32 dw0014;	// 14
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8333;
 
-typedef struct Eq_8334 {
-	Eq_705 t0000;	// 0
+typedef struct Eq_8334 {	// size: 4 4
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8334;
 
 typedef struct Eq_8335 {	// size: 4 4
-	struct Eq_8334 * ptr0000;	// 0
+	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8335;
 
 typedef struct Eq_8336 {	// size: 4 4
@@ -39325,148 +37906,7 @@ typedef struct Eq_8349 {	// size: 4 4
 	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8349;
 
-typedef struct Eq_8350 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8350;
-
-typedef struct Eq_8351 {
-	Eq_705 t0000;	// 0
-} Eq_8351;
-
-typedef struct Eq_8352 {	// size: 4 4
-	struct Eq_8351 * ptr0000;	// 0
-} Eq_8352;
-
-typedef union Eq_8353 {
-	int32 u0;
-	byte u1;
-	Eq_576 u2;
-} Eq_8353;
-
-typedef union Eq_8356 {
-	byte u0;
-	union Eq_705 ** u1;
-	Eq_576 u2;
-	Eq_3068 u3;
-	Eq_3127 u4;
-	Eq_3654 u5;
-} Eq_8356;
-
-typedef union Eq_8357 {
-	uint8 u0;
-	word32 u1;
-	Eq_2791 u2;
-} Eq_8357;
-
-typedef union Eq_8358 {
-	uint8 u0;
-	word32 u1;
-	Eq_698 u2;
-	Eq_2791 u3;
-	Eq_3654 u4;
-} Eq_8358;
-
-typedef union Eq_8359 {
-	struct Eq_8292 * u0;
-	Eq_3001 u1;
-	Eq_3065 u2;
-	Eq_3068 u3;
-	Eq_3130 u4;
-} Eq_8359;
-
-typedef struct Eq_8360 {	// size: 4 4
-	Eq_576 t0000;	// 0
-	Eq_8353 t002C;	// 2C
-	Eq_8356 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8357 t0037;	// 37
-	Eq_8358 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8359 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
-} Eq_8360;
-
-typedef struct Eq_8361 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8361;
-
-typedef struct Eq_8362 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8362;
-
-typedef struct Eq_8363 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8363;
-
-typedef struct Eq_8364 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8364;
-
-typedef struct Eq_8365 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8365;
-
-typedef struct Eq_8366 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8366;
-
-typedef struct Eq_8367 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8367;
-
-typedef struct Eq_8368 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8368;
-
-typedef struct Eq_8369 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8369;
-
-typedef struct Eq_8370 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8370;
-
-typedef struct Eq_8371 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8371;
-
-typedef struct Eq_8372 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8372;
-
-typedef struct Eq_8373 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8373;
-
-typedef struct Eq_8374 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8374;
-
-typedef struct Eq_8375 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8375;
-
-typedef struct Eq_8376 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8376;
-
-typedef struct Eq_8377 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8377;
-
-typedef struct Eq_8378 {	// size: 4 4
-	union Eq_576 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8378;
-
-typedef union Eq_8379 {
+typedef union Eq_8350 {
 	cu8 u0;
 	word32 u1;
 	Eq_5957 u2;
@@ -39475,9 +37915,9 @@ typedef union Eq_8379 {
 	Eq_7104 u5;
 	Eq_7215 u6;
 	Eq_7256 u7;
-} Eq_8379;
+} Eq_8350;
 
-typedef union Eq_8380 {
+typedef union Eq_8351 {
 	struct Eq_6087 * u0;
 	Eq_6622 u1;
 	Eq_6686 u2;
@@ -39485,80 +37925,121 @@ typedef union Eq_8380 {
 	Eq_6762 u4;
 	Eq_6807 u5;
 	Eq_7339 u6;
-} Eq_8380;
+} Eq_8351;
 
-typedef struct Eq_8381 {	// size: 1 1
+typedef struct Eq_8352 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8381;
+} Eq_8352;
 
-typedef struct Eq_8382 {	// size: 1 1
+typedef struct Eq_8353 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8382;
+} Eq_8353;
 
-typedef struct Eq_8383 {	// size: 1 1
+typedef struct Eq_8354 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8383;
+} Eq_8354;
 
-typedef struct Eq_8384 {	// size: 1 1
+typedef struct Eq_8355 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8384;
+} Eq_8355;
 
-typedef struct Eq_8385 {	// size: 1 1
+typedef struct Eq_8356 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8385;
+} Eq_8356;
 
-typedef struct Eq_8386 {	// size: 1 1
+typedef struct Eq_8357 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8386;
+} Eq_8357;
 
-typedef struct Eq_8387 {	// size: 1 1
+typedef struct Eq_8358 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8387;
+} Eq_8358;
 
-typedef struct Eq_8388 {	// size: 1 1
+typedef struct Eq_8359 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8388;
+} Eq_8359;
 
-typedef struct Eq_8389 {	// size: 1 1
+typedef struct Eq_8360 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8389;
+} Eq_8360;
 
-typedef struct Eq_8390 {	// size: 1 1
+typedef struct Eq_8361 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8390;
+} Eq_8361;
 
-typedef struct Eq_8391 {	// size: 1 1
+typedef struct Eq_8362 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8391;
+} Eq_8362;
 
-typedef struct Eq_8392 {	// size: 1 1
+typedef struct Eq_8363 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8392;
+} Eq_8363;
 
-typedef struct Eq_8393 {	// size: 1 1
+typedef struct Eq_8364 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8393;
+} Eq_8364;
 
-typedef struct Eq_8394 {	// size: 1 1
+typedef struct Eq_8365 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8394;
+} Eq_8365;
 
-typedef struct Eq_8395 {	// size: 1 1
+typedef struct Eq_8366 {	// size: 1 1
 	word32 dw0000;	// 0
 	byte b0003;	// 3
-} Eq_8395;
+} Eq_8366;
+
+typedef union Eq_8367 {
+	Eq_705 u0;
+	Eq_8312 u1;
+} Eq_8367;
+
+typedef union Eq_8368 {
+	Eq_705 u0;
+	Eq_8312 u1;
+} Eq_8368;
+
+typedef union Eq_8369 {
+	Eq_705 u0;
+	Eq_8312 u1;
+} Eq_8369;
+
+typedef union Eq_8370 {
+	Eq_705 u0;
+	Eq_8312 u1;
+} Eq_8370;
+
+typedef union Eq_8371 {
+	Eq_705 u0;
+	Eq_8312 u1;
+} Eq_8371;
+
+typedef union Eq_8372 {
+	Eq_705 u0;
+	Eq_8312 u1;
+} Eq_8372;
+
+typedef union Eq_8373 {
+	Eq_705 u0;
+	Eq_8312 u1;
+} Eq_8373;
+
+typedef union Eq_8374 {
+	Eq_705 u0;
+	Eq_8370 u1;
+	Eq_8373 u2;
+} Eq_8374;
 

--- a/subjects/Hunk-m68k/MAX.reko/MAX_code.c
+++ b/subjects/Hunk-m68k/MAX.reko/MAX_code.c
@@ -324,7 +324,7 @@ void fn00001354(int32 dwArg04, struct Eq_n * dwArg08)
 // 00001390: Register Eq_n fn00001390(Register Eq_n d0)
 Eq_n fn00001390(Eq_n d0)
 {
-	Eq_n a1_n;
+	byte ** a1_n;
 	Eq_n d1_n;
 	fn0000141C(fn00002F18(d0, 0x13DC, out d1_n, out a1_n), d1_n, a1_n, &globals->t13F0);
 	Eq_n d0_n = dwLoc08;
@@ -346,31 +346,31 @@ Eq_n fn00001408(Eq_n dwArg04, Eq_n dwArg08)
 	return d0_n;
 }
 
-// 0000141C: void fn0000141C(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack (ptr32 Eq_n) dwArg04)
-void fn0000141C(Eq_n d0, Eq_n d1, Eq_n a1, struct Eq_n * dwArg04)
+// 0000141C: void fn0000141C(Register Eq_n d0, Register Eq_n d1, Register (ptr32 (ptr32 byte)) a1, Stack (ptr32 Eq_n) dwArg04)
+void fn0000141C(Eq_n d0, Eq_n d1, byte ** a1, struct Eq_n * dwArg04)
 {
 	fn00001468(d0, d1, a1, *(union Eq_n *) 16116, dwArg04, fp + 8);
 }
 
-// 00001438: Register Eq_n fn00001438(Stack Eq_n bArg07, Stack Eq_n dwArg08)
-Eq_n fn00001438(Eq_n bArg07, Eq_n dwArg08)
+// 00001438: Register Eq_n fn00001438(Stack byte bArg07, Stack Eq_n dwArg08)
+Eq_n fn00001438(byte bArg07, Eq_n dwArg08)
 {
 	Eq_n d0_n = dwArg08;
 	if (dwArg08 != 0x00)
 	{
 		d0_n = *((word32) dwArg08 + 4);
 		if (d0_n - *((word32) dwArg08 + 8) < 0x00)
-			**((word32) dwArg08 + 4) = bArg07;
+			(*((word32) dwArg08 + 4))->u0 = bArg07;
 		*((word32) dwArg08 + 20) = (word32) *((word32) dwArg08 + 20) + 1;
 		--*((word32) dwArg08 + 4);
 	}
 	return d0_n;
 }
 
-// 00001468: void fn00001468(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
-void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
+// 00001468: void fn00001468(Register Eq_n d0, Register Eq_n d1, Register (ptr32 (ptr32 byte)) a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
+void fn00001468(Eq_n d0, Eq_n d1, byte ** a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
 {
-	Eq_n a7_n = fp + -0x0078;
+	struct Eq_n * a7_n = fp + -0x0078;
 	Eq_n d2_n = dwArg0C;
 	struct Eq_n * a4_n = dwArg08;
 	Eq_n a2_n = dwArg04;
@@ -384,8 +384,8 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 			Eq_n d3_n = 0;
 			if (a4_n->b0000 == 0x25)
 			{
-				*((word32) a7_n + 72) = 0x69;
-				*((word32) a7_n + 73) = 0x00;
+				a7_n[18] = (struct Eq_n) 0x69;
+				a7_n->b0049 = 0x00;
 				byte * a3_n = a4_n + 1;
 				uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 				Eq_n d6_n = -1;
@@ -393,7 +393,7 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				if ((d0_n & 0x04) != 0x00)
 				{
 					uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-					d6_n.u0 = 0;
+					&d6_n.u0->dw0000 = 0;
 					d0 = d0_n & 0x04;
 					if ((d0_n & 0x04) != 0x00)
 					{
@@ -415,8 +415,8 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				}
 				if (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))))
 				{
-					d7 = SEQ(SLICE(d7, word24, 8), *((word32) a7_n + 73));
-					d1 = SEQ(SLICE(d1, word24, 8), *((word32) a7_n + 72));
+					d7 = SEQ(SLICE(d7, word24, 8), a7_n->b0049);
+					d1 = SEQ(SLICE(d1, word24, 8), a7_n[18]);
 					do
 					{
 						if (*a3_n == 0x2A)
@@ -429,15 +429,15 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 							d1 = SEQ(SLICE(d1, word24, 8), *a3_n);
 						++a3_n;
 					} while (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))));
-					*((word32) a7_n + 72) = (byte) d1;
-					*((word32) a7_n + 73) = (byte) d7;
+					a7_n[18] = (struct Eq_n) (byte) d1;
+					a7_n->b0049 = (byte) d7;
 				}
-				if (*((word32) a7_n + 72) == 0x6A)
-					*((word32) a7_n + 72) = 0x01;
-				if (*((word32) a7_n + 72) == 116)
-					*((word32) a7_n + 72) = 0x69;
-				if (*((word32) a7_n + 72) == 122)
-					*((word32) a7_n + 72) = 0x6C;
+				if (a7_n[18] == 0x6A)
+					a7_n[18] = (struct Eq_n) 0x01;
+				if (a7_n[18] == 116)
+					a7_n[18] = (struct Eq_n) 0x69;
+				if (a7_n[18] == 122)
+					a7_n[18] = (struct Eq_n) 0x6C;
 				byte v83_n = *a3_n;
 				word24 v84_n = SLICE(d7, word24, 8);
 				struct Eq_n * a3_n = a3_n + 1;
@@ -458,7 +458,7 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 							byte * a0_n = *a1;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							*a1 = (byte **) (a0_n + 1);
 							byte v96_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v96_n);
@@ -495,19 +495,19 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 								d1 = SEQ(v147_n, v83_n - 115);
 								if (v83_n != 115)
 								{
-									*((word32) a7_n + 48) = 0x00;
-									*((word32) a7_n + 44) = 0x00;
-									*((word32) a7_n + 110) = 0x00;
+									a7_n[0x0C] = (struct Eq_n) 0x00;
+									a7_n[11] = (struct Eq_n) 0x00;
+									a7_n->dw006E = 0x00;
 									if (v83_n == 0x00)
 										--a3_n;
 									if (v83_n == 0x70)
 									{
-										*((word32) a7_n + 72) = 0x6C;
+										a7_n[18] = (struct Eq_n) 0x6C;
 										d7 = 0x0078;
 									}
 									if ((d5_n == 0x2D && (byte) d7 != 117 || d5_n == 0x2B) && d6_n - d3_n >= 0x00)
 									{
-										*((word32) a7_n + 110) = d5_n;
+										a7_n->dw006E = (word32) d5_n;
 										ui32 * a0_n = (word32) a2_n + 24;
 										*a0_n |= 0x01;
 										int32 * a0_n = (word32) a2_n + 20;
@@ -519,7 +519,7 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											byte * a0_n = *a1;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v231_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -535,7 +535,7 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0 = fn00002604(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0;
 										}
-										d5_n = *((word32) a7_n + 52);
+										d5_n = a7_n[0x0D];
 										d3_n = (word32) d3_n + 1;
 										d4_n = (word32) d4_n + 1;
 									}
@@ -555,7 +555,7 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												byte * a0_n = *a1;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												*a1 = (byte **) (a0_n + 1);
 												byte v249_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -571,8 +571,8 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00002604(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 64) = *((word32) a7_n + 52);
-											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+											a7_n[16] = a7_n[0x0D];
+											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 											Eq_n d3_n = (word32) d3_n + 1;
 											d0 = d0_n & 0xFF;
 											if (!__btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[(int32) (int16) (d0_n & 0xFF)].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0], 0x00))
@@ -591,7 +591,7 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 													byte * a0_n = *a1;
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
-													*a1 = a0_n + 1;
+													*a1 = (byte **) (a0_n + 1);
 													byte v271_n = *a0_n;
 													a2_n = a7_n->t0000;
 													a7_n->t0000 = d1;
@@ -607,12 +607,12 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 													d0_n = fn00002604(a7_n->t0000, out d1, out a1, out a5_n);
 													a7_n->t0038 = d0_n;
 												}
-												*((word32) a7_n + 74) = *((word32) a7_n + 52);
+												a7_n->dw004A = (word32) a7_n[0x0D];
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x44;
 												if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 													d7 = 0x0078;
-												if (*((word32) a7_n + 74) != ~0x00)
+												if (a7_n->dw004A != ~0x00)
 												{
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
@@ -622,7 +622,7 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											}
 											else
 												d7 = 111;
-											if (*((word32) a7_n + 64) != ~0x00)
+											if (a7_n[16] != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -659,7 +659,7 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											byte * a0_n = *a1;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v351_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -675,8 +675,8 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0_n = fn00002604(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0_n;
 										}
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
-										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+										a7_n[16] = a7_n[0x0D];
+										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 										Eq_n d3_n = (word32) d3_n + 1;
 										int32 d4_n = (word32) d4_n + 1;
 										d0 = d0_n & 0xFF;
@@ -696,7 +696,7 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												byte * a0_n = *a1;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												*a1 = (byte **) (a0_n + 1);
 												byte v372_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -712,17 +712,17 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00002604(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 74) = *((word32) a7_n + 52);
-											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55)) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
+											a7_n->dw004A = (word32) a7_n[0x0D];
+											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(SLICE(d0_n, word24, 8), a7_n->b0037) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 											d3_n = (word32) d3_n + 1;
 											d4_n = d4_n + 0x01;
 											d0 = d0_n & 0x44;
 											if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 											{
-												d5_n = *((word32) a7_n + 74);
+												d5_n = a7_n->dw004A;
 												goto l00001ED2;
 											}
-											if (*((word32) a7_n + 74) != ~0x00)
+											if (a7_n->dw004A != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -730,7 +730,7 @@ void fn00001468(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0 = fn00001438(*(a7_n - 1), a7_n->t0000);
 											}
 										}
-										if (*((word32) a7_n + 64) != ~0x00)
+										if (a7_n[16] != ~0x00)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
@@ -744,52 +744,52 @@ l00001ED2:
 									if ((byte) d7 != 0x78 && (byte) d7 != 88)
 									{
 										if ((byte) d7 == 111)
-											*((word32) a7_n + 52) = 0x08;
+											a7_n[0x0D] = (struct Eq_n) 0x08;
 										else
-											*((word32) a7_n + 52) = 0x0A;
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
+											a7_n[0x0D] = (struct Eq_n) 0x0A;
+										a7_n[16] = a7_n[0x0D];
 									}
 									else
-										*((word32) a7_n + 64) = 0x10;
-									*((word32) a7_n + 114) = *((word32) a7_n + 64);
+										a7_n[16] = (struct Eq_n) 0x10;
+									a7_n->dw0072 = (word32) a7_n[16];
 									uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(SLICE(d0, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-									*((word32) a7_n + 0x0084) = d2_n;
-									*((word32) a7_n + 52) = d4_n;
-									*((word32) a7_n + 74) = (byte) d7;
+									a7_n[33] = (struct Eq_n) d2_n;
+									a7_n[0x0D] = (struct Eq_n) d4_n;
+									a7_n->dw004A = (word32) (byte) d7;
 									d0 = d0_n & 0x44;
 									if ((d0_n & 0x44) != 0x00)
 									{
-										if (*((word32) a7_n + 114) == 0x0A)
+										if (a7_n->dw0072 == 0x0A)
 										{
 											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(SLICE(d0_n & 0x44, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											d0 = d0_n & 0x04;
 											if ((d0_n & 0x04) != 0x00)
 												goto l00001F6E;
 											goto l0000216E;
 										}
 l00001F6E:
-										if (*((word32) a7_n + 114) == 0x08)
+										if (a7_n->dw0072 == 0x08)
 										{
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d5_n <= 55)
 												goto l00001F8E;
 										}
 										else
 										{
 l00001F8E:
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 64) = d6_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n[16] = (struct Eq_n) d6_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d6_n - d3_n >= 0x00)
 											{
-												d7 = (int32) *((word32) a7_n + 114);
-												up32 a4_n = *((word32) a7_n + 64);
+												d7 = a7_n->dw0072;
+												up32 a4_n = a7_n[16];
 												do
 												{
 													struct Eq_n * a7_n = a7_n - 4;
@@ -797,7 +797,7 @@ l00001F8E:
 													Eq_n v419_n = a7_n->t0000;
 													a7_n->t0000 = d7 >> 31;
 													*(a7_n - 4) = d7;
-													*(a7_n - 8) = (union Eq_n *) a1;
+													*(a7_n - 8) = (byte ***) a1;
 													*(a7_n - 0x0C) = a7_n->dw0034;
 													*(a7_n - 16) = a7_n->dw0030;
 													*(a7_n - 20) = d7;
@@ -805,44 +805,44 @@ l00001F8E:
 													word32 d1_n;
 													a7_n->dw0044 = fn0000248C(d4_n, *(a7_n - 24), *(a7_n - 20), *(a7_n - 16), *(a7_n - 0x0C), out d1_n);
 													a7_n->dw0048 = d1_n;
-													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(a7_n->t0001, (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x04) != 0x00)
-														d4_n = d5_n - 0x30;
+													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(a7_n->n0001, (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x04) != 0x00)
+														d4_n = d5_n - (struct Eq_n *) 0x30;
 													else
 														d4_n.u0 = 0;
-													Eq_n d6_n;
+													struct Eq_n * d6_n;
 													*(a7_n - 4) = (union Eq_n *) v419_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d4_n + Mem2975[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = (union Eq_n *) d3_n;
 													int32 d0_n = d4_n >> 31;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + d0_n);
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < null) + ((word32) a7_n[16] + d0_n));
 													word32 v441_n = *(a7_n - 8);
 													word32 v442_n = *(a7_n - 4);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x01) != 0x00)
-														d6_n = d5_n - 55;
+														d6_n = d5_n - (struct Eq_n *) 55;
 													else
-														d6_n.u0 = 0;
-													Eq_n d2_n;
+														d6_n = null;
+													struct Eq_n * d2_n;
 													*(a7_n - 4) = v442_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d6_n + Mem3035[a7_n + 48:word32];
-													*((word32) a7_n + 0x0044) = d2_n;
+													a7_n[0x0011] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v441_n;
 													int32 d0_n = d6_n >> 31;
-													*((word32) a7_n + 64) = (word32) *((word32) a7_n + 44) + d0_n + (d2_n < 0x00);
+													a7_n[16] = (struct Eq_n) ((word32) a7_n[11] + d0_n + (d2_n < null));
 													word32 v453_n = *(a7_n - 8);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x02) != 0x00)
-														d2_n = d5_n - 0x57;
+														d2_n = d5_n - (struct Eq_n *) 0x57;
 													else
-														d2_n.u0 = 0;
+														d2_n = null;
 													Eq_n d0_n;
-													*(a7_n - 4) = (union Eq_n *) d2_n;
+													*(a7_n - 4) = (struct Eq_n **) d2_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d2_n + Mem3093[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v453_n;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + (d2_n >> 31));
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < null) + ((word32) a7_n[16] + (d2_n >> 31)));
 													ui32 * a0_n = (word32) a2_n + 24;
 													up32 v465_n = *(a7_n - 8);
 													d2_n = *(a7_n - 4);
@@ -855,7 +855,7 @@ l00001F8E:
 														a1 = (word32) a2_n + 4;
 														byte * a0_n = *a1;
 														*(a7_n - 4) = (union Eq_n *) a2_n;
-														*a1 = a0_n + 1;
+														*a1 = (byte **) (a0_n + 1);
 														d0_n = (uint32) (uint8) *a0_n;
 														a2_n = *(a7_n - 4);
 														d1 = (uint32) (uint8) (byte) d0_n;
@@ -868,7 +868,7 @@ l00001F8E:
 														d0_n = fn00002604(*(a7_n - 4), out d1_n, out a1, out a5_n);
 														d1 = d0_n;
 													}
-													*((word32) a7_n + 52) = (word32) *((word32) a7_n + 52) + 1;
+													a7_n[0x0D] = (struct Eq_n) ((word32) a7_n[0x0D] + 1);
 													uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(SLICE(d0_n, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 													d5_n = d1;
 													d3_n = v465_n + 0x01;
@@ -887,11 +887,11 @@ l00001F8E:
 										}
 									}
 l0000216E:
-									Eq_n v476_n = *((word32) a7_n + 74);
+									Eq_n v476_n = a7_n->dw004A;
 									d7 = SEQ(SLICE(d7, word24, 8), v476_n);
-									word32 d4_n = *((word32) a7_n + 52);
-									d2_n = *((word32) a7_n + 0x0084);
-									if (*((word32) a7_n + 110) != 0x00 && d3_n == 0x02)
+									word32 d4_n = a7_n[0x0D];
+									d2_n = a7_n[33];
+									if (a7_n->dw006E != 0x00 && d3_n == 0x02)
 									{
 										if (d5_n != ~0x00)
 										{
@@ -902,7 +902,7 @@ l0000216E:
 										}
 										--d3_n;
 										--d4_n;
-										d5_n = *((word32) a7_n + 110);
+										d5_n = a7_n->dw006E;
 									}
 									if (d5_n != ~0x00)
 									{
@@ -913,14 +913,14 @@ l0000216E:
 									}
 									d3_n = d3_n - 0x01;
 									d4_n = d4_n - 0x01;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										if (v476_n == 117)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = d0;
 											a7_n->b0038 = a7_n->b004C - 0x01;
-											a7_n = (char *) &a7_n->t0000 + 4;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
 											if (a7_n->b0038 != 0x00)
 											{
 												byte v517_n = a7_n->b0038 - 0x01;
@@ -972,58 +972,58 @@ l0000216E:
 										}
 										else
 										{
-											if (*((word32) a7_n + 110) == 0x2D)
+											if (a7_n->dw006E == 0x2D)
 											{
-												struct Eq_n * v528_n = (word32) a7_n + 44;
+												struct Eq_n * v528_n = a7_n + 11;
 												d1 = -v528_n->dw0004;
 												d0 = -v528_n->dw0000 - (d1 < 0x00);
-												a7_n = *((word32) a7_n + 56);
+												a7_n = (struct Eq_n *) a7_n[0x0E];
 											}
 											else
 											{
-												*((word32) a7_n + 56) = *((word32) a7_n + 48);
-												*((word32) a7_n + 52) = *((word32) a7_n + 44);
+												a7_n[0x0E] = a7_n[0x0C];
+												a7_n[0x0D] = a7_n[11];
 											}
-											Eq_n a7_n = a7_n - 4;
-											*a7_n = d0;
-											*((word32) a7_n + 48) = *((word32) a7_n + 76) - 0x01;
-											a7_n = (word32) a7_n + 4;
-											if (*((word32) a7_n + 48) != 0x00)
+											struct Eq_n * a7_n = a7_n - 4;
+											a7_n->t0000 = d0;
+											a7_n->b0030 = a7_n->b004C - 0x01;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
+											if (a7_n->b0030 != 0x00)
 											{
-												byte v540_n = *((word32) a7_n + 48) - 0x01;
-												*((word32) a7_n + 48) = v540_n;
+												byte v540_n = a7_n->b0030 - 0x01;
+												a7_n->b0030 = v540_n;
 												if (v540_n != 0x00)
 												{
-													byte v541_n = *((word32) a7_n + 48) - 0x66;
-													*((word32) a7_n + 48) = v541_n;
+													byte v541_n = a7_n->b0030 - 0x66;
+													a7_n->b0030 = v541_n;
 													if (v541_n != 0x00)
 													{
-														byte v542_n = *((word32) a7_n + 48) - 0x04;
-														*((word32) a7_n + 48) = v542_n;
+														byte v542_n = a7_n->b0030 - 0x04;
+														a7_n->b0030 = v542_n;
 														if (v542_n != 0x00)
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 														else
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 													}
 													else
 													{
 														d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-														d0 = *((word32) a7_n + 60);
+														d0 = a7_n->t003C;
 														**((word32) d2_n - 4) = (word16) d0;
 													}
 												}
 												else
 												{
 													d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-													d0 = *((word32) a7_n + 60);
+													d0 = a7_n->t003C;
 													**((word32) d2_n - 4) = (byte) d0;
 												}
 											}
@@ -1032,18 +1032,18 @@ l0000216E:
 												word32 d0_n = d2_n + 0x03 >>u 0x02;
 												d2_n = (d0_n << 0x02) + 0x04;
 												struct Eq_n * a0_n = *((word32) d2_n - 4);
-												a0_n->dw0004 = (word32) *((word32) a7_n + 60);
-												a0_n->dw0000 = (word32) *((word32) a7_n + 56);
+												a0_n->t0004 = a7_n->t003C;
+												a0_n->dw0000 = a7_n->dw0038;
 												d0 = d0_n << 0x02;
 											}
 										}
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 								else
 								{
 									byte * a5_n;
-									if (*((word32) a7_n + 73) == 0x00)
+									if (a7_n->b0049 == 0x00)
 									{
 										d0 = (word32) d2_n + 3 >> 0x02 << 0x02;
 										d2_n = (word32) d0 + 4;
@@ -1057,7 +1057,7 @@ l0000216E:
 										d0 = d0_n & 0x08;
 										if ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00)
 										{
-											byte v190_n = *((word32) a7_n + 73);
+											byte v190_n = a7_n->b0049;
 											d7 = SEQ(v84_n, v190_n);
 											do
 											{
@@ -1077,7 +1077,7 @@ l0000216E:
 													byte * a0_n = *a1;
 													union Eq_n * a7_n = a7_n - 4;
 													*a7_n = (union Eq_n *) a2_n;
-													*a1 = a0_n + 1;
+													*a1 = (byte **) (a0_n + 1);
 													byte v201_n = *a0_n;
 													a2_n = *a7_n;
 													d0 = SEQ(SLICE(d0, word24, 8), v201_n);
@@ -1099,7 +1099,7 @@ l0000216E:
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2BED)[SEQ(SLICE(d0, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x08;
 											} while ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00);
-											*((word32) a7_n + 73) = v190_n;
+											a7_n->b0049 = v190_n;
 										}
 									}
 									if (d5_n != ~0x00)
@@ -1111,18 +1111,18 @@ l0000216E:
 									}
 									d3_n = d3_n - 0x01;
 									--d4_n;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										*a5_n = 0x00;
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 							}
 							else
 							{
-								if (*((word32) a7_n + 73) == 0x00)
+								if (a7_n->b0049 == 0x00)
 								{
-									if (*((word32) a7_n + 72) == 0x01)
+									if (a7_n[18] == 0x01)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										struct Eq_n * a0_n = *d0;
@@ -1130,19 +1130,19 @@ l0000216E:
 										a0_n->dw0000 = 0x00;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x6C)
+									else if (a7_n[18] == 0x6C)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x68)
+									else if (a7_n[18] == 0x68)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (word16) d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x02)
+									else if (a7_n[18] == 0x02)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (byte) d4_n;
@@ -1155,16 +1155,16 @@ l0000216E:
 										d2_n = (word32) d0 + 4;
 									}
 								}
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 								d3_n.u0 = 1;
 							}
 						}
 						else
 						{
 							if (d6_n == ~0x00)
-								d6_n.u0 = 1;
+								&d6_n.u0->dw0000 = 1;
 							union Eq_n * a1_n;
-							if (*((word32) a7_n + 73) == 0x00)
+							if (a7_n->b0049 == 0x00)
 							{
 								d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 								d2_n = (word32) d0 + 4;
@@ -1176,7 +1176,7 @@ l0000216E:
 							*a0_n |= 0x01;
 							int32 * a0_n = (word32) a2_n + 20;
 							--*a0_n;
-							*((word32) a7_n + 44) = a1_n;
+							a7_n[11] = (struct Eq_n) a1_n;
 							if (*a0_n >= 0x00)
 							{
 								byte ** a1_n = (word32) a2_n + 4;
@@ -1193,7 +1193,7 @@ l0000216E:
 							}
 							else
 							{
-								int32 a1_n = *((word32) a7_n + 44);
+								int32 a1_n = a7_n[11];
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->t0000 = a2_n;
 								a7_n->dw0030 = a1_n;
@@ -1203,18 +1203,18 @@ l0000216E:
 								a7_n->t0038 = d0;
 								a7_n->dw0030 = a7_n->dw0030;
 							}
-							a1 = *((word32) a7_n + 44);
-							d5_n = *((word32) a7_n + 52);
+							a1 = (byte **) a7_n[11];
+							d5_n = a7_n[0x0D];
 							Eq_n d3_n = (word32) d3_n + 1;
 							int32 d4_n = (word32) d4_n + 1;
-							if (*((word32) a7_n + 52) != ~0x00)
+							if (a7_n[0x0D] != ~0x00)
 							{
-								*((word32) a7_n + 44) = a1;
+								a7_n[11] = (struct Eq_n) a1;
 								if (d6_n - d3_n >= 0x00)
 								{
-									byte v302_n = *((word32) a7_n + 73);
+									byte v302_n = a7_n->b0049;
 									d7 = SEQ(v84_n, v302_n);
-									byte * a4_n = *((word32) a7_n + 44);
+									byte * a4_n = a7_n[11];
 									do
 									{
 										if (v302_n == 0x00)
@@ -1233,7 +1233,7 @@ l0000216E:
 											byte * a0_n = *a1;
 											union Eq_n * a7_n = a7_n - 4;
 											*a7_n = (union Eq_n *) a2_n;
-											*a1 = a0_n + 1;
+											*a1 = (byte **) (a0_n + 1);
 											byte v314_n = *a0_n;
 											a2_n = *a7_n;
 											d0 = SEQ(SLICE(d0, word24, 8), v314_n);
@@ -1252,7 +1252,7 @@ l0000216E:
 										d3_n = (word32) d3_n + 1;
 										++d4_n;
 									} while (d1 != ~0x00 && d6_n - d3_n >= 0x00);
-									*((word32) a7_n + 73) = v302_n;
+									a7_n->b0049 = v302_n;
 								}
 							}
 							if (d5_n != ~0x00)
@@ -1264,22 +1264,22 @@ l0000216E:
 							}
 							d3_n = d3_n - 0x01;
 							d4_n = d4_n - 0x01;
-							if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							if (a7_n->b0049 == 0x00 && d3_n != 0x00)
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 					else
 					{
-						*((word32) a7_n + 44) = 0x00;
+						a7_n[11] = (struct Eq_n) 0x00;
 						if (a3_n->b0000 == 0x5E)
 						{
-							*((word32) a7_n + 44) = 0x01;
+							a7_n[11] = (struct Eq_n) 0x01;
 							++a3_n;
 						}
-						*((word32) a7_n + 52) = 0x00;
-						byte v544_n = *((word32) a7_n + 44);
+						a7_n[0x0D] = (struct Eq_n) 0x00;
+						Eq_n v544_n = a7_n[11];
 						d7 = SEQ(v84_n, v544_n);
-						Eq_n d1_n = *((word32) a7_n + 52);
+						Eq_n d1_n = a7_n[0x0D];
 						do
 						{
 							int32 d5_n;
@@ -1287,12 +1287,12 @@ l0000216E:
 								d5_n = 0xFF;
 							else
 								d5_n = 0;
-							*((word32) d1_n + ((word32) a7_n + 78)) = (byte) d5_n;
+							Mem796[a7_n + 78 + d1_n:byte] = SLICE(d5_n, byte, 0);
 							d1_n = (word32) d1_n + 1;
 						} while (d1_n < 0x20);
-						*((word32) a7_n + 0x0084) = d2_n;
-						*((word32) a7_n + 44) = v544_n;
-						byte v554_n = *((word32) a7_n + 44);
+						a7_n[33] = (struct Eq_n) d2_n;
+						a7_n[11] = (struct Eq_n) v544_n;
+						Eq_n v554_n = a7_n[11];
 						while (a3_n->b0000 != 0x00)
 						{
 							cu8 v556_n = a3_n->b0000;
@@ -1311,13 +1311,13 @@ l0000216E:
 							{
 								if (v554_n != 0x00)
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (~(1 << (d5_n & 7)) & d1_n);
 								}
 								else
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (1 << (d5_n & 7) | d1_n);
 								}
@@ -1328,9 +1328,9 @@ l0000216E:
 								break;
 						}
 						byte * a6_n;
-						d2_n = *((word32) a7_n + 0x0084);
+						d2_n = a7_n[33];
 						++a3_n;
-						if (*((word32) a7_n + 73) == 0x00)
+						if (a7_n->b0049 == 0x00)
 						{
 							word32 d0_n = d2_n + 0x03 >>u 0x02;
 							d2_n = (d0_n << 0x02) + 0x04;
@@ -1348,40 +1348,40 @@ l0000216E:
 						{
 							a1 = (word32) a2_n + 4;
 							byte * a0_n = *a1;
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*a1 = a0_n + 1;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
+							*a1 = (byte **) (a0_n + 1);
 							byte v585_n = *a0_n;
-							a2_n = *a7_n;
-							*a7_n = d1_n;
-							*((word32) a7_n + 48) = (uint32) (uint8) v585_n;
+							a2_n = a7_n->t0000;
+							a7_n->t0000 = d1_n;
+							a7_n->dw0030 = (uint32) (uint8) v585_n;
 							d0 = SEQ(SLICE(d0, word24, 8), v585_n);
-							d1 = *a7_n;
+							d1 = a7_n->t0000;
 						}
 						else
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
 							word32 a5_n;
-							d0 = fn00002604(*a7_n, out d1, out a1, out a5_n);
-							*((word32) a7_n + 48) = d0;
+							d0 = fn00002604(a7_n->t0000, out d1, out a1, out a5_n);
+							a7_n->t0030 = d0;
 						}
-						d5_n = *((word32) a7_n + 44);
+						d5_n = a7_n[11];
 						Eq_n d3_n = (word32) d3_n + 1;
 						int32 d4_n = (word32) d4_n + 1;
-						if (*((word32) a7_n + 44) != ~0x00)
+						if (a7_n[11] != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = (word32) a7_n + 78;
-							*(a7_n - 4) = a1;
-							(a7_n - 8)->u0 = 0x08;
-							*(a7_n - 0x0C) = d5_n;
-							d1 = (uint32) (uint8) *((word32) *a7_n + fn0000254C(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-							a1 = *(a7_n - 4);
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->ptr0000 = &a7_n->dw004A + 1;
+							*(a7_n - 4) = (byte ***) a1;
+							*(a7_n - 8) = 0x08;
+							*(a7_n - 0x0C) = (union Eq_n *) d5_n;
+							d1 = (uint32) (uint8) (a7_n->ptr0000 + fn0000254C(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+							a1 = (byte **) *(a7_n - 4);
 							d0 = 1 << (d5_n & 7) & d1;
 							if (d0 != 0x00 && d6_n - d3_n >= 0x00)
 							{
-								byte v601_n = *((word32) a7_n + 77);
+								byte v601_n = a7_n->b004D;
 								d7 = SEQ(SLICE(d7, word24, 8), v601_n);
 								do
 								{
@@ -1399,9 +1399,9 @@ l0000216E:
 									{
 										a1 = (word32) a2_n + 4;
 										byte * a0_n = *a1;
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
-										*a1 = a0_n + 1;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
+										*a1 = (byte **) (a0_n + 1);
 										byte v611_n = *a0_n;
 										a2_n = *a7_n;
 										d0 = SEQ(SLICE(d0, word24, 8), v611_n);
@@ -1409,8 +1409,8 @@ l0000216E:
 									}
 									else
 									{
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
 										word32 d1_n;
 										word32 a5_n;
 										d0 = fn00002604(*a7_n, out d1_n, out a1, out a5_n);
@@ -1421,31 +1421,31 @@ l0000216E:
 									++d4_n;
 									if (d1 == ~0x00)
 										break;
-									Eq_n a7_n = a7_n - 4;
-									*a7_n = (word32) a7_n + 78;
-									*(a7_n - 4) = a1;
-									(a7_n - 8)->u0 = 0x08;
-									*(a7_n - 0x0C) = d1;
-									d1 = (uint32) (uint8) *((word32) *a7_n + fn0000254C(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-									a1 = *(a7_n - 4);
+									ptr32 * a7_n = a7_n - 4;
+									*a7_n = &a7_n->dw004A + 1;
+									*(a7_n - 4) = (byte ***) a1;
+									*(a7_n - 8) = 0x08;
+									*(a7_n - 0x0C) = (union Eq_n *) d1;
+									d1 = (uint32) (uint8) (*a7_n + fn0000254C(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+									a1 = (byte **) *(a7_n - 4);
 									d0 = 1 << (d1 & 7) & d1;
 								} while (d0 != 0x00 && d6_n - d3_n >= 0x00);
-								*((word32) a7_n + 73) = v601_n;
+								a7_n->b0049 = v601_n;
 							}
 						}
 						if (d5_n != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*(a7_n - 4) = d5_n;
+							union Eq_n * a7_n = a7_n - 4;
+							*a7_n = (union Eq_n *) a2_n;
+							*(a7_n - 4) = (union Eq_n *) d5_n;
 							d0 = fn00001438(*(a7_n - 1), *a7_n);
 						}
 						d3_n = d3_n - 0x01;
 						d4_n = d4_n - 0x01;
-						if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+						if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 						{
 							*a6_n = 0x00;
-							*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 				}
@@ -1462,7 +1462,7 @@ l0000216E:
 						byte * a0_n = *a1;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						*a1 = (byte **) (a0_n + 1);
 						byte v163_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1_n;
@@ -1478,10 +1478,10 @@ l0000216E:
 						d0 = fn00002604(a7_n->t0000, out d1, out a1, out a5_n);
 						a7_n->t0030 = d0;
 					}
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n = (word32) d3_n.u0 + 1;
 					d4_n = (word32) d4_n + 1;
-					if (*((word32) a7_n + 44) != 0x25)
+					if (a7_n[11] != 0x25)
 					{
 						if (d5_n != ~0x00)
 						{
@@ -1516,7 +1516,7 @@ l0000216E:
 							byte * a0_n = *a1;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							*a1 = (byte **) (a0_n + 1);
 							byte v109_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v109_n);
@@ -1560,7 +1560,7 @@ l0000216E:
 						byte * a0_n = *a1;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						*a1 = (byte **) (a0_n + 1);
 						byte v130_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1;
@@ -1577,10 +1577,10 @@ l0000216E:
 						a7_n->t0030 = d0_n;
 					}
 					d0 = (int32) (int16) (int8) SEQ(SLICE(d0_n, word24, 8), a4_n->b0000);
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n.u0 = 0x01;
 					d4_n = (word32) d4_n + 1;
-					if (d0 - *((word32) a7_n + 44) != 0x00)
+					if (d0 - a7_n[11] != 0x00)
 					{
 						if (d5_n != ~0x00)
 						{
@@ -1665,7 +1665,7 @@ Eq_n fn0000257E(Eq_n d0, Eq_n d1, Eq_n d2, union Eq_n & d1Out)
 		if ((word16) d1_n < 0x80)
 		{
 			d1_n = __rol(d1_n, 0x08);
-			d3_n.u0 = 0x08;
+			&d3_n.u0->dw0000 = 0x08;
 		}
 		if ((word16) d1_n < 0x0800)
 		{
@@ -2251,7 +2251,7 @@ Eq_n fn00002F34(Eq_n d0, struct Eq_n * dwArg04, Eq_n dwArg08, Eq_n dwArg0C, stru
 					{
 						a0_n = 11245 + (SEQ(SLICE(d0_n, word24, 8), *a2_n) & 0xFF);
 						uint32 d0_n = (uint32) (uint8) a0_n->t0000;
-						d5_n.u0 = 0;
+						&d5_n.u0->dw0000 = 0;
 						d0_n = d0_n & 0x04;
 						if ((d0_n & 0x04) != 0x00)
 						{
@@ -2439,7 +2439,7 @@ l000031B2:
 						}
 						if (d4_n == 0x68)
 						{
-							Eq_n v262_n = a7_n->dw003E;
+							word16 v262_n = a7_n->w003E;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1;
 							a7_n->dw0040 = (uint32) (uint16) v262_n;
@@ -2448,7 +2448,7 @@ l000031B2:
 						}
 						if (d4_n == 0x02)
 						{
-							Eq_n v277_n = a7_n->dw003F;
+							byte v277_n = a7_n->b003F;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1;
 							a7_n->dw0040 = (uint32) (uint8) v277_n;
@@ -2559,7 +2559,7 @@ l0000340E:
 							}
 							if (d4_n == 0x02)
 							{
-								Eq_n v248_n = a7_n->dw0037;
+								byte v248_n = a7_n->b0037;
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->ptr0000 = d1;
 								int32 d1_n = (int32) (int16) (int8) SEQ(SLICE(d1, word24, 8), v248_n);
@@ -3056,7 +3056,7 @@ l00003B22:
 		word32 d1_n;
 		d1_n = fn00003B28(dwArg04, dwArg08, dwArg10, out d1_n, out d2_n);
 l00003B20:
-		d0_n.u0 = 0;
+		&d0_n.u0->dw0000 = 0;
 		goto l00003B22;
 	}
 }
@@ -3114,7 +3114,7 @@ l00003B42:
 					Eq_n d2_n = __swap(d5_n);
 					Eq_n d3_n = __swap(d7_n);
 					if ((word16) (d2_n - d3_n) == 0x00)
-						d1_n.u0 = 0xFFFF;
+						&d1_n.u0->dw0000 = 0xFFFF;
 					else
 						d1_n = __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_n % (uint16) d3_n), (uint16) (d5_n /u (uint16) d3_n))), word16, 16), 0x00));
 					Eq_n d6_n = __swap(SEQ(SLICE(d6_n, word16, 16), 0x00));

--- a/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG.globals.c
+++ b/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG.globals.c
@@ -10,6 +10,24 @@ struct Eq_n * g_ptr0004;
 word32 g_a0008[];
 ui32 g_a0010[];
 Eq_n g_t0078;
+struct Eq_n g_t12BC = 
+	{
+		1685025582,
+		
+		{
+			1818845810
+		},
+		&g_t61727900,
+		
+		{
+			0x4E494C3A
+		},
+		null,
+		&g_t48E72030,
+		0x47F90000,
+		0x3EB8203C,
+		16056,
+	};
 struct Eq_n g_t13E4 = 
 	{
 		0x25,
@@ -35,23 +53,20 @@ Eq_n g_t2815 =
 	};
 ptr32 g_ptr3D70 = 0x00;
 struct Eq_n * g_ptr3D74 = &g_t4000;
-Eq_n g_t3D78 = 
-	{
-		0x00
-	};
+struct Eq_n * g_ptr3D78 = null;
 struct Eq_n * g_ptr3D7C = &g_t10202;
 struct Eq_n * g_ptr3D80 = &g_t3030303;
 Eq_n g_t3D84 = 
 	{
-		0x04
+		0x04040404
 	};
 Eq_n g_t3D88 = 
 	{
-		0x04
+		0x04040404
 	};
 Eq_n g_t3D8C = 
 	{
-		0x05
+		0x05050505
 	};
 word32 g_dw3D98 = 0x05050505;
 ptr32 g_ptr3D9C = 0x06060606;
@@ -75,4 +90,6 @@ Eq_n g_t4000;
 Eq_n g_t10202;
 Eq_n g_t3030303;
 Eq_n g_t6060606;
+Eq_n g_t48E72030;
+Eq_n g_t61727900;
 

--- a/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG.h
+++ b/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG.h
@@ -4,7 +4,7 @@
 
 /*
 // Equivalence classes ////////////
-Eq_1: (struct "Globals" (0 (ptr32 Eq_116) ptr0000) (1 Eq_725 t0001) (4 (ptr32 Eq_4) ptr0004) (8 (arr word32) a0008) (10 (arr ui32) a0010) (78 Eq_1123 t0078) (13E4 (struct "Eq_621" 0001 (0 uint8 b0000) (1 cu8 b0001)) t13E4) (13E8 (struct "Eq_621" 0001) t13E8) (13EC (struct "Eq_621" 0001) t13EC) (13F4 byte b13F4) (1D6C byte b1D6C) (2815 Eq_4288 t2815) (3D70 ptr32 ptr3D70) (3D74 (ptr32 Eq_4) ptr3D74) (3D78 Eq_25 t3D78) (3D7C (ptr32 Eq_61) ptr3D7C) (3D80 (ptr32 Eq_61) ptr3D80) (3D84 Eq_25 t3D84) (3D88 Eq_25 t3D88) (3D8C Eq_25 t3D8C) (3D98 word32 dw3D98) (3D9C ptr32 ptr3D9C) (3DA0 int32 dw3DA0) (3DA4 (ptr32 Eq_2656) ptr3DA4) (3DA8 (ptr32 Eq_4) ptr3DA8) (3DAC Eq_3367 t3DAC) (3EB0 word32 dw3EB0) (3EB8 Eq_542 t3EB8) (3EBC word32 dw3EBC) (3EC8 (ptr32 Eq_557) ptr3EC8) (3ECC Eq_25 t3ECC) (3ED0 (ptr32 Eq_635) ptr3ED0) (3ED8 (ptr32 Eq_635) ptr3ED8) (4000 Eq_4 t4000) (10202 Eq_61 t10202) (3030303 Eq_61 t3030303) (6060606 Eq_2656 t6060606))
+Eq_1: (struct "Globals" (0 (ptr32 Eq_116) ptr0000) (1 Eq_725 t0001) (4 (ptr32 Eq_4) ptr0004) (8 (arr word32) a0008) (10 (arr ui32) a0010) (78 Eq_1123 t0078) (12BC (struct "Eq_25" 0004 (0 word32 dw0000) (4 Eq_134 t0004) (8 (ptr32 Eq_25) ptr0008) (C Eq_106 t000C) (10 (ptr32 (arr Eq_160)) ptr0010) (14 (ptr32 Eq_2878) ptr0014) (18 ptr32 ptr0018) (1C word32 dw001C) (20 word32 dw0020)) t12BC) (13E4 (struct "Eq_621" 0001 (0 uint8 b0000) (1 cu8 b0001)) t13E4) (13E8 (struct "Eq_621" 0001) t13E8) (13EC (struct "Eq_621" 0001) t13EC) (13F4 byte b13F4) (1D6C byte b1D6C) (2815 Eq_4288 t2815) (3D70 ptr32 ptr3D70) (3D74 (ptr32 Eq_4) ptr3D74) (3D78 (ptr32 Eq_25) ptr3D78) (3D7C (ptr32 Eq_61) ptr3D7C) (3D80 (ptr32 Eq_61) ptr3D80) (3D84 Eq_134 t3D84) (3D88 Eq_134 t3D88) (3D8C Eq_134 t3D8C) (3D98 word32 dw3D98) (3D9C ptr32 ptr3D9C) (3DA0 int32 dw3DA0) (3DA4 (ptr32 Eq_2878) ptr3DA4) (3DA8 (ptr32 Eq_4) ptr3DA8) (3DAC Eq_3367 t3DAC) (3EB0 word32 dw3EB0) (3EB8 Eq_542 t3EB8) (3EBC word32 dw3EBC) (3EC8 (ptr32 Eq_557) ptr3EC8) (3ECC Eq_73 t3ECC) (3ED0 (ptr32 Eq_635) ptr3ED0) (3ED8 (ptr32 Eq_635) ptr3ED8) (4000 Eq_4 t4000) (10202 Eq_61 t10202) (3030303 Eq_61 t3030303) (6060606 Eq_2878 t6060606) (48E72030 Eq_2878 t48E72030) (61727900 Eq_25 t61727900))
 	globals_t (in globals : (ptr32 (struct "Globals")))
 Eq_4: (struct "Eq_4" (0 word32 dw0000) (8 byte b0008) (C Eq_78 t000C) (10 word32 dw0010) (14 Eq_11 t0014) (18 up32 dw0018) (1C word32 dw001C))
 	T_4 (in a6_9 : (ptr32 Eq_4))
@@ -72,165 +72,169 @@ Eq_11: (union "Eq_11" (up32 u0) (cup16 u1))
 	T_3210 (in 0x27<16> : word16)
 	T_3263 (in Mem11[Mem11[0x00003D74<p32>:word32] + 20<i32>:word16] : word16)
 	T_3264 (in 0x27<16> : word16)
-Eq_19: (struct "Eq_19" (8 byte b0008) (3A word32 dw003A) (9C Eq_25 t009C) (A0 Eq_25 t00A0) (A4 word32 dw00A4) (AC (ptr32 Eq_61) ptr00AC) (B0 (ptr32 word32) ptr00B0) (E0 Eq_25 t00E0))
+Eq_19: (struct "Eq_19" (8 byte b0008) (3A word32 dw003A) (9C Eq_134 t009C) (A0 Eq_134 t00A0) (A4 word32 dw00A4) (AC (ptr32 Eq_61) ptr00AC) (B0 (ptr32 word32) ptr00B0) (E0 Eq_134 t00E0))
 	T_19 (in d0_36 : (ptr32 Eq_19))
 	T_24 (in FindTask(0<32>) : word32)
 	T_126 (in a3 : (ptr32 Eq_19))
 Eq_20: (fn (ptr32 Eq_19) (word32))
 	T_20 (in FindTask : ptr32)
 	T_21 (in signature of FindTask : void)
-Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((ptr32 Eq_8248) u4) (Eq_1290 u5) (Eq_6344 u6) (Eq_7207 u7))
-	T_25 (in a1_255 : Eq_25)
+Eq_25: (struct "Eq_25" 0004 (0 word32 dw0000) (4 Eq_134 t0004) (8 (ptr32 Eq_25) ptr0008) (C Eq_106 t000C) (10 (ptr32 (arr Eq_160)) ptr0010) (14 (ptr32 Eq_2878) ptr0014) (18 ptr32 ptr0018) (1C word32 dw001C) (20 word32 dw0020))
+	T_25 (in a1_255 : (ptr32 Eq_25))
 	T_26 (in 000012BC : ptr32)
-	T_27 (in d0_112 : Eq_25)
+	T_27 (in d0_112 : (ptr32 Eq_25))
 	T_34 (in OpenLibrary(0x12BC<u32>, 0<i32>) : word32)
 	T_35 (in 0<32> : word32)
 	T_58 (in Mem67[0x00003D78<p32>:word32] : word32)
-	T_73 (in d1_111 : Eq_25)
-	T_74 (in 0x10001<32> : word32)
 	T_82 (in AllocMem(d0_107 + 0x11<32>, 0x10001<32>) : word32)
 	T_83 (in 0<32> : word32)
 	T_92 (in library : word32)
 	T_94 (in Mem67[0x00003D78<p32>:word32] : word32)
-	T_112 (in (word32) d0_112 + 16<i32> + d0_100 : word32)
+	T_112 (in d0_112 + 16<i32> + d0_100 : word32)
 	T_115 (in Mem177[d0_112 + 8<i32>:word32] : word32)
-	T_134 (in d0_197 : Eq_25)
-	T_137 (in Mem194[d0_180 + 36<i32>:word32] : word32)
-	T_138 (in 0<32> : word32)
 	T_147 (in Mem179[d0_112 + 8<i32>:word32] : word32)
-	T_153 (in d0_262 : Eq_25)
-	T_159 (in (uint32) (uint8) 0<32>[d0_252 * 4<32>] : uint32)
-	T_204 (in Mem416[0x00003D84<p32>:word32] : word32)
-	T_209 (in Mem418[0x00003D88<p32>:word32] : word32)
-	T_229 (in SEQ(SLICE(d1_111, word24, 8), v40_292) : uip32)
 	T_242 (in Mem313[a6_266 + 0<32>:word32] : word32)
-	T_260 (in SEQ(v72_327, v71_324) : uip32)
 	T_267 (in a1_255 + 1<i32> : word32)
 	T_276 (in a1_255 + 1<i32> : word32)
 	T_281 (in a1_255 + 1<i32> : word32)
-	T_288 (in SEQ(SLICE(d1_111, word24, 8), v50_371) : uip32)
-	T_308 (in a2 : Eq_25)
+	T_308 (in a2 : (ptr32 Eq_25))
 	T_312 (in userFunction : word32)
-	T_316 (in Mem209[d0_112 + 4<i32>:word32] : word32)
-	T_317 (in 000012C8 : ptr32)
-	T_318 (in 0<32> : word32)
-	T_324 (in Mem214[0x00003D84<p32>:word32] : word32)
-	T_326 (in Mem216[0x00003D88<p32>:word32] : word32)
-	T_328 (in Mem218[0x00003D8C<p32>:word32] : word32)
-	T_331 (in Mem221[d0_36 + 156<i32>:word32] : word32)
-	T_334 (in Mem223[d0_36 + 160<i32>:word32] : word32)
 	T_359 (in a1_255 + 1<i32> : word32)
-	T_366 (in SEQ(v72_327, v75_337) : uip32)
-	T_374 (in 10<i32> : int32)
-	T_390 (in 27<i32> : int32)
-	T_392 (in Mem435[0x00003D8C<p32>:word32] : word32)
-	T_393 (in v92_428 : Eq_25)
-	T_396 (in Mem418[d0_36 + 224<i32>:word32] : word32)
-	T_398 (in Mem429[0x00003D8C<p32>:word32] : word32)
-	T_399 (in 0<32> : word32)
-	T_427 (in d1 : Eq_25)
-	T_428 (in a1 : Eq_25)
+	T_428 (in a1 : (ptr32 Eq_25))
 	T_449 (in message : word32)
-	T_472 (in v5_8 : Eq_25)
+	T_472 (in v5_8 : (ptr32 Eq_25))
 	T_477 (in Mem0[a7_6 - 8<i32> + 0<32>:word32] : word32)
 	T_489 (in Mem0[0x00003D78<p32>:word32] : word32)
 	T_491 (in 0<32> : word32)
-	T_580 (in d0_10 : Eq_25)
+	T_593 (in a1 : (ptr32 Eq_25))
+	T_620 (in a1 : (ptr32 Eq_25))
+	T_2890 (in a1Out : (ptr32 Eq_25))
+	T_2894 (in out a1 : ptr32)
+	T_3023 (in d0 : (ptr32 Eq_25))
+	T_3024 (in d0_158 : (ptr32 Eq_25))
+	T_3033 (in a3_120 : (ptr32 Eq_25))
+	T_3034 (in 0<32> : word32)
+	T_3041 (in AllocPooled(dwArg08, dwArg04) : word32)
+	T_3054 (in d0_50 : (ptr32 Eq_25))
+	T_3058 (in AllocMem(dwArg08 + 16<i32>, d1) : word32)
+	T_3059 (in 0<32> : word32)
+	T_3074 (in d0_82 : (ptr32 Eq_25))
+	T_3076 (in AllocMem(d3_77, d1) : word32)
+	T_3077 (in 0<32> : word32)
+	T_3087 (in d0_128 : (ptr32 Eq_25))
+	T_3092 (in Allocate(a5_162, dwArg08) : word32)
+	T_3093 (in 0<32> : word32)
+	T_3161 (in Allocate(d0_82 + 1<i32>, dwArg08) : word32)
+	T_3162 (in a2_142 : (ptr32 Eq_25))
+	T_3180 (in a2_149 + 4<i32> : word32)
+	T_3201 (in d0_50 + 16<i32> : word32)
+	T_3202 (in d0 : (ptr32 Eq_25))
+	T_3203 (in d0_51 : (ptr32 Eq_25))
+	T_3212 (in 0<32> : word32)
+	T_3213 (in a1 : word32)
+	T_3223 (in CreatePrivatePool(dwArg04, dwArg08, dwArg0C) : word32)
+	T_3224 (in d0_30 : (ptr32 Eq_25))
+	T_3228 (in AllocMem(24<i32>, 0<i32>) : word32)
+	T_3230 (in 0<32> : word32)
+	T_3242 (in Mem40[d0_30 + 8<i32>:word32] : word32)
+	T_4206 (in a1 : (ptr32 Eq_25))
+	T_4627 (in a2_1014 + 4<i32> : word32)
+	T_4741 (in a2_1014 + 4<i32> : word32)
+	T_4835 (in a2_1014 + 4<i32> : word32)
+	T_5018 (in a2_1014 + 4<i32> : word32)
+	T_5249 (in a2_1014 + 4<i32> : word32)
+	T_5443 (in a2_1014 + 4<i32> : word32)
+	T_5570 (in a2_1014 + 4<i32> : word32)
+	T_5742 (in a2_1014 + 4<i32> : word32)
+	T_5872 (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
+	T_5902 (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
+	T_5987 (in a2_1014 + 4<i32> : word32)
+	T_6170 (in a2_1014 + 4<i32> : word32)
+	T_6297 (in a2_1014 + 4<i32> : word32)
+	T_6756 (in a2_1014 + 4<i32> : word32)
+	T_6915 (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
+	T_7594 (in a2_1014 + 4<i32> : word32)
+	T_7658 (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
+	T_7693 (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
+	T_7758 (in a2_1014 + 4<i32> : word32)
+	T_7836 (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
+	T_7870 (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
+Eq_28: (fn (ptr32 Eq_25) (ptr32, int32))
+	T_28 (in OpenLibrary : ptr32)
+	T_29 (in signature of OpenLibrary : void)
+Eq_51: (fn void (word32))
+	T_51 (in Alert : ptr32)
+	T_52 (in signature of Alert : void)
+	T_96 (in Alert : ptr32)
+Eq_61: (struct "Eq_61" (0 word32 dw0000) (24 Eq_134 t0024))
+	T_61 (in Mem67[d0_36 + 172<i32>:word32] : word32)
+	T_62 (in 0<32> : word32)
+	T_87 (in Mem153[d0_36 + 172<i32>:word32] : word32)
+	T_88 (in 0<32> : word32)
+	T_99 (in dwLoc0C_569 : (ptr32 Eq_61))
+	T_118 (in d0_180 : (ptr32 Eq_61))
+	T_121 (in Mem179[d0_36 + 172<i32>:word32] : word32)
+	T_122 (in 0<32> : word32)
+	T_129 (in Mem187[0x00003D7C<p32>:word32] : word32)
+	T_131 (in Mem189[0x00003D80<p32>:word32] : word32)
+	T_211 (in d0_112 + 16<i32> : word32)
+	T_430 (in dwArg08 : (ptr32 Eq_61))
+Eq_73: (union "Eq_73" (byte u0) (word16 u1) ((ptr32 Eq_8241) u2))
+	T_73 (in d1_111 : Eq_73)
+	T_74 (in 0x10001<32> : word32)
+	T_229 (in SEQ(SLICE(d1_111, word24, 8), v40_292) : uip32)
+	T_260 (in SEQ(v72_327, v71_324) : uip32)
+	T_288 (in SEQ(SLICE(d1_111, word24, 8), v50_371) : uip32)
+	T_317 (in 000012C8 : ptr32)
+	T_366 (in SEQ(v72_327, v75_337) : uip32)
+	T_374 (in 10<i32> : int32)
+	T_390 (in 27<i32> : int32)
+	T_427 (in d1 : Eq_73)
+	T_580 (in d0_10 : Eq_73)
 	T_581 (in 0x3EAC<32> : word32)
-	T_591 (in d0 : Eq_25)
-	T_592 (in d1 : Eq_25)
-	T_593 (in a1 : Eq_25)
-	T_614 (in d0 : Eq_25)
-	T_618 (in d0 : Eq_25)
-	T_619 (in d1 : Eq_25)
-	T_620 (in a1 : Eq_25)
+	T_591 (in d0 : Eq_73)
+	T_592 (in d1 : Eq_73)
+	T_614 (in d0 : Eq_73)
+	T_618 (in d0 : Eq_73)
+	T_619 (in d1 : Eq_73)
 	T_625 (in fn00002B40(d0, d1, a1, &globals->t13E4) : word32)
 	T_627 (in fn00002B40(fn00002B40(d0, d1, a1, &globals->t13E4), d1, a1, &globals->t13E8) : word32)
 	T_629 (in fn00002B40(fn00002B40(fn00002B40(d0, d1, a1, &globals->t13E4), d1, a1, &globals->t13E8), d1, a1, &globals->t13EC) : word32)
 	T_631 (in fn000013FC(fn00002B40(fn00002B40(fn00002B40(d0, d1, a1, &globals->t13E4), d1, a1, &globals->t13E8), d1, a1, &globals->t13EC), &globals->b13F4) : word32)
-	T_634 (in d0 : Eq_25)
+	T_634 (in d0 : Eq_73)
 	T_643 (in fn00001418(d0, *(struct Eq_635 **) 0x3ED0<u32>, dwArg04, fp + 8<i32>) : word32)
-	T_644 (in d0_1952 : Eq_25)
-	T_652 (in d6_1480 : Eq_25)
+	T_644 (in d0_1952 : Eq_73)
+	T_652 (in d6_1480 : Eq_73)
 	T_653 (in 0<i32> : int32)
 	T_701 (in fn00001D98(*(a7_51 - 4<i32>), *a7_51, out a0_66, out a5_1579) : word32)
 	T_704 (in 0xFFFFFFFF<32> : word32)
-	T_718 (in d5_256 : Eq_25)
-	T_719 (in -1<i32> : int32)
-	T_730 (in d2_1005 : Eq_25)
-	T_733 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
-	T_734 (in d1_103 : Eq_25)
+	T_734 (in d1_103 : Eq_73)
 	T_736 (in d1_103 + 1<32> : word32)
 	T_737 (in 5<32> : word32)
 	T_742 (in Mem121[a7_99 + 0<32>:word32] : word32)
-	T_743 (in d1_123 : Eq_25)
+	T_743 (in d1_123 : Eq_73)
 	T_745 (in 1<i32> << d1_103 : word32)
 	T_748 (in Mem121[a7_99 + 0<32>:word32] : word32)
-	T_749 (in d2_1005 | d1_123 : word32)
 	T_752 (in 5<32> : word32)
 	T_754 (in 0<i32> : int32)
-	T_759 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
 	T_777 (in Mem143[a0_1447 + 0<32>:byte] : byte)
 	T_834 (in Mem102[a7_99 + 0<32>:word32] : word32)
 	T_837 (in Mem102[a7_99 + 0<32>:word32] : word32)
 	T_872 (in Mem248[a0_1447 + 0<32>:byte] : byte)
-	T_875 (in 0<i32> : int32)
-	T_903 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-	T_909 (in Mem278[a7_275 + 0<32>:word32] : word32)
-	T_913 (in  : word32)
-	T_914 (in 10<i32> : int32)
-	T_915 (in __swap(10<i32>) : word32)
-	T_922 (in __swap(d5_256) : word32)
-	T_927 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-	T_928 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
 	T_960 (in Mem278[a0_1447 + 0<32>:byte] : byte)
-	T_965 (in Mem278[a7_275 + 0<32>:word32] : word32)
 	T_967 (in d1_303 - 0x30<32> : word32)
-	T_969 (in d1_303 - 0x30<32> + d0_293 : word32)
-	T_1014 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-	T_1022 (in 10<i32> : int32)
-	T_1023 (in __swap(10<i32>) : word32)
-	T_1030 (in __swap(d2_1005) : word32)
-	T_1035 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-	T_1036 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
 	T_1068 (in Mem171[a0_1447 + 0<32>:byte] : byte)
 	T_1076 (in d1_196 - 0x30<32> : word32)
-	T_1078 (in d1_196 - 0x30<32> + d0_186 : word32)
-	T_1086 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
 	T_1114 (in d6_1480 + 1<32> : word32)
-	T_1185 (in 0<32> : word32)
-	T_1264 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-	T_1313 (in 0<32> : word32)
-	T_1488 (in d0_1566 : Eq_25)
+	T_1488 (in d0_1566 : Eq_73)
 	T_1493 (in a7_1465[18<i32>] & 2<i32> : word32)
 	T_1494 (in 0<32> : word32)
-	T_1533 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
 	T_1536 (in Mem1359[a7_1020 + 48<i32>:word32] : word32)
 	T_1614 (in fn00001D98(*(a7_1578 - 4<i32>), a7_1578->ptr0000, out a0_1447, out a5_1579) : word32)
 	T_1615 (in 0xFFFFFFFF<32> : word32)
 	T_1620 (in d6_1480 + 1<32> : word32)
-	T_1670 (in dwArg04 : Eq_25)
-	T_1671 (in dwArg08 : Eq_25)
-	T_1672 (in dwArg0C : Eq_25)
-	T_1673 (in dwArg10 : Eq_25)
-	T_1677 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_1682 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1687 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_1692 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_1754 (in dwArg04 : Eq_25)
-	T_1755 (in dwArg08 : Eq_25)
-	T_1756 (in dwArg0C : Eq_25)
-	T_1757 (in dwArg10 : Eq_25)
-	T_1758 (in d1Out : Eq_25)
-	T_1759 (in a0Out : Eq_25)
-	T_1763 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-	T_1768 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1773 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-	T_1778 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-	T_1779 (in out d1_1450 : ptr32)
-	T_1780 (in out a0_1447 : ptr32)
 	T_1804 (in Mem1478[a7_1383 + 52<i32>:word32] : word32)
-	T_1828 (in d0_1691 : Eq_25)
+	T_1828 (in d0_1691 : Eq_73)
 	T_1833 (in a7_1465[18<i32>] & 2<i32> : word32)
 	T_1834 (in 0<32> : word32)
 	T_1876 (in fn00001D98(*(a7_1465 - 8<i32>), *(a7_1465 - 4<i32>), out a0_1447, out a5_1579) : word32)
@@ -254,12 +258,8 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_2276 (in 0<32> : word32)
 	T_2279 (in Mem624[a0_1447 + 0<32>:word32] : word32)
 	T_2337 (in Mem611[a0_1447 + 0<32>:word32] : word32)
-	T_2344 (in 0<32> : word32)
-	T_2374 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-	T_2378 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
 	T_2403 (in SLICE(d6_1480, word16, 0) : word16)
 	T_2406 (in Mem599[a0_1447 + 0<32>:word16] : word16)
-	T_2434 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
 	T_2484 (in Mem575[a0_1447 + 0<32>:word32] : word32)
 	T_2494 (in SLICE(d6_1480, byte, 0) : byte)
 	T_2497 (in Mem587[a0_1447 + 0<32>:byte] : byte)
@@ -268,323 +268,14 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_2581 (in Mem66[a0_104 + 0<32>:byte] : byte)
 	T_2707 (in SLICE(dwArg04, byte, 0) : byte)
 	T_2710 (in Mem118[a0_112 + 0<32>:byte] : byte)
-	T_2890 (in a1Out : Eq_25)
-	T_2894 (in out a1 : ptr32)
-	T_3023 (in d0 : Eq_25)
-	T_3024 (in d0_158 : Eq_25)
-	T_3033 (in a3_120 : Eq_25)
-	T_3034 (in 0<32> : word32)
-	T_3041 (in AllocPooled(dwArg08, dwArg04) : word32)
-	T_3054 (in d0_50 : Eq_25)
-	T_3058 (in AllocMem(dwArg08 + 16<i32>, d1) : word32)
-	T_3059 (in 0<32> : word32)
-	T_3074 (in d0_82 : Eq_25)
-	T_3076 (in AllocMem(d3_77, d1) : word32)
-	T_3077 (in 0<32> : word32)
-	T_3087 (in d0_128 : Eq_25)
-	T_3092 (in Allocate(a5_162, dwArg08) : word32)
-	T_3093 (in 0<32> : word32)
-	T_3161 (in Allocate((word32) d0_82 + 4<i32>, dwArg08) : word32)
-	T_3162 (in a2_142 : Eq_25)
-	T_3180 (in a2_149 + 4<i32> : word32)
-	T_3201 (in d0_50 + 16<i32> : word32)
-	T_3202 (in d0 : Eq_25)
-	T_3203 (in d0_51 : Eq_25)
-	T_3212 (in 0<32> : word32)
-	T_3213 (in a1 : word32)
-	T_3223 (in CreatePrivatePool(dwArg04, dwArg08, dwArg0C) : word32)
-	T_3224 (in d0_30 : Eq_25)
-	T_3228 (in AllocMem(24<i32>, 0<i32>) : word32)
-	T_3230 (in 0<32> : word32)
-	T_3237 (in 0<32> : word32)
-	T_3239 (in Mem38[d0_30 + 4<i32>:word32] : word32)
-	T_3242 (in Mem40[d0_30 + 8<i32>:word32] : word32)
-	T_3315 (in d0 : Eq_25)
-	T_3316 (in d0_196 : Eq_25)
-	T_3317 (in d1_142 : Eq_25)
-	T_3318 (in a0_20 : Eq_25)
-	T_3319 (in d3_166 : Eq_25)
-	T_3320 (in 0<32> : word32)
-	T_3328 (in 0<32> : word32)
-	T_3334 (in d0 : Eq_25)
-	T_3335 (in d1 : Eq_25)
-	T_3336 (in d2 : Eq_25)
-	T_3337 (in d1Out : Eq_25)
-	T_3338 (in d2Out : Eq_25)
-	T_3339 (in out d1_318 : ptr32)
-	T_3340 (in out d2_319 : ptr32)
-	T_3341 (in fn000024BC(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-	T_3342 (in 0<i32> : int32)
-	T_3345 (in d6_30 : Eq_25)
-	T_3348 (in  : word32)
-	T_3349 (in  : word32)
-	T_3350 (in 8<32> : word32)
-	T_3351 (in __rol(dwArg0C, 8<32>) : word32)
-	T_3377 (in 8<32> : word32)
-	T_3378 (in __rol(d6_30, 8<32>) : word32)
-	T_3384 (in 8<32> : word32)
-	T_3385 (in __rol(d6_30, 8<32>) : word32)
-	T_3392 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_3393 (in d1_175 : Eq_25)
-	T_3394 (in d2_176 : Eq_25)
-	T_3395 (in d0_174 : Eq_25)
-	T_3397 (in 0<i32> : int32)
-	T_3398 (in out d1_175 : ptr32)
-	T_3399 (in out d2_176 : ptr32)
-	T_3400 (in fn000024BC(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-	T_3404 (in out d1_320 : ptr32)
-	T_3405 (in out d2_321 : ptr32)
-	T_3406 (in fn000024BC(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-	T_3417 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_3420 (in d0_85 : Eq_25)
-	T_3422 (in dwArg04 >> d4_61 : word32)
-	T_3425 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-	T_3428 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-	T_3429 (in out d1_86 : ptr32)
-	T_3430 (in out d2_322 : ptr32)
-	T_3431 (in fn000024BC(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-	T_3432 (in d3_72 : Eq_25)
-	T_3433 (in dwArg10 << d5_63 : word32)
-	T_3434 (in d5_101 : Eq_25)
-	T_3436 (in __swap(d0_85) : word32)
-	T_3437 (in d6_103 : Eq_25)
-	T_3439 (in __swap(d3_72) : word32)
-	T_3443 (in d2_107 : Eq_25)
-	T_3446 (in d0_85 * (word16) d3_72 : word32)
-	T_3447 (in __swap(d0_85 * (word16) d3_72) : word32)
-	T_3460 (in d6_82 : Eq_25)
-	T_3461 (in dwArg08 << d5_63 : word32)
-	T_3462 (in d2_124 : Eq_25)
-	T_3464 (in SEQ(v35_109, v39_116) : uipr32)
-	T_3465 (in __swap(SEQ(v35_109, v39_116)) : word32)
-	T_3473 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-	T_3474 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-	T_3478 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-	T_3479 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-	T_3501 (in d0_85 - 1<32> : word32)
-	T_3507 (in d7_13 : Eq_25)
-	T_3508 (in 0<32> : word32)
-	T_3512 (in d0 : Eq_25)
-	T_3513 (in d1 : Eq_25)
-	T_3514 (in d2 : Eq_25)
-	T_3515 (in d1Out : Eq_25)
-	T_3516 (in out d1 : ptr32)
-	T_3517 (in fn0000267A(d1, d2, d2, out d1) : word32)
-	T_3518 (in d6_17 : Eq_25)
-	T_3519 (in d5_19 : Eq_25)
-	T_3520 (in 0<32> : word32)
-	T_3522 (in d2_22 : Eq_25)
-	T_3524 (in __swap(d2) : word32)
-	T_3528 (in 0<32> : word32)
-	T_3537 (in 0<32> : word32)
-	T_3539 (in d0_281 : Eq_25)
-	T_3541 (in __swap(d0) : word32)
-	T_3542 (in d1_282 : Eq_25)
-	T_3544 (in __swap(d1) : word32)
-	T_3554 (in __swap(d1_282) : word32)
-	T_3561 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-	T_3562 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-	T_3567 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-	T_3573 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-	T_3574 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-	T_3578 (in d6_17 * 2<32> : word32)
-	T_3586 (in 0<32> : word32)
-	T_3588 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-	T_3590 (in d7_13 * 2<32> : word32)
-	T_3591 (in 0<32> : word32)
-	T_3595 (in d3_74 : Eq_25)
-	T_3602 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-	T_3603 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-	T_3606 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-	T_3607 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-	T_3608 (in d1_104 : Eq_25)
-	T_3609 (in 0xFFFF<32> : uipr32)
-	T_3610 (in d6_98 : Eq_25)
-	T_3614 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-	T_3615 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-	T_3616 (in d6_133 : Eq_25)
-	T_3618 (in __swap(d1_104) : word32)
-	T_3619 (in d3_140 : Eq_25)
-	T_3621 (in __swap(d6_133) : word32)
-	T_3622 (in d4_142 : Eq_25)
-	T_3624 (in __swap(d7_13) : word32)
-	T_3628 (in d6_146 : Eq_25)
-	T_3631 (in d6_133 * (word16) d7_13 : word32)
-	T_3632 (in __swap(d6_133 * (word16) d7_13) : word32)
-	T_3648 (in d6_178 : Eq_25)
-	T_3650 (in SEQ(v56_148, v59_155) : uipr32)
-	T_3651 (in __swap(SEQ(v56_148, v59_155)) : word32)
-	T_3652 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-	T_3653 (in d5_181 : word32)
-	T_3657 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-	T_3658 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-	T_3662 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-	T_3663 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-	T_3676 (in 0<32> : word32)
-	T_3678 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-	T_3679 (in 0<32> : word32)
-	T_3687 (in d1_104 - 1<32> : word32)
-	T_3688 (in d4_113 : Eq_25)
-	T_3691 (in __swap(d7_13) : word32)
-	T_3694 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-	T_3695 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-	T_3710 (in __swap(d7_13) : word32)
-	T_3714 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-	T_3716 (in d1_104 - 1<32> : word32)
-	T_3717 (in 0<32> : word32)
-	T_3723 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-	T_3724 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_3725 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-	T_3726 (in d6_220 : Eq_25)
-	T_3730 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-	T_3731 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-	T_3734 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-	T_3735 (in d5_221 : Eq_25)
-	T_3737 (in __swap(d5_181) : word32)
-	T_3742 (in d5_266 : Eq_25)
-	T_3744 (in __swap(d5_181) : word32)
-	T_3745 (in d6_267 : Eq_25)
-	T_3747 (in __swap(d6_178) : word32)
-	T_3750 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-	T_3753 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-	T_3757 (in d2_73 : Eq_25)
-	T_3759 (in __swap(d5_19) : word32)
-	T_3761 (in __swap(d7_13) : word32)
-	T_3771 (in d5_221 >> 1<32> : word32)
-	T_3776 (in  : word32)
-	T_3782 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-	T_3789 (in d0 : Eq_25)
-	T_3790 (in d2 : Eq_25)
-	T_3791 (in dwArg04 : Eq_25)
-	T_3792 (in dwArg08 : Eq_25)
-	T_3793 (in 0<32> : word32)
-	T_3795 (in 0<32> : word32)
-	T_3797 (in d0_36 : Eq_25)
-	T_3798 (in -dwArg04 : word32)
-	T_3799 (in 0<32> : word32)
-	T_3803 (in out d1_43 : ptr32)
-	T_3804 (in fn0000267A(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_3805 (in -fn0000267A(d0_36, dwArg08, d2, out d1_43) : word32)
-	T_3808 (in -dwArg08 : word32)
-	T_3809 (in out d1_55 : ptr32)
-	T_3810 (in fn0000267A(d0_36, -dwArg08, d2, out d1_55) : word32)
-	T_3813 (in out d1_88 : ptr32)
-	T_3814 (in fn0000267A(dwArg04, dwArg08, d2, out d1_88) : word32)
-	T_3817 (in -dwArg08 : word32)
-	T_3818 (in out d1_89 : ptr32)
-	T_3819 (in fn0000267A(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_3820 (in -fn0000267A(dwArg04, -dwArg08, d2, out d1_89) : word32)
-	T_3821 (in d1_22 : Eq_25)
-	T_3823 (in __swap(d1) : word32)
-	T_3828 (in d2_11 : Eq_25)
-	T_3829 (in SEQ(v11_10, v10_9) : uipr32)
-	T_3832 (in d3_18 : Eq_25)
-	T_3833 (in 16<i32> : int32)
-	T_3837 (in d0_134 : Eq_25)
-	T_3839 (in __swap(d0) : word32)
-	T_3840 (in d1_135 : Eq_25)
-	T_3842 (in __swap(d1_22) : word32)
-	T_3847 (in __swap(d2_11) : word32)
-	T_3852 (in d0_150 : Eq_25)
-	T_3854 (in __swap(d0_134) : word32)
-	T_3868 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-	T_3869 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-	T_3871 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-	T_3873 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-	T_3883 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-	T_3888 (in 8<32> : word32)
-	T_3889 (in __rol(d1_22, 8<32>) : word32)
-	T_3890 (in 8<32> : uipr32)
-	T_3895 (in 4<32> : word32)
-	T_3896 (in __rol(d1_22, 4<32>) : word32)
-	T_3901 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-	T_3906 (in 2<32> : word32)
-	T_3907 (in __rol(d1_22, 2<32>) : word32)
-	T_3912 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-	T_3918 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-	T_3919 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-	T_3926 (in __swap(d3_18) : word32)
-	T_3932 (in d1_90 : Eq_25)
-	T_3934 (in __swap(d1_22) : word32)
-	T_3935 (in d3_102 : Eq_25)
-	T_3936 (in SEQ(v53_82, v51_79) : uipr32)
-	T_3937 (in d0_108 : Eq_25)
-	T_3947 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-	T_3948 (in 0<32> : word32)
-	T_3951 (in 1<32> : word32)
-	T_3952 (in __rol(d1_22, 1<32>) : word32)
-	T_3957 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-	T_3961 (in __swap(d3_102) : word32)
-	T_3962 (in __rol(d0_108, __swap(d3_102)) : word32)
-	T_3963 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-	T_3966 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-	T_3969 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-	T_3970 (in d0_108 + d1_90 : word32)
-	T_3971 (in 0<32> : word32)
-	T_3973 (in d1 : Eq_25)
-	T_3974 (in d1_171 : Eq_25)
-	T_3975 (in d3_202 : Eq_25)
-	T_3976 (in 0<32> : word32)
-	T_3984 (in 0<32> : word32)
-	T_3988 (in out d1_171 : ptr32)
-	T_3989 (in out d2_354 : ptr32)
-	T_3990 (in fn000024BC(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-	T_3993 (in d6_33 : Eq_25)
-	T_3995 (in 8<32> : word32)
-	T_3996 (in __rol(dwArg0C, 8<32>) : word32)
-	T_4022 (in 8<32> : word32)
-	T_4023 (in __rol(d6_33, 8<32>) : word32)
-	T_4029 (in 8<32> : word32)
-	T_4030 (in __rol(d6_33, 8<32>) : word32)
-	T_4037 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-	T_4040 (in d0_88 : Eq_25)
-	T_4042 (in dwArg04 >> d4_64 : word32)
-	T_4045 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-	T_4048 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-	T_4049 (in out d1_89 : ptr32)
-	T_4050 (in out d2_90 : ptr32)
-	T_4051 (in fn000024BC(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-	T_4052 (in d3_75 : Eq_25)
-	T_4053 (in dwArg10 << d5_66 : word32)
-	T_4054 (in d7_104 : Eq_25)
-	T_4056 (in __swap(d0_88) : word32)
-	T_4057 (in d6_106 : Eq_25)
-	T_4059 (in __swap(d3_75) : word32)
-	T_4063 (in d2_110 : Eq_25)
-	T_4066 (in d0_88 * (word16) d3_75 : word32)
-	T_4067 (in __swap(d0_88 * (word16) d3_75) : word32)
-	T_4080 (in d2_127 : Eq_25)
-	T_4082 (in SEQ(v37_112, v40_119) : uipr32)
-	T_4083 (in __swap(SEQ(v37_112, v40_119)) : word32)
-	T_4093 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-	T_4094 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-	T_4098 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-	T_4099 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-	T_4118 (in dwArg08 - dwArg10 : word32)
-	T_4122 (in d1_211 : Eq_25)
-	T_4123 (in d2_212 : Eq_25)
-	T_4125 (in 0<i32> : int32)
-	T_4126 (in out d1_211 : ptr32)
-	T_4127 (in out d2_212 : ptr32)
-	T_4128 (in fn000024BC(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-	T_4131 (in out d1_171 : ptr32)
-	T_4132 (in out d2_355 : ptr32)
-	T_4133 (in fn000024BC(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-	T_4144 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-	T_4149 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-	T_4162 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
-	T_4204 (in d0 : Eq_25)
-	T_4205 (in d1 : Eq_25)
-	T_4206 (in a1 : Eq_25)
-	T_4207 (in dwArg04 : Eq_25)
-	T_4209 (in dwArg0C : Eq_25)
+	T_4204 (in d0 : Eq_73)
+	T_4205 (in d1 : Eq_73)
+	T_4207 (in dwArg04 : Eq_73)
 	T_4211 (in Mem10[0x00003ECC<p32>:word32] : word32)
-	T_4214 (in fp + 8<i32> : word32)
-	T_4215 (in fn00002B8C(d0, d1, a1, *(union Eq_25 *) 0x3ECC<u32>, dwArg04, fp + 8<i32>) : word32)
-	T_4216 (in d0 : Eq_25)
-	T_4217 (in bArg07 : Eq_25)
-	T_4218 (in dwArg08 : Eq_25)
-	T_4219 (in d0_10 : Eq_25)
+	T_4215 (in fn00002B8C(d0, d1, a1, *(union Eq_73 *) 0x3ECC<u32>, dwArg04, fp + 8<i32>) : word32)
+	T_4216 (in d0 : Eq_73)
+	T_4218 (in dwArg08 : Eq_73)
+	T_4219 (in d0_10 : Eq_73)
 	T_4220 (in 0<32> : word32)
 	T_4224 (in Mem5[dwArg08 + 4<i32>:word32] : word32)
 	T_4227 (in Mem5[dwArg08 + 8<i32>:word32] : word32)
@@ -592,53 +283,38 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_4242 (in *((word32) dwArg08 + 4<i32>) - 1<32> : word32)
 	T_4244 (in Mem25[dwArg08 + 4<i32>:word32] : word32)
 	T_4247 (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-	T_4250 (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-	T_4255 (in d2_1090 : Eq_25)
-	T_4257 (in a2_1014 : Eq_25)
-	T_4260 (in d5_1044 : Eq_25)
+	T_4257 (in a2_1014 : Eq_73)
+	T_4260 (in d5_1044 : Eq_73)
 	T_4261 (in 0<i32> : int32)
-	T_4267 (in d0_3698 : Eq_25)
+	T_4267 (in d0_3698 : Eq_73)
 	T_4268 (in 0xFFFFFFFF<32> : word32)
 	T_4292 (in d0_63 & 8<32> : word32)
-	T_4318 (in d6_1133 : Eq_25)
-	T_4319 (in -1<i32> : int32)
 	T_4321 (in d0_289 & 4<32> : word32)
-	T_4341 (in 0<i32> : int32)
 	T_4343 (in d0_305 & 4<32> : word32)
-	T_4352 (in Mem316[a7_313 + 0<32>:word32] : word32)
-	T_4355 (in 10<i32> : int32)
-	T_4356 (in __swap(10<i32>) : word32)
-	T_4366 (in __swap(d6_1133) : word32)
-	T_4371 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-	T_4372 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-	T_4398 (in Mem316[a7_313 + 0<32>:word32] : word32)
 	T_4400 (in d1_340 - 0x30<32> : word32)
-	T_4402 (in d1_340 - 0x30<32> + d0_331 : word32)
 	T_4404 (in d0_354 & 4<32> : word32)
 	T_4418 (in SEQ(SLICE(d1, word24, 8), Mem361[a7_1330 + 72<i32>:byte]) : uip32)
 	T_4465 (in 0<32> : word32)
 	T_4475 (in 2<i32> : int32)
 	T_4523 (in SEQ(SLICE(d1, word24, 8), Mem361[a3_279 + 0<32>:byte]) : uip32)
 	T_4529 (in 1<i32> : int32)
-	T_4566 (in d1_612 : Eq_25)
+	T_4566 (in d1_612 : Eq_73)
 	T_4569 (in SEQ(v147_608, v83_500 - 0x25<8>) : uip32)
-	T_4579 (in d0_540 : Eq_25)
+	T_4579 (in d0_540 : Eq_73)
 	T_4610 (in Mem535[a7_533 + 0<32>:word32] : word32)
-	T_4615 (in dwArg04 : Eq_25)
+	T_4615 (in dwArg04 : Eq_73)
 	T_4621 (in Mem535[a7_533 + 0<32>:word32] : word32)
 	T_4625 (in fn00003C30(*a7_533, out d1_5316, out a1, out a5_5317) : word32)
-	T_4627 (in a2_1014 + 4<i32> : word32)
 	T_4637 (in Mem554[a7_552 + 0<32>:word32] : word32)
 	T_4649 (in Mem558[a7_552 + 0<32>:word32] : word32)
 	T_4651 (in SEQ(SLICE(d0, word24, 8), v96_562) : uip32)
 	T_4653 (in (uint32) (uint8) v96_562 : uint32)
 	T_4668 (in d0_591 & 8<32> : word32)
-	T_4672 (in d0_111 : Eq_25)
-	T_4698 (in d0_187 : Eq_25)
+	T_4672 (in d0_111 : Eq_73)
+	T_4698 (in d0_187 : Eq_73)
 	T_4729 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_4735 (in Mem182[a7_180 + 0<32>:word32] : word32)
 	T_4739 (in fn00003C30(*a7_180, out d1_5318, out a1, out a5_5319) : word32)
-	T_4741 (in a2_1014 + 4<i32> : word32)
 	T_4751 (in Mem201[a7_199 + 0<32>:word32] : word32)
 	T_4763 (in Mem205[a7_199 + 0<32>:word32] : word32)
 	T_4765 (in SEQ(SLICE(d0, word24, 8), v109_209) : uip32)
@@ -647,14 +323,12 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_4787 (in 0xFFFFFFFF<32> : word32)
 	T_4797 (in Mem251[a7_248 + 0<32>:word32] : word32)
 	T_4802 (in Mem254[a7_248 - 4<i32> + 0<32>:word32] : word32)
-	T_4809 (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
 	T_4812 (in Mem254[a7_248 + 0<32>:word32] : word32)
 	T_4813 (in fn00002B5C(*(a7_248 - 1<i32>), *a7_248) : word32)
 	T_4821 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_4826 (in Mem81[a7_79 + 0<32>:word32] : word32)
 	T_4830 (in fn00003C30(a7_79->t0000, out d1, out a1, out a5_5320) : word32)
 	T_4833 (in Mem94[a7_79 + 48<i32>:word32] : word32)
-	T_4835 (in a2_1014 + 4<i32> : word32)
 	T_4845 (in Mem101[a7_99 + 0<32>:word32] : word32)
 	T_4857 (in Mem105[a7_99 + 0<32>:word32] : word32)
 	T_4860 (in Mem115[a7_99 + 0<32>:word32] : word32)
@@ -665,19 +339,16 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_4897 (in 0xFFFFFFFF<32> : word32)
 	T_4907 (in Mem151[a7_148 + 0<32>:word32] : word32)
 	T_4912 (in Mem154[a7_148 - 4<i32> + 0<32>:word32] : word32)
-	T_4918 (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
 	T_4921 (in Mem154[a7_148 + 0<32>:word32] : word32)
 	T_4922 (in fn00002B5C(*(a7_148 - 1<i32>), *a7_148) : word32)
-	T_4959 (in d1_1355 : Eq_25)
+	T_4959 (in d1_1355 : Eq_73)
 	T_4962 (in SEQ(v147_608, v83_500 - 0x63<8>) : uip32)
-	T_4964 (in 0xFFFFFFFF<32> : word32)
 	T_4968 (in SEQ(v147_608, v83_500 - 0x6E<8>) : uip32)
 	T_4977 (in SEQ(v147_608, v83_500 - 0x73<8>) : uip32)
 	T_5004 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_5009 (in Mem642[a7_640 + 0<32>:word32] : word32)
 	T_5013 (in fn00003C30(a7_640->t0000, out d1, out a1, out a5_5321) : word32)
 	T_5016 (in Mem655[a7_640 + 48<i32>:word32] : word32)
-	T_5018 (in a2_1014 + 4<i32> : word32)
 	T_5028 (in Mem662[a7_660 + 0<32>:word32] : word32)
 	T_5040 (in Mem666[a7_660 + 0<32>:word32] : word32)
 	T_5043 (in Mem686[a7_660 + 0<32>:word32] : word32)
@@ -687,38 +358,29 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_5070 (in 0xFFFFFFFF<32> : word32)
 	T_5081 (in Mem738[a7_735 + 0<32>:word32] : word32)
 	T_5086 (in Mem741[a7_735 - 4<i32> + 0<32>:word32] : word32)
-	T_5092 (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
 	T_5095 (in Mem741[a7_735 + 0<32>:word32] : word32)
 	T_5096 (in fn00002B5C(*(a7_735 - 1<i32>), *a7_735) : word32)
 	T_5099 (in 0x2D<32> : word32)
 	T_5112 (in (word32) d2_1090 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_5114 (in d0 + 4<32> : word32)
 	T_5118 (in 0xFFFFFFFF<32> : word32)
 	T_5143 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5156 (in d0 + 4<32> : word32)
 	T_5157 (in 0xFFFFFFFF<32> : word32)
 	T_5171 (in d0_1765 & 8<32> : word32)
 	T_5224 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5232 (in d0 + 4<32> : word32)
 	T_5238 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_5243 (in Mem1809[a7_1807 + 0<32>:word32] : word32)
 	T_5247 (in fn00003C30(*a7_1807, out d1_5322, out a1, out a5_1727) : word32)
-	T_5249 (in a2_1014 + 4<i32> : word32)
 	T_5259 (in Mem1828[a7_1826 + 0<32>:word32] : word32)
 	T_5271 (in Mem1832[a7_1826 + 0<32>:word32] : word32)
 	T_5273 (in SEQ(SLICE(d0, word24, 8), v201_1836) : uip32)
 	T_5275 (in (uint32) (uint8) v201_1836 : uint32)
 	T_5280 (in 0xFFFFFFFF<32> : word32)
 	T_5292 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5301 (in d0 + 4<32> : word32)
 	T_5317 (in d0_1871 & 8<32> : word32)
 	T_5331 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5339 (in d0 + 4<32> : word32)
 	T_5345 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5354 (in d0 + 4<32> : word32)
 	T_5369 (in Mem1903[a7_1897 + 0<32>:word32] : word32)
 	T_5374 (in Mem1906[a7_1897 - 4<i32> + 0<32>:word32] : word32)
-	T_5380 (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
 	T_5383 (in Mem1906[a7_1897 + 0<32>:word32] : word32)
 	T_5384 (in fn00002B5C(*(a7_1897 - 1<i32>), *a7_1897) : word32)
 	T_5385 (in 0x2B<32> : word32)
@@ -727,7 +389,6 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_5434 (in Mem2009[a7_2007 + 0<32>:word32] : word32)
 	T_5438 (in fn00003C30(a7_2007->t0000, out d1, out a1, out a5_5323) : word32)
 	T_5441 (in Mem2022[a7_2007 + 56<i32>:word32] : word32)
-	T_5443 (in a2_1014 + 4<i32> : word32)
 	T_5453 (in Mem2029[a7_2027 + 0<32>:word32] : word32)
 	T_5465 (in Mem2033[a7_2027 + 0<32>:word32] : word32)
 	T_5468 (in Mem2050[a7_2027 + 0<32>:word32] : word32)
@@ -736,29 +397,25 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_5481 (in Mem2062[a7_1330 + 52<i32>:word32] : word32)
 	T_5504 (in 0x30<32> : word32)
 	T_5518 (in d0_2109 & 4<32> : word32)
-	T_5525 (in d0_2155 : Eq_25)
+	T_5525 (in d0_2155 : Eq_73)
 	T_5556 (in Mem2150[a7_2148 + 0<32>:word32] : word32)
 	T_5561 (in Mem2150[a7_2148 + 0<32>:word32] : word32)
 	T_5565 (in fn00003C30(a7_2148->t0000, out d1, out a1, out a5_5324) : word32)
 	T_5568 (in Mem2163[a7_2148 + 56<i32>:word32] : word32)
-	T_5570 (in a2_1014 + 4<i32> : word32)
 	T_5580 (in Mem2170[a7_2168 + 0<32>:word32] : word32)
 	T_5592 (in Mem2174[a7_2168 + 0<32>:word32] : word32)
 	T_5595 (in Mem2185[a7_2168 + 0<32>:word32] : word32)
 	T_5602 (in SEQ(SLICE(d0, word24, 8), v249_2178) : uip32)
 	T_5605 (in Mem2191[a7_2168 + 0<32>:word32] : word32)
 	T_5622 (in d0_2209 & 0xFF<32> : word32)
-	T_5641 (in 1<i32> : int32)
 	T_5642 (in 0x78<32> : word32)
 	T_5650 (in SEQ(SLICE(d0_2209 & 0xFF<32>, word24, 8), SLICE(d0_2209 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
 	T_5657 (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-	T_5659 (in d0 + 4<32> : word32)
-	T_5697 (in d0_2253 : Eq_25)
+	T_5697 (in d0_2253 : Eq_73)
 	T_5728 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_5733 (in Mem2248[a7_2246 + 0<32>:word32] : word32)
 	T_5737 (in fn00003C30(a7_2246->t0000, out d1, out a1, out a5_5325) : word32)
 	T_5740 (in Mem2261[a7_2246 + 56<i32>:word32] : word32)
-	T_5742 (in a2_1014 + 4<i32> : word32)
 	T_5752 (in Mem2268[a7_2266 + 0<32>:word32] : word32)
 	T_5764 (in Mem2272[a7_2266 + 0<32>:word32] : word32)
 	T_5767 (in Mem2283[a7_2266 + 0<32>:word32] : word32)
@@ -774,18 +431,14 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_5859 (in Mem1444[a7_1425 + 0<32>:word32] : word32)
 	T_5866 (in SEQ(SLICE(d0, word24, 8), v284_1435) : uip32)
 	T_5869 (in Mem1450[a7_1425 + 0<32>:word32] : word32)
-	T_5872 (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
 	T_5875 (in Mem1456[a7_1330 + 52<i32>:word32] : word32)
 	T_5898 (in 0xFFFFFFFF<32> : word32)
-	T_5902 (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
 	T_5951 (in Mem2338[a7_2334 + 0<32>:word32] : word32)
-	T_5965 (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
 	T_5968 (in Mem2342[a7_2334 + 0<32>:word32] : word32)
 	T_5969 (in fn00002B5C(*(a7_2334 - 1<i32>), a7_2334->t0000) : word32)
 	T_5975 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_5981 (in Mem1514[a7_1512 + 0<32>:word32] : word32)
 	T_5985 (in fn00003C30(*a7_1512, out d1_5328, out a1, out a5_5329) : word32)
-	T_5987 (in a2_1014 + 4<i32> : word32)
 	T_5997 (in Mem1533[a7_1531 + 0<32>:word32] : word32)
 	T_6009 (in Mem1537[a7_1531 + 0<32>:word32] : word32)
 	T_6011 (in SEQ(SLICE(d0, word24, 8), v314_1541) : uip32)
@@ -793,21 +446,18 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_6018 (in 0xFFFFFFFF<32> : word32)
 	T_6047 (in Mem1591[a7_1585 + 0<32>:word32] : word32)
 	T_6052 (in Mem1594[a7_1585 - 4<i32> + 0<32>:word32] : word32)
-	T_6058 (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
 	T_6061 (in Mem1594[a7_1585 + 0<32>:word32] : word32)
 	T_6062 (in fn00002B5C(*(a7_1585 - 1<i32>), *a7_1585) : word32)
 	T_6068 (in Mem2373[a7_2368 + 0<32>:word32] : word32)
-	T_6082 (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
 	T_6085 (in Mem2377[a7_2368 + 0<32>:word32] : word32)
 	T_6086 (in fn00002B5C(*(a7_2368 - 1<i32>), a7_2368->t0000) : word32)
 	T_6109 (in d0_2124 & 0x44<32> : word32)
 	T_6120 (in 0x30<32> : word32)
-	T_6125 (in d0_2450 : Eq_25)
+	T_6125 (in d0_2450 : Eq_73)
 	T_6156 (in Mem2445[a7_2443 + 0<32>:word32] : word32)
 	T_6161 (in Mem2445[a7_2443 + 0<32>:word32] : word32)
 	T_6165 (in fn00003C30(a7_2443->t0000, out d1, out a1, out a5_5330) : word32)
 	T_6168 (in Mem2458[a7_2443 + 56<i32>:word32] : word32)
-	T_6170 (in a2_1014 + 4<i32> : word32)
 	T_6180 (in Mem2465[a7_2463 + 0<32>:word32] : word32)
 	T_6192 (in Mem2469[a7_2463 + 0<32>:word32] : word32)
 	T_6195 (in Mem2492[a7_2463 + 0<32>:word32] : word32)
@@ -816,40 +466,28 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_6225 (in d0_2517 & 0xFF<32> : word32)
 	T_6235 (in 0x78<32> : word32)
 	T_6243 (in SEQ(SLICE(d0_2517 & 0xFF<32>, word24, 8), SLICE(d0_2517 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
-	T_6252 (in d0_2559 : Eq_25)
+	T_6252 (in d0_2559 : Eq_73)
 	T_6283 (in Mem2554[a7_2552 + 0<32>:word32] : word32)
 	T_6288 (in Mem2554[a7_2552 + 0<32>:word32] : word32)
 	T_6292 (in fn00003C30(a7_2552->t0000, out d1, out a1, out a5_5331) : word32)
 	T_6295 (in Mem2567[a7_2552 + 56<i32>:word32] : word32)
-	T_6297 (in a2_1014 + 4<i32> : word32)
 	T_6307 (in Mem2574[a7_2572 + 0<32>:word32] : word32)
 	T_6319 (in Mem2578[a7_2572 + 0<32>:word32] : word32)
 	T_6322 (in Mem2589[a7_2572 + 0<32>:word32] : word32)
 	T_6329 (in SEQ(SLICE(d0, word24, 8), v372_2582) : uip32)
 	T_6332 (in Mem2595[a7_2572 + 0<32>:word32] : word32)
 	T_6357 (in d0_2620 & 0x44<32> : word32)
-	T_6390 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
 	T_6399 (in d0_2760 & 0x44<32> : word32)
 	T_6412 (in Mem2671[a7_2667 + 0<32>:word32] : word32)
-	T_6426 (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
 	T_6429 (in Mem2675[a7_2667 + 0<32>:word32] : word32)
 	T_6430 (in fn00002B5C(*(a7_2667 - 1<i32>), a7_2667->t0000) : word32)
 	T_6442 (in Mem2603[a7_1330 + 74<i32>:word32] : word32)
-	T_6455 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-	T_6485 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
 	T_6494 (in d0_2818 & 4<32> : word32)
-	T_6500 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-	T_6506 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-	T_6516 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
 	T_6524 (in 0x37<32> : word32)
-	T_6537 (in v419_2893 : Eq_25)
-	T_6542 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-	T_6667 (in d0_3135 : Eq_25)
-	T_6717 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_6667 (in d0_3135 : Eq_73)
 	T_6743 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6750 (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6754 (in fn00003C30(*(a7_1330 - 4<i32>), out d1_5332, out a1, out a5_5333) : word32)
-	T_6756 (in a2_1014 + 4<i32> : word32)
 	T_6764 (in Mem3149[a7_1330 - 4<i32> + 0<32>:word32] : word32)
 	T_6774 (in (uint32) (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint32)
 	T_6778 (in Mem3153[a7_1330 - 4<i32> + 0<32>:word32] : word32)
@@ -860,98 +498,62 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_6820 (in Mem3291[a7_1330 + 110<i32>:word32] : word32)
 	T_6826 (in Mem3272[a7_3259 + 0<32>:word32] : word32)
 	T_6831 (in Mem3275[a7_3259 - 4<i32> + 0<32>:word32] : word32)
-	T_6837 (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
 	T_6840 (in Mem3275[a7_3259 + 0<32>:word32] : word32)
 	T_6841 (in fn00002B5C(*(a7_3259 - 1<i32>), *a7_3259) : word32)
 	T_6847 (in Mem2639[a7_2635 + 0<32>:word32] : word32)
-	T_6861 (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
 	T_6864 (in Mem2643[a7_2635 + 0<32>:word32] : word32)
 	T_6865 (in fn00002B5C(*(a7_2635 - 1<i32>), a7_2635->t0000) : word32)
 	T_6883 (in d0_3206 & 4<32> : word32)
 	T_6891 (in 0x37<32> : word32)
-	T_6897 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_6900 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-	T_6902 (in d7 >> 31<i32> : word32)
-	T_6905 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-	T_6915 (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
-	T_6947 (in dwArg04 : Eq_25)
-	T_6948 (in dwArg08 : Eq_25)
-	T_6949 (in dwArg0C : Eq_25)
-	T_6950 (in dwArg10 : Eq_25)
-	T_6955 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-	T_6960 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-	T_6965 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-	T_6970 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
 	T_7009 (in Mem3303[a7_3299 + 0<32>:word32] : word32)
 	T_7014 (in Mem3306[a7_3299 - 4<i32> + 0<32>:word32] : word32)
-	T_7020 (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
 	T_7023 (in Mem3306[a7_3299 + 0<32>:word32] : word32)
 	T_7024 (in fn00002B5C(*(a7_3299 - 1<i32>), *a7_3299) : word32)
 	T_7053 (in Mem3476[a7_3474 + 0<32>:word32] : word32)
-	T_7077 (in (d0_3495 << 2<32>) + 4<32> : word32)
 	T_7084 (in Mem3485[a7_3474 + 52<i32>:word32] : word32)
 	T_7087 (in Mem3503[a0_3501 + 4<i32>:word32] : word32)
 	T_7094 (in d0_3495 << 2<32> : word32)
-	T_7113 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7116 (in Mem3508[a7_3474 + 52<i32>:word32] : word32)
 	T_7117 (in SLICE(d0, byte, 0) : byte)
 	T_7123 (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_7142 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7145 (in Mem3525[a7_3474 + 52<i32>:word32] : word32)
 	T_7146 (in SLICE(d0, word16, 0) : word16)
 	T_7152 (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_7171 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7174 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_7180 (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7188 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7191 (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
 	T_7197 (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
 	T_7223 (in -v528_3348->dw0004 : word32)
 	T_7228 (in 0<32> : word32)
 	T_7230 (in -v528_3348->dw0000 - (d1 < 0<32>) : word32)
 	T_7239 (in Mem3375[a7_3364 + 0<32>:word32] : word32)
-	T_7264 (in d1_1027 : Eq_25)
+	T_7264 (in d1_1027 : Eq_73)
 	T_7267 (in Mem773[a7_1330 + 52<i32>:word32] : word32)
-	T_7282 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_7289 (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
+	T_7292 (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
 	T_7299 (in d0_3398 << 2<32> : word32)
-	T_7318 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7321 (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
 	T_7322 (in SLICE(d0, byte, 0) : byte)
 	T_7328 (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-	T_7347 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7350 (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
 	T_7351 (in SLICE(d0, word16, 0) : word16)
 	T_7357 (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-	T_7376 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7379 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_7385 (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7393 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
 	T_7396 (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
 	T_7402 (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-	T_7406 (in SLICE(d5_785, byte, 0) : byte)
-	T_7410 (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
 	T_7412 (in d1_1027 + 1<32> : word32)
 	T_7413 (in 0x20<32> : word32)
-	T_7419 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-	T_7430 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
 	T_7445 (in SEQ(SLICE(d1_1027, word24, 8), v556_834) : uip32)
 	T_7471 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_7490 (in Mem889[a0_881 + 0<32>:byte] : byte)
 	T_7492 (in (uint32) (uint8) Mem889[a0_881 + 0<32>:byte] : uint32)
-	T_7498 (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-	T_7501 (in Mem895[a0_881 + 0<32>:byte] : byte)
-	T_7510 (in Mem889[a0_900 + 0<32>:byte] : byte)
 	T_7512 (in (uint32) (uint8) Mem889[a0_900 + 0<32>:byte] : uint32)
-	T_7519 (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-	T_7522 (in Mem914[a0_900 + 0<32>:byte] : byte)
 	T_7527 (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-	T_7540 (in (d0_957 << 2<32>) + 4<32> : word32)
 	T_7541 (in d0_957 << 2<32> : word32)
 	T_7580 (in Mem987[a7_985 + 0<32>:word32] : word32)
 	T_7585 (in Mem987[a7_985 + 0<32>:word32] : word32)
-	T_7589 (in fn00003C30(*a7_985, out d1, out a1, out a5_5334) : word32)
+	T_7589 (in fn00003C30(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
 	T_7592 (in Mem1000[a7_985 + 48<i32>:word32] : word32)
-	T_7594 (in a2_1014 + 4<i32> : word32)
 	T_7604 (in Mem1007[a7_1005 + 0<32>:word32] : word32)
 	T_7616 (in Mem1011[a7_1005 + 0<32>:word32] : word32)
 	T_7619 (in Mem1031[a7_1005 + 0<32>:word32] : word32)
@@ -959,23 +561,13 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_7629 (in Mem1037[a7_1005 + 0<32>:word32] : word32)
 	T_7632 (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
 	T_7644 (in 0xFFFFFFFF<32> : word32)
-	T_7650 (in a7_1330 + 78<i32> : word32)
-	T_7653 (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-	T_7658 (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
-	T_7659 (in 00000008 : ptr32)
-	T_7664 (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_7669 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_7672 (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-	T_7678 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-	T_7683 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
 	T_7688 (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn00002648(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)):byte] : uint32)
-	T_7693 (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
 	T_7698 (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
 	T_7699 (in 0<32> : word32)
 	T_7746 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_7752 (in Mem1184[a7_1182 + 0<32>:word32] : word32)
 	T_7756 (in fn00003C30(*a7_1182, out d1_5335, out a1, out a5_5336) : word32)
-	T_7758 (in a2_1014 + 4<i32> : word32)
 	T_7768 (in Mem1203[a7_1201 + 0<32>:word32] : word32)
 	T_7780 (in Mem1207[a7_1201 + 0<32>:word32] : word32)
 	T_7782 (in SEQ(SLICE(d0, word24, 8), v611_1211) : uip32)
@@ -983,75 +575,24 @@ Eq_25: (union "Eq_25" (uint8 u0) (ui24 u1) (word16 u2) ((ptr32 Eq_8241) u3) ((pt
 	T_7789 (in 0xFFFFFFFF<32> : word32)
 	T_7805 (in Mem1308[a7_1302 + 0<32>:word32] : word32)
 	T_7810 (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
-	T_7816 (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
 	T_7819 (in Mem1311[a7_1302 + 0<32>:word32] : word32)
 	T_7820 (in fn00002B5C(*(a7_1302 - 1<i32>), *a7_1302) : word32)
-	T_7828 (in a7_1330 + 78<i32> : word32)
-	T_7831 (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-	T_7836 (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
-	T_7837 (in 00000008 : ptr32)
-	T_7842 (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_7847 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_7850 (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-	T_7855 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-	T_7860 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
 	T_7865 (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn00002648(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)):byte] : uint32)
-	T_7870 (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
 	T_7875 (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
 	T_7876 (in 0<32> : word32)
-	T_7897 (in d0_23 : Eq_25)
-	T_7899 (in __swap(dwArg08) : word32)
-	T_7900 (in d1_25 : Eq_25)
-	T_7902 (in __swap(dwArg10) : word32)
-	T_7912 (in d2_39 : Eq_25)
-	T_7920 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-	T_7921 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-	T_7925 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-	T_7926 (in 0<32> : word32)
-	T_7928 (in d2_45 : Eq_25)
-	T_7930 (in __swap(d2_39) : word32)
-	T_7933 (in __swap(dwArg0C) : word32)
-	T_7936 (in d3_71 : Eq_25)
-	T_7940 (in __swap(dwArg08) : word32)
-	T_7945 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-	T_7946 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-	T_7949 (in __swap(dwArg04) : word32)
-	T_7952 (in d3_89 : Eq_25)
-	T_7956 (in __swap(dwArg10) : word32)
-	T_7961 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-	T_7962 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
 	T_7999 (in 0<32> : word32)
 	T_8038 (in Mem86[dwArg04 + 8<i32>:word32] : word32)
 	T_8039 (in 0<32> : word32)
 	T_8059 (in Mem135[dwArg04 + 8<i32>:word32] : word32)
 	T_8062 (in Mem137[dwArg04 + 4<i32>:word32] : word32)
-	T_8104 (in a0_153 : Eq_25)
+	T_8104 (in a0_153 : Eq_73)
 	T_8107 (in Mem149[dwArg04 + 4<i32>:word32] : word32)
 	T_8109 (in a0_153 + 1<i32> : word32)
 	T_8111 (in Mem157[dwArg04 + 4<i32>:word32] : word32)
 	T_8145 (in d0_117 + 1<i32> : word32)
 	T_8148 (in Mem131[dwArg04 + 8<i32>:word32] : word32)
-Eq_28: (fn Eq_25 (ptr32, int32))
-	T_28 (in OpenLibrary : ptr32)
-	T_29 (in signature of OpenLibrary : void)
-Eq_51: (fn void (word32))
-	T_51 (in Alert : ptr32)
-	T_52 (in signature of Alert : void)
-	T_96 (in Alert : ptr32)
-Eq_61: (struct "Eq_61" (0 word32 dw0000) (24 Eq_25 t0024))
-	T_61 (in Mem67[d0_36 + 172<i32>:word32] : word32)
-	T_62 (in 0<32> : word32)
-	T_87 (in Mem153[d0_36 + 172<i32>:word32] : word32)
-	T_88 (in 0<32> : word32)
-	T_99 (in dwLoc0C_569 : (ptr32 Eq_61))
-	T_118 (in d0_180 : (ptr32 Eq_61))
-	T_121 (in Mem179[d0_36 + 172<i32>:word32] : word32)
-	T_122 (in 0<32> : word32)
-	T_129 (in Mem187[0x00003D7C<p32>:word32] : word32)
-	T_131 (in Mem189[0x00003D80<p32>:word32] : word32)
-	T_211 (in d0_112 + 16<i32> : word32)
-	T_430 (in dwArg08 : (ptr32 Eq_61))
-Eq_75: (fn Eq_25 (Eq_77, Eq_78))
+Eq_75: (fn (ptr32 Eq_25) (Eq_77, Eq_78))
 	T_75 (in AllocMem : ptr32)
 	T_76 (in signature of AllocMem : void)
 	T_3055 (in AllocMem : ptr32)
@@ -1079,7 +620,7 @@ Eq_78: (union "Eq_78" (int32 u0) (ptr32 u1))
 	T_3073 (in Mem26[dwArg04 + 12<i32>:word32] : word32)
 	T_3097 (in Mem135[dwArg04 + 12<i32>:word32] : word32)
 	T_3227 (in 0<i32> : int32)
-Eq_90: (fn void (Eq_25))
+Eq_90: (fn void ((ptr32 Eq_25)))
 	T_90 (in CloseLibrary : ptr32)
 	T_91 (in signature of CloseLibrary : void)
 	T_487 (in CloseLibrary : ptr32)
@@ -1106,6 +647,28 @@ Eq_124: (fn void ((ptr32 Eq_19)))
 	T_124 (in fn00001214 : ptr32)
 	T_125 (in signature of fn00001214 : void)
 	T_304 (in fn00001214 : ptr32)
+Eq_134: (union "Eq_134" (int32 u0) (uint32 u1))
+	T_134 (in d0_197 : Eq_134)
+	T_137 (in Mem194[d0_180 + 36<i32>:word32] : word32)
+	T_138 (in 0<32> : word32)
+	T_153 (in d0_262 : Eq_134)
+	T_159 (in (uint32) (uint8) 0<32>[d0_252 * 4<32>] : uint32)
+	T_204 (in Mem416[0x00003D84<p32>:word32] : word32)
+	T_209 (in Mem418[0x00003D88<p32>:word32] : word32)
+	T_316 (in Mem209[d0_112 + 4<i32>:word32] : word32)
+	T_318 (in 0<32> : word32)
+	T_324 (in Mem214[0x00003D84<p32>:word32] : word32)
+	T_326 (in Mem216[0x00003D88<p32>:word32] : word32)
+	T_328 (in Mem218[0x00003D8C<p32>:word32] : word32)
+	T_331 (in Mem221[d0_36 + 156<i32>:word32] : word32)
+	T_334 (in Mem223[d0_36 + 160<i32>:word32] : word32)
+	T_392 (in Mem435[0x00003D8C<p32>:word32] : word32)
+	T_393 (in v92_428 : Eq_134)
+	T_396 (in Mem418[d0_36 + 224<i32>:word32] : word32)
+	T_398 (in Mem429[0x00003D8C<p32>:word32] : word32)
+	T_399 (in 0<32> : word32)
+	T_3237 (in 0<32> : word32)
+	T_3239 (in Mem38[d0_30 + 4<i32>:word32] : word32)
 Eq_160: (struct "Eq_160" 0001 (0 (arr Eq_160) a0000))
 	T_160 (in 0<8> : byte)
 	T_162 (in Mem263[a0_260 + d0_262:byte] : byte)
@@ -1121,11 +684,11 @@ Eq_200: (fn void ())
 Eq_205: (fn void ())
 	T_205 (in execPrivate5 : ptr32)
 	T_206 (in signature of execPrivate5 : void)
-Eq_306: (fn void (Eq_25))
+Eq_306: (fn void ((ptr32 Eq_25)))
 	T_306 (in fn0000126C : ptr32)
 	T_307 (in signature of fn0000126C : void)
 	T_493 (in fn0000126C : ptr32)
-Eq_310: (fn void (Eq_25))
+Eq_310: (fn void ((ptr32 Eq_25)))
 	T_310 (in Supervisor : ptr32)
 	T_311 (in signature of Supervisor : void)
 Eq_320: (fn void ())
@@ -1156,7 +719,7 @@ Eq_379: (struct "Eq_379" (0 int32 dw0000) (4 word32 dw0004))
 	T_3274 (in list : word32)
 	T_3282 (in a2_29 : (ptr32 Eq_379))
 	T_3284 (in a2_24 - 4<i32> : word32)
-Eq_425: (fn void (Eq_25, Eq_25, int32, (ptr32 Eq_61)))
+Eq_425: (fn void (Eq_73, (ptr32 Eq_25), int32, (ptr32 Eq_61)))
 	T_425 (in fn00001354 : ptr32)
 	T_426 (in signature of fn00001354 : void)
 Eq_432: (fn void (word32))
@@ -1168,7 +731,7 @@ Eq_438: (fn void (word32))
 Eq_444: (fn void ())
 	T_444 (in Forbid : ptr32)
 	T_445 (in signature of Forbid : void)
-Eq_447: (fn void (Eq_25))
+Eq_447: (fn void ((ptr32 Eq_25)))
 	T_447 (in ReplyMsg : ptr32)
 	T_448 (in signature of ReplyMsg : void)
 Eq_484: (fn void ())
@@ -1200,13 +763,13 @@ Eq_587: (fn word32 (ptr32, ptr32, ptr32))
 	T_587 (in fn0000131C : ptr32)
 	T_588 (in signature of fn0000131C : void)
 	T_3310 (in fn0000131C : ptr32)
-Eq_589: (fn ptr32 (Eq_25, Eq_25, Eq_25))
+Eq_589: (fn ptr32 (Eq_73, Eq_73, (ptr32 Eq_25)))
 	T_589 (in fn00001390 : ptr32)
 	T_590 (in signature of fn00001390 : void)
-Eq_612: (fn Eq_25 (Eq_25, (ptr32 byte)))
+Eq_612: (fn Eq_73 (Eq_73, (ptr32 byte)))
 	T_612 (in fn000013FC : ptr32)
 	T_613 (in signature of fn000013FC : void)
-Eq_616: (fn Eq_25 (Eq_25, Eq_25, Eq_25, (ptr32 Eq_621)))
+Eq_616: (fn Eq_73 (Eq_73, Eq_73, (ptr32 Eq_25), (ptr32 Eq_621)))
 	T_616 (in fn00002B40 : ptr32)
 	T_617 (in signature of fn00002B40 : void)
 	T_622 (in fn00002B40 : ptr32)
@@ -1226,7 +789,7 @@ Eq_621: (struct "Eq_621" 0001 (0 uint8 b0000) (1 cu8 b0001))
 	T_7432 (in a3_1955 + 1<i32> : word32)
 	T_7443 (in a3_1955 + 1<i32> : word32)
 	T_7460 (in a3_1955 + 2<i32> : word32)
-Eq_632: (fn Eq_25 (Eq_25, (ptr32 Eq_635), (ptr32 byte), Eq_637))
+Eq_632: (fn Eq_73 (Eq_73, (ptr32 Eq_635), (ptr32 byte), Eq_637))
 	T_632 (in fn00001418 : ptr32)
 	T_633 (in signature of fn00001418 : void)
 Eq_635: (struct "Eq_635" (0 word32 dw0000) (4 (ptr32 ui32) ptr0004) (8 (ptr32 ui32) ptr0008) (C (ptr32 Eq_635) ptr000C) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
@@ -1278,7 +841,7 @@ Eq_637: (union "Eq_637" (uint32 u0) (ptr32 u1))
 	T_1810 (in Mem1478[a7_1383 + 128<i32>:word32] : word32)
 	T_2284 (in ((word32) d3_1482 + 3<i32> >> 2<32> << 2<32>) + 4<32> : word32)
 	T_2530 (in ((word32) d3_1482 + 3<i32> >> 2<32> << 2<32>) + 4<32> : word32)
-Eq_645: (struct "Eq_645" 0004 (2C Eq_8249 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8250 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+Eq_645: (struct "Eq_645" 0004 (2C Eq_8242 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8243 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 	T_645 (in a7_1968 : (ptr32 Eq_645))
 	T_648 (in fp + -112<i32> : word32)
 	T_703 (in a7_51 + 4<i32> : word32)
@@ -1293,7 +856,7 @@ Eq_645: (struct "Eq_645" 0004 (2C Eq_8249 t002C) (30 word32 dw0030) (34 word32 d
 	T_1513 (in Mem1237[a7_1174 + 64<i32>:word32] : word32)
 	T_1788 (in a7_1383 + 4<i32> : word32)
 	T_2442 (in a7_992 + 4<i32> : word32)
-Eq_686: (fn Eq_25 (int32, (ptr32 Eq_635), (ptr32 ui32), ptr32))
+Eq_686: (fn Eq_73 (int32, (ptr32 Eq_635), (ptr32 ui32), ptr32))
 	T_686 (in fn00001D98 : ptr32)
 	T_687 (in signature of fn00001D98 : void)
 	T_1604 (in fn00001D98 : ptr32)
@@ -1302,6 +865,416 @@ Eq_686: (fn Eq_25 (int32, (ptr32 Eq_635), (ptr32 ui32), ptr32))
 	T_1976 (in fn00001D98 : ptr32)
 	T_2033 (in fn00001D98 : ptr32)
 	T_2082 (in fn00001D98 : ptr32)
+Eq_718: (union "Eq_718" ((ptr32 Eq_1290) u0) ((ptr32 Eq_8244) u1) ((ptr32 Eq_8245) u2))
+	T_718 (in d5_256 : Eq_718)
+	T_719 (in -1<i32> : int32)
+	T_730 (in d2_1005 : Eq_718)
+	T_733 (in Mem91[a7_1968 + 72<i32>:word32] : word32)
+	T_749 (in d2_1005 | d1_123 : word32)
+	T_759 (in Mem143[a7_1968 + 72<i32>:word32] : word32)
+	T_875 (in 0<i32> : int32)
+	T_903 (in Mem335[a7_1968 + 44<i32>:word32] : word32)
+	T_909 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_913 (in  : word32)
+	T_914 (in 10<i32> : int32)
+	T_915 (in __swap(10<i32>) : word32)
+	T_922 (in __swap(d5_256) : word32)
+	T_927 (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
+	T_928 (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
+	T_965 (in Mem278[a7_275 + 0<32>:word32] : word32)
+	T_969 (in d1_303 - 0x30<32> + d0_293 : word32)
+	T_1014 (in Mem143[a7_1968 + 64<i32>:word32] : word32)
+	T_1022 (in 10<i32> : int32)
+	T_1023 (in __swap(10<i32>) : word32)
+	T_1030 (in __swap(d2_1005) : word32)
+	T_1035 (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
+	T_1036 (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
+	T_1078 (in d1_196 - 0x30<32> + d0_186 : word32)
+	T_1086 (in Mem217[a7_1968 + 64<i32>:word32] : word32)
+	T_1185 (in 0<32> : word32)
+	T_1264 (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
+	T_1313 (in 0<32> : word32)
+	T_1533 (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
+	T_1670 (in dwArg04 : Eq_718)
+	T_1671 (in dwArg08 : Eq_718)
+	T_1672 (in dwArg0C : Eq_718)
+	T_1673 (in dwArg10 : Eq_718)
+	T_1677 (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_1682 (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_1687 (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_1692 (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_1754 (in dwArg04 : Eq_718)
+	T_1755 (in dwArg08 : Eq_718)
+	T_1756 (in dwArg0C : Eq_718)
+	T_1757 (in dwArg10 : Eq_718)
+	T_1758 (in d1Out : Eq_718)
+	T_1759 (in a0Out : Eq_718)
+	T_1763 (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
+	T_1768 (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
+	T_1773 (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
+	T_1778 (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
+	T_1779 (in out d1_1450 : ptr32)
+	T_1780 (in out a0_1447 : ptr32)
+	T_2344 (in 0<32> : word32)
+	T_2374 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_2378 (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
+	T_2434 (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
+	T_3315 (in d0 : Eq_718)
+	T_3316 (in d0_196 : Eq_718)
+	T_3317 (in d1_142 : Eq_718)
+	T_3318 (in a0_20 : Eq_718)
+	T_3319 (in d3_166 : Eq_718)
+	T_3320 (in 0<32> : word32)
+	T_3328 (in 0<32> : word32)
+	T_3334 (in d0 : Eq_718)
+	T_3335 (in d1 : Eq_718)
+	T_3336 (in d2 : Eq_718)
+	T_3337 (in d1Out : Eq_718)
+	T_3338 (in d2Out : Eq_718)
+	T_3339 (in out d1_318 : ptr32)
+	T_3340 (in out d2_319 : ptr32)
+	T_3341 (in fn000024BC(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
+	T_3342 (in 0<i32> : int32)
+	T_3345 (in d6_30 : Eq_718)
+	T_3348 (in  : word32)
+	T_3349 (in  : word32)
+	T_3350 (in 8<32> : word32)
+	T_3351 (in __rol(dwArg0C, 8<32>) : word32)
+	T_3377 (in 8<32> : word32)
+	T_3378 (in __rol(d6_30, 8<32>) : word32)
+	T_3384 (in 8<32> : word32)
+	T_3385 (in __rol(d6_30, 8<32>) : word32)
+	T_3392 (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_3393 (in d1_175 : Eq_718)
+	T_3394 (in d2_176 : Eq_718)
+	T_3395 (in d0_174 : Eq_718)
+	T_3397 (in 0<i32> : int32)
+	T_3398 (in out d1_175 : ptr32)
+	T_3399 (in out d2_176 : ptr32)
+	T_3400 (in fn000024BC(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
+	T_3404 (in out d1_320 : ptr32)
+	T_3405 (in out d2_321 : ptr32)
+	T_3406 (in fn000024BC(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
+	T_3417 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_3420 (in d0_85 : Eq_718)
+	T_3422 (in dwArg04 >> d4_61 : word32)
+	T_3425 (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
+	T_3428 (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
+	T_3429 (in out d1_86 : ptr32)
+	T_3430 (in out d2_322 : ptr32)
+	T_3431 (in fn000024BC(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
+	T_3432 (in d3_72 : Eq_718)
+	T_3433 (in dwArg10 << d5_63 : word32)
+	T_3434 (in d5_101 : Eq_718)
+	T_3436 (in __swap(d0_85) : word32)
+	T_3437 (in d6_103 : Eq_718)
+	T_3439 (in __swap(d3_72) : word32)
+	T_3443 (in d2_107 : Eq_718)
+	T_3446 (in d0_85 * (word16) d3_72 : word32)
+	T_3447 (in __swap(d0_85 * (word16) d3_72) : word32)
+	T_3460 (in d6_82 : Eq_718)
+	T_3461 (in dwArg08 << d5_63 : word32)
+	T_3462 (in d2_124 : Eq_718)
+	T_3464 (in SEQ(v35_109, v39_116) : uipr32)
+	T_3465 (in __swap(SEQ(v35_109, v39_116)) : word32)
+	T_3473 (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
+	T_3474 (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
+	T_3478 (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
+	T_3479 (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
+	T_3501 (in d0_85 - 1<32> : word32)
+	T_3507 (in d7_13 : Eq_718)
+	T_3508 (in 0<32> : word32)
+	T_3512 (in d0 : Eq_718)
+	T_3513 (in d1 : Eq_718)
+	T_3514 (in d2 : Eq_718)
+	T_3515 (in d1Out : Eq_718)
+	T_3516 (in out d1 : ptr32)
+	T_3517 (in fn0000267A(d1, d2, d2, out d1) : word32)
+	T_3518 (in d6_17 : Eq_718)
+	T_3519 (in d5_19 : Eq_718)
+	T_3520 (in 0<32> : word32)
+	T_3522 (in d2_22 : Eq_718)
+	T_3524 (in __swap(d2) : word32)
+	T_3528 (in 0<32> : word32)
+	T_3537 (in 0<32> : word32)
+	T_3539 (in d0_281 : Eq_718)
+	T_3541 (in __swap(d0) : word32)
+	T_3542 (in d1_282 : Eq_718)
+	T_3544 (in __swap(d1) : word32)
+	T_3554 (in __swap(d1_282) : word32)
+	T_3561 (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
+	T_3562 (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
+	T_3567 (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
+	T_3573 (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
+	T_3574 (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
+	T_3578 (in d6_17 * 2<32> : word32)
+	T_3586 (in 0<32> : word32)
+	T_3588 (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
+	T_3590 (in d7_13 * 2<32> : word32)
+	T_3591 (in 0<32> : word32)
+	T_3595 (in d3_74 : Eq_718)
+	T_3602 (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
+	T_3603 (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
+	T_3606 (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
+	T_3607 (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
+	T_3608 (in d1_104 : Eq_718)
+	T_3609 (in 0xFFFF<32> : uipr32)
+	T_3610 (in d6_98 : Eq_718)
+	T_3614 (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
+	T_3615 (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
+	T_3616 (in d6_133 : Eq_718)
+	T_3618 (in __swap(d1_104) : word32)
+	T_3619 (in d3_140 : Eq_718)
+	T_3621 (in __swap(d6_133) : word32)
+	T_3622 (in d4_142 : Eq_718)
+	T_3624 (in __swap(d7_13) : word32)
+	T_3628 (in d6_146 : Eq_718)
+	T_3631 (in d6_133 * (word16) d7_13 : word32)
+	T_3632 (in __swap(d6_133 * (word16) d7_13) : word32)
+	T_3648 (in d6_178 : Eq_718)
+	T_3650 (in SEQ(v56_148, v59_155) : uipr32)
+	T_3651 (in __swap(SEQ(v56_148, v59_155)) : word32)
+	T_3652 (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
+	T_3653 (in d5_181 : word32)
+	T_3657 (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
+	T_3658 (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
+	T_3662 (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
+	T_3663 (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
+	T_3676 (in 0<32> : word32)
+	T_3678 (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
+	T_3679 (in 0<32> : word32)
+	T_3687 (in d1_104 - 1<32> : word32)
+	T_3688 (in d4_113 : Eq_718)
+	T_3691 (in __swap(d7_13) : word32)
+	T_3694 (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
+	T_3695 (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
+	T_3710 (in __swap(d7_13) : word32)
+	T_3714 (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
+	T_3716 (in d1_104 - 1<32> : word32)
+	T_3717 (in 0<32> : word32)
+	T_3723 (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
+	T_3724 (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_3725 (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
+	T_3726 (in d6_220 : Eq_718)
+	T_3730 (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
+	T_3731 (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
+	T_3734 (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
+	T_3735 (in d5_221 : Eq_718)
+	T_3737 (in __swap(d5_181) : word32)
+	T_3742 (in d5_266 : Eq_718)
+	T_3744 (in __swap(d5_181) : word32)
+	T_3745 (in d6_267 : Eq_718)
+	T_3747 (in __swap(d6_178) : word32)
+	T_3750 (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
+	T_3753 (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
+	T_3757 (in d2_73 : Eq_718)
+	T_3759 (in __swap(d5_19) : word32)
+	T_3761 (in __swap(d7_13) : word32)
+	T_3771 (in d5_221 >> 1<32> : word32)
+	T_3776 (in  : word32)
+	T_3782 (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
+	T_3789 (in d0 : Eq_718)
+	T_3790 (in d2 : Eq_718)
+	T_3791 (in dwArg04 : Eq_718)
+	T_3792 (in dwArg08 : Eq_718)
+	T_3793 (in 0<32> : word32)
+	T_3795 (in 0<32> : word32)
+	T_3797 (in d0_36 : Eq_718)
+	T_3798 (in -dwArg04 : word32)
+	T_3799 (in 0<32> : word32)
+	T_3803 (in out d1_43 : ptr32)
+	T_3804 (in fn0000267A(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_3805 (in -fn0000267A(d0_36, dwArg08, d2, out d1_43) : word32)
+	T_3808 (in -dwArg08 : word32)
+	T_3809 (in out d1_55 : ptr32)
+	T_3810 (in fn0000267A(d0_36, -dwArg08, d2, out d1_55) : word32)
+	T_3813 (in out d1_88 : ptr32)
+	T_3814 (in fn0000267A(dwArg04, dwArg08, d2, out d1_88) : word32)
+	T_3817 (in -dwArg08 : word32)
+	T_3818 (in out d1_89 : ptr32)
+	T_3819 (in fn0000267A(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_3820 (in -fn0000267A(dwArg04, -dwArg08, d2, out d1_89) : word32)
+	T_3821 (in d1_22 : Eq_718)
+	T_3823 (in __swap(d1) : word32)
+	T_3828 (in d2_11 : Eq_718)
+	T_3829 (in SEQ(v11_10, v10_9) : uipr32)
+	T_3832 (in d3_18 : Eq_718)
+	T_3833 (in 16<i32> : int32)
+	T_3837 (in d0_134 : Eq_718)
+	T_3839 (in __swap(d0) : word32)
+	T_3840 (in d1_135 : Eq_718)
+	T_3842 (in __swap(d1_22) : word32)
+	T_3847 (in __swap(d2_11) : word32)
+	T_3852 (in d0_150 : Eq_718)
+	T_3854 (in __swap(d0_134) : word32)
+	T_3868 (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
+	T_3869 (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
+	T_3871 (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
+	T_3873 (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
+	T_3883 (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
+	T_3888 (in 8<32> : word32)
+	T_3889 (in __rol(d1_22, 8<32>) : word32)
+	T_3890 (in 8<32> : uipr32)
+	T_3895 (in 4<32> : word32)
+	T_3896 (in __rol(d1_22, 4<32>) : word32)
+	T_3901 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
+	T_3906 (in 2<32> : word32)
+	T_3907 (in __rol(d1_22, 2<32>) : word32)
+	T_3912 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
+	T_3918 (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
+	T_3919 (in __swap(SEQ(v11_10, (word16) d0)) : word32)
+	T_3926 (in __swap(d3_18) : word32)
+	T_3932 (in d1_90 : Eq_718)
+	T_3934 (in __swap(d1_22) : word32)
+	T_3935 (in d3_102 : Eq_718)
+	T_3936 (in SEQ(v53_82, v51_79) : uipr32)
+	T_3937 (in d0_108 : Eq_718)
+	T_3947 (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
+	T_3948 (in 0<32> : word32)
+	T_3951 (in 1<32> : word32)
+	T_3952 (in __rol(d1_22, 1<32>) : word32)
+	T_3957 (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
+	T_3961 (in __swap(d3_102) : word32)
+	T_3962 (in __rol(d0_108, __swap(d3_102)) : word32)
+	T_3963 (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
+	T_3966 (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
+	T_3969 (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
+	T_3970 (in d0_108 + d1_90 : word32)
+	T_3971 (in 0<32> : word32)
+	T_3973 (in d1 : Eq_718)
+	T_3974 (in d1_171 : Eq_718)
+	T_3975 (in d3_202 : Eq_718)
+	T_3976 (in 0<32> : word32)
+	T_3984 (in 0<32> : word32)
+	T_3988 (in out d1_171 : ptr32)
+	T_3989 (in out d2_354 : ptr32)
+	T_3990 (in fn000024BC(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
+	T_3993 (in d6_33 : Eq_718)
+	T_3995 (in 8<32> : word32)
+	T_3996 (in __rol(dwArg0C, 8<32>) : word32)
+	T_4022 (in 8<32> : word32)
+	T_4023 (in __rol(d6_33, 8<32>) : word32)
+	T_4029 (in 8<32> : word32)
+	T_4030 (in __rol(d6_33, 8<32>) : word32)
+	T_4037 (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
+	T_4040 (in d0_88 : Eq_718)
+	T_4042 (in dwArg04 >> d4_64 : word32)
+	T_4045 (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
+	T_4048 (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
+	T_4049 (in out d1_89 : ptr32)
+	T_4050 (in out d2_90 : ptr32)
+	T_4051 (in fn000024BC(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
+	T_4052 (in d3_75 : Eq_718)
+	T_4053 (in dwArg10 << d5_66 : word32)
+	T_4054 (in d7_104 : Eq_718)
+	T_4056 (in __swap(d0_88) : word32)
+	T_4057 (in d6_106 : Eq_718)
+	T_4059 (in __swap(d3_75) : word32)
+	T_4063 (in d2_110 : Eq_718)
+	T_4066 (in d0_88 * (word16) d3_75 : word32)
+	T_4067 (in __swap(d0_88 * (word16) d3_75) : word32)
+	T_4080 (in d2_127 : Eq_718)
+	T_4082 (in SEQ(v37_112, v40_119) : uipr32)
+	T_4083 (in __swap(SEQ(v37_112, v40_119)) : word32)
+	T_4093 (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
+	T_4094 (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
+	T_4098 (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
+	T_4099 (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
+	T_4118 (in dwArg08 - dwArg10 : word32)
+	T_4122 (in d1_211 : Eq_718)
+	T_4123 (in d2_212 : Eq_718)
+	T_4125 (in 0<i32> : int32)
+	T_4126 (in out d1_211 : ptr32)
+	T_4127 (in out d2_212 : ptr32)
+	T_4128 (in fn000024BC(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
+	T_4131 (in out d1_171 : ptr32)
+	T_4132 (in out d2_355 : ptr32)
+	T_4133 (in fn000024BC(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
+	T_4144 (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
+	T_4149 (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
+	T_4162 (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
+	T_4209 (in dwArg0C : Eq_718)
+	T_4214 (in fp + 8<i32> : word32)
+	T_4255 (in d2_1090 : Eq_718)
+	T_4318 (in d6_1133 : Eq_718)
+	T_4319 (in -1<i32> : int32)
+	T_4341 (in 0<i32> : int32)
+	T_4352 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_4355 (in 10<i32> : int32)
+	T_4356 (in __swap(10<i32>) : word32)
+	T_4366 (in __swap(d6_1133) : word32)
+	T_4371 (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
+	T_4372 (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
+	T_4398 (in Mem316[a7_313 + 0<32>:word32] : word32)
+	T_4402 (in d1_340 - 0x30<32> + d0_331 : word32)
+	T_4964 (in 0xFFFFFFFF<32> : word32)
+	T_5114 (in d0 + 4<32> : word32)
+	T_5156 (in d0 + 4<32> : word32)
+	T_5232 (in d0 + 4<32> : word32)
+	T_5301 (in d0 + 4<32> : word32)
+	T_5339 (in d0 + 4<32> : word32)
+	T_5354 (in d0 + 4<32> : word32)
+	T_5641 (in 1<i32> : int32)
+	T_5659 (in d0 + 4<32> : word32)
+	T_6390 (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
+	T_6455 (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
+	T_6485 (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
+	T_6500 (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
+	T_6506 (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
+	T_6516 (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
+	T_6537 (in v419_2893 : Eq_718)
+	T_6542 (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_6717 (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
+	T_6897 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_6900 (in Mem2889[a7_2886 + 0<32>:word32] : word32)
+	T_6902 (in d7 >> 31<i32> : word32)
+	T_6905 (in Mem2898[a7_2886 + 0<32>:word32] : word32)
+	T_6947 (in dwArg04 : Eq_718)
+	T_6948 (in dwArg08 : Eq_718)
+	T_6949 (in dwArg0C : Eq_718)
+	T_6950 (in dwArg10 : Eq_718)
+	T_6955 (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
+	T_6960 (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
+	T_6965 (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
+	T_6970 (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
+	T_7077 (in (d0_3495 << 2<32>) + 4<32> : word32)
+	T_7113 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7142 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7171 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7188 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7282 (in (d0_3398 << 2<32>) + 4<32> : word32)
+	T_7318 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7347 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7376 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7393 (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
+	T_7419 (in Mem820[a7_1330 + 132<i32>:word32] : word32)
+	T_7430 (in Mem946[a7_1330 + 132<i32>:word32] : word32)
+	T_7540 (in (d0_957 << 2<32>) + 4<32> : word32)
+	T_7678 (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
+	T_7683 (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
+	T_7855 (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
+	T_7860 (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
+	T_7897 (in d0_23 : Eq_718)
+	T_7899 (in __swap(dwArg08) : word32)
+	T_7900 (in d1_25 : Eq_718)
+	T_7902 (in __swap(dwArg10) : word32)
+	T_7912 (in d2_39 : Eq_718)
+	T_7920 (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
+	T_7921 (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
+	T_7925 (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
+	T_7926 (in 0<32> : word32)
+	T_7928 (in d2_45 : Eq_718)
+	T_7930 (in __swap(d2_39) : word32)
+	T_7933 (in __swap(dwArg0C) : word32)
+	T_7936 (in d3_71 : Eq_718)
+	T_7940 (in __swap(dwArg08) : word32)
+	T_7945 (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
+	T_7946 (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
+	T_7949 (in __swap(dwArg04) : word32)
+	T_7952 (in d3_89 : Eq_718)
+	T_7956 (in __swap(dwArg10) : word32)
+	T_7961 (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
+	T_7962 (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
 Eq_725: (struct "Eq_725" (0 Eq_2290 t0000) (3C word32 dw003C) (40 up32 dw0040))
 	T_725 (in d7_1024 : (ptr32 Eq_725))
 	T_726 (in 0<i32> : int32)
@@ -1314,7 +1287,7 @@ Eq_725: (struct "Eq_725" (0 Eq_2290 t0000) (3C word32 dw003C) (40 up32 dw0040))
 	T_2068 (in 1<32> : word32)
 	T_2350 (in 1<32> : word32)
 	T_2472 (in d7_1026 + 1<32> : word32)
-Eq_755: (struct "Eq_755" (0 Eq_25 t0000) (4 Eq_25 t0004))
+Eq_755: (struct "Eq_755" (0 Eq_73 t0000) (4 Eq_73 t0004))
 	T_755 (in a0_1447 : (ptr32 Eq_755))
 	T_773 (in 0x2815<u32> + (SEQ(SLICE(d0, word24, 8), *a2_135) & 0xFF<32>) : word32)
 	T_802 (in d0_159 + 4<32> : word32)
@@ -1337,7 +1310,7 @@ Eq_881: (union "Eq_881" (uint32 u0) (ptr32 u1))
 	T_881 (in 3<32> : word32)
 Eq_882: (union "Eq_882" (uint32 u0) (ptr32 u1))
 	T_882 (in d3_1482 + 3<32> : word32)
-Eq_911: (fn Eq_25 (Eq_25))
+Eq_911: (fn Eq_718 (Eq_718))
 	T_911 (in __swap : ptr32)
 	T_912 (in signature of __swap : void)
 	T_919 (in __swap : ptr32)
@@ -1462,34 +1435,6 @@ Eq_1123: (struct "Eq_1123" (0 word32 dw0000) (4 word32 dw0004))
 	T_2361 (in Mem916[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_2383 (in Mem935[a7_911 - 4<i32> + 0<32>:word32] : word32)
 	T_2421 (in Mem1000[a7_992 - 4<i32> + 0<32>:word32] : word32)
-Eq_1126: (union "Eq_1126" (ui24 u0) ((ptr32 Eq_8251) u1) (Eq_1290 u2))
-	T_1126 (in d0_1471 : Eq_1126)
-	T_1128 (in SEQ(SLICE(d0_159, word24, 8), v100_428) : uip32)
-	T_1173 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_1272 (in a2_1892 - a4_1925 : word32)
-	T_1275 (in Mem756[a7_1968 + 102<i32>:word32] : word32)
-	T_1297 (in Mem662[a7_1968 + 102<i32>:word32] : word32)
-	T_1308 (in Mem719[a7_1968 + 102<i32>:word32] : word32)
-	T_1310 (in d0_1471 + 1<32> : word32)
-	T_1421 (in Mem1516[a7_1508 + 0<32>:word32] : word32)
-	T_1431 (in Mem1531[a7_1508 + 0<32>:word32] : word32)
-	T_1434 (in Mem1537[a7_1508 + 0<32>:word32] : word32)
-	T_1435 (in d0_1541 : Eq_1126)
-	T_1438 (in Mem1537[a7_1508 + 0<32>:word32] : word32)
-	T_1467 (in Mem1546[a7_1508 + 0<32>:word32] : word32)
-	T_1547 (in d7_1371 : Eq_1126)
-	T_1550 (in Mem1367[v187_1368 + 4<i32>:word32] : word32)
-	T_1661 (in Mem1400[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1744 (in Mem1444[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-	T_1750 (in d1_1450 : Eq_1126)
-	T_1791 (in 0<32> : word32)
-	T_2269 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2331 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2399 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2478 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2490 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2503 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
-	T_2515 (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
 Eq_1159: (union "Eq_1159" (cu8 u0) (word32 u1))
 	T_1159 (in Mem535[a7_1968 + 44<i32>:byte] : byte)
 	T_1160 (in 0x70<8> : byte)
@@ -1519,20 +1464,8 @@ Eq_1241: (struct "Eq_1241" (0 (ptr32 Eq_1123) ptr0000) (30 byte b0030) (34 int32
 	T_1243 (in a7_1968 - 4<i32> : word32)
 Eq_1268: (union "Eq_1268" (bool u0) (int32 u1))
 	T_1268 (in d0_1181 < null : bool)
-Eq_1290: (union "Eq_1290" (ui24 u0) ((ptr32 Eq_8252) u1))
+Eq_1290: (struct "Eq_1290" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_1290 (in Mem662[a7_1968 + 102<i32>:word32] : word32)
-Eq_1291: (union "Eq_1291" (ui24 u0) ((ptr32 Eq_8253) u1) (Eq_1290 u2))
-	T_1291 (in d5_256 - a7_1968->t0066 : word32)
-	T_1292 (in 0<32> : word32)
-Eq_1296: (union "Eq_1296" (ui24 u0) ((ptr32 Eq_8254) u1) (Eq_1290 u2))
-	T_1296 (in a7_1968 + 102<i32> : word32)
-Eq_1303: (union "Eq_1303" (ui24 u0) ((ptr32 Eq_8255) u1) (Eq_1290 u2))
-	T_1303 (in d5_256 - d0_1471 : word32)
-	T_1304 (in 0<32> : word32)
-Eq_1307: (union "Eq_1307" (int32 u0) (uint32 u1) (Eq_1126 u2) (Eq_1290 u3))
-	T_1307 (in a7_1968 + 102<i32> : word32)
-Eq_1309: (union "Eq_1309" (ui24 u0) ((ptr32 Eq_8256) u1) (Eq_1290 u2))
-	T_1309 (in 1<32> : word32)
 Eq_1316: (union "Eq_1316" (uint32 u0) (ptr32 u1))
 	T_1316 (in 3<32> : word32)
 Eq_1317: (union "Eq_1317" (uint32 u0) (ptr32 u1))
@@ -1547,13 +1480,9 @@ Eq_1351: (union "Eq_1351" (uint32 u0) (ptr32 u1))
 Eq_1363: (struct "Eq_1363" (0 (ptr32 Eq_1123) ptr0000) (34 int32 dw0034))
 	T_1363 (in a7_1145 : (ptr32 Eq_1363))
 	T_1365 (in a7_1968 - 4<i32> : word32)
-Eq_1416: (struct "Eq_1416" (0 Eq_1126 t0000) (30 up32 dw0030) (34 up32 dw0034) (44 up32 dw0044))
+Eq_1416: (struct "Eq_1416" (0 (ptr32 Eq_1290) ptr0000) (30 up32 dw0030) (34 up32 dw0034) (44 up32 dw0044))
 	T_1416 (in a7_1508 : (ptr32 Eq_1416))
 	T_1418 (in a7_1465 - 4<i32> : word32)
-Eq_1433: (union "Eq_1433" (ui24 u0) ((ptr32 Eq_8257) u1) (Eq_1290 u2))
-	T_1433 (in a7_1508 + 0<32> : word32)
-Eq_1437: (union "Eq_1437" (ui24 u0) ((ptr32 Eq_8258) u1) (Eq_1290 u2))
-	T_1437 (in a7_1508 + 0<32> : word32)
 Eq_1448: (union "Eq_1448" (byte u0) (word32 u1))
 	T_1448 (in 0x10<32> : word32)
 	T_1451 (in Mem1293[a7_1020 + 44<i32>:word32] : word32)
@@ -1565,9 +1494,7 @@ Eq_1456: (union "Eq_1456" (byte u0) (ptr32 u1))
 Eq_1459: (union "Eq_1459" (byte u0) (word32 u1))
 	T_1459 (in Mem1296[a7_1020 + 44<i32>:word32] : word32)
 	T_1462 (in Mem1298[a7_1020 + 108<i32>:word32] : word32)
-Eq_1466: (union "Eq_1466" (ui24 u0) ((ptr32 Eq_8259) u1) (Eq_1290 u2))
-	T_1466 (in a7_1508 + 0<32> : word32)
-Eq_1540: (struct "Eq_1540" (0 word32 dw0000) (4 Eq_1126 t0004))
+Eq_1540: (struct "Eq_1540" (0 word32 dw0000) (4 (ptr32 Eq_1290) ptr0004))
 	T_1540 (in v187_1368 : (ptr32 Eq_1540))
 	T_1542 (in a7_1020 + 56<i32> : word32)
 Eq_1555: (union "Eq_1555" (byte u0) (word32 u1))
@@ -1588,17 +1515,17 @@ Eq_1584: (struct "Eq_1584" (0 (ptr32 Eq_635) ptr0000) (6E (arr byte) a006E))
 Eq_1621: (union "Eq_1621" (int32 u0) (up32 u1))
 	T_1621 (in d7_1024 - d2_1571 : word32)
 	T_1622 (in 0<32> : word32)
-Eq_1628: (struct "Eq_1628" (0 int32 dw0000) (34 Eq_25 t0034) (48 Eq_1115 t0048) (4C ui32 dw004C) (66 (ptr32 Eq_725) ptr0066) (6A word32 dw006A) (80 Eq_637 t0080))
+Eq_1628: (struct "Eq_1628" (0 int32 dw0000) (34 Eq_73 t0034) (48 Eq_1115 t0048) (4C ui32 dw004C) (66 (ptr32 Eq_725) ptr0066) (6A word32 dw006A) (80 Eq_637 t0080))
 	T_1628 (in a7_1383 : (ptr32 Eq_1628))
 	T_1630 (in a7_1020 - 4<i32> : word32)
-Eq_1668: (fn int32 (Eq_25, Eq_25, Eq_25, Eq_25))
+Eq_1668: (fn int32 (Eq_718, Eq_718, Eq_718, Eq_718))
 	T_1668 (in fn00002700 : ptr32)
 	T_1669 (in signature of fn00002700 : void)
-Eq_1752: (fn word32 (Eq_25, Eq_25, Eq_25, Eq_25, Eq_25, Eq_25))
+Eq_1752: (fn word32 (Eq_718, Eq_718, Eq_718, Eq_718, Eq_718, Eq_718))
 	T_1752 (in fn000023B8 : ptr32)
 	T_1753 (in signature of fn000023B8 : void)
 Eq_1792: (union "Eq_1792" (bool u0) (word32 u1))
-	T_1792 (in d1_1450 < 0<32> : bool)
+	T_1792 (in d1_1450 < null : bool)
 Eq_1824: (union "Eq_1824" (int32 u0) (up32 u1))
 	T_1824 (in Mem1496[a7_1465 + 102<i32>:word32] : word32)
 Eq_1825: (union "Eq_1825" (int32 u0) (up32 u1))
@@ -1660,9 +1587,6 @@ Eq_2046: (union "Eq_2046" (int32 u0) (up32 u1))
 	T_2046 (in d2_1847 : Eq_2046)
 	T_2047 (in 0<i32> : int32)
 	T_2058 (in d2_1847 + 1<32> : word32)
-Eq_2137: (union "Eq_2137" (byte u0) (word32 u1))
-	T_2137 (in v248_1105 : Eq_2137)
-	T_2140 (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
 Eq_2141: (struct "Eq_2141" (0 (ptr32 Eq_1123) ptr0000) (34 int32 dw0034) (38 int32 dw0038))
 	T_2141 (in a7_1109 : (ptr32 Eq_2141))
 	T_2143 (in a7_1968 - 4<i32> : word32)
@@ -1673,9 +1597,6 @@ Eq_2178: (union "Eq_2178" (uint32 u0) (ptr32 u1))
 	T_2178 (in 3<32> : word32)
 Eq_2179: (union "Eq_2179" (uint32 u0) (ptr32 u1))
 	T_2179 (in d3_1482 + 3<32> : word32)
-Eq_2202: (union "Eq_2202" (word16 u0) (word32 u1))
-	T_2202 (in v262_844 : Eq_2202)
-	T_2205 (in Mem843[a7_1968 + 62<i32>:word16] : word16)
 Eq_2206: (struct "Eq_2206" (0 (ptr32 Eq_1123) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2206 (in a7_848 : (ptr32 Eq_2206))
 	T_2208 (in a7_1968 - 4<i32> : word32)
@@ -1691,8 +1612,6 @@ Eq_2264: (union "Eq_2264" (uint32 u0) (ptr32 u1))
 	T_2264 (in 3<32> : word32)
 Eq_2265: (union "Eq_2265" (uint32 u0) (ptr32 u1))
 	T_2265 (in d3_1482 + 3<32> : word32)
-Eq_2271: (union "Eq_2271" (ui24 u0) ((ptr32 Eq_8260) u1) (Eq_1290 u2))
-	T_2271 (in d0_1471 + 0<32> : word32)
 Eq_2280: (union "Eq_2280" (uint32 u0) (ptr32 u1))
 	T_2280 (in d3_1482 + 3<32> : word32)
 Eq_2290: (union "Eq_2290" (ui32 u0) (byte u1))
@@ -1709,9 +1628,6 @@ Eq_2296: (union "Eq_2296" (cu8 u0) (word32 u1) (Eq_1159 u2) (Eq_1162 u3) (Eq_123
 	T_2299 (in Mem894[a7_1968 + 44<i32>:byte] : byte)
 Eq_2298: (union "Eq_2298" (cu8 u0) (word32 u1) (Eq_1159 u2) (Eq_1162 u3) (Eq_1237 u4) (Eq_2296 u5))
 	T_2298 (in a7_1968 + 44<i32> : word32)
-Eq_2302: (union "Eq_2302" (byte u0) (word32 u1))
-	T_2302 (in v277_869 : Eq_2302)
-	T_2305 (in Mem868[a7_1968 + 63<i32>:byte] : byte)
 Eq_2306: (struct "Eq_2306" (0 (ptr32 Eq_1123) ptr0000) (3C word32 dw003C) (40 uint32 dw0040))
 	T_2306 (in a7_873 : (ptr32 Eq_2306))
 	T_2308 (in a7_1968 - 4<i32> : word32)
@@ -1719,8 +1635,6 @@ Eq_2326: (union "Eq_2326" (uint32 u0) (ptr32 u1))
 	T_2326 (in 3<32> : word32)
 Eq_2327: (union "Eq_2327" (uint32 u0) (ptr32 u1))
 	T_2327 (in d3_1482 + 3<32> : word32)
-Eq_2333: (union "Eq_2333" (ui24 u0) ((ptr32 Eq_8261) u1) (Eq_1290 u2))
-	T_2333 (in d0_1471 + 0<32> : word32)
 Eq_2351: (struct "Eq_2351" (0 Eq_2290 t0000) (3C word32 dw003C) (40 up32 dw0040))
 	T_2351 (in a7_911 : (ptr32 Eq_2351))
 	T_2353 (in a7_1968 - 4<i32> : word32)
@@ -1730,8 +1644,6 @@ Eq_2394: (union "Eq_2394" (uint32 u0) (ptr32 u1))
 	T_2394 (in 3<32> : word32)
 Eq_2395: (union "Eq_2395" (uint32 u0) (ptr32 u1))
 	T_2395 (in d3_1482 + 3<32> : word32)
-Eq_2401: (union "Eq_2401" (ui24 u0) ((ptr32 Eq_8262) u1) (Eq_1290 u2))
-	T_2401 (in d0_1471 + 0<32> : word32)
 Eq_2407: (union "Eq_2407" (cu8 u0) (word32 u1) (Eq_1159 u2) (Eq_1162 u3) (Eq_1237 u4) (Eq_2296 u5))
 	T_2407 (in SLICE(d1_1068, byte, 0) : byte)
 	T_2410 (in Mem991[a7_1968 + 44<i32>:byte] : byte)
@@ -1768,110 +1680,36 @@ Eq_2473: (union "Eq_2473" (uint32 u0) (ptr32 u1))
 	T_2473 (in 3<32> : word32)
 Eq_2474: (union "Eq_2474" (uint32 u0) (ptr32 u1))
 	T_2474 (in d3_1482 + 3<32> : word32)
-Eq_2480: (union "Eq_2480" (ui24 u0) ((ptr32 Eq_8263) u1) (Eq_1290 u2))
-	T_2480 (in d0_1471 + 0<32> : word32)
 Eq_2485: (union "Eq_2485" (uint32 u0) (ptr32 u1))
 	T_2485 (in 3<32> : word32)
 Eq_2486: (union "Eq_2486" (uint32 u0) (ptr32 u1))
 	T_2486 (in d3_1482 + 3<32> : word32)
-Eq_2492: (union "Eq_2492" (ui24 u0) ((ptr32 Eq_8264) u1) (Eq_1290 u2))
-	T_2492 (in d0_1471 + 0<32> : word32)
 Eq_2498: (union "Eq_2498" (uint32 u0) (ptr32 u1))
 	T_2498 (in 3<32> : word32)
 Eq_2499: (union "Eq_2499" (uint32 u0) (ptr32 u1))
 	T_2499 (in d3_1482 + 3<32> : word32)
-Eq_2505: (union "Eq_2505" (ui24 u0) ((ptr32 Eq_8265) u1) (Eq_1290 u2))
-	T_2505 (in d0_1471 + 3<32> : word32)
 Eq_2510: (union "Eq_2510" (uint32 u0) (ptr32 u1))
 	T_2510 (in 3<32> : word32)
 Eq_2511: (union "Eq_2511" (uint32 u0) (ptr32 u1))
 	T_2511 (in d3_1482 + 3<32> : word32)
-Eq_2517: (union "Eq_2517" (ui24 u0) ((ptr32 Eq_8266) u1) (Eq_1290 u2))
-	T_2517 (in d0_1471 + 3<32> : word32)
 Eq_2522: (union "Eq_2522" (uint32 u0) (ptr32 u1))
 	T_2522 (in d3_1482 + 3<32> : word32)
 Eq_2527: (union "Eq_2527" (uint32 u0) (ptr32 u1))
 	T_2527 (in d3_1482 + 3<32> : word32)
-Eq_2531: (union "Eq_2531" (int32 u0) (uint32 u1) (Eq_1126 u2) (Eq_1290 u3) (Eq_1824 u4) (Eq_1886 u5) (Eq_1892 u6) (Eq_1960 u7) (Eq_2003 u8))
+Eq_2531: (union "Eq_2531" ((ptr32 Eq_1290) u0) ((ptr32 Eq_1290) u1) (Eq_1824 u2) (Eq_1886 u3) (Eq_1892 u4) (Eq_1960 u5) (Eq_2003 u6))
 	T_2531 (in 1<32> : word32)
 	T_2534 (in Mem525[a7_1968 + 102<i32>:word32] : word32)
-Eq_2533: (union "Eq_2533" (int32 u0) (uint32 u1) (Eq_1126 u2) (Eq_1290 u3) (Eq_1824 u4) (Eq_1886 u5) (Eq_1892 u6) (Eq_1960 u7) (Eq_2003 u8))
+Eq_2533: (union "Eq_2533" ((ptr32 Eq_1290) u0) (Eq_1824 u1) (Eq_1886 u2) (Eq_1892 u3) (Eq_1960 u4) (Eq_2003 u5))
 	T_2533 (in a7_1968 + 102<i32> : word32)
 Eq_2556: (fn uint32 (int32, (ptr32 Eq_635), (ptr32 ui32), ptr32))
 	T_2556 (in fn00001DF4 : ptr32)
 	T_2557 (in signature of fn00001DF4 : void)
-Eq_2595: (fn Eq_2601 (ptr32, ptr32))
+Eq_2595: (fn (ptr32 (ptr32 Eq_4258)) (ptr32, ptr32))
 	T_2595 (in fn00002388 : ptr32)
 	T_2596 (in signature of fn00002388 : void)
 	T_2771 (in fn00002388 : ptr32)
 	T_7995 (in fn00002388 : ptr32)
-Eq_2601: (union "Eq_2601" (byte u0) ((ptr32 Eq_8267) u1))
-	T_2601 (in fn00002388(out a1_35, out a5_127) : word32)
-	T_2774 (in fn00002388(out a1_21, out a5_23) : word32)
-	T_4616 (in d1Out : Eq_2601)
-	T_4622 (in out d1_5316 : ptr32)
-	T_4736 (in out d1_5318 : ptr32)
-	T_4827 (in out d1 : ptr32)
-	T_5010 (in out d1 : ptr32)
-	T_5244 (in out d1_5322 : ptr32)
-	T_5435 (in out d1 : ptr32)
-	T_5562 (in out d1 : ptr32)
-	T_5734 (in out d1 : ptr32)
-	T_5819 (in out d1 : ptr32)
-	T_5982 (in out d1_5328 : ptr32)
-	T_6162 (in out d1 : ptr32)
-	T_6289 (in out d1 : ptr32)
-	T_6751 (in out d1_5332 : ptr32)
-	T_7586 (in out d1 : ptr32)
-	T_7753 (in out d1_5335 : ptr32)
-	T_7994 (in d1_118 : Eq_2601)
-	T_7998 (in fn00002388(out a1_116, out a5_279) : word32)
-	T_8065 (in Mem137[dwArg04 + 0<32>:word32] : word32)
-Eq_2656: (struct "Eq_2656" (0 word32 dw0000) (4 word32 dw0004))
-	T_2656 (in d0_160 : (ptr32 Eq_2656))
-	T_2670 (in fn00001FB4(d4_143 + dwArg08->dw001C, out d1_161, out a0, out a1_337) : word32)
-	T_2671 (in 0<32> : word32)
-	T_2878 (in a0_13 : (ptr32 Eq_2656))
-	T_2880 (in Mem5[0x00003DA4<p32>:word32] : word32)
-	T_2886 (in dwArg08 : (ptr32 Eq_2656))
-	T_2887 (in dwArg0C : (ptr32 Eq_2656))
-	T_2888 (in d1Out : (ptr32 Eq_2656))
-	T_2892 (in out d1 : ptr32)
-	T_3115 (in d0_82 + 40<i32> : word32)
-	T_3118 (in Mem95[d0_82 + 20<i32>:word32] : word32)
-	T_3125 (in Mem97[d0_82 + 20<i32>:word32] : word32)
-	T_3129 (in a2_100 : (ptr32 Eq_2656))
-	T_3131 (in Mem99[d0_82 + 20<i32>:word32] : word32)
-	T_3146 (in Mem106[d0_82 + 20<i32>:word32] : word32)
-	T_3217 (in d1 : word32)
-	T_3221 (in puddleSize : word32)
-	T_3222 (in puddleThresh : word32)
-	T_3229 (in 0<i32> : int32)
-	T_3255 (in Mem48[d0_30 + 20<i32>:word32] : word32)
-	T_4233 (in Mem20[dwArg08 + 20<i32>:word32] : word32)
-	T_4235 (in Mem20[dwArg08 + 20<i32>:word32] + 1<32> : word32)
-	T_4237 (in Mem22[dwArg08 + 20<i32>:word32] : word32)
-	T_8016 (in d0_125 : (ptr32 Eq_2656))
-	T_8020 (in *((word32) dwArg04 + 24<i32>) & 0x200<32> : word32)
-	T_8021 (in 0<32> : word32)
-	T_8035 (in fn00003D2C(out a1_116, out a5_279) : word32)
-	T_8045 (in *((word32) dwArg04 + 24<i32>) & 4<i32> : word32)
-	T_8046 (in 0<32> : word32)
-	T_8056 (in 1<i32> : int32)
-	T_8071 (in Mem147[dwArg04 + 20<i32>:word32] : word32)
-	T_8072 (in v26_148 : (ptr32 Eq_2656))
-	T_8074 (in Mem147[dwArg04 + 20<i32>:word32] : word32)
-	T_8076 (in *((word32) dwArg04 + 20<i32>) - 1<32> : word32)
-	T_8078 (in Mem149[dwArg04 + 20<i32>:word32] : word32)
-	T_8079 (in 0<32> : word32)
-	T_8092 (in d0_117 : (ptr32 Eq_2656))
-	T_8101 (in fn00001FB4((word32) *((word32) dwArg04 + 28<i32>) + d4_100, out d1_118, out a0_318, out a1_116) : word32)
-	T_8102 (in 0<32> : word32)
-	T_8122 (in Mem149[dwArg04 + 20<i32>:word32] : word32)
-	T_8123 (in -1<i32> : int32)
-	T_8139 (in 0<32> : word32)
-	T_8142 (in Mem184[dwArg04 + 20<i32>:word32] : word32)
-Eq_2657: (fn (ptr32 Eq_2656) (int32, ptr32, ptr32, (ptr32 int32)))
+Eq_2657: (fn int32 (int32, ptr32, ptr32, (ptr32 int32)))
 	T_2657 (in fn00001FB4 : ptr32)
 	T_2658 (in signature of fn00001FB4 : void)
 	T_8093 (in fn00001FB4 : ptr32)
@@ -1892,7 +1730,25 @@ Eq_2862: (union "Eq_2862" (int32 u0) (ptr32 u1))
 	T_2914 (in 0<i32> : int32)
 	T_2920 (in d0_58 + 4<i32> : word32)
 	T_2921 (in 0<i32> : int32)
-Eq_2883: (fn (ptr32 Eq_4) (Eq_106, (ptr32 Eq_2656), (ptr32 Eq_2656), (ptr32 Eq_2656), (ptr32 Eq_4), Eq_25))
+Eq_2878: (struct "Eq_2878" (0 word32 dw0000) (4 word32 dw0004))
+	T_2878 (in a0_13 : (ptr32 Eq_2878))
+	T_2880 (in Mem5[0x00003DA4<p32>:word32] : word32)
+	T_2886 (in dwArg08 : (ptr32 Eq_2878))
+	T_2887 (in dwArg0C : (ptr32 Eq_2878))
+	T_2888 (in d1Out : (ptr32 Eq_2878))
+	T_2892 (in out d1 : ptr32)
+	T_3115 (in d0_82 + 40<i32> : word32)
+	T_3118 (in Mem95[d0_82 + 20<i32>:word32] : word32)
+	T_3125 (in Mem97[d0_82 + 20<i32>:word32] : word32)
+	T_3129 (in a2_100 : (ptr32 Eq_2878))
+	T_3131 (in Mem99[d0_82 + 20<i32>:word32] : word32)
+	T_3146 (in Mem106[d0_82 + 20<i32>:word32] : word32)
+	T_3217 (in d1 : word32)
+	T_3221 (in puddleSize : word32)
+	T_3222 (in puddleThresh : word32)
+	T_3229 (in 0<i32> : int32)
+	T_3255 (in Mem48[d0_30 + 20<i32>:word32] : word32)
+Eq_2883: (fn (ptr32 Eq_4) (Eq_106, (ptr32 Eq_2878), (ptr32 Eq_2878), (ptr32 Eq_2878), (ptr32 Eq_4), (ptr32 Eq_25)))
 	T_2883 (in fn000022A8 : ptr32)
 	T_2884 (in signature of fn000022A8 : void)
 Eq_2899: (fn (ptr32 int32) ((ptr32 Eq_4), up32, Eq_78, (ptr32 Eq_4)))
@@ -1910,38 +1766,22 @@ Eq_2970: (fn void ((ptr32 Eq_4)))
 Eq_3008: (fn void ((ptr32 Eq_4), up32, up32))
 	T_3008 (in Deallocate : ptr32)
 	T_3009 (in signature of Deallocate : void)
-Eq_3037: (fn Eq_25 (up32, (ptr32 Eq_4)))
+Eq_3037: (fn (ptr32 Eq_25) (up32, (ptr32 Eq_4)))
 	T_3037 (in AllocPooled : ptr32)
 	T_3038 (in signature of AllocPooled : void)
 Eq_3056: (union "Eq_3056" (int32 u0) (up32 u1))
 	T_3056 (in 16<i32> : int32)
-Eq_3088: (fn Eq_25 ((ptr32 Eq_4), up32))
+Eq_3088: (fn (ptr32 Eq_25) ((ptr32 Eq_4), up32))
 	T_3088 (in Allocate : ptr32)
 	T_3089 (in signature of Allocate : void)
 	T_3159 (in Allocate : ptr32)
-Eq_3119: (union "Eq_3119" (ui32 u0) (ptr32 u1))
-	T_3119 (in d0_82 + 40<i32> : word32)
-	T_3122 (in Mem97[d0_82 + 24<i32>:word32] : word32)
-	T_8003 (in Mem26[dwArg04 + 24<i32>:word32] : word32)
-	T_8011 (in Mem26[dwArg04 + 24<i32>:word32] : word32)
-	T_8013 (in *((word32) dwArg04 + 24<i32>) | 1<i32> : word32)
-	T_8015 (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-	T_8018 (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-	T_8043 (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-	T_8084 (in Mem86[dwArg04 + 24<i32>:word32] : word32)
-	T_8127 (in Mem149[dwArg04 + 24<i32>:word32] : word32)
-	T_8129 (in *((word32) dwArg04 + 24<i32>) | 16<i32> : word32)
-	T_8131 (in Mem172[dwArg04 + 24<i32>:word32] : word32)
-	T_8134 (in Mem149[dwArg04 + 24<i32>:word32] : word32)
-	T_8136 (in *((word32) dwArg04 + 24<i32>) | 8<i32> : word32)
-	T_8138 (in Mem179[dwArg04 + 24<i32>:word32] : word32)
 Eq_3151: (fn void ((ptr32 Eq_4), ptr32))
 	T_3151 (in AddHead : ptr32)
 	T_3152 (in signature of AddHead : void)
 Eq_3189: (fn void ((ptr32 Eq_4), ptr32))
 	T_3189 (in AddTail : ptr32)
 	T_3190 (in signature of AddTail : void)
-Eq_3218: (fn Eq_25 (Eq_106, (ptr32 Eq_2656), (ptr32 Eq_2656)))
+Eq_3218: (fn (ptr32 Eq_25) (Eq_106, (ptr32 Eq_2878), (ptr32 Eq_2878)))
 	T_3218 (in CreatePrivatePool : ptr32)
 	T_3219 (in signature of CreatePrivatePool : void)
 Eq_3268: (fn void ((ptr32 Eq_379)))
@@ -1954,7 +1794,7 @@ Eq_3272: (fn void ((ptr32 Eq_379)))
 Eq_3296: (fn void (int32, word32))
 	T_3296 (in SetSignal : ptr32)
 	T_3297 (in signature of SetSignal : void)
-Eq_3332: (fn Eq_25 (Eq_25, Eq_25, Eq_25, Eq_25, Eq_25))
+Eq_3332: (fn Eq_718 (Eq_718, Eq_718, Eq_718, Eq_718, Eq_718))
 	T_3332 (in fn000024BC : ptr32)
 	T_3333 (in signature of fn000024BC : void)
 	T_3396 (in fn000024BC : ptr32)
@@ -1964,7 +1804,7 @@ Eq_3332: (fn Eq_25 (Eq_25, Eq_25, Eq_25, Eq_25, Eq_25))
 	T_4041 (in fn000024BC : ptr32)
 	T_4124 (in fn000024BC : ptr32)
 	T_4130 (in fn000024BC : ptr32)
-Eq_3346: (fn Eq_25 (Eq_25, Eq_25))
+Eq_3346: (fn Eq_718 (Eq_718, Eq_718))
 	T_3346 (in __rol : ptr32)
 	T_3347 (in signature of __rol : void)
 	T_3376 (in __rol : ptr32)
@@ -1990,7 +1830,7 @@ Eq_3484: (union "Eq_3484" (bool u0) (word16 u1))
 	T_3484 (in v34_108 <u 0<16> : bool)
 Eq_3487: (union "Eq_3487" (bool u0) (word16 u1))
 	T_3487 (in v39_116 <u 0<16> : bool)
-Eq_3510: (fn Eq_25 (Eq_25, Eq_25, Eq_25, Eq_25))
+Eq_3510: (fn Eq_718 (Eq_718, Eq_718, Eq_718, Eq_718))
 	T_3510 (in fn0000267A : ptr32)
 	T_3511 (in signature of fn0000267A : void)
 	T_3802 (in fn0000267A : ptr32)
@@ -2008,7 +1848,7 @@ Eq_3671: (union "Eq_3671" (bool u0) (word16 u1))
 	T_3671 (in v59_155 <u 0<16> : bool)
 Eq_3677: (union "Eq_3677" (bool u0) (uint32 u1))
 	T_3677 (in d6_178 <u 0<32> : bool)
-Eq_3774: (fn Eq_25 (Eq_25, word32, bool))
+Eq_3774: (fn Eq_718 (Eq_718, word32, bool))
 	T_3774 (in __rcr : ptr32)
 	T_3775 (in signature of __rcr : void)
 Eq_4104: (union "Eq_4104" (bool u0) (word16 u1))
@@ -2021,11 +1861,11 @@ Eq_4148: (union "Eq_4148" (bool u0) (word32 u1))
 	T_4148 (in d3_135 < 0<32> : bool)
 Eq_4156: (union "Eq_4156" (bool u0) (ui32 u1))
 	T_4156 (in d6_157 < 0<32> : bool)
-Eq_4202: (fn Eq_25 (Eq_25, Eq_25, Eq_25, Eq_25, (ptr32 Eq_621), Eq_25))
+Eq_4202: (fn Eq_73 (Eq_73, Eq_73, (ptr32 Eq_25), Eq_73, (ptr32 Eq_621), Eq_718))
 	T_4202 (in fn00002B8C : ptr32)
 	T_4203 (in signature of fn00002B8C : void)
-Eq_4251: (union "Eq_4251" (uint8 u0) ((ptr32 Eq_8273) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_4251 (in a7_1330 : Eq_4251)
+Eq_4251: (struct "Eq_4251" 0004 (2C int32 dw002C) (30 Eq_8261 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8262 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+	T_4251 (in a7_1330 : (ptr32 Eq_4251))
 	T_4254 (in fp + -120<i32> : word32)
 	T_7063 (in a7_3474 + 4<i32> : word32)
 	T_7233 (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
@@ -2166,7 +2006,7 @@ Eq_4361: (union "Eq_4361" (int32 u0) (uint32 u1))
 	T_4361 (in 10<i32> : int32)
 Eq_4391: (union "Eq_4391" (int32 u0) (uint32 u1))
 	T_4391 (in (uint32) (uint8) Mem316[a3_279 + 0<32>:byte] : uint32)
-Eq_4613: (fn Eq_25 (Eq_25, Eq_2601, (ptr32 word32), (ptr32 byte)))
+Eq_4613: (fn Eq_73 (Eq_73, (ptr32 (ptr32 Eq_4258)), (ptr32 word32), (ptr32 byte)))
 	T_4613 (in fn00003C30 : ptr32)
 	T_4614 (in signature of fn00003C30 : void)
 	T_4732 (in fn00003C30 : ptr32)
@@ -2183,7 +2023,7 @@ Eq_4613: (fn Eq_25 (Eq_25, Eq_2601, (ptr32 word32), (ptr32 byte)))
 	T_6746 (in fn00003C30 : ptr32)
 	T_7582 (in fn00003C30 : ptr32)
 	T_7749 (in fn00003C30 : ptr32)
-Eq_4803: (fn Eq_25 (Eq_25, Eq_25))
+Eq_4803: (fn Eq_73 (byte, Eq_73))
 	T_4803 (in fn00002B5C : ptr32)
 	T_4804 (in signature of fn00002B5C : void)
 	T_4913 (in fn00002B5C : ptr32)
@@ -2197,27 +2037,21 @@ Eq_4803: (fn Eq_25 (Eq_25, Eq_25))
 	T_6856 (in fn00002B5C : ptr32)
 	T_7015 (in fn00002B5C : ptr32)
 	T_7811 (in fn00002B5C : ptr32)
-Eq_4816: (struct "Eq_4816" (0 Eq_25 t0000) (30 Eq_25 t0030))
+Eq_4816: (struct "Eq_4816" (0 Eq_73 t0000) (30 Eq_73 t0030))
 	T_4816 (in a7_79 : (ptr32 Eq_4816))
 	T_4818 (in a7_1330 - 4<i32> : word32)
-Eq_4840: (struct "Eq_4840" (0 Eq_25 t0000) (30 uint32 dw0030))
+Eq_4840: (struct "Eq_4840" (0 Eq_73 t0000) (30 uint32 dw0030))
 	T_4840 (in a7_99 : (ptr32 Eq_4840))
 	T_4842 (in a7_1330 - 4<i32> : word32)
-Eq_4870: (union "Eq_4870" (byte u0) ((ptr32 Eq_8274) u1))
-	T_4870 (in a7_99 + 0<32> : word32)
 Eq_4950: (union "Eq_4950" (int32 u0) (byte u1))
 	T_4950 (in 0<8> : byte)
 	T_4953 (in Mem761[a7_1330 + 44<i32>:byte] : byte)
-Eq_4999: (struct "Eq_4999" (0 Eq_25 t0000) (30 Eq_25 t0030))
+Eq_4999: (struct "Eq_4999" (0 Eq_73 t0000) (30 Eq_73 t0030))
 	T_4999 (in a7_640 : (ptr32 Eq_4999))
 	T_5001 (in a7_1330 - 4<i32> : word32)
-Eq_5023: (struct "Eq_5023" (0 Eq_25 t0000) (30 uint32 dw0030))
+Eq_5023: (struct "Eq_5023" (0 Eq_73 t0000) (30 uint32 dw0030))
 	T_5023 (in a7_660 : (ptr32 Eq_5023))
 	T_5025 (in a7_1330 - 4<i32> : word32)
-Eq_5042: (union "Eq_5042" (byte u0) ((ptr32 Eq_8275) u1))
-	T_5042 (in a7_660 + 0<32> : word32)
-Eq_5052: (union "Eq_5052" (byte u0) ((ptr32 Eq_8276) u1))
-	T_5052 (in a7_660 + 0<32> : word32)
 Eq_5139: (union "Eq_5139" (int32 u0) (uint32 u1))
 	T_5139 (in d2_1090 + 3<32> : word32)
 Eq_5144: (struct "Eq_5144" (0 word32 dw0000) (4 Eq_4258 t0004))
@@ -2236,31 +2070,23 @@ Eq_5355: (union "Eq_5355" (int32 u0) (uint32 u1))
 Eq_5390: (union "Eq_5390" (int32 u0) (uint32 u1))
 	T_5390 (in d6_1133 - d3_1850 : word32)
 	T_5391 (in 0<32> : word32)
-Eq_5424: (struct "Eq_5424" (0 Eq_25 t0000) (38 Eq_25 t0038))
+Eq_5424: (struct "Eq_5424" (0 Eq_73 t0000) (38 Eq_73 t0038))
 	T_5424 (in a7_2007 : (ptr32 Eq_5424))
 	T_5426 (in a7_1330 - 4<i32> : word32)
-Eq_5448: (struct "Eq_5448" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_5448: (struct "Eq_5448" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_5448 (in a7_2027 : (ptr32 Eq_5448))
 	T_5450 (in a7_1330 - 4<i32> : word32)
-Eq_5467: (union "Eq_5467" (byte u0) ((ptr32 Eq_8286) u1))
-	T_5467 (in a7_2027 + 0<32> : word32)
-Eq_5477: (union "Eq_5477" (byte u0) ((ptr32 Eq_8287) u1))
-	T_5477 (in a7_2027 + 0<32> : word32)
 Eq_5482: (union "Eq_5482" (int32 u0) (uint32 u1))
 	T_5482 (in 1<32> : word32)
 Eq_5522: (union "Eq_5522" (int32 u0) (uint32 u1))
 	T_5522 (in d6_1133 - d3_1850 : word32)
 	T_5523 (in 0<32> : word32)
-Eq_5551: (struct "Eq_5551" (0 Eq_25 t0000) (38 Eq_25 t0038))
+Eq_5551: (struct "Eq_5551" (0 Eq_73 t0000) (38 Eq_73 t0038))
 	T_5551 (in a7_2148 : (ptr32 Eq_5551))
 	T_5553 (in a7_1330 - 4<i32> : word32)
-Eq_5575: (struct "Eq_5575" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_5575: (struct "Eq_5575" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_5575 (in a7_2168 : (ptr32 Eq_5575))
 	T_5577 (in a7_1330 - 4<i32> : word32)
-Eq_5594: (union "Eq_5594" (byte u0) ((ptr32 Eq_8288) u1))
-	T_5594 (in a7_2168 + 0<32> : word32)
-Eq_5604: (union "Eq_5604" (byte u0) ((ptr32 Eq_8289) u1))
-	T_5604 (in a7_2168 + 0<32> : word32)
 Eq_5618: (union "Eq_5618" (int32 u0) (uint32 u1))
 	T_5618 (in d3_2201 : Eq_5618)
 	T_5620 (in d3_1850 + 1<32> : word32)
@@ -2273,26 +2099,18 @@ Eq_5623: (fn bool (Eq_4288, word16))
 Eq_5694: (union "Eq_5694" (int32 u0) (uint32 u1))
 	T_5694 (in d6_1133 - d3_2201 : word32)
 	T_5695 (in 0<32> : word32)
-Eq_5723: (struct "Eq_5723" (0 Eq_25 t0000) (38 Eq_25 t0038))
+Eq_5723: (struct "Eq_5723" (0 Eq_73 t0000) (38 Eq_73 t0038))
 	T_5723 (in a7_2246 : (ptr32 Eq_5723))
 	T_5725 (in a7_1330 - 4<i32> : word32)
-Eq_5747: (struct "Eq_5747" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_5747: (struct "Eq_5747" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_5747 (in a7_2266 : (ptr32 Eq_5747))
 	T_5749 (in a7_1330 - 4<i32> : word32)
-Eq_5766: (union "Eq_5766" (byte u0) ((ptr32 Eq_8292) u1))
-	T_5766 (in a7_2266 + 0<32> : word32)
-Eq_5776: (union "Eq_5776" (byte u0) ((ptr32 Eq_8293) u1))
-	T_5776 (in a7_2266 + 0<32> : word32)
-Eq_5804: (struct "Eq_5804" (0 Eq_25 t0000) (30 int32 dw0030) (38 Eq_25 t0038))
+Eq_5804: (struct "Eq_5804" (0 Eq_73 t0000) (30 int32 dw0030) (38 Eq_73 t0038))
 	T_5804 (in a7_1400 : (ptr32 Eq_5804))
 	T_5806 (in a7_1330 - 4<i32> : word32)
-Eq_5839: (struct "Eq_5839" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_5839: (struct "Eq_5839" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_5839 (in a7_1425 : (ptr32 Eq_5839))
 	T_5841 (in a7_1330 - 4<i32> : word32)
-Eq_5858: (union "Eq_5858" (byte u0) ((ptr32 Eq_8294) u1))
-	T_5858 (in a7_1425 + 0<32> : word32)
-Eq_5868: (union "Eq_5868" (byte u0) ((ptr32 Eq_8295) u1))
-	T_5868 (in a7_1425 + 0<32> : word32)
 Eq_5876: (union "Eq_5876" (int32 u0) (uint32 u1))
 	T_5876 (in d3_1462 : Eq_5876)
 	T_5878 (in d3_1850 + 1<32> : word32)
@@ -2309,7 +2127,7 @@ Eq_5894: (union "Eq_5894" (int32 u0) (uint32 u1))
 Eq_5903: (union "Eq_5903" (int32 u0) (uint32 u1))
 	T_5903 (in d6_1133 - d3_1462 : word32)
 	T_5904 (in 0<32> : word32)
-Eq_5946: (struct "Eq_5946" (0 Eq_25 t0000) (4E word32 dw004E))
+Eq_5946: (struct "Eq_5946" (0 Eq_73 t0000) (4E word32 dw004E))
 	T_5946 (in a7_2334 : (ptr32 Eq_5946))
 	T_5948 (in a7_1330 - 4<i32> : word32)
 Eq_6014: (union "Eq_6014" (int32 u0) (uint32 u1))
@@ -2319,7 +2137,7 @@ Eq_6023: (union "Eq_6023" (int32 u0) (uint32 u1))
 	T_6024 (in 0<32> : word32)
 Eq_6033: (union "Eq_6033" (int32 u0) (uint32 u1))
 	T_6033 (in 1<32> : word32)
-Eq_6063: (struct "Eq_6063" (0 Eq_25 t0000) (44 word32 dw0044))
+Eq_6063: (struct "Eq_6063" (0 Eq_73 t0000) (44 word32 dw0044))
 	T_6063 (in a7_2368 : (ptr32 Eq_6063))
 	T_6065 (in a7_1330 - 4<i32> : word32)
 Eq_6113: (union "Eq_6113" (int32 u0) (uint32 u1))
@@ -2328,16 +2146,12 @@ Eq_6113: (union "Eq_6113" (int32 u0) (uint32 u1))
 Eq_6122: (union "Eq_6122" (int32 u0) (uint32 u1))
 	T_6122 (in d6_1133 - d3_1850 : word32)
 	T_6123 (in 0<32> : word32)
-Eq_6151: (struct "Eq_6151" (0 Eq_25 t0000) (38 Eq_25 t0038))
+Eq_6151: (struct "Eq_6151" (0 Eq_73 t0000) (38 Eq_73 t0038))
 	T_6151 (in a7_2443 : (ptr32 Eq_6151))
 	T_6153 (in a7_1330 - 4<i32> : word32)
-Eq_6175: (struct "Eq_6175" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_6175: (struct "Eq_6175" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_6175 (in a7_2463 : (ptr32 Eq_6175))
 	T_6177 (in a7_1330 - 4<i32> : word32)
-Eq_6194: (union "Eq_6194" (byte u0) ((ptr32 Eq_8296) u1))
-	T_6194 (in a7_2463 + 0<32> : word32)
-Eq_6204: (union "Eq_6204" (byte u0) ((ptr32 Eq_8297) u1))
-	T_6204 (in a7_2463 + 0<32> : word32)
 Eq_6218: (union "Eq_6218" (int32 u0) (uint32 u1))
 	T_6218 (in d3_2508 : Eq_6218)
 	T_6220 (in d3_1850 + 1<32> : word32)
@@ -2346,18 +2160,12 @@ Eq_6219: (union "Eq_6219" (int32 u0) (uint32 u1))
 Eq_6249: (union "Eq_6249" (int32 u0) (uint32 u1))
 	T_6249 (in d6_1133 - d3_2508 : word32)
 	T_6250 (in 0<32> : word32)
-Eq_6278: (struct "Eq_6278" (0 Eq_25 t0000) (38 Eq_25 t0038))
+Eq_6278: (struct "Eq_6278" (0 Eq_73 t0000) (38 Eq_73 t0038))
 	T_6278 (in a7_2552 : (ptr32 Eq_6278))
 	T_6280 (in a7_1330 - 4<i32> : word32)
-Eq_6302: (struct "Eq_6302" (0 Eq_25 t0000) (38 uint32 dw0038))
+Eq_6302: (struct "Eq_6302" (0 Eq_73 t0000) (38 uint32 dw0038))
 	T_6302 (in a7_2572 : (ptr32 Eq_6302))
 	T_6304 (in a7_1330 - 4<i32> : word32)
-Eq_6321: (union "Eq_6321" (byte u0) ((ptr32 Eq_8298) u1))
-	T_6321 (in a7_2572 + 0<32> : word32)
-Eq_6331: (union "Eq_6331" (byte u0) ((ptr32 Eq_8299) u1))
-	T_6331 (in a7_2572 + 0<32> : word32)
-Eq_6344: (union "Eq_6344" (uint8 u0) (word32 u1))
-	T_6344 (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
 Eq_6352: (union "Eq_6352" (int32 u0) (uint32 u1))
 	T_6352 (in 1<32> : word32)
 Eq_6394: (union "Eq_6394" (byte u0) (word32 u1))
@@ -2365,7 +2173,7 @@ Eq_6394: (union "Eq_6394" (byte u0) (word32 u1))
 	T_6397 (in Mem2801[a7_1330 + 74<i32>:byte] : byte)
 Eq_6403: (union "Eq_6403" (int32 u0) (uint32 u1))
 	T_6403 (in 1<32> : word32)
-Eq_6407: (struct "Eq_6407" (0 Eq_25 t0000) (44 word32 dw0044))
+Eq_6407: (struct "Eq_6407" (0 Eq_73 t0000) (44 word32 dw0044))
 	T_6407 (in a7_2667 : (ptr32 Eq_6407))
 	T_6409 (in a7_1330 - 4<i32> : word32)
 Eq_6436: (union "Eq_6436" (int32 u0) (uint32 u1))
@@ -2431,345 +2239,85 @@ Eq_6700: (union "Eq_6700" (bool u0) (word32 u1))
 	T_6700 (in d2_3095 < 0<32> : bool)
 Eq_6814: (union "Eq_6814" (int32 u0) (uint32 u1))
 	T_6814 (in 1<32> : word32)
-Eq_6842: (struct "Eq_6842" (0 Eq_25 t0000) (4E word32 dw004E))
+Eq_6842: (struct "Eq_6842" (0 Eq_73 t0000) (4E word32 dw004E))
 	T_6842 (in a7_2635 : (ptr32 Eq_6842))
 	T_6844 (in a7_1330 - 4<i32> : word32)
-Eq_6893: (struct "Eq_6893" (0 Eq_25 t0000) (1 Eq_6982 t0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
+Eq_6893: (struct "Eq_6893" (0 Eq_718 t0000) (1 ui24 n0001) (30 word32 dw0030) (34 word32 dw0034) (44 word32 dw0044) (48 word32 dw0048))
 	T_6893 (in a7_2886 : (ptr32 Eq_6893))
 	T_6894 (in a7_1330 - 4<i32> : word32)
-Eq_6904: (union "Eq_6904" (ui24 u0) ((ptr32 Eq_8300) u1) (Eq_1290 u2))
-	T_6904 (in a7_2886 + 0<32> : word32)
-Eq_6944: (fn word32 (Eq_4258, Eq_25, Eq_25, Eq_25, Eq_25, ptr32))
+Eq_6944: (fn word32 (Eq_4258, Eq_718, Eq_718, Eq_718, Eq_718, ptr32))
 	T_6944 (in fn00003BB0 : ptr32)
 	T_6945 (in signature of fn00003BB0 : void)
-Eq_6981: (union "Eq_6981" (ui24 u0) ((ptr32 Eq_8301) u1) (Eq_1290 u2))
-	T_6981 (in a7_2886 + 1<32> : word32)
-Eq_6982: (union "Eq_6982" (ui24 u0) ((ptr32 Eq_8302) u1) (Eq_1290 u2))
-	T_6982 (in Mem2934[a7_2886 + 1<32>:word24] : word24)
 Eq_6995: (union "Eq_6995" (int32 u0) (uint32 u1))
 	T_6995 (in 1<32> : word32)
-Eq_7048: (struct "Eq_7048" (0 Eq_25 t0000) (30 word32 dw0030) (34 Eq_25 t0034) (38 byte b0038) (4C byte b004C))
+Eq_7048: (struct "Eq_7048" (0 Eq_73 t0000) (30 word32 dw0030) (34 Eq_73 t0034) (38 byte b0038) (4C byte b004C))
 	T_7048 (in a7_3474 : (ptr32 Eq_7048))
 	T_7050 (in a7_1330 - 4<i32> : word32)
-Eq_7078: (struct "Eq_7078" (0 word32 dw0000) (4 Eq_25 t0004))
+Eq_7078: (struct "Eq_7078" (0 word32 dw0000) (4 Eq_73 t0004))
 	T_7078 (in a0_3501 : (ptr32 Eq_7078))
 	T_7081 (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
-Eq_7144: (union "Eq_7144" (byte u0) ((ptr32 Eq_8311) u1))
-	T_7144 (in a7_3474 + 52<i32> : word32)
-Eq_7173: (union "Eq_7173" (byte u0) ((ptr32 Eq_8315) u1))
-	T_7173 (in a7_3474 + 52<i32> : word32)
-Eq_7190: (union "Eq_7190" (byte u0) ((ptr32 Eq_8319) u1))
-	T_7190 (in a7_3474 + 52<i32> : word32)
 Eq_7206: (union "Eq_7206" (int32 u0) (ptr32 u1) (Eq_6621 u2) (Eq_6680 u3))
 	T_7206 (in a7_1330 + 48<i32> : word32)
-Eq_7207: (union "Eq_7207" (int32 u0) (uint8 u1) (ptr32 u2) (Eq_6344 u3) (Eq_6621 u4) (Eq_6680 u5))
+Eq_7207: (union "Eq_7207" (int32 u0) (ptr32 u1) (Eq_6621 u2) (Eq_6680 u3))
 	T_7207 (in Mem3324[a7_1330 + 48<i32>:word32] : word32)
 	T_7210 (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
-Eq_7209: (union "Eq_7209" (uint8 u0) (word32 u1) (Eq_6344 u2))
-	T_7209 (in a7_1330 + 56<i32> : word32)
 Eq_7217: (struct "Eq_7217" (0 int32 dw0000) (4 word32 dw0004))
 	T_7217 (in v528_3348 : (ptr32 Eq_7217))
 	T_7219 (in a7_1330 + 44<i32> : word32)
 Eq_7229: (union "Eq_7229" (bool u0) (int32 u1))
 	T_7229 (in d1 < 0<32> : bool)
-Eq_7232: (union "Eq_7232" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7232 (in a7_1330 + 0x38<32> : word32)
-Eq_7234: (union "Eq_7234" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7234 (in a7_3364 : Eq_7234)
+Eq_7234: (struct "Eq_7234" (0 Eq_73 t0000) (30 byte b0030) (38 word32 dw0038) (3C Eq_73 t003C) (4C byte b004C))
+	T_7234 (in a7_3364 : (ptr32 Eq_7234))
 	T_7236 (in a7_1330 - 4<i32> : word32)
-Eq_7235: (union "Eq_7235" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7235 (in 4<i32> : int32)
-Eq_7238: (union "Eq_7238" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7238 (in a7_3364 + 0<32> : word32)
-Eq_7241: (union "Eq_7241" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7241 (in a7_3364 + 76<i32> : word32)
-Eq_7246: (union "Eq_7246" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7246 (in a7_3364 + 48<i32> : word32)
-Eq_7248: (union "Eq_7248" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7248 (in 4<i32> : int32)
-Eq_7251: (union "Eq_7251" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7251 (in a7_3364 + 48<i32> : word32)
-Eq_7257: (union "Eq_7257" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7257 (in a7_1330 + 52<i32> : word32)
-Eq_7261: (union "Eq_7261" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7261 (in a7_1330 + 44<i32> : word32)
-Eq_7266: (union "Eq_7266" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7266 (in a7_1330 + 52<i32> : word32)
-Eq_7270: (union "Eq_7270" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7270 (in a7_1330 + 44<i32> : word32)
-Eq_7283: (struct "Eq_7283" (0 word32 dw0000) (4 word32 dw0004))
+Eq_7259: (union "Eq_7259" (int32 u0) (byte u1))
+	T_7259 (in v544_774 : Eq_7259)
+	T_7262 (in Mem773[a7_1330 + 44<i32>:byte] : byte)
+	T_7415 (in 0<8> : byte)
+	T_7422 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+Eq_7268: (union "Eq_7268" (int32 u0) (byte u1))
+	T_7268 (in 1<8> : byte)
+	T_7271 (in Mem769[a7_1330 + 44<i32>:byte] : byte)
+Eq_7283: (struct "Eq_7283" (0 word32 dw0000) (4 Eq_73 t0004))
 	T_7283 (in a0_3404 : (ptr32 Eq_7283))
 	T_7286 (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
-Eq_7288: (union "Eq_7288" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7288 (in a7_3364 + 60<i32> : word32)
-Eq_7294: (union "Eq_7294" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7294 (in a7_3364 + 56<i32> : word32)
-Eq_7302: (union "Eq_7302" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7302 (in a7_3364 + 48<i32> : word32)
-Eq_7307: (union "Eq_7307" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7307 (in a7_3364 + 48<i32> : word32)
-Eq_7320: (union "Eq_7320" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7320 (in a7_3364 + 60<i32> : word32)
-Eq_7331: (union "Eq_7331" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7331 (in a7_3364 + 48<i32> : word32)
-Eq_7336: (union "Eq_7336" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7336 (in a7_3364 + 48<i32> : word32)
-Eq_7349: (union "Eq_7349" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7349 (in a7_3364 + 60<i32> : word32)
-Eq_7360: (union "Eq_7360" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7360 (in a7_3364 + 48<i32> : word32)
-Eq_7365: (union "Eq_7365" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7365 (in a7_3364 + 48<i32> : word32)
-Eq_7378: (union "Eq_7378" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7378 (in a7_3364 + 60<i32> : word32)
-Eq_7395: (union "Eq_7395" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7395 (in a7_3364 + 60<i32> : word32)
-Eq_7407: (union "Eq_7407" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7407 (in 78<i32> : int32)
-Eq_7408: (union "Eq_7408" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7408 (in a7_1330 + 78<i32> : word32)
-Eq_7409: (union "Eq_7409" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7409 (in a7_1330 + 78<i32> + d1_1027 : word32)
-Eq_7411: (union "Eq_7411" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7411 (in 1<32> : word32)
-Eq_7418: (union "Eq_7418" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7418 (in a7_1330 + 132<i32> : word32)
-Eq_7421: (union "Eq_7421" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7421 (in a7_1330 + 44<i32> : word32)
-Eq_7425: (union "Eq_7425" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7425 (in a7_1330 + 44<i32> : word32)
-Eq_7429: (union "Eq_7429" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7429 (in a7_1330 + 132<i32> : word32)
-Eq_7434: (union "Eq_7434" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7434 (in a7_1330 + 73<i32> : word32)
-Eq_7466: (union "Eq_7466" (byte u0) ((ptr32 Eq_8342) u1))
-	T_7466 (in d5_862 : Eq_7466)
-	T_7468 (in (uint32) (uint8) v556_834 : uint32)
-	T_7524 (in d5_862 + 1<32> : word32)
-Eq_7472: (union "Eq_7472" (byte u0) ((ptr32 Eq_8343) u1))
-	T_7472 (in d0 - d5_862 : word32)
-	T_7473 (in 0<32> : word32)
-Eq_7482: (union "Eq_7482" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7482 (in a0_881 : Eq_7482)
-	T_7487 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_7483: (union "Eq_7483" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7483 (in 78<i32> : int32)
-Eq_7484: (union "Eq_7484" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7484 (in a7_1330 + 78<i32> : word32)
-Eq_7486: (union "Eq_7486" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
+Eq_7423: (union "Eq_7423" (int32 u0) (byte u1))
+	T_7423 (in v554_824 : Eq_7423)
+	T_7426 (in Mem823[a7_1330 + 44<i32>:byte] : byte)
+	T_7480 (in 0<8> : byte)
+Eq_7486: (union "Eq_7486" (int32 u0) (uint32 u1))
 	T_7486 (in d5_862 >> 3<32> : word32)
-Eq_7489: (union "Eq_7489" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7489 (in a0_881 + 0<32> : word32)
-Eq_7500: (union "Eq_7500" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7500 (in a0_881 + 0<32> : word32)
-Eq_7502: (union "Eq_7502" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7502 (in a0_900 : Eq_7502)
-	T_7507 (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
-Eq_7503: (union "Eq_7503" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7503 (in 78<i32> : int32)
-Eq_7504: (union "Eq_7504" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7504 (in a7_1330 + 78<i32> : word32)
-Eq_7506: (union "Eq_7506" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
+Eq_7506: (union "Eq_7506" (int32 u0) (uint32 u1))
 	T_7506 (in d5_862 >> 3<32> : word32)
-Eq_7509: (union "Eq_7509" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7509 (in a0_900 + 0<32> : word32)
-Eq_7521: (union "Eq_7521" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7521 (in a0_900 + 0<32> : word32)
-Eq_7523: (union "Eq_7523" (byte u0) ((ptr32 Eq_8344) u1))
-	T_7523 (in 1<32> : word32)
-Eq_7528: (union "Eq_7528" (byte u0) ((ptr32 Eq_8345) u1))
-	T_7528 (in d0 - d5_862 : word32)
-	T_7529 (in 0<32> : word32)
-Eq_7575: (union "Eq_7575" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7575 (in a7_985 : Eq_7575)
+Eq_7575: (struct "Eq_7575" (0 Eq_73 t0000) (30 Eq_73 t0030))
+	T_7575 (in a7_985 : (ptr32 Eq_7575))
 	T_7577 (in a7_1330 - 4<i32> : word32)
-Eq_7576: (union "Eq_7576" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7576 (in 4<i32> : int32)
-Eq_7579: (union "Eq_7579" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7579 (in a7_985 + 0<32> : word32)
-Eq_7584: (union "Eq_7584" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7584 (in a7_985 + 0<32> : word32)
-Eq_7591: (union "Eq_7591" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7591 (in a7_985 + 48<i32> : word32)
-Eq_7599: (union "Eq_7599" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7599 (in a7_1005 : Eq_7599)
+Eq_7599: (struct "Eq_7599" (0 Eq_73 t0000) (30 uint32 dw0030))
+	T_7599 (in a7_1005 : (ptr32 Eq_7599))
 	T_7601 (in a7_1330 - 4<i32> : word32)
-Eq_7600: (union "Eq_7600" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7600 (in 4<i32> : int32)
-Eq_7603: (union "Eq_7603" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7603 (in a7_1005 + 0<32> : word32)
-Eq_7615: (union "Eq_7615" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7615 (in a7_1005 + 0<32> : word32)
-Eq_7618: (union "Eq_7618" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7618 (in a7_1005 + 0<32> : word32)
-Eq_7623: (union "Eq_7623" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7623 (in a7_1005 + 48<i32> : word32)
-Eq_7628: (union "Eq_7628" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7628 (in a7_1005 + 0<32> : word32)
-Eq_7631: (union "Eq_7631" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7631 (in a7_1330 + 44<i32> : word32)
 Eq_7633: (union "Eq_7633" (int32 u0) (uint32 u1))
 	T_7633 (in d3_1057 : Eq_7633)
 	T_7635 (in d3_1850 + 1<32> : word32)
 	T_7786 (in d3_1057 + 1<32> : word32)
 Eq_7634: (union "Eq_7634" (int32 u0) (uint32 u1))
 	T_7634 (in 1<32> : word32)
-Eq_7640: (union "Eq_7640" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7640 (in a7_1330 + 44<i32> : word32)
-Eq_7646: (union "Eq_7646" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7646 (in a7_1076 : Eq_7646)
+Eq_7646: (struct "Eq_7646" (0 ptr32 ptr0000) (4D byte b004D))
+	T_7646 (in a7_1076 : (ptr32 Eq_7646))
 	T_7648 (in a7_1330 - 4<i32> : word32)
-Eq_7647: (union "Eq_7647" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7647 (in 4<i32> : int32)
-Eq_7649: (union "Eq_7649" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7649 (in 78<i32> : int32)
-Eq_7652: (union "Eq_7652" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7652 (in a7_1076 + 0<32> : word32)
-Eq_7654: (union "Eq_7654" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7654 (in 4<i32> : int32)
-Eq_7655: (union "Eq_7655" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7655 (in a7_1076 - 4<i32> : word32)
-Eq_7657: (union "Eq_7657" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7657 (in a7_1076 - 4<i32> + 0<32> : word32)
-Eq_7660: (union "Eq_7660" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7660 (in 8<i32> : int32)
-Eq_7661: (union "Eq_7661" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7661 (in a7_1076 - 8<i32> : word32)
-Eq_7663: (union "Eq_7663" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7663 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_7665: (union "Eq_7665" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7665 (in 12<i32> : int32)
-Eq_7666: (union "Eq_7666" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7666 (in a7_1076 - 12<i32> : word32)
-Eq_7668: (union "Eq_7668" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7668 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_7671: (union "Eq_7671" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7671 (in a7_1076 + 0<32> : word32)
-Eq_7673: (fn int32 (Eq_25, Eq_25, Eq_25))
+Eq_7673: (fn int32 (Eq_718, Eq_718, Eq_718))
 	T_7673 (in fn00002648 : ptr32)
 	T_7674 (in signature of fn00002648 : void)
 	T_7851 (in fn00002648 : ptr32)
-Eq_7675: (union "Eq_7675" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7675 (in a7_1076 - 12<i32> : word32)
-Eq_7677: (union "Eq_7677" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7677 (in a7_1076 - 12<i32> + 0<32> : word32)
-Eq_7679: (union "Eq_7679" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7679 (in 8<i32> : int32)
-Eq_7680: (union "Eq_7680" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7680 (in a7_1076 - 8<i32> : word32)
-Eq_7682: (union "Eq_7682" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7682 (in a7_1076 - 8<i32> + 0<32> : word32)
-Eq_7689: (union "Eq_7689" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7689 (in 4<i32> : int32)
-Eq_7690: (union "Eq_7690" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7690 (in a7_1076 - 4<i32> : word32)
-Eq_7692: (union "Eq_7692" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7692 (in a7_1076 - 4<i32> + 0<32> : word32)
 Eq_7701: (union "Eq_7701" (int32 u0) (uint32 u1))
 	T_7701 (in d6_1133 - d3_1057 : word32)
 	T_7702 (in 0<32> : word32)
-Eq_7706: (union "Eq_7706" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7706 (in a7_1076 + 77<i32> : word32)
-Eq_7741: (union "Eq_7741" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7741 (in a7_1182 : Eq_7741)
-	T_7743 (in a7_1330 - 4<i32> : word32)
-Eq_7742: (union "Eq_7742" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7742 (in 4<i32> : int32)
-Eq_7745: (union "Eq_7745" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7745 (in a7_1182 + 0<32> : word32)
-Eq_7751: (union "Eq_7751" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7751 (in a7_1182 + 0<32> : word32)
-Eq_7763: (union "Eq_7763" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7763 (in a7_1201 : Eq_7763)
-	T_7765 (in a7_1330 - 4<i32> : word32)
-Eq_7764: (union "Eq_7764" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7764 (in 4<i32> : int32)
-Eq_7767: (union "Eq_7767" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7767 (in a7_1201 + 0<32> : word32)
-Eq_7779: (union "Eq_7779" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7779 (in a7_1201 + 0<32> : word32)
 Eq_7785: (union "Eq_7785" (int32 u0) (uint32 u1))
 	T_7785 (in 1<32> : word32)
 Eq_7791: (union "Eq_7791" (int32 u0) (uint32 u1))
 	T_7791 (in 1<32> : word32)
-Eq_7796: (union "Eq_7796" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7796 (in a7_1330 + 73<i32> : word32)
-Eq_7800: (union "Eq_7800" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7800 (in a7_1302 : Eq_7800)
-	T_7802 (in a7_1330 - 4<i32> : word32)
-Eq_7801: (union "Eq_7801" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7801 (in 4<i32> : int32)
-Eq_7804: (union "Eq_7804" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7804 (in a7_1302 + 0<32> : word32)
-Eq_7806: (union "Eq_7806" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7806 (in 4<i32> : int32)
-Eq_7807: (union "Eq_7807" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7807 (in a7_1302 - 4<i32> : word32)
-Eq_7809: (union "Eq_7809" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7809 (in a7_1302 - 4<i32> + 0<32> : word32)
-Eq_7812: (union "Eq_7812" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7812 (in 1<i32> : int32)
-Eq_7813: (union "Eq_7813" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7813 (in a7_1302 - 1<i32> : word32)
-Eq_7815: (union "Eq_7815" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7815 (in a7_1302 - 1<i32> + 0<32> : word32)
-Eq_7818: (union "Eq_7818" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7818 (in a7_1302 + 0<32> : word32)
-Eq_7822: (union "Eq_7822" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7822 (in a7_1330 + 73<i32> : word32)
-Eq_7824: (union "Eq_7824" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7824 (in a7_1237 : Eq_7824)
-	T_7826 (in a7_1330 - 4<i32> : word32)
-Eq_7825: (union "Eq_7825" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7825 (in 4<i32> : int32)
-Eq_7827: (union "Eq_7827" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7827 (in 78<i32> : int32)
-Eq_7830: (union "Eq_7830" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7830 (in a7_1237 + 0<32> : word32)
-Eq_7832: (union "Eq_7832" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7832 (in 4<i32> : int32)
-Eq_7833: (union "Eq_7833" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7833 (in a7_1237 - 4<i32> : word32)
-Eq_7835: (union "Eq_7835" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7835 (in a7_1237 - 4<i32> + 0<32> : word32)
-Eq_7838: (union "Eq_7838" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7838 (in 8<i32> : int32)
-Eq_7839: (union "Eq_7839" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7839 (in a7_1237 - 8<i32> : word32)
-Eq_7841: (union "Eq_7841" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7841 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_7843: (union "Eq_7843" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7843 (in 12<i32> : int32)
-Eq_7844: (union "Eq_7844" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7844 (in a7_1237 - 12<i32> : word32)
-Eq_7846: (union "Eq_7846" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7846 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_7849: (union "Eq_7849" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7849 (in a7_1237 + 0<32> : word32)
-Eq_7852: (union "Eq_7852" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7852 (in a7_1237 - 12<i32> : word32)
-Eq_7854: (union "Eq_7854" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7854 (in a7_1237 - 12<i32> + 0<32> : word32)
-Eq_7856: (union "Eq_7856" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7856 (in 8<i32> : int32)
-Eq_7857: (union "Eq_7857" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7857 (in a7_1237 - 8<i32> : word32)
-Eq_7859: (union "Eq_7859" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7859 (in a7_1237 - 8<i32> + 0<32> : word32)
-Eq_7866: (union "Eq_7866" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7866 (in 4<i32> : int32)
-Eq_7867: (union "Eq_7867" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7867 (in a7_1237 - 4<i32> : word32)
-Eq_7869: (union "Eq_7869" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7869 (in a7_1237 - 4<i32> + 0<32> : word32)
 Eq_7878: (union "Eq_7878" (int32 u0) (uint32 u1))
 	T_7878 (in d6_1133 - d3_1057 : word32)
 	T_7879 (in 0<32> : word32)
-Eq_7890: (union "Eq_7890" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7890 (in a7_1330 + 60<i32> : word32)
-Eq_7894: (union "Eq_7894" (uint8 u0) ((ptr32 Eq_8326) u1) (Eq_6344 u2) (Eq_7207 u3))
-	T_7894 (in a7_1330 + 60<i32> : word32)
-Eq_8029: (fn (ptr32 Eq_2656) (ptr32, ptr32))
+Eq_8029: (fn int32 (ptr32, ptr32))
 	T_8029 (in fn00003D2C : ptr32)
 	T_8030 (in signature of fn00003D2C : void)
 Eq_8066: (fn void ())
@@ -2777,25 +2325,25 @@ Eq_8066: (fn void ())
 	T_8067 (in signature of execPrivate2 : void)
 Eq_8184: (struct "Eq_8184" 0004 (0 byte b0000))
 	T_8184
-Eq_8241: (struct "Eq_8241" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8241: (struct "Eq_8241" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_73 t0004) (8 Eq_73 t0008) (14 int32 dw0014) (18 ui32 dw0018) (1C int32 dw001C))
 	T_8241
-Eq_8242: (struct "Eq_8242" (0 Eq_25 t0000))
+Eq_8242: (union "Eq_8242" (cu8 u0) (word32 u1) (Eq_1159 u2) (Eq_1162 u3) (Eq_1237 u4) (Eq_2296 u5) (Eq_2407 u6) (Eq_2448 u7))
 	T_8242
-Eq_8243: (union "Eq_8243" (int32 u0) (byte u1) (Eq_25 u2))
+Eq_8243: (union "Eq_8243" ((ptr32 Eq_1290) u0) (Eq_1824 u1) (Eq_1886 u2) (Eq_1892 u3) (Eq_1960 u4) (Eq_2003 u5) (Eq_2531 u6))
 	T_8243
-Eq_8244: (union "Eq_8244" (int32 u0) (uint32 u1) (byte u2) (ptr32 u3) (Eq_25 u4) (Eq_6621 u5) (Eq_6680 u6) (Eq_7207 u7))
+Eq_8244: (struct "Eq_8244" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8244
-Eq_8245: (union "Eq_8245" (uint8 u0) (word32 u1) (Eq_6344 u2))
+Eq_8245: (struct "Eq_8245" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8245
-Eq_8246: (union "Eq_8246" (uint8 u0) (word32 u1) (Eq_4251 u2) (Eq_6344 u3) (Eq_7207 u4))
+Eq_8246: (struct "Eq_8246" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8246
-Eq_8247: (union "Eq_8247" (int32 u0) (ptr32 u1) (Eq_6554 u2) (Eq_6618 u3) (Eq_6683 u4))
+Eq_8247: (struct "Eq_8247" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8247
-Eq_8248: (struct "Eq_8248" 0004 (FFFFFFFC (ptr32 Eq_8242) ptrFFFFFFFC) (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (arr Eq_160)) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020) (2C Eq_8243 t002C) (30 Eq_8244 t0030) (34 word32 dw0034) (37 Eq_8245 t0037) (38 Eq_8246 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8247 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8248: (struct "Eq_8248" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8248
-Eq_8249: (union "Eq_8249" (cu8 u0) (word32 u1) (Eq_1159 u2) (Eq_1162 u3) (Eq_1237 u4) (Eq_2296 u5) (Eq_2407 u6) (Eq_2448 u7))
+Eq_8249: (struct "Eq_8249" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8249
-Eq_8250: (union "Eq_8250" (int32 u0) (uint32 u1) (Eq_1126 u2) (Eq_1290 u3) (Eq_1824 u4) (Eq_1886 u5) (Eq_1892 u6) (Eq_1960 u7) (Eq_2003 u8) (Eq_2531 u9))
+Eq_8250: (struct "Eq_8250" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8250
 Eq_8251: (struct "Eq_8251" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8251
@@ -2817,182 +2365,100 @@ Eq_8259: (struct "Eq_8259" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8259
 Eq_8260: (struct "Eq_8260" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8260
-Eq_8261: (struct "Eq_8261" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8261: (union "Eq_8261" (int32 u0) (ptr32 u1) (Eq_6621 u2) (Eq_6680 u3) (Eq_7207 u4))
 	T_8261
-Eq_8262: (struct "Eq_8262" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8262: (union "Eq_8262" (int32 u0) (ptr32 u1) (Eq_6554 u2) (Eq_6618 u3) (Eq_6683 u4))
 	T_8262
-Eq_8263: (struct "Eq_8263" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8263: (struct "Eq_8263" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8263
-Eq_8264: (struct "Eq_8264" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8264: (struct "Eq_8264" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8264
-Eq_8265: (struct "Eq_8265" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8265: (struct "Eq_8265" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8265
-Eq_8266: (struct "Eq_8266" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8266: (struct "Eq_8266" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8266
-Eq_8267: (struct "Eq_8267" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (arr Eq_160)) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8267: (struct "Eq_8267" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8267
-Eq_8268: (union "Eq_8268" (int32 u0) (byte u1) (Eq_25 u2))
+Eq_8268: (struct "Eq_8268" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8268
-Eq_8269: (union "Eq_8269" (int32 u0) (uint32 u1) (byte u2) (ptr32 u3) (Eq_25 u4) (Eq_6621 u5) (Eq_6680 u6) (Eq_7207 u7))
+Eq_8269: (struct "Eq_8269" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8269
-Eq_8270: (union "Eq_8270" (uint8 u0) (word32 u1) (Eq_6344 u2))
+Eq_8270: (struct "Eq_8270" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8270
-Eq_8271: (union "Eq_8271" (uint8 u0) (word32 u1) (Eq_4251 u2) (Eq_6344 u3) (Eq_7207 u4))
+Eq_8271: (struct "Eq_8271" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8271
-Eq_8272: (union "Eq_8272" (int32 u0) (ptr32 u1) (Eq_6554 u2) (Eq_6618 u3) (Eq_6683 u4))
+Eq_8272: (struct "Eq_8272" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8272
-Eq_8273: (struct "Eq_8273" 0004 (0 Eq_25 t0000) (2C Eq_8268 t002C) (30 Eq_8269 t0030) (34 word32 dw0034) (37 Eq_8270 t0037) (38 Eq_8271 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8272 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
+Eq_8273: (struct "Eq_8273" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8273
-Eq_8274: (struct "Eq_8274" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8274: (struct "Eq_8274" 0001 (0 word32 dw0000) (3 byte b0003))
 	T_8274
-Eq_8275: (struct "Eq_8275" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8275: (struct "Eq_8275" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8275
-Eq_8276: (struct "Eq_8276" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8276: (struct "Eq_8276" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8276
-Eq_8277: (struct "Eq_8277" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8277: (struct "Eq_8277" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8277
-Eq_8278: (struct "Eq_8278" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8278: (struct "Eq_8278" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8278
-Eq_8279: (struct "Eq_8279" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8279: (struct "Eq_8279" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8279
-Eq_8280: (struct "Eq_8280" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8280: (struct "Eq_8280" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8280
-Eq_8281: (struct "Eq_8281" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8281: (struct "Eq_8281" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8281
-Eq_8282: (struct "Eq_8282" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8282: (struct "Eq_8282" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8282
-Eq_8283: (struct "Eq_8283" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8283: (struct "Eq_8283" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8283
-Eq_8284: (struct "Eq_8284" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8284: (struct "Eq_8284" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8284
-Eq_8285: (struct "Eq_8285" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8285: (struct "Eq_8285" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8285
-Eq_8286: (struct "Eq_8286" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8286: (struct "Eq_8286" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8286
-Eq_8287: (struct "Eq_8287" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8287: (struct "Eq_8287" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8287
-Eq_8288: (struct "Eq_8288" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8288: (struct "Eq_8288" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8288
-Eq_8289: (struct "Eq_8289" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160)))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8289: (struct "Eq_8289" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8289
-Eq_8290: (struct "Eq_8290" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8290: (struct "Eq_8290" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8290
-Eq_8291: (struct "Eq_8291" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8291: (struct "Eq_8291" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8291
-Eq_8292: (struct "Eq_8292" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8292: (struct "Eq_8292" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8292
-Eq_8293: (struct "Eq_8293" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8293: (struct "Eq_8293" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8293
-Eq_8294: (struct "Eq_8294" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8294: (struct "Eq_8294" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8294
-Eq_8295: (struct "Eq_8295" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8295: (struct "Eq_8295" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8295
-Eq_8296: (struct "Eq_8296" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8296: (struct "Eq_8296" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8296
-Eq_8297: (struct "Eq_8297" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8297: (struct "Eq_8297" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8297
-Eq_8298: (struct "Eq_8298" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8298: (struct "Eq_8298" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8298
-Eq_8299: (struct "Eq_8299" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
+Eq_8299: (struct "Eq_8299" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8299
-Eq_8300: (struct "Eq_8300" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8300: (struct "Eq_8300" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8300
-Eq_8301: (struct "Eq_8301" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8301: (struct "Eq_8301" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8301
-Eq_8302: (struct "Eq_8302" 0001 (0 word32 dw0000) (3 byte b0003))
+Eq_8302: (struct "Eq_8302" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8302
-Eq_8303: (struct "Eq_8303" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8303: (struct "Eq_8303" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8303
-Eq_8304: (struct "Eq_8304" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8304: (struct "Eq_8304" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8304
-Eq_8305: (struct "Eq_8305" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8305: (struct "Eq_8305" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8305
-Eq_8306: (struct "Eq_8306" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8306: (struct "Eq_8306" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8306
-Eq_8307: (struct "Eq_8307" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
+Eq_8307: (struct "Eq_8307" 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))
 	T_8307
-Eq_8308: (struct "Eq_8308" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8308
-Eq_8309: (struct "Eq_8309" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8309
-Eq_8310: (struct "Eq_8310" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8310
-Eq_8311: (struct "Eq_8311" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8311
-Eq_8312: (struct "Eq_8312" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8312
-Eq_8313: (struct "Eq_8313" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8313
-Eq_8314: (struct "Eq_8314" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8314
-Eq_8315: (struct "Eq_8315" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8315
-Eq_8316: (struct "Eq_8316" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8316
-Eq_8317: (struct "Eq_8317" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8317
-Eq_8318: (struct "Eq_8318" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8318
-Eq_8319: (struct "Eq_8319" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8319
-Eq_8320: (struct "Eq_8320" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8320
-Eq_8321: (union "Eq_8321" (int32 u0) (byte u1) (Eq_25 u2))
-	T_8321
-Eq_8322: (union "Eq_8322" (int32 u0) (uint32 u1) (byte u2) (ptr32 u3) (Eq_25 u4) (Eq_6621 u5) (Eq_6680 u6) (Eq_7207 u7))
-	T_8322
-Eq_8323: (union "Eq_8323" (uint8 u0) (word32 u1) (Eq_6344 u2))
-	T_8323
-Eq_8324: (union "Eq_8324" (uint8 u0) (word32 u1) (Eq_4251 u2) (Eq_6344 u3) (Eq_7207 u4))
-	T_8324
-Eq_8325: (union "Eq_8325" (int32 u0) (ptr32 u1) (Eq_6554 u2) (Eq_6618 u3) (Eq_6683 u4))
-	T_8325
-Eq_8326: (struct "Eq_8326" 0004 (0 Eq_25 t0000) (2C Eq_8321 t002C) (30 Eq_8322 t0030) (34 word32 dw0034) (37 Eq_8323 t0037) (38 Eq_8324 t0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8325 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (4C byte b004C) (4D byte b004D) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
-	T_8326
-Eq_8327: (struct "Eq_8327" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8327
-Eq_8328: (struct "Eq_8328" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8328
-Eq_8329: (struct "Eq_8329" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8329
-Eq_8330: (struct "Eq_8330" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8330
-Eq_8331: (struct "Eq_8331" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8331
-Eq_8332: (struct "Eq_8332" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8332
-Eq_8333: (struct "Eq_8333" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8333
-Eq_8334: (struct "Eq_8334" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8334
-Eq_8335: (struct "Eq_8335" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8335
-Eq_8336: (struct "Eq_8336" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8336
-Eq_8337: (struct "Eq_8337" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8337
-Eq_8338: (struct "Eq_8338" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8338
-Eq_8339: (struct "Eq_8339" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8339
-Eq_8340: (struct "Eq_8340" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8340
-Eq_8341: (struct "Eq_8341" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8341
-Eq_8342: (struct "Eq_8342" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (arr Eq_160)) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8342
-Eq_8343: (struct "Eq_8343" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8343
-Eq_8344: (struct "Eq_8344" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8344
-Eq_8345: (struct "Eq_8345" 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (arr Eq_160))))))) ptr0010) (14 (ptr32 Eq_2656) ptr0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))
-	T_8345
-Eq_8346: (struct "Eq_8346" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8346
-Eq_8347: (struct "Eq_8347" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8347
-Eq_8348: (struct "Eq_8348" 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))
-	T_8348
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -3090,17 +2556,17 @@ T_24: (in FindTask(0<32>) : word32)
   Class: Eq_19
   DataType: (ptr32 Eq_19)
   OrigDataType: word32
-T_25: (in a1_255 : Eq_25)
+T_25: (in a1_255 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  DataType: (ptr32 Eq_25)
+  OrigDataType: (ptr32 (struct 0001 (0 byte b0000)))
 T_26: (in 000012BC : ptr32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
-T_27: (in d0_112 : Eq_25)
+T_27: (in d0_112 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: (ptr32 (struct (0 T_104 t0000) (4 T_316 t0004) (8 T_25 t0008) (C T_106 t000C) (10 T_165 t0010)))
 T_28: (in OpenLibrary : ptr32)
   Class: Eq_28
@@ -3128,13 +2594,13 @@ T_33: (in 0<i32> : int32)
   OrigDataType: int32
 T_34: (in OpenLibrary(0x12BC<u32>, 0<i32>) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_35: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_36: (in d0_112 == 0<32> : bool)
+T_36: (in d0_112 == null : bool)
   Class: Eq_36
   DataType: bool
   OrigDataType: bool
@@ -3220,11 +2686,11 @@ T_56: (in d4_74 : int32)
   OrigDataType: int32
 T_57: (in 00003D78 : ptr32)
   Class: Eq_57
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 (ptr32 Eq_25))
   OrigDataType: (ptr32 (struct (0 T_58 t0000)))
 T_58: (in Mem67[0x00003D78<p32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_59: (in 172<i32> : int32)
   Class: Eq_59
@@ -3282,13 +2748,13 @@ T_72: (in d0_100 + d2_102 : word32)
   Class: Eq_71
   DataType: ui32
   OrigDataType: ui32
-T_73: (in d1_111 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+T_73: (in d1_111 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: byte
 T_74: (in 0x10001<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_75: (in AllocMem : ptr32)
   Class: Eq_75
@@ -3320,13 +2786,13 @@ T_81: (in 0x10001<32> : word32)
   OrigDataType: word32
 T_82: (in AllocMem(d0_107 + 0x11<32>, 0x10001<32>) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_83: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_84: (in d0_112 == 0<32> : bool)
+T_84: (in d0_112 == null : bool)
   Class: Eq_84
   DataType: bool
   OrigDataType: bool
@@ -3360,17 +2826,17 @@ T_91: (in signature of CloseLibrary : void)
   OrigDataType: 
 T_92: (in library : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: 
 T_93: (in 00003D78 : ptr32)
   Class: Eq_93
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 (ptr32 Eq_25))
   OrigDataType: (ptr32 (struct (0 T_94 t0000)))
 T_94: (in Mem67[0x00003D78<p32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_95: (in CloseLibrary(globals->t3D78) : void)
+T_95: (in CloseLibrary(globals->ptr3D78) : void)
   Class: Eq_95
   DataType: void
   OrigDataType: void
@@ -3408,8 +2874,8 @@ T_103: (in d0_112 + 0<32> : word32)
   OrigDataType: word32
 T_104: (in Mem169[d0_112 + 0<32>:word32] : word32)
   Class: Eq_77
-  DataType: Eq_25
-  OrigDataType: Eq_77
+  DataType: Eq_77
+  OrigDataType: word32
 T_105: (in 1<32> : word32)
   Class: Eq_105
   DataType: int32
@@ -3428,8 +2894,8 @@ T_108: (in d0_112 + 12<i32> : word32)
   OrigDataType: ptr32
 T_109: (in Mem173[d0_112 + 12<i32>:word32] : word32)
   Class: Eq_106
-  DataType: Eq_25
-  OrigDataType: Eq_106
+  DataType: Eq_106
+  OrigDataType: word32
 T_110: (in 16<i32> : int32)
   Class: Eq_110
   DataType: int32
@@ -3438,9 +2904,9 @@ T_111: (in d0_112 + 16<i32> : word32)
   Class: Eq_111
   DataType: ptr32
   OrigDataType: ptr32
-T_112: (in (word32) d0_112 + 16<i32> + d0_100 : word32)
+T_112: (in d0_112 + 16<i32> + d0_100 : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_113: (in 8<i32> : int32)
   Class: Eq_113
@@ -3452,7 +2918,7 @@ T_114: (in d0_112 + 8<i32> : word32)
   OrigDataType: ptr32
 T_115: (in Mem177[d0_112 + 8<i32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_116: (in 0<32> : word32)
   Class: Eq_116
@@ -3526,9 +2992,9 @@ T_133: (in Mem194[0<32>:word32] : word32)
   Class: Eq_116
   DataType: (ptr32 Eq_116)
   OrigDataType: word32
-T_134: (in d0_197 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_134: (in d0_197 : Eq_134)
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: ui32
 T_135: (in 36<i32> : int32)
   Class: Eq_135
@@ -3539,12 +3005,12 @@ T_136: (in d0_180 + 36<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_137: (in Mem194[d0_180 + 36<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_138: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_134
+  DataType: int32
   OrigDataType: word32
 T_139: (in d0_197 == 0<32> : bool)
   Class: Eq_139
@@ -3580,7 +3046,7 @@ T_146: (in d0_112 + 8<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_147: (in Mem179[d0_112 + 8<i32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_148: (in a0_260 : (ptr32 (arr Eq_160)))
   Class: Eq_148
@@ -3602,9 +3068,9 @@ T_152: (in (d0_252 << 2<32>) + 1<i32> : word32)
   Class: Eq_148
   DataType: (ptr32 (arr Eq_160))
   OrigDataType: ui32
-T_153: (in d0_262 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_153: (in d0_262 : Eq_134)
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: (union (int32 u0) (uint32 u1))
 T_154: (in 0<32> : word32)
   Class: Eq_154
@@ -3627,8 +3093,8 @@ T_158: (in (uint8) 0<32>[d0_252 * 4<32>] : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_159: (in (uint32) (uint8) 0<32>[d0_252 * 4<32>] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: uint32
 T_160: (in 0<8> : byte)
   Class: Eq_160
@@ -3652,8 +3118,8 @@ T_164: (in d0_112 + 16<i32> : word32)
   OrigDataType: ptr32
 T_165: (in Mem265[d0_112 + 16<i32>:word32] : word32)
   Class: Eq_148
-  DataType: Eq_25
-  OrigDataType: (ptr32 (arr Eq_160))
+  DataType: (ptr32 (arr Eq_160))
+  OrigDataType: word32
 T_166: (in a6_266 : (ptr32 word32))
   Class: Eq_166
   DataType: (ptr32 word32)
@@ -3772,7 +3238,7 @@ T_194: (in a1_255 + 0<32> : word32)
   OrigDataType: ptr32
 T_195: (in Mem380[a1_255 + 0<32>:byte] : byte)
   Class: Eq_192
-  DataType: Eq_25
+  DataType: byte
   OrigDataType: byte
 T_196: (in 0<32> : word32)
   Class: Eq_196
@@ -3804,11 +3270,11 @@ T_202: (in execPrivate4() : void)
   OrigDataType: void
 T_203: (in 00003D84 : ptr32)
   Class: Eq_203
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_204 t0000)))
 T_204: (in Mem416[0x00003D84<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_205: (in execPrivate5 : ptr32)
   Class: Eq_205
@@ -3824,11 +3290,11 @@ T_207: (in execPrivate5() : void)
   OrigDataType: void
 T_208: (in 00003D88 : ptr32)
   Class: Eq_208
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_209 t0000)))
 T_209: (in Mem418[0x00003D88<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_210: (in 16<i32> : int32)
   Class: Eq_210
@@ -3907,8 +3373,8 @@ T_228: (in SLICE(d1_111, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_229: (in SEQ(SLICE(d1_111, word24, 8), v40_292) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_230: (in 0<8> : byte)
   Class: Eq_220
@@ -3938,7 +3404,7 @@ T_236: (in Mem291[d0_112 + 12<i32>:word32] : word32)
   Class: Eq_106
   DataType: Eq_106
   OrigDataType: int32
-T_237: (in d3_267 - *((word32) d0_112 + 12<i32>) : word32)
+T_237: (in d3_267 - d0_112[3<i32>] : word32)
   Class: Eq_237
   DataType: int32
   OrigDataType: int32
@@ -3946,7 +3412,7 @@ T_238: (in 0<32> : word32)
   Class: Eq_237
   DataType: int32
   OrigDataType: word32
-T_239: (in d3_267 - *((word32) d0_112 + 12<i32>) == 0<32> : bool)
+T_239: (in d3_267 - d0_112[3<i32>] == 0<32> : bool)
   Class: Eq_239
   DataType: bool
   OrigDataType: bool
@@ -3960,7 +3426,7 @@ T_241: (in a6_266 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_242: (in Mem313[a6_266 + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_243: (in 4<i32> : int32)
   Class: Eq_243
@@ -4031,8 +3497,8 @@ T_259: (in a2_290 + 1<i32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_260: (in SEQ(v72_327, v71_324) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_261: (in 0<8> : byte)
   Class: Eq_252
@@ -4052,7 +3518,7 @@ T_264: (in a1_255 + 0<32> : word32)
   OrigDataType: (ptr32 byte)
 T_265: (in Mem366[a1_255 + 0<32>:byte] : byte)
   Class: Eq_220
-  DataType: Eq_25
+  DataType: byte
   OrigDataType: byte
 T_266: (in 1<i32> : int32)
   Class: Eq_266
@@ -4060,7 +3526,7 @@ T_266: (in 1<i32> : int32)
   OrigDataType: int32
 T_267: (in a1_255 + 1<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_268: (in v50_371 : byte)
   Class: Eq_268
@@ -4088,7 +3554,7 @@ T_273: (in a1_255 + 0<32> : word32)
   OrigDataType: (ptr32 byte)
 T_274: (in Mem516[a1_255 + 0<32>:byte] : byte)
   Class: Eq_271
-  DataType: Eq_25
+  DataType: byte
   OrigDataType: byte
 T_275: (in 1<i32> : int32)
   Class: Eq_275
@@ -4096,7 +3562,7 @@ T_275: (in 1<i32> : int32)
   OrigDataType: int32
 T_276: (in a1_255 + 1<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_277: (in 0<32> : word32)
   Class: Eq_277
@@ -4108,7 +3574,7 @@ T_278: (in a1_255 + 0<32> : word32)
   OrigDataType: (ptr32 byte)
 T_279: (in Mem523[a1_255 + 0<32>:byte] : byte)
   Class: Eq_268
-  DataType: Eq_25
+  DataType: byte
   OrigDataType: byte
 T_280: (in 1<i32> : int32)
   Class: Eq_280
@@ -4116,7 +3582,7 @@ T_280: (in 1<i32> : int32)
   OrigDataType: int32
 T_281: (in a1_255 + 1<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_282: (in 0<32> : word32)
   Class: Eq_282
@@ -4143,8 +3609,8 @@ T_287: (in SLICE(d1_111, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_288: (in SEQ(SLICE(d1_111, word24, 8), v50_371) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_289: (in 0<8> : byte)
   Class: Eq_268
@@ -4222,9 +3688,9 @@ T_307: (in signature of fn0000126C : void)
   Class: Eq_306
   DataType: (ptr32 Eq_306)
   OrigDataType: 
-T_308: (in a2 : Eq_25)
+T_308: (in a2 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_309: (in fn0000126C(d0_112) : void)
   Class: Eq_309
@@ -4240,7 +3706,7 @@ T_311: (in signature of Supervisor : void)
   OrigDataType: 
 T_312: (in userFunction : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: 
 T_313: (in Supervisor(d0_112) : void)
   Class: Eq_313
@@ -4255,16 +3721,16 @@ T_315: (in d0_112 + 4<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_316: (in Mem209[d0_112 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_317: (in 000012C8 : ptr32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: ptr32
 T_318: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_134
+  DataType: int32
   OrigDataType: word32
 T_319: (in d0_197 != 0<32> : bool)
   Class: Eq_319
@@ -4284,27 +3750,27 @@ T_322: (in Enable() : void)
   OrigDataType: void
 T_323: (in 00003D84 : ptr32)
   Class: Eq_323
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_324 t0000)))
 T_324: (in Mem214[0x00003D84<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_325: (in 00003D88 : ptr32)
   Class: Eq_325
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_326 t0000)))
 T_326: (in Mem216[0x00003D88<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_327: (in 00003D8C : ptr32)
   Class: Eq_327
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_328 t0000)))
 T_328: (in Mem218[0x00003D8C<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_329: (in 156<i32> : int32)
   Class: Eq_329
@@ -4315,8 +3781,8 @@ T_330: (in d0_36 + 156<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_331: (in Mem221[d0_36 + 156<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_332: (in 160<i32> : int32)
   Class: Eq_332
@@ -4327,8 +3793,8 @@ T_333: (in d0_36 + 160<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_334: (in Mem223[d0_36 + 160<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_335: (in d0_227 : word32)
   Class: Eq_335
@@ -4420,7 +3886,7 @@ T_356: (in a1_255 + 0<32> : word32)
   OrigDataType: (ptr32 byte)
 T_357: (in Mem362[a1_255 + 0<32>:byte] : byte)
   Class: Eq_354
-  DataType: Eq_25
+  DataType: byte
   OrigDataType: byte
 T_358: (in 1<i32> : int32)
   Class: Eq_358
@@ -4428,7 +3894,7 @@ T_358: (in 1<i32> : int32)
   OrigDataType: int32
 T_359: (in a1_255 + 1<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_360: (in v75_337 : byte)
   Class: Eq_360
@@ -4455,8 +3921,8 @@ T_365: (in a2_290 + 1<i32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_366: (in SEQ(v72_327, v75_337) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_367: (in 0xDF<8> : byte)
   Class: Eq_367
@@ -4487,8 +3953,8 @@ T_373: (in (v75_337 & 0xDF<8>) != 0x45<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_374: (in 10<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_375: (in a5_713 : word32)
   Class: Eq_375
@@ -4551,20 +4017,20 @@ T_389: (in fn0000127C(out a1_714, out a5_715) : word32)
   DataType: word32
   OrigDataType: word32
 T_390: (in 27<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_391: (in 00003D8C : ptr32)
   Class: Eq_391
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_392 t0000)))
 T_392: (in Mem435[0x00003D8C<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
-T_393: (in v92_428 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_393: (in v92_428 : Eq_134)
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_394: (in 224<i32> : int32)
   Class: Eq_394
@@ -4575,20 +4041,20 @@ T_395: (in d0_36 + 224<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_396: (in Mem418[d0_36 + 224<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_397: (in 00003D8C : ptr32)
   Class: Eq_397
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_134)
   OrigDataType: (ptr32 (struct (0 T_398 t0000)))
 T_398: (in Mem429[0x00003D8C<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_134
+  DataType: Eq_134
   OrigDataType: word32
 T_399: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_134
+  DataType: int32
   OrigDataType: word32
 T_400: (in v92_428 != 0<32> : bool)
   Class: Eq_400
@@ -4698,13 +4164,13 @@ T_426: (in signature of fn00001354 : void)
   Class: Eq_425
   DataType: (ptr32 Eq_425)
   OrigDataType: 
-T_427: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_427: (in d1 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_428: (in a1 : Eq_25)
+T_428: (in a1 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_429: (in dwArg04 : int32)
   Class: Eq_169
@@ -4788,7 +4254,7 @@ T_448: (in signature of ReplyMsg : void)
   OrigDataType: 
 T_449: (in message : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: 
 T_450: (in ReplyMsg(a2) : void)
   Class: Eq_450
@@ -4878,9 +4344,9 @@ T_471: (in Mem0[a7_6 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_379
   DataType: (ptr32 Eq_379)
   OrigDataType: word32
-T_472: (in v5_8 : Eq_25)
+T_472: (in v5_8 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_473: (in 8<i32> : int32)
   Class: Eq_473
@@ -4888,7 +4354,7 @@ T_473: (in 8<i32> : int32)
   OrigDataType: int32
 T_474: (in a7_6 - 8<i32> : word32)
   Class: Eq_474
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 (ptr32 Eq_25))
   OrigDataType: (ptr32 (struct (0 T_477 t0000)))
 T_475: (in 0<32> : word32)
   Class: Eq_475
@@ -4900,7 +4366,7 @@ T_476: (in a7_6 - 8<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_477: (in Mem0[a7_6 - 8<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_478: (in d1_14 : word32)
   Class: Eq_462
@@ -4944,21 +4410,21 @@ T_487: (in CloseLibrary : ptr32)
   OrigDataType: (ptr32 (fn T_490 (T_489)))
 T_488: (in 00003D78 : ptr32)
   Class: Eq_488
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 (ptr32 Eq_25))
   OrigDataType: (ptr32 (struct (0 T_489 t0000)))
 T_489: (in Mem0[0x00003D78<p32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_490: (in CloseLibrary(globals->t3D78) : void)
+T_490: (in CloseLibrary(globals->ptr3D78) : void)
   Class: Eq_95
   DataType: void
   OrigDataType: void
 T_491: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_492: (in v5_8 == 0<32> : bool)
+T_492: (in v5_8 == null : bool)
   Class: Eq_492
   DataType: bool
   OrigDataType: bool
@@ -5310,13 +4776,13 @@ T_579: (in 00003EB0 : ptr32)
   Class: Eq_578
   DataType: (ptr32 (ptr32 code))
   OrigDataType: ptr32
-T_580: (in d0_10 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_580: (in d0_10 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_581: (in 0x3EAC<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_582: (in 0x3EAC<32> : word32)
   Class: Eq_582
@@ -5354,17 +4820,17 @@ T_590: (in signature of fn00001390 : void)
   Class: Eq_589
   DataType: (ptr32 Eq_589)
   OrigDataType: 
-T_591: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_591: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_592: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_592: (in d1 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_593: (in a1 : Eq_25)
+T_593: (in a1 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_594: (in fn00001390(d0_10, d1, a1) : word32)
   Class: Eq_452
@@ -5446,9 +4912,9 @@ T_613: (in signature of fn000013FC : void)
   Class: Eq_612
   DataType: (ptr32 Eq_612)
   OrigDataType: 
-T_614: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_614: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_615: (in dwArg04 : (ptr32 byte))
   Class: Eq_615
@@ -5462,17 +4928,17 @@ T_617: (in signature of fn00002B40 : void)
   Class: Eq_616
   DataType: (ptr32 Eq_616)
   OrigDataType: 
-T_618: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_618: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_619: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_619: (in d1 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_620: (in a1 : Eq_25)
+T_620: (in a1 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_621: (in dwArg04 : (ptr32 Eq_621))
   Class: Eq_621
@@ -5491,32 +4957,32 @@ T_624: (in 000013E4 : ptr32)
   DataType: (ptr32 Eq_621)
   OrigDataType: ptr32
 T_625: (in fn00002B40(d0, d1, a1, &globals->t13E4) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_626: (in 000013E8 : ptr32)
   Class: Eq_621
   DataType: (ptr32 Eq_621)
   OrigDataType: ptr32
 T_627: (in fn00002B40(fn00002B40(d0, d1, a1, &globals->t13E4), d1, a1, &globals->t13E8) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_628: (in 000013EC : ptr32)
   Class: Eq_621
   DataType: (ptr32 Eq_621)
   OrigDataType: ptr32
 T_629: (in fn00002B40(fn00002B40(fn00002B40(d0, d1, a1, &globals->t13E4), d1, a1, &globals->t13E8), d1, a1, &globals->t13EC) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_630: (in 000013F4 : ptr32)
   Class: Eq_615
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_631: (in fn000013FC(fn00002B40(fn00002B40(fn00002B40(d0, d1, a1, &globals->t13E4), d1, a1, &globals->t13E8), d1, a1, &globals->t13EC), &globals->b13F4) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_632: (in fn00001418 : ptr32)
   Class: Eq_632
@@ -5526,10 +4992,10 @@ T_633: (in signature of fn00001418 : void)
   Class: Eq_632
   DataType: (ptr32 Eq_632)
   OrigDataType: 
-T_634: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_25)
+T_634: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (ptr32 Eq_73)
 T_635: (in dwArg04 : (ptr32 Eq_635))
   Class: Eq_635
   DataType: (ptr32 Eq_635)
@@ -5563,17 +5029,17 @@ T_642: (in fp + 8<i32> : word32)
   DataType: Eq_637
   OrigDataType: ptr32
 T_643: (in fn00001418(d0, *(struct Eq_635 **) 0x3ED0<u32>, dwArg04, fp + 8<i32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_644: (in d0_1952 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_644: (in d0_1952 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_645: (in a7_1968 : (ptr32 Eq_645))
   Class: Eq_645
   DataType: (ptr32 Eq_645)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1159 u2) (T_1165 u3) (T_1240 u4) (T_2299 u5) (T_2410 u6) (T_2451 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1290 u2) (T_1297 u3) (T_1308 u4) (T_1824 u5) (T_1889 u6) (T_1892 u7) (T_1960 u8) (T_2006 u9) (T_2534 u10)) u0066) (6A byte b006A)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1159 u2) (T_1165 u3) (T_1240 u4) (T_2299 u5) (T_2410 u6) (T_2451 u7)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (48 ui32 dw0048) (66 (union (int32 u0) (uint32 u1) (T_1290 u2) (T_1297 u3) (T_1308 u4) (T_1824 u5) (T_1889 u6) (T_1892 u7) (T_1960 u8) (T_2006 u9) (T_2534 u10)) u0066) (6A byte b006A)))
 T_646: (in fp : ptr32)
   Class: Eq_646
   DataType: ptr32
@@ -5589,7 +5055,7 @@ T_648: (in fp + -112<i32> : word32)
 T_649: (in d3_1482 : Eq_637)
   Class: Eq_637
   DataType: Eq_637
-  OrigDataType: word32
+  OrigDataType: (ptr32 Eq_1290)
 T_650: (in a5_1579 : (ptr32 Eq_635))
   Class: Eq_635
   DataType: (ptr32 Eq_635)
@@ -5598,13 +5064,13 @@ T_651: (in a4_1925 : (ptr32 byte))
   Class: Eq_615
   DataType: (ptr32 byte)
   OrigDataType: (union ((ptr32 byte) u1) (ptr32 u0))
-T_652: (in d6_1480 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_652: (in d6_1480 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_653: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_654: (in 0<32> : word32)
   Class: Eq_654
@@ -5795,8 +5261,8 @@ T_700: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_701: (in fn00001D98(*(a7_51 - 4<i32>), *a7_51, out a0_66, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_702: (in 4<i32> : int32)
   Class: Eq_702
@@ -5807,8 +5273,8 @@ T_703: (in a7_51 + 4<i32> : word32)
   DataType: (ptr32 Eq_645)
   OrigDataType: ptr32
 T_704: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_705: (in d0 != 0xFFFFFFFF<32> : bool)
   Class: Eq_705
@@ -5860,15 +5326,15 @@ T_716: (in a7_1968 + 102<i32> : word32)
   OrigDataType: ptr32
 T_717: (in Mem91[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_714
-  DataType: Eq_8250
+  DataType: Eq_8243
   OrigDataType: word32
-T_718: (in d5_256 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (struct "Eq_645" 0004 (2C Eq_8249 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8250 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
+T_718: (in d5_256 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: (struct "Eq_645" 0004 (2C Eq_8242 t002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 Eq_8243 t0066) (6A byte b006A) (6C word32 dw006C) (7C word32 dw007C))
 T_719: (in -1<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_720: (in d4_376 : int32)
   Class: Eq_720
@@ -5910,10 +5376,10 @@ T_729: (in a4_1925 + 1<i32> : word32)
   Class: Eq_727
   DataType: (ptr32 uint8)
   OrigDataType: ptr32
-T_730: (in d2_1005 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_25)
+T_730: (in d2_1005 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: (ptr32 Eq_718)
 T_731: (in 72<i32> : int32)
   Class: Eq_731
   DataType: int32
@@ -5923,32 +5389,32 @@ T_732: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_733: (in Mem91[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_734: (in d1_103 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_25)
+T_734: (in d1_103 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (ptr32 Eq_73)
 T_735: (in 1<32> : word32)
   Class: Eq_735
   DataType: word32
   OrigDataType: word32
 T_736: (in d1_103 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_737: (in 5<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: up32
 T_738: (in d1_103 < 5<32> : bool)
   Class: Eq_738
   DataType: bool
   OrigDataType: bool
-T_739: (in a7_99 : (ptr32 Eq_25))
+T_739: (in a7_99 : (ptr32 Eq_73))
   Class: Eq_739
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_614 t0000)))
 T_740: (in 0<32> : word32)
   Class: Eq_740
@@ -5959,20 +5425,20 @@ T_741: (in a7_99 + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_742: (in Mem121[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_743: (in d1_123 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_743: (in d1_123 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_744: (in 1<i32> : int32)
   Class: Eq_744
   DataType: int32
   OrigDataType: int32
 T_745: (in 1<i32> << d1_103 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_746: (in 0<32> : word32)
   Class: Eq_746
@@ -5983,12 +5449,12 @@ T_747: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_748: (in Mem121[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_749: (in d2_1005 | d1_123 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_750: (in 1<i32> : int32)
   Class: Eq_750
@@ -5999,16 +5465,16 @@ T_751: (in a2_135 + 1<i32> : word32)
   DataType: (ptr32 uint8)
   OrigDataType: ptr32
 T_752: (in 5<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: up32
 T_753: (in d1_103 < 5<32> : bool)
   Class: Eq_753
   DataType: bool
   OrigDataType: bool
 T_754: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_755: (in a0_1447 : (ptr32 Eq_755))
   Class: Eq_755
@@ -6027,8 +5493,8 @@ T_758: (in a7_1968 + 72<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_759: (in Mem143[a7_1968 + 72<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_760: (in 0<32> : word32)
   Class: Eq_760
@@ -6099,8 +5565,8 @@ T_776: (in a0_1447 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_777: (in Mem143[a0_1447 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_778: (in (uint8) Mem143[a0_1447 + 0<32>:byte] : uint8)
   Class: Eq_778
@@ -6316,7 +5782,7 @@ T_830: (in 4<i32> : int32)
   OrigDataType: int32
 T_831: (in a7_1968 - 4<i32> : word32)
   Class: Eq_739
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_832: (in 0<32> : word32)
   Class: Eq_832
@@ -6327,8 +5793,8 @@ T_833: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 Eq_833)
   OrigDataType: (ptr32 (union (int32 u1) (up32 u0)))
 T_834: (in Mem102[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: (union (int32 u1) (up32 u0))
 T_835: (in 0<32> : word32)
   Class: Eq_835
@@ -6339,8 +5805,8 @@ T_836: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_837: (in Mem102[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_838: (in 00001D70 : ptr32)
   Class: Eq_838
@@ -6479,8 +5945,8 @@ T_871: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_872: (in Mem248[a0_1447 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_873: (in (uint8) Mem248[a0_1447 + 0<32>:byte] : uint8)
   Class: Eq_873
@@ -6491,8 +5957,8 @@ T_874: (in (uint32) (uint8) Mem248[a0_1447 + 0<32>:byte] : uint32)
   DataType: uint32
   OrigDataType: uint32
 T_875: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_876: (in 4<32> : word32)
   Class: Eq_876
@@ -6603,12 +6069,12 @@ T_902: (in a7_1968 + 44<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_903: (in Mem335[a7_1968 + 44<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_904: (in a7_275 : (ptr32 Eq_25))
+T_904: (in a7_275 : (ptr32 Eq_718))
   Class: Eq_904
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_718 t0000)))
 T_905: (in 4<i32> : int32)
   Class: Eq_905
@@ -6616,7 +6082,7 @@ T_905: (in 4<i32> : int32)
   OrigDataType: int32
 T_906: (in a7_1968 - 4<i32> : word32)
   Class: Eq_904
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: ptr32
 T_907: (in 0<32> : word32)
   Class: Eq_907
@@ -6627,8 +6093,8 @@ T_908: (in a7_275 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_909: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_910: (in d1_284 : uint32)
   Class: Eq_910
@@ -6643,16 +6109,16 @@ T_912: (in signature of __swap : void)
   DataType: (ptr32 Eq_911)
   OrigDataType: 
 T_913: (in  : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: 
 T_914: (in 10<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_915: (in __swap(10<i32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_916: (in SLICE(d5_256, word16, 0) : word16)
   Class: Eq_916
@@ -6679,8 +6145,8 @@ T_921: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_922 (T_718)))
 T_922: (in __swap(d5_256) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_923: (in 0xA<16> : word16)
   Class: Eq_923
@@ -6699,12 +6165,12 @@ T_926: (in SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_927: (in SEQ(SLICE(d1_284, word16, 16), SLICE(d1_284 + __swap(d5_256) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_928: (in __swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_929: (in SLICE(__swap(SEQ(SLICE(d1_284, word16, 16), (word16) (d1_284 + __swap(d5_256) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_929
@@ -6831,8 +6297,8 @@ T_959: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_960: (in Mem278[a0_1447 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_961: (in (uint8) Mem278[a0_1447 + 0<32>:byte] : uint8)
   Class: Eq_961
@@ -6851,24 +6317,24 @@ T_964: (in a7_275 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_965: (in Mem278[a7_275 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_966: (in 0x30<32> : word32)
   Class: Eq_966
   DataType: int32
   OrigDataType: int32
 T_967: (in d1_303 - 0x30<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_968: (in d1_303 - 0x30<32> : word32)
   Class: Eq_968
   DataType: int32
   OrigDataType: int32
 T_969: (in d1_303 - 0x30<32> + d0_293 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_970: (in 4<32> : word32)
   Class: Eq_970
@@ -7047,8 +6513,8 @@ T_1013: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1014: (in Mem143[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1015: (in 4<i32> : int32)
   Class: Eq_1015
@@ -7079,12 +6545,12 @@ T_1021: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_1023 (T_1022)))
 T_1022: (in 10<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_1023: (in __swap(10<i32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_1024: (in SLICE(d2_1005, word16, 0) : word16)
   Class: Eq_1024
@@ -7111,8 +6577,8 @@ T_1029: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_1030 (T_730)))
 T_1030: (in __swap(d2_1005) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_1031: (in 0xA<16> : word16)
   Class: Eq_1031
@@ -7131,12 +6597,12 @@ T_1034: (in SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_1035: (in SEQ(SLICE(d1_177, word16, 16), SLICE(d1_177 + __swap(d2_1005) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_1036: (in __swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1037: (in SLICE(__swap(SEQ(SLICE(d1_177, word16, 16), (word16) (d1_177 + __swap(d2_1005) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_1037
@@ -7263,8 +6729,8 @@ T_1067: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_1068: (in Mem171[a0_1447 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_1069: (in (uint8) Mem171[a0_1447 + 0<32>:byte] : uint8)
   Class: Eq_1069
@@ -7295,16 +6761,16 @@ T_1075: (in 0x30<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_1076: (in d1_196 - 0x30<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_1077: (in d1_196 - 0x30<32> : word32)
   Class: Eq_1077
   DataType: int32
   OrigDataType: int32
 T_1078: (in d1_196 - 0x30<32> + d0_186 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_1079: (in 4<32> : word32)
   Class: Eq_1079
@@ -7335,8 +6801,8 @@ T_1085: (in a7_1968 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_1086: (in Mem217[a7_1968 + 64<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1087: (in 0x6C<32> : word32)
   Class: Eq_720
@@ -7447,8 +6913,8 @@ T_1113: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_1114: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_1115: (in d5_1481 : Eq_1115)
   Class: Eq_1115
@@ -7494,17 +6960,17 @@ T_1125: (in SEQ(SLICE(d1_103, word24, 8), v100_428) : uip32)
   Class: Eq_1123
   DataType: (ptr32 Eq_1123)
   OrigDataType: uip32
-T_1126: (in d0_1471 : Eq_1126)
+T_1126: (in d0_1471 : (ptr32 Eq_1290))
   Class: Eq_1126
-  DataType: Eq_1126
-  OrigDataType: word32
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_1127: (in SLICE(d0_159, word24, 8) : word24)
   Class: Eq_1127
   DataType: word24
   OrigDataType: word24
 T_1128: (in SEQ(SLICE(d0_159, word24, 8), v100_428) : uip32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: uip32
 T_1129: (in 0x25<8> : byte)
   Class: Eq_1116
@@ -7532,7 +6998,7 @@ T_1134: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1135: (in Mem465[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1132
-  DataType: Eq_8250
+  DataType: Eq_8243
   OrigDataType: word32
 T_1136: (in 00001D6C : ptr32)
   Class: Eq_615
@@ -7684,7 +7150,7 @@ T_1172: (in 2<32> : word32)
   OrigDataType: word32
 T_1173: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: ui32
 T_1174: (in 0<32> : word32)
   Class: Eq_1174
@@ -7712,7 +7178,7 @@ T_1179: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1180: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1177
-  DataType: Eq_8250
+  DataType: Eq_8243
   OrigDataType: word32
 T_1181: (in 4<32> : word32)
   Class: Eq_1181
@@ -7731,8 +7197,8 @@ T_1184: (in a1_661 : (ptr32 byte))
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct 0001 (0 byte b0000)))
 T_1185: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_1186: (in d5_256 == 0<32> : bool)
   Class: Eq_1186
@@ -7769,7 +7235,7 @@ T_1193: (in d3_1050 : ptr32)
 T_1194: (in a7_1020 : (ptr32 Eq_645))
   Class: Eq_645
   DataType: (ptr32 Eq_645)
-  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1159 u2) (T_1165 u3) (T_1240 u4) (T_2299 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 word32 dw0037) (38 word32 dw0038) (3C word32 dw003C) (3E word32 dw003E) (3F word32 dw003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1290 u2) (T_1297 u3) (T_1308 u4) (T_1824 u5) (T_1889 u6) (T_1892 u7) (T_1960 u8) (T_2006 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
+  OrigDataType: (ptr32 (struct 0004 (2C (union (cu8 u0) (word32 u1) (T_1159 u2) (T_1165 u3) (T_1240 u4) (T_2299 u5)) u002C) (30 word32 dw0030) (34 word32 dw0034) (37 byte b0037) (38 word32 dw0038) (3C word32 dw003C) (3E word16 w003E) (3F byte b003F) (40 word32 dw0040) (44 word32 dw0044) (48 ui32 dw0048) (62 word32 dw0062) (66 (union (int32 u0) (uint32 u1) (T_1290 u2) (T_1297 u3) (T_1308 u4) (T_1824 u5) (T_1889 u6) (T_1892 u7) (T_1960 u8) (T_2006 u9)) u0066) (6C word32 dw006C) (7C word32 dw007C)))
 T_1195: (in SLICE(d1_1068, byte, 0) : byte)
   Class: Eq_1195
   DataType: byte
@@ -8036,7 +7502,7 @@ T_1260: (in 8<i32> : int32)
   OrigDataType: int32
 T_1261: (in a7_1174 - 8<i32> : word32)
   Class: Eq_1261
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_1264 t0000)))
 T_1262: (in 0<32> : word32)
   Class: Eq_1262
@@ -8047,8 +7513,8 @@ T_1263: (in a7_1174 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1264: (in Mem1188[a7_1174 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1265: (in 4<i32> : int32)
   Class: Eq_1265
@@ -8080,7 +7546,7 @@ T_1271: (in d1_1182 - (d0_1181 < null) >= 0<32> : bool)
   OrigDataType: bool
 T_1272: (in a2_1892 - a4_1925 : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_1273: (in 102<i32> : int32)
   Class: Eq_1273
@@ -8092,8 +7558,8 @@ T_1274: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1275: (in Mem756[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1126
-  DataType: Eq_8250
-  OrigDataType: Eq_1126
+  DataType: Eq_8243
+  OrigDataType: (ptr32 Eq_1290)
 T_1276: (in 0<32> : word32)
   Class: Eq_1276
   DataType: word32
@@ -8152,17 +7618,17 @@ T_1289: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_1290: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1290
-  DataType: Eq_1290
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_1291: (in d5_256 - a7_1968->t0066 : word32)
   Class: Eq_1291
-  DataType: Eq_1291
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_1292: (in 0<32> : word32)
   Class: Eq_1291
-  DataType: ui24
+  DataType: (ptr32 Eq_1290)
   OrigDataType: up32
-T_1293: (in d5_256 - a7_1968->t0066 <= 0<32> : bool)
+T_1293: (in d5_256 - a7_1968->t0066 <= null : bool)
   Class: Eq_1293
   DataType: bool
   OrigDataType: bool
@@ -8176,12 +7642,12 @@ T_1295: (in 102<i32> : int32)
   OrigDataType: int32
 T_1296: (in a7_1968 + 102<i32> : word32)
   Class: Eq_1296
-  DataType: (ptr32 Eq_1296)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2)))
+  DataType: (ptr32 (ptr32 Eq_1290))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2)))
 T_1297: (in Mem662[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1126
-  DataType: Eq_1126
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_1298: (in 0<32> : word32)
   Class: Eq_1298
   DataType: word32
@@ -8204,13 +7670,13 @@ T_1302: (in *a1_661 != 0<8> : bool)
   OrigDataType: bool
 T_1303: (in d5_256 - d0_1471 : word32)
   Class: Eq_1303
-  DataType: Eq_1303
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_1304: (in 0<32> : word32)
   Class: Eq_1303
-  DataType: ui24
+  DataType: (ptr32 Eq_1290)
   OrigDataType: up32
-T_1305: (in d5_256 - d0_1471 <= 0<32> : bool)
+T_1305: (in d5_256 - d0_1471 <= null : bool)
   Class: Eq_1305
   DataType: bool
   OrigDataType: bool
@@ -8220,20 +7686,20 @@ T_1306: (in 102<i32> : int32)
   OrigDataType: int32
 T_1307: (in a7_1968 + 102<i32> : word32)
   Class: Eq_1307
-  DataType: (ptr32 Eq_1307)
+  DataType: (ptr32 (ptr32 Eq_1290))
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (T_1290 u2) (T_1297 u3)))
 T_1308: (in Mem719[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_1126
-  DataType: Eq_8250
-  OrigDataType: Eq_1126
+  DataType: Eq_8243
+  OrigDataType: (ptr32 Eq_1290)
 T_1309: (in 1<32> : word32)
   Class: Eq_1309
-  DataType: ui24
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_1310: (in d0_1471 + 1<32> : word32)
   Class: Eq_1126
-  DataType: Eq_1126
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_1311: (in 1<i32> : int32)
   Class: Eq_1311
   DataType: int32
@@ -8243,8 +7709,8 @@ T_1312: (in a1_661 + 1<i32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_1313: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: up32
 T_1314: (in d5_256 <= 0<32> : bool)
   Class: Eq_1314
@@ -8676,7 +8142,7 @@ T_1420: (in a7_1508 + 0<32> : word32)
   OrigDataType: ptr32
 T_1421: (in Mem1516[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_1422: (in 48<i32> : int32)
   Class: Eq_1422
@@ -8716,7 +8182,7 @@ T_1430: (in a7_1508 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_1431: (in Mem1531[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_1432: (in 0<32> : word32)
   Class: Eq_1432
@@ -8724,28 +8190,28 @@ T_1432: (in 0<32> : word32)
   OrigDataType: word32
 T_1433: (in a7_1508 + 0<32> : word32)
   Class: Eq_1433
-  DataType: (ptr32 Eq_1433)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2)))
+  DataType: (ptr32 (ptr32 Eq_1290))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2)))
 T_1434: (in Mem1537[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1126
-  DataType: Eq_1126
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
-T_1435: (in d0_1541 : Eq_1126)
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
+T_1435: (in d0_1541 : (ptr32 Eq_1290))
   Class: Eq_1126
-  DataType: Eq_1126
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_1436: (in 0<32> : word32)
   Class: Eq_1436
   DataType: word32
   OrigDataType: word32
 T_1437: (in a7_1508 + 0<32> : word32)
   Class: Eq_1437
-  DataType: (ptr32 Eq_1437)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2)))
+  DataType: (ptr32 (ptr32 Eq_1290))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2)))
 T_1438: (in Mem1537[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1126
-  DataType: Eq_1126
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_1439: (in 52<i32> : int32)
   Class: Eq_1439
   DataType: int32
@@ -8856,12 +8322,12 @@ T_1465: (in 0<32> : word32)
   OrigDataType: word32
 T_1466: (in a7_1508 + 0<32> : word32)
   Class: Eq_1466
-  DataType: (ptr32 Eq_1466)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2)))
+  DataType: (ptr32 (ptr32 Eq_1290))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2)))
 T_1467: (in Mem1546[a7_1508 + 0<32>:word32] : word32)
   Class: Eq_1126
-  DataType: Eq_1126
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_1468: (in 68<i32> : int32)
   Class: Eq_1468
   DataType: int32
@@ -8942,9 +8408,9 @@ T_1487: (in Mem1564[a7_1465 + 48<i32>:word32] : word32)
   Class: Eq_1484
   DataType: word32
   OrigDataType: word32
-T_1488: (in d0_1566 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1488: (in d0_1566 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_1489: (in 72<i32> : int32)
   Class: Eq_1489
@@ -8963,12 +8429,12 @@ T_1492: (in 2<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_1493: (in a7_1465[18<i32>] & 2<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_1494: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_1495: (in d0_1566 == 0<32> : bool)
   Class: Eq_1495
@@ -9123,8 +8589,8 @@ T_1532: (in a7_1020 + 68<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1533: (in Mem1340[a7_1020 + 68<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1534: (in 48<i32> : int32)
   Class: Eq_1534
@@ -9135,8 +8601,8 @@ T_1535: (in a7_1020 + 48<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1536: (in Mem1359[a7_1020 + 48<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_1537: (in 98<i32> : int32)
   Class: Eq_1537
@@ -9178,9 +8644,9 @@ T_1546: (in Mem1367[v187_1368 + 0<32>:word32] : word32)
   Class: Eq_1543
   DataType: word32
   OrigDataType: word32
-T_1547: (in d7_1371 : Eq_1126)
+T_1547: (in d7_1371 : (ptr32 Eq_1290))
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_1548: (in 4<i32> : int32)
   Class: Eq_1548
@@ -9192,7 +8658,7 @@ T_1549: (in v187_1368 + 4<i32> : word32)
   OrigDataType: ptr32
 T_1550: (in Mem1367[v187_1368 + 4<i32>:word32] : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_1551: (in d3_1373 : word32)
   Class: Eq_1551
@@ -9447,12 +8913,12 @@ T_1613: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1614: (in fn00001D98(*(a7_1578 - 4<i32>), a7_1578->ptr0000, out a0_1447, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_1615: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_1616: (in d0_1566 != 0xFFFFFFFF<32> : bool)
   Class: Eq_1616
@@ -9471,8 +8937,8 @@ T_1619: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_1620: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_1621: (in d7_1024 - d2_1571 : word32)
   Class: Eq_1621
@@ -9624,7 +9090,7 @@ T_1657: (in 20<i32> : int32)
   OrigDataType: int32
 T_1658: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1658
-  DataType: (ptr32 Eq_1126)
+  DataType: (ptr32 (ptr32 Eq_1290))
   OrigDataType: (ptr32 (struct (0 T_1661 t0000)))
 T_1659: (in 0<32> : word32)
   Class: Eq_1659
@@ -9636,7 +9102,7 @@ T_1660: (in a7_1383 - 20<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_1661: (in Mem1400[a7_1383 - 20<i32> + 0<32>:word32] : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_1662: (in 24<i32> : int32)
   Class: Eq_1662
@@ -9670,25 +9136,25 @@ T_1669: (in signature of fn00002700 : void)
   Class: Eq_1668
   DataType: (ptr32 Eq_1668)
   OrigDataType: 
-T_1670: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1670: (in dwArg04 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_1671: (in dwArg08 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1671: (in dwArg08 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_1672: (in dwArg0C : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1672: (in dwArg0C : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_1673: (in dwArg10 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1673: (in dwArg10 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_1674: (in a7_1383 - 24<i32> : word32)
   Class: Eq_1674
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_1677 t0000)))
 T_1675: (in 0<32> : word32)
   Class: Eq_1675
@@ -9699,8 +9165,8 @@ T_1676: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1677: (in Mem1403[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1678: (in 20<i32> : int32)
   Class: Eq_1678
@@ -9708,7 +9174,7 @@ T_1678: (in 20<i32> : int32)
   OrigDataType: int32
 T_1679: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1679
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_1682 t0000)))
 T_1680: (in 0<32> : word32)
   Class: Eq_1680
@@ -9719,8 +9185,8 @@ T_1681: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1682: (in Mem1403[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1683: (in 16<i32> : int32)
   Class: Eq_1683
@@ -9728,7 +9194,7 @@ T_1683: (in 16<i32> : int32)
   OrigDataType: int32
 T_1684: (in a7_1383 - 16<i32> : word32)
   Class: Eq_1684
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_1687 t0000)))
 T_1685: (in 0<32> : word32)
   Class: Eq_1685
@@ -9739,8 +9205,8 @@ T_1686: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1687: (in Mem1403[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1688: (in 12<i32> : int32)
   Class: Eq_1688
@@ -9748,7 +9214,7 @@ T_1688: (in 12<i32> : int32)
   OrigDataType: int32
 T_1689: (in a7_1383 - 12<i32> : word32)
   Class: Eq_1689
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_1692 t0000)))
 T_1690: (in 0<32> : word32)
   Class: Eq_1690
@@ -9759,8 +9225,8 @@ T_1691: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1692: (in Mem1403[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1693: (in fn00002700(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>)) : word32)
   Class: Eq_1667
@@ -9956,7 +9422,7 @@ T_1740: (in 20<i32> : int32)
   OrigDataType: int32
 T_1741: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1741
-  DataType: (ptr32 Eq_1126)
+  DataType: (ptr32 (ptr32 Eq_1290))
   OrigDataType: (ptr32 (struct (0 T_1744 t0000)))
 T_1742: (in 0<32> : word32)
   Class: Eq_1742
@@ -9968,7 +9434,7 @@ T_1743: (in a7_1383 - 20<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_1744: (in Mem1444[a7_1383 - 20<i32> + 0<32>:word32] : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_1745: (in 24<i32> : int32)
   Class: Eq_1745
@@ -9990,9 +9456,9 @@ T_1749: (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
   Class: Eq_1543
   DataType: word32
   OrigDataType: word32
-T_1750: (in d1_1450 : Eq_1126)
+T_1750: (in d1_1450 : (ptr32 Eq_1290))
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: up32
 T_1751: (in d0_1449 : word32)
   Class: Eq_1543
@@ -10006,33 +9472,33 @@ T_1753: (in signature of fn000023B8 : void)
   Class: Eq_1752
   DataType: (ptr32 Eq_1752)
   OrigDataType: 
-T_1754: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1754: (in dwArg04 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_1755: (in dwArg08 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1755: (in dwArg08 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_1756: (in dwArg0C : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1756: (in dwArg0C : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_1757: (in dwArg10 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1757: (in dwArg10 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_1758: (in d1Out : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1758: (in d1Out : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
-T_1759: (in a0Out : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1759: (in a0Out : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_1760: (in a7_1383 - 24<i32> : word32)
   Class: Eq_1760
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_1763 t0000)))
 T_1761: (in 0<32> : word32)
   Class: Eq_1761
@@ -10043,8 +9509,8 @@ T_1762: (in a7_1383 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1763: (in Mem1446[a7_1383 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1764: (in 20<i32> : int32)
   Class: Eq_1764
@@ -10052,7 +9518,7 @@ T_1764: (in 20<i32> : int32)
   OrigDataType: int32
 T_1765: (in a7_1383 - 20<i32> : word32)
   Class: Eq_1765
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_1768 t0000)))
 T_1766: (in 0<32> : word32)
   Class: Eq_1766
@@ -10063,8 +9529,8 @@ T_1767: (in a7_1383 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1768: (in Mem1446[a7_1383 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1769: (in 16<i32> : int32)
   Class: Eq_1769
@@ -10072,7 +9538,7 @@ T_1769: (in 16<i32> : int32)
   OrigDataType: int32
 T_1770: (in a7_1383 - 16<i32> : word32)
   Class: Eq_1770
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_1773 t0000)))
 T_1771: (in 0<32> : word32)
   Class: Eq_1771
@@ -10083,8 +9549,8 @@ T_1772: (in a7_1383 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1773: (in Mem1446[a7_1383 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1774: (in 12<i32> : int32)
   Class: Eq_1774
@@ -10092,7 +9558,7 @@ T_1774: (in 12<i32> : int32)
   OrigDataType: int32
 T_1775: (in a7_1383 - 12<i32> : word32)
   Class: Eq_1775
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_1778 t0000)))
 T_1776: (in 0<32> : word32)
   Class: Eq_1776
@@ -10103,16 +9569,16 @@ T_1777: (in a7_1383 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1778: (in Mem1446[a7_1383 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_1779: (in out d1_1450 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_1780: (in out a0_1447 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: (ptr32 (struct (0 T_777 t0000)))
 T_1781: (in fn000023B8(*(a7_1383 - 24<i32>), *(a7_1383 - 20<i32>), *(a7_1383 - 16<i32>), *(a7_1383 - 12<i32>), out d1_1450, out a0_1447) : word32)
   Class: Eq_1543
@@ -10156,13 +9622,13 @@ T_1790: (in d3_1373 + 1<32> : word32)
   OrigDataType: word32
 T_1791: (in 0<32> : word32)
   Class: Eq_1126
-  DataType: ui24
+  DataType: (ptr32 Eq_1290)
   OrigDataType: up32
-T_1792: (in d1_1450 < 0<32> : bool)
+T_1792: (in d1_1450 < null : bool)
   Class: Eq_1792
   DataType: Eq_1792
   OrigDataType: (union (bool u0) (word32 u1))
-T_1793: (in d0_1449 - (d1_1450 < 0<32>) : word32)
+T_1793: (in d0_1449 - (d1_1450 < null) : word32)
   Class: Eq_1793
   DataType: word32
   OrigDataType: word32
@@ -10170,7 +9636,7 @@ T_1794: (in 0<32> : word32)
   Class: Eq_1793
   DataType: word32
   OrigDataType: word32
-T_1795: (in d0_1449 - (d1_1450 < 0<32>) != 0<32> : bool)
+T_1795: (in d0_1449 - (d1_1450 < null) != 0<32> : bool)
   Class: Eq_1795
   DataType: bool
   OrigDataType: bool
@@ -10207,8 +9673,8 @@ T_1803: (in a7_1383 + 52<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1804: (in Mem1478[a7_1383 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_1805: (in 72<i32> : int32)
   Class: Eq_1805
@@ -10302,9 +9768,9 @@ T_1827: (in d5_1481 - a7_1465->t0066 > 0<32> : bool)
   Class: Eq_1827
   DataType: bool
   OrigDataType: bool
-T_1828: (in d0_1691 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_1828: (in d0_1691 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_1829: (in 72<i32> : int32)
   Class: Eq_1829
@@ -10323,12 +9789,12 @@ T_1832: (in 2<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_1833: (in a7_1465[18<i32>] & 2<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_1834: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_1835: (in d0_1691 != 0<32> : bool)
   Class: Eq_1835
@@ -10495,12 +9961,12 @@ T_1875: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1876: (in fn00001D98(*(a7_1465 - 8<i32>), *(a7_1465 - 4<i32>), out a0_1447, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_1877: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_1878: (in fn00001D98(*(a7_1465 - 8<i32>), *(a7_1465 - 4<i32>), out a0_1447, out a5_1579) != 0xFFFFFFFF<32> : bool)
   Class: Eq_1878
@@ -10519,8 +9985,8 @@ T_1881: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_1882: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_1883: (in a4_1632 - d2_1625 : word32)
   Class: Eq_1883
@@ -10715,12 +10181,12 @@ T_1930: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1931: (in fn00001D98(*(a7_1706 - 4<i32>), a7_1706->ptr0000, out a0_2918, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_1932: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_1933: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_1933
@@ -10739,8 +10205,8 @@ T_1936: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_1937: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_1938: (in d7_1024 - d2_1696 : word32)
   Class: Eq_1938
@@ -10935,12 +10401,12 @@ T_1985: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1986: (in fn00001D98(*(a7_1761 - 4<i32>), *a7_1761, out a0_2919, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_1987: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_1988: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_1988
@@ -10959,8 +10425,8 @@ T_1991: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_1992: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_1993: (in d5_1481 - d2_1747 : word32)
   Class: Eq_1993
@@ -10991,12 +10457,12 @@ T_1999: (in 4<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_2000: (in a7_1465[18<i32>] & 4<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_2001: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2002: (in d0 == 0<32> : bool)
   Class: Eq_2002
@@ -11031,8 +10497,8 @@ T_2009: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_2010: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_2011: (in a4_1798 - d2_1791 : word32)
   Class: Eq_2011
@@ -11163,12 +10629,12 @@ T_2042: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2043: (in fn00001D98(*(a7_1800 - 4<i32>), *a7_1800, out a0_2920, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2044: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2045: (in d0_1691 != 0xFFFFFFFF<32> : bool)
   Class: Eq_2045
@@ -11231,8 +10697,8 @@ T_2059: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_2060: (in d6_1480 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_2061: (in a3_1852 - d2_1847 : word32)
   Class: Eq_2061
@@ -11359,12 +10825,12 @@ T_2091: (in out a5_1579 : ptr32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2092: (in fn00001D98(*(a7_1854 - 4<i32>), *a7_1854, out a0_2921, out a5_1579) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2093: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2094: (in d0 != 0xFFFFFFFF<32> : bool)
   Class: Eq_2094
@@ -11538,22 +11004,22 @@ T_2136: (in Mem1091[a7_1057 + 0<32>:word32] : word32)
   Class: Eq_1123
   DataType: (ptr32 Eq_1123)
   OrigDataType: int32
-T_2137: (in v248_1105 : Eq_2137)
+T_2137: (in v248_1105 : byte)
   Class: Eq_2137
-  DataType: Eq_2137
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2138: (in 55<i32> : int32)
   Class: Eq_2138
   DataType: int32
   OrigDataType: int32
 T_2139: (in a7_1968 + 55<i32> : word32)
   Class: Eq_2139
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2140: (in Mem1104[a7_1968 + 55<i32>:byte] : byte)
   Class: Eq_2137
-  DataType: Eq_2137
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2141: (in a7_1109 : (ptr32 Eq_2141))
   Class: Eq_2141
   DataType: (ptr32 Eq_2141)
@@ -11768,8 +11234,8 @@ T_2193: (in 56<i32> : int32)
   OrigDataType: int32
 T_2194: (in a7_1968 + 56<i32> : word32)
   Class: Eq_2194
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2195: (in Mem836[a7_1968 + 56<i32>:word32] : word32)
   Class: Eq_2192
   DataType: word32
@@ -11798,22 +11264,22 @@ T_2201: (in d4_376 != 2<32> : bool)
   Class: Eq_2201
   DataType: bool
   OrigDataType: bool
-T_2202: (in v262_844 : Eq_2202)
+T_2202: (in v262_844 : word16)
   Class: Eq_2202
-  DataType: Eq_2202
-  OrigDataType: (union (word16 u0) (word32 u1))
+  DataType: word16
+  OrigDataType: word16
 T_2203: (in 62<i32> : int32)
   Class: Eq_2203
   DataType: int32
   OrigDataType: int32
 T_2204: (in a7_1968 + 62<i32> : word32)
   Class: Eq_2204
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2205: (in Mem843[a7_1968 + 62<i32>:word16] : word16)
   Class: Eq_2202
-  DataType: Eq_2202
-  OrigDataType: word32
+  DataType: word16
+  OrigDataType: word16
 T_2206: (in a7_848 : (ptr32 Eq_2206))
   Class: Eq_2206
   DataType: (ptr32 Eq_2206)
@@ -12068,7 +11534,7 @@ T_2268: (in 2<32> : word32)
   OrigDataType: word32
 T_2269: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: ui32
 T_2270: (in 0<32> : word32)
   Class: Eq_2270
@@ -12076,8 +11542,8 @@ T_2270: (in 0<32> : word32)
   OrigDataType: word32
 T_2271: (in d0_1471 + 0<32> : word32)
   Class: Eq_2271
-  DataType: Eq_2271
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_2272: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_755
   DataType: (ptr32 Eq_755)
@@ -12091,12 +11557,12 @@ T_2274: (in a0_1447 + 4<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2275: (in Mem623[a0_1447 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2276: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_2277: (in 0<32> : word32)
   Class: Eq_2277
@@ -12107,9 +11573,9 @@ T_2278: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_2279: (in Mem624[a0_1447 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: byte
 T_2280: (in d3_1482 + 3<32> : word32)
   Class: Eq_2280
   DataType: Eq_2280
@@ -12198,22 +11664,22 @@ T_2301: (in d0_891 == 0<32> : bool)
   Class: Eq_2301
   DataType: bool
   OrigDataType: bool
-T_2302: (in v277_869 : Eq_2302)
+T_2302: (in v277_869 : byte)
   Class: Eq_2302
-  DataType: Eq_2302
-  OrigDataType: (union (byte u0) (word32 u1))
+  DataType: byte
+  OrigDataType: byte
 T_2303: (in 63<i32> : int32)
   Class: Eq_2303
   DataType: int32
   OrigDataType: int32
 T_2304: (in a7_1968 + 63<i32> : word32)
   Class: Eq_2304
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_2305: (in Mem868[a7_1968 + 63<i32>:byte] : byte)
   Class: Eq_2302
-  DataType: Eq_2302
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_2306: (in a7_873 : (ptr32 Eq_2306))
   Class: Eq_2306
   DataType: (ptr32 Eq_2306)
@@ -12316,7 +11782,7 @@ T_2330: (in 2<32> : word32)
   OrigDataType: word32
 T_2331: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: ui32
 T_2332: (in 0<32> : word32)
   Class: Eq_2332
@@ -12324,8 +11790,8 @@ T_2332: (in 0<32> : word32)
   OrigDataType: word32
 T_2333: (in d0_1471 + 0<32> : word32)
   Class: Eq_2333
-  DataType: Eq_2333
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_2334: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_755
   DataType: (ptr32 Eq_755)
@@ -12339,8 +11805,8 @@ T_2336: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_2337: (in Mem611[a0_1447 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2338: (in SLICE(d1_1068, byte, 0) : byte)
   Class: Eq_2338
@@ -12367,8 +11833,8 @@ T_2343: (in (byte) d1_1068 == 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_2344: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_2345: (in d5_256 != 0<32> : bool)
   Class: Eq_2345
@@ -12476,7 +11942,7 @@ T_2370: (in 8<i32> : int32)
   OrigDataType: int32
 T_2371: (in a7_911 - 8<i32> : word32)
   Class: Eq_2371
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_2374 t0000)))
 T_2372: (in 0<32> : word32)
   Class: Eq_2372
@@ -12487,12 +11953,12 @@ T_2373: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2374: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_2375: (in a7_911 - 8<i32> : word32)
   Class: Eq_2375
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_2378 t0000)))
 T_2376: (in 0<32> : word32)
   Class: Eq_2376
@@ -12503,8 +11969,8 @@ T_2377: (in a7_911 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2378: (in Mem935[a7_911 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_2379: (in 4<i32> : int32)
   Class: Eq_2379
@@ -12588,7 +12054,7 @@ T_2398: (in 2<32> : word32)
   OrigDataType: word32
 T_2399: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: ui32
 T_2400: (in 0<32> : word32)
   Class: Eq_2400
@@ -12596,15 +12062,15 @@ T_2400: (in 0<32> : word32)
   OrigDataType: word32
 T_2401: (in d0_1471 + 0<32> : word32)
   Class: Eq_2401
-  DataType: Eq_2401
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_2402: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_755
   DataType: (ptr32 Eq_755)
   OrigDataType: word32
 T_2403: (in SLICE(d6_1480, word16, 0) : word16)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word16
 T_2404: (in 0<32> : word32)
   Class: Eq_2404
@@ -12615,8 +12081,8 @@ T_2405: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_2406: (in Mem599[a0_1447 + 0<32>:word16] : word16)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2407: (in SLICE(d1_1068, byte, 0) : byte)
   Class: Eq_2407
@@ -12716,7 +12182,7 @@ T_2430: (in 8<i32> : int32)
   OrigDataType: int32
 T_2431: (in a7_992 - 8<i32> : word32)
   Class: Eq_2431
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_2434 t0000)))
 T_2432: (in 0<32> : word32)
   Class: Eq_2432
@@ -12727,8 +12193,8 @@ T_2433: (in a7_992 - 8<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_2434: (in Mem1008[a7_992 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_2435: (in d1_1017 : word32)
   Class: Eq_2435
@@ -12904,7 +12370,7 @@ T_2477: (in 2<32> : word32)
   OrigDataType: word32
 T_2478: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: ui32
 T_2479: (in 0<32> : word32)
   Class: Eq_2479
@@ -12912,8 +12378,8 @@ T_2479: (in 0<32> : word32)
   OrigDataType: word32
 T_2480: (in d0_1471 + 0<32> : word32)
   Class: Eq_2480
-  DataType: Eq_2480
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_2481: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_755
   DataType: (ptr32 Eq_755)
@@ -12927,8 +12393,8 @@ T_2483: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_2484: (in Mem575[a0_1447 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2485: (in 3<32> : word32)
   Class: Eq_2485
@@ -12952,7 +12418,7 @@ T_2489: (in 2<32> : word32)
   OrigDataType: word32
 T_2490: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: ui32
 T_2491: (in 0<32> : word32)
   Class: Eq_2491
@@ -12960,15 +12426,15 @@ T_2491: (in 0<32> : word32)
   OrigDataType: word32
 T_2492: (in d0_1471 + 0<32> : word32)
   Class: Eq_2492
-  DataType: Eq_2492
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_2493: (in Mem535[d0_1471 + 0<32>:word32] : word32)
   Class: Eq_755
   DataType: (ptr32 Eq_755)
   OrigDataType: word32
 T_2494: (in SLICE(d6_1480, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2495: (in 0<32> : word32)
   Class: Eq_2495
@@ -12979,8 +12445,8 @@ T_2496: (in a0_1447 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_2497: (in Mem587[a0_1447 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_2498: (in 3<32> : word32)
   Class: Eq_2498
@@ -13004,7 +12470,7 @@ T_2502: (in 2<32> : word32)
   OrigDataType: word32
 T_2503: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: ui32
 T_2504: (in 3<32> : word32)
   Class: Eq_2504
@@ -13012,8 +12478,8 @@ T_2504: (in 3<32> : word32)
   OrigDataType: word32
 T_2505: (in d0_1471 + 3<32> : word32)
   Class: Eq_2505
-  DataType: Eq_2505
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_2506: (in Mem341[d0_1471 + 3<32>:byte] : byte)
   Class: Eq_2506
   DataType: byte
@@ -13052,7 +12518,7 @@ T_2514: (in 2<32> : word32)
   OrigDataType: word32
 T_2515: (in (word32) d3_1482 + 3<i32> >> 2<32> << 2<32> : word32)
   Class: Eq_1126
-  DataType: Eq_1126
+  DataType: (ptr32 Eq_1290)
   OrigDataType: ui32
 T_2516: (in 3<32> : word32)
   Class: Eq_2516
@@ -13060,8 +12526,8 @@ T_2516: (in 3<32> : word32)
   OrigDataType: word32
 T_2517: (in d0_1471 + 3<32> : word32)
   Class: Eq_2517
-  DataType: Eq_2517
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: (ptr32 Eq_1290)
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_2518: (in Mem341[d0_1471 + 3<32>:byte] : byte)
   Class: Eq_2518
   DataType: byte
@@ -13116,7 +12582,7 @@ T_2530: (in ((word32) d3_1482 + 3<i32> >> 2<32> << 2<32>) + 4<32> : word32)
   OrigDataType: ui32
 T_2531: (in 1<32> : word32)
   Class: Eq_2531
-  DataType: int32
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_2532: (in 102<i32> : int32)
   Class: Eq_2532
@@ -13128,8 +12594,8 @@ T_2533: (in a7_1968 + 102<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (uint32 u1) (Eq_1290 u2) (Eq_1126 u3) (Eq_1126 u4) (Eq_1824 u5) (Eq_1886 u6) (Eq_1892 u7) (Eq_1960 u8) (Eq_2003 u9)))
 T_2534: (in Mem525[a7_1968 + 102<i32>:word32] : word32)
   Class: Eq_2531
-  DataType: Eq_8250
-  OrigDataType: int32
+  DataType: Eq_8243
+  OrigDataType: (ptr32 Eq_1290)
 T_2535: (in 0<i32> : int32)
   Class: Eq_1115
   DataType: int32
@@ -13291,8 +12757,8 @@ T_2574: (in Mem63[dwArg08 + 4<i32>:word32] : word32)
   DataType: (ptr32 ui32)
   OrigDataType: word32
 T_2575: (in SLICE(dwArg04, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2576: (in 0<32> : word32)
   Class: Eq_2576
@@ -13303,8 +12769,8 @@ T_2577: (in a0_104 + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_2578: (in Mem66[a0_104 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2579: (in 0<32> : word32)
   Class: Eq_2579
@@ -13315,8 +12781,8 @@ T_2580: (in a0_104 + 0<32> : word32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 byte)
 T_2581: (in Mem66[a0_104 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2582: (in (uint8) Mem66[a0_104 + 0<32>:byte] : uint8)
   Class: Eq_2582
@@ -13396,7 +12862,7 @@ T_2600: (in out a5_127 : ptr32)
   OrigDataType: ptr32
 T_2601: (in fn00002388(out a1_35, out a5_127) : word32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: word32
 T_2602: (in 0<32> : word32)
   Class: Eq_635
@@ -13614,9 +13080,9 @@ T_2655: (in a1_337 : word32)
   Class: Eq_2655
   DataType: word32
   OrigDataType: word32
-T_2656: (in d0_160 : (ptr32 Eq_2656))
+T_2656: (in d0_160 : int32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
 T_2657: (in fn00001FB4 : ptr32)
   Class: Eq_2657
@@ -13672,13 +13138,13 @@ T_2669: (in out a1_337 : ptr32)
   OrigDataType: ptr32
 T_2670: (in fn00001FB4(d4_143 + dwArg08->dw001C, out d1_161, out a0, out a1_337) : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
 T_2671: (in 0<32> : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
-T_2672: (in d0_160 != null : bool)
+T_2672: (in d0_160 != 0<32> : bool)
   Class: Eq_2672
   DataType: bool
   OrigDataType: bool
@@ -13819,8 +13285,8 @@ T_2706: (in Mem116[dwArg08 + 4<i32>:word32] : word32)
   DataType: (ptr32 ui32)
   OrigDataType: word32
 T_2707: (in SLICE(dwArg04, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2708: (in 0<32> : word32)
   Class: Eq_2708
@@ -13831,8 +13297,8 @@ T_2709: (in a0_112 + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_2710: (in Mem118[a0_112 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_2711: (in a1_338 : word32)
   Class: Eq_2711
@@ -14088,7 +13554,7 @@ T_2773: (in out a5_23 : ptr32)
   OrigDataType: ptr32
 T_2774: (in fn00002388(out a1_21, out a5_23) : word32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: word32
 T_2775: (in 0<32> : word32)
   Class: Eq_635
@@ -14502,17 +13968,17 @@ T_2877: (in globals->ptr3DA8 != null : bool)
   Class: Eq_2877
   DataType: bool
   OrigDataType: bool
-T_2878: (in a0_13 : (ptr32 Eq_2656))
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+T_2878: (in a0_13 : (ptr32 Eq_2878))
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: word32
 T_2879: (in 00003DA4 : ptr32)
   Class: Eq_2879
-  DataType: (ptr32 (ptr32 Eq_2656))
+  DataType: (ptr32 (ptr32 Eq_2878))
   OrigDataType: (ptr32 (struct (0 T_2880 t0000)))
 T_2880: (in Mem5[0x00003DA4<p32>:word32] : word32)
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: word32
 T_2881: (in 0<32> : word32)
   Class: Eq_116
@@ -14534,33 +14000,33 @@ T_2885: (in dwArg04 : Eq_106)
   Class: Eq_106
   DataType: Eq_106
   OrigDataType: word32
-T_2886: (in dwArg08 : (ptr32 Eq_2656))
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+T_2886: (in dwArg08 : (ptr32 Eq_2878))
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: up32
-T_2887: (in dwArg0C : (ptr32 Eq_2656))
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+T_2887: (in dwArg0C : (ptr32 Eq_2878))
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: up32
-T_2888: (in d1Out : (ptr32 Eq_2656))
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+T_2888: (in d1Out : (ptr32 Eq_2878))
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: ptr32
 T_2889: (in a0Out : (ptr32 Eq_4))
   Class: Eq_4
   DataType: (ptr32 Eq_4)
   OrigDataType: ptr32
-T_2890: (in a1Out : Eq_25)
+T_2890: (in a1Out : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_2891: (in dwLoc10 : word32)
   Class: Eq_106
   DataType: Eq_106
   OrigDataType: word32
 T_2892: (in out d1 : ptr32)
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: ptr32
 T_2893: (in out a0 : ptr32)
   Class: Eq_4
@@ -14568,7 +14034,7 @@ T_2893: (in out a0 : ptr32)
   OrigDataType: ptr32
 T_2894: (in out a1 : ptr32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_2895: (in fn000022A8(dwLoc10, a0_13, a0_13, out d1, out a0, out a1) : word32)
   Class: Eq_4
@@ -15082,13 +14548,13 @@ T_3022: (in a2_40->dw001C - dwArg04->dw0010 != 0<32> : bool)
   Class: Eq_3022
   DataType: bool
   OrigDataType: bool
-T_3023: (in d0 : Eq_25)
+T_3023: (in d0 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3024: (in d0_158 : Eq_25)
+T_3024: (in d0_158 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3025: (in a0_115 : (ptr32 Eq_4))
   Class: Eq_4
@@ -15122,13 +14588,13 @@ T_3032: (in a0_115->t0014 < 0x27<16> : bool)
   Class: Eq_3032
   DataType: bool
   OrigDataType: bool
-T_3033: (in a3_120 : Eq_25)
+T_3033: (in a3_120 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  DataType: (ptr32 Eq_25)
+  OrigDataType: ptr32
 T_3034: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3035: (in 0<32> : word32)
   Class: Eq_4
@@ -15156,7 +14622,7 @@ T_3040: (in poolHeader : word32)
   OrigDataType: 
 T_3041: (in AllocPooled(dwArg08, dwArg04) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3042: (in d1 : word32)
   Class: Eq_78
@@ -15206,9 +14672,9 @@ T_3053: (in Mem26[dwArg04 + 12<i32>:word32] : word32)
   Class: Eq_78
   DataType: Eq_78
   OrigDataType: word32
-T_3054: (in d0_50 : Eq_25)
+T_3054: (in d0_50 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: (ptr32 (struct (0 T_3188 t0000) (C T_3199 t000C)))
 T_3055: (in AllocMem : ptr32)
   Class: Eq_75
@@ -15224,13 +14690,13 @@ T_3057: (in dwArg08 + 16<i32> : word32)
   OrigDataType: up32
 T_3058: (in AllocMem(dwArg08 + 16<i32>, d1) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3059: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3060: (in d0_50 == 0<32> : bool)
+T_3060: (in d0_50 == null : bool)
   Class: Eq_3060
   DataType: bool
   OrigDataType: bool
@@ -15286,9 +14752,9 @@ T_3073: (in Mem26[dwArg04 + 12<i32>:word32] : word32)
   Class: Eq_78
   DataType: Eq_78
   OrigDataType: word32
-T_3074: (in d0_82 : Eq_25)
+T_3074: (in d0_82 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: (ptr32 (struct (0 T_3109 t0000) (C T_3113 t000C) (14 T_3115 t0014) (18 T_3122 t0018) (1C T_3150 t001C) (20 T_3068 t0020)))
 T_3075: (in AllocMem : ptr32)
   Class: Eq_75
@@ -15296,13 +14762,13 @@ T_3075: (in AllocMem : ptr32)
   OrigDataType: (ptr32 (fn T_3076 (T_3065, T_3042)))
 T_3076: (in AllocMem(d3_77, d1) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3077: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3078: (in d0_82 == 0<32> : bool)
+T_3078: (in d0_82 == null : bool)
   Class: Eq_3078
   DataType: bool
   OrigDataType: bool
@@ -15338,9 +14804,9 @@ T_3086: (in Mem26[a5_162 + 0<32>:word32] : word32)
   Class: Eq_4
   DataType: (ptr32 Eq_4)
   OrigDataType: word32
-T_3087: (in d0_128 : Eq_25)
+T_3087: (in d0_128 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3088: (in Allocate : ptr32)
   Class: Eq_3088
@@ -15360,13 +14826,13 @@ T_3091: (in byteSize : word32)
   OrigDataType: 
 T_3092: (in Allocate(a5_162, dwArg08) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3093: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3094: (in d0_128 != 0<32> : bool)
+T_3094: (in d0_128 != null : bool)
   Class: Eq_3094
   DataType: bool
   OrigDataType: bool
@@ -15428,8 +14894,8 @@ T_3108: (in d0_82 + 0<32> : word32)
   OrigDataType: word32
 T_3109: (in Mem88[d0_82 + 0<32>:word32] : word32)
   Class: Eq_77
-  DataType: Eq_25
-  OrigDataType: Eq_77
+  DataType: Eq_77
+  OrigDataType: word32
 T_3110: (in 0xA<8> : byte)
   Class: Eq_106
   DataType: byte
@@ -15444,15 +14910,15 @@ T_3112: (in d0_82 + 12<i32> : word32)
   OrigDataType: ptr32
 T_3113: (in Mem91[d0_82 + 12<i32>:byte] : byte)
   Class: Eq_106
-  DataType: Eq_25
+  DataType: Eq_106
   OrigDataType: byte
 T_3114: (in 40<i32> : int32)
   Class: Eq_3114
   DataType: int32
   OrigDataType: int32
 T_3115: (in d0_82 + 40<i32> : word32)
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: ptr32
 T_3116: (in 20<i32> : int32)
   Class: Eq_3116
@@ -15463,12 +14929,12 @@ T_3117: (in d0_82 + 20<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3118: (in Mem95[d0_82 + 20<i32>:word32] : word32)
-  Class: Eq_2656
-  DataType: Eq_25
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: word32
 T_3119: (in d0_82 + 40<i32> : word32)
   Class: Eq_3119
-  DataType: Eq_3119
+  DataType: ptr32
   OrigDataType: ptr32
 T_3120: (in 24<i32> : int32)
   Class: Eq_3120
@@ -15480,7 +14946,7 @@ T_3121: (in d0_82 + 24<i32> : word32)
   OrigDataType: ptr32
 T_3122: (in Mem97[d0_82 + 24<i32>:word32] : word32)
   Class: Eq_3119
-  DataType: Eq_25
+  DataType: ptr32
   OrigDataType: word32
 T_3123: (in 0<32> : word32)
   Class: Eq_3123
@@ -15491,8 +14957,8 @@ T_3124: (in d0_82 + 20<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_3125: (in Mem97[d0_82 + 20<i32>:word32] : word32)
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: (ptr32 (struct (0 T_3128 t0000)))
 T_3126: (in 0<32> : word32)
   Class: Eq_3126
@@ -15504,19 +14970,19 @@ T_3127: (in Mem97[d0_82 + 20<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_3128: (in Mem99[Mem97[d0_82 + 20<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_3123
-  DataType: Eq_25
+  DataType: word32
   OrigDataType: word32
-T_3129: (in a2_100 : (ptr32 Eq_2656))
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+T_3129: (in a2_100 : (ptr32 Eq_2878))
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: (ptr32 (struct (4 T_3068 t0004)))
 T_3130: (in d0_82 + 20<i32> : word32)
   Class: Eq_3130
   DataType: (ptr32 ptr32)
   OrigDataType: (ptr32 ptr32)
 T_3131: (in Mem99[d0_82 + 20<i32>:word32] : word32)
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: ptr32
 T_3132: (in 16<i32> : int32)
   Class: Eq_3132
@@ -15560,7 +15026,7 @@ T_3141: (in d0_82 + 32<i32> : word32)
   OrigDataType: ptr32
 T_3142: (in Mem106[d0_82 + 32<i32>:word32] : word32)
   Class: Eq_3019
-  DataType: Eq_25
+  DataType: word32
   OrigDataType: word32
 T_3143: (in d0_82 + 32<i32> : word32)
   Class: Eq_3143
@@ -15575,12 +15041,12 @@ T_3145: (in d0_82 + 20<i32> : word32)
   DataType: (ptr32 ptr32)
   OrigDataType: (ptr32 ptr32)
 T_3146: (in Mem106[d0_82 + 20<i32>:word32] : word32)
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: ptr32
 T_3147: (in Mem106[d0_82 + 32<i32>:word32] + Mem106[d0_82 + 20<i32>:word32] : word32)
   Class: Eq_3147
-  DataType: int32
+  DataType: word32
   OrigDataType: word32
 T_3148: (in 28<i32> : int32)
   Class: Eq_3148
@@ -15592,7 +15058,7 @@ T_3149: (in d0_82 + 28<i32> : word32)
   OrigDataType: ptr32
 T_3150: (in Mem110[d0_82 + 28<i32>:word32] : word32)
   Class: Eq_3147
-  DataType: int32
+  DataType: word32
   OrigDataType: word32
 T_3151: (in AddHead : ptr32)
   Class: Eq_3151
@@ -15618,7 +15084,7 @@ T_3156: (in d0_82 + 4<i32> : word32)
   Class: Eq_3154
   DataType: ptr32
   OrigDataType: ptr32
-T_3157: (in AddHead(dwArg04, (word32) d0_82 + 4<i32>) : void)
+T_3157: (in AddHead(dwArg04, d0_82 + 1<i32>) : void)
   Class: Eq_3157
   DataType: void
   OrigDataType: void
@@ -15634,14 +15100,14 @@ T_3160: (in d0_82 + 4<i32> : word32)
   Class: Eq_4
   DataType: (ptr32 Eq_4)
   OrigDataType: ptr32
-T_3161: (in Allocate((word32) d0_82 + 4<i32>, dwArg08) : word32)
+T_3161: (in Allocate(d0_82 + 1<i32>, dwArg08) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3162: (in a2_142 : Eq_25)
+T_3162: (in a2_142 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 Eq_25)
+  OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
 T_3163: (in d2_145 : uint32)
   Class: Eq_3163
   DataType: uint32
@@ -15676,7 +15142,7 @@ T_3170: (in a2_142 + 0<32> : word32)
   OrigDataType: word32
 T_3171: (in Mem148[a2_142 + 0<32>:word32] : word32)
   Class: Eq_3168
-  DataType: Eq_25
+  DataType: word32
   OrigDataType: word32
 T_3172: (in a2_149 : (ptr32 word32))
   Class: Eq_3172
@@ -15712,7 +15178,7 @@ T_3179: (in 4<i32> : int32)
   OrigDataType: int32
 T_3180: (in a2_149 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
 T_3181: (in 1<32> : word32)
   Class: Eq_3181
@@ -15744,8 +15210,8 @@ T_3187: (in d0_50 + 0<32> : word32)
   OrigDataType: word32
 T_3188: (in Mem56[d0_50 + 0<32>:word32] : word32)
   Class: Eq_77
-  DataType: Eq_25
-  OrigDataType: Eq_77
+  DataType: Eq_77
+  OrigDataType: word32
 T_3189: (in AddTail : ptr32)
   Class: Eq_3189
   DataType: (ptr32 Eq_3189)
@@ -15770,7 +15236,7 @@ T_3194: (in d0_50 + 4<i32> : word32)
   Class: Eq_3192
   DataType: ptr32
   OrigDataType: ptr32
-T_3195: (in AddTail(dwArg04, (word32) d0_50 + 4<i32>) : void)
+T_3195: (in AddTail(dwArg04, d0_50 + 1<i32>) : void)
   Class: Eq_3195
   DataType: void
   OrigDataType: void
@@ -15788,23 +15254,23 @@ T_3198: (in d0_50 + 12<i32> : word32)
   OrigDataType: ptr32
 T_3199: (in Mem62[d0_50 + 12<i32>:word32] : word32)
   Class: Eq_106
-  DataType: Eq_25
-  OrigDataType: int32
+  DataType: Eq_106
+  OrigDataType: word32
 T_3200: (in 16<i32> : int32)
   Class: Eq_3200
   DataType: int32
   OrigDataType: int32
 T_3201: (in d0_50 + 16<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: ptr32
-T_3202: (in d0 : Eq_25)
+T_3202: (in d0 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3203: (in d0_51 : Eq_25)
+T_3203: (in d0_51 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3204: (in a0_17 : (ptr32 Eq_4))
   Class: Eq_4
@@ -15840,12 +15306,12 @@ T_3211: (in a0_17->t0014 < 0x27<16> : bool)
   OrigDataType: bool
 T_3212: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3213: (in a1 : word32)
   Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+  DataType: (ptr32 Eq_25)
+  OrigDataType: word32
 T_3214: (in dwArg08 - dwArg0C : word32)
   Class: Eq_3214
   DataType: up32
@@ -15859,8 +15325,8 @@ T_3216: (in dwArg08 - dwArg0C < 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_3217: (in d1 : word32)
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: (union ((ptr32 (struct (0 word32 dw0000) (4 word32 dw0004))) u1) (ptr32 u0))
 T_3218: (in CreatePrivatePool : ptr32)
   Class: Eq_3218
@@ -15875,20 +15341,20 @@ T_3220: (in requirements : word32)
   DataType: Eq_106
   OrigDataType: 
 T_3221: (in puddleSize : word32)
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: 
 T_3222: (in puddleThresh : word32)
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: 
 T_3223: (in CreatePrivatePool(dwArg04, dwArg08, dwArg0C) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3224: (in d0_30 : Eq_25)
+T_3224: (in d0_30 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: (ptr32 (struct (0 T_3236 t0000) (4 T_3239 t0004) (8 T_3242 t0008) (C T_3245 t000C) (10 T_3252 t0010) (14 T_3255 t0014)))
 T_3225: (in AllocMem : ptr32)
   Class: Eq_75
@@ -15904,17 +15370,17 @@ T_3227: (in 0<i32> : int32)
   OrigDataType: int32
 T_3228: (in AllocMem(24<i32>, 0<i32>) : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3229: (in 0<i32> : int32)
-  Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
   OrigDataType: int32
 T_3230: (in 0<32> : word32)
   Class: Eq_25
-  DataType: uint8
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
-T_3231: (in d0_30 == 0<32> : bool)
+T_3231: (in d0_30 == null : bool)
   Class: Eq_3231
   DataType: bool
   OrigDataType: bool
@@ -15936,20 +15402,20 @@ T_3235: (in d0_30 + 0<32> : word32)
   OrigDataType: word32
 T_3236: (in Mem37[d0_30 + 0<32>:word32] : word32)
   Class: Eq_3233
-  DataType: Eq_25
+  DataType: word32
   OrigDataType: word32
 T_3237: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_134
+  DataType: int32
   OrigDataType: word32
 T_3238: (in d0_30 + 4<i32> : word32)
   Class: Eq_3238
   DataType: ptr32
   OrigDataType: ptr32
 T_3239: (in Mem38[d0_30 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+  Class: Eq_134
+  DataType: Eq_134
+  OrigDataType: word32
 T_3240: (in 8<i32> : int32)
   Class: Eq_3240
   DataType: int32
@@ -15960,7 +15426,7 @@ T_3241: (in d0_30 + 8<i32> : word32)
   OrigDataType: ptr32
 T_3242: (in Mem40[d0_30 + 8<i32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_3243: (in 12<i32> : int32)
   Class: Eq_3243
@@ -15972,8 +15438,8 @@ T_3244: (in d0_30 + 12<i32> : word32)
   OrigDataType: ptr32
 T_3245: (in Mem42[d0_30 + 12<i32>:word32] : word32)
   Class: Eq_106
-  DataType: Eq_25
-  OrigDataType: Eq_106
+  DataType: Eq_106
+  OrigDataType: word32
 T_3246: (in 7<32> : word32)
   Class: Eq_3246
   DataType: word32
@@ -16000,8 +15466,8 @@ T_3251: (in d0_30 + 16<i32> : word32)
   OrigDataType: ptr32
 T_3252: (in Mem46[d0_30 + 16<i32>:word32] : word32)
   Class: Eq_148
-  DataType: Eq_25
-  OrigDataType: (ptr32 (arr Eq_160))
+  DataType: (ptr32 (arr Eq_160))
+  OrigDataType: word32
 T_3253: (in 20<i32> : int32)
   Class: Eq_3253
   DataType: int32
@@ -16011,9 +15477,9 @@ T_3254: (in d0_30 + 20<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_3255: (in Mem48[d0_30 + 20<i32>:word32] : word32)
-  Class: Eq_2656
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_2656)
+  Class: Eq_2878
+  DataType: (ptr32 Eq_2878)
+  OrigDataType: word32
 T_3256: (in d0_30 + 4<i32> : word32)
   Class: Eq_4
   DataType: (ptr32 Eq_4)
@@ -16250,29 +15716,29 @@ T_3314: (in fn0000131C(0x14<u32>, out a1, out a5) : word32)
   Class: Eq_597
   DataType: word32
   OrigDataType: word32
-T_3315: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3315: (in d0 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3316: (in d0_196 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
-T_3317: (in d1_142 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3316: (in d0_196 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: (ptr32 Eq_1290)
+T_3317: (in d1_142 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_3318: (in a0_20 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3318: (in a0_20 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
-T_3319: (in d3_166 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3319: (in d3_166 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
 T_3320: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3321: (in dwArg0C != 0<32> : bool)
   Class: Eq_3321
@@ -16303,8 +15769,8 @@ T_3327: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_3328: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3329: (in dwArg10 != 0<32> : bool)
   Class: Eq_3329
@@ -16326,41 +15792,41 @@ T_3333: (in signature of fn000024BC : void)
   Class: Eq_3332
   DataType: (ptr32 Eq_3332)
   OrigDataType: 
-T_3334: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 word32 dw0000) (4 T_134 t0004) (8 T_25 t0008) (C T_106 t000C) (10 T_148 t0010) (14 T_2878 t0014) (18 T_3122 t0018) (1C T_3150 t001C) (20 T_3068 t0020))) u1) (up32 u0))
-T_3335: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3334: (in d0 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: (union (int32 u1) (up32 u0))
+T_3335: (in d1 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: up32
-T_3336: (in d2 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3336: (in d2 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: (union (int32 u0) (up32 u1))
-T_3337: (in d1Out : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3337: (in d1Out : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
-T_3338: (in d2Out : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3338: (in d2Out : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3339: (in out d1_318 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3340: (in out d2_319 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3341: (in fn000024BC(dwArg04, dwArg08, dwArg10, out d1_318, out d2_319) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3342: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_3343: (in d4_29 : int32)
   Class: Eq_3343
@@ -16370,9 +15836,9 @@ T_3344: (in 24<i32> : int32)
   Class: Eq_3343
   DataType: int32
   OrigDataType: int32
-T_3345: (in d6_30 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3345: (in d6_30 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uip32
 T_3346: (in __rol : ptr32)
   Class: Eq_3346
@@ -16383,20 +15849,20 @@ T_3347: (in signature of __rol : void)
   DataType: (ptr32 Eq_3346)
   OrigDataType: 
 T_3348: (in  : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: 
 T_3349: (in  : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: 
 T_3350: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3351: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3352: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3352
@@ -16499,12 +15965,12 @@ T_3376: (in __rol : ptr32)
   DataType: (ptr32 Eq_3346)
   OrigDataType: (ptr32 (fn T_3378 (T_3345, T_3377)))
 T_3377: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3378: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3379: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3379
@@ -16527,12 +15993,12 @@ T_3383: (in __rol : ptr32)
   DataType: (ptr32 Eq_3346)
   OrigDataType: (ptr32 (fn T_3385 (T_3345, T_3384)))
 T_3384: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3385: (in __rol(d6_30, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3386: (in SLICE(d6_30, byte, 0) : byte)
   Class: Eq_3386
@@ -16559,40 +16025,40 @@ T_3391: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_3392: (in SEQ(SLICE(d6_30, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uip32
-T_3393: (in d1_175 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3393: (in d1_175 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3394: (in d2_176 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3394: (in d2_176 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3395: (in d0_174 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3395: (in d0_174 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3396: (in fn000024BC : ptr32)
   Class: Eq_3332
   DataType: (ptr32 Eq_3332)
   OrigDataType: (ptr32 (fn T_3400 (T_3397, T_1754, T_3319, T_3398, T_3399)))
 T_3397: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_3398: (in out d1_175 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3399: (in out d2_176 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3400: (in fn000024BC(0<i32>, dwArg04, d3_166, out d1_175, out d2_176) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3401: (in d2_321 : word32)
   Class: Eq_3401
@@ -16607,16 +16073,16 @@ T_3403: (in fn000024BC : ptr32)
   DataType: (ptr32 Eq_3332)
   OrigDataType: (ptr32 (fn T_3406 (T_3393, T_1755, T_3394, T_3404, T_3405)))
 T_3404: (in out d1_320 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3405: (in out d2_321 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3406: (in fn000024BC(d1_175, dwArg08, d2_176, out d1_320, out d2_321) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3407: (in 1<i32> : int32)
   Class: Eq_3407
@@ -16659,8 +16125,8 @@ T_3416: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_3417: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
 T_3418: (in d1_86 : word32)
   Class: Eq_3418
@@ -16670,17 +16136,17 @@ T_3419: (in d2_322 : word32)
   Class: Eq_3419
   DataType: word32
   OrigDataType: word32
-T_3420: (in d0_85 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3420: (in d0_85 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3421: (in fn000024BC : ptr32)
   Class: Eq_3332
   DataType: (ptr32 Eq_3332)
   OrigDataType: (ptr32 (fn T_3431 (T_3422, T_3425, T_3428, T_3429, T_3430)))
 T_3422: (in dwArg04 >> d4_61 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3423: (in dwArg04 << d5_63 : word32)
   Class: Eq_3423
@@ -16691,8 +16157,8 @@ T_3424: (in dwArg08 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3425: (in dwArg04 << d5_63 | dwArg08 >> d4_61 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_3426: (in dwArg0C << d5_63 : word32)
   Class: Eq_3426
@@ -16703,52 +16169,52 @@ T_3427: (in dwArg10 >> d4_61 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3428: (in dwArg0C << d5_63 | dwArg10 >> d4_61 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_3429: (in out d1_86 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3430: (in out d2_322 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3431: (in fn000024BC(dwArg04 >> d4_61, dwArg04 << d5_63 | dwArg08 >> d4_61, dwArg0C << d5_63 | dwArg10 >> d4_61, out d1_86, out d2_322) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3432: (in d3_72 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3432: (in d3_72 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3433: (in dwArg10 << d5_63 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
-T_3434: (in d5_101 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3434: (in d5_101 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3435: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3436 (T_3420)))
 T_3436: (in __swap(d0_85) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3437: (in d6_103 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3437: (in d6_103 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3438: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3439 (T_3432)))
 T_3439: (in __swap(d3_72) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3440: (in d3_102 : uint32)
   Class: Eq_3440
@@ -16762,9 +16228,9 @@ T_3442: (in d3_72 * (word16) d5_101 : word32)
   Class: Eq_3440
   DataType: uint32
   OrigDataType: uint32
-T_3443: (in d2_107 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3443: (in d2_107 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3444: (in __swap : ptr32)
   Class: Eq_911
@@ -16775,12 +16241,12 @@ T_3445: (in SLICE(d3_72, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3446: (in d0_85 * (word16) d3_72 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3447: (in __swap(d0_85 * (word16) d3_72) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3448: (in v34_108 : cup16)
   Class: Eq_3448
@@ -16830,29 +16296,29 @@ T_3459: (in SLICE(SEQ(v35_109, v34_108) + d4_104, word16, 0) : word16)
   Class: Eq_3456
   DataType: cup16
   OrigDataType: word16
-T_3460: (in d6_82 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3460: (in d6_82 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3461: (in dwArg08 << d5_63 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
-T_3462: (in d2_124 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3462: (in d2_124 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3463: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3465 (T_3464)))
 T_3464: (in SEQ(v35_109, v39_116) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3465: (in __swap(SEQ(v35_109, v39_116)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3466: (in d5_105 : uint32)
   Class: Eq_3466
@@ -16883,12 +16349,12 @@ T_3472: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3473: (in SEQ(SLICE(d3_102, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3474: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3475: (in __swap : ptr32)
   Class: Eq_911
@@ -16903,12 +16369,12 @@ T_3477: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3478: (in SEQ(SLICE(d4_104, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3479: (in __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3480: (in __swap(SEQ(SLICE(d3_102, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_104, word16, 16), 0<16>)) : word32)
   Class: Eq_3480
@@ -16995,8 +16461,8 @@ T_3500: (in 1<32> : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3501: (in d0_85 - 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3502: (in 0<32> : word32)
   Class: Eq_3469
@@ -17018,13 +16484,13 @@ T_3506: (in d6_82 - d2_124 >= 0<32> : bool)
   Class: Eq_3506
   DataType: bool
   OrigDataType: bool
-T_3507: (in d7_13 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3507: (in d7_13 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: (union (int32 u0) (uint32 u1))
 T_3508: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3509: (in d2 == 0<32> : bool)
   Class: Eq_3509
@@ -17038,57 +16504,57 @@ T_3511: (in signature of fn0000267A : void)
   Class: Eq_3510
   DataType: (ptr32 Eq_3510)
   OrigDataType: 
-T_3512: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3512: (in d0 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_3513: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3513: (in d1 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3514: (in d2 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3514: (in d2 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3515: (in d1Out : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3515: (in d1Out : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3516: (in out d1 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3517: (in fn0000267A(d1, d2, d2, out d1) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3518: (in d6_17 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3518: (in d6_17 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_3519: (in d5_19 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3519: (in d5_19 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3520: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3521: (in d0 != 0<32> : bool)
   Class: Eq_3521
   DataType: bool
   OrigDataType: bool
-T_3522: (in d2_22 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3522: (in d2_22 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3523: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3524 (T_3336)))
 T_3524: (in __swap(d2) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3525: (in SLICE(d2_22, word16, 0) : word16)
   Class: Eq_3525
@@ -17103,8 +16569,8 @@ T_3527: (in (word16) d2_22 != 0<16> : bool)
   DataType: bool
   OrigDataType: bool
 T_3528: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3529: (in d1 == 0<32> : bool)
   Class: Eq_3529
@@ -17139,36 +16605,36 @@ T_3536: (in 0<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_3537: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_3538: (in d2 < 0<32> : bool)
   Class: Eq_3538
   DataType: bool
   OrigDataType: bool
-T_3539: (in d0_281 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3539: (in d0_281 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3540: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3541 (T_3334)))
 T_3541: (in __swap(d0) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3542: (in d1_282 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3542: (in d1_282 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3543: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3544 (T_3335)))
 T_3544: (in __swap(d1) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3545: (in d0_285 : uint32)
   Class: Eq_3545
@@ -17207,8 +16673,8 @@ T_3553: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3554 (T_3542)))
 T_3554: (in __swap(d1_282) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3555: (in SLICE(__swap(d1_282), word16, 0) : word16)
   Class: Eq_3555
@@ -17235,12 +16701,12 @@ T_3560: (in (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3561: (in (uint32) (uint16) (d0_285 /u SLICE(d2, uint16, 0)) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3562: (in __swap((uint32) (uint16) (d0_285 /u (uint16) d2)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3563: (in SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16) : word16)
   Class: Eq_3563
@@ -17259,8 +16725,8 @@ T_3566: (in (uint16) (d0_295 /u SLICE(d2, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3567: (in SEQ(SLICE(__swap((uint32) (uint16) (d0_285 /u (uint16) d2)), word16, 16), (uint16) (d0_295 /u SLICE(d2, uint16, 0))) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3568: (in __swap : ptr32)
   Class: Eq_911
@@ -17283,12 +16749,12 @@ T_3572: (in 0<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3573: (in SEQ((uint16) (d0_295 % SLICE(d2, uint16, 0)), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3574: (in __swap(SEQ((uint16) (d0_295 % (uint16) d2), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3575: (in v41_64 : word16)
   Class: Eq_3575
@@ -17303,8 +16769,8 @@ T_3577: (in 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3578: (in d6_17 * 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_3579: (in SLICE(d0_44, word16, 16) : word16)
   Class: Eq_3579
@@ -17335,28 +16801,28 @@ T_3585: (in d5_19 * 2<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3586: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: up32
 T_3587: (in d6_17 < 0<32> : bool)
   Class: Eq_3587
   DataType: bool
   OrigDataType: bool
 T_3588: (in d5_19 * 2<32> + (d6_17 < 0<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_3589: (in 2<32> : word32)
   Class: Eq_3589
   DataType: ui32
   OrigDataType: ui32
 T_3590: (in d7_13 * 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_3591: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_3592: (in d7_13 > 0<32> : bool)
   Class: Eq_3592
@@ -17370,9 +16836,9 @@ T_3594: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3603 (T_3602)))
-T_3595: (in d3_74 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3595: (in d3_74 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3596: (in SLICE(d3_74, uint16, 0) : uint16)
   Class: Eq_3596
@@ -17399,12 +16865,12 @@ T_3601: (in (uint16) (d5_19 /u SLICE(d3_74, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3602: (in SEQ((uint16) (d5_19 % SLICE(d3_74, uint16, 0)), (uint16) (d5_19 /u SLICE(d3_74, uint16, 0))) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3603: (in __swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3604: (in SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16) : word16)
   Class: Eq_3604
@@ -17415,24 +16881,24 @@ T_3605: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3606: (in SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3607: (in __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_19 % (uint16) d3_74), (uint16) (d5_19 /u (uint16) d3_74))), word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3608: (in d1_104 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+T_3608: (in d1_104 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: (ptr32 Eq_1290)
 T_3609: (in 0xFFFF<32> : uipr32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: uipr32
-T_3610: (in d6_98 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3610: (in d6_98 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3611: (in __swap : ptr32)
   Class: Eq_911
@@ -17447,48 +16913,48 @@ T_3613: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3614: (in SEQ(SLICE(d6_17, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3615: (in __swap(SEQ(SLICE(d6_17, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3616: (in d6_133 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3616: (in d6_133 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3617: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3618 (T_3608)))
 T_3618: (in __swap(d1_104) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3619: (in d3_140 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3619: (in d3_140 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3620: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3621 (T_3616)))
 T_3621: (in __swap(d6_133) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3622: (in d4_142 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3622: (in d4_142 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3623: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3624 (T_3507)))
 T_3624: (in __swap(d7_13) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3625: (in d5_141 : uint32)
   Class: Eq_3625
@@ -17502,9 +16968,9 @@ T_3627: (in d7_13 * (word16) d3_140 : word32)
   Class: Eq_3625
   DataType: uint32
   OrigDataType: uint32
-T_3628: (in d6_146 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3628: (in d6_146 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3629: (in __swap : ptr32)
   Class: Eq_911
@@ -17515,12 +16981,12 @@ T_3630: (in SLICE(d7_13, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3631: (in d6_133 * (word16) d7_13 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3632: (in __swap(d6_133 * (word16) d7_13) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3633: (in v55_147 : cup16)
   Class: Eq_3633
@@ -17582,29 +17048,29 @@ T_3647: (in d3_140 * (word16) d4_142 : word32)
   Class: Eq_3645
   DataType: uint32
   OrigDataType: uint32
-T_3648: (in d6_178 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3648: (in d6_178 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3649: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3651 (T_3650)))
 T_3650: (in SEQ(v56_148, v59_155) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3651: (in __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3652: (in d6_17 - __swap(SEQ(v56_148, v59_155)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3653: (in d5_181 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3654: (in __swap : ptr32)
   Class: Eq_911
@@ -17619,12 +17085,12 @@ T_3656: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3657: (in SEQ(SLICE(d5_141, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3658: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3659: (in __swap : ptr32)
   Class: Eq_911
@@ -17639,12 +17105,12 @@ T_3661: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3662: (in SEQ(SLICE(d2_143, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3663: (in __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3664: (in __swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>)) : word32)
   Class: Eq_3664
@@ -17695,20 +17161,20 @@ T_3675: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ
   DataType: uint32
   OrigDataType: uint32
 T_3676: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: up32
 T_3677: (in d6_178 <u 0<32> : bool)
   Class: Eq_3677
   DataType: Eq_3677
   OrigDataType: (union (bool u0) (uint32 u1))
 T_3678: (in d5_19 - ((__swap(SEQ(SLICE(d5_141, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d2_143, word16, 16), 0<16>))) + SEQ(SLICE(d3_144, word16, 16), (SLICE(d3_144, word16, 0) + (v55_147 <u 0<16>)) + (v59_155 <u 0<16>))) - (d6_178 <u 0<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3679: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: up32
 T_3680: (in d5_181 >= 0<32> : bool)
   Class: Eq_3680
@@ -17739,12 +17205,12 @@ T_3686: (in 1<32> : word32)
   DataType: uipr32
   OrigDataType: uipr32
 T_3687: (in d1_104 - 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
-T_3688: (in d4_113 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3688: (in d4_113 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3689: (in __swap : ptr32)
   Class: Eq_911
@@ -17755,8 +17221,8 @@ T_3690: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3691 (T_3507)))
 T_3691: (in __swap(d7_13) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3692: (in SLICE(d1_104, word16, 0) : word16)
   Class: Eq_3692
@@ -17767,12 +17233,12 @@ T_3693: (in __swap(d7_13) * (word16) d1_104 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3694: (in d5_19 - __swap(d7_13) * (word16) d1_104 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3695: (in __swap(d5_19 - __swap(d7_13) * (word16) d1_104) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3696: (in wLoc22_442 : word16)
   Class: Eq_3696
@@ -17831,8 +17297,8 @@ T_3709: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3710 (T_3507)))
 T_3710: (in __swap(d7_13) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3711: (in SLICE(__swap(d7_13), word16, 16) : word16)
   Class: Eq_3711
@@ -17847,20 +17313,20 @@ T_3713: (in SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : uipr32)
   DataType: uipr32
   OrigDataType: uipr32
 T_3714: (in d6_178 + SEQ(SLICE(__swap(d7_13), word16, 16), 0<16>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3715: (in 1<32> : word32)
   Class: Eq_3715
   DataType: uint32
   OrigDataType: uint32
 T_3716: (in d1_104 - 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3717: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: up32
 T_3718: (in d6_178 < 0<32> : bool)
   Class: Eq_3718
@@ -17883,20 +17349,20 @@ T_3722: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3723: (in SEQ(SLICE(d7_13, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3724: (in __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3725: (in d5_181 + (d6_178 <u 0<32>) + __swap(SEQ(SLICE(d7_13, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_3726: (in d6_220 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3726: (in d6_220 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3727: (in __swap : ptr32)
   Class: Eq_911
@@ -17911,12 +17377,12 @@ T_3729: (in SLICE(d5_181, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3730: (in SEQ(SLICE(d6_178, word16, 16), SLICE(d5_181, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3731: (in __swap(SEQ(SLICE(d6_178, word16, 16), (word16) d5_181)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3732: (in SLICE(dwLoc24, word16, 16) : word16)
   Class: Eq_3732
@@ -17927,20 +17393,20 @@ T_3733: (in SLICE(d1_104, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3734: (in SEQ(SLICE(dwLoc24, word16, 16), SLICE(d1_104, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
-T_3735: (in d5_221 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3735: (in d5_221 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3736: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3737 (T_3653)))
 T_3737: (in __swap(d5_181) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3738: (in v82_224 : word16)
   Class: Eq_3738
@@ -17958,29 +17424,29 @@ T_3741: (in v41_64 == 0<16> : bool)
   Class: Eq_3741
   DataType: bool
   OrigDataType: bool
-T_3742: (in d5_266 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3742: (in d5_266 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3743: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3744 (T_3653)))
 T_3744: (in __swap(d5_181) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3745: (in d6_267 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3745: (in d6_267 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3746: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3747 (T_3648)))
 T_3747: (in __swap(d6_178) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3748: (in SLICE(d5_266, word16, 16) : word16)
   Class: Eq_3748
@@ -17991,8 +17457,8 @@ T_3749: (in SLICE(d6_267, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3750: (in SEQ(SLICE(d5_266, word16, 16), SLICE(d6_267, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3751: (in SLICE(d6_267, word16, 16) : word16)
   Class: Eq_3751
@@ -18003,8 +17469,8 @@ T_3752: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3753: (in SEQ(SLICE(d6_267, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3754: (in true : bool)
   Class: Eq_3533
@@ -18018,25 +17484,25 @@ T_3756: (in SEQ(SLICE(d1_104, word16, 0), wLoc22_442) : word32)
   Class: Eq_3697
   DataType: word32
   OrigDataType: word32
-T_3757: (in d2_73 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3757: (in d2_73 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3758: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3759 (T_3519)))
 T_3759: (in __swap(d5_19) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3760: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3761 (T_3507)))
 T_3761: (in __swap(d7_13) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3762: (in d2_73 - d3_74 : word32)
   Class: Eq_3762
@@ -18075,8 +17541,8 @@ T_3770: (in 1<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3771: (in d5_221 >> 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3772: (in v86_241 : word16)
   Class: Eq_3772
@@ -18095,8 +17561,8 @@ T_3775: (in signature of __rcr : void)
   DataType: (ptr32 Eq_3774)
   OrigDataType: 
 T_3776: (in  : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: 
 T_3777: (in  : word32)
   Class: Eq_3777
@@ -18119,8 +17585,8 @@ T_3781: (in SLICE(cond(d5_221), bool, 4) : bool)
   DataType: bool
   OrigDataType: bool
 T_3782: (in __rcr(d6_220, 1<32>, SLICE(cond(d5_221), bool, 4)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3783: (in SLICE(d7_230, word16, 16) : word16)
   Class: Eq_3783
@@ -18146,49 +17612,49 @@ T_3788: (in v86_241 != 0<16> : bool)
   Class: Eq_3788
   DataType: bool
   OrigDataType: bool
-T_3789: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3789: (in d0 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3790: (in d2 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3790: (in d2 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3791: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3791: (in dwArg04 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
-T_3792: (in dwArg08 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3792: (in dwArg08 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
 T_3793: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_3794: (in dwArg04 > 0<32> : bool)
   Class: Eq_3794
   DataType: bool
   OrigDataType: bool
 T_3795: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_3796: (in dwArg08 > 0<32> : bool)
   Class: Eq_3796
   DataType: bool
   OrigDataType: bool
-T_3797: (in d0_36 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3797: (in d0_36 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
 T_3798: (in -dwArg04 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
 T_3799: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_3800: (in dwArg08 > 0<32> : bool)
   Class: Eq_3800
@@ -18203,16 +17669,16 @@ T_3802: (in fn0000267A : ptr32)
   DataType: (ptr32 Eq_3510)
   OrigDataType: (ptr32 (fn T_3804 (T_3797, T_3792, T_3790, T_3803)))
 T_3803: (in out d1_43 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3804: (in fn0000267A(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3805: (in -fn0000267A(d0_36, dwArg08, d2, out d1_43) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3806: (in d1_55 : word32)
   Class: Eq_3806
@@ -18223,16 +17689,16 @@ T_3807: (in fn0000267A : ptr32)
   DataType: (ptr32 Eq_3510)
   OrigDataType: (ptr32 (fn T_3810 (T_3797, T_3808, T_3790, T_3809)))
 T_3808: (in -dwArg08 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
 T_3809: (in out d1_55 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3810: (in fn0000267A(d0_36, -dwArg08, d2, out d1_55) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3811: (in d1_88 : word32)
   Class: Eq_3811
@@ -18243,12 +17709,12 @@ T_3812: (in fn0000267A : ptr32)
   DataType: (ptr32 Eq_3510)
   OrigDataType: (ptr32 (fn T_3814 (T_3791, T_3792, T_3790, T_3813)))
 T_3813: (in out d1_88 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3814: (in fn0000267A(dwArg04, dwArg08, d2, out d1_88) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3815: (in d1_89 : word32)
   Class: Eq_3815
@@ -18259,32 +17725,32 @@ T_3816: (in fn0000267A : ptr32)
   DataType: (ptr32 Eq_3510)
   OrigDataType: (ptr32 (fn T_3819 (T_3791, T_3817, T_3790, T_3818)))
 T_3817: (in -dwArg08 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
 T_3818: (in out d1_89 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3819: (in fn0000267A(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3820: (in -fn0000267A(dwArg04, -dwArg08, d2, out d1_89) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3821: (in d1_22 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3821: (in d1_22 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3822: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3823 (T_3513)))
 T_3823: (in __swap(d1) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3824: (in v10_9 : word16)
   Class: Eq_3824
@@ -18302,13 +17768,13 @@ T_3827: (in SLICE(d2, word16, 16) : word16)
   Class: Eq_3826
   DataType: word16
   OrigDataType: word16
-T_3828: (in d2_11 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3828: (in d2_11 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3829: (in SEQ(v11_10, v10_9) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3830: (in 0<16> : word16)
   Class: Eq_3824
@@ -18318,13 +17784,13 @@ T_3831: (in v10_9 != 0<16> : bool)
   Class: Eq_3831
   DataType: bool
   OrigDataType: bool
-T_3832: (in d3_18 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+T_3832: (in d3_18 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: (ptr32 Eq_1290)
 T_3833: (in 16<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_3834: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3834
@@ -18338,29 +17804,29 @@ T_3836: (in (word16) d1_22 >= 0x80<16> : bool)
   Class: Eq_3836
   DataType: bool
   OrigDataType: bool
-T_3837: (in d0_134 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3837: (in d0_134 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3838: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3839 (T_3512)))
 T_3839: (in __swap(d0) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3840: (in d1_135 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3840: (in d1_135 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3841: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3842 (T_3821)))
 T_3842: (in __swap(d1_22) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3843: (in v14_137 : word16)
   Class: Eq_3843
@@ -18379,8 +17845,8 @@ T_3846: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3847 (T_3828)))
 T_3847: (in __swap(d2_11) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3848: (in SLICE(__swap(d2_11), word16, 16) : word16)
   Class: Eq_3848
@@ -18398,17 +17864,17 @@ T_3851: (in v14_137 == 0<16> : bool)
   Class: Eq_3851
   DataType: bool
   OrigDataType: bool
-T_3852: (in d0_150 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3852: (in d0_150 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3853: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3854 (T_3837)))
 T_3854: (in __swap(d0_134) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3855: (in d2_154 : uint32)
   Class: Eq_3855
@@ -18463,28 +17929,28 @@ T_3867: (in (uint16) (d2_154 % SLICE(d1_135, uint16, 0)) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3868: (in SEQ((uint16) (d2_154 % SLICE(d1_135, uint16, 0)), v34_157) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3869: (in __swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3870: (in SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0) : word16)
   Class: Eq_3870
   DataType: word16
   OrigDataType: word16
 T_3871: (in SEQ(SLICE(d1_135, word16, 16), SLICE(__swap(SEQ((uint16) (d2_154 % (uint16) d1_135), v34_157)), word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3872: (in SLICE(d0_150, word16, 16) : word16)
   Class: Eq_3872
   DataType: word16
   OrigDataType: word16
 T_3873: (in SEQ(SLICE(d0_150, word16, 16), v34_157) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3874: (in v17_143 : uint16)
   Class: Eq_3874
@@ -18523,8 +17989,8 @@ T_3882: (in SLICE(d0_134, word16, 16) : word16)
   DataType: word16
   OrigDataType: word16
 T_3883: (in SEQ(SLICE(d0_134, word16, 16), v17_143) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3884: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3884
@@ -18543,16 +18009,16 @@ T_3887: (in __rol : ptr32)
   DataType: (ptr32 Eq_3346)
   OrigDataType: (ptr32 (fn T_3889 (T_3821, T_3888)))
 T_3888: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3889: (in __rol(d1_22, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3890: (in 8<32> : uipr32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: uipr32
 T_3891: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3891
@@ -18571,12 +18037,12 @@ T_3894: (in __rol : ptr32)
   DataType: (ptr32 Eq_3346)
   OrigDataType: (ptr32 (fn T_3896 (T_3821, T_3895)))
 T_3895: (in 4<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3896: (in __rol(d1_22, 4<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3897: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_3897
@@ -18595,8 +18061,8 @@ T_3900: (in (word16) d3_18 - 4<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3901: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 4<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3902: (in SLICE(d1_22, word16, 0) : word16)
   Class: Eq_3902
@@ -18615,12 +18081,12 @@ T_3905: (in __rol : ptr32)
   DataType: (ptr32 Eq_3346)
   OrigDataType: (ptr32 (fn T_3907 (T_3821, T_3906)))
 T_3906: (in 2<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3907: (in __rol(d1_22, 2<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3908: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_3908
@@ -18639,8 +18105,8 @@ T_3911: (in (word16) d3_18 - 2<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3912: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 2<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3913: (in d0_71 : uint32)
   Class: Eq_3913
@@ -18663,12 +18129,12 @@ T_3917: (in SLICE(d0, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_3918: (in SEQ(v11_10, SLICE(d0, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3919: (in __swap(SEQ(v11_10, (word16) d0)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3920: (in SLICE(__swap(SEQ(v11_10, (word16) d0)), word16, 16) : word16)
   Class: Eq_3920
@@ -18695,8 +18161,8 @@ T_3925: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3926 (T_3832)))
 T_3926: (in __swap(d3_18) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3927: (in SLICE(__swap(d3_18), word16, 16) : word16)
   Class: Eq_3924
@@ -18718,29 +18184,29 @@ T_3931: (in (uint16) (d0_71 /u SLICE(d1_22, uint16, 0)) : uint16)
   Class: Eq_3928
   DataType: uint16
   OrigDataType: uint16
-T_3932: (in d1_90 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3932: (in d1_90 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3933: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3934 (T_3821)))
 T_3934: (in __swap(d1_22) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3935: (in d3_102 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3935: (in d3_102 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3936: (in SEQ(v53_82, v51_79) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
-T_3937: (in d0_108 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3937: (in d0_108 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3938: (in SLICE(d1_22, uint16, 0) : uint16)
   Class: Eq_3938
@@ -18779,12 +18245,12 @@ T_3946: (in SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_3947: (in SEQ((uint16) (d0_71 % (uint16) d1_22), (word16) d2_75) - SEQ(SLICE(d2_75, word16, 16), v51_79) * (word16) d1_90 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3948: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: up32
 T_3949: (in d0_108 >= 0<32> : bool)
   Class: Eq_3949
@@ -18795,12 +18261,12 @@ T_3950: (in __rol : ptr32)
   DataType: (ptr32 Eq_3346)
   OrigDataType: (ptr32 (fn T_3952 (T_3821, T_3951)))
 T_3951: (in 1<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3952: (in __rol(d1_22, 1<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3953: (in SLICE(d3_18, word16, 16) : word16)
   Class: Eq_3953
@@ -18819,8 +18285,8 @@ T_3956: (in (word16) d3_18 - 1<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_3957: (in SEQ(SLICE(d3_18, word16, 16), SLICE(d3_18, word16, 0) - 1<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3958: (in __swap : ptr32)
   Class: Eq_911
@@ -18835,16 +18301,16 @@ T_3960: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_3961 (T_3935)))
 T_3961: (in __swap(d3_102) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3962: (in __rol(d0_108, __swap(d3_102)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3963: (in __swap(__rol(d0_108, __swap(d3_102))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3964: (in SLICE(d3_102, word16, 0) : word16)
   Class: Eq_3964
@@ -18855,8 +18321,8 @@ T_3965: (in (uint16) SLICE(d3_102, word16, 0) : uint16)
   DataType: uint16
   OrigDataType: uint16
 T_3966: (in (uint32) (uint16) SLICE(d3_102, word16, 0) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3967: (in 1<16> : word16)
   Class: Eq_3967
@@ -18867,36 +18333,36 @@ T_3968: (in v51_79 - 1<16> : word16)
   DataType: uint16
   OrigDataType: uint16
 T_3969: (in SEQ(v53_82, v51_79 - 1<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_3970: (in d0_108 + d1_90 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_3971: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: up32
 T_3972: (in d0_108 >= 0<32> : bool)
   Class: Eq_3972
   DataType: bool
   OrigDataType: bool
-T_3973: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3973: (in d1 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_3974: (in d1_171 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3974: (in d1_171 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_3975: (in d3_202 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3975: (in d3_202 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
 T_3976: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3977: (in dwArg0C != 0<32> : bool)
   Class: Eq_3977
@@ -18927,8 +18393,8 @@ T_3983: (in dwArg04 - dwArg10 >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_3984: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3985: (in dwArg10 != 0<32> : bool)
   Class: Eq_3985
@@ -18943,16 +18409,16 @@ T_3987: (in fn000024BC : ptr32)
   DataType: (ptr32 Eq_3332)
   OrigDataType: (ptr32 (fn T_3990 (T_1670, T_1671, T_1673, T_3988, T_3989)))
 T_3988: (in out d1_171 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3989: (in out d2_354 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_3990: (in fn000024BC(dwArg04, dwArg08, dwArg10, out d1_171, out d2_354) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3991: (in d4_32 : int32)
   Class: Eq_3991
@@ -18962,21 +18428,21 @@ T_3992: (in 24<i32> : int32)
   Class: Eq_3991
   DataType: int32
   OrigDataType: int32
-T_3993: (in d6_33 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_3993: (in d6_33 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uip32
 T_3994: (in __rol : ptr32)
   Class: Eq_3346
   DataType: (ptr32 Eq_3346)
   OrigDataType: (ptr32 (fn T_3996 (T_1672, T_3995)))
 T_3995: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_3996: (in __rol(dwArg0C, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_3997: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_3997
@@ -19079,12 +18545,12 @@ T_4021: (in __rol : ptr32)
   DataType: (ptr32 Eq_3346)
   OrigDataType: (ptr32 (fn T_4023 (T_3993, T_4022)))
 T_4022: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_4023: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4024: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4024
@@ -19107,12 +18573,12 @@ T_4028: (in __rol : ptr32)
   DataType: (ptr32 Eq_3346)
   OrigDataType: (ptr32 (fn T_4030 (T_3993, T_4029)))
 T_4029: (in 8<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_4030: (in __rol(d6_33, 8<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4031: (in SLICE(d6_33, byte, 0) : byte)
   Class: Eq_4031
@@ -19139,8 +18605,8 @@ T_4036: (in SLICE(dwArg0C, byte, 0) : byte)
   DataType: byte
   OrigDataType: byte
 T_4037: (in SEQ(SLICE(d6_33, word24, 8), SLICE(dwArg0C, byte, 0)) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uip32
 T_4038: (in d1_89 : ui32)
   Class: Eq_4038
@@ -19150,17 +18616,17 @@ T_4039: (in d2_90 : word32)
   Class: Eq_4039
   DataType: word32
   OrigDataType: word32
-T_4040: (in d0_88 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4040: (in d0_88 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_4041: (in fn000024BC : ptr32)
   Class: Eq_3332
   DataType: (ptr32 Eq_3332)
   OrigDataType: (ptr32 (fn T_4051 (T_4042, T_4045, T_4048, T_4049, T_4050)))
 T_4042: (in dwArg04 >> d4_64 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_4043: (in dwArg04 << d5_66 : word32)
   Class: Eq_4043
@@ -19171,8 +18637,8 @@ T_4044: (in dwArg08 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4045: (in dwArg04 << d5_66 | dwArg08 >> d4_64 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_4046: (in dwArg0C << d5_66 : word32)
   Class: Eq_4046
@@ -19183,52 +18649,52 @@ T_4047: (in dwArg10 >> d4_64 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4048: (in dwArg0C << d5_66 | dwArg10 >> d4_64 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_4049: (in out d1_89 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_4050: (in out d2_90 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_4051: (in fn000024BC(dwArg04 >> d4_64, dwArg04 << d5_66 | dwArg08 >> d4_64, dwArg0C << d5_66 | dwArg10 >> d4_64, out d1_89, out d2_90) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_4052: (in d3_75 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4052: (in d3_75 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_4053: (in dwArg10 << d5_66 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
-T_4054: (in d7_104 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4054: (in d7_104 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_4055: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_4056 (T_4040)))
 T_4056: (in __swap(d0_88) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_4057: (in d6_106 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4057: (in d6_106 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4058: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_4059 (T_4052)))
 T_4059: (in __swap(d3_75) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4060: (in d3_105 : uint32)
   Class: Eq_4060
@@ -19242,9 +18708,9 @@ T_4062: (in d3_75 * (word16) d7_104 : word32)
   Class: Eq_4060
   DataType: uint32
   OrigDataType: uint32
-T_4063: (in d2_110 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4063: (in d2_110 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4064: (in __swap : ptr32)
   Class: Eq_911
@@ -19255,12 +18721,12 @@ T_4065: (in SLICE(d3_75, word16, 0) : word16)
   DataType: uint16
   OrigDataType: uint16
 T_4066: (in d0_88 * (word16) d3_75 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_4067: (in __swap(d0_88 * (word16) d3_75) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4068: (in v36_111 : cup16)
   Class: Eq_4068
@@ -19310,21 +18776,21 @@ T_4079: (in SLICE(SEQ(v37_112, v36_111) + d4_107, word16, 0) : word16)
   Class: Eq_4076
   DataType: cup16
   OrigDataType: word16
-T_4080: (in d2_127 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4080: (in d2_127 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_4081: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_4083 (T_4082)))
 T_4082: (in SEQ(v37_112, v40_119) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_4083: (in __swap(SEQ(v37_112, v40_119)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4084: (in d7_108 : uint32)
   Class: Eq_4084
@@ -19363,12 +18829,12 @@ T_4092: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4093: (in SEQ(SLICE(d3_105, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_4094: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4095: (in __swap : ptr32)
   Class: Eq_911
@@ -19383,12 +18849,12 @@ T_4097: (in 0<16> : word16)
   DataType: word16
   OrigDataType: word16
 T_4098: (in SEQ(SLICE(d4_107, word16, 16), 0<16>) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_4099: (in __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4100: (in __swap(SEQ(SLICE(d3_105, word16, 16), 0<16>)) + __swap(SEQ(SLICE(d4_107, word16, 16), 0<16>)) : word32)
   Class: Eq_4100
@@ -19463,8 +18929,8 @@ T_4117: (in dwArg0C - dwArg04 < 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_4118: (in dwArg08 - dwArg10 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_4119: (in dwArg10 - dwArg08 : word32)
   Class: Eq_4119
@@ -19478,33 +18944,33 @@ T_4121: (in dwArg10 - dwArg08 > 0<32> : bool)
   Class: Eq_4121
   DataType: bool
   OrigDataType: bool
-T_4122: (in d1_211 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4122: (in d1_211 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_4123: (in d2_212 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4123: (in d2_212 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4124: (in fn000024BC : ptr32)
   Class: Eq_3332
   DataType: (ptr32 Eq_3332)
   OrigDataType: (ptr32 (fn T_4128 (T_4125, T_1670, T_3975, T_4126, T_4127)))
 T_4125: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_4126: (in out d1_211 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_4127: (in out d2_212 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_4128: (in fn000024BC(0<i32>, dwArg04, d3_202, out d1_211, out d2_212) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4129: (in d2_355 : word32)
   Class: Eq_4129
@@ -19515,16 +18981,16 @@ T_4130: (in fn000024BC : ptr32)
   DataType: (ptr32 Eq_3332)
   OrigDataType: (ptr32 (fn T_4133 (T_4122, T_1671, T_4123, T_4131, T_4132)))
 T_4131: (in out d1_171 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: (union (uint32 u0) (ptr32 u1))
 T_4132: (in out d2_355 : ptr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_4133: (in fn000024BC(d1_211, dwArg08, d2_212, out d1_171, out d2_355) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4134: (in 1<i32> : int32)
   Class: Eq_4134
@@ -19567,8 +19033,8 @@ T_4143: (in (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) 
   DataType: int16
   OrigDataType: int16
 T_4144: (in (int32) (int16) SEQ((uint16) (1<i32> % SLICE(dwArg10, uint16, 0)), (uint16) (1<i32> /u SLICE(dwArg10, uint16, 0))) : int32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
 T_4145: (in d3_135 - d3_75 : word32)
   Class: Eq_4089
@@ -19587,8 +19053,8 @@ T_4148: (in d3_135 < 0<32> : bool)
   DataType: Eq_4148
   OrigDataType: (union (bool u0) (word32 u1))
 T_4149: (in d2_127 - d2_90 - (d3_135 < 0<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4150: (in 0<32> : word32)
   Class: Eq_4111
@@ -19639,8 +19105,8 @@ T_4161: (in d6_157 >> d5_66 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_4162: (in d1_89 - d2_127 - (d6_157 < 0<32>) << 32<i32> - d5_66 | d6_157 >> d5_66 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_4163: (in d6_85 - d3_135 : word32)
   Class: Eq_4163
@@ -19806,37 +19272,37 @@ T_4203: (in signature of fn00002B8C : void)
   Class: Eq_4202
   DataType: (ptr32 Eq_4202)
   OrigDataType: 
-T_4204: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4204: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
-T_4205: (in d1 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4205: (in d1 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
-T_4206: (in a1 : Eq_25)
+T_4206: (in a1 : (ptr32 Eq_25))
   Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: Eq_7867
-T_4207: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
+  OrigDataType: (ptr32 (struct (0 T_4628 t0000)))
+T_4207: (in dwArg04 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4208: (in dwArg08 : (ptr32 Eq_621))
   Class: Eq_621
   DataType: (ptr32 Eq_621)
   OrigDataType: (ptr32 (struct (0 T_4264 t0000)))
-T_4209: (in dwArg0C : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4209: (in dwArg0C : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4210: (in 00003ECC : ptr32)
   Class: Eq_4210
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4211 t0000)))
 T_4211: (in Mem10[0x00003ECC<p32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4212: (in fp : ptr32)
   Class: Eq_4212
@@ -19847,32 +19313,32 @@ T_4213: (in 8<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4214: (in fp + 8<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
-T_4215: (in fn00002B8C(d0, d1, a1, *(union Eq_25 *) 0x3ECC<u32>, dwArg04, fp + 8<i32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+T_4215: (in fn00002B8C(d0, d1, a1, *(union Eq_73 *) 0x3ECC<u32>, dwArg04, fp + 8<i32>) : word32)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_4216: (in d0 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4216: (in d0 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_4217: (in bArg07 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4217: (in bArg07 : byte)
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
-T_4218: (in dwArg08 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4218: (in dwArg08 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: (ptr32 (struct (4 T_4216 t0004) (8 T_4227 t0008) (14 T_4233 t0014)))
-T_4219: (in d0_10 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4219: (in d0_10 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: up32
 T_4220: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_4221: (in dwArg08 == 0<32> : bool)
   Class: Eq_4221
@@ -19887,8 +19353,8 @@ T_4223: (in dwArg08 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_4224: (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4225: (in 8<i32> : int32)
   Class: Eq_4225
@@ -19899,8 +19365,8 @@ T_4226: (in dwArg08 + 8<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4227: (in Mem5[dwArg08 + 8<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: up32
 T_4228: (in d0_10 - *((word32) dwArg08 + 8<i32>) : word32)
   Class: Eq_4228
@@ -19924,7 +19390,7 @@ T_4232: (in dwArg08 + 20<i32> : word32)
   OrigDataType: ptr32
 T_4233: (in Mem20[dwArg08 + 20<i32>:word32] : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
 T_4234: (in 1<32> : word32)
   Class: Eq_4234
@@ -19932,7 +19398,7 @@ T_4234: (in 1<32> : word32)
   OrigDataType: word32
 T_4235: (in Mem20[dwArg08 + 20<i32>:word32] + 1<32> : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
 T_4236: (in dwArg08 + 20<i32> : word32)
   Class: Eq_4236
@@ -19940,7 +19406,7 @@ T_4236: (in dwArg08 + 20<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_4237: (in Mem22[dwArg08 + 20<i32>:word32] : word32)
   Class: Eq_2656
-  DataType: Eq_25
+  DataType: Eq_73
   OrigDataType: word32
 T_4238: (in 4<i32> : int32)
   Class: Eq_4238
@@ -19951,24 +19417,24 @@ T_4239: (in dwArg08 + 4<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4240: (in Mem22[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4241: (in 1<32> : word32)
   Class: Eq_4241
   DataType: word32
   OrigDataType: word32
 T_4242: (in *((word32) dwArg08 + 4<i32>) - 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4243: (in dwArg08 + 4<i32> : word32)
   Class: Eq_4243
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4244: (in Mem25[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4245: (in 4<i32> : int32)
   Class: Eq_4245
@@ -19979,8 +19445,8 @@ T_4246: (in dwArg08 + 4<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4247: (in Mem5[dwArg08 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: (ptr32 (struct (0 T_4250 t0000)))
 T_4248: (in 0<32> : word32)
   Class: Eq_4248
@@ -19991,13 +19457,13 @@ T_4249: (in Mem5[dwArg08 + 4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_4250: (in Mem16[Mem5[dwArg08 + 4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: Eq_73
   OrigDataType: byte
-T_4251: (in a7_1330 : Eq_4251)
+T_4251: (in a7_1330 : (ptr32 Eq_4251))
   Class: Eq_4251
-  DataType: Eq_4251
-  OrigDataType: word32
+  DataType: (ptr32 Eq_4251)
+  OrigDataType: (ptr32 (struct 0004 (2C int32 dw002C) (30 (union (int32 u0) (ptr32 u1) (T_6621 u2) (T_6687 u3) (T_7207 u4)) u0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 (union (int32 u0) (ptr32 u1) (T_6554 u2) (T_6625 u3) (T_6683 u4)) u0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084)))
 T_4252: (in fp : ptr32)
   Class: Eq_4252
   DataType: ptr32
@@ -20008,20 +19474,20 @@ T_4253: (in -120<i32> : int32)
   OrigDataType: int32
 T_4254: (in fp + -120<i32> : word32)
   Class: Eq_4251
-  DataType: Eq_4251
+  DataType: (ptr32 Eq_4251)
   OrigDataType: ptr32
-T_4255: (in d2_1090 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: Eq_4251
+T_4255: (in d2_1090 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: (struct "Eq_4251" 0004 (2C int32 dw002C) (30 Eq_8261 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8262 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_4256: (in a4_274 : (ptr32 Eq_621))
   Class: Eq_621
   DataType: (ptr32 Eq_621)
   OrigDataType: (ptr32 (struct 0001 (0 uint8 b0000)))
-T_4257: (in a2_1014 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: Eq_7763
+T_4257: (in a2_1014 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (ptr32 Eq_73)
 T_4258: (in d4_132 : Eq_4258)
   Class: Eq_4258
   DataType: Eq_4258
@@ -20030,13 +19496,13 @@ T_4259: (in 0<i32> : int32)
   Class: Eq_4258
   DataType: int32
   OrigDataType: int32
-T_4260: (in d5_1044 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: Eq_4251
+T_4260: (in d5_1044 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (struct "Eq_4251" 0004 (2C int32 dw002C) (30 Eq_8261 t0030) (34 word32 dw0034) (37 uint8 b0037) (38 word32 dw0038) (3C word32 dw003C) (40 word32 dw0040) (44 Eq_8262 t0044) (48 byte b0048) (49 byte b0049) (4A word32 dw004A) (6E word32 dw006E) (72 word32 dw0072) (84 word32 dw0084))
 T_4261: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_4262: (in 0<32> : word32)
   Class: Eq_4262
@@ -20058,13 +19524,13 @@ T_4266: (in dwArg08->b0000 == 0<8> : bool)
   Class: Eq_4266
   DataType: bool
   OrigDataType: bool
-T_4267: (in d0_3698 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+T_4267: (in d0_3698 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: byte
 T_4268: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_4269: (in d5_1044 != 0xFFFFFFFF<32> : bool)
   Class: Eq_4269
@@ -20159,8 +19625,8 @@ T_4291: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_4292: (in d0_63 & 8<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4293: (in d0_63 & 8<32> : word32)
   Class: Eq_4293
@@ -20188,7 +19654,7 @@ T_4298: (in a7_1330 + 72<i32> : word32)
   OrigDataType: ptr32
 T_4299: (in Mem277[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4296
-  DataType: Eq_4251
+  DataType: byte
   OrigDataType: byte
 T_4300: (in 0<8> : byte)
   Class: Eq_4300
@@ -20204,7 +19670,7 @@ T_4302: (in a7_1330 + 73<i32> : word32)
   OrigDataType: ptr32
 T_4303: (in Mem278[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_4300
-  DataType: Eq_4251
+  DataType: byte
   OrigDataType: byte
 T_4304: (in a3_279 : (ptr32 byte))
   Class: Eq_4304
@@ -20262,21 +19728,21 @@ T_4317: (in (uint32) (uint8) Mem278[0x00002815<p32> + (uint32) ((uint8) Mem278[a
   Class: Eq_4307
   DataType: uint32
   OrigDataType: uint32
-T_4318: (in d6_1133 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: uint8
+T_4318: (in d6_1133 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: (ptr32 Eq_1290)
 T_4319: (in -1<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_4320: (in 4<32> : word32)
   Class: Eq_4320
   DataType: ui32
   OrigDataType: ui32
 T_4321: (in d0_289 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4322: (in d0_289 & 4<32> : word32)
   Class: Eq_4322
@@ -20355,16 +19821,16 @@ T_4340: (in (uint32) (uint8) Mem278[0x00002815<p32> + (uint32) ((uint8) Mem278[a
   DataType: uint32
   OrigDataType: uint32
 T_4341: (in 0<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_4342: (in 4<32> : word32)
   Class: Eq_4342
   DataType: ui32
   OrigDataType: ui32
 T_4343: (in d0_305 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4344: (in d0_305 & 4<32> : word32)
   Class: Eq_4344
@@ -20378,9 +19844,9 @@ T_4346: (in (d0_305 & 4<32>) == 0<32> : bool)
   Class: Eq_4346
   DataType: bool
   OrigDataType: bool
-T_4347: (in a7_313 : (ptr32 Eq_25))
+T_4347: (in a7_313 : (ptr32 Eq_718))
   Class: Eq_4347
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_718 t0000)))
 T_4348: (in 4<i32> : int32)
   Class: Eq_4348
@@ -20388,7 +19854,7 @@ T_4348: (in 4<i32> : int32)
   OrigDataType: int32
 T_4349: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4347
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: ptr32
 T_4350: (in 0<32> : word32)
   Class: Eq_4350
@@ -20399,8 +19865,8 @@ T_4351: (in a7_313 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4352: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4353: (in d1_322 : uint32)
   Class: Eq_4353
@@ -20411,12 +19877,12 @@ T_4354: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_4356 (T_4355)))
 T_4355: (in 10<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_4356: (in __swap(10<i32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_4357: (in SLICE(d6_1133, word16, 0) : word16)
   Class: Eq_4357
@@ -20455,8 +19921,8 @@ T_4365: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_4366 (T_4318)))
 T_4366: (in __swap(d6_1133) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_4367: (in 0xA<16> : word16)
   Class: Eq_4367
@@ -20475,12 +19941,12 @@ T_4370: (in SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0) : word16)
   DataType: word16
   OrigDataType: word16
 T_4371: (in SEQ(SLICE(d1_322, word16, 16), SLICE(d1_322 + __swap(d6_1133) *u 0xA<16>, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_4372: (in __swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4373: (in SLICE(__swap(SEQ(SLICE(d1_322, word16, 16), (word16) (d1_322 + __swap(d6_1133) * 0xA<16>))), word16, 16) : word16)
   Class: Eq_4373
@@ -20583,32 +20049,32 @@ T_4397: (in a7_313 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4398: (in Mem316[a7_313 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_4399: (in 0x30<32> : word32)
   Class: Eq_4399
   DataType: uint32
   OrigDataType: uint32
 T_4400: (in d1_340 - 0x30<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_4401: (in d1_340 - 0x30<32> : word32)
   Class: Eq_4401
   DataType: uint32
   OrigDataType: uint32
 T_4402: (in d1_340 - 0x30<32> + d0_331 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_4403: (in 4<32> : word32)
   Class: Eq_4403
   DataType: ui32
   OrigDataType: ui32
 T_4404: (in d0_354 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4405: (in d0_354 & 4<32> : word32)
   Class: Eq_4405
@@ -20663,8 +20129,8 @@ T_4417: (in Mem361[a7_1330 + 72<i32>:byte] : byte)
   DataType: byte
   OrigDataType: byte
 T_4418: (in SEQ(SLICE(d1, word24, 8), Mem361[a7_1330 + 72<i32>:byte]) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4419: (in 0<32> : word32)
   Class: Eq_4419
@@ -20802,7 +20268,7 @@ T_4452: (in 0x6A<8> : byte)
   Class: Eq_4451
   DataType: byte
   OrigDataType: byte
-T_4453: (in *((word32) a7_1330 + 72<i32>) != 0x6A<8> : bool)
+T_4453: (in a7_1330[18<i32>] != 0x6A<8> : bool)
   Class: Eq_4453
   DataType: bool
   OrigDataType: bool
@@ -20851,8 +20317,8 @@ T_4464: (in *a3_279 == 0x68<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_4465: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_4466: (in false : bool)
   Class: Eq_4466
@@ -20891,8 +20357,8 @@ T_4474: (in *a3_279 != 0x68<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_4475: (in 2<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_4476: (in 0<32> : word32)
   Class: Eq_4476
@@ -21048,7 +20514,7 @@ T_4513: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4514: (in Mem463[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4511
-  DataType: Eq_4251
+  DataType: byte
   OrigDataType: byte
 T_4515: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_4515
@@ -21064,7 +20530,7 @@ T_4517: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4518: (in Mem469[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_4515
-  DataType: Eq_4251
+  DataType: byte
   OrigDataType: byte
 T_4519: (in SLICE(d1, word24, 8) : word24)
   Class: Eq_4519
@@ -21083,8 +20549,8 @@ T_4522: (in Mem361[a3_279 + 0<32>:byte] : byte)
   DataType: byte
   OrigDataType: byte
 T_4523: (in SEQ(SLICE(d1, word24, 8), Mem361[a3_279 + 0<32>:byte]) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4524: (in 0<32> : word32)
   Class: Eq_4524
@@ -21107,8 +20573,8 @@ T_4528: (in *a3_279 != 0x6C<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_4529: (in 1<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_4530: (in 72<i32> : int32)
   Class: Eq_4530
@@ -21126,7 +20592,7 @@ T_4533: (in 0x74<8> : byte)
   Class: Eq_4532
   DataType: byte
   OrigDataType: byte
-T_4534: (in *((word32) a7_1330 + 72<i32>) != 0x74<8> : bool)
+T_4534: (in a7_1330[18<i32>] != 0x74<8> : bool)
   Class: Eq_4534
   DataType: bool
   OrigDataType: bool
@@ -21144,7 +20610,7 @@ T_4537: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4538: (in Mem477[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4535
-  DataType: Eq_4251
+  DataType: byte
   OrigDataType: byte
 T_4539: (in 72<i32> : int32)
   Class: Eq_4539
@@ -21162,7 +20628,7 @@ T_4542: (in 0x7A<8> : byte)
   Class: Eq_4541
   DataType: byte
   OrigDataType: byte
-T_4543: (in *((word32) a7_1330 + 72<i32>) != 0x7A<8> : bool)
+T_4543: (in a7_1330[18<i32>] != 0x7A<8> : bool)
   Class: Eq_4543
   DataType: bool
   OrigDataType: bool
@@ -21180,7 +20646,7 @@ T_4546: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4547: (in Mem485[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4544
-  DataType: Eq_4251
+  DataType: byte
   OrigDataType: byte
 T_4548: (in v83_500 : byte)
   Class: Eq_4548
@@ -21244,7 +20710,7 @@ T_4562: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_4563: (in Mem493[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_4560
-  DataType: Eq_4251
+  DataType: byte
   OrigDataType: byte
 T_4564: (in v147_608 : word24)
   Class: Eq_4564
@@ -21254,9 +20720,9 @@ T_4565: (in SLICE(d1, word24, 8) : word24)
   Class: Eq_4564
   DataType: word24
   OrigDataType: word24
-T_4566: (in d1_612 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4566: (in d1_612 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4567: (in 0x25<8> : byte)
   Class: Eq_4548
@@ -21267,8 +20733,8 @@ T_4568: (in v83_500 - 0x25<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_4569: (in SEQ(v147_608, v83_500 - 0x25<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4570: (in v83_500 == 0x25<8> : bool)
   Class: Eq_4570
@@ -21306,9 +20772,9 @@ T_4578: (in v83_500 == 0x5B<8> : bool)
   Class: Eq_4578
   DataType: bool
   OrigDataType: bool
-T_4579: (in d0_540 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4579: (in d0_540 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4580: (in a0_523 : (ptr32 ui32))
   Class: Eq_4580
@@ -21410,9 +20876,9 @@ T_4604: (in v90_528 < 0<32> : bool)
   Class: Eq_4604
   DataType: bool
   OrigDataType: bool
-T_4605: (in a7_533 : (ptr32 Eq_25))
+T_4605: (in a7_533 : (ptr32 Eq_73))
   Class: Eq_4605
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4207 t0000)))
 T_4606: (in 4<i32> : int32)
   Class: Eq_4606
@@ -21420,7 +20886,7 @@ T_4606: (in 4<i32> : int32)
   OrigDataType: int32
 T_4607: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4605
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_4608: (in 0<32> : word32)
   Class: Eq_4608
@@ -21431,8 +20897,8 @@ T_4609: (in a7_533 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4610: (in Mem535[a7_533 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4611: (in d1_5316 : word32)
   Class: Eq_4611
@@ -21450,13 +20916,13 @@ T_4614: (in signature of fn00003C30 : void)
   Class: Eq_4613
   DataType: (ptr32 Eq_4613)
   OrigDataType: 
-T_4615: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4615: (in dwArg04 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: (ptr32 (struct (0 T_8065 t0000) (4 T_8038 t0004) (8 T_8038 t0008) (14 T_8016 t0014) (18 T_8003 t0018) (1C T_8026 t001C)))
-T_4616: (in d1Out : Eq_2601)
+T_4616: (in d1Out : (ptr32 (ptr32 Eq_4258)))
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: ptr32
 T_4617: (in a1Out : (ptr32 word32))
   Class: Eq_4617
@@ -21475,12 +20941,12 @@ T_4620: (in a7_533 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4621: (in Mem535[a7_533 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4622: (in out d1_5316 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: ptr32
 T_4623: (in out a1 : ptr32)
   Class: Eq_4617
@@ -21491,8 +20957,8 @@ T_4624: (in out a5_5317 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_4625: (in fn00003C30(*a7_533, out d1_5316, out a1, out a5_5317) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4626: (in 4<i32> : int32)
   Class: Eq_4626
@@ -21500,7 +20966,7 @@ T_4626: (in 4<i32> : int32)
   OrigDataType: int32
 T_4627: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_4628: (in a0_551 : (ptr32 byte))
   Class: Eq_4628
@@ -21518,9 +20984,9 @@ T_4631: (in Mem529[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
   DataType: (ptr32 byte)
   OrigDataType: word32
-T_4632: (in a7_552 : (ptr32 Eq_25))
+T_4632: (in a7_552 : (ptr32 Eq_73))
   Class: Eq_4632
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4207 t0000)))
 T_4633: (in 4<i32> : int32)
   Class: Eq_4633
@@ -21528,7 +20994,7 @@ T_4633: (in 4<i32> : int32)
   OrigDataType: int32
 T_4634: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4632
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_4635: (in 0<32> : word32)
   Class: Eq_4635
@@ -21539,8 +21005,8 @@ T_4636: (in a7_552 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4637: (in Mem554[a7_552 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4638: (in 1<i32> : int32)
   Class: Eq_4638
@@ -21560,8 +21026,8 @@ T_4641: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_4642: (in Mem558[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: word32
 T_4643: (in v96_562 : byte)
   Class: Eq_4643
   DataType: byte
@@ -21587,24 +21053,24 @@ T_4648: (in a7_552 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4649: (in Mem558[a7_552 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4650: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_4650
   DataType: word24
   OrigDataType: word24
 T_4651: (in SEQ(SLICE(d0, word24, 8), v96_562) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4652: (in (uint8) v96_562 : uint8)
   Class: Eq_4652
   DataType: uint8
   OrigDataType: uint8
 T_4653: (in (uint32) (uint8) v96_562 : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_4654: (in d0_591 : uint32)
   Class: Eq_4654
@@ -21663,8 +21129,8 @@ T_4667: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_4668: (in d0_591 & 8<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4669: (in d0_591 & 8<32> : word32)
   Class: Eq_4669
@@ -21678,9 +21144,9 @@ T_4671: (in (d0_591 & 8<32>) != 0<32> : bool)
   Class: Eq_4671
   DataType: bool
   OrigDataType: bool
-T_4672: (in d0_111 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4672: (in d0_111 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4673: (in a0_70 : (ptr32 ui32))
   Class: Eq_4673
@@ -21782,9 +21248,9 @@ T_4697: (in v126_74 < 0<32> : bool)
   Class: Eq_4697
   DataType: bool
   OrigDataType: bool
-T_4698: (in d0_187 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4698: (in d0_187 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4699: (in a0_170 : (ptr32 ui32))
   Class: Eq_4699
@@ -21886,9 +21352,9 @@ T_4723: (in v105_175 < 0<32> : bool)
   Class: Eq_4723
   DataType: bool
   OrigDataType: bool
-T_4724: (in a7_180 : (ptr32 Eq_25))
+T_4724: (in a7_180 : (ptr32 Eq_73))
   Class: Eq_4724
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4207 t0000)))
 T_4725: (in 4<i32> : int32)
   Class: Eq_4725
@@ -21896,7 +21362,7 @@ T_4725: (in 4<i32> : int32)
   OrigDataType: int32
 T_4726: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4724
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_4727: (in 0<32> : word32)
   Class: Eq_4727
@@ -21907,8 +21373,8 @@ T_4728: (in a7_180 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4729: (in Mem182[a7_180 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4730: (in d1_5318 : word32)
   Class: Eq_4730
@@ -21931,12 +21397,12 @@ T_4734: (in a7_180 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4735: (in Mem182[a7_180 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4736: (in out d1_5318 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: ptr32
 T_4737: (in out a1 : ptr32)
   Class: Eq_4617
@@ -21947,8 +21413,8 @@ T_4738: (in out a5_5319 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_4739: (in fn00003C30(*a7_180, out d1_5318, out a1, out a5_5319) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4740: (in 4<i32> : int32)
   Class: Eq_4740
@@ -21956,7 +21422,7 @@ T_4740: (in 4<i32> : int32)
   OrigDataType: int32
 T_4741: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_4742: (in a0_198 : (ptr32 byte))
   Class: Eq_4628
@@ -21974,9 +21440,9 @@ T_4745: (in Mem176[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
-T_4746: (in a7_199 : (ptr32 Eq_25))
+T_4746: (in a7_199 : (ptr32 Eq_73))
   Class: Eq_4746
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4207 t0000)))
 T_4747: (in 4<i32> : int32)
   Class: Eq_4747
@@ -21984,7 +21450,7 @@ T_4747: (in 4<i32> : int32)
   OrigDataType: int32
 T_4748: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4746
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_4749: (in 0<32> : word32)
   Class: Eq_4749
@@ -21995,8 +21461,8 @@ T_4750: (in a7_199 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4751: (in Mem201[a7_199 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4752: (in 1<i32> : int32)
   Class: Eq_4752
@@ -22016,8 +21482,8 @@ T_4755: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_4756: (in Mem205[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_4757: (in v109_209 : byte)
   Class: Eq_4643
   DataType: byte
@@ -22043,24 +21509,24 @@ T_4762: (in a7_199 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4763: (in Mem205[a7_199 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4764: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_4764
   DataType: word24
   OrigDataType: word24
 T_4765: (in SEQ(SLICE(d0, word24, 8), v109_209) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4766: (in (uint8) v109_209 : uint8)
   Class: Eq_4766
   DataType: uint8
   OrigDataType: uint8
 T_4767: (in (uint32) (uint8) v109_209 : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_4768: (in d0_238 : uint32)
   Class: Eq_4768
@@ -22119,8 +21585,8 @@ T_4781: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_4782: (in d0_238 & 8<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_4783: (in d0_238 & 8<32> : word32)
   Class: Eq_4783
@@ -22139,8 +21605,8 @@ T_4786: (in 1<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_4787: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_4788: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_4788
@@ -22158,9 +21624,9 @@ T_4791: (in 1<i32> : int32)
   Class: Eq_4270
   DataType: int32
   OrigDataType: int32
-T_4792: (in a7_248 : (ptr32 Eq_25))
+T_4792: (in a7_248 : (ptr32 Eq_73))
   Class: Eq_4792
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4207 t0000)))
 T_4793: (in 4<i32> : int32)
   Class: Eq_4793
@@ -22168,7 +21634,7 @@ T_4793: (in 4<i32> : int32)
   OrigDataType: int32
 T_4794: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4792
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_4795: (in 0<32> : word32)
   Class: Eq_4795
@@ -22179,8 +21645,8 @@ T_4796: (in a7_248 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4797: (in Mem251[a7_248 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4798: (in 4<i32> : int32)
   Class: Eq_4798
@@ -22188,7 +21654,7 @@ T_4798: (in 4<i32> : int32)
   OrigDataType: int32
 T_4799: (in a7_248 - 4<i32> : word32)
   Class: Eq_4799
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4802 t0000)))
 T_4800: (in 0<32> : word32)
   Class: Eq_4800
@@ -22199,8 +21665,8 @@ T_4801: (in a7_248 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4802: (in Mem254[a7_248 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4803: (in fn00002B5C : ptr32)
   Class: Eq_4803
@@ -22216,7 +21682,7 @@ T_4805: (in 1<i32> : int32)
   OrigDataType: int32
 T_4806: (in a7_248 - 1<i32> : word32)
   Class: Eq_4806
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4809 t0000)))
 T_4807: (in 0<32> : word32)
   Class: Eq_4807
@@ -22227,8 +21693,8 @@ T_4808: (in a7_248 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4809: (in Mem254[a7_248 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_4810: (in 0<32> : word32)
   Class: Eq_4810
@@ -22239,12 +21705,12 @@ T_4811: (in a7_248 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4812: (in Mem254[a7_248 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4813: (in fn00002B5C(*(a7_248 - 1<i32>), *a7_248) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4814: (in 1<i32> : int32)
   Class: Eq_4814
@@ -22275,8 +21741,8 @@ T_4820: (in a7_79 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4821: (in Mem81[a7_79 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4822: (in a5_5320 : word32)
   Class: Eq_4822
@@ -22295,12 +21761,12 @@ T_4825: (in a7_79 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4826: (in Mem81[a7_79 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4827: (in out d1 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: (union (int32 u1) (uint32 u0) (ptr32 u2))
 T_4828: (in out a1 : ptr32)
   Class: Eq_4617
@@ -22311,8 +21777,8 @@ T_4829: (in out a5_5320 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_4830: (in fn00003C30(a7_79->t0000, out d1, out a1, out a5_5320) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4831: (in 48<i32> : int32)
   Class: Eq_4831
@@ -22323,8 +21789,8 @@ T_4832: (in a7_79 + 48<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4833: (in Mem94[a7_79 + 48<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4834: (in 4<i32> : int32)
   Class: Eq_4834
@@ -22332,7 +21798,7 @@ T_4834: (in 4<i32> : int32)
   OrigDataType: int32
 T_4835: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_4836: (in a0_98 : (ptr32 byte))
   Class: Eq_4628
@@ -22371,8 +21837,8 @@ T_4844: (in a7_99 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4845: (in Mem101[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4846: (in 1<i32> : int32)
   Class: Eq_4846
@@ -22392,8 +21858,8 @@ T_4849: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_4850: (in Mem105[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_4851: (in v130_109 : byte)
   Class: Eq_4643
   DataType: byte
@@ -22419,8 +21885,8 @@ T_4856: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4857: (in Mem105[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4858: (in 0<32> : word32)
   Class: Eq_4858
@@ -22431,8 +21897,8 @@ T_4859: (in a7_99 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4860: (in Mem115[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4861: (in (uint8) v130_109 : uint8)
   Class: Eq_4861
@@ -22463,8 +21929,8 @@ T_4867: (in SLICE(d0_63 & 8<32>, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_4868: (in SEQ(SLICE(d0_63 & 8<32>, word24, 8), v130_109) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4869: (in 0<32> : word32)
   Class: Eq_4869
@@ -22472,12 +21938,12 @@ T_4869: (in 0<32> : word32)
   OrigDataType: word32
 T_4870: (in a7_99 + 0<32> : word32)
   Class: Eq_4870
-  DataType: (ptr32 Eq_4870)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_4871: (in Mem121[a7_99 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_4872: (in SLICE(d0_111, word24, 8) : word24)
   Class: Eq_4872
   DataType: word24
@@ -22507,8 +21973,8 @@ T_4878: (in (int16) (int8) SEQ(SLICE(d0_111, word24, 8), Mem127[a4_274 + 0<32>:b
   DataType: int16
   OrigDataType: int16
 T_4879: (in (int32) (int16) (int8) SEQ(SLICE(d0_111, word24, 8), Mem127[a4_274 + 0<32>:byte]) : int32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_4880: (in 44<i32> : int32)
   Class: Eq_4880
@@ -22519,8 +21985,8 @@ T_4881: (in a7_1330 + 44<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4882: (in Mem127[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4883: (in 1<32> : word32)
   Class: Eq_4270
@@ -22546,7 +22012,7 @@ T_4888: (in Mem127[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_4888
   DataType: int32
   OrigDataType: int32
-T_4889: (in d0 - *((word32) a7_1330 + 44<i32>) : word32)
+T_4889: (in d0 - a7_1330[11<i32>] : word32)
   Class: Eq_4889
   DataType: int32
   OrigDataType: int32
@@ -22554,7 +22020,7 @@ T_4890: (in 0<32> : word32)
   Class: Eq_4889
   DataType: int32
   OrigDataType: word32
-T_4891: (in d0 - *((word32) a7_1330 + 44<i32>) == 0<32> : bool)
+T_4891: (in d0 - a7_1330[11<i32>] == 0<32> : bool)
   Class: Eq_4891
   DataType: bool
   OrigDataType: bool
@@ -22579,8 +22045,8 @@ T_4896: (in a4_274->b0000 != 0<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_4897: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_4898: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_4898
@@ -22598,9 +22064,9 @@ T_4901: (in d4_132 - 1<32> : word32)
   Class: Eq_4258
   DataType: Eq_4258
   OrigDataType: int32
-T_4902: (in a7_148 : (ptr32 Eq_25))
+T_4902: (in a7_148 : (ptr32 Eq_73))
   Class: Eq_4902
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_4903: (in 4<i32> : int32)
   Class: Eq_4903
@@ -22608,7 +22074,7 @@ T_4903: (in 4<i32> : int32)
   OrigDataType: int32
 T_4904: (in a7_1330 - 4<i32> : word32)
   Class: Eq_4902
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_4905: (in 0<32> : word32)
   Class: Eq_4905
@@ -22619,8 +22085,8 @@ T_4906: (in a7_148 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4907: (in Mem151[a7_148 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4908: (in 4<i32> : int32)
   Class: Eq_4908
@@ -22628,7 +22094,7 @@ T_4908: (in 4<i32> : int32)
   OrigDataType: int32
 T_4909: (in a7_148 - 4<i32> : word32)
   Class: Eq_4909
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_4912 t0000)))
 T_4910: (in 0<32> : word32)
   Class: Eq_4910
@@ -22639,8 +22105,8 @@ T_4911: (in a7_148 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4912: (in Mem154[a7_148 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4913: (in fn00002B5C : ptr32)
   Class: Eq_4803
@@ -22652,7 +22118,7 @@ T_4914: (in 1<i32> : int32)
   OrigDataType: int32
 T_4915: (in a7_148 - 1<i32> : word32)
   Class: Eq_4915
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4918 t0000)))
 T_4916: (in 0<32> : word32)
   Class: Eq_4916
@@ -22663,8 +22129,8 @@ T_4917: (in a7_148 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_4918: (in Mem154[a7_148 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_4919: (in 0<32> : word32)
   Class: Eq_4919
@@ -22675,12 +22141,12 @@ T_4920: (in a7_148 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_4921: (in Mem154[a7_148 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4922: (in fn00002B5C(*(a7_148 - 1<i32>), *a7_148) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_4923: (in a0_628 : (ptr32 ui32))
   Class: Eq_4923
@@ -22804,8 +22270,8 @@ T_4952: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_4953: (in Mem761[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_4950
-  DataType: Eq_4251
-  OrigDataType: byte
+  DataType: Eq_4950
+  OrigDataType: int32
 T_4954: (in 0<32> : word32)
   Class: Eq_4954
   DataType: word32
@@ -22826,9 +22292,9 @@ T_4958: (in a3_1955->b0000 != 0x5E<8> : bool)
   Class: Eq_4958
   DataType: bool
   OrigDataType: bool
-T_4959: (in d1_1355 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_4959: (in d1_1355 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4960: (in 0x63<8> : byte)
   Class: Eq_4548
@@ -22839,16 +22305,16 @@ T_4961: (in v83_500 - 0x63<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_4962: (in SEQ(v147_608, v83_500 - 0x63<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4963: (in v83_500 == 0x63<8> : bool)
   Class: Eq_4963
   DataType: bool
   OrigDataType: bool
 T_4964: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: word32
 T_4965: (in d6_1133 != 0xFFFFFFFF<32> : bool)
   Class: Eq_4965
@@ -22863,8 +22329,8 @@ T_4967: (in v83_500 - 0x6E<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_4968: (in SEQ(v147_608, v83_500 - 0x6E<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4969: (in v83_500 == 0x6E<8> : bool)
   Class: Eq_4969
@@ -22886,7 +22352,7 @@ T_4973: (in 0<8> : byte)
   Class: Eq_4972
   DataType: byte
   OrigDataType: byte
-T_4974: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_4974: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_4974
   DataType: bool
   OrigDataType: bool
@@ -22899,8 +22365,8 @@ T_4976: (in v83_500 - 0x73<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_4977: (in SEQ(v147_608, v83_500 - 0x73<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_4978: (in v83_500 == 0x73<8> : bool)
   Class: Eq_4978
@@ -22926,7 +22392,7 @@ T_4983: (in 0<8> : byte)
   Class: Eq_4982
   DataType: byte
   OrigDataType: byte
-T_4984: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_4984: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_4984
   DataType: bool
   OrigDataType: bool
@@ -22944,7 +22410,7 @@ T_4987: (in a7_1330 + 48<i32> : word32)
   OrigDataType: ptr32
 T_4988: (in Mem1948[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_4985
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
 T_4989: (in 0<32> : word32)
   Class: Eq_4989
@@ -22960,7 +22426,7 @@ T_4991: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_4992: (in Mem1949[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_4989
-  DataType: Eq_4251
+  DataType: int32
   OrigDataType: int32
 T_4993: (in 0<32> : word32)
   Class: Eq_4993
@@ -22976,7 +22442,7 @@ T_4995: (in a7_1330 + 110<i32> : word32)
   OrigDataType: ptr32
 T_4996: (in Mem1950[a7_1330 + 110<i32>:word32] : word32)
   Class: Eq_4993
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
 T_4997: (in 0<8> : byte)
   Class: Eq_4548
@@ -23007,8 +22473,8 @@ T_5003: (in a7_640 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5004: (in Mem642[a7_640 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5005: (in a5_5321 : word32)
   Class: Eq_5005
@@ -23027,12 +22493,12 @@ T_5008: (in a7_640 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5009: (in Mem642[a7_640 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5010: (in out d1 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: (union (int32 u0) (uint32 u1) (ptr32 u2))
 T_5011: (in out a1 : ptr32)
   Class: Eq_4617
@@ -23043,8 +22509,8 @@ T_5012: (in out a5_5321 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5013: (in fn00003C30(a7_640->t0000, out d1, out a1, out a5_5321) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5014: (in 48<i32> : int32)
   Class: Eq_5014
@@ -23055,8 +22521,8 @@ T_5015: (in a7_640 + 48<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5016: (in Mem655[a7_640 + 48<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5017: (in 4<i32> : int32)
   Class: Eq_5017
@@ -23064,7 +22530,7 @@ T_5017: (in 4<i32> : int32)
   OrigDataType: int32
 T_5018: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_5019: (in a0_659 : (ptr32 byte))
   Class: Eq_4628
@@ -23103,8 +22569,8 @@ T_5027: (in a7_660 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5028: (in Mem662[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5029: (in 1<i32> : int32)
   Class: Eq_5029
@@ -23124,8 +22590,8 @@ T_5032: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_5033: (in Mem666[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_5034: (in v163_670 : byte)
   Class: Eq_4643
   DataType: byte
@@ -23151,8 +22617,8 @@ T_5039: (in a7_660 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5040: (in Mem666[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5041: (in 0<32> : word32)
   Class: Eq_5041
@@ -23160,12 +22626,12 @@ T_5041: (in 0<32> : word32)
   OrigDataType: word32
 T_5042: (in a7_660 + 0<32> : word32)
   Class: Eq_5042
-  DataType: (ptr32 Eq_5042)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_5043: (in Mem686[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5044: (in (uint8) v163_670 : uint8)
   Class: Eq_5044
   DataType: uint8
@@ -23191,8 +22657,8 @@ T_5049: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5050: (in SEQ(SLICE(d0, word24, 8), v163_670) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5051: (in 0<32> : word32)
   Class: Eq_5051
@@ -23200,12 +22666,12 @@ T_5051: (in 0<32> : word32)
   OrigDataType: word32
 T_5052: (in a7_660 + 0<32> : word32)
   Class: Eq_5052
-  DataType: (ptr32 Eq_5052)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_5053: (in Mem692[a7_660 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5054: (in 44<i32> : int32)
   Class: Eq_5054
   DataType: int32
@@ -23215,8 +22681,8 @@ T_5055: (in a7_1330 + 44<i32> : word32)
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
 T_5056: (in Mem698[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_5057: (in 1<32> : word32)
   Class: Eq_5057
@@ -23250,7 +22716,7 @@ T_5064: (in 0x25<32> : word32)
   Class: Eq_5063
   DataType: int32
   OrigDataType: word32
-T_5065: (in *((word32) a7_1330 + 44<i32>) == 0x25<32> : bool)
+T_5065: (in a7_1330[11<i32>] == 0x25<32> : bool)
   Class: Eq_5065
   DataType: bool
   OrigDataType: bool
@@ -23271,8 +22737,8 @@ T_5069: (in a3_1955 - 1<i32> : word32)
   DataType: (ptr32 Eq_621)
   OrigDataType: ptr32
 T_5070: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5071: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5071
@@ -23294,9 +22760,9 @@ T_5075: (in d4_132 - 1<32> : word32)
   Class: Eq_4258
   DataType: Eq_4258
   OrigDataType: int32
-T_5076: (in a7_735 : (ptr32 Eq_25))
+T_5076: (in a7_735 : (ptr32 Eq_73))
   Class: Eq_5076
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_5077: (in 4<i32> : int32)
   Class: Eq_5077
@@ -23304,7 +22770,7 @@ T_5077: (in 4<i32> : int32)
   OrigDataType: int32
 T_5078: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5076
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_5079: (in 0<32> : word32)
   Class: Eq_5079
@@ -23315,8 +22781,8 @@ T_5080: (in a7_735 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5081: (in Mem738[a7_735 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5082: (in 4<i32> : int32)
   Class: Eq_5082
@@ -23324,7 +22790,7 @@ T_5082: (in 4<i32> : int32)
   OrigDataType: int32
 T_5083: (in a7_735 - 4<i32> : word32)
   Class: Eq_5083
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_5086 t0000)))
 T_5084: (in 0<32> : word32)
   Class: Eq_5084
@@ -23335,8 +22801,8 @@ T_5085: (in a7_735 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5086: (in Mem741[a7_735 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5087: (in fn00002B5C : ptr32)
   Class: Eq_4803
@@ -23348,7 +22814,7 @@ T_5088: (in 1<i32> : int32)
   OrigDataType: int32
 T_5089: (in a7_735 - 1<i32> : word32)
   Class: Eq_5089
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5092 t0000)))
 T_5090: (in 0<32> : word32)
   Class: Eq_5090
@@ -23359,8 +22825,8 @@ T_5091: (in a7_735 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5092: (in Mem741[a7_735 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_5093: (in 0<32> : word32)
   Class: Eq_5093
@@ -23371,12 +22837,12 @@ T_5094: (in a7_735 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5095: (in Mem741[a7_735 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5096: (in fn00002B5C(*(a7_735 - 1<i32>), *a7_735) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5097: (in 0<32> : word32)
   Class: Eq_4270
@@ -23387,8 +22853,8 @@ T_5098: (in d3_130 == 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_5099: (in 0x2D<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5100: (in d5_1044 != 0x2D<32> : bool)
   Class: Eq_5100
@@ -23408,7 +22874,7 @@ T_5103: (in a7_1330 + 72<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5104: (in Mem1962[a7_1330 + 72<i32>:byte] : byte)
   Class: Eq_5101
-  DataType: Eq_4251
+  DataType: byte
   OrigDataType: byte
 T_5105: (in 120<i32> : int32)
   Class: Eq_4408
@@ -23439,16 +22905,16 @@ T_5111: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5112: (in (word32) d2_1090 + 3<i32> >> 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5113: (in 4<32> : word32)
   Class: Eq_5113
   DataType: word32
   OrigDataType: word32
 T_5114: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
 T_5115: (in 0<32> : word32)
   Class: Eq_5115
@@ -23463,8 +22929,8 @@ T_5117: (in Mem629[d0 + 0<32>:word32] : word32)
   DataType: (ptr32 byte)
   OrigDataType: word32
 T_5118: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5119: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5119
@@ -23496,7 +22962,7 @@ T_5125: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5126: (in Mem1716[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_5124
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
 T_5127: (in 1<i32> : int32)
   Class: Eq_4270
@@ -23518,7 +22984,7 @@ T_5131: (in 1<8> : byte)
   Class: Eq_5130
   DataType: byte
   OrigDataType: byte
-T_5132: (in *((word32) a7_1330 + 72<i32>) != 1<8> : bool)
+T_5132: (in a7_1330[18<i32>] != 1<8> : bool)
   Class: Eq_5132
   DataType: bool
   OrigDataType: bool
@@ -23538,14 +23004,14 @@ T_5136: (in 0x6C<8> : byte)
   Class: Eq_5135
   DataType: byte
   OrigDataType: byte
-T_5137: (in *((word32) a7_1330 + 72<i32>) != 0x6C<8> : bool)
+T_5137: (in a7_1330[18<i32>] != 0x6C<8> : bool)
   Class: Eq_5137
   DataType: bool
   OrigDataType: bool
 T_5138: (in 3<32> : word32)
   Class: Eq_5138
-  DataType: (ptr32 Eq_8277)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8263)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5139: (in d2_1090 + 3<32> : word32)
   Class: Eq_5139
   DataType: Eq_5139
@@ -23563,8 +23029,8 @@ T_5142: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5143: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5144: (in a0_1704 : (ptr32 Eq_5144))
   Class: Eq_5144
@@ -23615,12 +23081,12 @@ T_5155: (in 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_5156: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_5157: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5158: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5158
@@ -23675,8 +23141,8 @@ T_5170: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5171: (in d0_1765 & 8<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5172: (in d0_1765 & 8<32> : word32)
   Class: Eq_5172
@@ -23862,18 +23328,18 @@ T_5217: (in 0x68<8> : byte)
   Class: Eq_5216
   DataType: byte
   OrigDataType: byte
-T_5218: (in *((word32) a7_1330 + 72<i32>) != 0x68<8> : bool)
+T_5218: (in a7_1330[18<i32>] != 0x68<8> : bool)
   Class: Eq_5218
   DataType: bool
   OrigDataType: bool
 T_5219: (in 3<32> : word32)
   Class: Eq_5219
-  DataType: (ptr32 Eq_8278)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8264)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5220: (in d2_1090 + 3<32> : word32)
   Class: Eq_5220
-  DataType: (ptr32 Eq_8279)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8265)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5221: (in 2<32> : word32)
   Class: Eq_5221
   DataType: word32
@@ -23887,8 +23353,8 @@ T_5223: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5224: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5225: (in 0<32> : word32)
   Class: Eq_5225
@@ -23912,19 +23378,19 @@ T_5229: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_5230: (in Mem1694[Mem629[d0 + 0<32>:word32] + 0<32>:word32] : word32)
   Class: Eq_4258
-  DataType: Eq_25
+  DataType: Eq_73
   OrigDataType: Eq_4258
 T_5231: (in 4<32> : word32)
   Class: Eq_5231
   DataType: int32
   OrigDataType: int32
 T_5232: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
-T_5233: (in a7_1807 : (ptr32 Eq_25))
+T_5233: (in a7_1807 : (ptr32 Eq_73))
   Class: Eq_5233
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_5234: (in 4<i32> : int32)
   Class: Eq_5234
@@ -23932,7 +23398,7 @@ T_5234: (in 4<i32> : int32)
   OrigDataType: int32
 T_5235: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5233
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_5236: (in 0<32> : word32)
   Class: Eq_5236
@@ -23943,8 +23409,8 @@ T_5237: (in a7_1807 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5238: (in Mem1809[a7_1807 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5239: (in d1_5322 : word32)
   Class: Eq_5239
@@ -23963,12 +23429,12 @@ T_5242: (in a7_1807 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5243: (in Mem1809[a7_1807 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5244: (in out d1_5322 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: ptr32
 T_5245: (in out a1 : ptr32)
   Class: Eq_4617
@@ -23979,8 +23445,8 @@ T_5246: (in out a5_1727 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct 0001 (0 byte b0000)))
 T_5247: (in fn00003C30(*a7_1807, out d1_5322, out a1, out a5_1727) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5248: (in 4<i32> : int32)
   Class: Eq_5248
@@ -23988,7 +23454,7 @@ T_5248: (in 4<i32> : int32)
   OrigDataType: int32
 T_5249: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_5250: (in a0_1825 : (ptr32 byte))
   Class: Eq_4628
@@ -24006,9 +23472,9 @@ T_5253: (in Mem1802[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
-T_5254: (in a7_1826 : (ptr32 Eq_25))
+T_5254: (in a7_1826 : (ptr32 Eq_73))
   Class: Eq_5254
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_5255: (in 4<i32> : int32)
   Class: Eq_5255
@@ -24016,7 +23482,7 @@ T_5255: (in 4<i32> : int32)
   OrigDataType: int32
 T_5256: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5254
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_5257: (in 0<32> : word32)
   Class: Eq_5257
@@ -24027,8 +23493,8 @@ T_5258: (in a7_1826 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5259: (in Mem1828[a7_1826 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5260: (in 1<i32> : int32)
   Class: Eq_5260
@@ -24048,8 +23514,8 @@ T_5263: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_5264: (in Mem1832[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_5265: (in v201_1836 : byte)
   Class: Eq_4643
   DataType: byte
@@ -24075,24 +23541,24 @@ T_5270: (in a7_1826 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5271: (in Mem1832[a7_1826 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5272: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_5272
   DataType: word24
   OrigDataType: word24
 T_5273: (in SEQ(SLICE(d0, word24, 8), v201_1836) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5274: (in (uint8) v201_1836 : uint8)
   Class: Eq_5274
   DataType: uint8
   OrigDataType: uint8
 T_5275: (in (uint32) (uint8) v201_1836 : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_5276: (in 1<32> : word32)
   Class: Eq_5276
@@ -24111,8 +23577,8 @@ T_5279: (in d4_132 + 1<32> : word32)
   DataType: Eq_4258
   OrigDataType: int32
 T_5280: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5281: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5281
@@ -24134,18 +23600,18 @@ T_5285: (in 2<8> : byte)
   Class: Eq_5284
   DataType: byte
   OrigDataType: byte
-T_5286: (in *((word32) a7_1330 + 72<i32>) != 2<8> : bool)
+T_5286: (in a7_1330[18<i32>] != 2<8> : bool)
   Class: Eq_5286
   DataType: bool
   OrigDataType: bool
 T_5287: (in 3<32> : word32)
   Class: Eq_5287
-  DataType: (ptr32 Eq_8280)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8266)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5288: (in d2_1090 + 3<32> : word32)
   Class: Eq_5288
-  DataType: (ptr32 Eq_8281)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8267)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5289: (in 2<32> : word32)
   Class: Eq_5289
   DataType: word32
@@ -24159,8 +23625,8 @@ T_5291: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5292: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5293: (in SLICE(d4_132, word16, 0) : word16)
   Class: Eq_4258
@@ -24188,15 +23654,15 @@ T_5298: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_5299: (in Mem1682[Mem629[d0 + 0<32>:word32] + 0<32>:word16] : word16)
   Class: Eq_4258
-  DataType: Eq_25
+  DataType: Eq_73
   OrigDataType: Eq_4258
 T_5300: (in 4<32> : word32)
   Class: Eq_5300
   DataType: int32
   OrigDataType: int32
 T_5301: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_5302: (in 73<i32> : int32)
   Class: Eq_5302
@@ -24208,7 +23674,7 @@ T_5303: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_5304: (in Mem1889[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_5178
-  DataType: Eq_4251
+  DataType: byte
   OrigDataType: byte
 T_5305: (in d0_1871 : uint32)
   Class: Eq_5305
@@ -24259,8 +23725,8 @@ T_5316: (in 8<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5317: (in d0_1871 & 8<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5318: (in d0_1871 & 8<32> : word32)
   Class: Eq_5318
@@ -24296,12 +23762,12 @@ T_5325: (in v190_1777 != 0<8> : bool)
   OrigDataType: bool
 T_5326: (in 3<32> : word32)
   Class: Eq_5326
-  DataType: (ptr32 Eq_8282)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8268)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5327: (in d2_1090 + 3<32> : word32)
   Class: Eq_5327
-  DataType: (ptr32 Eq_8283)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8269)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5328: (in 2<32> : word32)
   Class: Eq_5328
   DataType: word32
@@ -24315,8 +23781,8 @@ T_5330: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5331: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5332: (in 0<32> : word32)
   Class: Eq_5332
@@ -24340,24 +23806,24 @@ T_5336: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: (ptr32 int32)
 T_5337: (in Mem1658[Mem629[d0 + 0<32>:word32] + 0<32>:word32] : word32)
   Class: Eq_4258
-  DataType: Eq_25
+  DataType: Eq_73
   OrigDataType: Eq_4258
 T_5338: (in 4<32> : word32)
   Class: Eq_5338
   DataType: int32
   OrigDataType: int32
 T_5339: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_5340: (in 3<32> : word32)
   Class: Eq_5340
-  DataType: (ptr32 Eq_8284)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8270)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5341: (in d2_1090 + 3<32> : word32)
   Class: Eq_5341
-  DataType: (ptr32 Eq_8285)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8271)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5342: (in 2<32> : word32)
   Class: Eq_5342
   DataType: word32
@@ -24371,8 +23837,8 @@ T_5344: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5345: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5346: (in SLICE(d4_132, byte, 0) : byte)
   Class: Eq_4258
@@ -24400,15 +23866,15 @@ T_5351: (in Mem629[d0 + 0<32>:word32] + 0<32> : word32)
   OrigDataType: (ptr32 int32)
 T_5352: (in Mem1670[Mem629[d0 + 0<32>:word32] + 0<32>:byte] : byte)
   Class: Eq_4258
-  DataType: Eq_25
+  DataType: Eq_73
   OrigDataType: Eq_4258
 T_5353: (in 4<32> : word32)
   Class: Eq_5353
   DataType: int32
   OrigDataType: int32
 T_5354: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_5355: (in 1<32> : word32)
   Class: Eq_5355
@@ -24442,13 +23908,13 @@ T_5362: (in 0<8> : byte)
   Class: Eq_5361
   DataType: byte
   OrigDataType: byte
-T_5363: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5363: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5363
   DataType: bool
   OrigDataType: bool
-T_5364: (in a7_1897 : (ptr32 Eq_25))
+T_5364: (in a7_1897 : (ptr32 Eq_73))
   Class: Eq_5364
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_5365: (in 4<i32> : int32)
   Class: Eq_5365
@@ -24456,7 +23922,7 @@ T_5365: (in 4<i32> : int32)
   OrigDataType: int32
 T_5366: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5364
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_5367: (in 0<32> : word32)
   Class: Eq_5367
@@ -24467,8 +23933,8 @@ T_5368: (in a7_1897 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5369: (in Mem1903[a7_1897 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5370: (in 4<i32> : int32)
   Class: Eq_5370
@@ -24476,7 +23942,7 @@ T_5370: (in 4<i32> : int32)
   OrigDataType: int32
 T_5371: (in a7_1897 - 4<i32> : word32)
   Class: Eq_5371
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_5374 t0000)))
 T_5372: (in 0<32> : word32)
   Class: Eq_5372
@@ -24487,8 +23953,8 @@ T_5373: (in a7_1897 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5374: (in Mem1906[a7_1897 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5375: (in fn00002B5C : ptr32)
   Class: Eq_4803
@@ -24500,7 +23966,7 @@ T_5376: (in 1<i32> : int32)
   OrigDataType: int32
 T_5377: (in a7_1897 - 1<i32> : word32)
   Class: Eq_5377
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5380 t0000)))
 T_5378: (in 0<32> : word32)
   Class: Eq_5378
@@ -24511,8 +23977,8 @@ T_5379: (in a7_1897 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5380: (in Mem1906[a7_1897 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_5381: (in 0<32> : word32)
   Class: Eq_5381
@@ -24523,16 +23989,16 @@ T_5382: (in a7_1897 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5383: (in Mem1906[a7_1897 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5384: (in fn00002B5C(*(a7_1897 - 1<i32>), *a7_1897) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5385: (in 0x2B<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5386: (in d5_1044 != 0x2B<32> : bool)
   Class: Eq_5386
@@ -24583,9 +24049,9 @@ T_5397: (in a7_1330 + 110<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5398: (in Mem1994[a7_1330 + 110<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4251
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_5399: (in a0_1999 : (ptr32 ui32))
   Class: Eq_5399
   DataType: (ptr32 ui32)
@@ -24707,8 +24173,8 @@ T_5428: (in a7_2007 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5429: (in Mem2009[a7_2007 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5430: (in a5_5323 : word32)
   Class: Eq_5430
@@ -24727,12 +24193,12 @@ T_5433: (in a7_2007 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5434: (in Mem2009[a7_2007 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5435: (in out d1 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 (struct (0 T_5230 t0000))) ptr0000))) u0) (uint32 u1) (ptr32 u2))
 T_5436: (in out a1 : ptr32)
   Class: Eq_4617
@@ -24743,8 +24209,8 @@ T_5437: (in out a5_5323 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5438: (in fn00003C30(a7_2007->t0000, out d1, out a1, out a5_5323) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5439: (in 56<i32> : int32)
   Class: Eq_5439
@@ -24755,8 +24221,8 @@ T_5440: (in a7_2007 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5441: (in Mem2022[a7_2007 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5442: (in 4<i32> : int32)
   Class: Eq_5442
@@ -24764,7 +24230,7 @@ T_5442: (in 4<i32> : int32)
   OrigDataType: int32
 T_5443: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_5444: (in a0_2026 : (ptr32 byte))
   Class: Eq_4628
@@ -24803,8 +24269,8 @@ T_5452: (in a7_2027 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5453: (in Mem2029[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5454: (in 1<i32> : int32)
   Class: Eq_5454
@@ -24824,8 +24290,8 @@ T_5457: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_5458: (in Mem2033[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_5459: (in v231_2037 : byte)
   Class: Eq_4643
   DataType: byte
@@ -24851,8 +24317,8 @@ T_5464: (in a7_2027 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5465: (in Mem2033[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5466: (in 0<32> : word32)
   Class: Eq_5466
@@ -24860,12 +24326,12 @@ T_5466: (in 0<32> : word32)
   OrigDataType: word32
 T_5467: (in a7_2027 + 0<32> : word32)
   Class: Eq_5467
-  DataType: (ptr32 Eq_5467)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_5468: (in Mem2050[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5469: (in (uint8) v231_2037 : uint8)
   Class: Eq_5469
   DataType: uint8
@@ -24891,8 +24357,8 @@ T_5474: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5475: (in SEQ(SLICE(d0, word24, 8), v231_2037) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5476: (in 0<32> : word32)
   Class: Eq_5476
@@ -24900,12 +24366,12 @@ T_5476: (in 0<32> : word32)
   OrigDataType: word32
 T_5477: (in a7_2027 + 0<32> : word32)
   Class: Eq_5477
-  DataType: (ptr32 Eq_5477)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_5478: (in Mem2056[a7_2027 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5479: (in 52<i32> : int32)
   Class: Eq_5479
   DataType: int32
@@ -24915,8 +24381,8 @@ T_5480: (in a7_1330 + 52<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5481: (in Mem2062[a7_1330 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5482: (in 1<32> : word32)
   Class: Eq_5482
@@ -24984,7 +24450,7 @@ T_5497: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_5498: (in Mem1946[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_5496
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
 T_5499: (in d4_2510 : Eq_4258)
   Class: Eq_4258
@@ -25007,8 +24473,8 @@ T_5503: (in (byte) d7 != 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_5504: (in 0x30<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5505: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_5505
@@ -25063,8 +24529,8 @@ T_5517: (in 4<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5518: (in d0_2109 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5519: (in d0_2109 & 4<32> : word32)
   Class: Eq_5519
@@ -25090,9 +24556,9 @@ T_5524: (in d6_1133 - d3_1850 < 0<32> : bool)
   Class: Eq_5524
   DataType: bool
   OrigDataType: bool
-T_5525: (in d0_2155 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_5525: (in d0_2155 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5526: (in a0_2139 : (ptr32 ui32))
   Class: Eq_5526
@@ -25215,8 +24681,8 @@ T_5555: (in a7_2148 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5556: (in Mem2150[a7_2148 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5557: (in a5_5324 : word32)
   Class: Eq_5557
@@ -25235,12 +24701,12 @@ T_5560: (in a7_2148 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5561: (in Mem2150[a7_2148 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5562: (in out d1 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: (ptr32 (struct 0004 (0 (ptr32 (struct (0 T_5230 t0000))) ptr0000)))
 T_5563: (in out a1 : ptr32)
   Class: Eq_4617
@@ -25251,8 +24717,8 @@ T_5564: (in out a5_5324 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5565: (in fn00003C30(a7_2148->t0000, out d1, out a1, out a5_5324) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5566: (in 56<i32> : int32)
   Class: Eq_5566
@@ -25263,8 +24729,8 @@ T_5567: (in a7_2148 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5568: (in Mem2163[a7_2148 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5569: (in 4<i32> : int32)
   Class: Eq_5569
@@ -25272,7 +24738,7 @@ T_5569: (in 4<i32> : int32)
   OrigDataType: int32
 T_5570: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_5571: (in a0_2167 : (ptr32 byte))
   Class: Eq_4628
@@ -25311,8 +24777,8 @@ T_5579: (in a7_2168 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5580: (in Mem2170[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5581: (in 1<i32> : int32)
   Class: Eq_5581
@@ -25332,8 +24798,8 @@ T_5584: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_5585: (in Mem2174[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_5586: (in v249_2178 : byte)
   Class: Eq_4643
   DataType: byte
@@ -25359,8 +24825,8 @@ T_5591: (in a7_2168 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5592: (in Mem2174[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5593: (in 0<32> : word32)
   Class: Eq_5593
@@ -25368,12 +24834,12 @@ T_5593: (in 0<32> : word32)
   OrigDataType: word32
 T_5594: (in a7_2168 + 0<32> : word32)
   Class: Eq_5594
-  DataType: (ptr32 Eq_5594)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_5595: (in Mem2185[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5596: (in (uint8) v249_2178 : uint8)
   Class: Eq_5596
   DataType: uint8
@@ -25399,8 +24865,8 @@ T_5601: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5602: (in SEQ(SLICE(d0, word24, 8), v249_2178) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5603: (in 0<32> : word32)
   Class: Eq_5603
@@ -25408,12 +24874,12 @@ T_5603: (in 0<32> : word32)
   OrigDataType: word32
 T_5604: (in a7_2168 + 0<32> : word32)
   Class: Eq_5604
-  DataType: (ptr32 Eq_5604)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_5605: (in Mem2191[a7_2168 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5606: (in 52<i32> : int32)
   Class: Eq_5606
   DataType: int32
@@ -25452,12 +24918,12 @@ T_5614: (in 55<i32> : int32)
   OrigDataType: int32
 T_5615: (in a7_1330 + 55<i32> : word32)
   Class: Eq_5615
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_5616: (in Mem2199[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_5616
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_5617: (in SEQ(SLICE(d0_2155, word24, 8), Mem2199[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_5612
   DataType: ui32
@@ -25479,8 +24945,8 @@ T_5621: (in 0xFF<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5622: (in d0_2209 & 0xFF<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5623: (in __btst : ptr32)
   Class: Eq_5623
@@ -25550,17 +25016,17 @@ T_5639: (in 0<8> : byte)
   Class: Eq_5638
   DataType: byte
   OrigDataType: byte
-T_5640: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_5640: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_5640
   DataType: bool
   OrigDataType: bool
 T_5641: (in 1<i32> : int32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: int32
 T_5642: (in 0x78<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5643: (in d0 != 0x78<32> : bool)
   Class: Eq_5643
@@ -25591,8 +25057,8 @@ T_5649: (in (byte) (d0_2209 & 0xFF<32>) | 0x20<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_5650: (in SEQ(SLICE(d0_2209 & 0xFF<32>, word24, 8), SLICE(d0_2209 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5651: (in 0<32> : word32)
   Class: Eq_5635
@@ -25600,12 +25066,12 @@ T_5651: (in 0<32> : word32)
   OrigDataType: word32
 T_5652: (in 3<32> : word32)
   Class: Eq_5652
-  DataType: (ptr32 Eq_8290)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8272)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5653: (in d2_1090 + 3<32> : word32)
   Class: Eq_5653
-  DataType: (ptr32 Eq_8291)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8273)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_5654: (in 2<32> : word32)
   Class: Eq_5654
   DataType: word32
@@ -25619,16 +25085,16 @@ T_5656: (in 2<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_5657: (in d2_1090 + 3<32> >>u 2<32> << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5658: (in 4<32> : word32)
   Class: Eq_5658
   DataType: int32
   OrigDataType: int32
 T_5659: (in d0 + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ptr32
 T_5660: (in 0<32> : word32)
   Class: Eq_5660
@@ -25740,8 +25206,8 @@ T_5686: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5687: (in Mem1393[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_5635
-  DataType: Eq_4251
-  OrigDataType: (ptr32 Eq_4258)
+  DataType: (ptr32 Eq_4258)
+  OrigDataType: int32
 T_5688: (in 0<32> : word32)
   Class: Eq_5688
   DataType: word32
@@ -25778,9 +25244,9 @@ T_5696: (in d6_1133 - d3_2201 < 0<32> : bool)
   Class: Eq_5696
   DataType: bool
   OrigDataType: bool
-T_5697: (in d0_2253 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_5697: (in d0_2253 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5698: (in a0_2236 : (ptr32 ui32))
   Class: Eq_5698
@@ -25903,8 +25369,8 @@ T_5727: (in a7_2246 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5728: (in Mem2248[a7_2246 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5729: (in a5_5325 : word32)
   Class: Eq_5729
@@ -25923,13 +25389,13 @@ T_5732: (in a7_2246 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5733: (in Mem2248[a7_2246 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5734: (in out d1 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4258))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5735: (in out a1 : ptr32)
   Class: Eq_4617
   DataType: (ptr32 word32)
@@ -25939,8 +25405,8 @@ T_5736: (in out a5_5325 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5737: (in fn00003C30(a7_2246->t0000, out d1, out a1, out a5_5325) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5738: (in 56<i32> : int32)
   Class: Eq_5738
@@ -25951,8 +25417,8 @@ T_5739: (in a7_2246 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5740: (in Mem2261[a7_2246 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5741: (in 4<i32> : int32)
   Class: Eq_5741
@@ -25960,7 +25426,7 @@ T_5741: (in 4<i32> : int32)
   OrigDataType: int32
 T_5742: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_5743: (in a0_2265 : (ptr32 byte))
   Class: Eq_4628
@@ -25999,8 +25465,8 @@ T_5751: (in a7_2266 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5752: (in Mem2268[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5753: (in 1<i32> : int32)
   Class: Eq_5753
@@ -26020,8 +25486,8 @@ T_5756: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_5757: (in Mem2272[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_5758: (in v271_2276 : byte)
   Class: Eq_4643
   DataType: byte
@@ -26047,8 +25513,8 @@ T_5763: (in a7_2266 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5764: (in Mem2272[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5765: (in 0<32> : word32)
   Class: Eq_5765
@@ -26056,12 +25522,12 @@ T_5765: (in 0<32> : word32)
   OrigDataType: word32
 T_5766: (in a7_2266 + 0<32> : word32)
   Class: Eq_5766
-  DataType: (ptr32 Eq_5766)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_5767: (in Mem2283[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5768: (in (uint8) v271_2276 : uint8)
   Class: Eq_5768
   DataType: uint8
@@ -26087,8 +25553,8 @@ T_5773: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5774: (in SEQ(SLICE(d0, word24, 8), v271_2276) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5775: (in 0<32> : word32)
   Class: Eq_5775
@@ -26096,12 +25562,12 @@ T_5775: (in 0<32> : word32)
   OrigDataType: word32
 T_5776: (in a7_2266 + 0<32> : word32)
   Class: Eq_5776
-  DataType: (ptr32 Eq_5776)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_5777: (in Mem2289[a7_2266 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5778: (in 52<i32> : int32)
   Class: Eq_5778
   DataType: int32
@@ -26175,8 +25641,8 @@ T_5795: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_5796: (in d0_2317 & 0x44<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_5797: (in d0_2317 & 0x44<32> : word32)
   Class: Eq_5797
@@ -26227,8 +25693,8 @@ T_5808: (in a7_1400 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5809: (in Mem1402[a7_1400 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5810: (in 48<i32> : int32)
   Class: Eq_5810
@@ -26263,13 +25729,13 @@ T_5817: (in a7_1400 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5818: (in Mem1404[a7_1400 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5819: (in out d1 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4258))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5820: (in out a1_5326 : ptr32)
   Class: Eq_4617
   DataType: (ptr32 word32)
@@ -26279,8 +25745,8 @@ T_5821: (in out a5_5327 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5822: (in fn00003C30(a7_1400->t0000, out d1, out a1_5326, out a5_5327) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5823: (in 56<i32> : int32)
   Class: Eq_5823
@@ -26291,8 +25757,8 @@ T_5824: (in a7_1400 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5825: (in Mem1417[a7_1400 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5826: (in 48<i32> : int32)
   Class: Eq_5826
@@ -26367,8 +25833,8 @@ T_5843: (in a7_1425 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5844: (in Mem1427[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5845: (in 1<i32> : int32)
   Class: Eq_5845
@@ -26415,8 +25881,8 @@ T_5855: (in a7_1425 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5856: (in Mem1431[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5857: (in 0<32> : word32)
   Class: Eq_5857
@@ -26424,12 +25890,12 @@ T_5857: (in 0<32> : word32)
   OrigDataType: word32
 T_5858: (in a7_1425 + 0<32> : word32)
   Class: Eq_5858
-  DataType: (ptr32 Eq_5858)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_5859: (in Mem1444[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5860: (in (uint8) v284_1435 : uint8)
   Class: Eq_5860
   DataType: uint8
@@ -26455,8 +25921,8 @@ T_5865: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_5866: (in SEQ(SLICE(d0, word24, 8), v284_1435) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_5867: (in 0<32> : word32)
   Class: Eq_5867
@@ -26464,12 +25930,12 @@ T_5867: (in 0<32> : word32)
   OrigDataType: word32
 T_5868: (in a7_1425 + 0<32> : word32)
   Class: Eq_5868
-  DataType: (ptr32 Eq_5868)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_5869: (in Mem1450[a7_1425 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_5870: (in 44<i32> : int32)
   Class: Eq_5870
   DataType: int32
@@ -26480,7 +25946,7 @@ T_5871: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5872: (in Mem1456[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: int32
 T_5873: (in 52<i32> : int32)
   Class: Eq_5873
@@ -26491,8 +25957,8 @@ T_5874: (in a7_1330 + 52<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5875: (in Mem1456[a7_1330 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5876: (in d3_1462 : Eq_5876)
   Class: Eq_5876
@@ -26534,7 +26000,7 @@ T_5885: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_5884
   DataType: word32
   OrigDataType: word32
-T_5886: (in *((word32) a7_1330 + 52<i32>) == 0xFFFFFFFF<32> : bool)
+T_5886: (in a7_1330[13<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_5886
   DataType: bool
   OrigDataType: bool
@@ -26554,7 +26020,7 @@ T_5890: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_5889
   DataType: word32
   OrigDataType: word32
-T_5891: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_5891: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_5891
   DataType: bool
   OrigDataType: bool
@@ -26583,8 +26049,8 @@ T_5897: (in 120<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_5898: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_5899: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_5899
@@ -26600,8 +26066,8 @@ T_5901: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_5902: (in Mem1472[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_4251
-  OrigDataType: Eq_25
+  DataType: (ptr32 Eq_25)
+  OrigDataType: int32
 T_5903: (in d6_1133 - d3_1462 : word32)
   Class: Eq_5903
   DataType: Eq_5903
@@ -26795,8 +26261,8 @@ T_5950: (in a7_2334 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5951: (in Mem2338[a7_2334 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5952: (in 78<i32> : int32)
   Class: Eq_5952
@@ -26840,7 +26306,7 @@ T_5961: (in 1<i32> : int32)
   OrigDataType: int32
 T_5962: (in a7_2334 - 1<i32> : word32)
   Class: Eq_5962
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_5965 t0000)))
 T_5963: (in 0<32> : word32)
   Class: Eq_5963
@@ -26851,8 +26317,8 @@ T_5964: (in a7_2334 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5965: (in Mem2342[a7_2334 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_5966: (in 0<32> : word32)
   Class: Eq_5966
@@ -26863,16 +26329,16 @@ T_5967: (in a7_2334 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5968: (in Mem2342[a7_2334 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5969: (in fn00002B5C(*(a7_2334 - 1<i32>), a7_2334->t0000) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_5970: (in a7_1512 : (ptr32 Eq_25))
+T_5970: (in a7_1512 : (ptr32 Eq_73))
   Class: Eq_5970
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_5971: (in 4<i32> : int32)
   Class: Eq_5971
@@ -26880,7 +26346,7 @@ T_5971: (in 4<i32> : int32)
   OrigDataType: int32
 T_5972: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5970
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_5973: (in 0<32> : word32)
   Class: Eq_5973
@@ -26891,8 +26357,8 @@ T_5974: (in a7_1512 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5975: (in Mem1514[a7_1512 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5976: (in d1_5328 : word32)
   Class: Eq_5976
@@ -26915,12 +26381,12 @@ T_5980: (in a7_1512 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_5981: (in Mem1514[a7_1512 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5982: (in out d1_5328 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: ptr32
 T_5983: (in out a1 : ptr32)
   Class: Eq_4617
@@ -26931,8 +26397,8 @@ T_5984: (in out a5_5329 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_5985: (in fn00003C30(*a7_1512, out d1_5328, out a1, out a5_5329) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5986: (in 4<i32> : int32)
   Class: Eq_5986
@@ -26940,7 +26406,7 @@ T_5986: (in 4<i32> : int32)
   OrigDataType: int32
 T_5987: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_5988: (in a0_1530 : (ptr32 byte))
   Class: Eq_4628
@@ -26958,9 +26424,9 @@ T_5991: (in Mem1507[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
-T_5992: (in a7_1531 : (ptr32 Eq_25))
+T_5992: (in a7_1531 : (ptr32 Eq_73))
   Class: Eq_5992
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_5993: (in 4<i32> : int32)
   Class: Eq_5993
@@ -26968,7 +26434,7 @@ T_5993: (in 4<i32> : int32)
   OrigDataType: int32
 T_5994: (in a7_1330 - 4<i32> : word32)
   Class: Eq_5992
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_5995: (in 0<32> : word32)
   Class: Eq_5995
@@ -26979,8 +26445,8 @@ T_5996: (in a7_1531 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_5997: (in Mem1533[a7_1531 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_5998: (in 1<i32> : int32)
   Class: Eq_5998
@@ -27000,8 +26466,8 @@ T_6001: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_6002: (in Mem1537[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_6003: (in v314_1541 : byte)
   Class: Eq_4643
   DataType: byte
@@ -27027,24 +26493,24 @@ T_6008: (in a7_1531 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6009: (in Mem1537[a7_1531 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6010: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_6010
   DataType: word24
   OrigDataType: word24
 T_6011: (in SEQ(SLICE(d0, word24, 8), v314_1541) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6012: (in (uint8) v314_1541 : uint8)
   Class: Eq_6012
   DataType: uint8
   OrigDataType: uint8
 T_6013: (in (uint32) (uint8) v314_1541 : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_6014: (in 1<32> : word32)
   Class: Eq_6014
@@ -27063,8 +26529,8 @@ T_6017: (in d4_1466 + 1<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_6018: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_6019: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6019
@@ -27080,7 +26546,7 @@ T_6021: (in a7_1330 + 73<i32> : word32)
   OrigDataType: (ptr32 byte)
 T_6022: (in Mem1577[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_5906
-  DataType: Eq_4251
+  DataType: byte
   OrigDataType: byte
 T_6023: (in d6_1133 - d3_1462 : word32)
   Class: Eq_6023
@@ -27118,7 +26584,7 @@ T_6031: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6030
   DataType: word32
   OrigDataType: word32
-T_6032: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_6032: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6032
   DataType: bool
   OrigDataType: bool
@@ -27154,13 +26620,13 @@ T_6040: (in 0<8> : byte)
   Class: Eq_6039
   DataType: byte
   OrigDataType: byte
-T_6041: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_6041: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_6041
   DataType: bool
   OrigDataType: bool
-T_6042: (in a7_1585 : (ptr32 Eq_25))
+T_6042: (in a7_1585 : (ptr32 Eq_73))
   Class: Eq_6042
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_6043: (in 4<i32> : int32)
   Class: Eq_6043
@@ -27168,7 +26634,7 @@ T_6043: (in 4<i32> : int32)
   OrigDataType: int32
 T_6044: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6042
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_6045: (in 0<32> : word32)
   Class: Eq_6045
@@ -27179,8 +26645,8 @@ T_6046: (in a7_1585 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6047: (in Mem1591[a7_1585 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6048: (in 4<i32> : int32)
   Class: Eq_6048
@@ -27188,7 +26654,7 @@ T_6048: (in 4<i32> : int32)
   OrigDataType: int32
 T_6049: (in a7_1585 - 4<i32> : word32)
   Class: Eq_6049
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6052 t0000)))
 T_6050: (in 0<32> : word32)
   Class: Eq_6050
@@ -27199,8 +26665,8 @@ T_6051: (in a7_1585 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6052: (in Mem1594[a7_1585 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6053: (in fn00002B5C : ptr32)
   Class: Eq_4803
@@ -27212,7 +26678,7 @@ T_6054: (in 1<i32> : int32)
   OrigDataType: int32
 T_6055: (in a7_1585 - 1<i32> : word32)
   Class: Eq_6055
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6058 t0000)))
 T_6056: (in 0<32> : word32)
   Class: Eq_6056
@@ -27223,8 +26689,8 @@ T_6057: (in a7_1585 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6058: (in Mem1594[a7_1585 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_6059: (in 0<32> : word32)
   Class: Eq_6059
@@ -27235,12 +26701,12 @@ T_6060: (in a7_1585 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6061: (in Mem1594[a7_1585 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6062: (in fn00002B5C(*(a7_1585 - 1<i32>), *a7_1585) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6063: (in a7_2368 : (ptr32 Eq_6063))
   Class: Eq_6063
@@ -27263,8 +26729,8 @@ T_6067: (in a7_2368 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6068: (in Mem2373[a7_2368 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6069: (in 68<i32> : int32)
   Class: Eq_6069
@@ -27308,7 +26774,7 @@ T_6078: (in 1<i32> : int32)
   OrigDataType: int32
 T_6079: (in a7_2368 - 1<i32> : word32)
   Class: Eq_6079
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6082 t0000)))
 T_6080: (in 0<32> : word32)
   Class: Eq_6080
@@ -27319,8 +26785,8 @@ T_6081: (in a7_2368 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6082: (in Mem2377[a7_2368 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_6083: (in 0<32> : word32)
   Class: Eq_6083
@@ -27331,12 +26797,12 @@ T_6084: (in a7_2368 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6085: (in Mem2377[a7_2368 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6086: (in fn00002B5C(*(a7_2368 - 1<i32>), a7_2368->t0000) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6087: (in 0<32> : word32)
   Class: Eq_4270
@@ -27372,7 +26838,7 @@ T_6094: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6095: (in Mem1625[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_6093
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
 T_6096: (in d0_2124 : uint32)
   Class: Eq_6096
@@ -27427,8 +26893,8 @@ T_6108: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6109: (in d0_2124 & 0x44<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6110: (in d0_2124 & 0x44<32> : word32)
   Class: Eq_6110
@@ -27471,8 +26937,8 @@ T_6119: (in (byte) d7 == 0x78<8> : bool)
   DataType: bool
   OrigDataType: bool
 T_6120: (in 0x30<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_6121: (in d5_1044 != 0x30<32> : bool)
   Class: Eq_6121
@@ -27490,9 +26956,9 @@ T_6124: (in d6_1133 - d3_1850 < 0<32> : bool)
   Class: Eq_6124
   DataType: bool
   OrigDataType: bool
-T_6125: (in d0_2450 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6125: (in d0_2450 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6126: (in a0_2430 : (ptr32 ui32))
   Class: Eq_6126
@@ -27615,8 +27081,8 @@ T_6155: (in a7_2443 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6156: (in Mem2445[a7_2443 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6157: (in a5_5330 : word32)
   Class: Eq_6157
@@ -27635,13 +27101,13 @@ T_6160: (in a7_2443 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6161: (in Mem2445[a7_2443 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6162: (in out d1 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4258))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_6163: (in out a1 : ptr32)
   Class: Eq_4617
   DataType: (ptr32 word32)
@@ -27651,8 +27117,8 @@ T_6164: (in out a5_5330 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_6165: (in fn00003C30(a7_2443->t0000, out d1, out a1, out a5_5330) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6166: (in 56<i32> : int32)
   Class: Eq_6166
@@ -27663,8 +27129,8 @@ T_6167: (in a7_2443 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6168: (in Mem2458[a7_2443 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6169: (in 4<i32> : int32)
   Class: Eq_6169
@@ -27672,7 +27138,7 @@ T_6169: (in 4<i32> : int32)
   OrigDataType: int32
 T_6170: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_6171: (in a0_2462 : (ptr32 byte))
   Class: Eq_4628
@@ -27711,8 +27177,8 @@ T_6179: (in a7_2463 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6180: (in Mem2465[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6181: (in 1<i32> : int32)
   Class: Eq_6181
@@ -27732,8 +27198,8 @@ T_6184: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_6185: (in Mem2469[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_6186: (in v351_2473 : byte)
   Class: Eq_4643
   DataType: byte
@@ -27759,8 +27225,8 @@ T_6191: (in a7_2463 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6192: (in Mem2469[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6193: (in 0<32> : word32)
   Class: Eq_6193
@@ -27768,12 +27234,12 @@ T_6193: (in 0<32> : word32)
   OrigDataType: word32
 T_6194: (in a7_2463 + 0<32> : word32)
   Class: Eq_6194
-  DataType: (ptr32 Eq_6194)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_6195: (in Mem2492[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_6196: (in (uint8) v351_2473 : uint8)
   Class: Eq_6196
   DataType: uint8
@@ -27799,8 +27265,8 @@ T_6201: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_6202: (in SEQ(SLICE(d0, word24, 8), v351_2473) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6203: (in 0<32> : word32)
   Class: Eq_6203
@@ -27808,12 +27274,12 @@ T_6203: (in 0<32> : word32)
   OrigDataType: word32
 T_6204: (in a7_2463 + 0<32> : word32)
   Class: Eq_6204
-  DataType: (ptr32 Eq_6204)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_6205: (in Mem2498[a7_2463 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_6206: (in 52<i32> : int32)
   Class: Eq_6206
   DataType: int32
@@ -27852,12 +27318,12 @@ T_6214: (in 55<i32> : int32)
   OrigDataType: int32
 T_6215: (in a7_1330 + 55<i32> : word32)
   Class: Eq_6215
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_6216: (in Mem2506[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_6216
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_6217: (in SEQ(SLICE(d0_2450, word24, 8), Mem2506[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_6212
   DataType: ui32
@@ -27891,8 +27357,8 @@ T_6224: (in 0xFF<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6225: (in d0_2517 & 0xFF<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6226: (in __btst : ptr32)
   Class: Eq_5623
@@ -27931,8 +27397,8 @@ T_6234: (in __btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[(int3
   DataType: bool
   OrigDataType: bool
 T_6235: (in 0x78<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_6236: (in d0 != 0x78<32> : bool)
   Class: Eq_6236
@@ -27963,8 +27429,8 @@ T_6242: (in (byte) (d0_2517 & 0xFF<32>) | 0x20<8> : byte)
   DataType: byte
   OrigDataType: byte
 T_6243: (in SEQ(SLICE(d0_2517 & 0xFF<32>, word24, 8), SLICE(d0_2517 & 0xFF<32>, byte, 0) | 0x20<8>) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6244: (in 64<i32> : int32)
   Class: Eq_6244
@@ -27982,7 +27448,7 @@ T_6247: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6246
   DataType: word32
   OrigDataType: word32
-T_6248: (in *((word32) a7_1330 + 64<i32>) == 0xFFFFFFFF<32> : bool)
+T_6248: (in a7_1330[16<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_6248
   DataType: bool
   OrigDataType: bool
@@ -27998,9 +27464,9 @@ T_6251: (in d6_1133 - d3_2508 < 0<32> : bool)
   Class: Eq_6251
   DataType: bool
   OrigDataType: bool
-T_6252: (in d0_2559 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6252: (in d0_2559 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6253: (in a0_2542 : (ptr32 ui32))
   Class: Eq_6253
@@ -28123,8 +27589,8 @@ T_6282: (in a7_2552 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6283: (in Mem2554[a7_2552 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6284: (in a5_5331 : word32)
   Class: Eq_6284
@@ -28143,13 +27609,13 @@ T_6287: (in a7_2552 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6288: (in Mem2554[a7_2552 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6289: (in out d1 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4258))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_6290: (in out a1 : ptr32)
   Class: Eq_4617
   DataType: (ptr32 word32)
@@ -28159,8 +27625,8 @@ T_6291: (in out a5_5331 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_6292: (in fn00003C30(a7_2552->t0000, out d1, out a1, out a5_5331) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6293: (in 56<i32> : int32)
   Class: Eq_6293
@@ -28171,8 +27637,8 @@ T_6294: (in a7_2552 + 56<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6295: (in Mem2567[a7_2552 + 56<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6296: (in 4<i32> : int32)
   Class: Eq_6296
@@ -28180,7 +27646,7 @@ T_6296: (in 4<i32> : int32)
   OrigDataType: int32
 T_6297: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_6298: (in a0_2571 : (ptr32 byte))
   Class: Eq_4628
@@ -28219,8 +27685,8 @@ T_6306: (in a7_2572 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6307: (in Mem2574[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6308: (in 1<i32> : int32)
   Class: Eq_6308
@@ -28240,8 +27706,8 @@ T_6311: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_6312: (in Mem2578[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_6313: (in v372_2582 : byte)
   Class: Eq_4643
   DataType: byte
@@ -28267,8 +27733,8 @@ T_6318: (in a7_2572 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6319: (in Mem2578[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6320: (in 0<32> : word32)
   Class: Eq_6320
@@ -28276,12 +27742,12 @@ T_6320: (in 0<32> : word32)
   OrigDataType: word32
 T_6321: (in a7_2572 + 0<32> : word32)
   Class: Eq_6321
-  DataType: (ptr32 Eq_6321)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_6322: (in Mem2589[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_6323: (in (uint8) v372_2582 : uint8)
   Class: Eq_6323
   DataType: uint8
@@ -28307,8 +27773,8 @@ T_6328: (in SLICE(d0, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_6329: (in SEQ(SLICE(d0, word24, 8), v372_2582) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_6330: (in 0<32> : word32)
   Class: Eq_6330
@@ -28316,12 +27782,12 @@ T_6330: (in 0<32> : word32)
   OrigDataType: word32
 T_6331: (in a7_2572 + 0<32> : word32)
   Class: Eq_6331
-  DataType: (ptr32 Eq_6331)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_6332: (in Mem2595[a7_2572 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_6333: (in 52<i32> : int32)
   Class: Eq_6333
   DataType: int32
@@ -28364,12 +27830,12 @@ T_6342: (in 55<i32> : int32)
   OrigDataType: int32
 T_6343: (in a7_1330 + 55<i32> : word32)
   Class: Eq_6343
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_6344: (in Mem2603[a7_1330 + 55<i32>:byte] : byte)
   Class: Eq_6344
-  DataType: Eq_6344
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_6344 u2))
+  DataType: uint8
+  OrigDataType: uint8
 T_6345: (in SEQ(SLICE(d0_2559, word24, 8), Mem2603[a7_1330 + 55<i32>:byte]) : uip32)
   Class: Eq_6345
   DataType: ui32
@@ -28378,7 +27844,7 @@ T_6346: (in 0xFF<32> : word32)
   Class: Eq_6346
   DataType: ui32
   OrigDataType: ui32
-T_6347: (in SEQ(SLICE(d0_2559, word24, 8), *((word32) a7_1330 + 55<i32>)) & 0xFF<32> : word32)
+T_6347: (in SEQ(SLICE(d0_2559, word24, 8), a7_1330->b0037) & 0xFF<32> : word32)
   Class: Eq_6347
   DataType: int32
   OrigDataType: int32
@@ -28419,8 +27885,8 @@ T_6356: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6357: (in d0_2620 & 0x44<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6358: (in d0_2620 & 0x44<32> : word32)
   Class: Eq_6358
@@ -28448,7 +27914,7 @@ T_6363: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6364: (in Mem2726[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_6361
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
 T_6365: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6365
@@ -28551,9 +28017,9 @@ T_6389: (in a7_1330 + 132<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6390: (in Mem2790[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4251
-  OrigDataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: word32
 T_6391: (in 52<i32> : int32)
   Class: Eq_6391
   DataType: int32
@@ -28564,8 +28030,8 @@ T_6392: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6393: (in Mem2796[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4258
-  DataType: Eq_4251
-  OrigDataType: Eq_4258
+  DataType: Eq_4258
+  OrigDataType: word32
 T_6394: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6394
   DataType: Eq_6394
@@ -28580,15 +28046,15 @@ T_6396: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6397: (in Mem2801[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6394
-  DataType: Eq_4251
-  OrigDataType: Eq_6394
+  DataType: Eq_6394
+  OrigDataType: word32
 T_6398: (in 0x44<32> : word32)
   Class: Eq_6398
   DataType: ui32
   OrigDataType: ui32
 T_6399: (in d0_2760 & 0x44<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6400: (in d0_2760 & 0x44<32> : word32)
   Class: Eq_6400
@@ -28639,8 +28105,8 @@ T_6411: (in a7_2667 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6412: (in Mem2671[a7_2667 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6413: (in 68<i32> : int32)
   Class: Eq_6413
@@ -28684,7 +28150,7 @@ T_6422: (in 1<i32> : int32)
   OrigDataType: int32
 T_6423: (in a7_2667 - 1<i32> : word32)
   Class: Eq_6423
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6426 t0000)))
 T_6424: (in 0<32> : word32)
   Class: Eq_6424
@@ -28695,8 +28161,8 @@ T_6425: (in a7_2667 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6426: (in Mem2675[a7_2667 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_6427: (in 0<32> : word32)
   Class: Eq_6427
@@ -28707,12 +28173,12 @@ T_6428: (in a7_2667 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6429: (in Mem2675[a7_2667 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6430: (in fn00002B5C(*(a7_2667 - 1<i32>), a7_2667->t0000) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6431: (in 74<i32> : int32)
   Class: Eq_6431
@@ -28730,7 +28196,7 @@ T_6434: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_6433
   DataType: word32
   OrigDataType: word32
-T_6435: (in *((word32) a7_1330 + 74<i32>) == 0xFFFFFFFF<32> : bool)
+T_6435: (in a7_1330->dw004A == 0xFFFFFFFF<32> : bool)
   Class: Eq_6435
   DataType: bool
   OrigDataType: bool
@@ -28759,8 +28225,8 @@ T_6441: (in a7_1330 + 74<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6442: (in Mem2603[a7_1330 + 74<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6443: (in v476_3238 : Eq_6443)
   Class: Eq_6443
@@ -28811,8 +28277,8 @@ T_6454: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6455: (in Mem3235[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_6456: (in 110<i32> : int32)
   Class: Eq_6456
@@ -28830,7 +28296,7 @@ T_6459: (in 0<32> : word32)
   Class: Eq_6458
   DataType: word32
   OrigDataType: word32
-T_6460: (in *((word32) a7_1330 + 110<i32>) == 0<32> : bool)
+T_6460: (in a7_1330->dw006E == 0<32> : bool)
   Class: Eq_6460
   DataType: bool
   OrigDataType: bool
@@ -28850,7 +28316,7 @@ T_6464: (in 0xA<32> : word32)
   Class: Eq_6463
   DataType: word32
   OrigDataType: word32
-T_6465: (in *((word32) a7_1330 + 114<i32>) != 0xA<32> : bool)
+T_6465: (in a7_1330->dw0072 != 0xA<32> : bool)
   Class: Eq_6465
   DataType: bool
   OrigDataType: bool
@@ -28870,7 +28336,7 @@ T_6469: (in 8<32> : word32)
   Class: Eq_6468
   DataType: word32
   OrigDataType: word32
-T_6470: (in *((word32) a7_1330 + 114<i32>) != 8<32> : bool)
+T_6470: (in a7_1330->dw0072 != 8<32> : bool)
   Class: Eq_6470
   DataType: bool
   OrigDataType: bool
@@ -28931,9 +28397,9 @@ T_6484: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6485: (in Mem2821[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4251
-  OrigDataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: word32
 T_6486: (in 52<i32> : int32)
   Class: Eq_6486
   DataType: int32
@@ -28944,8 +28410,8 @@ T_6487: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6488: (in Mem2823[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4258
-  DataType: Eq_4251
-  OrigDataType: Eq_4258
+  DataType: Eq_4258
+  OrigDataType: word32
 T_6489: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6489
   DataType: Eq_6489
@@ -28960,15 +28426,15 @@ T_6491: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6492: (in Mem2825[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6489
-  DataType: Eq_4251
-  OrigDataType: Eq_6489
+  DataType: Eq_6489
+  OrigDataType: word32
 T_6493: (in 4<32> : word32)
   Class: Eq_6493
   DataType: ui32
   OrigDataType: ui32
 T_6494: (in d0_2818 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6495: (in d0_2818 & 4<32> : word32)
   Class: Eq_6495
@@ -28991,9 +28457,9 @@ T_6499: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6500: (in Mem2851[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4251
-  OrigDataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: word32
 T_6501: (in 52<i32> : int32)
   Class: Eq_6501
   DataType: int32
@@ -29004,8 +28470,8 @@ T_6502: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6503: (in Mem2854[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4258
-  DataType: Eq_4251
-  OrigDataType: Eq_4258
+  DataType: Eq_4258
+  OrigDataType: word32
 T_6504: (in 64<i32> : int32)
   Class: Eq_6504
   DataType: int32
@@ -29015,9 +28481,9 @@ T_6505: (in a7_1330 + 64<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6506: (in Mem2866[a7_1330 + 64<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4251
-  OrigDataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: word32
 T_6507: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6507
   DataType: Eq_6507
@@ -29032,8 +28498,8 @@ T_6509: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6510: (in Mem2869[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6507
-  DataType: Eq_4251
-  OrigDataType: Eq_6507
+  DataType: Eq_6507
+  OrigDataType: word32
 T_6511: (in d6_1133 - d3_2423 : word32)
   Class: Eq_6511
   DataType: Eq_6511
@@ -29055,9 +28521,9 @@ T_6515: (in a7_1330 + 132<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6516: (in Mem2837[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4251
-  OrigDataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: word32
 T_6517: (in 52<i32> : int32)
   Class: Eq_6517
   DataType: int32
@@ -29068,8 +28534,8 @@ T_6518: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6519: (in Mem2840[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_4258
-  DataType: Eq_4251
-  OrigDataType: Eq_4258
+  DataType: Eq_4258
+  OrigDataType: word32
 T_6520: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_6520
   DataType: Eq_6520
@@ -29084,11 +28550,11 @@ T_6522: (in a7_1330 + 74<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6523: (in Mem2843[a7_1330 + 74<i32>:byte] : byte)
   Class: Eq_6520
-  DataType: Eq_4251
-  OrigDataType: Eq_6520
+  DataType: Eq_6520
+  OrigDataType: word32
 T_6524: (in 0x37<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_6525: (in d5_1044 > 0x37<32> : bool)
   Class: Eq_6525
@@ -29138,9 +28604,9 @@ T_6536: (in d6_3015 : Eq_6536)
   Class: Eq_6536
   DataType: Eq_6536
   OrigDataType: int32
-T_6537: (in v419_2893 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6537: (in v419_2893 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_6538: (in 4<i32> : int32)
   Class: Eq_6538
@@ -29148,7 +28614,7 @@ T_6538: (in 4<i32> : int32)
   OrigDataType: int32
 T_6539: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6539
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_6542 t0000)))
 T_6540: (in 0<32> : word32)
   Class: Eq_6540
@@ -29159,8 +28625,8 @@ T_6541: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6542: (in Mem2967[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_6543: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6543
@@ -29224,8 +28690,8 @@ T_6557: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6558: (in Mem2980[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6551
-  DataType: Eq_4251
-  OrigDataType: Eq_6551
+  DataType: Eq_6551
+  OrigDataType: word32
 T_6559: (in 8<i32> : int32)
   Class: Eq_6559
   DataType: int32
@@ -29296,8 +28762,8 @@ T_6575: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_6576: (in Mem2992[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_6573
-  DataType: Eq_4251
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_6577: (in v441_2993 : word32)
   Class: Eq_6577
   DataType: word32
@@ -29492,8 +28958,8 @@ T_6624: (in a7_1330 + 68<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (ptr32 u1) (T_6554 u2)))
 T_6625: (in Mem3040[a7_1330 + 68<i32>:word32] : word32)
   Class: Eq_6618
-  DataType: Eq_4251
-  OrigDataType: Eq_6618
+  DataType: Eq_6618
+  OrigDataType: (union (int32 u0) (ptr32 u1) (T_6554 u2))
 T_6626: (in 8<i32> : int32)
   Class: Eq_6626
   DataType: int32
@@ -29550,7 +29016,7 @@ T_6639: (in d2_3037 < 0<32> : bool)
   Class: Eq_6639
   DataType: bool
   OrigDataType: bool
-T_6640: (in (word32) *((word32) a7_1330 + 44<i32>) + d0_3029 + (d2_3037 < 0<32>) : word32)
+T_6640: (in (word32) a7_1330[11<i32>] + d0_3029 + (d2_3037 < 0<32>) : word32)
   Class: Eq_6640
   DataType: int32
   OrigDataType: int32
@@ -29564,8 +29030,8 @@ T_6642: (in a7_1330 + 64<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6643: (in Mem3051[a7_1330 + 64<i32>:word32] : word32)
   Class: Eq_6640
-  DataType: Eq_4251
-  OrigDataType: int32
+  DataType: int32
+  OrigDataType: word32
 T_6644: (in v453_3052 : word32)
   Class: Eq_6644
   DataType: word32
@@ -29658,9 +29124,9 @@ T_6666: (in d5_1044 - 0x57<32> : word32)
   Class: Eq_6605
   DataType: Eq_6605
   OrigDataType: ptr32
-T_6667: (in d0_3135 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6667: (in d0_3135 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_6668: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6668
@@ -29740,8 +29206,8 @@ T_6686: (in a7_1330 + 48<i32> : word32)
   OrigDataType: (ptr32 (union (int32 u0) (ptr32 u1) (T_6621 u2)))
 T_6687: (in Mem3098[a7_1330 + 48<i32>:word32] : word32)
   Class: Eq_6680
-  DataType: Eq_4251
-  OrigDataType: Eq_6680
+  DataType: Eq_6680
+  OrigDataType: (union (int32 u0) (ptr32 u1) (T_6621 u2))
 T_6688: (in 8<i32> : int32)
   Class: Eq_6688
   DataType: int32
@@ -29808,8 +29274,8 @@ T_6703: (in a7_1330 + 44<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_6704: (in Mem3108[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_6701
-  DataType: Eq_4251
-  OrigDataType: bool
+  DataType: int32
+  OrigDataType: int32
 T_6705: (in a0_3119 : (ptr32 ui32))
   Class: Eq_6705
   DataType: (ptr32 ui32)
@@ -29848,7 +29314,7 @@ T_6713: (in Mem3108[a7_1330 - 8<i32> + 0<32>:word32] : word32)
   OrigDataType: word32
 T_6714: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6714
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_6717 t0000)))
 T_6715: (in 0<32> : word32)
   Class: Eq_6715
@@ -29859,8 +29325,8 @@ T_6716: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6717: (in Mem3108[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_6718: (in 0<32> : word32)
   Class: Eq_6718
@@ -29952,7 +29418,7 @@ T_6739: (in v468_3124 < 0<32> : bool)
   OrigDataType: bool
 T_6740: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6740
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6743 t0000)))
 T_6741: (in 0<32> : word32)
   Class: Eq_6741
@@ -29963,8 +29429,8 @@ T_6742: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6743: (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6744: (in d1_5332 : word32)
   Class: Eq_6744
@@ -29980,7 +29446,7 @@ T_6746: (in fn00003C30 : ptr32)
   OrigDataType: (ptr32 (fn T_6754 (T_6750, T_6751, T_6752, T_6753)))
 T_6747: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6747
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6750 t0000)))
 T_6748: (in 0<32> : word32)
   Class: Eq_6748
@@ -29991,12 +29457,12 @@ T_6749: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6750: (in Mem3130[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6751: (in out d1_5332 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: ptr32
 T_6752: (in out a1 : ptr32)
   Class: Eq_4617
@@ -30007,8 +29473,8 @@ T_6753: (in out a5_5333 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_6754: (in fn00003C30(*(a7_1330 - 4<i32>), out d1_5332, out a1, out a5_5333) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6755: (in 4<i32> : int32)
   Class: Eq_6755
@@ -30016,7 +29482,7 @@ T_6755: (in 4<i32> : int32)
   OrigDataType: int32
 T_6756: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_6757: (in a0_3146 : (ptr32 byte))
   Class: Eq_4628
@@ -30036,7 +29502,7 @@ T_6760: (in Mem3125[a1 + 0<32>:word32] : word32)
   OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_6761: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6761
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6764 t0000)))
 T_6762: (in 0<32> : word32)
   Class: Eq_6762
@@ -30047,8 +29513,8 @@ T_6763: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6764: (in Mem3149[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6765: (in 1<i32> : int32)
   Class: Eq_6765
@@ -30068,8 +29534,8 @@ T_6768: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_6769: (in Mem3153[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_6770: (in 0<32> : word32)
   Class: Eq_6770
   DataType: word32
@@ -30087,12 +29553,12 @@ T_6773: (in (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_6774: (in (uint32) (uint8) Mem3153[a0_3146 + 0<32>:byte] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_6775: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6775
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6778 t0000)))
 T_6776: (in 0<32> : word32)
   Class: Eq_6776
@@ -30103,8 +29569,8 @@ T_6777: (in a7_1330 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6778: (in Mem3153[a7_1330 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6779: (in SLICE(d0_3135, byte, 0) : byte)
   Class: Eq_6779
@@ -30115,8 +29581,8 @@ T_6780: (in (uint8) SLICE(d0_3135, byte, 0) : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_6781: (in (uint32) (uint8) SLICE(d0_3135, byte, 0) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_6782: (in 52<i32> : int32)
   Class: Eq_6782
@@ -30148,7 +29614,7 @@ T_6788: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_6789: (in Mem3172[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_6786
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
 T_6790: (in d0_3184 : uint32)
   Class: Eq_6790
@@ -30207,8 +29673,8 @@ T_6803: (in 0x44<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6804: (in d0_3184 & 0x44<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6805: (in d0_3184 & 0x44<32> : word32)
   Class: Eq_6805
@@ -30223,8 +29689,8 @@ T_6807: (in (d0_3184 & 0x44<32>) == 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_6808: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_6809: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6809
@@ -30239,8 +29705,8 @@ T_6811: (in d3_2423 != 2<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_6812: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_6813: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_6813
@@ -30271,12 +29737,12 @@ T_6819: (in a7_1330 + 110<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6820: (in Mem3291[a7_1330 + 110<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
-T_6821: (in a7_3259 : (ptr32 Eq_25))
+T_6821: (in a7_3259 : (ptr32 Eq_73))
   Class: Eq_6821
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_6822: (in 4<i32> : int32)
   Class: Eq_6822
@@ -30284,7 +29750,7 @@ T_6822: (in 4<i32> : int32)
   OrigDataType: int32
 T_6823: (in a7_1330 - 4<i32> : word32)
   Class: Eq_6821
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_6824: (in 0<32> : word32)
   Class: Eq_6824
@@ -30295,8 +29761,8 @@ T_6825: (in a7_3259 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6826: (in Mem3272[a7_3259 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6827: (in 4<i32> : int32)
   Class: Eq_6827
@@ -30304,7 +29770,7 @@ T_6827: (in 4<i32> : int32)
   OrigDataType: int32
 T_6828: (in a7_3259 - 4<i32> : word32)
   Class: Eq_6828
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_6831 t0000)))
 T_6829: (in 0<32> : word32)
   Class: Eq_6829
@@ -30315,8 +29781,8 @@ T_6830: (in a7_3259 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6831: (in Mem3275[a7_3259 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6832: (in fn00002B5C : ptr32)
   Class: Eq_4803
@@ -30328,7 +29794,7 @@ T_6833: (in 1<i32> : int32)
   OrigDataType: int32
 T_6834: (in a7_3259 - 1<i32> : word32)
   Class: Eq_6834
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6837 t0000)))
 T_6835: (in 0<32> : word32)
   Class: Eq_6835
@@ -30339,8 +29805,8 @@ T_6836: (in a7_3259 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6837: (in Mem3275[a7_3259 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_6838: (in 0<32> : word32)
   Class: Eq_6838
@@ -30351,12 +29817,12 @@ T_6839: (in a7_3259 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6840: (in Mem3275[a7_3259 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6841: (in fn00002B5C(*(a7_3259 - 1<i32>), *a7_3259) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6842: (in a7_2635 : (ptr32 Eq_6842))
   Class: Eq_6842
@@ -30379,8 +29845,8 @@ T_6846: (in a7_2635 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6847: (in Mem2639[a7_2635 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6848: (in 78<i32> : int32)
   Class: Eq_6848
@@ -30424,7 +29890,7 @@ T_6857: (in 1<i32> : int32)
   OrigDataType: int32
 T_6858: (in a7_2635 - 1<i32> : word32)
   Class: Eq_6858
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_6861 t0000)))
 T_6859: (in 0<32> : word32)
   Class: Eq_6859
@@ -30435,8 +29901,8 @@ T_6860: (in a7_2635 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6861: (in Mem2643[a7_2635 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_6862: (in 0<32> : word32)
   Class: Eq_6862
@@ -30447,12 +29913,12 @@ T_6863: (in a7_2635 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6864: (in Mem2643[a7_2635 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6865: (in fn00002B5C(*(a7_2635 - 1<i32>), a7_2635->t0000) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_6866: (in 0xA<32> : word32)
   Class: Eq_4408
@@ -30523,8 +29989,8 @@ T_6882: (in 4<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_6883: (in d0_3206 & 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_6884: (in d0_3206 & 4<32> : word32)
   Class: Eq_6884
@@ -30555,8 +30021,8 @@ T_6890: (in a4_2881 - (v465_3109 + 1<32>) >= 0<32> : bool)
   DataType: bool
   OrigDataType: bool
 T_6891: (in 0x37<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: int32
 T_6892: (in d1 > 0x37<32> : bool)
   Class: Eq_6892
@@ -30579,8 +30045,8 @@ T_6896: (in a7_2886 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6897: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_6898: (in 0<32> : word32)
   Class: Eq_6898
@@ -30591,16 +30057,16 @@ T_6899: (in a7_2886 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_6900: (in Mem2889[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_6901: (in 31<i32> : int32)
   Class: Eq_6901
   DataType: int32
   OrigDataType: int32
 T_6902: (in d7 >> 31<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: int32
 T_6903: (in 0<32> : word32)
   Class: Eq_6903
@@ -30608,12 +30074,12 @@ T_6903: (in 0<32> : word32)
   OrigDataType: word32
 T_6904: (in a7_2886 + 0<32> : word32)
   Class: Eq_6904
-  DataType: (ptr32 Eq_6904)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2)))
+  DataType: (ptr32 (ptr32 Eq_1290))
+  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2)))
 T_6905: (in Mem2898[a7_2886 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (T_1290 u2))
 T_6906: (in 4<i32> : int32)
   Class: Eq_6906
   DataType: int32
@@ -30640,7 +30106,7 @@ T_6911: (in 8<i32> : int32)
   OrigDataType: int32
 T_6912: (in a7_2886 - 8<i32> : word32)
   Class: Eq_6912
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 (ptr32 Eq_25))
   OrigDataType: (ptr32 (struct (0 T_6915 t0000)))
 T_6913: (in 0<32> : word32)
   Class: Eq_6913
@@ -30652,7 +30118,7 @@ T_6914: (in a7_2886 - 8<i32> + 0<32> : word32)
   OrigDataType: ptr32
 T_6915: (in Mem2905[a7_2886 - 8<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_6916: (in 52<i32> : int32)
   Class: Eq_6916
@@ -30778,21 +30244,21 @@ T_6946: (in d4 : Eq_4258)
   Class: Eq_4258
   DataType: Eq_4258
   OrigDataType: word32
-T_6947: (in dwArg04 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6947: (in dwArg04 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_6948: (in dwArg08 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6948: (in dwArg08 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_6949: (in dwArg0C : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6949: (in dwArg0C : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
-T_6950: (in dwArg10 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_6950: (in dwArg10 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_6951: (in d1Out : ptr32)
   Class: Eq_6951
@@ -30800,7 +30266,7 @@ T_6951: (in d1Out : ptr32)
   OrigDataType: ptr32
 T_6952: (in a7_2886 - 24<i32> : word32)
   Class: Eq_6952
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_6955 t0000)))
 T_6953: (in 0<32> : word32)
   Class: Eq_6953
@@ -30811,8 +30277,8 @@ T_6954: (in a7_2886 - 24<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6955: (in Mem2918[a7_2886 - 24<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_6956: (in 20<i32> : int32)
   Class: Eq_6956
@@ -30820,7 +30286,7 @@ T_6956: (in 20<i32> : int32)
   OrigDataType: int32
 T_6957: (in a7_2886 - 20<i32> : word32)
   Class: Eq_6957
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_6960 t0000)))
 T_6958: (in 0<32> : word32)
   Class: Eq_6958
@@ -30831,8 +30297,8 @@ T_6959: (in a7_2886 - 20<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6960: (in Mem2918[a7_2886 - 20<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_6961: (in 16<i32> : int32)
   Class: Eq_6961
@@ -30840,7 +30306,7 @@ T_6961: (in 16<i32> : int32)
   OrigDataType: int32
 T_6962: (in a7_2886 - 16<i32> : word32)
   Class: Eq_6962
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_6965 t0000)))
 T_6963: (in 0<32> : word32)
   Class: Eq_6963
@@ -30851,8 +30317,8 @@ T_6964: (in a7_2886 - 16<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6965: (in Mem2918[a7_2886 - 16<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_6966: (in 12<i32> : int32)
   Class: Eq_6966
@@ -30860,7 +30326,7 @@ T_6966: (in 12<i32> : int32)
   OrigDataType: int32
 T_6967: (in a7_2886 - 12<i32> : word32)
   Class: Eq_6967
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_718)
   OrigDataType: (ptr32 (struct (0 T_6970 t0000)))
 T_6968: (in 0<32> : word32)
   Class: Eq_6968
@@ -30871,8 +30337,8 @@ T_6969: (in a7_2886 - 12<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_6970: (in Mem2918[a7_2886 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_6971: (in out d1_2921 : ptr32)
   Class: Eq_6951
@@ -30916,12 +30382,12 @@ T_6980: (in 1<32> : word32)
   OrigDataType: word32
 T_6981: (in a7_2886 + 1<32> : word32)
   Class: Eq_6981
-  DataType: (ptr32 Eq_6981)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2)))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_6982: (in Mem2934[a7_2886 + 1<32>:word24] : word24)
   Class: Eq_6982
-  DataType: Eq_6982
-  OrigDataType: (union ((ptr32 (struct 0001 (0 word32 dw0000) (3 byte b0003))) u0) (uint32 u1) (ui24 u3) (T_1290 u2))
+  DataType: ui24
+  OrigDataType: ui24
 T_6983: (in SLICE(d5_1044, byte, 0) : byte)
   Class: Eq_6983
   DataType: uint8
@@ -30934,7 +30400,7 @@ T_6985: (in 0xFF<32> : word32)
   Class: Eq_6985
   DataType: ui32
   OrigDataType: ui32
-T_6986: (in SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32> : word32)
+T_6986: (in SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32> : word32)
   Class: Eq_6986
   DataType: int32
   OrigDataType: int32
@@ -30958,7 +30424,7 @@ T_6991: (in 4<32> : word32)
   Class: Eq_6991
   DataType: ui32
   OrigDataType: ui32
-T_6992: (in (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32> : word32)
+T_6992: (in (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32> : word32)
   Class: Eq_6992
   DataType: ui32
   OrigDataType: ui32
@@ -30966,7 +30432,7 @@ T_6993: (in 0<32> : word32)
   Class: Eq_6992
   DataType: ui32
   OrigDataType: word32
-T_6994: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(a7_2886->t0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32>) == 0<32> : bool)
+T_6994: (in ((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(a7_2886->n0001, (byte) d5_1044) & 0xFF<32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>].a0000)[0<i32>] & 4<32>) == 0<32> : bool)
   Class: Eq_6994
   DataType: bool
   OrigDataType: bool
@@ -31002,13 +30468,13 @@ T_7002: (in 0<8> : byte)
   Class: Eq_7001
   DataType: byte
   OrigDataType: byte
-T_7003: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7003: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7003
   DataType: bool
   OrigDataType: bool
-T_7004: (in a7_3299 : (ptr32 Eq_25))
+T_7004: (in a7_3299 : (ptr32 Eq_73))
   Class: Eq_7004
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_7005: (in 4<i32> : int32)
   Class: Eq_7005
@@ -31016,7 +30482,7 @@ T_7005: (in 4<i32> : int32)
   OrigDataType: int32
 T_7006: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7004
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: ptr32
 T_7007: (in 0<32> : word32)
   Class: Eq_7007
@@ -31027,8 +30493,8 @@ T_7008: (in a7_3299 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7009: (in Mem3303[a7_3299 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7010: (in 4<i32> : int32)
   Class: Eq_7010
@@ -31036,7 +30502,7 @@ T_7010: (in 4<i32> : int32)
   OrigDataType: int32
 T_7011: (in a7_3299 - 4<i32> : word32)
   Class: Eq_7011
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7014 t0000)))
 T_7012: (in 0<32> : word32)
   Class: Eq_7012
@@ -31047,8 +30513,8 @@ T_7013: (in a7_3299 - 4<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7014: (in Mem3306[a7_3299 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7015: (in fn00002B5C : ptr32)
   Class: Eq_4803
@@ -31060,7 +30526,7 @@ T_7016: (in 1<i32> : int32)
   OrigDataType: int32
 T_7017: (in a7_3299 - 1<i32> : word32)
   Class: Eq_7017
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7020 t0000)))
 T_7018: (in 0<32> : word32)
   Class: Eq_7018
@@ -31071,8 +30537,8 @@ T_7019: (in a7_3299 - 1<i32> + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7020: (in Mem3306[a7_3299 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_7021: (in 0<32> : word32)
   Class: Eq_7021
@@ -31083,12 +30549,12 @@ T_7022: (in a7_3299 + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7023: (in Mem3306[a7_3299 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7024: (in fn00002B5C(*(a7_3299 - 1<i32>), *a7_3299) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7025: (in 0xA<32> : word32)
   Class: Eq_7025
@@ -31104,7 +30570,7 @@ T_7027: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7028: (in Mem2714[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7025
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
 T_7029: (in 8<32> : word32)
   Class: Eq_7029
@@ -31120,7 +30586,7 @@ T_7031: (in a7_1330 + 52<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7032: (in Mem2717[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7029
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
 T_7033: (in 52<i32> : int32)
   Class: Eq_7033
@@ -31178,7 +30644,7 @@ T_7046: (in 0x2D<32> : word32)
   Class: Eq_7045
   DataType: word32
   OrigDataType: word32
-T_7047: (in *((word32) a7_1330 + 110<i32>) != 0x2D<32> : bool)
+T_7047: (in a7_1330->dw006E != 0x2D<32> : bool)
   Class: Eq_7047
   DataType: bool
   OrigDataType: bool
@@ -31203,8 +30669,8 @@ T_7052: (in a7_3474 + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7053: (in Mem3476[a7_3474 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7054: (in 76<i32> : int32)
   Class: Eq_7054
@@ -31244,7 +30710,7 @@ T_7062: (in 4<i32> : int32)
   OrigDataType: int32
 T_7063: (in a7_3474 + 4<i32> : word32)
   Class: Eq_4251
-  DataType: Eq_4251
+  DataType: (ptr32 Eq_4251)
   OrigDataType: ptr32
 T_7064: (in 56<i32> : int32)
   Class: Eq_7064
@@ -31272,12 +30738,12 @@ T_7069: (in d0_3495 : word32)
   OrigDataType: uint32
 T_7070: (in 3<32> : word32)
   Class: Eq_7070
-  DataType: (ptr32 Eq_8303)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8275)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7071: (in d2_1090 + 3<32> : word32)
   Class: Eq_7071
-  DataType: (ptr32 Eq_8304)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8276)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7072: (in 2<32> : word32)
   Class: Eq_7072
   DataType: word32
@@ -31299,8 +30765,8 @@ T_7076: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7077: (in (d0_3495 << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_7078: (in a0_3501 : (ptr32 Eq_7078))
   Class: Eq_7078
@@ -31312,8 +30778,8 @@ T_7079: (in -4<i32> : int32)
   OrigDataType: int32
 T_7080: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7080
-  DataType: (ptr32 Eq_8305)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8277)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7081: (in Mem3485[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7078
   DataType: (ptr32 Eq_7078)
@@ -31327,8 +30793,8 @@ T_7083: (in a7_3474 + 52<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_7084: (in Mem3485[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7085: (in 4<i32> : int32)
   Class: Eq_7085
@@ -31339,8 +30805,8 @@ T_7086: (in a0_3501 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7087: (in Mem3503[a0_3501 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7088: (in 48<i32> : int32)
   Class: Eq_7088
@@ -31367,8 +30833,8 @@ T_7093: (in Mem3505[a0_3501 + 0<32>:word32] : word32)
   DataType: word32
   OrigDataType: word32
 T_7094: (in d0_3495 << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_7095: (in v517_3507 : byte)
   Class: Eq_7058
@@ -31416,12 +30882,12 @@ T_7105: (in v517_3507 == 0<8> : bool)
   OrigDataType: bool
 T_7106: (in 3<32> : word32)
   Class: Eq_7106
-  DataType: (ptr32 Eq_8306)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8278)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7107: (in d2_1090 + 3<32> : word32)
   Class: Eq_7107
-  DataType: (ptr32 Eq_8307)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8279)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7108: (in 2<32> : word32)
   Class: Eq_7108
   DataType: word32
@@ -31443,8 +30909,8 @@ T_7112: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7113: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_7114: (in 52<i32> : int32)
   Class: Eq_7114
@@ -31455,12 +30921,12 @@ T_7115: (in a7_3474 + 52<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_7116: (in Mem3508[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7117: (in SLICE(d0, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_7118: (in -4<i32> : int32)
   Class: Eq_7118
@@ -31468,11 +30934,11 @@ T_7118: (in -4<i32> : int32)
   OrigDataType: int32
 T_7119: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7119
-  DataType: (ptr32 Eq_8308)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8280)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7120: (in Mem3508[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7120
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7123 t0000)))
 T_7121: (in 0<32> : word32)
   Class: Eq_7121
@@ -31483,9 +30949,9 @@ T_7122: (in Mem3508[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7123: (in Mem3522[Mem3508[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: byte
+  Class: Eq_73
+  DataType: Eq_718
+  OrigDataType: Eq_73
 T_7124: (in v518_3524 : byte)
   Class: Eq_7058
   DataType: byte
@@ -31532,12 +30998,12 @@ T_7134: (in v518_3524 == 0<8> : bool)
   OrigDataType: bool
 T_7135: (in 3<32> : word32)
   Class: Eq_7135
-  DataType: (ptr32 Eq_8309)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8281)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7136: (in d2_1090 + 3<32> : word32)
   Class: Eq_7136
-  DataType: (ptr32 Eq_8310)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8282)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7137: (in 2<32> : word32)
   Class: Eq_7137
   DataType: word32
@@ -31559,8 +31025,8 @@ T_7141: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7142: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_7143: (in 52<i32> : int32)
   Class: Eq_7143
@@ -31568,15 +31034,15 @@ T_7143: (in 52<i32> : int32)
   OrigDataType: int32
 T_7144: (in a7_3474 + 52<i32> : word32)
   Class: Eq_7144
-  DataType: (ptr32 Eq_7144)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_7145: (in Mem3525[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7146: (in SLICE(d0, word16, 0) : word16)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word16
 T_7147: (in -4<i32> : int32)
   Class: Eq_7147
@@ -31584,11 +31050,11 @@ T_7147: (in -4<i32> : int32)
   OrigDataType: int32
 T_7148: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7148
-  DataType: (ptr32 Eq_8312)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8283)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7149: (in Mem3525[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7149
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7152 t0000)))
 T_7150: (in 0<32> : word32)
   Class: Eq_7150
@@ -31599,9 +31065,9 @@ T_7151: (in Mem3525[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7152: (in Mem3539[Mem3525[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word16
+  Class: Eq_73
+  DataType: Eq_718
+  OrigDataType: Eq_73
 T_7153: (in v519_3541 : byte)
   Class: Eq_7058
   DataType: byte
@@ -31648,12 +31114,12 @@ T_7163: (in v519_3541 == 0<8> : bool)
   OrigDataType: bool
 T_7164: (in 3<32> : word32)
   Class: Eq_7164
-  DataType: (ptr32 Eq_8313)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8284)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7165: (in d2_1090 + 3<32> : word32)
   Class: Eq_7165
-  DataType: (ptr32 Eq_8314)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8285)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7166: (in 2<32> : word32)
   Class: Eq_7166
   DataType: word32
@@ -31675,8 +31141,8 @@ T_7170: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7171: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_7172: (in 52<i32> : int32)
   Class: Eq_7172
@@ -31684,23 +31150,23 @@ T_7172: (in 52<i32> : int32)
   OrigDataType: int32
 T_7173: (in a7_3474 + 52<i32> : word32)
   Class: Eq_7173
-  DataType: (ptr32 Eq_7173)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_7174: (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7175: (in -4<i32> : int32)
   Class: Eq_7175
   DataType: int32
   OrigDataType: int32
 T_7176: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7176
-  DataType: (ptr32 Eq_8316)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8286)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7177: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7177
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7180 t0000)))
 T_7178: (in 0<32> : word32)
   Class: Eq_7178
@@ -31711,17 +31177,17 @@ T_7179: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7180: (in Mem3556[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_718
+  OrigDataType: Eq_73
 T_7181: (in 3<32> : word32)
   Class: Eq_7181
-  DataType: (ptr32 Eq_8317)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8287)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7182: (in d2_1090 + 3<32> : word32)
   Class: Eq_7182
-  DataType: (ptr32 Eq_8318)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8288)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7183: (in 2<32> : word32)
   Class: Eq_7183
   DataType: word32
@@ -31743,8 +31209,8 @@ T_7187: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7188: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_7189: (in 52<i32> : int32)
   Class: Eq_7189
@@ -31752,23 +31218,23 @@ T_7189: (in 52<i32> : int32)
   OrigDataType: int32
 T_7190: (in a7_3474 + 52<i32> : word32)
   Class: Eq_7190
-  DataType: (ptr32 Eq_7190)
-  OrigDataType: (ptr32 (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0)))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_7191: (in Mem3542[a7_3474 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7192: (in -4<i32> : int32)
   Class: Eq_7192
   DataType: int32
   OrigDataType: int32
 T_7193: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7193
-  DataType: (ptr32 Eq_8320)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8289)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7194: (in Mem3542[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7194
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7197 t0000)))
 T_7195: (in 0<32> : word32)
   Class: Eq_7195
@@ -31779,9 +31245,9 @@ T_7196: (in Mem3542[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7197: (in Mem3569[Mem3542[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_718
+  OrigDataType: Eq_73
 T_7198: (in 60<i32> : int32)
   Class: Eq_7198
   DataType: int32
@@ -31808,7 +31274,7 @@ T_7203: (in a7_1330 + 60<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_7204: (in Mem3574[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_7202
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
 T_7205: (in 48<i32> : int32)
   Class: Eq_7205
@@ -31828,12 +31294,12 @@ T_7208: (in 56<i32> : int32)
   OrigDataType: int32
 T_7209: (in a7_1330 + 56<i32> : word32)
   Class: Eq_7209
-  DataType: (ptr32 Eq_7209)
-  OrigDataType: (ptr32 (union (uint8 u0) (word32 u1) (T_6344 u2)))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7210: (in Mem3344[a7_1330 + 56<i32>:word32] : word32)
   Class: Eq_7207
   DataType: Eq_7207
-  OrigDataType: (union (uint8 u0) (word32 u1) (T_6344 u2))
+  OrigDataType: word32
 T_7211: (in 44<i32> : int32)
   Class: Eq_7211
   DataType: int32
@@ -31883,8 +31349,8 @@ T_7222: (in Mem3324[v528_3348 + 4<i32>:word32] : word32)
   DataType: word32
   OrigDataType: word32
 T_7223: (in -v528_3348->dw0004 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7224: (in 0<32> : word32)
   Class: Eq_7224
@@ -31903,16 +31369,16 @@ T_7227: (in -v528_3348->dw0000 : word32)
   DataType: int32
   OrigDataType: int32
 T_7228: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: up32
 T_7229: (in d1 < 0<32> : bool)
   Class: Eq_7229
   DataType: Eq_7229
   OrigDataType: (union (bool u0) (int32 u1))
 T_7230: (in -v528_3348->dw0000 - (d1 < 0<32>) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: int32
 T_7231: (in 0x38<32> : word32)
   Class: Eq_7231
@@ -31920,44 +31386,44 @@ T_7231: (in 0x38<32> : word32)
   OrigDataType: word32
 T_7232: (in a7_1330 + 0x38<32> : word32)
   Class: Eq_7232
-  DataType: (ptr32 Eq_7232)
-  OrigDataType: (ptr32 (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3)))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7233: (in Mem3324[a7_1330 + 0x38<32>:word32] : word32)
   Class: Eq_4251
-  DataType: Eq_4251
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
-T_7234: (in a7_3364 : Eq_7234)
+  DataType: (ptr32 Eq_4251)
+  OrigDataType: word32
+T_7234: (in a7_3364 : (ptr32 Eq_7234))
   Class: Eq_7234
-  DataType: Eq_7234
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_7234)
+  OrigDataType: (ptr32 (struct (0 T_7239 t0000) (30 T_7244 t0030) (38 T_7295 t0038) (3C T_73 t003C) (4C T_7242 t004C)))
 T_7235: (in 4<i32> : int32)
   Class: Eq_7235
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7236: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7234
-  DataType: Eq_7234
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_7234)
+  OrigDataType: ptr32
 T_7237: (in 0<32> : word32)
   Class: Eq_7237
   DataType: word32
   OrigDataType: word32
 T_7238: (in a7_3364 + 0<32> : word32)
   Class: Eq_7238
-  DataType: Eq_7238
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7239: (in Mem3375[a7_3364 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7234
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7240: (in 76<i32> : int32)
   Class: Eq_7240
   DataType: int32
   OrigDataType: int32
 T_7241: (in a7_3364 + 76<i32> : word32)
   Class: Eq_7241
-  DataType: Eq_7241
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7242: (in Mem3375[a7_3364 + 76<i32>:byte] : byte)
   Class: Eq_7242
   DataType: byte
@@ -31966,7 +31432,7 @@ T_7243: (in 1<8> : byte)
   Class: Eq_7243
   DataType: byte
   OrigDataType: byte
-T_7244: (in *((word32) a7_3364 + 76<i32>) - 1<8> : byte)
+T_7244: (in a7_3364->b004C - 1<8> : byte)
   Class: Eq_7244
   DataType: byte
   OrigDataType: byte
@@ -31976,37 +31442,37 @@ T_7245: (in 48<i32> : int32)
   OrigDataType: int32
 T_7246: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7246
-  DataType: Eq_7246
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7247: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
   Class: Eq_7244
-  DataType: Eq_7234
+  DataType: byte
   OrigDataType: byte
 T_7248: (in 4<i32> : int32)
   Class: Eq_7248
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7249: (in a7_3364 + 4<i32> : word32)
   Class: Eq_4251
-  DataType: Eq_4251
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_4251)
+  OrigDataType: ptr32
 T_7250: (in 48<i32> : int32)
   Class: Eq_7250
   DataType: int32
   OrigDataType: int32
 T_7251: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7251
-  DataType: Eq_7251
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7252: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7252
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7253: (in 0<8> : byte)
-  Class: Eq_7252
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
-T_7254: (in *((word32) a7_3364 + 48<i32>) == 0<8> : bool)
+T_7254: (in a7_3364->b0030 == 0<8> : bool)
   Class: Eq_7254
   DataType: bool
   OrigDataType: bool
@@ -32020,35 +31486,35 @@ T_7256: (in 52<i32> : int32)
   OrigDataType: int32
 T_7257: (in a7_1330 + 52<i32> : word32)
   Class: Eq_7257
-  DataType: Eq_7257
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7258: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
   Class: Eq_7255
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
-T_7259: (in v544_774 : byte)
+T_7259: (in v544_774 : Eq_7259)
   Class: Eq_7259
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7259
+  OrigDataType: (union (int32 u0) (byte u1))
 T_7260: (in 44<i32> : int32)
   Class: Eq_7260
   DataType: int32
   OrigDataType: int32
 T_7261: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7261
-  DataType: Eq_7261
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7262: (in Mem773[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7259
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7259
+  OrigDataType: int32
 T_7263: (in SEQ(v84_506, v544_774) : uip32)
   Class: Eq_4408
   DataType: int32
   OrigDataType: uip32
-T_7264: (in d1_1027 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7264: (in d1_1027 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7265: (in 52<i32> : int32)
   Class: Eq_7265
@@ -32056,11 +31522,11 @@ T_7265: (in 52<i32> : int32)
   OrigDataType: int32
 T_7266: (in a7_1330 + 52<i32> : word32)
   Class: Eq_7266
-  DataType: Eq_7266
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7267: (in Mem773[a7_1330 + 52<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7268: (in 1<8> : byte)
   Class: Eq_7268
@@ -32072,12 +31538,12 @@ T_7269: (in 44<i32> : int32)
   OrigDataType: int32
 T_7270: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7270
-  DataType: Eq_7270
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7271: (in Mem769[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7268
-  DataType: Eq_4251
-  OrigDataType: byte
+  DataType: Eq_7268
+  OrigDataType: int32
 T_7272: (in 1<i32> : int32)
   Class: Eq_7272
   DataType: int32
@@ -32092,12 +31558,12 @@ T_7274: (in d0_3398 : word32)
   OrigDataType: uint32
 T_7275: (in 3<32> : word32)
   Class: Eq_7275
-  DataType: (ptr32 Eq_8327)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8290)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7276: (in d2_1090 + 3<32> : word32)
   Class: Eq_7276
-  DataType: (ptr32 Eq_8328)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8291)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7277: (in 2<32> : word32)
   Class: Eq_7277
   DataType: word32
@@ -32119,8 +31585,8 @@ T_7281: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7282: (in (d0_3398 << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_7283: (in a0_3404 : (ptr32 Eq_7283))
   Class: Eq_7283
@@ -32132,8 +31598,8 @@ T_7284: (in -4<i32> : int32)
   OrigDataType: int32
 T_7285: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7285
-  DataType: (ptr32 Eq_8329)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8292)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7286: (in Mem3384[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7283
   DataType: (ptr32 Eq_7283)
@@ -32144,11 +31610,11 @@ T_7287: (in 60<i32> : int32)
   OrigDataType: int32
 T_7288: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7288
-  DataType: Eq_7288
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7289: (in Mem3384[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_7289
-  DataType: word32
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7290: (in 4<i32> : int32)
   Class: Eq_7290
@@ -32159,8 +31625,8 @@ T_7291: (in a0_3404 + 4<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7292: (in Mem3406[a0_3404 + 4<i32>:word32] : word32)
-  Class: Eq_7289
-  DataType: word32
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7293: (in 56<i32> : int32)
   Class: Eq_7293
@@ -32168,8 +31634,8 @@ T_7293: (in 56<i32> : int32)
   OrigDataType: int32
 T_7294: (in a7_3364 + 56<i32> : word32)
   Class: Eq_7294
-  DataType: Eq_7294
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7295: (in Mem3406[a7_3364 + 56<i32>:word32] : word32)
   Class: Eq_7295
   DataType: word32
@@ -32187,11 +31653,11 @@ T_7298: (in Mem3408[a0_3404 + 0<32>:word32] : word32)
   DataType: word32
   OrigDataType: word32
 T_7299: (in d0_3398 << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_7300: (in v540_3410 : byte)
-  Class: Eq_7300
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7301: (in 48<i32> : int32)
@@ -32200,18 +31666,18 @@ T_7301: (in 48<i32> : int32)
   OrigDataType: int32
 T_7302: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7302
-  DataType: Eq_7302
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7303: (in Mem3384[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7303
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7304: (in 1<8> : byte)
   Class: Eq_7304
   DataType: byte
   OrigDataType: byte
-T_7305: (in *((word32) a7_3364 + 48<i32>) - 1<8> : byte)
-  Class: Eq_7300
+T_7305: (in a7_3364->b0030 - 1<8> : byte)
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7306: (in 48<i32> : int32)
@@ -32220,14 +31686,14 @@ T_7306: (in 48<i32> : int32)
   OrigDataType: int32
 T_7307: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7307
-  DataType: Eq_7307
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7308: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7300
-  DataType: Eq_7234
+  Class: Eq_7244
+  DataType: byte
   OrigDataType: byte
 T_7309: (in 0<8> : byte)
-  Class: Eq_7300
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7310: (in v540_3410 == 0<8> : bool)
@@ -32236,12 +31702,12 @@ T_7310: (in v540_3410 == 0<8> : bool)
   OrigDataType: bool
 T_7311: (in 3<32> : word32)
   Class: Eq_7311
-  DataType: (ptr32 Eq_8330)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8293)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7312: (in d2_1090 + 3<32> : word32)
   Class: Eq_7312
-  DataType: (ptr32 Eq_8331)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8294)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7313: (in 2<32> : word32)
   Class: Eq_7313
   DataType: word32
@@ -32263,8 +31729,8 @@ T_7317: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7318: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_7319: (in 60<i32> : int32)
   Class: Eq_7319
@@ -32272,15 +31738,15 @@ T_7319: (in 60<i32> : int32)
   OrigDataType: int32
 T_7320: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7320
-  DataType: Eq_7320
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7321: (in Mem3411[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7322: (in SLICE(d0, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: byte
 T_7323: (in -4<i32> : int32)
   Class: Eq_7323
@@ -32288,11 +31754,11 @@ T_7323: (in -4<i32> : int32)
   OrigDataType: int32
 T_7324: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7324
-  DataType: (ptr32 Eq_8332)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8295)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7325: (in Mem3411[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7325
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7328 t0000)))
 T_7326: (in 0<32> : word32)
   Class: Eq_7326
@@ -32303,11 +31769,11 @@ T_7327: (in Mem3411[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7328: (in Mem3425[Mem3411[d2_1090 + -4<i32>:word32] + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: byte
+  Class: Eq_73
+  DataType: Eq_718
+  OrigDataType: Eq_73
 T_7329: (in v541_3427 : byte)
-  Class: Eq_7329
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7330: (in 48<i32> : int32)
@@ -32316,18 +31782,18 @@ T_7330: (in 48<i32> : int32)
   OrigDataType: int32
 T_7331: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7331
-  DataType: Eq_7331
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7332: (in Mem3411[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7332
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7333: (in 0x66<8> : byte)
   Class: Eq_7333
   DataType: byte
   OrigDataType: byte
-T_7334: (in *((word32) a7_3364 + 48<i32>) - 0x66<8> : byte)
-  Class: Eq_7329
+T_7334: (in a7_3364->b0030 - 0x66<8> : byte)
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7335: (in 48<i32> : int32)
@@ -32336,14 +31802,14 @@ T_7335: (in 48<i32> : int32)
   OrigDataType: int32
 T_7336: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7336
-  DataType: Eq_7336
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7337: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7329
-  DataType: Eq_7234
+  Class: Eq_7244
+  DataType: byte
   OrigDataType: byte
 T_7338: (in 0<8> : byte)
-  Class: Eq_7329
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7339: (in v541_3427 == 0<8> : bool)
@@ -32352,12 +31818,12 @@ T_7339: (in v541_3427 == 0<8> : bool)
   OrigDataType: bool
 T_7340: (in 3<32> : word32)
   Class: Eq_7340
-  DataType: (ptr32 Eq_8333)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8296)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7341: (in d2_1090 + 3<32> : word32)
   Class: Eq_7341
-  DataType: (ptr32 Eq_8334)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8297)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7342: (in 2<32> : word32)
   Class: Eq_7342
   DataType: word32
@@ -32379,8 +31845,8 @@ T_7346: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7347: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_7348: (in 60<i32> : int32)
   Class: Eq_7348
@@ -32388,15 +31854,15 @@ T_7348: (in 60<i32> : int32)
   OrigDataType: int32
 T_7349: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7349
-  DataType: Eq_7349
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_7350: (in Mem3428[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7351: (in SLICE(d0, word16, 0) : word16)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word16
 T_7352: (in -4<i32> : int32)
   Class: Eq_7352
@@ -32404,11 +31870,11 @@ T_7352: (in -4<i32> : int32)
   OrigDataType: int32
 T_7353: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7353
-  DataType: (ptr32 Eq_8335)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8298)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7354: (in Mem3428[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7354
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7357 t0000)))
 T_7355: (in 0<32> : word32)
   Class: Eq_7355
@@ -32419,11 +31885,11 @@ T_7356: (in Mem3428[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7357: (in Mem3442[Mem3428[d2_1090 + -4<i32>:word32] + 0<32>:word16] : word16)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word16
+  Class: Eq_73
+  DataType: Eq_718
+  OrigDataType: Eq_73
 T_7358: (in v542_3444 : byte)
-  Class: Eq_7358
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7359: (in 48<i32> : int32)
@@ -32432,18 +31898,18 @@ T_7359: (in 48<i32> : int32)
   OrigDataType: int32
 T_7360: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7360
-  DataType: Eq_7360
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7361: (in Mem3428[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7361
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7362: (in 4<8> : byte)
   Class: Eq_7362
   DataType: byte
   OrigDataType: byte
-T_7363: (in *((word32) a7_3364 + 48<i32>) - 4<8> : byte)
-  Class: Eq_7358
+T_7363: (in a7_3364->b0030 - 4<8> : byte)
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7364: (in 48<i32> : int32)
@@ -32452,14 +31918,14 @@ T_7364: (in 48<i32> : int32)
   OrigDataType: int32
 T_7365: (in a7_3364 + 48<i32> : word32)
   Class: Eq_7365
-  DataType: Eq_7365
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7366: (in Mem3445[a7_3364 + 48<i32>:byte] : byte)
-  Class: Eq_7358
-  DataType: Eq_7234
+  Class: Eq_7244
+  DataType: byte
   OrigDataType: byte
 T_7367: (in 0<8> : byte)
-  Class: Eq_7358
+  Class: Eq_7244
   DataType: byte
   OrigDataType: byte
 T_7368: (in v542_3444 == 0<8> : bool)
@@ -32468,12 +31934,12 @@ T_7368: (in v542_3444 == 0<8> : bool)
   OrigDataType: bool
 T_7369: (in 3<32> : word32)
   Class: Eq_7369
-  DataType: (ptr32 Eq_8336)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8299)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7370: (in d2_1090 + 3<32> : word32)
   Class: Eq_7370
-  DataType: (ptr32 Eq_8337)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8300)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7371: (in 2<32> : word32)
   Class: Eq_7371
   DataType: word32
@@ -32495,8 +31961,8 @@ T_7375: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7376: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_7377: (in 60<i32> : int32)
   Class: Eq_7377
@@ -32504,23 +31970,23 @@ T_7377: (in 60<i32> : int32)
   OrigDataType: int32
 T_7378: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7378
-  DataType: Eq_7378
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_7379: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7380: (in -4<i32> : int32)
   Class: Eq_7380
   DataType: int32
   OrigDataType: int32
 T_7381: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7381
-  DataType: (ptr32 Eq_8338)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8301)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7382: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7382
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7385 t0000)))
 T_7383: (in 0<32> : word32)
   Class: Eq_7383
@@ -32531,17 +31997,17 @@ T_7384: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7385: (in Mem3459[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_718
+  OrigDataType: Eq_73
 T_7386: (in 3<32> : word32)
   Class: Eq_7386
-  DataType: (ptr32 Eq_8339)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8302)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7387: (in d2_1090 + 3<32> : word32)
   Class: Eq_7387
-  DataType: (ptr32 Eq_8340)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8303)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7388: (in 2<32> : word32)
   Class: Eq_7388
   DataType: word32
@@ -32563,8 +32029,8 @@ T_7392: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7393: (in (d2_1090 + 3<32> >>u 2<32> << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_7394: (in 60<i32> : int32)
   Class: Eq_7394
@@ -32572,23 +32038,23 @@ T_7394: (in 60<i32> : int32)
   OrigDataType: int32
 T_7395: (in a7_3364 + 60<i32> : word32)
   Class: Eq_7395
-  DataType: Eq_7395
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_7396: (in Mem3445[a7_3364 + 60<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7397: (in -4<i32> : int32)
   Class: Eq_7397
   DataType: int32
   OrigDataType: int32
 T_7398: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7398
-  DataType: (ptr32 Eq_8341)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8304)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7399: (in Mem3445[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7399
-  DataType: (ptr32 Eq_25)
+  DataType: (ptr32 Eq_73)
   OrigDataType: (ptr32 (struct (0 T_7402 t0000)))
 T_7400: (in 0<32> : word32)
   Class: Eq_7400
@@ -32599,9 +32065,9 @@ T_7401: (in Mem3445[d2_1090 + -4<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7402: (in Mem3472[Mem3445[d2_1090 + -4<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_718
+  OrigDataType: Eq_73
 T_7403: (in 0<i32> : int32)
   Class: Eq_7403
   DataType: int32
@@ -32615,36 +32081,36 @@ T_7405: (in 0xFF<32> : word32)
   DataType: int32
   OrigDataType: word32
 T_7406: (in SLICE(d5_785, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7406
+  DataType: byte
   OrigDataType: byte
 T_7407: (in 78<i32> : int32)
   Class: Eq_7407
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7408: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7408
-  DataType: Eq_7408
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7409: (in a7_1330 + 78<i32> + d1_1027 : word32)
   Class: Eq_7409
-  DataType: Eq_7409
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7410 t0000)))
 T_7410: (in Mem796[a7_1330 + 78<i32> + d1_1027:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7406
+  DataType: byte
   OrigDataType: byte
 T_7411: (in 1<32> : word32)
   Class: Eq_7411
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: word32
+  OrigDataType: word32
 T_7412: (in d1_1027 + 1<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: int32
 T_7413: (in 0x20<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: up32
 T_7414: (in d1_1027 < 0x20<32> : bool)
   Class: Eq_7414
@@ -32664,40 +32130,40 @@ T_7417: (in 132<i32> : int32)
   OrigDataType: int32
 T_7418: (in a7_1330 + 132<i32> : word32)
   Class: Eq_7418
-  DataType: Eq_7418
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7419: (in Mem820[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_4251
-  OrigDataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
+  OrigDataType: word32
 T_7420: (in 44<i32> : int32)
   Class: Eq_7420
   DataType: int32
   OrigDataType: int32
 T_7421: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7421
-  DataType: Eq_7421
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7422: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7259
-  DataType: Eq_4251
-  OrigDataType: byte
-T_7423: (in v554_824 : byte)
+  DataType: Eq_7259
+  OrigDataType: int32
+T_7423: (in v554_824 : Eq_7423)
   Class: Eq_7423
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7423
+  OrigDataType: (union (int32 u1) (byte u0))
 T_7424: (in 44<i32> : int32)
   Class: Eq_7424
   DataType: int32
   OrigDataType: int32
 T_7425: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7425
-  DataType: Eq_7425
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7426: (in Mem823[a7_1330 + 44<i32>:byte] : byte)
   Class: Eq_7423
-  DataType: byte
-  OrigDataType: byte
+  DataType: Eq_7423
+  OrigDataType: int32
 T_7427: (in a6_1164 : (ptr32 byte))
   Class: Eq_7427
   DataType: (ptr32 byte)
@@ -32708,11 +32174,11 @@ T_7428: (in 132<i32> : int32)
   OrigDataType: int32
 T_7429: (in a7_1330 + 132<i32> : word32)
   Class: Eq_7429
-  DataType: Eq_7429
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7430: (in Mem946[a7_1330 + 132<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7431: (in 1<i32> : int32)
   Class: Eq_7431
@@ -32728,8 +32194,8 @@ T_7433: (in 73<i32> : int32)
   OrigDataType: int32
 T_7434: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7434
-  DataType: Eq_7434
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7435: (in Mem946[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7435
   DataType: byte
@@ -32738,7 +32204,7 @@ T_7436: (in 0<8> : byte)
   Class: Eq_7435
   DataType: byte
   OrigDataType: byte
-T_7437: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7437: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7437
   DataType: bool
   OrigDataType: bool
@@ -32771,8 +32237,8 @@ T_7444: (in SLICE(d1_1027, word24, 8) : word24)
   DataType: word24
   OrigDataType: word24
 T_7445: (in SEQ(SLICE(d1_1027, word24, 8), v556_834) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_7446: (in 0<32> : word32)
   Class: Eq_7446
@@ -32854,17 +32320,17 @@ T_7465: (in SEQ(SLICE(d7, word24, 8), Mem829[a3_1955 + 1<i32>:byte]) : uip32)
   Class: Eq_4408
   DataType: int32
   OrigDataType: uip32
-T_7466: (in d5_862 : Eq_7466)
+T_7466: (in d5_862 : (ptr32 (ptr32 Eq_4258)))
   Class: Eq_7466
-  DataType: Eq_7466
-  OrigDataType: word32
+  DataType: (ptr32 (ptr32 Eq_4258))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7467: (in (uint8) v556_834 : uint8)
   Class: Eq_7467
   DataType: uint8
   OrigDataType: uint8
 T_7468: (in (uint32) (uint8) v556_834 : uint32)
   Class: Eq_7466
-  DataType: Eq_7466
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: uint32
 T_7469: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_7469
@@ -32875,18 +32341,18 @@ T_7470: (in (uint8) SLICE(d7, byte, 0) : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_7471: (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7472: (in d0 - d5_862 : word32)
   Class: Eq_7472
-  DataType: Eq_7472
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4258))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7473: (in 0<32> : word32)
   Class: Eq_7472
-  DataType: byte
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: up32
-T_7474: (in d0 - d5_862 < 0<32> : bool)
+T_7474: (in d0 - d5_862 < null : bool)
   Class: Eq_7474
   DataType: bool
   OrigDataType: bool
@@ -32918,18 +32384,18 @@ T_7481: (in v554_824 == 0<8> : bool)
   Class: Eq_7481
   DataType: bool
   OrigDataType: bool
-T_7482: (in a0_881 : Eq_7482)
+T_7482: (in a0_881 : word32)
   Class: Eq_7482
-  DataType: Eq_7482
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7490 t0000)))
 T_7483: (in 78<i32> : int32)
   Class: Eq_7483
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7484: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7484
-  DataType: Eq_7484
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7485: (in 3<32> : word32)
   Class: Eq_7485
   DataType: word32
@@ -32937,30 +32403,30 @@ T_7485: (in 3<32> : word32)
 T_7486: (in d5_862 >> 3<32> : word32)
   Class: Eq_7486
   DataType: Eq_7486
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_7487: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_7482
-  DataType: Eq_7482
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_7488: (in 0<32> : word32)
   Class: Eq_7488
   DataType: word32
   OrigDataType: word32
 T_7489: (in a0_881 + 0<32> : word32)
   Class: Eq_7489
-  DataType: Eq_7489
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7490: (in Mem889[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7490
+  DataType: byte
   OrigDataType: byte
 T_7491: (in (uint8) Mem889[a0_881 + 0<32>:byte] : uint8)
   Class: Eq_7491
   DataType: uint8
   OrigDataType: uint8
 T_7492: (in (uint32) (uint8) Mem889[a0_881 + 0<32>:byte] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7493: (in 1<i32> : int32)
   Class: Eq_7493
@@ -32983,8 +32449,8 @@ T_7497: (in 1<i32> << (d5_862 & 7<i32>) | d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7498: (in SLICE(1<i32> << (d5_862 & 7<i32>) | d1_1027, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7490
+  DataType: byte
   OrigDataType: byte
 T_7499: (in 0<32> : word32)
   Class: Eq_7499
@@ -32992,24 +32458,24 @@ T_7499: (in 0<32> : word32)
   OrigDataType: word32
 T_7500: (in a0_881 + 0<32> : word32)
   Class: Eq_7500
-  DataType: Eq_7500
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7501: (in Mem895[a0_881 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_7482
-  OrigDataType: Eq_25
-T_7502: (in a0_900 : Eq_7502)
+  Class: Eq_7490
+  DataType: byte
+  OrigDataType: byte
+T_7502: (in a0_900 : word32)
   Class: Eq_7502
-  DataType: Eq_7502
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7510 t0000)))
 T_7503: (in 78<i32> : int32)
   Class: Eq_7503
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7504: (in a7_1330 + 78<i32> : word32)
   Class: Eq_7504
-  DataType: Eq_7504
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7505: (in 3<32> : word32)
   Class: Eq_7505
   DataType: word32
@@ -33017,30 +32483,30 @@ T_7505: (in 3<32> : word32)
 T_7506: (in d5_862 >> 3<32> : word32)
   Class: Eq_7506
   DataType: Eq_7506
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  OrigDataType: (union (int32 u1) (uint32 u0))
 T_7507: (in a7_1330 + 78<i32> + (d5_862 >>u 3<32>) : word32)
   Class: Eq_7502
-  DataType: Eq_7502
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: ptr32
 T_7508: (in 0<32> : word32)
   Class: Eq_7508
   DataType: word32
   OrigDataType: word32
 T_7509: (in a0_900 + 0<32> : word32)
   Class: Eq_7509
-  DataType: Eq_7509
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7510: (in Mem889[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7510
+  DataType: byte
   OrigDataType: byte
 T_7511: (in (uint8) Mem889[a0_900 + 0<32>:byte] : uint8)
   Class: Eq_7511
   DataType: uint8
   OrigDataType: uint8
 T_7512: (in (uint32) (uint8) Mem889[a0_900 + 0<32>:byte] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7513: (in 1<i32> : int32)
   Class: Eq_7513
@@ -33067,8 +32533,8 @@ T_7518: (in ~(1<i32> << (d5_862 & 7<i32>)) & d1_1027 : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7519: (in SLICE(~(1<i32> << (d5_862 & 7<i32>)) & d1_1027, byte, 0) : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7510
+  DataType: byte
   OrigDataType: byte
 T_7520: (in 0<32> : word32)
   Class: Eq_7520
@@ -33076,20 +32542,20 @@ T_7520: (in 0<32> : word32)
   OrigDataType: word32
 T_7521: (in a0_900 + 0<32> : word32)
   Class: Eq_7521
-  DataType: Eq_7521
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7522: (in Mem914[a0_900 + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_7502
-  OrigDataType: Eq_25
+  Class: Eq_7510
+  DataType: byte
+  OrigDataType: byte
 T_7523: (in 1<32> : word32)
   Class: Eq_7523
-  DataType: byte
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4258))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7524: (in d5_862 + 1<32> : word32)
   Class: Eq_7466
-  DataType: Eq_7466
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4258))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7525: (in SLICE(d7, byte, 0) : byte)
   Class: Eq_7525
   DataType: byte
@@ -33099,18 +32565,18 @@ T_7526: (in (uint8) SLICE(d7, byte, 0) : uint8)
   DataType: uint8
   OrigDataType: uint8
 T_7527: (in (uint32) (uint8) SLICE(d7, byte, 0) : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7528: (in d0 - d5_862 : word32)
   Class: Eq_7528
-  DataType: Eq_7528
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4258))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7529: (in 0<32> : word32)
   Class: Eq_7528
-  DataType: byte
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: up32
-T_7530: (in d0 - d5_862 >= 0<32> : bool)
+T_7530: (in d0 - d5_862 >= null : bool)
   Class: Eq_7530
   DataType: bool
   OrigDataType: bool
@@ -33124,12 +32590,12 @@ T_7532: (in d0_957 : word32)
   OrigDataType: uint32
 T_7533: (in 3<32> : word32)
   Class: Eq_7533
-  DataType: (ptr32 Eq_8346)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8305)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7534: (in d2_1090 + 3<32> : word32)
   Class: Eq_7534
-  DataType: (ptr32 Eq_8347)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8306)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7535: (in 2<32> : word32)
   Class: Eq_7535
   DataType: word32
@@ -33151,12 +32617,12 @@ T_7539: (in 4<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_7540: (in (d0_957 << 2<32>) + 4<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: ui32
 T_7541: (in d0_957 << 2<32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_7542: (in -4<i32> : int32)
   Class: Eq_7542
@@ -33164,8 +32630,8 @@ T_7542: (in -4<i32> : int32)
   OrigDataType: int32
 T_7543: (in d2_1090 + -4<i32> : word32)
   Class: Eq_7543
-  DataType: (ptr32 Eq_8348)
-  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_25) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
+  DataType: (ptr32 Eq_8307)
+  OrigDataType: (union ((ptr32 (struct 0004 (FFFFFFFC (ptr32 Eq_73) ptrFFFFFFFC))) u0) (uint32 u1) (ptr32 u2))
 T_7544: (in Mem946[d2_1090 + -4<i32>:word32] : word32)
   Class: Eq_7427
   DataType: (ptr32 byte)
@@ -33290,30 +32756,30 @@ T_7574: (in a3_1955->b0000 == 0<8> : bool)
   Class: Eq_7574
   DataType: bool
   OrigDataType: bool
-T_7575: (in a7_985 : Eq_7575)
+T_7575: (in a7_985 : (ptr32 Eq_7575))
   Class: Eq_7575
-  DataType: Eq_7575
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_7575)
+  OrigDataType: (ptr32 (struct (0 T_73 t0000) (30 T_7592 t0030)))
 T_7576: (in 4<i32> : int32)
   Class: Eq_7576
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7577: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7575
-  DataType: Eq_7575
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_7575)
+  OrigDataType: ptr32
 T_7578: (in 0<32> : word32)
   Class: Eq_7578
   DataType: word32
   OrigDataType: word32
 T_7579: (in a7_985 + 0<32> : word32)
   Class: Eq_7579
-  DataType: Eq_7579
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7580: (in Mem987[a7_985 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7575
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7581: (in a5_5334 : word32)
   Class: Eq_7581
   DataType: word32
@@ -33328,16 +32794,16 @@ T_7583: (in 0<32> : word32)
   OrigDataType: word32
 T_7584: (in a7_985 + 0<32> : word32)
   Class: Eq_7584
-  DataType: Eq_7584
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7585: (in Mem987[a7_985 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7586: (in out d1 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
-  OrigDataType: (union ((ptr32 (struct 0004 (0 (ptr32 Eq_4258) ptr0000) (4 Eq_25 t0004) (8 Eq_25 t0008) (C Eq_106 t000C) (10 (ptr32 Eq_148) ptr0010) (14 Eq_2656 t0014) (18 Eq_3119 t0018) (1C int32 dw001C) (20 word32 dw0020))) u1) (byte u2) (ptr32 u0))
+  DataType: (ptr32 (ptr32 Eq_4258))
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7587: (in out a1 : ptr32)
   Class: Eq_4617
   DataType: (ptr32 word32)
@@ -33346,9 +32812,9 @@ T_7588: (in out a5_5334 : ptr32)
   Class: Eq_4618
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_7589: (in fn00003C30(*a7_985, out d1, out a1, out a5_5334) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+T_7589: (in fn00003C30(a7_985->t0000, out d1, out a1, out a5_5334) : word32)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7590: (in 48<i32> : int32)
   Class: Eq_7590
@@ -33356,19 +32822,19 @@ T_7590: (in 48<i32> : int32)
   OrigDataType: int32
 T_7591: (in a7_985 + 48<i32> : word32)
   Class: Eq_7591
-  DataType: Eq_7591
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7592: (in Mem1000[a7_985 + 48<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7575
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7593: (in 4<i32> : int32)
   Class: Eq_7593
   DataType: int32
   OrigDataType: int32
 T_7594: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_7595: (in a0_1004 : (ptr32 byte))
   Class: Eq_4628
@@ -33386,30 +32852,30 @@ T_7598: (in Mem981[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
-T_7599: (in a7_1005 : Eq_7599)
+T_7599: (in a7_1005 : (ptr32 Eq_7599))
   Class: Eq_7599
-  DataType: Eq_7599
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_7599)
+  OrigDataType: (ptr32 (struct (0 T_73 t0000) (30 T_7624 t0030)))
 T_7600: (in 4<i32> : int32)
   Class: Eq_7600
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7601: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7599
-  DataType: Eq_7599
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_7599)
+  OrigDataType: ptr32
 T_7602: (in 0<32> : word32)
   Class: Eq_7602
   DataType: word32
   OrigDataType: word32
 T_7603: (in a7_1005 + 0<32> : word32)
   Class: Eq_7603
-  DataType: Eq_7603
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7604: (in Mem1007[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7599
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7605: (in 1<i32> : int32)
   Class: Eq_7605
   DataType: int32
@@ -33428,8 +32894,8 @@ T_7608: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_7609: (in Mem1011[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_7610: (in v585_1015 : byte)
   Class: Eq_4643
   DataType: byte
@@ -33452,11 +32918,11 @@ T_7614: (in 0<32> : word32)
   OrigDataType: word32
 T_7615: (in a7_1005 + 0<32> : word32)
   Class: Eq_7615
-  DataType: Eq_7615
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7616: (in Mem1011[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7617: (in 0<32> : word32)
   Class: Eq_7617
@@ -33464,12 +32930,12 @@ T_7617: (in 0<32> : word32)
   OrigDataType: word32
 T_7618: (in a7_1005 + 0<32> : word32)
   Class: Eq_7618
-  DataType: Eq_7618
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_7619: (in Mem1031[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7599
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7620: (in (uint8) v585_1015 : uint8)
   Class: Eq_7620
   DataType: uint8
@@ -33484,19 +32950,19 @@ T_7622: (in 48<i32> : int32)
   OrigDataType: int32
 T_7623: (in a7_1005 + 48<i32> : word32)
   Class: Eq_7623
-  DataType: Eq_7623
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7624: (in Mem1037[a7_1005 + 48<i32>:word32] : word32)
   Class: Eq_7621
-  DataType: Eq_7599
-  OrigDataType: uint32
+  DataType: uint32
+  OrigDataType: word32
 T_7625: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_7625
   DataType: word24
   OrigDataType: word24
 T_7626: (in SEQ(SLICE(d0, word24, 8), v585_1015) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_7627: (in 0<32> : word32)
   Class: Eq_7627
@@ -33504,24 +32970,24 @@ T_7627: (in 0<32> : word32)
   OrigDataType: word32
 T_7628: (in a7_1005 + 0<32> : word32)
   Class: Eq_7628
-  DataType: Eq_7628
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 (ptr32 (ptr32 Eq_4258)))
+  OrigDataType: (ptr32 (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0)))
 T_7629: (in Mem1037[a7_1005 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: (union ((ptr32 (ptr32 Eq_4258)) u1) (ptr32 u0))
 T_7630: (in 44<i32> : int32)
   Class: Eq_7630
   DataType: int32
   OrigDataType: int32
 T_7631: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7631
-  DataType: Eq_7631
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7632: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: word32
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: int32
 T_7633: (in d3_1057 : Eq_7633)
   Class: Eq_7633
   DataType: Eq_7633
@@ -33552,135 +33018,135 @@ T_7639: (in 44<i32> : int32)
   OrigDataType: int32
 T_7640: (in a7_1330 + 44<i32> : word32)
   Class: Eq_7640
-  DataType: Eq_7640
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
 T_7641: (in Mem1043[a7_1330 + 44<i32>:word32] : word32)
   Class: Eq_7641
-  DataType: word32
-  OrigDataType: word32
+  DataType: int32
+  OrigDataType: int32
 T_7642: (in 0xFFFFFFFF<32> : word32)
   Class: Eq_7641
-  DataType: word32
+  DataType: int32
   OrigDataType: word32
-T_7643: (in *((word32) a7_1330 + 44<i32>) == 0xFFFFFFFF<32> : bool)
+T_7643: (in a7_1330[11<i32>] == 0xFFFFFFFF<32> : bool)
   Class: Eq_7643
   DataType: bool
   OrigDataType: bool
 T_7644: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_7645: (in d5_1044 == 0xFFFFFFFF<32> : bool)
   Class: Eq_7645
   DataType: bool
   OrigDataType: bool
-T_7646: (in a7_1076 : Eq_7646)
+T_7646: (in a7_1076 : (ptr32 Eq_7646))
   Class: Eq_7646
-  DataType: Eq_7646
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_7646)
+  OrigDataType: (ptr32 (struct (0 T_7650 t0000) (4D T_7707 t004D)))
 T_7647: (in 4<i32> : int32)
   Class: Eq_7647
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7648: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7646
-  DataType: Eq_7646
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_7646)
+  OrigDataType: ptr32
 T_7649: (in 78<i32> : int32)
   Class: Eq_7649
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7650: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  Class: Eq_7650
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7651: (in 0<32> : word32)
   Class: Eq_7651
   DataType: word32
   OrigDataType: word32
 T_7652: (in a7_1076 + 0<32> : word32)
   Class: Eq_7652
-  DataType: Eq_7652
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7653: (in Mem1078[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7646
+  Class: Eq_7650
+  DataType: ptr32
   OrigDataType: word32
 T_7654: (in 4<i32> : int32)
   Class: Eq_7654
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7655: (in a7_1076 - 4<i32> : word32)
   Class: Eq_7655
-  DataType: Eq_7655
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 (ptr32 Eq_25))
+  OrigDataType: (ptr32 (struct (0 T_7658 t0000)))
 T_7656: (in 0<32> : word32)
   Class: Eq_7656
   DataType: word32
   OrigDataType: word32
 T_7657: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_7657
-  DataType: Eq_7657
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7658: (in Mem1082[a7_1076 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_7655
-  OrigDataType: Eq_25
+  DataType: (ptr32 Eq_25)
+  OrigDataType: word32
 T_7659: (in 00000008 : ptr32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_7659
+  DataType: ptr32
   OrigDataType: ptr32
 T_7660: (in 8<i32> : int32)
   Class: Eq_7660
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7661: (in a7_1076 - 8<i32> : word32)
   Class: Eq_7661
-  DataType: Eq_7661
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7664 t0000)))
 T_7662: (in 0<32> : word32)
   Class: Eq_7662
   DataType: word32
   OrigDataType: word32
 T_7663: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_7663
-  DataType: Eq_7663
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7664: (in Mem1084[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7661
-  OrigDataType: uint8
+  Class: Eq_7659
+  DataType: ptr32
+  OrigDataType: word32
 T_7665: (in 12<i32> : int32)
   Class: Eq_7665
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7666: (in a7_1076 - 12<i32> : word32)
   Class: Eq_7666
-  DataType: Eq_7666
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_7669 t0000)))
 T_7667: (in 0<32> : word32)
   Class: Eq_7667
   DataType: word32
   OrigDataType: word32
 T_7668: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_7668
-  DataType: Eq_7668
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7669: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7666
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7670: (in 0<32> : word32)
   Class: Eq_7670
   DataType: word32
   OrigDataType: word32
 T_7671: (in a7_1076 + 0<32> : word32)
   Class: Eq_7671
-  DataType: Eq_7671
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7672: (in Mem1087[a7_1076 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7650
+  DataType: ptr32
   OrigDataType: ptr32
 T_7673: (in fn00002648 : ptr32)
   Class: Eq_7673
@@ -33692,45 +33158,45 @@ T_7674: (in signature of fn00002648 : void)
   OrigDataType: 
 T_7675: (in a7_1076 - 12<i32> : word32)
   Class: Eq_7675
-  DataType: Eq_7675
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_718)
+  OrigDataType: (ptr32 (struct (0 T_7678 t0000)))
 T_7676: (in 0<32> : word32)
   Class: Eq_7676
   DataType: word32
   OrigDataType: word32
 T_7677: (in a7_1076 - 12<i32> + 0<32> : word32)
   Class: Eq_7677
-  DataType: Eq_7677
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7678: (in Mem1087[a7_1076 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7679: (in 8<i32> : int32)
   Class: Eq_7679
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7680: (in a7_1076 - 8<i32> : word32)
   Class: Eq_7680
-  DataType: Eq_7680
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_718)
+  OrigDataType: (ptr32 (struct (0 T_7683 t0000)))
 T_7681: (in 0<32> : word32)
   Class: Eq_7681
   DataType: word32
   OrigDataType: word32
 T_7682: (in a7_1076 - 8<i32> + 0<32> : word32)
   Class: Eq_7682
-  DataType: Eq_7682
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7683: (in Mem1087[a7_1076 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7684: (in fn00002648(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_7684
   DataType: int32
   OrigDataType: int32
-T_7685: (in Mem1087[a7_1076 + 0<32>:word32] + fn00002648(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
+T_7685: (in a7_1076->ptr0000 + fn00002648(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)) : word32)
   Class: Eq_7685
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7686 t0000)))
@@ -33743,28 +33209,28 @@ T_7687: (in (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn00002648(d2_1090
   DataType: uint8
   OrigDataType: uint8
 T_7688: (in (uint32) (uint8) Mem1087[Mem1087[a7_1076 + 0<32>:word32] + fn00002648(d2_1090, *(a7_1076 - 12<i32>), *(a7_1076 - 8<i32>)):byte] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7689: (in 4<i32> : int32)
   Class: Eq_7689
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7690: (in a7_1076 - 4<i32> : word32)
   Class: Eq_7690
-  DataType: Eq_7690
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 (ptr32 Eq_25))
+  OrigDataType: (ptr32 (struct (0 T_7693 t0000)))
 T_7691: (in 0<32> : word32)
   Class: Eq_7691
   DataType: word32
   OrigDataType: word32
 T_7692: (in a7_1076 - 4<i32> + 0<32> : word32)
   Class: Eq_7692
-  DataType: Eq_7692
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7693: (in Mem1087[a7_1076 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_7694: (in 1<i32> : int32)
   Class: Eq_7694
@@ -33783,12 +33249,12 @@ T_7697: (in 1<i32> << (d5_1044 & 7<i32>) : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7698: (in 1<i32> << (d5_1044 & 7<i32>) & d1 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_7699: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_7700: (in d0 == 0<32> : bool)
   Class: Eq_7700
@@ -33816,8 +33282,8 @@ T_7705: (in 77<i32> : int32)
   OrigDataType: int32
 T_7706: (in a7_1076 + 77<i32> : word32)
   Class: Eq_7706
-  DataType: Eq_7706
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7707: (in Mem1087[a7_1076 + 77<i32>:byte] : byte)
   Class: Eq_7704
   DataType: byte
@@ -33954,30 +33420,30 @@ T_7740: (in a6_1164 + 1<i32> : word32)
   Class: Eq_7427
   DataType: (ptr32 byte)
   OrigDataType: ptr32
-T_7741: (in a7_1182 : Eq_7741)
+T_7741: (in a7_1182 : (ptr32 Eq_73))
   Class: Eq_7741
-  DataType: Eq_7741
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_7742: (in 4<i32> : int32)
   Class: Eq_7742
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7743: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7741
-  DataType: Eq_7741
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: ptr32
 T_7744: (in 0<32> : word32)
   Class: Eq_7744
   DataType: word32
   OrigDataType: word32
 T_7745: (in a7_1182 + 0<32> : word32)
   Class: Eq_7745
-  DataType: Eq_7745
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7746: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7741
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7747: (in d1_5335 : word32)
   Class: Eq_7747
   DataType: word32
@@ -33996,15 +33462,15 @@ T_7750: (in 0<32> : word32)
   OrigDataType: word32
 T_7751: (in a7_1182 + 0<32> : word32)
   Class: Eq_7751
-  DataType: Eq_7751
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7752: (in Mem1184[a7_1182 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7753: (in out d1_5335 : ptr32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: ptr32
 T_7754: (in out a1 : ptr32)
   Class: Eq_4617
@@ -34015,8 +33481,8 @@ T_7755: (in out a5_5336 : ptr32)
   DataType: (ptr32 byte)
   OrigDataType: ptr32
 T_7756: (in fn00003C30(*a7_1182, out d1_5335, out a1, out a5_5336) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7757: (in 4<i32> : int32)
   Class: Eq_7757
@@ -34024,7 +33490,7 @@ T_7757: (in 4<i32> : int32)
   OrigDataType: int32
 T_7758: (in a2_1014 + 4<i32> : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_7759: (in a0_1200 : (ptr32 byte))
   Class: Eq_4628
@@ -34042,30 +33508,30 @@ T_7762: (in Mem1177[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
-T_7763: (in a7_1201 : Eq_7763)
+T_7763: (in a7_1201 : (ptr32 Eq_73))
   Class: Eq_7763
-  DataType: Eq_7763
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_7764: (in 4<i32> : int32)
   Class: Eq_7764
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7765: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7763
-  DataType: Eq_7763
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: ptr32
 T_7766: (in 0<32> : word32)
   Class: Eq_7766
   DataType: word32
   OrigDataType: word32
 T_7767: (in a7_1201 + 0<32> : word32)
   Class: Eq_7767
-  DataType: Eq_7767
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7768: (in Mem1203[a7_1201 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7763
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7769: (in 1<i32> : int32)
   Class: Eq_7769
   DataType: int32
@@ -34084,8 +33550,8 @@ T_7772: (in a1 + 0<32> : word32)
   OrigDataType: (ptr32 (ptr32 (struct (0 T_4646 t0000))))
 T_7773: (in Mem1207[a1 + 0<32>:word32] : word32)
   Class: Eq_4628
-  DataType: Eq_25
-  OrigDataType: (ptr32 byte)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_4646 t0000)))
 T_7774: (in v611_1211 : byte)
   Class: Eq_4643
   DataType: byte
@@ -34108,27 +33574,27 @@ T_7778: (in 0<32> : word32)
   OrigDataType: word32
 T_7779: (in a7_1201 + 0<32> : word32)
   Class: Eq_7779
-  DataType: Eq_7779
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7780: (in Mem1207[a7_1201 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7781: (in SLICE(d0, word24, 8) : word24)
   Class: Eq_7781
   DataType: word24
   OrigDataType: word24
 T_7782: (in SEQ(SLICE(d0, word24, 8), v611_1211) : uip32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uip32
 T_7783: (in (uint8) v611_1211 : uint8)
   Class: Eq_7783
   DataType: uint8
   OrigDataType: uint8
 T_7784: (in (uint32) (uint8) v611_1211 : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7785: (in 1<32> : word32)
   Class: Eq_7785
@@ -34147,8 +33613,8 @@ T_7788: (in d4_1070 + 1<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_7789: (in 0xFFFFFFFF<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_7790: (in d1 == 0xFFFFFFFF<32> : bool)
   Class: Eq_7790
@@ -34176,8 +33642,8 @@ T_7795: (in 73<i32> : int32)
   OrigDataType: int32
 T_7796: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7796
-  DataType: Eq_7796
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7797: (in Mem1331[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7797
   DataType: byte
@@ -34186,77 +33652,77 @@ T_7798: (in 0<8> : byte)
   Class: Eq_7797
   DataType: byte
   OrigDataType: byte
-T_7799: (in *((word32) a7_1330 + 73<i32>) != 0<8> : bool)
+T_7799: (in a7_1330->b0049 != 0<8> : bool)
   Class: Eq_7799
   DataType: bool
   OrigDataType: bool
-T_7800: (in a7_1302 : Eq_7800)
+T_7800: (in a7_1302 : (ptr32 Eq_73))
   Class: Eq_7800
-  DataType: Eq_7800
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_73 t0000)))
 T_7801: (in 4<i32> : int32)
   Class: Eq_7801
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7802: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7800
-  DataType: Eq_7800
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: ptr32
 T_7803: (in 0<32> : word32)
   Class: Eq_7803
   DataType: word32
   OrigDataType: word32
 T_7804: (in a7_1302 + 0<32> : word32)
   Class: Eq_7804
-  DataType: Eq_7804
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7805: (in Mem1308[a7_1302 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7800
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7806: (in 4<i32> : int32)
   Class: Eq_7806
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7807: (in a7_1302 - 4<i32> : word32)
   Class: Eq_7807
-  DataType: Eq_7807
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_7810 t0000)))
 T_7808: (in 0<32> : word32)
   Class: Eq_7808
   DataType: word32
   OrigDataType: word32
 T_7809: (in a7_1302 - 4<i32> + 0<32> : word32)
   Class: Eq_7809
-  DataType: Eq_7809
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7810: (in Mem1311[a7_1302 - 4<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7807
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7811: (in fn00002B5C : ptr32)
   Class: Eq_4803
   DataType: (ptr32 Eq_4803)
   OrigDataType: (ptr32 (fn T_7820 (T_7816, T_7819)))
 T_7812: (in 1<i32> : int32)
   Class: Eq_7812
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7813: (in a7_1302 - 1<i32> : word32)
   Class: Eq_7813
-  DataType: Eq_7813
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 (struct (0 T_7816 t0000)))
 T_7814: (in 0<32> : word32)
   Class: Eq_7814
   DataType: word32
   OrigDataType: word32
 T_7815: (in a7_1302 - 1<i32> + 0<32> : word32)
   Class: Eq_7815
-  DataType: Eq_7815
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7816: (in Mem1311[a7_1302 - 1<i32> + 0<32>:byte] : byte)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_4217
+  DataType: byte
   OrigDataType: byte
 T_7817: (in 0<32> : word32)
   Class: Eq_7817
@@ -34264,15 +33730,15 @@ T_7817: (in 0<32> : word32)
   OrigDataType: word32
 T_7818: (in a7_1302 + 0<32> : word32)
   Class: Eq_7818
-  DataType: Eq_7818
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7819: (in Mem1311[a7_1302 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7820: (in fn00002B5C(*(a7_1302 - 1<i32>), *a7_1302) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_7821: (in 73<i32> : int32)
   Class: Eq_7821
@@ -34280,119 +33746,119 @@ T_7821: (in 73<i32> : int32)
   OrigDataType: int32
 T_7822: (in a7_1330 + 73<i32> : word32)
   Class: Eq_7822
-  DataType: Eq_7822
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_7823: (in Mem1294[a7_1330 + 73<i32>:byte] : byte)
   Class: Eq_7704
-  DataType: Eq_4251
+  DataType: byte
   OrigDataType: byte
-T_7824: (in a7_1237 : Eq_7824)
+T_7824: (in a7_1237 : (ptr32 ptr32))
   Class: Eq_7824
-  DataType: Eq_7824
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7828 t0000)))
 T_7825: (in 4<i32> : int32)
   Class: Eq_7825
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7826: (in a7_1330 - 4<i32> : word32)
   Class: Eq_7824
-  DataType: Eq_7824
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
 T_7827: (in 78<i32> : int32)
   Class: Eq_7827
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7828: (in a7_1330 + 78<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  Class: Eq_7828
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7829: (in 0<32> : word32)
   Class: Eq_7829
   DataType: word32
   OrigDataType: word32
 T_7830: (in a7_1237 + 0<32> : word32)
   Class: Eq_7830
-  DataType: Eq_7830
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7831: (in Mem1239[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7824
+  Class: Eq_7828
+  DataType: ptr32
   OrigDataType: word32
 T_7832: (in 4<i32> : int32)
   Class: Eq_7832
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7833: (in a7_1237 - 4<i32> : word32)
   Class: Eq_7833
-  DataType: Eq_7833
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 (ptr32 Eq_25))
+  OrigDataType: (ptr32 (struct (0 T_7836 t0000)))
 T_7834: (in 0<32> : word32)
   Class: Eq_7834
   DataType: word32
   OrigDataType: word32
 T_7835: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_7835
-  DataType: Eq_7835
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7836: (in Mem1243[a7_1237 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_7833
-  OrigDataType: Eq_25
+  DataType: (ptr32 Eq_25)
+  OrigDataType: word32
 T_7837: (in 00000008 : ptr32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_7837
+  DataType: ptr32
   OrigDataType: ptr32
 T_7838: (in 8<i32> : int32)
   Class: Eq_7838
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7839: (in a7_1237 - 8<i32> : word32)
   Class: Eq_7839
-  DataType: Eq_7839
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_7842 t0000)))
 T_7840: (in 0<32> : word32)
   Class: Eq_7840
   DataType: word32
   OrigDataType: word32
 T_7841: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_7841
-  DataType: Eq_7841
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7842: (in Mem1245[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7839
-  OrigDataType: uint8
+  Class: Eq_7837
+  DataType: ptr32
+  OrigDataType: word32
 T_7843: (in 12<i32> : int32)
   Class: Eq_7843
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7844: (in a7_1237 - 12<i32> : word32)
   Class: Eq_7844
-  DataType: Eq_7844
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_73)
+  OrigDataType: (ptr32 (struct (0 T_7847 t0000)))
 T_7845: (in 0<32> : word32)
   Class: Eq_7845
   DataType: word32
   OrigDataType: word32
 T_7846: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_7846
-  DataType: Eq_7846
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7847: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_7844
-  OrigDataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_7848: (in 0<32> : word32)
   Class: Eq_7848
   DataType: word32
   OrigDataType: word32
 T_7849: (in a7_1237 + 0<32> : word32)
   Class: Eq_7849
-  DataType: Eq_7849
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7850: (in Mem1248[a7_1237 + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_7828
+  DataType: ptr32
   OrigDataType: ptr32
 T_7851: (in fn00002648 : ptr32)
   Class: Eq_7673
@@ -34400,45 +33866,45 @@ T_7851: (in fn00002648 : ptr32)
   OrigDataType: (ptr32 (fn T_7861 (T_4255, T_7855, T_7860)))
 T_7852: (in a7_1237 - 12<i32> : word32)
   Class: Eq_7852
-  DataType: Eq_7852
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_718)
+  OrigDataType: (ptr32 (struct (0 T_7855 t0000)))
 T_7853: (in 0<32> : word32)
   Class: Eq_7853
   DataType: word32
   OrigDataType: word32
 T_7854: (in a7_1237 - 12<i32> + 0<32> : word32)
   Class: Eq_7854
-  DataType: Eq_7854
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7855: (in Mem1248[a7_1237 - 12<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7856: (in 8<i32> : int32)
   Class: Eq_7856
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7857: (in a7_1237 - 8<i32> : word32)
   Class: Eq_7857
-  DataType: Eq_7857
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 Eq_718)
+  OrigDataType: (ptr32 (struct (0 T_7860 t0000)))
 T_7858: (in 0<32> : word32)
   Class: Eq_7858
   DataType: word32
   OrigDataType: word32
 T_7859: (in a7_1237 - 8<i32> + 0<32> : word32)
   Class: Eq_7859
-  DataType: Eq_7859
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7860: (in Mem1248[a7_1237 - 8<i32> + 0<32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7861: (in fn00002648(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_7684
   DataType: int32
   OrigDataType: int32
-T_7862: (in Mem1248[a7_1237 + 0<32>:word32] + fn00002648(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
+T_7862: (in *a7_1237 + fn00002648(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)) : word32)
   Class: Eq_7862
   DataType: (ptr32 byte)
   OrigDataType: (ptr32 (struct (0 T_7863 t0000)))
@@ -34451,28 +33917,28 @@ T_7864: (in (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn00002648(d2_1090
   DataType: uint8
   OrigDataType: uint8
 T_7865: (in (uint32) (uint8) Mem1248[Mem1248[a7_1237 + 0<32>:word32] + fn00002648(d2_1090, *(a7_1237 - 12<i32>), *(a7_1237 - 8<i32>)):byte] : uint32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: uint32
 T_7866: (in 4<i32> : int32)
   Class: Eq_7866
-  DataType: uint8
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: int32
+  OrigDataType: int32
 T_7867: (in a7_1237 - 4<i32> : word32)
   Class: Eq_7867
-  DataType: Eq_7867
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 (ptr32 Eq_25))
+  OrigDataType: (ptr32 (struct (0 T_7870 t0000)))
 T_7868: (in 0<32> : word32)
   Class: Eq_7868
   DataType: word32
   OrigDataType: word32
 T_7869: (in a7_1237 - 4<i32> + 0<32> : word32)
   Class: Eq_7869
-  DataType: Eq_7869
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_7870: (in Mem1248[a7_1237 - 4<i32> + 0<32>:word32] : word32)
   Class: Eq_25
-  DataType: Eq_25
+  DataType: (ptr32 Eq_25)
   OrigDataType: word32
 T_7871: (in 1<i32> : int32)
   Class: Eq_7871
@@ -34491,12 +33957,12 @@ T_7874: (in 1<i32> << (d1 & 7<i32>) : word32)
   DataType: ui32
   OrigDataType: ui32
 T_7875: (in 1<i32> << (d1 & 7<i32>) & d1 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: ui32
 T_7876: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_7877: (in d0 == 0<32> : bool)
   Class: Eq_7877
@@ -34552,8 +34018,8 @@ T_7889: (in 60<i32> : int32)
   OrigDataType: int32
 T_7890: (in a7_1330 + 60<i32> : word32)
   Class: Eq_7890
-  DataType: Eq_7890
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7891: (in Mem1348[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_7891
   DataType: word32
@@ -34568,39 +34034,39 @@ T_7893: (in Mem1348[a7_1330 + 60<i32>:word32] + 1<32> : word32)
   OrigDataType: word32
 T_7894: (in a7_1330 + 60<i32> : word32)
   Class: Eq_7894
-  DataType: Eq_7894
-  OrigDataType: (union (uint8 u0) ((ptr32 Eq_8326) u1) (T_6344 u2) (T_7210 u3))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_7895: (in Mem1351[a7_1330 + 60<i32>:word32] : word32)
   Class: Eq_7893
-  DataType: Eq_4251
+  DataType: word32
   OrigDataType: word32
 T_7896: (in d0 : uint32)
   Class: Eq_7896
   DataType: uint32
   OrigDataType: word32
-T_7897: (in d0_23 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7897: (in d0_23 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7898: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_7899 (T_6948)))
 T_7899: (in __swap(dwArg08) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
-T_7900: (in d1_25 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7900: (in d1_25 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_7901: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_7902 (T_6950)))
 T_7902: (in __swap(dwArg10) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7903: (in d4_29 : uint32)
   Class: Eq_7903
@@ -34638,9 +34104,9 @@ T_7911: (in d1_25 * (word16) d0_23 : word32)
   Class: Eq_7909
   DataType: uint32
   OrigDataType: uint32
-T_7912: (in d2_39 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7912: (in d2_39 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_7913: (in SLICE(d1_25, word16, 0) : word16)
   Class: Eq_7913
@@ -34671,12 +34137,12 @@ T_7919: (in (word16) d4_29 ^ (word16) d4_29 : word16)
   DataType: ui16
   OrigDataType: ui16
 T_7920: (in SEQ(SLICE(d4_29, word16, 16), SLICE(d4_29, word16, 0) ^ SLICE(d4_29, word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_7921: (in __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7922: (in dwArg08 *u SLICE(d1_25, word16, 0) + __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) : word32)
   Class: Eq_7922
@@ -34691,28 +34157,28 @@ T_7924: (in dwArg10 * (word16) d0_23 : word32)
   DataType: uint32
   OrigDataType: uint32
 T_7925: (in (word32) __swap(SEQ(SLICE(d4_29, word16, 16), (word16) d4_29 ^ (word16) d4_29)) + dwArg08 * (word16) d1_25 + dwArg10 * (word16) d0_23 : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_7926: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_718
+  DataType: (ptr32 Eq_1290)
   OrigDataType: up32
 T_7927: (in d2_39 >= 0<32> : bool)
   Class: Eq_7927
   DataType: bool
   OrigDataType: bool
-T_7928: (in d2_45 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7928: (in d2_45 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7929: (in __swap : ptr32)
   Class: Eq_911
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_7930 (T_7912)))
 T_7930: (in __swap(d2_39) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7931: (in d3_65 : uint32)
   Class: Eq_7931
@@ -34723,8 +34189,8 @@ T_7932: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_7933 (T_6949)))
 T_7933: (in __swap(dwArg0C) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_7934: (in SLICE(dwArg08, word16, 0) : word16)
   Class: Eq_7934
@@ -34734,9 +34200,9 @@ T_7935: (in __swap(dwArg0C) * (word16) dwArg08 : word32)
   Class: Eq_7931
   DataType: uint32
   OrigDataType: uint32
-T_7936: (in d3_71 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7936: (in d3_71 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7937: (in __swap : ptr32)
   Class: Eq_911
@@ -34751,8 +34217,8 @@ T_7939: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_7940 (T_6948)))
 T_7940: (in __swap(dwArg08) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_7941: (in SLICE(dwArg0C, word16, 0) : word16)
   Class: Eq_7941
@@ -34771,12 +34237,12 @@ T_7944: (in SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_7945: (in SEQ(SLICE(d3_65, word16, 16), SLICE(d3_65 + __swap(dwArg08) *u SLICE(dwArg0C, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_7946: (in __swap(SEQ(SLICE(d3_65, word16, 16), (word16) (d3_65 + __swap(dwArg08) * (word16) dwArg0C))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7947: (in d3_83 : uint32)
   Class: Eq_7947
@@ -34787,8 +34253,8 @@ T_7948: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_7949 (T_6947)))
 T_7949: (in __swap(dwArg04) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_7950: (in SLICE(dwArg10, word16, 0) : word16)
   Class: Eq_7950
@@ -34798,9 +34264,9 @@ T_7951: (in __swap(dwArg04) * (word16) dwArg10 : word32)
   Class: Eq_7947
   DataType: uint32
   OrigDataType: uint32
-T_7952: (in d3_89 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_7952: (in d3_89 : Eq_718)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7953: (in __swap : ptr32)
   Class: Eq_911
@@ -34815,8 +34281,8 @@ T_7955: (in __swap : ptr32)
   DataType: (ptr32 Eq_911)
   OrigDataType: (ptr32 (fn T_7956 (T_6950)))
 T_7956: (in __swap(dwArg10) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uint32
 T_7957: (in SLICE(dwArg04, word16, 0) : word16)
   Class: Eq_7957
@@ -34835,12 +34301,12 @@ T_7960: (in SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 
   DataType: word16
   OrigDataType: word16
 T_7961: (in SEQ(SLICE(d3_83, word16, 16), SLICE(d3_83 + __swap(dwArg10) *u SLICE(dwArg04, word16, 0), word16, 0)) : uipr32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: uipr32
 T_7962: (in __swap(SEQ(SLICE(d3_83, word16, 16), (word16) (d3_83 + __swap(dwArg10) * (word16) dwArg04))) : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: word32
 T_7963: (in SLICE(d2_45, word16, 16) : word16)
   Class: Eq_7963
@@ -34966,10 +34432,10 @@ T_7993: (in a1_116 : (ptr32 word32))
   Class: Eq_4617
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_7994: (in d1_118 : Eq_2601)
+T_7994: (in d1_118 : (ptr32 (ptr32 Eq_4258)))
   Class: Eq_2601
-  DataType: Eq_2601
-  OrigDataType: Eq_25
+  DataType: (ptr32 (ptr32 Eq_4258))
+  OrigDataType: word32
 T_7995: (in fn00002388 : ptr32)
   Class: Eq_2595
   DataType: (ptr32 Eq_2595)
@@ -34984,11 +34450,11 @@ T_7997: (in out a5_279 : ptr32)
   OrigDataType: ptr32
 T_7998: (in fn00002388(out a1_116, out a5_279) : word32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: word32
 T_7999: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_8000: (in dwArg04 != 0<32> : bool)
   Class: Eq_8000
@@ -35003,8 +34469,8 @@ T_8002: (in dwArg04 + 24<i32> : word32)
   DataType: word32
   OrigDataType: word32
 T_8003: (in Mem26[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3119
-  DataType: Eq_3119
+  Class: Eq_8003
+  DataType: ui32
   OrigDataType: ui32
 T_8004: (in 42<i32> : int32)
   Class: Eq_8004
@@ -35035,36 +34501,36 @@ T_8010: (in dwArg04 + 24<i32> : word32)
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8011: (in Mem26[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3119
-  DataType: Eq_3119
+  Class: Eq_8003
+  DataType: ui32
   OrigDataType: ui32
 T_8012: (in 1<i32> : int32)
   Class: Eq_8012
   DataType: int32
   OrigDataType: int32
 T_8013: (in *((word32) dwArg04 + 24<i32>) | 1<i32> : word32)
-  Class: Eq_3119
-  DataType: Eq_3119
+  Class: Eq_8003
+  DataType: ui32
   OrigDataType: ui32
 T_8014: (in dwArg04 + 24<i32> : word32)
   Class: Eq_8014
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8015: (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3119
-  DataType: Eq_25
-  OrigDataType: Eq_3119
-T_8016: (in d0_125 : (ptr32 Eq_2656))
+  Class: Eq_8003
+  DataType: Eq_73
+  OrigDataType: ui32
+T_8016: (in d0_125 : int32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: int32
 T_8017: (in dwArg04 + 24<i32> : word32)
   Class: Eq_8017
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8018: (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3119
-  DataType: Eq_3119
+  Class: Eq_8003
+  DataType: ui32
   OrigDataType: ui32
 T_8019: (in 0x200<32> : word32)
   Class: Eq_8019
@@ -35072,13 +34538,13 @@ T_8019: (in 0x200<32> : word32)
   OrigDataType: ui32
 T_8020: (in *((word32) dwArg04 + 24<i32>) & 0x200<32> : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: ui32
 T_8021: (in 0<32> : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
-T_8022: (in d0_125 == null : bool)
+T_8022: (in d0_125 == 0<32> : bool)
   Class: Eq_8022
   DataType: bool
   OrigDataType: bool
@@ -35095,11 +34561,11 @@ T_8025: (in dwArg04 + 28<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_8026: (in Mem49[dwArg04 + 28<i32>:word32] : word32)
-  Class: Eq_3147
+  Class: Eq_8026
   DataType: int32
   OrigDataType: word32
 T_8027: (in 0<32> : word32)
-  Class: Eq_3147
+  Class: Eq_8026
   DataType: int32
   OrigDataType: word32
 T_8028: (in *((word32) dwArg04 + 28<i32>) != 0<32> : bool)
@@ -35132,7 +34598,7 @@ T_8034: (in out a5_279 : ptr32)
   OrigDataType: ptr32
 T_8035: (in fn00003D2C(out a1_116, out a5_279) : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
 T_8036: (in 8<i32> : int32)
   Class: Eq_8036
@@ -35143,12 +34609,12 @@ T_8037: (in dwArg04 + 8<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_8038: (in Mem86[dwArg04 + 8<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8039: (in 0<32> : word32)
-  Class: Eq_25
-  DataType: uint8
+  Class: Eq_73
+  DataType: byte
   OrigDataType: word32
 T_8040: (in *((word32) dwArg04 + 8<i32>) != 0<32> : bool)
   Class: Eq_8040
@@ -35163,8 +34629,8 @@ T_8042: (in dwArg04 + 24<i32> : word32)
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8043: (in Mem49[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3119
-  DataType: Eq_3119
+  Class: Eq_8003
+  DataType: ui32
   OrigDataType: ui32
 T_8044: (in 4<i32> : int32)
   Class: Eq_8044
@@ -35172,18 +34638,18 @@ T_8044: (in 4<i32> : int32)
   OrigDataType: int32
 T_8045: (in *((word32) dwArg04 + 24<i32>) & 4<i32> : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: ui32
 T_8046: (in 0<32> : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
-T_8047: (in d0_125 == null : bool)
+T_8047: (in d0_125 == 0<32> : bool)
   Class: Eq_8047
   DataType: bool
   OrigDataType: bool
 T_8048: (in 0x400<32> : word32)
-  Class: Eq_3147
+  Class: Eq_8026
   DataType: int32
   OrigDataType: word32
 T_8049: (in 28<i32> : int32)
@@ -35195,11 +34661,11 @@ T_8050: (in dwArg04 + 28<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8051: (in Mem79[dwArg04 + 28<i32>:word32] : word32)
-  Class: Eq_3147
-  DataType: Eq_25
+  Class: Eq_8026
+  DataType: Eq_73
   OrigDataType: int32
 T_8052: (in 1<i32> : int32)
-  Class: Eq_3147
+  Class: Eq_8026
   DataType: int32
   OrigDataType: int32
 T_8053: (in 28<i32> : int32)
@@ -35211,12 +34677,12 @@ T_8054: (in dwArg04 + 28<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8055: (in Mem83[dwArg04 + 28<i32>:word32] : word32)
-  Class: Eq_3147
-  DataType: Eq_25
+  Class: Eq_8026
+  DataType: Eq_73
   OrigDataType: int32
 T_8056: (in 1<i32> : int32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: int32
 T_8057: (in 8<i32> : int32)
   Class: Eq_8057
@@ -35227,8 +34693,8 @@ T_8058: (in dwArg04 + 8<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8059: (in Mem135[dwArg04 + 8<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8060: (in 4<i32> : int32)
   Class: Eq_8060
@@ -35239,8 +34705,8 @@ T_8061: (in dwArg04 + 4<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_8062: (in Mem137[dwArg04 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8063: (in 0<32> : word32)
   Class: Eq_8063
@@ -35252,7 +34718,7 @@ T_8064: (in dwArg04 + 0<32> : word32)
   OrigDataType: ptr32
 T_8065: (in Mem137[dwArg04 + 0<32>:word32] : word32)
   Class: Eq_2601
-  DataType: Eq_2601
+  DataType: (ptr32 (ptr32 Eq_4258))
   OrigDataType: word32
 T_8066: (in execPrivate2 : ptr32)
   Class: Eq_8066
@@ -35276,11 +34742,11 @@ T_8070: (in dwArg04 + 20<i32> : word32)
   OrigDataType: ptr32
 T_8071: (in Mem147[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2656
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_2656)
-T_8072: (in v26_148 : (ptr32 Eq_2656))
+  DataType: Eq_73
+  OrigDataType: int32
+T_8072: (in v26_148 : int32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: int32
 T_8073: (in dwArg04 + 20<i32> : word32)
   Class: Eq_8073
@@ -35288,7 +34754,7 @@ T_8073: (in dwArg04 + 20<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_8074: (in Mem147[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
 T_8075: (in 1<32> : word32)
   Class: Eq_8075
@@ -35296,7 +34762,7 @@ T_8075: (in 1<32> : word32)
   OrigDataType: word32
 T_8076: (in *((word32) dwArg04 + 20<i32>) - 1<32> : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
 T_8077: (in dwArg04 + 20<i32> : word32)
   Class: Eq_8077
@@ -35304,13 +34770,13 @@ T_8077: (in dwArg04 + 20<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_8078: (in Mem149[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2656
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_2656)
+  DataType: Eq_73
+  OrigDataType: int32
 T_8079: (in 0<32> : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: int32
-T_8080: (in v26_148 >= null : bool)
+T_8080: (in v26_148 >= 0<32> : bool)
   Class: Eq_8080
   DataType: bool
   OrigDataType: bool
@@ -35327,8 +34793,8 @@ T_8083: (in dwArg04 + 24<i32> : word32)
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8084: (in Mem86[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3119
-  DataType: Eq_3119
+  Class: Eq_8003
+  DataType: ui32
   OrigDataType: ui32
 T_8085: (in 0x80<32> : word32)
   Class: Eq_8085
@@ -35358,9 +34824,9 @@ T_8091: (in a0_318 : word32)
   Class: Eq_8091
   DataType: word32
   OrigDataType: word32
-T_8092: (in d0_117 : (ptr32 Eq_2656))
+T_8092: (in d0_117 : int32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
 T_8093: (in fn00001FB4 : ptr32)
   Class: Eq_2657
@@ -35375,7 +34841,7 @@ T_8095: (in dwArg04 + 28<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8096: (in Mem86[dwArg04 + 28<i32>:word32] : word32)
-  Class: Eq_3147
+  Class: Eq_8026
   DataType: int32
   OrigDataType: word32
 T_8097: (in d4_100 + Mem86[dwArg04 + 28<i32>:word32] : word32)
@@ -35396,19 +34862,19 @@ T_8100: (in out a1_116 : ptr32)
   OrigDataType: ptr32
 T_8101: (in fn00001FB4((word32) *((word32) dwArg04 + 28<i32>) + d4_100, out d1_118, out a0_318, out a1_116) : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
 T_8102: (in 0<32> : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
-T_8103: (in d0_117 != null : bool)
+T_8103: (in d0_117 != 0<32> : bool)
   Class: Eq_8103
   DataType: bool
   OrigDataType: bool
-T_8104: (in a0_153 : Eq_25)
-  Class: Eq_25
-  DataType: Eq_25
+T_8104: (in a0_153 : Eq_73)
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: (ptr32 (struct (0 T_8116 t0000)))
 T_8105: (in 4<i32> : int32)
   Class: Eq_8105
@@ -35419,24 +34885,24 @@ T_8106: (in dwArg04 + 4<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8107: (in Mem149[dwArg04 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8108: (in 1<i32> : int32)
   Class: Eq_8108
   DataType: int32
   OrigDataType: int32
 T_8109: (in a0_153 + 1<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8110: (in dwArg04 + 4<i32> : word32)
   Class: Eq_8110
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8111: (in Mem157[dwArg04 + 4<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8112: (in dwArg04 + 4<i32> : word32)
   Class: Eq_4617
@@ -35480,13 +34946,13 @@ T_8121: (in dwArg04 + 20<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_8122: (in Mem149[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: int32
 T_8123: (in -1<i32> : int32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: int32
-T_8124: (in *((word32) dwArg04 + 20<i32>) != (struct Eq_2656 *) -1<i32> : bool)
+T_8124: (in *((word32) dwArg04 + 20<i32>) != -1<i32> : bool)
   Class: Eq_8124
   DataType: bool
   OrigDataType: bool
@@ -35499,25 +34965,25 @@ T_8126: (in dwArg04 + 24<i32> : word32)
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8127: (in Mem149[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3119
-  DataType: Eq_3119
+  Class: Eq_8003
+  DataType: ui32
   OrigDataType: ui32
 T_8128: (in 16<i32> : int32)
   Class: Eq_8128
   DataType: int32
   OrigDataType: int32
 T_8129: (in *((word32) dwArg04 + 24<i32>) | 16<i32> : word32)
-  Class: Eq_3119
-  DataType: Eq_3119
+  Class: Eq_8003
+  DataType: ui32
   OrigDataType: ui32
 T_8130: (in dwArg04 + 24<i32> : word32)
   Class: Eq_8130
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8131: (in Mem172[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3119
-  DataType: Eq_25
-  OrigDataType: Eq_3119
+  Class: Eq_8003
+  DataType: Eq_73
+  OrigDataType: ui32
 T_8132: (in 24<i32> : int32)
   Class: Eq_8132
   DataType: int32
@@ -35527,28 +34993,28 @@ T_8133: (in dwArg04 + 24<i32> : word32)
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8134: (in Mem149[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3119
-  DataType: Eq_3119
+  Class: Eq_8003
+  DataType: ui32
   OrigDataType: ui32
 T_8135: (in 8<i32> : int32)
   Class: Eq_8135
   DataType: int32
   OrigDataType: int32
 T_8136: (in *((word32) dwArg04 + 24<i32>) | 8<i32> : word32)
-  Class: Eq_3119
-  DataType: Eq_3119
+  Class: Eq_8003
+  DataType: ui32
   OrigDataType: ui32
 T_8137: (in dwArg04 + 24<i32> : word32)
   Class: Eq_8137
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
 T_8138: (in Mem179[dwArg04 + 24<i32>:word32] : word32)
-  Class: Eq_3119
-  DataType: Eq_25
-  OrigDataType: Eq_3119
+  Class: Eq_8003
+  DataType: Eq_73
+  OrigDataType: ui32
 T_8139: (in 0<32> : word32)
   Class: Eq_2656
-  DataType: (ptr32 Eq_2656)
+  DataType: int32
   OrigDataType: word32
 T_8140: (in 20<i32> : int32)
   Class: Eq_8140
@@ -35560,8 +35026,8 @@ T_8141: (in dwArg04 + 20<i32> : word32)
   OrigDataType: (ptr32 int32)
 T_8142: (in Mem184[dwArg04 + 20<i32>:word32] : word32)
   Class: Eq_2656
-  DataType: Eq_25
-  OrigDataType: (ptr32 Eq_2656)
+  DataType: Eq_73
+  OrigDataType: int32
 T_8143: (in -1<i32> : int32)
   Class: Eq_7990
   DataType: int32
@@ -35571,8 +35037,8 @@ T_8144: (in 1<i32> : int32)
   DataType: int32
   OrigDataType: int32
 T_8145: (in d0_117 + 1<i32> : word32)
-  Class: Eq_25
-  DataType: Eq_25
+  Class: Eq_73
+  DataType: Eq_73
   OrigDataType: word32
 T_8146: (in 8<i32> : int32)
   Class: Eq_8146
@@ -35583,9 +35049,9 @@ T_8147: (in dwArg04 + 8<i32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_8148: (in Mem131[dwArg04 + 8<i32>:word32] : word32)
-  Class: Eq_25
-  DataType: Eq_25
-  OrigDataType: (ptr32 char)
+  Class: Eq_73
+  DataType: Eq_73
+  OrigDataType: word32
 T_8149: (in d0_117 + 1<i32> : word32)
   Class: Eq_4617
   DataType: (ptr32 word32)
@@ -36222,172 +35688,9 @@ T_8307:
   Class: Eq_8307
   DataType: Eq_8307
   OrigDataType: 
-T_8308:
-  Class: Eq_8308
-  DataType: Eq_8308
-  OrigDataType: 
-T_8309:
-  Class: Eq_8309
-  DataType: Eq_8309
-  OrigDataType: 
-T_8310:
-  Class: Eq_8310
-  DataType: Eq_8310
-  OrigDataType: 
-T_8311:
-  Class: Eq_8311
-  DataType: Eq_8311
-  OrigDataType: 
-T_8312:
-  Class: Eq_8312
-  DataType: Eq_8312
-  OrigDataType: 
-T_8313:
-  Class: Eq_8313
-  DataType: Eq_8313
-  OrigDataType: 
-T_8314:
-  Class: Eq_8314
-  DataType: Eq_8314
-  OrigDataType: 
-T_8315:
-  Class: Eq_8315
-  DataType: Eq_8315
-  OrigDataType: 
-T_8316:
-  Class: Eq_8316
-  DataType: Eq_8316
-  OrigDataType: 
-T_8317:
-  Class: Eq_8317
-  DataType: Eq_8317
-  OrigDataType: 
-T_8318:
-  Class: Eq_8318
-  DataType: Eq_8318
-  OrigDataType: 
-T_8319:
-  Class: Eq_8319
-  DataType: Eq_8319
-  OrigDataType: 
-T_8320:
-  Class: Eq_8320
-  DataType: Eq_8320
-  OrigDataType: 
-T_8321:
-  Class: Eq_8321
-  DataType: Eq_8321
-  OrigDataType: 
-T_8322:
-  Class: Eq_8322
-  DataType: Eq_8322
-  OrigDataType: 
-T_8323:
-  Class: Eq_8323
-  DataType: Eq_8323
-  OrigDataType: 
-T_8324:
-  Class: Eq_8324
-  DataType: Eq_8324
-  OrigDataType: 
-T_8325:
-  Class: Eq_8325
-  DataType: Eq_8325
-  OrigDataType: 
-T_8326:
-  Class: Eq_8326
-  DataType: Eq_8326
-  OrigDataType: 
-T_8327:
-  Class: Eq_8327
-  DataType: Eq_8327
-  OrigDataType: 
-T_8328:
-  Class: Eq_8328
-  DataType: Eq_8328
-  OrigDataType: 
-T_8329:
-  Class: Eq_8329
-  DataType: Eq_8329
-  OrigDataType: 
-T_8330:
-  Class: Eq_8330
-  DataType: Eq_8330
-  OrigDataType: 
-T_8331:
-  Class: Eq_8331
-  DataType: Eq_8331
-  OrigDataType: 
-T_8332:
-  Class: Eq_8332
-  DataType: Eq_8332
-  OrigDataType: 
-T_8333:
-  Class: Eq_8333
-  DataType: Eq_8333
-  OrigDataType: 
-T_8334:
-  Class: Eq_8334
-  DataType: Eq_8334
-  OrigDataType: 
-T_8335:
-  Class: Eq_8335
-  DataType: Eq_8335
-  OrigDataType: 
-T_8336:
-  Class: Eq_8336
-  DataType: Eq_8336
-  OrigDataType: 
-T_8337:
-  Class: Eq_8337
-  DataType: Eq_8337
-  OrigDataType: 
-T_8338:
-  Class: Eq_8338
-  DataType: Eq_8338
-  OrigDataType: 
-T_8339:
-  Class: Eq_8339
-  DataType: Eq_8339
-  OrigDataType: 
-T_8340:
-  Class: Eq_8340
-  DataType: Eq_8340
-  OrigDataType: 
-T_8341:
-  Class: Eq_8341
-  DataType: Eq_8341
-  OrigDataType: 
-T_8342:
-  Class: Eq_8342
-  DataType: Eq_8342
-  OrigDataType: 
-T_8343:
-  Class: Eq_8343
-  DataType: Eq_8343
-  OrigDataType: 
-T_8344:
-  Class: Eq_8344
-  DataType: Eq_8344
-  OrigDataType: 
-T_8345:
-  Class: Eq_8345
-  DataType: Eq_8345
-  OrigDataType: 
-T_8346:
-  Class: Eq_8346
-  DataType: Eq_8346
-  OrigDataType: 
-T_8347:
-  Class: Eq_8347
-  DataType: Eq_8347
-  OrigDataType: 
-T_8348:
-  Class: Eq_8348
-  DataType: Eq_8348
-  OrigDataType: 
 */
-typedef struct Eq_621;
+typedef struct Eq_25;
+struct Eq_621;
 struct Globals {
 	struct Eq_116 * ptr0000;	// 0
 	Eq_725 t0001;	// 1
@@ -36395,6 +35698,7 @@ struct Globals {
 	word32 a0008[];	// 8
 	ui32 a0010[];	// 10
 	Eq_1123 t0078;	// 78
+	struct Eq_25 t12BC;	// 12BC
 	struct Eq_621 t13E4;	// 13E4
 	struct Eq_621 t13E8;	// 13E8
 	struct Eq_621 t13EC;	// 13EC
@@ -36403,29 +35707,31 @@ struct Globals {
 	Eq_4288 t2815;	// 2815
 	ptr32 ptr3D70;	// 3D70
 	struct Eq_4 * ptr3D74;	// 3D74
-	Eq_25 t3D78;	// 3D78
+	struct Eq_25 * ptr3D78;	// 3D78
 	struct Eq_61 * ptr3D7C;	// 3D7C
 	struct Eq_61 * ptr3D80;	// 3D80
-	Eq_25 t3D84;	// 3D84
-	Eq_25 t3D88;	// 3D88
-	Eq_25 t3D8C;	// 3D8C
+	Eq_134 t3D84;	// 3D84
+	Eq_134 t3D88;	// 3D88
+	Eq_134 t3D8C;	// 3D8C
 	word32 dw3D98;	// 3D98
 	ptr32 ptr3D9C;	// 3D9C
 	int32 dw3DA0;	// 3DA0
-	struct Eq_2656 * ptr3DA4;	// 3DA4
+	struct Eq_2878 * ptr3DA4;	// 3DA4
 	struct Eq_4 * ptr3DA8;	// 3DA8
 	Eq_3367 t3DAC;	// 3DAC
 	word32 dw3EB0;	// 3EB0
 	Eq_542 t3EB8;	// 3EB8
 	word32 dw3EBC;	// 3EBC
 	struct Eq_557 * ptr3EC8;	// 3EC8
-	Eq_25 t3ECC;	// 3ECC
+	Eq_73 t3ECC;	// 3ECC
 	struct Eq_635 * ptr3ED0;	// 3ED0
 	struct Eq_635 * ptr3ED8;	// 3ED8
 	Eq_4 t4000;	// 4000
 	Eq_61 t10202;	// 10202
 	Eq_61 t3030303;	// 3030303
-	Eq_2656 t6060606;	// 6060606
+	Eq_2878 t6060606;	// 6060606
+	Eq_2878 t48E72030;	// 48E72030
+	Eq_25 t61727900;	// 61727900
 } Eq_1;
 
 typedef struct Eq_4 {
@@ -36446,37 +35752,44 @@ typedef union Eq_11 {
 typedef struct Eq_19 {
 	byte b0008;	// 8
 	word32 dw003A;	// 3A
-	Eq_25 t009C;	// 9C
-	Eq_25 t00A0;	// A0
+	Eq_134 t009C;	// 9C
+	Eq_134 t00A0;	// A0
 	word32 dw00A4;	// A4
 	struct Eq_61 * ptr00AC;	// AC
 	word32 * ptr00B0;	// B0
-	Eq_25 t00E0;	// E0
+	Eq_134 t00E0;	// E0
 } Eq_19;
 
 typedef Eq_19 * (Eq_20)(word32);
 
-typedef union Eq_25 {
-	uint8 u0;
-	ui24 u1;
-	word16 u2;
-	struct Eq_8241 * u3;
-	struct Eq_8248 * u4;
-	Eq_1290 u5;
-	Eq_6344 u6;
-	Eq_7207 u7;
+typedef struct Eq_25 {	// size: 4 4
+	word32 dw0000;	// 0
+	Eq_134 t0004;	// 4
+	struct Eq_25 * ptr0008;	// 8
+	Eq_106 t000C;	// C
+	Eq_160 (* ptr0010)[];	// 10
+	struct Eq_2878 * ptr0014;	// 14
+	ptr32 ptr0018;	// 18
+	word32 dw001C;	// 1C
+	word32 dw0020;	// 20
 } Eq_25;
 
-typedef Eq_25 (Eq_28)(ptr32, int32);
+typedef Eq_25 * (Eq_28)(ptr32, int32);
 
 typedef void (Eq_51)(word32);
 
 typedef struct Eq_61 {
 	word32 dw0000;	// 0
-	Eq_25 t0024;	// 24
+	Eq_134 t0024;	// 24
 } Eq_61;
 
-typedef Eq_25 (Eq_75)(Eq_77, Eq_78);
+typedef union Eq_73 {
+	byte u0;
+	word16 u1;
+	struct Eq_8241 * u2;
+} Eq_73;
+
+typedef Eq_25 * (Eq_75)(Eq_77, Eq_78);
 
 typedef union Eq_77 {
 	int32 u0;
@@ -36488,7 +35801,7 @@ typedef union Eq_78 {
 	ptr32 u1;
 } Eq_78;
 
-typedef void (Eq_90)(Eq_25);
+typedef void (Eq_90)(Eq_25 *);
 
 typedef union Eq_106 {
 	int32 u0;
@@ -36500,6 +35813,11 @@ typedef struct Eq_116 {
 } Eq_116;
 
 typedef void (Eq_124)(Eq_19 *);
+
+typedef union Eq_134 {
+	int32 u0;
+	uint32 u1;
+} Eq_134;
 
 typedef struct Eq_160 {	// size: 1 1
 	Eq_160 a0000[];	// 0
@@ -36514,9 +35832,9 @@ typedef void (Eq_200)();
 
 typedef void (Eq_205)();
 
-typedef void (Eq_306)(Eq_25);
+typedef void (Eq_306)(Eq_25 *);
 
-typedef void (Eq_310)(Eq_25);
+typedef void (Eq_310)(Eq_25 *);
 
 typedef void (Eq_320)();
 
@@ -36527,7 +35845,7 @@ typedef struct Eq_379 {
 	word32 dw0004;	// 4
 } Eq_379;
 
-typedef void (Eq_425)(Eq_25, Eq_25, int32, Eq_61 *);
+typedef void (Eq_425)(Eq_73, Eq_25 *, int32, Eq_61 *);
 
 typedef void (Eq_432)(word32);
 
@@ -36535,7 +35853,7 @@ typedef void (Eq_438)(word32);
 
 typedef void (Eq_444)();
 
-typedef void (Eq_447)(Eq_25);
+typedef void (Eq_447)(Eq_25 *);
 
 typedef void (Eq_484)();
 
@@ -36556,18 +35874,18 @@ typedef word32 (Eq_565)(ptr32, ptr32, ptr32);
 
 typedef word32 (Eq_587)(ptr32, ptr32, ptr32);
 
-typedef ptr32 (Eq_589)(Eq_25, Eq_25, Eq_25);
+typedef ptr32 (Eq_589)(Eq_73, Eq_73, Eq_25 *);
 
-typedef Eq_25 (Eq_612)(Eq_25, byte *);
+typedef Eq_73 (Eq_612)(Eq_73, byte *);
 
-typedef Eq_25 (Eq_616)(Eq_25, Eq_25, Eq_25, Eq_621 *);
+typedef Eq_73 (Eq_616)(Eq_73, Eq_73, Eq_25 *, Eq_621 *);
 
 typedef struct Eq_621 {	// size: 1 1
 	uint8 b0000;	// 0
 	cu8 b0001;	// 1
 } Eq_621;
 
-typedef Eq_25 (Eq_632)(Eq_25, Eq_635 *, byte *, Eq_637);
+typedef Eq_73 (Eq_632)(Eq_73, Eq_635 *, byte *, Eq_637);
 
 typedef struct Eq_635 {
 	word32 dw0000;	// 0
@@ -36585,25 +35903,31 @@ typedef union Eq_637 {
 } Eq_637;
 
 typedef struct Eq_645 {	// size: 4 4
-	Eq_8249 t002C;	// 2C
+	Eq_8242 t002C;	// 2C
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
-	word32 dw0037;	// 37
+	byte b0037;	// 37
 	word32 dw0038;	// 38
 	word32 dw003C;	// 3C
-	word32 dw003E;	// 3E
-	word32 dw003F;	// 3F
+	word16 w003E;	// 3E
+	byte b003F;	// 3F
 	word32 dw0040;	// 40
 	word32 dw0044;	// 44
 	ui32 dw0048;	// 48
 	word32 dw0062;	// 62
-	Eq_8250 t0066;	// 66
+	Eq_8243 t0066;	// 66
 	byte b006A;	// 6A
 	word32 dw006C;	// 6C
 	word32 dw007C;	// 7C
 } Eq_645;
 
-typedef Eq_25 (Eq_686)(int32, Eq_635 *, ui32 *, ptr32);
+typedef Eq_73 (Eq_686)(int32, Eq_635 *, ui32 *, ptr32);
+
+typedef union Eq_718 {
+	struct Eq_1290 * u0;
+	struct Eq_8244 * u1;
+	struct Eq_8245 * u2;
+} Eq_718;
 
 typedef struct Eq_725 {
 	Eq_2290 t0000;	// 0
@@ -36612,8 +35936,8 @@ typedef struct Eq_725 {
 } Eq_725;
 
 typedef struct Eq_755 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0004;	// 4
+	Eq_73 t0000;	// 0
+	Eq_73 t0004;	// 4
 } Eq_755;
 
 typedef union Eq_833 {
@@ -36636,7 +35960,7 @@ typedef union Eq_882 {
 	ptr32 u1;
 } Eq_882;
 
-typedef Eq_25 (Eq_911)(Eq_25);
+typedef Eq_718 (Eq_911)(Eq_718);
 
 typedef union Eq_934 {
 	int32 u0;
@@ -36663,12 +35987,6 @@ typedef struct Eq_1123 {
 	word32 dw0000;	// 0
 	word32 dw0004;	// 4
 } Eq_1123;
-
-typedef union Eq_1126 {
-	ui24 u0;
-	struct Eq_8251 * u1;
-	Eq_1290 u2;
-} Eq_1126;
 
 typedef union Eq_1159 {
 	cu8 u0;
@@ -36739,41 +36057,10 @@ typedef union Eq_1268 {
 	int32 u1;
 } Eq_1268;
 
-typedef union Eq_1290 {
-	ui24 u0;
-	struct Eq_8252 * u1;
+typedef struct Eq_1290 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_1290;
-
-typedef union Eq_1291 {
-	ui24 u0;
-	struct Eq_8253 * u1;
-	Eq_1290 u2;
-} Eq_1291;
-
-typedef union Eq_1296 {
-	ui24 u0;
-	struct Eq_8254 * u1;
-	Eq_1290 u2;
-} Eq_1296;
-
-typedef union Eq_1303 {
-	ui24 u0;
-	struct Eq_8255 * u1;
-	Eq_1290 u2;
-} Eq_1303;
-
-typedef union Eq_1307 {
-	int32 u0;
-	uint32 u1;
-	Eq_1126 u2;
-	Eq_1290 u3;
-} Eq_1307;
-
-typedef union Eq_1309 {
-	ui24 u0;
-	struct Eq_8256 * u1;
-	Eq_1290 u2;
-} Eq_1309;
 
 typedef union Eq_1316 {
 	uint32 u0;
@@ -36808,23 +36095,11 @@ typedef struct Eq_1363 {
 } Eq_1363;
 
 typedef struct Eq_1416 {
-	Eq_1126 t0000;	// 0
+	struct Eq_1290 * ptr0000;	// 0
 	up32 dw0030;	// 30
 	up32 dw0034;	// 34
 	up32 dw0044;	// 44
 } Eq_1416;
-
-typedef union Eq_1433 {
-	ui24 u0;
-	struct Eq_8257 * u1;
-	Eq_1290 u2;
-} Eq_1433;
-
-typedef union Eq_1437 {
-	ui24 u0;
-	struct Eq_8258 * u1;
-	Eq_1290 u2;
-} Eq_1437;
 
 typedef union Eq_1448 {
 	byte u0;
@@ -36841,15 +36116,9 @@ typedef union Eq_1459 {
 	word32 u1;
 } Eq_1459;
 
-typedef union Eq_1466 {
-	ui24 u0;
-	struct Eq_8259 * u1;
-	Eq_1290 u2;
-} Eq_1466;
-
 typedef struct Eq_1540 {
 	word32 dw0000;	// 0
-	Eq_1126 t0004;	// 4
+	struct Eq_1290 * ptr0004;	// 4
 } Eq_1540;
 
 typedef union Eq_1555 {
@@ -36879,7 +36148,7 @@ typedef union Eq_1621 {
 
 typedef struct Eq_1628 {
 	int32 dw0000;	// 0
-	Eq_25 t0034;	// 34
+	Eq_73 t0034;	// 34
 	Eq_1115 t0048;	// 48
 	ui32 dw004C;	// 4C
 	struct Eq_725 * ptr0066;	// 66
@@ -36887,9 +36156,9 @@ typedef struct Eq_1628 {
 	Eq_637 t0080;	// 80
 } Eq_1628;
 
-typedef int32 (Eq_1668)(Eq_25, Eq_25, Eq_25, Eq_25);
+typedef int32 (Eq_1668)(Eq_718, Eq_718, Eq_718, Eq_718);
 
-typedef word32 (Eq_1752)(Eq_25, Eq_25, Eq_25, Eq_25, Eq_25, Eq_25);
+typedef word32 (Eq_1752)(Eq_718, Eq_718, Eq_718, Eq_718, Eq_718, Eq_718);
 
 typedef union Eq_1792 {
 	bool u0;
@@ -37032,11 +36301,6 @@ typedef union Eq_2046 {
 	up32 u1;
 } Eq_2046;
 
-typedef union Eq_2137 {
-	byte u0;
-	word32 u1;
-} Eq_2137;
-
 typedef struct Eq_2141 {
 	struct Eq_1123 * ptr0000;	// 0
 	int32 dw0034;	// 34
@@ -37057,11 +36321,6 @@ typedef union Eq_2179 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2179;
-
-typedef union Eq_2202 {
-	word16 u0;
-	word32 u1;
-} Eq_2202;
 
 typedef struct Eq_2206 {
 	struct Eq_1123 * ptr0000;	// 0
@@ -37099,12 +36358,6 @@ typedef union Eq_2265 {
 	ptr32 u1;
 } Eq_2265;
 
-typedef union Eq_2271 {
-	ui24 u0;
-	struct Eq_8260 * u1;
-	Eq_1290 u2;
-} Eq_2271;
-
 typedef union Eq_2280 {
 	uint32 u0;
 	ptr32 u1;
@@ -37132,11 +36385,6 @@ typedef union Eq_2298 {
 	Eq_2296 u5;
 } Eq_2298;
 
-typedef union Eq_2302 {
-	byte u0;
-	word32 u1;
-} Eq_2302;
-
 typedef struct Eq_2306 {
 	struct Eq_1123 * ptr0000;	// 0
 	word32 dw003C;	// 3C
@@ -37152,12 +36400,6 @@ typedef union Eq_2327 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2327;
-
-typedef union Eq_2333 {
-	ui24 u0;
-	struct Eq_8261 * u1;
-	Eq_1290 u2;
-} Eq_2333;
 
 typedef struct Eq_2351 {
 	Eq_2290 t0000;	// 0
@@ -37179,12 +36421,6 @@ typedef union Eq_2395 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2395;
-
-typedef union Eq_2401 {
-	ui24 u0;
-	struct Eq_8262 * u1;
-	Eq_1290 u2;
-} Eq_2401;
 
 typedef union Eq_2407 {
 	cu8 u0;
@@ -37298,12 +36534,6 @@ typedef union Eq_2474 {
 	ptr32 u1;
 } Eq_2474;
 
-typedef union Eq_2480 {
-	ui24 u0;
-	struct Eq_8263 * u1;
-	Eq_1290 u2;
-} Eq_2480;
-
 typedef union Eq_2485 {
 	uint32 u0;
 	ptr32 u1;
@@ -37313,12 +36543,6 @@ typedef union Eq_2486 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2486;
-
-typedef union Eq_2492 {
-	ui24 u0;
-	struct Eq_8264 * u1;
-	Eq_1290 u2;
-} Eq_2492;
 
 typedef union Eq_2498 {
 	uint32 u0;
@@ -37330,12 +36554,6 @@ typedef union Eq_2499 {
 	ptr32 u1;
 } Eq_2499;
 
-typedef union Eq_2505 {
-	ui24 u0;
-	struct Eq_8265 * u1;
-	Eq_1290 u2;
-} Eq_2505;
-
 typedef union Eq_2510 {
 	uint32 u0;
 	ptr32 u1;
@@ -37345,12 +36563,6 @@ typedef union Eq_2511 {
 	uint32 u0;
 	ptr32 u1;
 } Eq_2511;
-
-typedef union Eq_2517 {
-	ui24 u0;
-	struct Eq_8266 * u1;
-	Eq_1290 u2;
-} Eq_2517;
 
 typedef union Eq_2522 {
 	uint32 u0;
@@ -37363,44 +36575,29 @@ typedef union Eq_2527 {
 } Eq_2527;
 
 typedef union Eq_2531 {
-	int32 u0;
-	uint32 u1;
-	Eq_1126 u2;
-	Eq_1290 u3;
-	Eq_1824 u4;
-	Eq_1886 u5;
-	Eq_1892 u6;
-	Eq_1960 u7;
-	Eq_2003 u8;
+	struct Eq_1290 * u0;
+	struct Eq_1290 * u1;
+	Eq_1824 u2;
+	Eq_1886 u3;
+	Eq_1892 u4;
+	Eq_1960 u5;
+	Eq_2003 u6;
 } Eq_2531;
 
 typedef union Eq_2533 {
-	int32 u0;
-	uint32 u1;
-	Eq_1126 u2;
-	Eq_1290 u3;
-	Eq_1824 u4;
-	Eq_1886 u5;
-	Eq_1892 u6;
-	Eq_1960 u7;
-	Eq_2003 u8;
+	struct Eq_1290 * u0;
+	Eq_1824 u1;
+	Eq_1886 u2;
+	Eq_1892 u3;
+	Eq_1960 u4;
+	Eq_2003 u5;
 } Eq_2533;
 
 typedef uint32 (Eq_2556)(int32, Eq_635 *, ui32 *, ptr32);
 
-typedef Eq_2601 (Eq_2595)(ptr32, ptr32);
+typedef Eq_4258 * * (Eq_2595)(ptr32, ptr32);
 
-typedef union Eq_2601 {
-	byte u0;
-	struct Eq_8267 * u1;
-} Eq_2601;
-
-typedef struct Eq_2656 {
-	word32 dw0000;	// 0
-	word32 dw0004;	// 4
-} Eq_2656;
-
-typedef Eq_2656 * (Eq_2657)(int32, ptr32, ptr32, int32 *);
+typedef int32 (Eq_2657)(int32, ptr32, ptr32, int32 *);
 
 typedef void (Eq_2690)();
 
@@ -37411,7 +36608,12 @@ typedef union Eq_2862 {
 	ptr32 u1;
 } Eq_2862;
 
-typedef Eq_4 * (Eq_2883)(Eq_106, Eq_2656 *, Eq_2656 *, Eq_2656 *, Eq_4 *, Eq_25);
+typedef struct Eq_2878 {
+	word32 dw0000;	// 0
+	word32 dw0004;	// 4
+} Eq_2878;
+
+typedef Eq_4 * (Eq_2883)(Eq_106, Eq_2878 *, Eq_2878 *, Eq_2878 *, Eq_4 *, Eq_25 *);
 
 typedef int32 * (Eq_2899)(Eq_4 *, up32, Eq_78, Eq_4 *);
 
@@ -37423,25 +36625,20 @@ typedef void (Eq_2970)(Eq_4 *);
 
 typedef void (Eq_3008)(Eq_4 *, up32, up32);
 
-typedef Eq_25 (Eq_3037)(up32, Eq_4 *);
+typedef Eq_25 * (Eq_3037)(up32, Eq_4 *);
 
 typedef union Eq_3056 {
 	int32 u0;
 	up32 u1;
 } Eq_3056;
 
-typedef Eq_25 (Eq_3088)(Eq_4 *, up32);
-
-typedef union Eq_3119 {
-	ui32 u0;
-	ptr32 u1;
-} Eq_3119;
+typedef Eq_25 * (Eq_3088)(Eq_4 *, up32);
 
 typedef void (Eq_3151)(Eq_4 *, ptr32);
 
 typedef void (Eq_3189)(Eq_4 *, ptr32);
 
-typedef Eq_25 (Eq_3218)(Eq_106, Eq_2656 *, Eq_2656 *);
+typedef Eq_25 * (Eq_3218)(Eq_106, Eq_2878 *, Eq_2878 *);
 
 typedef void (Eq_3268)(Eq_379 *);
 
@@ -37449,9 +36646,9 @@ typedef void (Eq_3272)(Eq_379 *);
 
 typedef void (Eq_3296)(int32, word32);
 
-typedef Eq_25 (Eq_3332)(Eq_25, Eq_25, Eq_25, Eq_25, Eq_25);
+typedef Eq_718 (Eq_3332)(Eq_718, Eq_718, Eq_718, Eq_718, Eq_718);
 
-typedef Eq_25 (Eq_3346)(Eq_25, Eq_25);
+typedef Eq_718 (Eq_3346)(Eq_718, Eq_718);
 
 typedef struct Eq_3367 {	// size: 1 1
 	Eq_3367 a0000[];	// 0
@@ -37472,7 +36669,7 @@ typedef union Eq_3487 {
 	word16 u1;
 } Eq_3487;
 
-typedef Eq_25 (Eq_3510)(Eq_25, Eq_25, Eq_25, Eq_25);
+typedef Eq_718 (Eq_3510)(Eq_718, Eq_718, Eq_718, Eq_718);
 
 typedef union Eq_3533 {
 	bool u0;
@@ -37494,7 +36691,7 @@ typedef union Eq_3677 {
 	uint32 u1;
 } Eq_3677;
 
-typedef Eq_25 (Eq_3774)(Eq_25, word32, bool);
+typedef Eq_718 (Eq_3774)(Eq_718, word32, bool);
 
 typedef union Eq_4104 {
 	bool u0;
@@ -37521,13 +36718,23 @@ typedef union Eq_4156 {
 	ui32 u1;
 } Eq_4156;
 
-typedef Eq_25 (Eq_4202)(Eq_25, Eq_25, Eq_25, Eq_25, Eq_621 *, Eq_25);
+typedef Eq_73 (Eq_4202)(Eq_73, Eq_73, Eq_25 *, Eq_73, Eq_621 *, Eq_718);
 
-typedef union Eq_4251 {
-	uint8 u0;
-	struct Eq_8273 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
+typedef struct Eq_4251 {	// size: 4 4
+	int32 dw002C;	// 2C
+	Eq_8261 t0030;	// 30
+	word32 dw0034;	// 34
+	uint8 b0037;	// 37
+	word32 dw0038;	// 38
+	word32 dw003C;	// 3C
+	word32 dw0040;	// 40
+	Eq_8262 t0044;	// 44
+	byte b0048;	// 48
+	byte b0049;	// 49
+	word32 dw004A;	// 4A
+	word32 dw006E;	// 6E
+	word32 dw0072;	// 72
+	word32 dw0084;	// 84
 } Eq_4251;
 
 typedef union Eq_4258 {
@@ -37571,24 +36778,19 @@ typedef union Eq_4391 {
 	uint32 u1;
 } Eq_4391;
 
-typedef Eq_25 (Eq_4613)(Eq_25, Eq_2601, word32 *, byte *);
+typedef Eq_73 (Eq_4613)(Eq_73, Eq_4258 * *, word32 *, byte *);
 
-typedef Eq_25 (Eq_4803)(Eq_25, Eq_25);
+typedef Eq_73 (Eq_4803)(byte, Eq_73);
 
 typedef struct Eq_4816 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0030;	// 30
+	Eq_73 t0000;	// 0
+	Eq_73 t0030;	// 30
 } Eq_4816;
 
 typedef struct Eq_4840 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0030;	// 30
 } Eq_4840;
-
-typedef union Eq_4870 {
-	byte u0;
-	struct Eq_8274 * u1;
-} Eq_4870;
 
 typedef union Eq_4950 {
 	int32 u0;
@@ -37596,24 +36798,14 @@ typedef union Eq_4950 {
 } Eq_4950;
 
 typedef struct Eq_4999 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0030;	// 30
+	Eq_73 t0000;	// 0
+	Eq_73 t0030;	// 30
 } Eq_4999;
 
 typedef struct Eq_5023 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0030;	// 30
 } Eq_5023;
-
-typedef union Eq_5042 {
-	byte u0;
-	struct Eq_8275 * u1;
-} Eq_5042;
-
-typedef union Eq_5052 {
-	byte u0;
-	struct Eq_8276 * u1;
-} Eq_5052;
 
 typedef union Eq_5139 {
 	int32 u0;
@@ -37651,24 +36843,14 @@ typedef union Eq_5390 {
 } Eq_5390;
 
 typedef struct Eq_5424 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0038;	// 38
+	Eq_73 t0000;	// 0
+	Eq_73 t0038;	// 38
 } Eq_5424;
 
 typedef struct Eq_5448 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5448;
-
-typedef union Eq_5467 {
-	byte u0;
-	struct Eq_8286 * u1;
-} Eq_5467;
-
-typedef union Eq_5477 {
-	byte u0;
-	struct Eq_8287 * u1;
-} Eq_5477;
 
 typedef union Eq_5482 {
 	int32 u0;
@@ -37681,24 +36863,14 @@ typedef union Eq_5522 {
 } Eq_5522;
 
 typedef struct Eq_5551 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0038;	// 38
+	Eq_73 t0000;	// 0
+	Eq_73 t0038;	// 38
 } Eq_5551;
 
 typedef struct Eq_5575 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5575;
-
-typedef union Eq_5594 {
-	byte u0;
-	struct Eq_8288 * u1;
-} Eq_5594;
-
-typedef union Eq_5604 {
-	byte u0;
-	struct Eq_8289 * u1;
-} Eq_5604;
 
 typedef union Eq_5618 {
 	int32 u0;
@@ -37718,45 +36890,25 @@ typedef union Eq_5694 {
 } Eq_5694;
 
 typedef struct Eq_5723 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0038;	// 38
+	Eq_73 t0000;	// 0
+	Eq_73 t0038;	// 38
 } Eq_5723;
 
 typedef struct Eq_5747 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5747;
 
-typedef union Eq_5766 {
-	byte u0;
-	struct Eq_8292 * u1;
-} Eq_5766;
-
-typedef union Eq_5776 {
-	byte u0;
-	struct Eq_8293 * u1;
-} Eq_5776;
-
 typedef struct Eq_5804 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	int32 dw0030;	// 30
-	Eq_25 t0038;	// 38
+	Eq_73 t0038;	// 38
 } Eq_5804;
 
 typedef struct Eq_5839 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_5839;
-
-typedef union Eq_5858 {
-	byte u0;
-	struct Eq_8294 * u1;
-} Eq_5858;
-
-typedef union Eq_5868 {
-	byte u0;
-	struct Eq_8295 * u1;
-} Eq_5868;
 
 typedef union Eq_5876 {
 	int32 u0;
@@ -37789,7 +36941,7 @@ typedef union Eq_5903 {
 } Eq_5903;
 
 typedef struct Eq_5946 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	word32 dw004E;	// 4E
 } Eq_5946;
 
@@ -37809,7 +36961,7 @@ typedef union Eq_6033 {
 } Eq_6033;
 
 typedef struct Eq_6063 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	word32 dw0044;	// 44
 } Eq_6063;
 
@@ -37824,24 +36976,14 @@ typedef union Eq_6122 {
 } Eq_6122;
 
 typedef struct Eq_6151 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0038;	// 38
+	Eq_73 t0000;	// 0
+	Eq_73 t0038;	// 38
 } Eq_6151;
 
 typedef struct Eq_6175 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_6175;
-
-typedef union Eq_6194 {
-	byte u0;
-	struct Eq_8296 * u1;
-} Eq_6194;
-
-typedef union Eq_6204 {
-	byte u0;
-	struct Eq_8297 * u1;
-} Eq_6204;
 
 typedef union Eq_6218 {
 	int32 u0;
@@ -37859,29 +37001,14 @@ typedef union Eq_6249 {
 } Eq_6249;
 
 typedef struct Eq_6278 {
-	Eq_25 t0000;	// 0
-	Eq_25 t0038;	// 38
+	Eq_73 t0000;	// 0
+	Eq_73 t0038;	// 38
 } Eq_6278;
 
 typedef struct Eq_6302 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	uint32 dw0038;	// 38
 } Eq_6302;
-
-typedef union Eq_6321 {
-	byte u0;
-	struct Eq_8298 * u1;
-} Eq_6321;
-
-typedef union Eq_6331 {
-	byte u0;
-	struct Eq_8299 * u1;
-} Eq_6331;
-
-typedef union Eq_6344 {
-	uint8 u0;
-	word32 u1;
-} Eq_6344;
 
 typedef union Eq_6352 {
 	int32 u0;
@@ -37899,7 +37026,7 @@ typedef union Eq_6403 {
 } Eq_6403;
 
 typedef struct Eq_6407 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	word32 dw0044;	// 44
 } Eq_6407;
 
@@ -38018,38 +37145,20 @@ typedef union Eq_6814 {
 } Eq_6814;
 
 typedef struct Eq_6842 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	word32 dw004E;	// 4E
 } Eq_6842;
 
 typedef struct Eq_6893 {
-	Eq_25 t0000;	// 0
-	Eq_6982 t0001;	// 1
+	Eq_718 t0000;	// 0
+	ui24 n0001;	// 1
 	word32 dw0030;	// 30
 	word32 dw0034;	// 34
 	word32 dw0044;	// 44
 	word32 dw0048;	// 48
 } Eq_6893;
 
-typedef union Eq_6904 {
-	ui24 u0;
-	struct Eq_8300 * u1;
-	Eq_1290 u2;
-} Eq_6904;
-
-typedef word32 (Eq_6944)(Eq_4258, Eq_25, Eq_25, Eq_25, Eq_25, ptr32);
-
-typedef union Eq_6981 {
-	ui24 u0;
-	struct Eq_8301 * u1;
-	Eq_1290 u2;
-} Eq_6981;
-
-typedef union Eq_6982 {
-	ui24 u0;
-	struct Eq_8302 * u1;
-	Eq_1290 u2;
-} Eq_6982;
+typedef word32 (Eq_6944)(Eq_4258, Eq_718, Eq_718, Eq_718, Eq_718, ptr32);
 
 typedef union Eq_6995 {
 	int32 u0;
@@ -38057,32 +37166,17 @@ typedef union Eq_6995 {
 } Eq_6995;
 
 typedef struct Eq_7048 {
-	Eq_25 t0000;	// 0
+	Eq_73 t0000;	// 0
 	word32 dw0030;	// 30
-	Eq_25 t0034;	// 34
+	Eq_73 t0034;	// 34
 	byte b0038;	// 38
 	byte b004C;	// 4C
 } Eq_7048;
 
 typedef struct Eq_7078 {
 	word32 dw0000;	// 0
-	Eq_25 t0004;	// 4
+	Eq_73 t0004;	// 4
 } Eq_7078;
-
-typedef union Eq_7144 {
-	byte u0;
-	struct Eq_8311 * u1;
-} Eq_7144;
-
-typedef union Eq_7173 {
-	byte u0;
-	struct Eq_8315 * u1;
-} Eq_7173;
-
-typedef union Eq_7190 {
-	byte u0;
-	struct Eq_8319 * u1;
-} Eq_7190;
 
 typedef union Eq_7206 {
 	int32 u0;
@@ -38093,18 +37187,10 @@ typedef union Eq_7206 {
 
 typedef union Eq_7207 {
 	int32 u0;
-	uint8 u1;
-	ptr32 u2;
-	Eq_6344 u3;
-	Eq_6621 u4;
-	Eq_6680 u5;
+	ptr32 u1;
+	Eq_6621 u2;
+	Eq_6680 u3;
 } Eq_7207;
-
-typedef union Eq_7209 {
-	uint8 u0;
-	word32 u1;
-	Eq_6344 u2;
-} Eq_7209;
 
 typedef struct Eq_7217 {
 	int32 dw0000;	// 0
@@ -38116,436 +37202,53 @@ typedef union Eq_7229 {
 	int32 u1;
 } Eq_7229;
 
-typedef union Eq_7232 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7232;
-
-typedef union Eq_7234 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
+typedef struct Eq_7234 {
+	Eq_73 t0000;	// 0
+	byte b0030;	// 30
+	word32 dw0038;	// 38
+	Eq_73 t003C;	// 3C
+	byte b004C;	// 4C
 } Eq_7234;
 
-typedef union Eq_7235 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7235;
+typedef union Eq_7259 {
+	int32 u0;
+	byte u1;
+} Eq_7259;
 
-typedef union Eq_7238 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7238;
-
-typedef union Eq_7241 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7241;
-
-typedef union Eq_7246 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7246;
-
-typedef union Eq_7248 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7248;
-
-typedef union Eq_7251 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7251;
-
-typedef union Eq_7257 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7257;
-
-typedef union Eq_7261 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7261;
-
-typedef union Eq_7266 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7266;
-
-typedef union Eq_7270 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7270;
+typedef union Eq_7268 {
+	int32 u0;
+	byte u1;
+} Eq_7268;
 
 typedef struct Eq_7283 {
 	word32 dw0000;	// 0
-	word32 dw0004;	// 4
+	Eq_73 t0004;	// 4
 } Eq_7283;
 
-typedef union Eq_7288 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7288;
-
-typedef union Eq_7294 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7294;
-
-typedef union Eq_7302 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7302;
-
-typedef union Eq_7307 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7307;
-
-typedef union Eq_7320 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7320;
-
-typedef union Eq_7331 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7331;
-
-typedef union Eq_7336 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7336;
-
-typedef union Eq_7349 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7349;
-
-typedef union Eq_7360 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7360;
-
-typedef union Eq_7365 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7365;
-
-typedef union Eq_7378 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7378;
-
-typedef union Eq_7395 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7395;
-
-typedef union Eq_7407 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7407;
-
-typedef union Eq_7408 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7408;
-
-typedef union Eq_7409 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7409;
-
-typedef union Eq_7411 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7411;
-
-typedef union Eq_7418 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7418;
-
-typedef union Eq_7421 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7421;
-
-typedef union Eq_7425 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7425;
-
-typedef union Eq_7429 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7429;
-
-typedef union Eq_7434 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7434;
-
-typedef union Eq_7466 {
-	byte u0;
-	struct Eq_8342 * u1;
-} Eq_7466;
-
-typedef union Eq_7472 {
-	byte u0;
-	struct Eq_8343 * u1;
-} Eq_7472;
-
-typedef union Eq_7482 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7482;
-
-typedef union Eq_7483 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7483;
-
-typedef union Eq_7484 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7484;
+typedef union Eq_7423 {
+	int32 u0;
+	byte u1;
+} Eq_7423;
 
 typedef union Eq_7486 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_7486;
 
-typedef union Eq_7489 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7489;
-
-typedef union Eq_7500 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7500;
-
-typedef union Eq_7502 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7502;
-
-typedef union Eq_7503 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7503;
-
-typedef union Eq_7504 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7504;
-
 typedef union Eq_7506 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
+	int32 u0;
+	uint32 u1;
 } Eq_7506;
 
-typedef union Eq_7509 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7509;
-
-typedef union Eq_7521 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7521;
-
-typedef union Eq_7523 {
-	byte u0;
-	struct Eq_8344 * u1;
-} Eq_7523;
-
-typedef union Eq_7528 {
-	byte u0;
-	struct Eq_8345 * u1;
-} Eq_7528;
-
-typedef union Eq_7575 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
+typedef struct Eq_7575 {
+	Eq_73 t0000;	// 0
+	Eq_73 t0030;	// 30
 } Eq_7575;
 
-typedef union Eq_7576 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7576;
-
-typedef union Eq_7579 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7579;
-
-typedef union Eq_7584 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7584;
-
-typedef union Eq_7591 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7591;
-
-typedef union Eq_7599 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
+typedef struct Eq_7599 {
+	Eq_73 t0000;	// 0
+	uint32 dw0030;	// 30
 } Eq_7599;
-
-typedef union Eq_7600 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7600;
-
-typedef union Eq_7603 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7603;
-
-typedef union Eq_7615 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7615;
-
-typedef union Eq_7618 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7618;
-
-typedef union Eq_7623 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7623;
-
-typedef union Eq_7628 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7628;
-
-typedef union Eq_7631 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7631;
 
 typedef union Eq_7633 {
 	int32 u0;
@@ -38557,236 +37260,17 @@ typedef union Eq_7634 {
 	uint32 u1;
 } Eq_7634;
 
-typedef union Eq_7640 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7640;
-
-typedef union Eq_7646 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
+typedef struct Eq_7646 {
+	ptr32 ptr0000;	// 0
+	byte b004D;	// 4D
 } Eq_7646;
 
-typedef union Eq_7647 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7647;
-
-typedef union Eq_7649 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7649;
-
-typedef union Eq_7652 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7652;
-
-typedef union Eq_7654 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7654;
-
-typedef union Eq_7655 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7655;
-
-typedef union Eq_7657 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7657;
-
-typedef union Eq_7660 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7660;
-
-typedef union Eq_7661 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7661;
-
-typedef union Eq_7663 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7663;
-
-typedef union Eq_7665 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7665;
-
-typedef union Eq_7666 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7666;
-
-typedef union Eq_7668 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7668;
-
-typedef union Eq_7671 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7671;
-
-typedef int32 (Eq_7673)(Eq_25, Eq_25, Eq_25);
-
-typedef union Eq_7675 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7675;
-
-typedef union Eq_7677 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7677;
-
-typedef union Eq_7679 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7679;
-
-typedef union Eq_7680 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7680;
-
-typedef union Eq_7682 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7682;
-
-typedef union Eq_7689 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7689;
-
-typedef union Eq_7690 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7690;
-
-typedef union Eq_7692 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7692;
+typedef int32 (Eq_7673)(Eq_718, Eq_718, Eq_718);
 
 typedef union Eq_7701 {
 	int32 u0;
 	uint32 u1;
 } Eq_7701;
-
-typedef union Eq_7706 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7706;
-
-typedef union Eq_7741 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7741;
-
-typedef union Eq_7742 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7742;
-
-typedef union Eq_7745 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7745;
-
-typedef union Eq_7751 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7751;
-
-typedef union Eq_7763 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7763;
-
-typedef union Eq_7764 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7764;
-
-typedef union Eq_7767 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7767;
-
-typedef union Eq_7779 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7779;
 
 typedef union Eq_7785 {
 	int32 u0;
@@ -38798,264 +37282,12 @@ typedef union Eq_7791 {
 	uint32 u1;
 } Eq_7791;
 
-typedef union Eq_7796 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7796;
-
-typedef union Eq_7800 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7800;
-
-typedef union Eq_7801 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7801;
-
-typedef union Eq_7804 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7804;
-
-typedef union Eq_7806 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7806;
-
-typedef union Eq_7807 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7807;
-
-typedef union Eq_7809 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7809;
-
-typedef union Eq_7812 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7812;
-
-typedef union Eq_7813 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7813;
-
-typedef union Eq_7815 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7815;
-
-typedef union Eq_7818 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7818;
-
-typedef union Eq_7822 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7822;
-
-typedef union Eq_7824 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7824;
-
-typedef union Eq_7825 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7825;
-
-typedef union Eq_7827 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7827;
-
-typedef union Eq_7830 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7830;
-
-typedef union Eq_7832 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7832;
-
-typedef union Eq_7833 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7833;
-
-typedef union Eq_7835 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7835;
-
-typedef union Eq_7838 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7838;
-
-typedef union Eq_7839 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7839;
-
-typedef union Eq_7841 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7841;
-
-typedef union Eq_7843 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7843;
-
-typedef union Eq_7844 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7844;
-
-typedef union Eq_7846 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7846;
-
-typedef union Eq_7849 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7849;
-
-typedef union Eq_7852 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7852;
-
-typedef union Eq_7854 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7854;
-
-typedef union Eq_7856 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7856;
-
-typedef union Eq_7857 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7857;
-
-typedef union Eq_7859 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7859;
-
-typedef union Eq_7866 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7866;
-
-typedef union Eq_7867 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7867;
-
-typedef union Eq_7869 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7869;
-
 typedef union Eq_7878 {
 	int32 u0;
 	uint32 u1;
 } Eq_7878;
 
-typedef union Eq_7890 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7890;
-
-typedef union Eq_7894 {
-	uint8 u0;
-	struct Eq_8326 * u1;
-	Eq_6344 u2;
-	Eq_7207 u3;
-} Eq_7894;
-
-typedef Eq_2656 * (Eq_8029)(ptr32, ptr32);
+typedef int32 (Eq_8029)(ptr32, ptr32);
 
 typedef void (Eq_8066)();
 
@@ -39063,84 +37295,16 @@ typedef struct Eq_8184 {	// size: 4 4
 	byte b0000;	// 0
 } Eq_8184;
 
-typedef struct Eq_8241 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8241 {	// size: 4 4
+	union Eq_4258 * ptr0000;	// 0
+	Eq_73 t0004;	// 4
+	Eq_73 t0008;	// 8
+	int32 dw0014;	// 14
+	ui32 dw0018;	// 18
+	int32 dw001C;	// 1C
 } Eq_8241;
 
-typedef struct Eq_8242 {
-	Eq_25 t0000;	// 0
-} Eq_8242;
-
-typedef union Eq_8243 {
-	int32 u0;
-	byte u1;
-	Eq_25 u2;
-} Eq_8243;
-
-typedef union Eq_8244 {
-	int32 u0;
-	uint32 u1;
-	byte u2;
-	ptr32 u3;
-	Eq_25 u4;
-	Eq_6621 u5;
-	Eq_6680 u6;
-	Eq_7207 u7;
-} Eq_8244;
-
-typedef union Eq_8245 {
-	uint8 u0;
-	word32 u1;
-	Eq_6344 u2;
-} Eq_8245;
-
-typedef union Eq_8246 {
-	uint8 u0;
-	word32 u1;
-	Eq_4251 u2;
-	Eq_6344 u3;
-	Eq_7207 u4;
-} Eq_8246;
-
-typedef union Eq_8247 {
-	int32 u0;
-	ptr32 u1;
-	Eq_6554 u2;
-	Eq_6618 u3;
-	Eq_6683 u4;
-} Eq_8247;
-
-typedef struct Eq_8248 {	// size: 4 4
-	struct Eq_8242 * ptrFFFFFFFC;	// FFFFFFFC
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (* ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-	Eq_8243 t002C;	// 2C
-	Eq_8244 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8245 t0037;	// 37
-	Eq_8246 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8247 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
-} Eq_8248;
-
-typedef union Eq_8249 {
+typedef union Eq_8242 {
 	cu8 u0;
 	word32 u1;
 	Eq_1159 u2;
@@ -39149,19 +37313,50 @@ typedef union Eq_8249 {
 	Eq_2296 u5;
 	Eq_2407 u6;
 	Eq_2448 u7;
+} Eq_8242;
+
+typedef union Eq_8243 {
+	struct Eq_1290 * u0;
+	Eq_1824 u1;
+	Eq_1886 u2;
+	Eq_1892 u3;
+	Eq_1960 u4;
+	Eq_2003 u5;
+	Eq_2531 u6;
+} Eq_8243;
+
+typedef struct Eq_8244 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8244;
+
+typedef struct Eq_8245 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
+} Eq_8245;
+
+typedef struct Eq_8246 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8246;
+
+typedef struct Eq_8247 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8247;
+
+typedef struct Eq_8248 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
+} Eq_8248;
+
+typedef struct Eq_8249 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_8249;
 
-typedef union Eq_8250 {
-	int32 u0;
-	uint32 u1;
-	Eq_1126 u2;
-	Eq_1290 u3;
-	Eq_1824 u4;
-	Eq_1886 u5;
-	Eq_1892 u6;
-	Eq_1960 u7;
-	Eq_2003 u8;
-	Eq_2531 u9;
+typedef struct Eq_8250 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_8250;
 
 typedef struct Eq_8251 {	// size: 1 1
@@ -39214,618 +37409,200 @@ typedef struct Eq_8260 {	// size: 1 1
 	byte b0003;	// 3
 } Eq_8260;
 
-typedef struct Eq_8261 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef union Eq_8261 {
+	int32 u0;
+	ptr32 u1;
+	Eq_6621 u2;
+	Eq_6680 u3;
+	Eq_7207 u4;
 } Eq_8261;
 
-typedef struct Eq_8262 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef union Eq_8262 {
+	int32 u0;
+	ptr32 u1;
+	Eq_6554 u2;
+	Eq_6618 u3;
+	Eq_6683 u4;
 } Eq_8262;
 
-typedef struct Eq_8263 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8263 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8263;
 
-typedef struct Eq_8264 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8264 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8264;
 
-typedef struct Eq_8265 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8265 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8265;
 
-typedef struct Eq_8266 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8266 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8266;
 
 typedef struct Eq_8267 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (* ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8267;
 
-typedef union Eq_8268 {
-	int32 u0;
-	byte u1;
-	Eq_25 u2;
+typedef struct Eq_8268 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8268;
 
-typedef union Eq_8269 {
-	int32 u0;
-	uint32 u1;
-	byte u2;
-	ptr32 u3;
-	Eq_25 u4;
-	Eq_6621 u5;
-	Eq_6680 u6;
-	Eq_7207 u7;
+typedef struct Eq_8269 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8269;
 
-typedef union Eq_8270 {
-	uint8 u0;
-	word32 u1;
-	Eq_6344 u2;
+typedef struct Eq_8270 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8270;
 
-typedef union Eq_8271 {
-	uint8 u0;
-	word32 u1;
-	Eq_4251 u2;
-	Eq_6344 u3;
-	Eq_7207 u4;
+typedef struct Eq_8271 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8271;
 
-typedef union Eq_8272 {
-	int32 u0;
-	ptr32 u1;
-	Eq_6554 u2;
-	Eq_6618 u3;
-	Eq_6683 u4;
+typedef struct Eq_8272 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8272;
 
 typedef struct Eq_8273 {	// size: 4 4
-	Eq_25 t0000;	// 0
-	Eq_8268 t002C;	// 2C
-	Eq_8269 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8270 t0037;	// 37
-	Eq_8271 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8272 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8273;
 
-typedef struct Eq_8274 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+typedef struct Eq_8274 {	// size: 1 1
+	word32 dw0000;	// 0
+	byte b0003;	// 3
 } Eq_8274;
 
 typedef struct Eq_8275 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8275;
 
 typedef struct Eq_8276 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8276;
 
 typedef struct Eq_8277 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8277;
 
 typedef struct Eq_8278 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8278;
 
 typedef struct Eq_8279 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8279;
 
 typedef struct Eq_8280 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8280;
 
 typedef struct Eq_8281 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8281;
 
 typedef struct Eq_8282 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8282;
 
 typedef struct Eq_8283 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8283;
 
 typedef struct Eq_8284 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8284;
 
 typedef struct Eq_8285 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8285;
 
 typedef struct Eq_8286 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8286;
 
 typedef struct Eq_8287 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8287;
 
 typedef struct Eq_8288 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8288;
 
 typedef struct Eq_8289 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (******* ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8289;
 
 typedef struct Eq_8290 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8290;
 
 typedef struct Eq_8291 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8291;
 
 typedef struct Eq_8292 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8292;
 
 typedef struct Eq_8293 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8293;
 
 typedef struct Eq_8294 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8294;
 
 typedef struct Eq_8295 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8295;
 
 typedef struct Eq_8296 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8296;
 
 typedef struct Eq_8297 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8297;
 
 typedef struct Eq_8298 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8298;
 
 typedef struct Eq_8299 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (**** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8299;
 
-typedef struct Eq_8300 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8300 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8300;
 
-typedef struct Eq_8301 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8301 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8301;
 
-typedef struct Eq_8302 {	// size: 1 1
-	word32 dw0000;	// 0
-	byte b0003;	// 3
+typedef struct Eq_8302 {	// size: 4 4
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8302;
 
 typedef struct Eq_8303 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8303;
 
 typedef struct Eq_8304 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8304;
 
 typedef struct Eq_8305 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8305;
 
 typedef struct Eq_8306 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8306;
 
 typedef struct Eq_8307 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
+	union Eq_73 * ptrFFFFFFFC;	// FFFFFFFC
 } Eq_8307;
-
-typedef struct Eq_8308 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8308;
-
-typedef struct Eq_8309 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8309;
-
-typedef struct Eq_8310 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8310;
-
-typedef struct Eq_8311 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8311;
-
-typedef struct Eq_8312 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8312;
-
-typedef struct Eq_8313 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8313;
-
-typedef struct Eq_8314 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8314;
-
-typedef struct Eq_8315 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8315;
-
-typedef struct Eq_8316 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8316;
-
-typedef struct Eq_8317 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8317;
-
-typedef struct Eq_8318 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8318;
-
-typedef struct Eq_8319 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8319;
-
-typedef struct Eq_8320 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8320;
-
-typedef union Eq_8321 {
-	int32 u0;
-	byte u1;
-	Eq_25 u2;
-} Eq_8321;
-
-typedef union Eq_8322 {
-	int32 u0;
-	uint32 u1;
-	byte u2;
-	ptr32 u3;
-	Eq_25 u4;
-	Eq_6621 u5;
-	Eq_6680 u6;
-	Eq_7207 u7;
-} Eq_8322;
-
-typedef union Eq_8323 {
-	uint8 u0;
-	word32 u1;
-	Eq_6344 u2;
-} Eq_8323;
-
-typedef union Eq_8324 {
-	uint8 u0;
-	word32 u1;
-	Eq_4251 u2;
-	Eq_6344 u3;
-	Eq_7207 u4;
-} Eq_8324;
-
-typedef union Eq_8325 {
-	int32 u0;
-	ptr32 u1;
-	Eq_6554 u2;
-	Eq_6618 u3;
-	Eq_6683 u4;
-} Eq_8325;
-
-typedef struct Eq_8326 {	// size: 4 4
-	Eq_25 t0000;	// 0
-	Eq_8321 t002C;	// 2C
-	Eq_8322 t0030;	// 30
-	word32 dw0034;	// 34
-	Eq_8323 t0037;	// 37
-	Eq_8324 t0038;	// 38
-	word32 dw003C;	// 3C
-	word32 dw0040;	// 40
-	Eq_8325 t0044;	// 44
-	byte b0048;	// 48
-	byte b0049;	// 49
-	word32 dw004A;	// 4A
-	byte b004C;	// 4C
-	byte b004D;	// 4D
-	word32 dw006E;	// 6E
-	word32 dw0072;	// 72
-	word32 dw0084;	// 84
-} Eq_8326;
-
-typedef struct Eq_8327 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8327;
-
-typedef struct Eq_8328 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8328;
-
-typedef struct Eq_8329 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8329;
-
-typedef struct Eq_8330 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8330;
-
-typedef struct Eq_8331 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8331;
-
-typedef struct Eq_8332 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8332;
-
-typedef struct Eq_8333 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8333;
-
-typedef struct Eq_8334 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8334;
-
-typedef struct Eq_8335 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8335;
-
-typedef struct Eq_8336 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8336;
-
-typedef struct Eq_8337 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8337;
-
-typedef struct Eq_8338 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8338;
-
-typedef struct Eq_8339 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8339;
-
-typedef struct Eq_8340 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8340;
-
-typedef struct Eq_8341 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8341;
-
-typedef struct Eq_8342 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (* ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8342;
-
-typedef struct Eq_8343 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8343;
-
-typedef struct Eq_8344 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8344;
-
-typedef struct Eq_8345 {	// size: 4 4
-	union Eq_4258 * ptr0000;	// 0
-	Eq_25 t0004;	// 4
-	Eq_25 t0008;	// 8
-	Eq_106 t000C;	// C
-	Eq_160 (****** ptr0010)[];	// 10
-	struct Eq_2656 * ptr0014;	// 14
-	Eq_3119 t0018;	// 18
-	int32 dw001C;	// 1C
-	word32 dw0020;	// 20
-} Eq_8345;
-
-typedef struct Eq_8346 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8346;
-
-typedef struct Eq_8347 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8347;
-
-typedef struct Eq_8348 {	// size: 4 4
-	union Eq_25 * ptrFFFFFFFC;	// FFFFFFFC
-} Eq_8348;
 

--- a/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG_code.c
+++ b/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG_code.c
@@ -23,12 +23,12 @@ void fn00001000(int32 d0, byte * a0)
 	globals->ptr3D70 = fp;
 	globals->ptr3D74 = a6_n;
 	struct Eq_n * d0_n = FindTask(0x00);
-	Eq_n a1_n = 0x12BC;
-	Eq_n d0_n = OpenLibrary(0x12BC, 0);
-	if (d0_n != 0x00)
+	struct Eq_n * a1_n = &globals->t12BC;
+	struct Eq_n * d0_n = OpenLibrary(0x12BC, 0);
+	if (d0_n != null)
 	{
 		int32 d4_n;
-		globals->t3D78 = d0_n;
+		globals->ptr3D78 = d0_n;
 		if (d0_n->ptr00AC == null)
 		{
 			d4_n = 2;
@@ -50,13 +50,13 @@ void fn00001000(int32 d0, byte * a0)
 		ui32 d0_n = d0_n + d2_n;
 		Eq_n d1_n = 0x00010001;
 		d0_n = AllocMem(d0_n + 0x11, 0x00010001);
-		if (d0_n != 0x00)
+		if (d0_n != null)
 		{
 			struct Eq_n * dwLoc0C_n;
 			word32 a0_n;
-			*d0_n = d0_n + 0x11;
-			*((word32) d0_n + 0x0C) = d4_n - 0x01;
-			*((word32) d0_n + 8) = (word32) d0_n + 16 + d0_n;
+			d0_n->dw0000 = (word32) (d0_n + 0x11);
+			d0_n[3] = (struct Eq_n) (d4_n - 0x01);
+			d0_n[2] = (struct Eq_n) (d0_n + 4 + d0_n / 4);
 			null = null;
 			struct Eq_n * d0_n = d0_n->ptr00AC;
 			if (d0_n == null)
@@ -70,7 +70,7 @@ void fn00001000(int32 d0, byte * a0)
 				if (d0_n != 0x00)
 					Enable();
 				Supervisor(d0_n);
-				*((word32) d0_n + 4) = d0_n;
+				d0_n[1] = (struct Eq_n) d0_n;
 				d1_n.u0 = 4808;
 				if (d0_n == 0x00)
 				{
@@ -92,12 +92,12 @@ l000011F8:
 				goto l00001202;
 			}
 			ui32 d0_n = ((ui32[]) 16)[d0_n];
-			a1_n = *((word32) d0_n + 8);
+			a1_n = (struct Eq_n *) d0_n[2];
 			Eq_n (* a0_n)[] = (d0_n << 0x02) + 1;
 			Eq_n d0_n = (uint32) (uint8) null[d0_n].b0000;
 			Mem263[a0_n + d0_n:byte] = 0x00;
-			*((word32) d0_n + 16) = a0_n;
-			word32 * a6_n = (word32) d0_n + 20;
+			d0_n[4] = (struct Eq_n) a0_n;
+			word32 * a6_n = d0_n + 5;
 			int32 d3_n = 1;
 			struct Eq_n * a0_n = a0 + d2_n;
 			do
@@ -118,15 +118,15 @@ l000010E6:
 				if (v40_n == 0x00)
 					goto l00001148;
 			} while (v40_n == 0x20 || v40_n == 0x09);
-			if (d3_n - *((word32) d0_n + 0x0C) != 0x00)
+			if (d3_n - d0_n[3] != 0x00)
 			{
-				*a6_n = (word32) a1_n;
+				*a6_n = a1_n;
 				++a6_n;
 				d3_n = SEQ(SLICE(d3_n, word16, 16), (word16) d3_n + 0x01);
 				if (v40_n != 0x22)
 				{
-					*a1_n = v40_n;
-					a1_n = (word32) a1_n + 1;
+					a1_n->dw0000 = (word32) v40_n;
+					a1_n = (struct Eq_n *) ((char *) &a1_n->dw0000 + 1);
 					while (true)
 					{
 						byte v50_n = *a2_n;
@@ -136,8 +136,8 @@ l000010E6:
 							break;
 						if (v50_n == 0x20)
 							goto l00001116;
-						*a1_n = v50_n;
-						a1_n = (word32) a1_n + 1;
+						a1_n->dw0000 = (word32) v50_n;
+						a1_n = (struct Eq_n *) ((char *) &a1_n->dw0000 + 1);
 					}
 				}
 				else
@@ -153,8 +153,8 @@ l000010E6:
 						if (v71_n == 0x22)
 						{
 l00001116:
-							*a1_n = 0x00;
-							a1_n = (word32) a1_n + 1;
+							a1_n->dw0000 = (word32) 0x00;
+							a1_n = (struct Eq_n *) ((char *) &a1_n->dw0000 + 1);
 							goto l000010E6;
 						}
 						if (v71_n == 0x2A)
@@ -167,19 +167,19 @@ l00001116:
 							else if ((v75_n & 223) == 0x45)
 								d1_n.u0 = 27;
 						}
-						*a1_n = (byte) d1_n;
-						a1_n = (word32) a1_n + 1;
+						a1_n->dw0000 = (word32) (byte) d1_n;
+						a1_n = (struct Eq_n *) ((char *) &a1_n->dw0000 + 1);
 					}
 				}
 			}
 l00001148:
-			*a1_n = 0x00;
+			a1_n->dw0000 = (word32) 0x00;
 			*a6_n = 0x00;
 			execPrivate4();
 			globals->t3D84 = d0_n;
 			execPrivate5();
 			globals->t3D88 = d0_n;
-			dwLoc0C_n = (word32) d0_n + 16;
+			dwLoc0C_n = (struct Eq_n *) (d0_n + 4);
 			dwLoc10 = d3_n;
 			if (globals->ptr3D74->t0014 >= 0x24)
 			{
@@ -207,7 +207,7 @@ l00001202:
 			globals->t3D8C = d0_n;
 			goto l0000117E;
 		}
-		CloseLibrary(globals->t3D78);
+		CloseLibrary(globals->ptr3D78);
 		Alert(0x00010000);
 	}
 	else
@@ -226,8 +226,8 @@ void fn00001214(struct Eq_n * a3)
 	GetMsg((char *) &a3->dw003A + 0x0022);
 }
 
-// 0000126C: void fn0000126C(Register Eq_n a2)
-void fn0000126C(Eq_n a2)
+// 0000126C: void fn0000126C(Register (ptr32 Eq_n) a2)
+void fn0000126C(struct Eq_n * a2)
 {
 	Forbid();
 	ReplyMsg(a2);
@@ -249,12 +249,12 @@ word32 fn0000127C(struct Eq_n & a1Out, struct Eq_n & a5Out)
 {
 	ptr32 a7_n = globals->ptr3D70;
 	struct Eq_n * v7_n = *(a7_n - 4);
-	Eq_n v5_n = *(a7_n - 8);
+	struct Eq_n * v5_n = *(a7_n - 8);
 	word32 d1_n = v7_n->dw0004;
 	if (d1_n != 0x00)
 		execPrivate1();
-	CloseLibrary(globals->t3D78);
-	if (v5_n != 0x00)
+	CloseLibrary(globals->ptr3D78);
+	if (v5_n != null)
 		fn0000126C(v5_n);
 	FreeMem(v7_n, v7_n->dw0000);
 	a1Out = v7_n;
@@ -305,8 +305,8 @@ word32 fn0000131C(ptr32 dwArg04, ptr32 & a1Out, ptr32 & a5Out)
 	return d1;
 }
 
-// 00001354: void fn00001354(Register Eq_n d1, Register Eq_n a1, Stack int32 dwArg04, Stack (ptr32 Eq_n) dwArg08)
-void fn00001354(Eq_n d1, Eq_n a1, int32 dwArg04, struct Eq_n * dwArg08)
+// 00001354: void fn00001354(Register Eq_n d1, Register (ptr32 Eq_n) a1, Stack int32 dwArg04, Stack (ptr32 Eq_n) dwArg08)
+void fn00001354(Eq_n d1, struct Eq_n * a1, int32 dwArg04, struct Eq_n * dwArg08)
 {
 	<anonymous> ** a3_n = (<anonymous> **) 0x3EB0;
 	Eq_n d0_n = 16044;
@@ -323,8 +323,8 @@ void fn00001354(Eq_n d1, Eq_n a1, int32 dwArg04, struct Eq_n * dwArg08)
 	fn0000131C(fn00001390(d0_n, d1, a1), out a1_n, out a5_n);
 }
 
-// 00001390: Register Eq_n fn00001390(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1)
-Eq_n fn00001390(Eq_n d0, Eq_n d1, Eq_n a1)
+// 00001390: Register Eq_n fn00001390(Register Eq_n d0, Register Eq_n d1, Register (ptr32 Eq_n) a1)
+Eq_n fn00001390(Eq_n d0, Eq_n d1, struct Eq_n * a1)
 {
 	return fn000013FC(fn00002B40(fn00002B40(fn00002B40(d0, d1, a1, &globals->t13E4), d1, a1, &globals->t13E8), d1, a1, &globals->t13EC), &globals->b13F4);
 }
@@ -444,7 +444,7 @@ Eq_n fn00001418(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 					{
 						a0_n = 10261 + (SEQ(SLICE(d0_n, word24, 8), *a2_n) & 0xFF);
 						uint32 d0_n = (uint32) (uint8) a0_n->t0000;
-						d5_n.u0 = 0;
+						&d5_n.u0->dw0000 = 0;
 						d0_n = d0_n & 0x04;
 						if ((d0_n & 0x04) != 0x00)
 						{
@@ -493,7 +493,7 @@ Eq_n fn00001418(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 				Eq_n v100_n = *a2_n;
 				byte * a2_n = a2_n + 1;
 				struct Eq_n * d1_n = SEQ(SLICE(d1_n, word24, 8), v100_n);
-				Eq_n d0_n = SEQ(SLICE(d0_n, word24, 8), v100_n);
+				struct Eq_n * d0_n = SEQ(SLICE(d0_n, word24, 8), v100_n);
 				if (v100_n != 0x25)
 				{
 					if (v100_n != 88)
@@ -515,7 +515,7 @@ Eq_n fn00001418(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 									if (v100_n == 0x00)
 										a2_n -= (byte *) 1;
 									d0_n = a2_n - a4_n;
-									a7_n->t0066.u2 = d0_n;
+									a7_n->t0066 = d0_n;
 									a7_n[16] = (struct Eq_n) 0x00;
 									a3_n = a4_n;
 									d5_n.u0 = 0;
@@ -523,20 +523,20 @@ Eq_n fn00001418(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 								else
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a3_n = (byte *) *d0_n;
+									a3_n = d0_n->dw0000;
 									a7_n->t0066 = 0x00;
-									d3_n = (word32) d0_n + 4;
-									a0_n = (word32) d0_n + 4;
+									d3_n = d0_n + 4;
+									a0_n = (struct Eq_n *) (d0_n + 4);
 									byte * a1_n = a3_n;
-									if ((d5_n == 0x00 || d5_n - a7_n->t0066 > 0x00) && *a3_n != 0x00)
+									if ((d5_n == 0x00 || d5_n - a7_n->t0066 > null) && *a3_n != 0x00)
 									{
-										d0_n = a7_n->t0066;
+										d0_n = (struct Eq_n *) a7_n->t0066;
 										do
 										{
-											d0_n = (word32) d0_n + 1;
+											++d0_n;
 											++a1_n;
-										} while ((d5_n <= 0x00 || d5_n - d0_n > 0x00) && *a1_n != 0x00);
-										a7_n->t0066.u2 = d0_n;
+										} while ((d5_n <= 0x00 || d5_n - d0_n > null) && *a1_n != 0x00);
+										a7_n->t0066 = d0_n;
 									}
 									d5_n.u0 = 0;
 								}
@@ -546,32 +546,32 @@ Eq_n fn00001418(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 								if (d4_n == 0x01)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0004 = d6_n;
 									a0_n->t0000.u0 = 0x00;
 								}
 								else if (d4_n == 0x6C)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = d6_n;
 								}
 								else if (d4_n == 0x68)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = (word16) d6_n;
 								}
 								else if (d4_n == 0x02)
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = (byte) d6_n;
 								}
 								else
 								{
 									d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-									a0_n = (struct Eq_n *) *d0_n;
+									a0_n = d0_n->dw0000;
 									a0_n->t0000 = d6_n;
 								}
 								d3_n = ((word32) d3_n + 3 >> 0x02 << 0x02) + 0x04;
@@ -584,16 +584,16 @@ Eq_n fn00001418(Eq_n d0, struct Eq_n * dwArg04, byte * dwArg08, Eq_n dwArg0C)
 							if (d4_n == 0x6C)
 							{
 								d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-								*a3_n = (byte) *((word32) d0_n + 3);
+								*a3_n = (byte) d0_n[3];
 							}
 							else
 							{
 								d0_n = (word32) d3_n + 3 >> 0x02 << 0x02;
-								*a3_n = (byte) *((word32) d0_n + 3);
+								*a3_n = (byte) d0_n[3];
 							}
 							a0_n = ((word32) d3_n + 3 >> 0x02 << 0x02) + 0x04;
 							d3_n = ((word32) d3_n + 3 >> 0x02 << 0x02) + 0x04;
-							a7_n->t0066.u0 = 0x01;
+							a7_n->t0066 = 0x01;
 							d5_n.u0 = 0;
 						}
 						goto l00001B84;
@@ -632,7 +632,7 @@ l00001696:
 						}
 						if (d4_n == 0x68)
 						{
-							Eq_n v262_n = a7_n->dw003E;
+							word16 v262_n = a7_n->w003E;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1_n;
 							a7_n->dw0040 = (uint32) (uint16) v262_n;
@@ -641,7 +641,7 @@ l00001696:
 						}
 						if (d4_n == 0x02)
 						{
-							Eq_n v277_n = a7_n->dw003F;
+							byte v277_n = a7_n->b003F;
 							struct Eq_n * a7_n = a7_n - 4;
 							a7_n->ptr0000 = d1_n;
 							a7_n->dw0040 = (uint32) (uint8) v277_n;
@@ -752,7 +752,7 @@ l000018F2:
 							}
 							if (d4_n == 0x02)
 							{
-								Eq_n v248_n = a7_n->dw0037;
+								byte v248_n = a7_n->b0037;
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->ptr0000 = d1_n;
 								int32 d1_n = (int32) (int16) (int8) SEQ(SLICE(d1_n, word24, 8), v248_n);
@@ -821,7 +821,7 @@ l00001934:
 					a7_n->dw0062 = d7_n;
 					struct Eq_n * v187_n = a7_n + 0x0E;
 					word32 d6_n = v187_n->dw0000;
-					Eq_n d7_n = v187_n->t0004;
+					struct Eq_n * d7_n = v187_n->ptr0004;
 					word32 d3_n = a7_n->t0066;
 					Eq_n a1_n = a7_n[11];
 					do
@@ -833,7 +833,7 @@ l00001934:
 						*(a7_n - 8) = (union Eq_n *) a1_n;
 						*(a7_n - 0x0C) = d1_n;
 						*(a7_n - 16) = d1_n >> 31;
-						*(a7_n - 20) = (union Eq_n *) d7_n;
+						*(a7_n - 20) = (struct Eq_n **) d7_n;
 						*(a7_n - 24) = d6_n;
 						int32 d1_n = fn00002700(*(a7_n - 24), *(a7_n - 20), *(a7_n - 16), *(a7_n - 0x0C));
 						ptr32 v191_n = *(a7_n - 8);
@@ -846,9 +846,9 @@ l00001934:
 						*(a7_n - 8) = v191_n;
 						*(a7_n - 0x0C) = d1_n;
 						*(a7_n - 16) = d0_n;
-						*(a7_n - 20) = (union Eq_n *) d7_n;
+						*(a7_n - 20) = (struct Eq_n **) d7_n;
 						*(a7_n - 24) = d6_n;
-						Eq_n d1_n;
+						struct Eq_n * d1_n;
 						word32 d0_n = fn000023B8(*(a7_n - 24), *(a7_n - 20), *(a7_n - 16), *(a7_n - 0x0C), out d1_n, out a0_n);
 						a1_n = *(a7_n - 8);
 						d6_n = d0_n;
@@ -856,7 +856,7 @@ l00001934:
 						a7_n = (struct Eq_n *) (&a7_n->dw0000 + 1);
 						++d3_n;
 						d0_n = d1_n;
-					} while (d0_n - (d1_n < 0x00) != 0x00);
+					} while (d0_n - (d1_n < null) != 0x00);
 					a7_n->dw006A = d3_n;
 					d7_n = a7_n->ptr0066;
 					d6_n = a7_n->t0034;
@@ -879,15 +879,15 @@ l00001B84:
 				else
 					a7_n[11] = (struct Eq_n) d5_n;
 				struct Eq_n * a7_n = a7_n - 4;
-				a7_n->t0000 = d0_n;
+				a7_n->ptr0000 = d0_n;
 				a7_n->dw0034 = d7_n + a7_n->dw0030 / 0x0044;
-				a7_n->t0000 = a7_n->t0000;
-				Eq_n d0_n = a7_n->t0000;
+				a7_n->ptr0000 = a7_n->ptr0000;
+				struct Eq_n * d0_n = a7_n->ptr0000;
 				if (a7_n->dw0034 - a7_n->dw0044 >= 0x00)
 					a7_n->dw0030 = 0x00;
 				else
 				{
-					a7_n->t0000 = d0_n;
+					a7_n->ptr0000 = d0_n;
 					a7_n->dw0030 = a7_n->dw0044 - a7_n->dw0034;
 				}
 				a7_n[0x0C] = a7_n[11];
@@ -1108,13 +1108,13 @@ int32 fn00001DF4(int32 dwArg04, struct Eq_n * dwArg08, ui32 & a0Out, ptr32 & a5O
 			d4_n = 1;
 		word32 d1_n;
 		word32 a1_n;
-		struct Eq_n * d0_n = fn00001FB4(d4_n + dwArg08->dw001C, out d1_n, out a0, out a1_n);
-		if (d0_n == null)
+		int32 d0_n = fn00001FB4(d4_n + dwArg08->dw001C, out d1_n, out a0, out a1_n);
+		if (d0_n == 0x00)
 		{
 			d0_n = -1;
 			goto l00001F02;
 		}
-		dwArg08->ptr0008 = (ui32 *) ((char *) &d0_n->dw0000 + 1);
+		dwArg08->ptr0008 = d0_n + 1;
 	}
 	else
 	{
@@ -1286,10 +1286,10 @@ void fn000020E8(struct Eq_n * dwArg04, up32 dwArg08, up32 dwArg0C)
 		FreePooled(dwArg08, dwArg04);
 }
 
-// 00002184: Register Eq_n fn00002184(Stack (ptr32 Eq_n) dwArg04, Stack up32 dwArg08, Register out Eq_n d1Out, Register out (ptr32 Eq_n) a0Out)
-Eq_n fn00002184(struct Eq_n * dwArg04, up32 dwArg08, union Eq_n & d1Out, struct Eq_n & a0Out)
+// 00002184: Register (ptr32 Eq_n) fn00002184(Stack (ptr32 Eq_n) dwArg04, Stack up32 dwArg08, Register out Eq_n d1Out, Register out (ptr32 Eq_n) a0Out)
+struct Eq_n * fn00002184(struct Eq_n * dwArg04, up32 dwArg08, union Eq_n & d1Out, struct Eq_n & a0Out)
 {
-	Eq_n d0_n;
+	struct Eq_n * d0_n;
 	struct Eq_n * a0_n = globals->ptr3D74;
 	if (a0_n->t0014 >= 0x27)
 	{
@@ -1298,7 +1298,7 @@ Eq_n fn00002184(struct Eq_n * dwArg04, up32 dwArg08, union Eq_n & d1Out, struct 
 	}
 	else
 	{
-		Eq_n a3_n = 0x00;
+		struct Eq_n * a3_n = null;
 		if (dwArg04 != null && dwArg08 != 0x00)
 		{
 			if (dwArg08 - dwArg04->t0014 < 0x00)
@@ -1308,43 +1308,43 @@ Eq_n fn00002184(struct Eq_n * dwArg04, up32 dwArg08, union Eq_n & d1Out, struct 
 				{
 					if (a5_n->b0008 != 0x00)
 					{
-						Eq_n d0_n = Allocate(a5_n, dwArg08);
+						struct Eq_n * d0_n = Allocate(a5_n, dwArg08);
 						a0_n = a5_n;
 						a3_n = d0_n;
-						if (d0_n != 0x00)
+						if (d0_n != null)
 							goto l00002256;
 					}
 					a5_n = a5_n->dw0000;
 				}
 				Eq_n d3_n = dwArg04->dw0010 + 40;
 				d1 = dwArg04->t000C;
-				Eq_n d0_n = AllocMem(d3_n, d1);
+				struct Eq_n * d0_n = AllocMem(d3_n, d1);
 				a3_n = d0_n;
-				if (d0_n != 0x00)
+				if (d0_n != null)
 				{
-					*d0_n = d3_n;
-					*((word32) d0_n + 0x0C) = 0x0A;
-					*((word32) d0_n + 20) = (word32) d0_n + 40;
-					*((word32) d0_n + 24) = (word32) d0_n + 40;
-					**((word32) d0_n + 20) = 0x00;
-					struct Eq_n * a2_n = *((word32) d0_n + 20);
+					d0_n->dw0000 = (word32) d3_n;
+					d0_n[3] = (struct Eq_n) 0x0A;
+					d0_n[5] = (struct Eq_n) (d0_n + 0x0A);
+					d0_n[6] = (struct Eq_n) (d0_n + 0x0A);
+					*d0_n[5].dw0000 = (struct Eq_n) 0x00;
+					struct Eq_n * a2_n = d0_n[5];
 					a2_n->dw0004 = dwArg04->dw0010;
-					*((word32) d0_n + 32) = a2_n->dw0004;
+					d0_n[8] = (struct Eq_n) a2_n->dw0004;
 					Mem110[d0_n + 28:word32] = Mem106[d0_n + 32:word32] + Mem106[d0_n + 20:word32];
-					AddHead(dwArg04, (word32) d0_n + 4);
-					a0_n = (word32) d0_n + 4;
-					a3_n = Allocate((word32) d0_n + 4, dwArg08);
+					AddHead(dwArg04, d0_n + 1);
+					a0_n = (struct Eq_n *) (d0_n + 1);
+					a3_n = Allocate(d0_n + 1, dwArg08);
 l00002256:
 					if ((dwArg04->t000C & 0x00010000) != 0x00)
 					{
-						Eq_n a2_n = a3_n;
+						struct Eq_n * a2_n = a3_n;
 						uint32 d2_n;
 						do
 						{
+							a2_n->dw0000 = 0x00;
+							word32 * a2_n = a2_n + 1;
 							*a2_n = 0x00;
-							word32 * a2_n = (word32) a2_n + 4;
-							*a2_n = 0x00;
-							a2_n = a2_n + 1;
+							a2_n = (struct Eq_n *) (a2_n + 1);
 							--d2_n;
 						} while (d2_n != 0x00);
 					}
@@ -1353,15 +1353,15 @@ l00002256:
 			else
 			{
 				d1 = dwArg04->t000C;
-				Eq_n d0_n = AllocMem(dwArg08 + 16, d1);
+				struct Eq_n * d0_n = AllocMem(dwArg08 + 16, d1);
 				a3_n = d0_n;
-				if (d0_n != 0x00)
+				if (d0_n != null)
 				{
-					*d0_n = dwArg08 + 16;
-					AddTail(dwArg04, (word32) d0_n + 4);
-					*((word32) d0_n + 0x0C) = 0x00;
+					d0_n->dw0000 = (word32) (dwArg08 + 16);
+					AddTail(dwArg04, d0_n + 1);
+					d0_n[3] = (struct Eq_n) 0x00;
 					a0_n = dwArg04;
-					a3_n = (word32) d0_n + 16;
+					a3_n = d0_n + 4;
 				}
 			}
 		}
@@ -1372,10 +1372,10 @@ l00002256:
 	return d0_n;
 }
 
-// 000022A8: Register Eq_n fn000022A8(Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack (ptr32 Eq_n) dwArg0C, Register out (ptr32 Eq_n) d1Out, Register out (ptr32 Eq_n) a0Out, Register out Eq_n a1Out)
-Eq_n fn000022A8(Eq_n dwArg04, struct Eq_n * dwArg08, struct Eq_n * dwArg0C, struct Eq_n & d1Out, struct Eq_n & a0Out, union Eq_n & a1Out)
+// 000022A8: Register (ptr32 Eq_n) fn000022A8(Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack (ptr32 Eq_n) dwArg0C, Register out (ptr32 Eq_n) d1Out, Register out (ptr32 Eq_n) a0Out, Register out (ptr32 Eq_n) a1Out)
+struct Eq_n * fn000022A8(Eq_n dwArg04, struct Eq_n * dwArg08, struct Eq_n * dwArg0C, struct Eq_n & d1Out, struct Eq_n & a0Out, struct Eq_n & a1Out)
 {
-	Eq_n d0_n;
+	struct Eq_n * d0_n;
 	struct Eq_n * a0_n = globals->ptr3D74;
 	if (a0_n->t0014 >= 0x27)
 	{
@@ -1384,21 +1384,21 @@ Eq_n fn000022A8(Eq_n dwArg04, struct Eq_n * dwArg08, struct Eq_n * dwArg0C, stru
 	}
 	else
 	{
-		a1.u0 = 0x00;
+		a1 = null;
 		if (dwArg08 - dwArg0C >= 0x00)
 		{
-			Eq_n d0_n = AllocMem(24, 0);
+			struct Eq_n * d0_n = AllocMem(24, 0);
 			d1 = null;
 			a1 = d0_n;
-			if (d0_n != 0x00)
+			if (d0_n != null)
 			{
-				*d0_n = (word32) d0_n + 4;
-				((word32) d0_n + 4)->u0 = 0x00;
-				*((word32) d0_n + 8) = d0_n;
-				*((word32) d0_n + 0x0C) = dwArg04;
-				*((word32) d0_n + 16) = (char *) &dwArg08->dw0004 + 3 & -8;
-				*((word32) d0_n + 20) = dwArg0C;
-				a0_n = (word32) d0_n + 4;
+				d0_n->dw0000 = d0_n + 1;
+				d0_n[1] = (struct Eq_n) 0x00;
+				d0_n[2] = (struct Eq_n) d0_n;
+				d0_n[3] = (struct Eq_n) dwArg04;
+				d0_n[4] = (struct Eq_n) ((char *) &dwArg08->dw0004 + 3 & -8);
+				d0_n[5] = (struct Eq_n) dwArg0C;
+				a0_n = (struct Eq_n *) (d0_n + 1);
 			}
 		}
 		d0_n = a1;
@@ -1526,7 +1526,7 @@ l000024B6:
 		word32 d1_n;
 		d1_n = fn000024BC(dwArg04, dwArg08, dwArg10, out d1_n, out d2_n);
 l000024B4:
-		d0_n.u0 = 0;
+		&d0_n.u0->dw0000 = 0;
 		goto l000024B6;
 	}
 }
@@ -1584,7 +1584,7 @@ l000024D6:
 					Eq_n d2_n = __swap(d5_n);
 					Eq_n d3_n = __swap(d7_n);
 					if ((word16) (d2_n - d3_n) == 0x00)
-						d1_n.u0 = 0xFFFF;
+						&d1_n.u0->dw0000 = 0xFFFF;
 					else
 						d1_n = __swap(SEQ(SLICE(__swap(SEQ((uint16) (d5_n % (uint16) d3_n), (uint16) (d5_n /u (uint16) d3_n))), word16, 16), 0x00));
 					Eq_n d6_n = __swap(SEQ(SLICE(d6_n, word16, 16), 0x00));
@@ -1696,7 +1696,7 @@ Eq_n fn0000267A(Eq_n d0, Eq_n d1, Eq_n d2, union Eq_n & d1Out)
 		if ((word16) d1_n < 0x80)
 		{
 			d1_n = __rol(d1_n, 0x08);
-			d3_n.u0 = 0x08;
+			&d3_n.u0->dw0000 = 0x08;
 		}
 		if ((word16) d1_n < 0x0800)
 		{
@@ -1857,31 +1857,31 @@ void fn00002AFC(struct Eq_n * dwArg04)
 	}
 }
 
-// 00002B40: Register Eq_n fn00002B40(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack (ptr32 Eq_n) dwArg04)
-Eq_n fn00002B40(Eq_n d0, Eq_n d1, Eq_n a1, struct Eq_n * dwArg04)
+// 00002B40: Register Eq_n fn00002B40(Register Eq_n d0, Register Eq_n d1, Register (ptr32 Eq_n) a1, Stack (ptr32 Eq_n) dwArg04)
+Eq_n fn00002B40(Eq_n d0, Eq_n d1, struct Eq_n * a1, struct Eq_n * dwArg04)
 {
 	return fn00002B8C(d0, d1, a1, *(union Eq_n *) 0x3ECC, dwArg04, fp + 8);
 }
 
-// 00002B5C: Register Eq_n fn00002B5C(Stack Eq_n bArg07, Stack Eq_n dwArg08)
-Eq_n fn00002B5C(Eq_n bArg07, Eq_n dwArg08)
+// 00002B5C: Register Eq_n fn00002B5C(Stack byte bArg07, Stack Eq_n dwArg08)
+Eq_n fn00002B5C(byte bArg07, Eq_n dwArg08)
 {
 	Eq_n d0_n = dwArg08;
 	if (dwArg08 != 0x00)
 	{
 		d0_n = *((word32) dwArg08 + 4);
 		if (d0_n - *((word32) dwArg08 + 8) < 0x00)
-			**((word32) dwArg08 + 4) = bArg07;
+			(*((word32) dwArg08 + 4))->u0 = bArg07;
 		*((word32) dwArg08 + 20) = (word32) *((word32) dwArg08 + 20) + 1;
 		--*((word32) dwArg08 + 4);
 	}
 	return d0_n;
 }
 
-// 00002B8C: Register Eq_n fn00002B8C(Register Eq_n d0, Register Eq_n d1, Register Eq_n a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
-Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
+// 00002B8C: Register Eq_n fn00002B8C(Register Eq_n d0, Register Eq_n d1, Register (ptr32 Eq_n) a1, Stack Eq_n dwArg04, Stack (ptr32 Eq_n) dwArg08, Stack Eq_n dwArg0C)
+Eq_n fn00002B8C(Eq_n d0, Eq_n d1, struct Eq_n * a1, Eq_n dwArg04, struct Eq_n * dwArg08, Eq_n dwArg0C)
 {
-	Eq_n a7_n = fp + -0x0078;
+	struct Eq_n * a7_n = fp + -0x0078;
 	Eq_n d2_n = dwArg0C;
 	struct Eq_n * a4_n = dwArg08;
 	Eq_n a2_n = dwArg04;
@@ -1895,8 +1895,8 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 			Eq_n d3_n = 0;
 			if (a4_n->b0000 == 0x25)
 			{
-				*((word32) a7_n + 72) = 0x69;
-				*((word32) a7_n + 73) = 0x00;
+				a7_n[18] = (struct Eq_n) 0x69;
+				a7_n->b0049 = 0x00;
 				byte * a3_n = a4_n + 1;
 				uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 				Eq_n d6_n = -1;
@@ -1904,7 +1904,7 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				if ((d0_n & 0x04) != 0x00)
 				{
 					uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[(uint32) (uint8) *a3_n].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-					d6_n.u0 = 0;
+					&d6_n.u0->dw0000 = 0;
 					d0 = d0_n & 0x04;
 					if ((d0_n & 0x04) != 0x00)
 					{
@@ -1926,8 +1926,8 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 				}
 				if (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))))
 				{
-					d7 = SEQ(SLICE(d7, word24, 8), *((word32) a7_n + 73));
-					d1 = SEQ(SLICE(d1, word24, 8), *((word32) a7_n + 72));
+					d7 = SEQ(SLICE(d7, word24, 8), a7_n->b0049);
+					d1 = SEQ(SLICE(d1, word24, 8), a7_n[18]);
 					do
 					{
 						if (*a3_n == 0x2A)
@@ -1940,15 +1940,15 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 							d1 = SEQ(SLICE(d1, word24, 8), *a3_n);
 						++a3_n;
 					} while (*a3_n == 0x68 || (*a3_n == 0x6C || (*a3_n == 0x4C || (*a3_n == 122 || (*a3_n == 0x6A || (*a3_n == 116 || *a3_n == 0x2A))))));
-					*((word32) a7_n + 72) = (byte) d1;
-					*((word32) a7_n + 73) = (byte) d7;
+					a7_n[18] = (struct Eq_n) (byte) d1;
+					a7_n->b0049 = (byte) d7;
 				}
-				if (*((word32) a7_n + 72) == 0x6A)
-					*((word32) a7_n + 72) = 0x01;
-				if (*((word32) a7_n + 72) == 116)
-					*((word32) a7_n + 72) = 0x69;
-				if (*((word32) a7_n + 72) == 122)
-					*((word32) a7_n + 72) = 0x6C;
+				if (a7_n[18] == 0x6A)
+					a7_n[18] = (struct Eq_n) 0x01;
+				if (a7_n[18] == 116)
+					a7_n[18] = (struct Eq_n) 0x69;
+				if (a7_n[18] == 122)
+					a7_n[18] = (struct Eq_n) 0x6C;
 				byte v83_n = *a3_n;
 				word24 v84_n = SLICE(d7, word24, 8);
 				struct Eq_n * a3_n = a3_n + 1;
@@ -1966,10 +1966,10 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 						if (v90_n >= 0x00)
 						{
 							a1 = (word32) a2_n + 4;
-							byte * a0_n = *a1;
+							byte * a0_n = a1->dw0000;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							a1->dw0000 = a0_n + 1;
 							byte v96_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v96_n);
@@ -2006,19 +2006,19 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 								d1 = SEQ(v147_n, v83_n - 115);
 								if (v83_n != 115)
 								{
-									*((word32) a7_n + 48) = 0x00;
-									*((word32) a7_n + 44) = 0x00;
-									*((word32) a7_n + 110) = 0x00;
+									a7_n[0x0C] = (struct Eq_n) 0x00;
+									a7_n[11] = (struct Eq_n) 0x00;
+									a7_n->dw006E = 0x00;
 									if (v83_n == 0x00)
 										--a3_n;
 									if (v83_n == 0x70)
 									{
-										*((word32) a7_n + 72) = 0x6C;
+										a7_n[18] = (struct Eq_n) 0x6C;
 										d7 = 0x0078;
 									}
 									if ((d5_n == 0x2D && (byte) d7 != 117 || d5_n == 0x2B) && d6_n - d3_n >= 0x00)
 									{
-										*((word32) a7_n + 110) = d5_n;
+										a7_n->dw006E = (word32) d5_n;
 										ui32 * a0_n = (word32) a2_n + 24;
 										*a0_n |= 0x01;
 										int32 * a0_n = (word32) a2_n + 20;
@@ -2027,10 +2027,10 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 										if (v227_n >= 0x00)
 										{
 											a1 = (word32) a2_n + 4;
-											byte * a0_n = *a1;
+											byte * a0_n = a1->dw0000;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											a1->dw0000 = a0_n + 1;
 											byte v231_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -2046,7 +2046,7 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0 = fn00003C30(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0;
 										}
-										d5_n = *((word32) a7_n + 52);
+										d5_n = a7_n[0x0D];
 										d3_n = (word32) d3_n + 1;
 										d4_n = (word32) d4_n + 1;
 									}
@@ -2063,10 +2063,10 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											if (v245_n >= 0x00)
 											{
 												a1 = (word32) a2_n + 4;
-												byte * a0_n = *a1;
+												byte * a0_n = a1->dw0000;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												a1->dw0000 = a0_n + 1;
 												byte v249_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -2082,8 +2082,8 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00003C30(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 64) = *((word32) a7_n + 52);
-											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+											a7_n[16] = a7_n[0x0D];
+											ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 											Eq_n d3_n = (word32) d3_n + 1;
 											d0 = d0_n & 0xFF;
 											if (!__btst((&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[(int32) (int16) (d0_n & 0xFF)].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0], 0x00))
@@ -2099,10 +2099,10 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												if (v267_n >= 0x00)
 												{
 													a1 = (word32) a2_n + 4;
-													byte * a0_n = *a1;
+													byte * a0_n = a1->dw0000;
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
-													*a1 = a0_n + 1;
+													a1->dw0000 = a0_n + 1;
 													byte v271_n = *a0_n;
 													a2_n = a7_n->t0000;
 													a7_n->t0000 = d1;
@@ -2118,12 +2118,12 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 													d0_n = fn00003C30(a7_n->t0000, out d1, out a1, out a5_n);
 													a7_n->t0038 = d0_n;
 												}
-												*((word32) a7_n + 74) = *((word32) a7_n + 52);
+												a7_n->dw004A = (word32) a7_n[0x0D];
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x44;
 												if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 													d7 = 0x0078;
-												if (*((word32) a7_n + 74) != ~0x00)
+												if (a7_n->dw004A != ~0x00)
 												{
 													struct Eq_n * a7_n = a7_n - 4;
 													a7_n->t0000 = a2_n;
@@ -2133,7 +2133,7 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											}
 											else
 												d7 = 111;
-											if (*((word32) a7_n + 64) != ~0x00)
+											if (a7_n[16] != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -2167,10 +2167,10 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 										if (v347_n >= 0x00)
 										{
 											a1 = (word32) a2_n + 4;
-											byte * a0_n = *a1;
+											byte * a0_n = a1->dw0000;
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
-											*a1 = a0_n + 1;
+											a1->dw0000 = a0_n + 1;
 											byte v351_n = *a0_n;
 											a2_n = a7_n->t0000;
 											a7_n->t0000 = d1;
@@ -2186,8 +2186,8 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											d0_n = fn00003C30(a7_n->t0000, out d1, out a1, out a5_n);
 											a7_n->t0038 = d0_n;
 										}
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
-										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55));
+										a7_n[16] = a7_n[0x0D];
+										ui32 d0_n = SEQ(SLICE(d0_n, word24, 8), a7_n->b0037);
 										Eq_n d3_n = (word32) d3_n + 1;
 										int32 d4_n = (word32) d4_n + 1;
 										d0 = d0_n & 0xFF;
@@ -2204,10 +2204,10 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 											if (v368_n >= 0x00)
 											{
 												a1 = (word32) a2_n + 4;
-												byte * a0_n = *a1;
+												byte * a0_n = a1->dw0000;
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
-												*a1 = a0_n + 1;
+												a1->dw0000 = a0_n + 1;
 												byte v372_n = *a0_n;
 												a2_n = a7_n->t0000;
 												a7_n->t0000 = d1;
@@ -2223,17 +2223,17 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0_n = fn00003C30(a7_n->t0000, out d1, out a1, out a5_n);
 												a7_n->t0038 = d0_n;
 											}
-											*((word32) a7_n + 74) = *((word32) a7_n + 52);
-											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(SLICE(d0_n, word24, 8), *((word32) a7_n + 55)) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
+											a7_n->dw004A = (word32) a7_n[0x0D];
+											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(SLICE(d0_n, word24, 8), a7_n->b0037) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 											d3_n = (word32) d3_n + 1;
 											d4_n = d4_n + 0x01;
 											d0 = d0_n & 0x44;
 											if ((d0_n & 0x44) != 0x00 && d6_n - ((word32) d3_n + 1) >= 0x00)
 											{
-												d5_n = *((word32) a7_n + 74);
+												d5_n = a7_n->dw004A;
 												goto l000035F6;
 											}
-											if (*((word32) a7_n + 74) != ~0x00)
+											if (a7_n->dw004A != ~0x00)
 											{
 												struct Eq_n * a7_n = a7_n - 4;
 												a7_n->t0000 = a2_n;
@@ -2241,7 +2241,7 @@ Eq_n fn00002B8C(Eq_n d0, Eq_n d1, Eq_n a1, Eq_n dwArg04, struct Eq_n * dwArg08, 
 												d0 = fn00002B5C(*(a7_n - 1), a7_n->t0000);
 											}
 										}
-										if (*((word32) a7_n + 64) != ~0x00)
+										if (a7_n[16] != ~0x00)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = a2_n;
@@ -2255,52 +2255,52 @@ l000035F6:
 									if ((byte) d7 != 0x78 && (byte) d7 != 88)
 									{
 										if ((byte) d7 == 111)
-											*((word32) a7_n + 52) = 0x08;
+											a7_n[0x0D] = (struct Eq_n) 0x08;
 										else
-											*((word32) a7_n + 52) = 0x0A;
-										*((word32) a7_n + 64) = *((word32) a7_n + 52);
+											a7_n[0x0D] = (struct Eq_n) 0x0A;
+										a7_n[16] = a7_n[0x0D];
 									}
 									else
-										*((word32) a7_n + 64) = 0x10;
-									*((word32) a7_n + 114) = *((word32) a7_n + 64);
+										a7_n[16] = (struct Eq_n) 0x10;
+									a7_n->dw0072 = (word32) a7_n[16];
 									uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(SLICE(d0, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-									*((word32) a7_n + 0x0084) = d2_n;
-									*((word32) a7_n + 52) = d4_n;
-									*((word32) a7_n + 74) = (byte) d7;
+									a7_n[33] = (struct Eq_n) d2_n;
+									a7_n[0x0D] = (struct Eq_n) d4_n;
+									a7_n->dw004A = (word32) (byte) d7;
 									d0 = d0_n & 0x44;
 									if ((d0_n & 0x44) != 0x00)
 									{
-										if (*((word32) a7_n + 114) == 0x0A)
+										if (a7_n->dw0072 == 0x0A)
 										{
 											uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(SLICE(d0_n & 0x44, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											d0 = d0_n & 0x04;
 											if ((d0_n & 0x04) != 0x00)
 												goto l00003692;
 											goto l00003892;
 										}
 l00003692:
-										if (*((word32) a7_n + 114) == 0x08)
+										if (a7_n->dw0072 == 0x08)
 										{
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d5_n <= 55)
 												goto l000036B2;
 										}
 										else
 										{
 l000036B2:
-											*((word32) a7_n + 0x0084) = d2_n;
-											*((word32) a7_n + 52) = d4_n;
-											*((word32) a7_n + 64) = d6_n;
-											*((word32) a7_n + 74) = (byte) d7;
+											a7_n[33] = (struct Eq_n) d2_n;
+											a7_n[0x0D] = (struct Eq_n) d4_n;
+											a7_n[16] = (struct Eq_n) d6_n;
+											a7_n->dw004A = (word32) (byte) d7;
 											if (d6_n - d3_n >= 0x00)
 											{
-												d7 = (int32) *((word32) a7_n + 114);
-												up32 a4_n = *((word32) a7_n + 64);
+												d7 = a7_n->dw0072;
+												up32 a4_n = a7_n[16];
 												do
 												{
 													struct Eq_n * a7_n = a7_n - 4;
@@ -2308,7 +2308,7 @@ l000036B2:
 													Eq_n v419_n = a7_n->t0000;
 													a7_n->t0000 = d7 >> 31;
 													*(a7_n - 4) = d7;
-													*(a7_n - 8) = (union Eq_n *) a1;
+													*(a7_n - 8) = (struct Eq_n **) a1;
 													*(a7_n - 0x0C) = a7_n->dw0034;
 													*(a7_n - 16) = a7_n->dw0030;
 													*(a7_n - 20) = d7;
@@ -2316,7 +2316,7 @@ l000036B2:
 													word32 d1_n;
 													a7_n->dw0044 = fn00003BB0(d4_n, *(a7_n - 24), *(a7_n - 20), *(a7_n - 16), *(a7_n - 0x0C), out d1_n);
 													a7_n->dw0048 = d1_n;
-													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(a7_n->t0001, (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x04) != 0x00)
+													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(a7_n->n0001, (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x04) != 0x00)
 														d4_n = d5_n - 0x30;
 													else
 														d4_n.u0 = 0;
@@ -2324,10 +2324,10 @@ l000036B2:
 													*(a7_n - 4) = (union Eq_n *) v419_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d4_n + Mem2975[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = (union Eq_n *) d3_n;
 													int32 d0_n = d4_n >> 31;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + d0_n);
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < 0x00) + ((word32) a7_n[16] + d0_n));
 													word32 v441_n = *(a7_n - 8);
 													word32 v442_n = *(a7_n - 4);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x01) != 0x00)
@@ -2338,10 +2338,10 @@ l000036B2:
 													*(a7_n - 4) = v442_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d6_n + Mem3035[a7_n + 48:word32];
-													*((word32) a7_n + 0x0044) = d2_n;
+													a7_n[0x0011] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v441_n;
 													int32 d0_n = d6_n >> 31;
-													*((word32) a7_n + 64) = (word32) *((word32) a7_n + 44) + d0_n + (d2_n < 0x00);
+													a7_n[16] = (struct Eq_n) ((word32) a7_n[11] + d0_n + (d2_n < 0x00));
 													word32 v453_n = *(a7_n - 8);
 													if (((uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(SLICE(d0_n, word24, 8), (byte) d5_n) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0] & 0x02) != 0x00)
 														d2_n = d5_n - 0x57;
@@ -2351,9 +2351,9 @@ l000036B2:
 													*(a7_n - 4) = (union Eq_n *) d2_n;
 													*(a7_n - 4) = *(a7_n - 4);
 													word32 d2_n = d2_n + Mem3093[a7_n + 0x0044:word32];
-													*((word32) a7_n + 48) = d2_n;
+													a7_n[0x0C] = (struct Eq_n) d2_n;
 													*(a7_n - 8) = v453_n;
-													*((word32) a7_n + 44) = (bool) (d2_n < 0x00) + ((word32) (*((word32) a7_n + 64)) + (d2_n >> 31));
+													a7_n[11] = (struct Eq_n) ((bool) (d2_n < 0x00) + ((word32) a7_n[16] + (d2_n >> 31)));
 													ui32 * a0_n = (word32) a2_n + 24;
 													up32 v465_n = *(a7_n - 8);
 													d2_n = *(a7_n - 4);
@@ -2364,9 +2364,9 @@ l000036B2:
 													if (v468_n >= 0x00)
 													{
 														a1 = (word32) a2_n + 4;
-														byte * a0_n = *a1;
+														byte * a0_n = a1->dw0000;
 														*(a7_n - 4) = (union Eq_n *) a2_n;
-														*a1 = a0_n + 1;
+														a1->dw0000 = a0_n + 1;
 														d0_n = (uint32) (uint8) *a0_n;
 														a2_n = *(a7_n - 4);
 														d1 = (uint32) (uint8) (byte) d0_n;
@@ -2379,7 +2379,7 @@ l000036B2:
 														d0_n = fn00003C30(*(a7_n - 4), out d1_n, out a1, out a5_n);
 														d1 = d0_n;
 													}
-													*((word32) a7_n + 52) = (word32) *((word32) a7_n + 52) + 1;
+													a7_n[0x0D] = (struct Eq_n) ((word32) a7_n[0x0D] + 1);
 													uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(SLICE(d0_n, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 													d5_n = d1;
 													d3_n = v465_n + 0x01;
@@ -2398,11 +2398,11 @@ l000036B2:
 										}
 									}
 l00003892:
-									Eq_n v476_n = *((word32) a7_n + 74);
+									Eq_n v476_n = a7_n->dw004A;
 									d7 = SEQ(SLICE(d7, word24, 8), v476_n);
-									word32 d4_n = *((word32) a7_n + 52);
-									d2_n = *((word32) a7_n + 0x0084);
-									if (*((word32) a7_n + 110) != 0x00 && d3_n == 0x02)
+									word32 d4_n = a7_n[0x0D];
+									d2_n = a7_n[33];
+									if (a7_n->dw006E != 0x00 && d3_n == 0x02)
 									{
 										if (d5_n != ~0x00)
 										{
@@ -2413,7 +2413,7 @@ l00003892:
 										}
 										--d3_n;
 										--d4_n;
-										d5_n = *((word32) a7_n + 110);
+										d5_n = a7_n->dw006E;
 									}
 									if (d5_n != ~0x00)
 									{
@@ -2424,14 +2424,14 @@ l00003892:
 									}
 									d3_n = d3_n - 0x01;
 									d4_n = d4_n - 0x01;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										if (v476_n == 117)
 										{
 											struct Eq_n * a7_n = a7_n - 4;
 											a7_n->t0000 = d0;
 											a7_n->b0038 = a7_n->b004C - 0x01;
-											a7_n = (char *) &a7_n->t0000 + 4;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
 											if (a7_n->b0038 != 0x00)
 											{
 												byte v517_n = a7_n->b0038 - 0x01;
@@ -2483,58 +2483,58 @@ l00003892:
 										}
 										else
 										{
-											if (*((word32) a7_n + 110) == 0x2D)
+											if (a7_n->dw006E == 0x2D)
 											{
-												struct Eq_n * v528_n = (word32) a7_n + 44;
+												struct Eq_n * v528_n = a7_n + 11;
 												d1 = -v528_n->dw0004;
 												d0 = -v528_n->dw0000 - (d1 < 0x00);
-												a7_n = *((word32) a7_n + 56);
+												a7_n = (struct Eq_n *) a7_n[0x0E];
 											}
 											else
 											{
-												*((word32) a7_n + 56) = *((word32) a7_n + 48);
-												*((word32) a7_n + 52) = *((word32) a7_n + 44);
+												a7_n[0x0E] = a7_n[0x0C];
+												a7_n[0x0D] = a7_n[11];
 											}
-											Eq_n a7_n = a7_n - 4;
-											*a7_n = d0;
-											*((word32) a7_n + 48) = *((word32) a7_n + 76) - 0x01;
-											a7_n = (word32) a7_n + 4;
-											if (*((word32) a7_n + 48) != 0x00)
+											struct Eq_n * a7_n = a7_n - 4;
+											a7_n->t0000 = d0;
+											a7_n->b0030 = a7_n->b004C - 0x01;
+											a7_n = (struct Eq_n *) ((char *) &a7_n->t0000 + 4);
+											if (a7_n->b0030 != 0x00)
 											{
-												byte v540_n = *((word32) a7_n + 48) - 0x01;
-												*((word32) a7_n + 48) = v540_n;
+												byte v540_n = a7_n->b0030 - 0x01;
+												a7_n->b0030 = v540_n;
 												if (v540_n != 0x00)
 												{
-													byte v541_n = *((word32) a7_n + 48) - 0x66;
-													*((word32) a7_n + 48) = v541_n;
+													byte v541_n = a7_n->b0030 - 0x66;
+													a7_n->b0030 = v541_n;
 													if (v541_n != 0x00)
 													{
-														byte v542_n = *((word32) a7_n + 48) - 0x04;
-														*((word32) a7_n + 48) = v542_n;
+														byte v542_n = a7_n->b0030 - 0x04;
+														a7_n->b0030 = v542_n;
 														if (v542_n != 0x00)
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 														else
 														{
 															d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-															d0 = *((word32) a7_n + 60);
+															d0 = a7_n->t003C;
 															**((word32) d2_n - 4) = d0;
 														}
 													}
 													else
 													{
 														d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-														d0 = *((word32) a7_n + 60);
+														d0 = a7_n->t003C;
 														**((word32) d2_n - 4) = (word16) d0;
 													}
 												}
 												else
 												{
 													d2_n = (d2_n + 0x03 >>u 0x02 << 0x02) + 0x04;
-													d0 = *((word32) a7_n + 60);
+													d0 = a7_n->t003C;
 													**((word32) d2_n - 4) = (byte) d0;
 												}
 											}
@@ -2543,18 +2543,18 @@ l00003892:
 												word32 d0_n = d2_n + 0x03 >>u 0x02;
 												d2_n = (d0_n << 0x02) + 0x04;
 												struct Eq_n * a0_n = *((word32) d2_n - 4);
-												a0_n->dw0004 = (word32) *((word32) a7_n + 60);
-												a0_n->dw0000 = (word32) *((word32) a7_n + 56);
+												a0_n->t0004 = a7_n->t003C;
+												a0_n->dw0000 = a7_n->dw0038;
 												d0 = d0_n << 0x02;
 											}
 										}
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 								else
 								{
 									byte * a5_n;
-									if (*((word32) a7_n + 73) == 0x00)
+									if (a7_n->b0049 == 0x00)
 									{
 										d0 = (word32) d2_n + 3 >> 0x02 << 0x02;
 										d2_n = (word32) d0 + 4;
@@ -2568,7 +2568,7 @@ l00003892:
 										d0 = d0_n & 0x08;
 										if ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00)
 										{
-											byte v190_n = *((word32) a7_n + 73);
+											byte v190_n = a7_n->b0049;
 											d7 = SEQ(v84_n, v190_n);
 											do
 											{
@@ -2585,10 +2585,10 @@ l00003892:
 												if (v197_n >= 0x00)
 												{
 													a1 = (word32) a2_n + 4;
-													byte * a0_n = *a1;
+													byte * a0_n = a1->dw0000;
 													union Eq_n * a7_n = a7_n - 4;
 													*a7_n = (union Eq_n *) a2_n;
-													*a1 = a0_n + 1;
+													a1->dw0000 = a0_n + 1;
 													byte v201_n = *a0_n;
 													a2_n = *a7_n;
 													d0 = SEQ(SLICE(d0, word24, 8), v201_n);
@@ -2610,7 +2610,7 @@ l00003892:
 												uint32 d0_n = (uint32) (uint8) (&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&globals->t2815)[SEQ(SLICE(d0, word24, 8), (byte) d1) & 0xFF].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0].a0000)[0];
 												d0 = d0_n & 0x08;
 											} while ((d0_n & 0x08) == 0x00 && d6_n - d3_n >= 0x00);
-											*((word32) a7_n + 73) = v190_n;
+											a7_n->b0049 = v190_n;
 										}
 									}
 									if (d5_n != ~0x00)
@@ -2622,18 +2622,18 @@ l00003892:
 									}
 									d3_n = d3_n - 0x01;
 									--d4_n;
-									if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+									if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 									{
 										*a5_n = 0x00;
-										*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+										a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 									}
 								}
 							}
 							else
 							{
-								if (*((word32) a7_n + 73) == 0x00)
+								if (a7_n->b0049 == 0x00)
 								{
-									if (*((word32) a7_n + 72) == 0x01)
+									if (a7_n[18] == 0x01)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										struct Eq_n * a0_n = *d0;
@@ -2641,19 +2641,19 @@ l00003892:
 										a0_n->dw0000 = 0x00;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x6C)
+									else if (a7_n[18] == 0x6C)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x68)
+									else if (a7_n[18] == 0x68)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (word16) d4_n;
 										d2_n = (word32) d0 + 4;
 									}
-									else if (*((word32) a7_n + 72) == 0x02)
+									else if (a7_n[18] == 0x02)
 									{
 										d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 										**d0 = (byte) d4_n;
@@ -2666,16 +2666,16 @@ l00003892:
 										d2_n = (word32) d0 + 4;
 									}
 								}
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 								d3_n.u0 = 1;
 							}
 						}
 						else
 						{
 							if (d6_n == ~0x00)
-								d6_n.u0 = 1;
+								&d6_n.u0->dw0000 = 1;
 							union Eq_n * a1_n;
-							if (*((word32) a7_n + 73) == 0x00)
+							if (a7_n->b0049 == 0x00)
 							{
 								d0 = d2_n + 0x03 >>u 0x02 << 0x02;
 								d2_n = (word32) d0 + 4;
@@ -2687,7 +2687,7 @@ l00003892:
 							*a0_n |= 0x01;
 							int32 * a0_n = (word32) a2_n + 20;
 							--*a0_n;
-							*((word32) a7_n + 44) = a1_n;
+							a7_n[11] = (struct Eq_n) a1_n;
 							if (*a0_n >= 0x00)
 							{
 								byte ** a1_n = (word32) a2_n + 4;
@@ -2704,7 +2704,7 @@ l00003892:
 							}
 							else
 							{
-								int32 a1_n = *((word32) a7_n + 44);
+								int32 a1_n = a7_n[11];
 								struct Eq_n * a7_n = a7_n - 4;
 								a7_n->t0000 = a2_n;
 								a7_n->dw0030 = a1_n;
@@ -2714,18 +2714,18 @@ l00003892:
 								a7_n->t0038 = d0;
 								a7_n->dw0030 = a7_n->dw0030;
 							}
-							a1 = *((word32) a7_n + 44);
-							d5_n = *((word32) a7_n + 52);
+							a1 = (struct Eq_n *) a7_n[11];
+							d5_n = a7_n[0x0D];
 							Eq_n d3_n = (word32) d3_n + 1;
 							int32 d4_n = (word32) d4_n + 1;
-							if (*((word32) a7_n + 52) != ~0x00)
+							if (a7_n[0x0D] != ~0x00)
 							{
-								*((word32) a7_n + 44) = a1;
+								a7_n[11] = (struct Eq_n) a1;
 								if (d6_n - d3_n >= 0x00)
 								{
-									byte v302_n = *((word32) a7_n + 73);
+									byte v302_n = a7_n->b0049;
 									d7 = SEQ(v84_n, v302_n);
-									byte * a4_n = *((word32) a7_n + 44);
+									byte * a4_n = a7_n[11];
 									do
 									{
 										if (v302_n == 0x00)
@@ -2741,10 +2741,10 @@ l00003892:
 										if (v310_n >= 0x00)
 										{
 											a1 = (word32) a2_n + 4;
-											byte * a0_n = *a1;
+											byte * a0_n = a1->dw0000;
 											union Eq_n * a7_n = a7_n - 4;
 											*a7_n = (union Eq_n *) a2_n;
-											*a1 = a0_n + 1;
+											a1->dw0000 = a0_n + 1;
 											byte v314_n = *a0_n;
 											a2_n = *a7_n;
 											d0 = SEQ(SLICE(d0, word24, 8), v314_n);
@@ -2763,7 +2763,7 @@ l00003892:
 										d3_n = (word32) d3_n + 1;
 										++d4_n;
 									} while (d1 != ~0x00 && d6_n - d3_n >= 0x00);
-									*((word32) a7_n + 73) = v302_n;
+									a7_n->b0049 = v302_n;
 								}
 							}
 							if (d5_n != ~0x00)
@@ -2775,22 +2775,22 @@ l00003892:
 							}
 							d3_n = d3_n - 0x01;
 							d4_n = d4_n - 0x01;
-							if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
-								*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							if (a7_n->b0049 == 0x00 && d3_n != 0x00)
+								a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 					else
 					{
-						*((word32) a7_n + 44) = 0x00;
+						a7_n[11] = (struct Eq_n) 0x00;
 						if (a3_n->b0000 == 0x5E)
 						{
-							*((word32) a7_n + 44) = 0x01;
+							a7_n[11] = (struct Eq_n) 0x01;
 							++a3_n;
 						}
-						*((word32) a7_n + 52) = 0x00;
-						byte v544_n = *((word32) a7_n + 44);
+						a7_n[0x0D] = (struct Eq_n) 0x00;
+						Eq_n v544_n = a7_n[11];
 						d7 = SEQ(v84_n, v544_n);
-						Eq_n d1_n = *((word32) a7_n + 52);
+						Eq_n d1_n = a7_n[0x0D];
 						do
 						{
 							int32 d5_n;
@@ -2798,12 +2798,12 @@ l00003892:
 								d5_n = 0xFF;
 							else
 								d5_n = 0;
-							*((word32) d1_n + ((word32) a7_n + 78)) = (byte) d5_n;
+							Mem796[a7_n + 78 + d1_n:byte] = SLICE(d5_n, byte, 0);
 							d1_n = (word32) d1_n + 1;
 						} while (d1_n < 0x20);
-						*((word32) a7_n + 0x0084) = d2_n;
-						*((word32) a7_n + 44) = v544_n;
-						byte v554_n = *((word32) a7_n + 44);
+						a7_n[33] = (struct Eq_n) d2_n;
+						a7_n[11] = (struct Eq_n) v544_n;
+						Eq_n v554_n = a7_n[11];
 						while (a3_n->b0000 != 0x00)
 						{
 							cu8 v556_n = a3_n->b0000;
@@ -2816,32 +2816,32 @@ l00003892:
 							}
 							else
 								d7 = SEQ(SLICE(d7, word24, 8), v556_n);
-							Eq_n d5_n = (uint32) (uint8) v556_n;
+							union Eq_n ** d5_n = (uint32) (uint8) v556_n;
 							d0 = (uint32) (uint8) (byte) d7;
-							while (d0 - d5_n >= 0x00)
+							while (d0 - d5_n >= null)
 							{
 								if (v554_n != 0x00)
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (~(1 << (d5_n & 7)) & d1_n);
 								}
 								else
 								{
-									Eq_n a0_n = (word32) (d5_n >> 0x03) + ((word32) a7_n + 78);
+									word32 a0_n = a7_n + 78 + (d5_n >>u 0x03);
 									d1_n = (uint32) (uint8) *a0_n;
 									*a0_n = (byte) (1 << (d5_n & 7) | d1_n);
 								}
-								d5_n = (word32) d5_n + 1;
+								++d5_n;
 								d0 = (uint32) (uint8) (byte) d7;
 							}
 							if (a3_n->b0000 == 0x5D)
 								break;
 						}
 						byte * a6_n;
-						d2_n = *((word32) a7_n + 0x0084);
+						d2_n = a7_n[33];
 						++a3_n;
-						if (*((word32) a7_n + 73) == 0x00)
+						if (a7_n->b0049 == 0x00)
 						{
 							word32 d0_n = d2_n + 0x03 >>u 0x02;
 							d2_n = (d0_n << 0x02) + 0x04;
@@ -2858,41 +2858,41 @@ l00003892:
 						if (v581_n >= 0x00)
 						{
 							a1 = (word32) a2_n + 4;
-							byte * a0_n = *a1;
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*a1 = a0_n + 1;
+							byte * a0_n = a1->dw0000;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
+							a1->dw0000 = a0_n + 1;
 							byte v585_n = *a0_n;
-							a2_n = *a7_n;
-							*a7_n = d1_n;
-							*((word32) a7_n + 48) = (uint32) (uint8) v585_n;
+							a2_n = a7_n->t0000;
+							a7_n->t0000 = d1_n;
+							a7_n->dw0030 = (uint32) (uint8) v585_n;
 							d0 = SEQ(SLICE(d0, word24, 8), v585_n);
-							d1 = *a7_n;
+							d1 = a7_n->t0000;
 						}
 						else
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->t0000 = a2_n;
 							word32 a5_n;
-							d0 = fn00003C30(*a7_n, out d1, out a1, out a5_n);
-							*((word32) a7_n + 48) = d0;
+							d0 = fn00003C30(a7_n->t0000, out d1, out a1, out a5_n);
+							a7_n->t0030 = d0;
 						}
-						d5_n = *((word32) a7_n + 44);
+						d5_n = a7_n[11];
 						Eq_n d3_n = (word32) d3_n + 1;
 						int32 d4_n = (word32) d4_n + 1;
-						if (*((word32) a7_n + 44) != ~0x00)
+						if (a7_n[11] != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = (word32) a7_n + 78;
-							*(a7_n - 4) = a1;
-							(a7_n - 8)->u0 = 0x08;
-							*(a7_n - 0x0C) = d5_n;
-							d1 = (uint32) (uint8) *((word32) *a7_n + fn00002648(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-							a1 = *(a7_n - 4);
+							struct Eq_n * a7_n = a7_n - 4;
+							a7_n->ptr0000 = &a7_n->dw004A + 1;
+							*(a7_n - 4) = (struct Eq_n **) a1;
+							*(a7_n - 8) = 0x08;
+							*(a7_n - 0x0C) = (union Eq_n *) d5_n;
+							d1 = (uint32) (uint8) (a7_n->ptr0000 + fn00002648(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+							a1 = (struct Eq_n *) *(a7_n - 4);
 							d0 = 1 << (d5_n & 7) & d1;
 							if (d0 != 0x00 && d6_n - d3_n >= 0x00)
 							{
-								byte v601_n = *((word32) a7_n + 77);
+								byte v601_n = a7_n->b004D;
 								d7 = SEQ(SLICE(d7, word24, 8), v601_n);
 								do
 								{
@@ -2909,10 +2909,10 @@ l00003892:
 									if (v607_n >= 0x00)
 									{
 										a1 = (word32) a2_n + 4;
-										byte * a0_n = *a1;
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
-										*a1 = a0_n + 1;
+										byte * a0_n = a1->dw0000;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
+										a1->dw0000 = a0_n + 1;
 										byte v611_n = *a0_n;
 										a2_n = *a7_n;
 										d0 = SEQ(SLICE(d0, word24, 8), v611_n);
@@ -2920,8 +2920,8 @@ l00003892:
 									}
 									else
 									{
-										Eq_n a7_n = a7_n - 4;
-										*a7_n = a2_n;
+										union Eq_n * a7_n = a7_n - 4;
+										*a7_n = (union Eq_n *) a2_n;
 										word32 d1_n;
 										word32 a5_n;
 										d0 = fn00003C30(*a7_n, out d1_n, out a1, out a5_n);
@@ -2932,31 +2932,31 @@ l00003892:
 									++d4_n;
 									if (d1 == ~0x00)
 										break;
-									Eq_n a7_n = a7_n - 4;
-									*a7_n = (word32) a7_n + 78;
-									*(a7_n - 4) = a1;
-									(a7_n - 8)->u0 = 0x08;
-									*(a7_n - 0x0C) = d1;
-									d1 = (uint32) (uint8) *((word32) *a7_n + fn00002648(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
-									a1 = *(a7_n - 4);
+									ptr32 * a7_n = a7_n - 4;
+									*a7_n = &a7_n->dw004A + 1;
+									*(a7_n - 4) = (struct Eq_n **) a1;
+									*(a7_n - 8) = 0x08;
+									*(a7_n - 0x0C) = (union Eq_n *) d1;
+									d1 = (uint32) (uint8) (*a7_n + fn00002648(d2_n, *(a7_n - 0x0C), *(a7_n - 8)));
+									a1 = (struct Eq_n *) *(a7_n - 4);
 									d0 = 1 << (d1 & 7) & d1;
 								} while (d0 != 0x00 && d6_n - d3_n >= 0x00);
-								*((word32) a7_n + 73) = v601_n;
+								a7_n->b0049 = v601_n;
 							}
 						}
 						if (d5_n != ~0x00)
 						{
-							Eq_n a7_n = a7_n - 4;
-							*a7_n = a2_n;
-							*(a7_n - 4) = d5_n;
+							union Eq_n * a7_n = a7_n - 4;
+							*a7_n = (union Eq_n *) a2_n;
+							*(a7_n - 4) = (union Eq_n *) d5_n;
 							d0 = fn00002B5C(*(a7_n - 1), *a7_n);
 						}
 						d3_n = d3_n - 0x01;
 						d4_n = d4_n - 0x01;
-						if (*((word32) a7_n + 73) == 0x00 && d3_n != 0x00)
+						if (a7_n->b0049 == 0x00 && d3_n != 0x00)
 						{
 							*a6_n = 0x00;
-							*((word32) a7_n + 60) = (word32) *((word32) a7_n + 60) + 1;
+							a7_n[0x0F] = (struct Eq_n) ((word32) a7_n[0x0F] + 1);
 						}
 					}
 				}
@@ -2970,10 +2970,10 @@ l00003892:
 					if (v159_n >= 0x00)
 					{
 						a1 = (word32) a2_n + 4;
-						byte * a0_n = *a1;
+						byte * a0_n = a1->dw0000;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						a1->dw0000 = a0_n + 1;
 						byte v163_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1_n;
@@ -2989,10 +2989,10 @@ l00003892:
 						d0 = fn00003C30(a7_n->t0000, out d1, out a1, out a5_n);
 						a7_n->t0030 = d0;
 					}
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n = (word32) d3_n.u0 + 1;
 					d4_n = (word32) d4_n + 1;
-					if (*((word32) a7_n + 44) != 0x25)
+					if (a7_n[11] != 0x25)
 					{
 						if (d5_n != ~0x00)
 						{
@@ -3024,10 +3024,10 @@ l00003892:
 						if (v105_n >= 0x00)
 						{
 							a1 = (word32) a2_n + 4;
-							byte * a0_n = *a1;
+							byte * a0_n = a1->dw0000;
 							union Eq_n * a7_n = a7_n - 4;
 							*a7_n = (union Eq_n *) a2_n;
-							*a1 = a0_n + 1;
+							a1->dw0000 = a0_n + 1;
 							byte v109_n = *a0_n;
 							a2_n = *a7_n;
 							d0_n = SEQ(SLICE(d0, word24, 8), v109_n);
@@ -3068,10 +3068,10 @@ l00003892:
 					if (v126_n >= 0x00)
 					{
 						a1 = (word32) a2_n + 4;
-						byte * a0_n = *a1;
+						byte * a0_n = a1->dw0000;
 						struct Eq_n * a7_n = a7_n - 4;
 						a7_n->t0000 = a2_n;
-						*a1 = a0_n + 1;
+						a1->dw0000 = a0_n + 1;
 						byte v130_n = *a0_n;
 						a2_n = a7_n->t0000;
 						a7_n->t0000 = d1;
@@ -3088,10 +3088,10 @@ l00003892:
 						a7_n->t0030 = d0_n;
 					}
 					d0 = (int32) (int16) (int8) SEQ(SLICE(d0_n, word24, 8), a4_n->b0000);
-					d5_n = *((word32) a7_n + 44);
+					d5_n = a7_n[11];
 					d3_n.u0 = 0x01;
 					d4_n = (word32) d4_n + 1;
-					if (d0 - *((word32) a7_n + 44) != 0x00)
+					if (d0 - a7_n[11] != 0x00)
 					{
 						if (d5_n != ~0x00)
 						{
@@ -3135,13 +3135,13 @@ uint32 fn00003BB0(Eq_n d4, Eq_n dwArg04, Eq_n dwArg08, Eq_n dwArg0C, Eq_n dwArg1
 	return (uint32) (uint16) (word16) d2_n + d1_n + (dwArg0C * (word16) dwArg08 + SEQ(SLICE(d3_n, word16, 16), (word16) d3_n ^ (word16) d3_n)) + (dwArg04 * (word16) dwArg10 + SEQ(SLICE(d3_n, word16, 16), (word16) d3_n ^ (word16) d3_n));
 }
 
-// 00003C30: Register int32 fn00003C30(Stack Eq_n dwArg04, Register out Eq_n d1Out, Register out (ptr32 word32) a1Out, Register out (ptr32 byte) a5Out)
+// 00003C30: Register int32 fn00003C30(Stack Eq_n dwArg04, Register out (ptr32 (ptr32 Eq_n)) d1Out, Register out (ptr32 word32) a1Out, Register out (ptr32 byte) a5Out)
 int32 fn00003C30(Eq_n dwArg04, union Eq_n & d1Out, word32 & a1Out, byte & a5Out)
 {
 	int32 d0_n;
 	byte * a5_n;
 	word32 * a1_n;
-	Eq_n d1_n = fn00002388(out a1_n, out a5_n);
+	union Eq_n ** d1_n = fn00002388(out a1_n, out a5_n);
 	if (dwArg04 == 0x00)
 	{
 		d0_n = -1;
@@ -3153,16 +3153,16 @@ int32 fn00003C30(Eq_n dwArg04, union Eq_n & d1Out, word32 & a1Out, byte & a5Out)
 		goto l00003D26;
 	}
 	*((word32) dwArg04 + 24) |= 1;
-	struct Eq_n * d0_n = *((word32) dwArg04 + 24) & 0x0200;
-	if (d0_n != null)
+	int32 d0_n = *((word32) dwArg04 + 24) & 0x0200;
+	if (d0_n != 0x00)
 		d0_n = fn00003D2C(out a1_n, out a5_n);
 	if (*((word32) dwArg04 + 28) == 0x00)
 	{
 		d0_n = *((word32) dwArg04 + 24) & 4;
-		if (d0_n != null)
+		if (d0_n != 0x00)
 		{
 			*((word32) dwArg04 + 28) = 1;
-			d0_n = (struct Eq_n *) 1;
+			d0_n = 1;
 		}
 		else
 			*((word32) dwArg04 + 28) = 0x0400;
@@ -3175,29 +3175,29 @@ int32 fn00003C30(Eq_n dwArg04, union Eq_n & d1Out, word32 & a1Out, byte & a5Out)
 		else
 			d4_n = 1;
 		word32 a0_n;
-		struct Eq_n * d0_n = fn00001FB4((word32) *((word32) dwArg04 + 28) + d4_n, out d1_n, out a0_n, out a1_n);
+		int32 d0_n = fn00001FB4((word32) *((word32) dwArg04 + 28) + d4_n, out d1_n, out a0_n, out a1_n);
 		d0_n = d0_n;
-		if (d0_n == null)
+		if (d0_n == 0x00)
 		{
 			d0_n = -1;
 			goto l00003D26;
 		}
-		*((word32) dwArg04 + 8) = (char *) &d0_n->dw0000 + 1;
-		a1_n = (word32 *) ((char *) &d0_n->dw0000 + 1);
+		*((word32) dwArg04 + 8) = d0_n + 1;
+		a1_n = d0_n + 1;
 	}
 	*((word32) dwArg04 + 4) = *((word32) dwArg04 + 8);
-	d1_n = *dwArg04;
+	d1_n = (union Eq_n **) *dwArg04;
 	execPrivate2();
 	*((word32) dwArg04 + 20) = d0_n;
-	struct Eq_n * v26_n = *((word32) dwArg04 + 20) - 0x01;
+	int32 v26_n = *((word32) dwArg04 + 20) - 0x01;
 	*((word32) dwArg04 + 20) = v26_n;
-	if (v26_n < null)
+	if (v26_n < 0x00)
 	{
-		if (*((word32) dwArg04 + 20) == (struct Eq_n *) -1)
+		if (*((word32) dwArg04 + 20) == -1)
 			*((word32) dwArg04 + 24) |= 8;
 		else
 			*((word32) dwArg04 + 24) |= 16;
-		*((word32) dwArg04 + 20) = null;
+		*((word32) dwArg04 + 20) = 0x00;
 		d0_n = -1;
 	}
 	else

--- a/subjects/OpenRISC/sunxi/blob.reko/blob.c
+++ b/subjects/OpenRISC/sunxi/blob.reko/blob.c
@@ -648,10 +648,10 @@ l0000606C:
 				r3->t0020 = r24_n;
 			if ((word32) r3->dw0024 == 0x00)
 				r3->dw0024 = r20_n;
-			*(word32 *) 0x01C63030 = (word32) r3->dw001A;
-			*(word32 *) 0x01C63034 = (word32) r3->dw001E;
-			*(word32 *) 0x01C63038 = (word32) r3->t0022;
-			*(word32 *) 0x01C6303C = (word32) r3->dw0026;
+			*(word32 *) 0x01C63030 = (word32) r3->w001A;
+			*(word32 *) 0x01C63034 = (word32) r3->w001E;
+			*(word32 *) 0x01C63038 = (word32) r3->w0022;
+			*(word32 *) 0x01C6303C = (word32) r3->w0026;
 			*(ui32 *) 29765676 = r3->dw000C >> 0x04 & 0x03;
 			*(ui32 *) 29765720 = dwArg74 << 0x10 | dwArg7C | r16_n << 0x18 | dwArg8C << 0x08;
 			*(ui32 *) 0x01C6305C = dwArg60 << 0x10 | dwArg70 << 0x08 | dwArg78;
@@ -2117,7 +2117,7 @@ Eq_n fn00007AE0(struct Eq_n * r4, Eq_n r14, Eq_n r15, Eq_n r18, ptr32 r20)
 			else
 			{
 				uint32 r11_n = fn00006E54();
-				r2_n->t0014 = r11_n << 0x10 | (word32) r2_n->dw0016;
+				r2_n->t0014 = r11_n << 0x10 | (word32) r2_n->w0016;
 				r14_n = r11_n;
 			}
 			ui32 r5_n;

--- a/subjects/OpenRISC/sunxi/blob.reko/blob.h
+++ b/subjects/OpenRISC/sunxi/blob.reko/blob.h
@@ -2365,7 +2365,7 @@ Eq_536: (fn void ())
 	T_13437 (in __csync : ptr32)
 Eq_608: (struct "Eq_608" (1700080 ui32 dw1700080) (1F01C30 ui32 dw1F01C30))
 	T_608 (in r14_56 : (ptr32 Eq_608))
-Eq_636: (struct "Eq_636" (0 Eq_1020 t0000) (4 Eq_6 t0004) (8 ui32 dw0008) (C uint32 dw000C) (14 ui32 dw0014) (18 Eq_1072 t0018) (1A int32 dw001A) (1C int32 dw001C) (1E word32 dw001E) (20 Eq_6 t0020) (22 Eq_1810 t0022) (24 word32 dw0024) (26 word32 dw0026) (28 ui32 dw0028) (2C uint32 dw002C) (30 ui32 dw0030) (54 uint32 dw0054) (58 uint32 dw0058) (5C uint32 dw005C))
+Eq_636: (struct "Eq_636" (0 Eq_1020 t0000) (4 Eq_6 t0004) (8 ui32 dw0008) (C uint32 dw000C) (14 ui32 dw0014) (18 Eq_1072 t0018) (1A word16 w001A) (1C int32 dw001C) (1E word16 w001E) (20 Eq_6 t0020) (22 word16 w0022) (24 word32 dw0024) (26 word16 w0026) (28 ui32 dw0028) (2C uint32 dw002C) (30 ui32 dw0030) (54 uint32 dw0054) (58 uint32 dw0058) (5C uint32 dw005C))
 	T_636 (in r3 : (ptr32 Eq_636))
 	T_1002 (in r3 : (ptr32 Eq_636))
 	T_4038 (in r2_31 : (ptr32 Eq_636))
@@ -2753,10 +2753,6 @@ Eq_1480: (union "Eq_1480" (int32 u0) (uint32 u1))
 	T_1480 (in r14_28 >> 1<32> : word32)
 Eq_1512: (union "Eq_1512" (int32 u0) (uint32 u1))
 	T_1512 (in r14_28 >> 1<32> : word32)
-Eq_1809: (union "Eq_1809" (int32 u0) (up32 u1))
-	T_1809 (in r3 + 34<i32> : word32)
-Eq_1810: (union "Eq_1810" (int32 u0) (up32 u1))
-	T_1810 (in Mem2251[r3 + 34<i32>:word16] : word16)
 Eq_1922: (union "Eq_1922" (int32 u0) (uint32 u1))
 	T_1922 (in -1<i32> : int32)
 Eq_1934: (union "Eq_1934" (int32 u0) (uint32 u1))
@@ -2781,7 +2777,7 @@ Eq_2954: (union "Eq_2954" (int32 u0) (uint32 u1))
 	T_2954 (in r14_28 >> 1<32> : word32)
 Eq_2986: (union "Eq_2986" (int32 u0) (uint32 u1))
 	T_2986 (in r14_28 >> 1<32> : word32)
-Eq_3026: (struct "Eq_3026" (0 uint32 dw0000) (4 Eq_3339 t0004) (8 word32 dw0008) (10 Eq_3343 t0010) (14 Eq_3343 t0014) (16 word32 dw0016) (1C int32 dw001C) (24 int32 dw0024) (38 ui32 dw0038) (44 uint32 dw0044) (50 int32 dw0050) (54 word32 dw0054) (58 word32 dw0058) (5C Eq_3032 t005C))
+Eq_3026: (struct "Eq_3026" (0 uint32 dw0000) (4 Eq_3339 t0004) (8 word32 dw0008) (10 Eq_3343 t0010) (14 Eq_3343 t0014) (16 word16 w0016) (1C int32 dw001C) (24 int32 dw0024) (38 ui32 dw0038) (44 uint32 dw0044) (50 int32 dw0050) (54 word32 dw0054) (58 word32 dw0058) (5C Eq_3032 t005C))
 	T_3026 (in r3 : (ptr32 Eq_3026))
 	T_3083 (in r3 : (ptr32 Eq_3026))
 	T_3191 (in r3 : (ptr32 Eq_3026))
@@ -3246,7 +3242,7 @@ Eq_3343: (union "Eq_3343" (int32 u0) (uint32 u1) (ptr32 u2))
 	T_5388 (in r14_91 : Eq_3343)
 	T_5391 (in Mem13[r2_71 + 20<i32>:word32] : word32)
 	T_5392 (in 0<i32> : int32)
-	T_5498 (in r11_94 << 0x10<32> | (word32) r2_71->dw0016 : word32)
+	T_5498 (in r11_94 << 0x10<32> | (word32) r2_71->w0016 : word32)
 	T_5501 (in Mem105[r2_71 + 20<i32>:word32] : word32)
 	T_5651 (in r18 : Eq_3343)
 	T_15228 (in r18_1762 : Eq_3343)
@@ -12661,12 +12657,12 @@ T_1796: (in 26<i32> : int32)
   OrigDataType: int32
 T_1797: (in r3 + 26<i32> : word32)
   Class: Eq_1797
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_1798: (in Mem2237[r3 + 26<i32>:word16] : word16)
   Class: Eq_1798
-  DataType: int32
-  OrigDataType: int32
+  DataType: word16
+  OrigDataType: word16
 T_1799: (in (word32) Mem2237[r3 + 26<i32>:word16] : word32)
   Class: Eq_1799
   DataType: word32
@@ -12685,12 +12681,12 @@ T_1802: (in 30<i32> : int32)
   OrigDataType: int32
 T_1803: (in r3 + 30<i32> : word32)
   Class: Eq_1803
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_1804: (in Mem2247[r3 + 30<i32>:word16] : word16)
   Class: Eq_1804
-  DataType: word32
-  OrigDataType: word32
+  DataType: word16
+  OrigDataType: word16
 T_1805: (in (word32) Mem2247[r3 + 30<i32>:word16] : word32)
   Class: Eq_1805
   DataType: word32
@@ -12709,12 +12705,12 @@ T_1808: (in 34<i32> : int32)
   OrigDataType: int32
 T_1809: (in r3 + 34<i32> : word32)
   Class: Eq_1809
-  DataType: (ptr32 Eq_1809)
-  OrigDataType: (ptr32 (union (int32 u0) (up32 u1)))
+  DataType: ptr32
+  OrigDataType: ptr32
 T_1810: (in Mem2251[r3 + 34<i32>:word16] : word16)
   Class: Eq_1810
-  DataType: Eq_1810
-  OrigDataType: (union (int32 u0) (up32 u1))
+  DataType: word16
+  OrigDataType: word16
 T_1811: (in (word32) Mem2251[r3 + 34<i32>:word16] : word32)
   Class: Eq_1811
   DataType: word32
@@ -12733,12 +12729,12 @@ T_1814: (in 38<i32> : int32)
   OrigDataType: int32
 T_1815: (in r3 + 38<i32> : word32)
   Class: Eq_1815
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_1816: (in Mem2255[r3 + 38<i32>:word16] : word16)
   Class: Eq_1816
-  DataType: word32
-  OrigDataType: word32
+  DataType: word16
+  OrigDataType: word16
 T_1817: (in (word32) Mem2255[r3 + 38<i32>:word16] : word32)
   Class: Eq_1817
   DataType: word32
@@ -27453,17 +27449,17 @@ T_5494: (in 22<i32> : int32)
   OrigDataType: int32
 T_5495: (in r2_71 + 22<i32> : word32)
   Class: Eq_5495
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_5496: (in Mem13[r2_71 + 22<i32>:word16] : word16)
   Class: Eq_5496
-  DataType: word32
-  OrigDataType: word32
+  DataType: word16
+  OrigDataType: word16
 T_5497: (in (word32) Mem13[r2_71 + 22<i32>:word16] : word32)
   Class: Eq_5497
   DataType: ui32
   OrigDataType: ui32
-T_5498: (in r11_94 << 0x10<32> | (word32) r2_71->dw0016 : word32)
+T_5498: (in r11_94 << 0x10<32> | (word32) r2_71->w0016 : word32)
   Class: Eq_3343
   DataType: Eq_3343
   OrigDataType: ui32
@@ -78270,13 +78266,13 @@ typedef struct Eq_636 {
 	uint32 dw000C;	// C
 	ui32 dw0014;	// 14
 	Eq_1072 t0018;	// 18
-	int32 dw001A;	// 1A
+	word16 w001A;	// 1A
 	int32 dw001C;	// 1C
-	word32 dw001E;	// 1E
+	word16 w001E;	// 1E
 	Eq_6 t0020;	// 20
-	Eq_1810 t0022;	// 22
+	word16 w0022;	// 22
 	word32 dw0024;	// 24
-	word32 dw0026;	// 26
+	word16 w0026;	// 26
 	ui32 dw0028;	// 28
 	uint32 dw002C;	// 2C
 	ui32 dw0030;	// 30
@@ -78363,16 +78359,6 @@ typedef union Eq_1512 {
 	uint32 u1;
 } Eq_1512;
 
-typedef union Eq_1809 {
-	int32 u0;
-	up32 u1;
-} Eq_1809;
-
-typedef union Eq_1810 {
-	int32 u0;
-	up32 u1;
-} Eq_1810;
-
 typedef union Eq_1922 {
 	int32 u0;
 	uint32 u1;
@@ -78439,7 +78425,7 @@ typedef struct Eq_3026 {
 	word32 dw0008;	// 8
 	Eq_3343 t0010;	// 10
 	Eq_3343 t0014;	// 14
-	word32 dw0016;	// 16
+	word16 w0016;	// 16
 	int32 dw001C;	// 1C
 	int32 dw0024;	// 24
 	ui32 dw0038;	// 38

--- a/subjects/PDP-11/spcinv.reko/spcinv.h
+++ b/subjects/PDP-11/spcinv.reko/spcinv.h
@@ -3786,8 +3786,8 @@ T_761: (in 1<16> : word16)
   OrigDataType: word16
 T_762: (in sp_206 + 1<16> : word16)
   Class: Eq_762
-  DataType: (ptr16 word16)
-  OrigDataType: (ptr16 word16)
+  DataType: ptr16
+  OrigDataType: ptr16
 T_763: (in Mem209[sp_206 + 1<16>:byte] : byte)
   Class: Eq_599
   DataType: Eq_599

--- a/subjects/PE/PPC/hello_ppc.reko/hello_ppc.h
+++ b/subjects/PE/PPC/hello_ppc.reko/hello_ppc.h
@@ -324,7 +324,7 @@ Eq_2: (union "Eq_2" ((ptr32 Eq_5628) u0) ((ptr32 Eq_5629) u1))
 	T_5143 (in r2 : Eq_2)
 	T_5233 (in fn00402404(r2, r29_22, *((word32) r2 + 348<i32>), r31_62, out r29_68, out r30_70) : word32)
 	T_5238 (in fn00400220(fn00402404(r2, r29_22, *((word32) r2 + 348<i32>), r31_62, out r29_68, out r30_70), r13, r14, r15, r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28, r29_68, r30_70, r31_62, lr, out r3_132, out r29_131, out r30_133, out r31_134) : word32)
-Eq_17: (union "Eq_17" (byte u0) ((ptr32 Eq_5631) u1) ((arr Eq_17) u2) (Eq_5632 u3))
+Eq_17: (union "Eq_17" (byte u0) ((ptr32 (arr byte)) u1) ((ptr32 Eq_5631) u2) ((arr Eq_17) u3) (Eq_5632 u4))
 	T_17 (in r27 : Eq_17)
 	T_18 (in r28 : Eq_17)
 	T_19 (in r29 : Eq_17)
@@ -1483,7 +1483,7 @@ Eq_2359: (fn void (Eq_2))
 	T_2360 (in signature of fn00404134 : void)
 Eq_2524: (struct "Eq_2524" (0 ptr32 ptr0000) (4 ptr32 ptr0004) (8 (ptr32 Eq_1096) ptr0008))
 	T_2524 (in v5 : word32)
-Eq_2574: (struct "Eq_2574" (FFFFFFA0 (arr Eq_5550) aFFFFFFA0))
+Eq_2574: (struct "Eq_2574" (FFFFFFA0 (arr (arr Eq_5550)) aFFFFFFA0))
 	T_2574 (in fp : ptr32)
 	T_2608 (in 0xFFFFFFA0<32> : word32)
 	T_2656 (in 0xFFFFFFA0<32> : word32)
@@ -1494,7 +1494,7 @@ Eq_2652: (fn void (Eq_2))
 	T_2652 (in fn00403F3C : ptr32)
 	T_2653 (in signature of fn00403F3C : void)
 	T_5015 (in fn00403F3C : ptr32)
-Eq_2659: (fn void (Eq_2, Eq_2662))
+Eq_2659: (fn void (Eq_2, (ptr32 (arr (arr Eq_5550)))))
 	T_2659 (in fn00403104 : ptr32)
 	T_2660 (in signature of fn00403104 : void)
 	T_2762 (in fn00403104 : ptr32)
@@ -1502,30 +1502,6 @@ Eq_2659: (fn void (Eq_2, Eq_2662))
 	T_4883 (in fn00403104 : ptr32)
 	T_4973 (in fn00403104 : ptr32)
 	T_4980 (in fn00403104 : ptr32)
-Eq_2662: (union "Eq_2662" (int32 u0) (ptr32 u1))
-	T_2662 (in r3 : Eq_2662)
-	T_2663 (in fp + 0xFFFFFFA0<32> : word32)
-	T_2717 (in r3_66 : Eq_2662)
-	T_2749 (in (int32) (int16) r31_78 : int32)
-	T_2750 (in 0<32> : word32)
-	T_2759 (in (int32) Mem82[r31_78 + 2<i32>:int16] : int32)
-	T_2760 (in 0<32> : word32)
-	T_2775 (in fp + 0xFFFFFFA0<32> : word32)
-	T_3091 (in r3_130 : Eq_2662)
-	T_3094 (in 0<32> : word32)
-	T_3149 (in fp + 0xFFFFFF98<32> : word32)
-	T_3151 (in 0<32> : word32)
-	T_3191 (in fp + 0xFFFFFF98<32> : word32)
-	T_3231 (in fp + 0xFFFFFF98<32> : word32)
-	T_3269 (in fp + 0xFFFFFF98<32> : word32)
-	T_3304 (in fp + 0xFFFFFF98<32> : word32)
-	T_3305 (in 0<32> : word32)
-	T_4884 (in fp + 0xFFFFFFA0<32> : word32)
-	T_4907 (in r3_130 : Eq_2662)
-	T_4908 (in 0<32> : word32)
-	T_4970 (in 0<32> : word32)
-	T_4983 (in fp + 0xFFFFFFA0<32> : word32)
-	T_5017 (in fp + 0xFFFFFFA0<32> : word32)
 Eq_2673: (struct "Eq_2673" (0 (ptr32 Eq_189) ptr0000) (4 (ptr32 Eq_189) ptr0004) (8 Eq_17 t0008))
 	T_2673 (in v11 : word32)
 Eq_2726: (struct "Eq_2726" (2 int16 w0002) (4 (ptr32 Eq_2733) ptr0004) (C (ptr32 Eq_189) ptr000C) (10 Eq_17 t0010))
@@ -1615,7 +1591,7 @@ Eq_3004: (struct "Eq_3004" (0 (ptr32 Eq_2843) ptr0000) (4 (ptr32 word32) ptr0004
 	T_3004 (in v3 : word32)
 Eq_3033: (struct "Eq_3033" (0 ptr32 ptr0000) (4 Eq_17 t0004) (8 (ptr32 Eq_189) ptr0008) (C (ptr32 Eq_189) ptr000C) (10 (ptr32 Eq_189) ptr0010) (14 Eq_17 t0014))
 	T_3033 (in v3 : word32)
-Eq_3115: (struct "Eq_3115" (FFFFFF98 (arr Eq_5567) aFFFFFF98))
+Eq_3115: (struct "Eq_3115" (FFFFFF98 (arr (arr Eq_5550)) aFFFFFF98))
 	T_3115 (in fp : ptr32)
 	T_3192 (in 0xFFFFFFBF<32> : word32)
 	T_3232 (in 0xFFFFFF98<32> : word32)
@@ -1765,7 +1741,7 @@ Eq_4739: (struct "Eq_4739" 0001 (0 Eq_5634 t0000))
 	T_5603
 Eq_4743: (struct "Eq_4743" (0 (ptr32 Eq_87) ptr0000) (4 ptr32 ptr0004) (8 Eq_17 t0008))
 	T_4743 (in v9 : word32)
-Eq_4787: (struct "Eq_4787" (FFFFFEA0 (arr byte) aFFFFFEA0) (FFFFFFA0 (arr Eq_5606) aFFFFFFA0))
+Eq_4787: (struct "Eq_4787" (FFFFFEA0 (arr byte) aFFFFFEA0) (FFFFFFA0 (arr (arr Eq_5550)) aFFFFFFA0))
 	T_4787 (in fp : ptr32)
 	T_4837 (in 0xFFFFFFA0<32> : word32)
 	T_4839 (in 0xFFFFFFA0<32> : word32)
@@ -1780,7 +1756,7 @@ Eq_4894: (struct "Eq_4894" (0 ptr32 ptr0000) (4 word32 dw0004) (8 word32 dw0008)
 Eq_4955: (fn void (Eq_2))
 	T_4955 (in fn00403F24 : ptr32)
 	T_4956 (in signature of fn00403F24 : void)
-Eq_4959: (struct "Eq_4959" (FFFFFFA0 (arr Eq_5622) aFFFFFFA0))
+Eq_4959: (struct "Eq_4959" (FFFFFFA0 (arr (arr Eq_5550)) aFFFFFFA0))
 	T_4959 (in fp : ptr32)
 	T_4960 (in 0xFFFFFFA0<32> : word32)
 Eq_5030: (struct "Eq_5030" (0 word32 dw0000) (4 word32 dw0004) (8 word32 dw0008) (C ui32 dw000C))
@@ -1835,7 +1811,6 @@ Eq_5550: (struct "Eq_5550" 0001 (0 word32 dw0000))
 	T_5556
 	T_5558
 	T_5560
-Eq_5567: (struct "Eq_5567" 0001 (0 word32 dw0000))
 	T_5567
 	T_5569
 	T_5571
@@ -1851,19 +1826,17 @@ Eq_5567: (struct "Eq_5567" 0001 (0 word32 dw0000))
 	T_5591
 	T_5593
 	T_5595
-Eq_5597: (struct "Eq_5597" 0004 (0 word16 w0000))
-	T_5597
-Eq_5606: (struct "Eq_5606" 0001 (0 word32 dw0000))
 	T_5606
 	T_5608
 	T_5610
 	T_5612
 	T_5614
 	T_5616
-Eq_5622: (struct "Eq_5622" 0001 (0 word32 dw0000))
 	T_5622
 	T_5624
 	T_5626
+Eq_5597: (struct "Eq_5597" 0004 (0 word16 w0000))
+	T_5597
 Eq_5628: (struct "Eq_5628" 0001 (0 int32 dw0000) (C ui32 dw000C) (48 word32 dw0048) (6C word32 dw006C))
 	T_5628
 Eq_5629: (struct "Eq_5629" 0010 (0 (ptr32 (ptr32 (arr Eq_1902))) ptr0000) (4 ui32 dw0004) (8 Eq_17 t0008) (C ui32 dw000C) (44 (ptr32 byte) ptr0044) (48 (ptr32 Eq_76) ptr0048) (4C (ptr32 word32) ptr004C) (50 (ptr32 (arr Eq_17)) ptr0050) (54 (ptr32 Eq_457) ptr0054) (58 (ptr32 (ptr32 (arr word16))) ptr0058) (64 (ptr32 word32) ptr0064) (68 (ptr32 Eq_972) ptr0068) (70 (ptr32 byte) ptr0070) (74 (ptr32 (ptr32 Eq_189)) ptr0074) (78 (ptr32 (arr Eq_1376)) ptr0078) (7C (ptr32 word32) ptr007C) (80 (ptr32 (ptr32 (ptr32 code))) ptr0080) (8C word32 dw008C) (90 (ptr32 word32) ptr0090) (94 word32 dw0094) (98 (ptr32 (ptr32 word16)) ptr0098) (9C (ptr32 (arr (ptr32 Eq_2726))) ptr009C) (A4 (ptr32 int32) ptr00A4) (A8 (ptr32 (ptr32 (ptr32 code))) ptr00A8) (AC (ptr32 (ptr32 (ptr32 code))) ptr00AC) (B0 (ptr32 (ptr32 (ptr32 code))) ptr00B0) (B4 (ptr32 (ptr32 (ptr32 code))) ptr00B4) (B8 (ptr32 word32) ptr00B8) (BC (ptr32 (ptr32 (ptr32 (ptr32 code)))) ptr00BC) (C0 (ptr32 (ptr32 (ptr32 (ptr32 code)))) ptr00C0) (C4 (ptr32 (ptr32 (ptr32 code))) ptr00C4) (C8 (ptr32 (ptr32 (ptr32 code))) ptr00C8) (CC (ptr32 (ptr32 (ptr32 code))) ptr00CC) (D0 (ptr32 (ptr32 (ptr32 code))) ptr00D0) (D4 (ptr32 (ptr32 Eq_2988)) ptr00D4) (D8 (ptr32 byte) ptr00D8) (DC (ptr32 int32) ptr00DC) (E0 (ptr32 (ptr32 (ptr32 code))) ptr00E0) (E4 (ptr32 Eq_4062) ptr00E4) (E8 (ptr32 (ptr32 (ptr32 code))) ptr00E8) (EC (ptr32 Eq_4633) ptr00EC) (F0 (ptr32 ui32) ptr00F0) (F4 (ptr32 Eq_2914) ptr00F4) (F8 (ptr32 (ptr32 code)) ptr00F8) (FC (ptr32 (ptr32 code)) ptr00FC) (100 (ptr32 (ptr32 code)) ptr0100) (104 (ptr32 (ptr32 code)) ptr0104) (108 (ptr32 (ptr32 code)) ptr0108) (10C (ptr32 (ptr32 code)) ptr010C) (110 (ptr32 (ptr32 code)) ptr0110) (114 (ptr32 (ptr32 code)) ptr0114) (118 (ptr32 (ptr32 code)) ptr0118) (11C (ptr32 (ptr32 code)) ptr011C) (120 (ptr32 (ptr32 code)) ptr0120) (124 (ptr32 (ptr32 code)) ptr0124) (128 (ptr32 (ptr32 code)) ptr0128) (12C (ptr32 (ptr32 code)) ptr012C) (130 (ptr32 (ptr32 code)) ptr0130) (134 (ptr32 (ptr32 code)) ptr0134) (138 (ptr32 (ptr32 code)) ptr0138) (13C (ptr32 (ptr32 code)) ptr013C) (140 (ptr32 (ptr32 code)) ptr0140) (144 (ptr32 (ptr32 code)) ptr0144) (148 (ptr32 (ptr32 code)) ptr0148) (14C (ptr32 (ptr32 code)) ptr014C) (150 (ptr32 (ptr32 code)) ptr0150) (154 (ptr32 word32) ptr0154) (158 (ptr32 Eq_2843) ptr0158) (15C (ptr32 word32) ptr015C) (160 (ptr32 ptr32) ptr0160))
@@ -12225,8 +12198,8 @@ T_2586: (in 0<32> : word32)
   OrigDataType: word32
 T_2587: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_2587
-  DataType: (ptr32 (arr Eq_5550))
-  OrigDataType: (ptr32 (struct (0 (arr T_5552) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_2588: (in 4<32> : word32)
   Class: Eq_2588
   DataType: word32
@@ -12249,8 +12222,8 @@ T_2592: (in 0<32> : word32)
   OrigDataType: word32
 T_2593: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_2593
-  DataType: (ptr32 (arr Eq_5550))
-  OrigDataType: (ptr32 (struct (0 (arr T_5554) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_2594: (in 8<32> : word32)
   Class: Eq_2594
   DataType: word32
@@ -12373,8 +12346,8 @@ T_2623: (in 0<32> : word32)
   OrigDataType: word32
 T_2624: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_2624
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_2625: (in fp + 0xFFFFFFA0<32> + r11_100 : word32)
   Class: Eq_2625
   DataType: (ptr32 word32)
@@ -12401,8 +12374,8 @@ T_2630: (in 0<32> : word32)
   OrigDataType: word32
 T_2631: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_2631
-  DataType: (ptr32 (arr Eq_5550))
-  OrigDataType: (ptr32 (struct (0 (arr T_5556) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_2632: (in fp + 0xFFFFFFA0<32> + r11_102 : word32)
   Class: Eq_2632
   DataType: (ptr32 word32)
@@ -12417,8 +12390,8 @@ T_2634: (in 0<32> : word32)
   OrigDataType: word32
 T_2635: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_2635
-  DataType: (ptr32 (arr Eq_5550))
-  OrigDataType: (ptr32 (struct (0 (arr T_5558) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_2636: (in 4<32> : word32)
   Class: Eq_2636
   DataType: word32
@@ -12441,8 +12414,8 @@ T_2640: (in 0<32> : word32)
   OrigDataType: word32
 T_2641: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_2641
-  DataType: (ptr32 (arr Eq_5550))
-  OrigDataType: (ptr32 (struct (0 (arr T_5560) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_2642: (in 8<32> : word32)
   Class: Eq_2642
   DataType: word32
@@ -12523,15 +12496,15 @@ T_2661: (in r2 : Eq_2)
   Class: Eq_2
   DataType: Eq_2
   OrigDataType: (ptr32 (struct (7C T_4086 t007C) (A4 T_4071 t00A4) (E4 T_4065 t00E4)))
-T_2662: (in r3 : Eq_2662)
+T_2662: (in r3 : (ptr32 (arr (arr Eq_5550))))
   Class: Eq_2662
-  DataType: Eq_2662
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: word32
 T_2663: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_2662
-  DataType: Eq_2662
-  OrigDataType: ptr32
-T_2664: (in fn00403104(dwLoc84, &fp->aFFFFFFA0->dw0000) : void)
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
+T_2664: (in fn00403104(dwLoc84, fp + 0xFFFFFFA0<32>) : void)
   Class: Eq_2664
   DataType: void
   OrigDataType: void
@@ -12743,10 +12716,10 @@ T_2716: (in (r11_125 & 0x10<32>) != 0<32> : bool)
   Class: Eq_2716
   DataType: bool
   OrigDataType: bool
-T_2717: (in r3_66 : Eq_2662)
+T_2717: (in r3_66 : (ptr32 (arr (arr Eq_5550))))
   Class: Eq_2662
-  DataType: Eq_2662
-  OrigDataType: int32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (union ((ptr32 (arr (arr Eq_5550))) u0) (ptr32 u1))
 T_2718: (in 0x40<32> : word32)
   Class: Eq_2718
   DataType: ui32
@@ -12873,13 +12846,13 @@ T_2748: (in (int16) r31_78 : int16)
   OrigDataType: int16
 T_2749: (in (int32) (int16) r31_78 : int32)
   Class: Eq_2662
-  DataType: Eq_2662
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: int32
 T_2750: (in 0<32> : word32)
   Class: Eq_2662
-  DataType: int32
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: word32
-T_2751: (in r3_66 == 0<32> : bool)
+T_2751: (in r3_66 == null : bool)
   Class: Eq_2751
   DataType: bool
   OrigDataType: bool
@@ -12913,13 +12886,13 @@ T_2758: (in Mem82[r31_78 + 2<i32>:int16] : int16)
   OrigDataType: int16
 T_2759: (in (int32) Mem82[r31_78 + 2<i32>:int16] : int32)
   Class: Eq_2662
-  DataType: Eq_2662
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: int32
 T_2760: (in 0<32> : word32)
   Class: Eq_2662
-  DataType: int32
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: word32
-T_2761: (in r3_66 != 0<32> : bool)
+T_2761: (in r3_66 != null : bool)
   Class: Eq_2761
   DataType: bool
   OrigDataType: bool
@@ -12977,7 +12950,7 @@ T_2774: (in 0xFFFFFFA0<32> : word32)
   OrigDataType: int32
 T_2775: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_2662
-  DataType: Eq_2662
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: ptr32
 T_2776: (in dwLoc38 : word32)
   Class: Eq_1225
@@ -14239,10 +14212,10 @@ T_3090: (in (r11_39 & 0x40<32>) != 0<32> : bool)
   Class: Eq_3090
   DataType: bool
   OrigDataType: bool
-T_3091: (in r3_130 : Eq_2662)
+T_3091: (in r3_130 : (ptr32 (arr (arr Eq_5550))))
   Class: Eq_2662
-  DataType: Eq_2662
-  OrigDataType: (ptr32 Eq_3115)
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr T_5567) a0000))))
 T_3092: (in 0<32> : word32)
   Class: Eq_1699
   DataType: word32
@@ -14253,7 +14226,7 @@ T_3093: (in r5 == 0<32> : bool)
   OrigDataType: bool
 T_3094: (in 0<32> : word32)
   Class: Eq_2662
-  DataType: int32
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: word32
 T_3095: (in 1<32> : word32)
   Class: Eq_1699
@@ -14368,29 +14341,29 @@ T_3122: (in r11_108 + 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_3123: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3124: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3124
-  DataType: (ptr32 (arr Eq_5567))
+  DataType: (ptr32 (arr Eq_5550))
   OrigDataType: (ptr32 (struct (0 (arr T_5567) a0000)))
 T_3125: (in fp + 0xFFFFFF98<32> + r11_116 : word32)
   Class: Eq_3125
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3126 t0000)))
 T_3126: (in Mem117[fp + 0xFFFFFF98<32> + r11_116:word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3127: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3128: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3128
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5569) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3129: (in 4<32> : word32)
   Class: Eq_3129
   DataType: word32
@@ -14404,17 +14377,17 @@ T_3131: (in fp + 0xFFFFFF98<32> + (r11_116 + 4<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3132 t0000)))
 T_3132: (in Mem119[fp + 0xFFFFFF98<32> + (r11_116 + 4<32>):word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3133: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3134: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3134
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5571) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3135: (in 8<32> : word32)
   Class: Eq_3135
   DataType: word32
@@ -14428,7 +14401,7 @@ T_3137: (in fp + 0xFFFFFF98<32> + (r11_116 + 8<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3138 t0000)))
 T_3138: (in Mem121[fp + 0xFFFFFF98<32> + (r11_116 + 8<32>):word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3139: (in 0xC<32> : word32)
@@ -14473,17 +14446,17 @@ T_3148: (in fn00403FFC(r2) : void)
   OrigDataType: void
 T_3149: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_2662
-  DataType: Eq_2662
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3150: (in dwLoc8C : word32)
   Class: Eq_2
   DataType: Eq_2
   OrigDataType: word32
 T_3151: (in 0<32> : word32)
   Class: Eq_2662
-  DataType: int32
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: word32
-T_3152: (in r3_130 == 0<32> : bool)
+T_3152: (in r3_130 == null : bool)
   Class: Eq_3152
   DataType: bool
   OrigDataType: bool
@@ -14513,8 +14486,8 @@ T_3158: (in 0xFFFFFF98<32> : word32)
   OrigDataType: int32
 T_3159: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3159
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3160: (in fp + 0xFFFFFF98<32> + r11_147 : word32)
   Class: Eq_3160
   DataType: (ptr32 word32)
@@ -14536,29 +14509,29 @@ T_3164: (in r11_147 + 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_3165: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3166: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3166
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5573) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3167: (in fp + 0xFFFFFF98<32> + r11_154 : word32)
   Class: Eq_3167
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3168 t0000)))
 T_3168: (in Mem155[fp + 0xFFFFFF98<32> + r11_154:word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3169: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3170: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3170
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5575) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3171: (in 4<32> : word32)
   Class: Eq_3171
   DataType: word32
@@ -14572,17 +14545,17 @@ T_3173: (in fp + 0xFFFFFF98<32> + (r11_154 + 4<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3174 t0000)))
 T_3174: (in Mem157[fp + 0xFFFFFF98<32> + (r11_154 + 4<32>):word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3175: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3176: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3176
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5577) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3177: (in 8<32> : word32)
   Class: Eq_3177
   DataType: word32
@@ -14596,7 +14569,7 @@ T_3179: (in fp + 0xFFFFFF98<32> + (r11_154 + 8<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3180 t0000)))
 T_3180: (in Mem159[fp + 0xFFFFFF98<32> + (r11_154 + 8<32>):word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3181: (in 0xC<32> : word32)
@@ -14641,8 +14614,8 @@ T_3190: (in fn00404014(r2) : void)
   OrigDataType: void
 T_3191: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_2662
-  DataType: Eq_2662
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3192: (in 0xFFFFFFBF<32> : word32)
   Class: Eq_3115
   DataType: (ptr32 Eq_3115)
@@ -14673,8 +14646,8 @@ T_3198: (in 0<32> : word32)
   OrigDataType: word32
 T_3199: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3199
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3200: (in fp + 0xFFFFFF98<32> + r11_187 : word32)
   Class: Eq_3200
   DataType: (ptr32 word32)
@@ -14696,29 +14669,29 @@ T_3204: (in r11_187 + 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_3205: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3206: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3206
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5579) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3207: (in fp + 0xFFFFFF98<32> + r11_194 : word32)
   Class: Eq_3207
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3208 t0000)))
 T_3208: (in Mem195[fp + 0xFFFFFF98<32> + r11_194:word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3209: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3210: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3210
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5581) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3211: (in 4<32> : word32)
   Class: Eq_3211
   DataType: word32
@@ -14732,17 +14705,17 @@ T_3213: (in fp + 0xFFFFFF98<32> + (r11_194 + 4<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3214 t0000)))
 T_3214: (in Mem197[fp + 0xFFFFFF98<32> + (r11_194 + 4<32>):word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3215: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3216: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3216
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5583) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3217: (in 8<32> : word32)
   Class: Eq_3217
   DataType: word32
@@ -14756,7 +14729,7 @@ T_3219: (in fp + 0xFFFFFF98<32> + (r11_194 + 8<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3220 t0000)))
 T_3220: (in Mem199[fp + 0xFFFFFF98<32> + (r11_194 + 8<32>):word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3221: (in 0xC<32> : word32)
@@ -14801,8 +14774,8 @@ T_3230: (in fn0040402C(dwLoc8C) : void)
   OrigDataType: void
 T_3231: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_2662
-  DataType: Eq_2662
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3232: (in 0xFFFFFF98<32> : word32)
   Class: Eq_3115
   DataType: (ptr32 Eq_3115)
@@ -14833,8 +14806,8 @@ T_3238: (in 0<32> : word32)
   OrigDataType: word32
 T_3239: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3239
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3240: (in fp + 0xFFFFFF98<32> + r11_219 : word32)
   Class: Eq_3240
   DataType: (ptr32 word32)
@@ -14856,29 +14829,29 @@ T_3244: (in r11_219 + 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_3245: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3246: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3246
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5585) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3247: (in fp + 0xFFFFFF98<32> + r11_226 : word32)
   Class: Eq_3247
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3248 t0000)))
 T_3248: (in Mem227[fp + 0xFFFFFF98<32> + r11_226:word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3249: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3250: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3250
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5587) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3251: (in 4<32> : word32)
   Class: Eq_3251
   DataType: word32
@@ -14892,17 +14865,17 @@ T_3253: (in fp + 0xFFFFFF98<32> + (r11_226 + 4<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3254 t0000)))
 T_3254: (in Mem229[fp + 0xFFFFFF98<32> + (r11_226 + 4<32>):word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3255: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3256: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3256
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5589) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3257: (in 8<32> : word32)
   Class: Eq_3257
   DataType: word32
@@ -14916,7 +14889,7 @@ T_3259: (in fp + 0xFFFFFF98<32> + (r11_226 + 8<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3260 t0000)))
 T_3260: (in Mem231[fp + 0xFFFFFF98<32> + (r11_226 + 8<32>):word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3261: (in 0xC<32> : word32)
@@ -14953,8 +14926,8 @@ T_3268: (in fn00404014(dwLoc8C) : void)
   OrigDataType: void
 T_3269: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_2662
-  DataType: Eq_2662
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3270: (in 0<32> : word32)
   Class: Eq_3270
   DataType: word32
@@ -14965,8 +14938,8 @@ T_3271: (in 0xFFFFFF98<32> : word32)
   OrigDataType: int32
 T_3272: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3272
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3273: (in fp + 0xFFFFFF98<32> + r11_71 : word32)
   Class: Eq_3273
   DataType: (ptr32 word32)
@@ -14988,29 +14961,29 @@ T_3277: (in r11_71 + 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_3278: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3279: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3279
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5591) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3280: (in fp + 0xFFFFFF98<32> + r11_79 : word32)
   Class: Eq_3280
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3281 t0000)))
 T_3281: (in Mem80[fp + 0xFFFFFF98<32> + r11_79:word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3282: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3283: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3283
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5593) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3284: (in 4<32> : word32)
   Class: Eq_3284
   DataType: word32
@@ -15024,17 +14997,17 @@ T_3286: (in fp + 0xFFFFFF98<32> + (r11_79 + 4<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3287 t0000)))
 T_3287: (in Mem82[fp + 0xFFFFFF98<32> + (r11_79 + 4<32>):word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3288: (in 0<32> : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3289: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_3289
-  DataType: (ptr32 (arr Eq_5567))
-  OrigDataType: (ptr32 (struct (0 (arr T_5595) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3290: (in 8<32> : word32)
   Class: Eq_3290
   DataType: word32
@@ -15048,7 +15021,7 @@ T_3292: (in fp + 0xFFFFFF98<32> + (r11_79 + 8<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_3293 t0000)))
 T_3293: (in Mem84[fp + 0xFFFFFF98<32> + (r11_79 + 8<32>):word32] : word32)
-  Class: Eq_3123
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_3294: (in 0xC<32> : word32)
@@ -15093,13 +15066,13 @@ T_3303: (in fn00403FE4(r2) : void)
   OrigDataType: void
 T_3304: (in fp + 0xFFFFFF98<32> : word32)
   Class: Eq_2662
-  DataType: Eq_2662
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_3305: (in 0<32> : word32)
   Class: Eq_2662
-  DataType: int32
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: word32
-T_3306: (in r3_130 != 0<32> : bool)
+T_3306: (in r3_130 != null : bool)
   Class: Eq_3306
   DataType: bool
   OrigDataType: bool
@@ -21066,7 +21039,7 @@ T_4796: (in fn004032AC : ptr32)
 T_4797: (in fp + 0xFFFFFEA0<32> : word32)
   Class: Eq_17
   DataType: Eq_17
-  OrigDataType: ptr32
+  OrigDataType: (ptr32 (arr T_5604))
 T_4798: (in fn004032AC(fp->aFFFFFEA0) : void)
   Class: Eq_3633
   DataType: void
@@ -21120,29 +21093,29 @@ T_4810: (in r11_72 + 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_4811: (in 0<32> : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4812: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_4812
-  DataType: (ptr32 (arr Eq_5606))
+  DataType: (ptr32 (arr Eq_5550))
   OrigDataType: (ptr32 (struct (0 (arr T_5606) a0000)))
 T_4813: (in fp + 0xFFFFFFA0<32> + r11_80 : word32)
   Class: Eq_4813
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_4814 t0000)))
 T_4814: (in Mem81[fp + 0xFFFFFFA0<32> + r11_80:word32] : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4815: (in 0<32> : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4816: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_4816
-  DataType: (ptr32 (arr Eq_5606))
-  OrigDataType: (ptr32 (struct (0 (arr T_5608) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_4817: (in 4<32> : word32)
   Class: Eq_4817
   DataType: word32
@@ -21156,17 +21129,17 @@ T_4819: (in fp + 0xFFFFFFA0<32> + (r11_80 + 4<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_4820 t0000)))
 T_4820: (in Mem83[fp + 0xFFFFFFA0<32> + (r11_80 + 4<32>):word32] : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4821: (in 0<32> : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4822: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_4822
-  DataType: (ptr32 (arr Eq_5606))
-  OrigDataType: (ptr32 (struct (0 (arr T_5610) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_4823: (in 8<32> : word32)
   Class: Eq_4823
   DataType: word32
@@ -21180,7 +21153,7 @@ T_4825: (in fp + 0xFFFFFFA0<32> + (r11_80 + 8<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_4826 t0000)))
 T_4826: (in Mem85[fp + 0xFFFFFFA0<32> + (r11_80 + 8<32>):word32] : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4827: (in 0xC<32> : word32)
@@ -21261,8 +21234,8 @@ T_4845: (in 0<32> : word32)
   OrigDataType: word32
 T_4846: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_4846
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_4847: (in fp + 0xFFFFFFA0<32> + r11_101 : word32)
   Class: Eq_4847
   DataType: (ptr32 word32)
@@ -21284,29 +21257,29 @@ T_4851: (in r11_101 + 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_4852: (in 0<32> : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4853: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_4853
-  DataType: (ptr32 (arr Eq_5606))
-  OrigDataType: (ptr32 (struct (0 (arr T_5612) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_4854: (in fp + 0xFFFFFFA0<32> + r11_108 : word32)
   Class: Eq_4854
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_4855 t0000)))
 T_4855: (in Mem109[fp + 0xFFFFFFA0<32> + r11_108:word32] : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4856: (in 0<32> : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4857: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_4857
-  DataType: (ptr32 (arr Eq_5606))
-  OrigDataType: (ptr32 (struct (0 (arr T_5614) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_4858: (in 4<32> : word32)
   Class: Eq_4858
   DataType: word32
@@ -21320,17 +21293,17 @@ T_4860: (in fp + 0xFFFFFFA0<32> + (r11_108 + 4<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_4861 t0000)))
 T_4861: (in Mem111[fp + 0xFFFFFFA0<32> + (r11_108 + 4<32>):word32] : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4862: (in 0<32> : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4863: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_4863
-  DataType: (ptr32 (arr Eq_5606))
-  OrigDataType: (ptr32 (struct (0 (arr T_5616) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_4864: (in 8<32> : word32)
   Class: Eq_4864
   DataType: word32
@@ -21344,7 +21317,7 @@ T_4866: (in fp + 0xFFFFFFA0<32> + (r11_108 + 8<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_4867 t0000)))
 T_4867: (in Mem113[fp + 0xFFFFFFA0<32> + (r11_108 + 8<32>):word32] : word32)
-  Class: Eq_4811
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4868: (in 0xC<32> : word32)
@@ -21413,9 +21386,9 @@ T_4883: (in fn00403104 : ptr32)
   OrigDataType: (ptr32 (fn T_4885 (T_4877, T_4884)))
 T_4884: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_2662
-  DataType: Eq_2662
-  OrigDataType: ptr32
-T_4885: (in fn00403104(dwLoc0184, &fp->aFFFFFFA0->dw0000) : void)
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
+T_4885: (in fn00403104(dwLoc0184, fp + 0xFFFFFFA0<32>) : void)
   Class: Eq_2664
   DataType: void
   OrigDataType: void
@@ -21503,13 +21476,13 @@ T_4906: (in Mem20[v5 + 12<i32>:word32] : word32)
   Class: Eq_17
   DataType: Eq_17
   OrigDataType: word32
-T_4907: (in r3_130 : Eq_2662)
+T_4907: (in r3_130 : (ptr32 (arr (arr Eq_5550))))
   Class: Eq_2662
-  DataType: Eq_2662
-  OrigDataType: (ptr32 Eq_4959)
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_4908: (in 0<32> : word32)
   Class: Eq_2662
-  DataType: int32
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: word32
 T_4909: (in r4_8 <= r3 : bool)
   Class: Eq_4909
@@ -21757,9 +21730,9 @@ T_4969: (in Mem135[r28_32 + 0<32>:byte] : byte)
   OrigDataType: byte
 T_4970: (in 0<32> : word32)
   Class: Eq_2662
-  DataType: int32
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: word32
-T_4971: (in r3_130 == 0<32> : bool)
+T_4971: (in r3_130 == null : bool)
   Class: Eq_4971
   DataType: bool
   OrigDataType: bool
@@ -21809,9 +21782,9 @@ T_4982: (in 0xFFFFFFA0<32> : word32)
   OrigDataType: int32
 T_4983: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_2662
-  DataType: Eq_2662
+  DataType: (ptr32 (arr (arr Eq_5550)))
   OrigDataType: ptr32
-T_4984: (in fn00403104(dwLoc84, &fp->aFFFFFFA0->dw0000) : void)
+T_4984: (in fn00403104(dwLoc84, fp + 0xFFFFFFA0<32>) : void)
   Class: Eq_2664
   DataType: void
   OrigDataType: void
@@ -21848,29 +21821,29 @@ T_4992: (in r11_77 + 4<32> : word32)
   DataType: int32
   OrigDataType: int32
 T_4993: (in 0<32> : word32)
-  Class: Eq_4993
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4994: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_4994
-  DataType: (ptr32 (arr Eq_5622))
+  DataType: (ptr32 (arr Eq_5550))
   OrigDataType: (ptr32 (struct (0 (arr T_5622) a0000)))
 T_4995: (in fp + 0xFFFFFFA0<32> + r11_84 : word32)
   Class: Eq_4995
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_4996 t0000)))
 T_4996: (in Mem85[fp + 0xFFFFFFA0<32> + r11_84:word32] : word32)
-  Class: Eq_4993
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4997: (in 0<32> : word32)
-  Class: Eq_4993
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_4998: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_4998
-  DataType: (ptr32 (arr Eq_5622))
-  OrigDataType: (ptr32 (struct (0 (arr T_5624) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_4999: (in 4<32> : word32)
   Class: Eq_4999
   DataType: word32
@@ -21884,17 +21857,17 @@ T_5001: (in fp + 0xFFFFFFA0<32> + (r11_84 + 4<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_5002 t0000)))
 T_5002: (in Mem87[fp + 0xFFFFFFA0<32> + (r11_84 + 4<32>):word32] : word32)
-  Class: Eq_4993
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_5003: (in 0<32> : word32)
-  Class: Eq_4993
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_5004: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_5004
-  DataType: (ptr32 (arr Eq_5622))
-  OrigDataType: (ptr32 (struct (0 (arr T_5626) a0000)))
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_5005: (in 8<32> : word32)
   Class: Eq_5005
   DataType: word32
@@ -21908,7 +21881,7 @@ T_5007: (in fp + 0xFFFFFFA0<32> + (r11_84 + 8<32>) : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_5008 t0000)))
 T_5008: (in Mem89[fp + 0xFFFFFFA0<32> + (r11_84 + 8<32>):word32] : word32)
-  Class: Eq_4993
+  Class: Eq_2582
   DataType: word32
   OrigDataType: word32
 T_5009: (in 0xC<32> : word32)
@@ -21945,8 +21918,8 @@ T_5016: (in fn00403F3C(dwLoc84) : void)
   OrigDataType: void
 T_5017: (in fp + 0xFFFFFFA0<32> : word32)
   Class: Eq_2662
-  DataType: Eq_2662
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr (arr Eq_5550)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr Eq_5550) a0000))))
 T_5018: (in r11_9 : ui32)
   Class: Eq_5018
   DataType: ui32
@@ -24081,15 +24054,15 @@ T_5550:
   OrigDataType: (struct 0001 (0 T_2585 t0000))
 T_5551:
   Class: Eq_5551
-  DataType: (arr Eq_5550)
-  OrigDataType: (arr T_5550)
+  DataType: (arr (arr Eq_5550))
+  OrigDataType: (arr (struct (0 (arr Eq_5550) a0000)))
 T_5552:
   Class: Eq_5550
   DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_2591 t0000))
 T_5553:
   Class: Eq_5551
-  DataType: (arr Eq_5550)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5552)
 T_5554:
   Class: Eq_5550
@@ -24097,7 +24070,7 @@ T_5554:
   OrigDataType: (struct 0001 (0 T_2597 t0000))
 T_5555:
   Class: Eq_5551
-  DataType: (arr Eq_5550)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5554)
 T_5556:
   Class: Eq_5550
@@ -24105,7 +24078,7 @@ T_5556:
   OrigDataType: (struct 0001 (0 T_2633 t0000))
 T_5557:
   Class: Eq_5551
-  DataType: (arr Eq_5550)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5556)
 T_5558:
   Class: Eq_5550
@@ -24113,7 +24086,7 @@ T_5558:
   OrigDataType: (struct 0001 (0 T_2639 t0000))
 T_5559:
   Class: Eq_5551
-  DataType: (arr Eq_5550)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5558)
 T_5560:
   Class: Eq_5550
@@ -24121,7 +24094,7 @@ T_5560:
   OrigDataType: (struct 0001 (0 T_2645 t0000))
 T_5561:
   Class: Eq_5551
-  DataType: (arr Eq_5550)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5560)
 T_5562:
   Class: Eq_1376
@@ -24144,124 +24117,124 @@ T_5566:
   DataType: Eq_1376
   OrigDataType: (arr T_5565)
 T_5567:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3126 t0000))
 T_5568:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
-  OrigDataType: (arr T_5567)
+  DataType: (arr (arr Eq_5550))
+  OrigDataType: (arr (struct (0 (arr Eq_5550) a0000)))
 T_5569:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3132 t0000))
 T_5570:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5569)
 T_5571:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3138 t0000))
 T_5572:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5571)
 T_5573:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3168 t0000))
 T_5574:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5573)
 T_5575:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3174 t0000))
 T_5576:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5575)
 T_5577:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3180 t0000))
 T_5578:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5577)
 T_5579:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3208 t0000))
 T_5580:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5579)
 T_5581:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3214 t0000))
 T_5582:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5581)
 T_5583:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3220 t0000))
 T_5584:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5583)
 T_5585:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3248 t0000))
 T_5586:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5585)
 T_5587:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3254 t0000))
 T_5588:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5587)
 T_5589:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3260 t0000))
 T_5590:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5589)
 T_5591:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3281 t0000))
 T_5592:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5591)
 T_5593:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3287 t0000))
 T_5594:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5593)
 T_5595:
-  Class: Eq_5567
-  DataType: Eq_5567
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_3293 t0000))
 T_5596:
   Class: Eq_5568
-  DataType: (arr Eq_5567)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5595)
 T_5597:
   Class: Eq_5597
@@ -24300,52 +24273,52 @@ T_5605:
   DataType: (arr byte)
   OrigDataType: (arr T_5604)
 T_5606:
-  Class: Eq_5606
-  DataType: Eq_5606
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_4814 t0000))
 T_5607:
   Class: Eq_5607
-  DataType: (arr Eq_5606)
-  OrigDataType: (arr T_5606)
+  DataType: (arr (arr Eq_5550))
+  OrigDataType: (arr (struct (0 (arr Eq_5550) a0000)))
 T_5608:
-  Class: Eq_5606
-  DataType: Eq_5606
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_4820 t0000))
 T_5609:
   Class: Eq_5607
-  DataType: (arr Eq_5606)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5608)
 T_5610:
-  Class: Eq_5606
-  DataType: Eq_5606
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_4826 t0000))
 T_5611:
   Class: Eq_5607
-  DataType: (arr Eq_5606)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5610)
 T_5612:
-  Class: Eq_5606
-  DataType: Eq_5606
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_4855 t0000))
 T_5613:
   Class: Eq_5607
-  DataType: (arr Eq_5606)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5612)
 T_5614:
-  Class: Eq_5606
-  DataType: Eq_5606
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_4861 t0000))
 T_5615:
   Class: Eq_5607
-  DataType: (arr Eq_5606)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5614)
 T_5616:
-  Class: Eq_5606
-  DataType: Eq_5606
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_4867 t0000))
 T_5617:
   Class: Eq_5607
-  DataType: (arr Eq_5606)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5616)
 T_5618:
   Class: Eq_1376
@@ -24364,28 +24337,28 @@ T_5621:
   DataType: (ptr32 Eq_2726)
   OrigDataType: (struct 0004 (0 T_4965 t0000))
 T_5622:
-  Class: Eq_5622
-  DataType: Eq_5622
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_4996 t0000))
 T_5623:
   Class: Eq_5623
-  DataType: (arr Eq_5622)
-  OrigDataType: (arr T_5622)
+  DataType: (arr (arr Eq_5550))
+  OrigDataType: (arr (struct (0 (arr Eq_5550) a0000)))
 T_5624:
-  Class: Eq_5622
-  DataType: Eq_5622
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_5002 t0000))
 T_5625:
   Class: Eq_5623
-  DataType: (arr Eq_5622)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5624)
 T_5626:
-  Class: Eq_5622
-  DataType: Eq_5622
+  Class: Eq_5550
+  DataType: Eq_5550
   OrigDataType: (struct 0001 (0 T_5008 t0000))
 T_5627:
   Class: Eq_5623
-  DataType: (arr Eq_5622)
+  DataType: (arr (arr Eq_5550))
   OrigDataType: (arr T_5626)
 T_5628:
   Class: Eq_5628
@@ -24442,9 +24415,10 @@ typedef union Eq_2 {
 
 typedef union Eq_17 {
 	byte u0;
-	struct Eq_5631 * u1;
-	Eq_17 u2[];
-	Eq_5632 u3;
+	byte (* u1)[];
+	struct Eq_5631 * u2;
+	Eq_17 u3[];
+	Eq_5632 u4;
 } Eq_17;
 
 typedef Eq_2 (Eq_31)(Eq_2, byte *, word32, word32, word32, word32, word32, word32, word32, word32, word32, word32, word32, word32, ptr32, ptr32, Eq_17, Eq_17, Eq_17, Eq_17, ptr32 *, word32, ptr32, ptr32, ptr32);
@@ -24810,19 +24784,14 @@ typedef struct Eq_2524 {
 } Eq_2524;
 
 typedef struct Eq_2574 {
-	Eq_5550 aFFFFFFA0[];	// FFFFFFA0
+	Eq_5550 aFFFFFFA0[][];	// FFFFFFA0
 } Eq_2574;
 
 typedef void (Eq_2604)(Eq_2);
 
 typedef void (Eq_2652)(Eq_2);
 
-typedef void (Eq_2659)(Eq_2, Eq_2662);
-
-typedef union Eq_2662 {
-	int32 u0;
-	ptr32 u1;
-} Eq_2662;
+typedef void (Eq_2659)(Eq_2, Eq_5550[] *[]);
 
 typedef struct Eq_2673 {
 	struct Eq_189 * ptr0000;	// 0
@@ -24893,7 +24862,7 @@ typedef struct Eq_3033 {
 } Eq_3033;
 
 typedef struct Eq_3115 {
-	Eq_5567 aFFFFFF98[];	// FFFFFF98
+	Eq_5550 aFFFFFF98[][];	// FFFFFF98
 } Eq_3115;
 
 typedef void (Eq_3145)(Eq_2);
@@ -25068,7 +25037,7 @@ typedef struct Eq_4743 {
 
 typedef struct Eq_4787 {
 	byte aFFFFFEA0[];	// FFFFFEA0
-	Eq_5606 aFFFFFFA0[];	// FFFFFFA0
+	Eq_5550 aFFFFFFA0[][];	// FFFFFFA0
 } Eq_4787;
 
 typedef void (Eq_4833)(Eq_2);
@@ -25085,7 +25054,7 @@ typedef struct Eq_4894 {
 typedef void (Eq_4955)(Eq_2);
 
 typedef struct Eq_4959 {
-	Eq_5622 aFFFFFFA0[];	// FFFFFFA0
+	Eq_5550 aFFFFFFA0[][];	// FFFFFFA0
 } Eq_4959;
 
 typedef struct Eq_5030 {
@@ -25151,21 +25120,9 @@ typedef struct Eq_5550 {	// size: 1 1
 	word32 dw0000;	// 0
 } Eq_5550;
 
-typedef struct Eq_5567 {	// size: 1 1
-	word32 dw0000;	// 0
-} Eq_5567;
-
 typedef struct Eq_5597 {	// size: 4 4
 	word16 w0000;	// 0
 } Eq_5597;
-
-typedef struct Eq_5606 {	// size: 1 1
-	word32 dw0000;	// 0
-} Eq_5606;
-
-typedef struct Eq_5622 {	// size: 1 1
-	word32 dw0000;	// 0
-} Eq_5622;
 
 typedef struct Eq_5628 {	// size: 1 1
 	int32 dw0000;	// 0

--- a/subjects/PE/PPC/hello_ppc.reko/hello_ppc_text.c
+++ b/subjects/PE/PPC/hello_ppc.reko/hello_ppc_text.c
@@ -1250,11 +1250,11 @@ Eq_n fn004020BC(Eq_n r2, struct Eq_n * r3, ptr32 r29, ptr32 r30, struct Eq_n * r
 				word32 ctr_n;
 				for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 				{
-					(&fp->aFFFFFFA0->dw0000)[r11_n] = (struct Eq_n) 0x00;
+					Mem69[fp + ~0x5F + r11_n:word32] = 0x00;
 					int32 r11_n = r11_n + 0x04;
-					(&fp->aFFFFFFA0->dw0000)[r11_n] = (struct Eq_n) 0x00;
-					(&fp->aFFFFFFA0->dw0000)[r11_n + 0x04] = (struct Eq_n) 0x00;
-					(&fp->aFFFFFFA0->dw0000)[r11_n + 0x08] = (struct Eq_n) 0x00;
+					Mem71[fp + ~0x5F + r11_n:word32] = 0x00;
+					Mem73[fp + ~0x5F + (r11_n + 0x04):word32] = 0x00;
+					Mem75[fp + ~0x5F + (r11_n + 0x08):word32] = 0x00;
 					r11_n = r11_n + 0x0C;
 				}
 				fn00404074(r2);
@@ -1264,11 +1264,11 @@ Eq_n fn004020BC(Eq_n r2, struct Eq_n * r3, ptr32 r29, ptr32 r30, struct Eq_n * r
 					word32 ctr_n;
 					for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 					{
-						(&fp->aFFFFFFA0->dw0000)[r11_n] = (struct Eq_n) 0x00;
+						Mem101[fp + ~0x5F + r11_n:word32] = 0x00;
 						int32 r11_n = r11_n + 0x04;
-						(&fp->aFFFFFFA0->dw0000)[r11_n] = (struct Eq_n) 0x00;
-						(&fp->aFFFFFFA0->dw0000)[r11_n + 0x04] = (struct Eq_n) 0x00;
-						(&fp->aFFFFFFA0->dw0000)[r11_n + 0x08] = (struct Eq_n) 0x00;
+						Mem103[fp + ~0x5F + r11_n:word32] = 0x00;
+						Mem105[fp + ~0x5F + (r11_n + 0x04):word32] = 0x00;
+						Mem107[fp + ~0x5F + (r11_n + 0x08):word32] = 0x00;
 						r11_n = r11_n + 0x0C;
 					}
 					fn00403F3C(dwLoc84);
@@ -1281,7 +1281,7 @@ Eq_n fn004020BC(Eq_n r2, struct Eq_n * r3, ptr32 r29, ptr32 r30, struct Eq_n * r
 					}
 					else
 					{
-						fn00403104(dwLoc84, &fp->aFFFFFFA0->dw0000);
+						fn00403104(dwLoc84, fp + ~0x5F);
 						r3Out = ~0x00;
 						&r29Out.u0->dw0000 = (struct Eq_n *) <invalid>;
 						&r30Out.u0->dw0000 = (struct Eq_n *) <invalid>;
@@ -1320,7 +1320,7 @@ Eq_n fn00402248(Eq_n r2, struct Eq_n * r3, Eq_n r4, struct Eq_n * r5, struct Eq_
 		word32 r11_n = (int32) (int8) (word32) Mem24[Mem24[r2 + 0x0078:word32] + r3:byte];
 		if ((r11_n & 0x01) != 0x00 && (r11_n & 0x10) == 0x00)
 		{
-			Eq_n r3_n;
+			Eq_n (* r3_n)[][];
 			if ((r11_n & 0x40) != 0x00)
 			{
 				struct Eq_n * r31_n = *((word32) *((word32) r2 + 0x009C) + r3 * 0x04);
@@ -1328,9 +1328,9 @@ Eq_n fn00402248(Eq_n r2, struct Eq_n * r3, Eq_n r4, struct Eq_n * r5, struct Eq_
 				r31_n->t0010 = r4;
 				r31_n->ptr000C = r5;
 				fn00403F10(r2, r30_n->ptr0010);
-				r3_n.u0 = (int32) (int16) r31_n;
-				if (r3_n != 0x00)
-					r3_n.u0 = (int32) r31_n->w0002;
+				r3_n = (int32) (int16) r31_n;
+				if (r3_n != null)
+					r3_n = (int32) r31_n->w0002;
 				else
 					r11_n = r5 - r31_n->ptr000C;
 			}
@@ -1340,7 +1340,7 @@ Eq_n fn00402248(Eq_n r2, struct Eq_n * r3, Eq_n r4, struct Eq_n * r5, struct Eq_
 				r3_n = fp + ~0x5F;
 				r11_n = dwLoc38;
 			}
-			if (r3_n != 0x00)
+			if (r3_n != null)
 			{
 				fn00403104(dwLoc8C, r3_n);
 				r3Out.u0 = ~0x00;
@@ -1488,7 +1488,7 @@ Eq_n fn004026B8(Eq_n r2, struct Eq_n * r3, word32 r5, ptr32 r26, Eq_n r27, struc
 		word32 r11_n = (int32) (int8) (word32) Mem35[Mem35[r2 + 0x0078:word32] + r3:byte];
 		if ((r11_n & 0x01) != 0x00 && (r11_n & 0x40) == 0x00)
 		{
-			Eq_n r3_n;
+			Eq_n (* r3_n)[][];
 			if (r5 != 0x00)
 			{
 				if (r5 != 0x01)
@@ -1507,15 +1507,15 @@ Eq_n fn004026B8(Eq_n r2, struct Eq_n * r3, word32 r5, ptr32 r26, Eq_n r27, struc
 					word32 ctr_n;
 					for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 					{
-						(&fp->aFFFFFF98->dw0000)[r11_n] = (struct Eq_n) 0x00;
+						Mem115[fp + ~0x67 + r11_n:word32] = 0x00;
 						int32 r11_n = r11_n + 0x04;
-						(&fp->aFFFFFF98->dw0000)[r11_n] = (struct Eq_n) 0x00;
-						(&fp->aFFFFFF98->dw0000)[r11_n + 0x04] = (struct Eq_n) 0x00;
-						(&fp->aFFFFFF98->dw0000)[r11_n + 0x08] = (struct Eq_n) 0x00;
+						Mem117[fp + ~0x67 + r11_n:word32] = 0x00;
+						Mem119[fp + ~0x67 + (r11_n + 0x04):word32] = 0x00;
+						Mem121[fp + ~0x67 + (r11_n + 0x08):word32] = 0x00;
 						r11_n = r11_n + 0x0C;
 					}
 					fn00403FFC(r2);
-					r3_n = &fp->aFFFFFF98->dw0000;
+					r3_n = fp + ~0x67;
 					r2 = dwLoc8C;
 				}
 				else
@@ -1524,35 +1524,35 @@ Eq_n fn004026B8(Eq_n r2, struct Eq_n * r3, word32 r5, ptr32 r26, Eq_n r27, struc
 					word32 ctr_n;
 					for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 					{
-						(&fp->aFFFFFF98->dw0000)[r11_n] = (struct Eq_n) 0x00;
+						Mem78[fp + ~0x67 + r11_n:word32] = 0x00;
 						int32 r11_n = r11_n + 0x04;
-						(&fp->aFFFFFF98->dw0000)[r11_n] = (struct Eq_n) 0x00;
-						(&fp->aFFFFFF98->dw0000)[r11_n + 0x04] = (struct Eq_n) 0x00;
-						(&fp->aFFFFFF98->dw0000)[r11_n + 0x08] = (struct Eq_n) 0x00;
+						Mem80[fp + ~0x67 + r11_n:word32] = 0x00;
+						Mem82[fp + ~0x67 + (r11_n + 0x04):word32] = 0x00;
+						Mem84[fp + ~0x67 + (r11_n + 0x08):word32] = 0x00;
 						r11_n = r11_n + 0x0C;
 					}
 					fn00403FE4(r2);
-					r3_n = &fp->aFFFFFF98->dw0000;
+					r3_n = fp + ~0x67;
 					r2 = dwLoc8C;
 				}
 			}
 			else
-				r3_n.u0 = 0x00;
-			if (r3_n == 0x00)
+				r3_n = null;
+			if (r3_n == null)
 			{
 				int32 r11_n = 0x00;
 				word32 ctr_n;
 				for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 				{
-					(&fp->aFFFFFF98->dw0000)[r11_n] = (struct Eq_n) 0x00;
+					Mem153[fp + ~0x67 + r11_n:word32] = 0x00;
 					int32 r11_n = r11_n + 0x04;
-					(&fp->aFFFFFF98->dw0000)[r11_n] = (struct Eq_n) 0x00;
-					(&fp->aFFFFFF98->dw0000)[r11_n + 0x04] = (struct Eq_n) 0x00;
-					(&fp->aFFFFFF98->dw0000)[r11_n + 0x08] = (struct Eq_n) 0x00;
+					Mem155[fp + ~0x67 + r11_n:word32] = 0x00;
+					Mem157[fp + ~0x67 + (r11_n + 0x04):word32] = 0x00;
+					Mem159[fp + ~0x67 + (r11_n + 0x08):word32] = 0x00;
 					r11_n = r11_n + 0x0C;
 				}
 				fn00404014(r2);
-				r3_n = &fp->aFFFFFF98->dw0000;
+				r3_n = fp + ~0x67;
 				r2 = dwLoc8C;
 				if (fp == (struct Eq_n *) ~0x40)
 				{
@@ -1560,15 +1560,15 @@ Eq_n fn004026B8(Eq_n r2, struct Eq_n * r3, word32 r5, ptr32 r26, Eq_n r27, struc
 					word32 ctr_n;
 					for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 					{
-						(&fp->aFFFFFF98->dw0000)[r11_n] = (struct Eq_n) 0x00;
+						Mem193[fp + ~0x67 + r11_n:word32] = 0x00;
 						int32 r11_n = r11_n + 0x04;
-						(&fp->aFFFFFF98->dw0000)[r11_n] = (struct Eq_n) 0x00;
-						(&fp->aFFFFFF98->dw0000)[r11_n + 0x04] = (struct Eq_n) 0x00;
-						(&fp->aFFFFFF98->dw0000)[r11_n + 0x08] = (struct Eq_n) 0x00;
+						Mem195[fp + ~0x67 + r11_n:word32] = 0x00;
+						Mem197[fp + ~0x67 + (r11_n + 0x04):word32] = 0x00;
+						Mem199[fp + ~0x67 + (r11_n + 0x08):word32] = 0x00;
 						r11_n = r11_n + 0x0C;
 					}
 					fn0040402C(dwLoc8C);
-					r3_n = &fp->aFFFFFF98->dw0000;
+					r3_n = fp + ~0x67;
 					r2 = dwLoc8C;
 					if (fp == (struct Eq_n *) ~0x67)
 					{
@@ -1576,20 +1576,20 @@ Eq_n fn004026B8(Eq_n r2, struct Eq_n * r3, word32 r5, ptr32 r26, Eq_n r27, struc
 						word32 ctr_n;
 						for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 						{
-							(&fp->aFFFFFF98->dw0000)[r11_n] = (struct Eq_n) 0x00;
+							Mem225[fp + ~0x67 + r11_n:word32] = 0x00;
 							int32 r11_n = r11_n + 0x04;
-							(&fp->aFFFFFF98->dw0000)[r11_n] = (struct Eq_n) 0x00;
-							(&fp->aFFFFFF98->dw0000)[r11_n + 0x04] = (struct Eq_n) 0x00;
-							(&fp->aFFFFFF98->dw0000)[r11_n + 0x08] = (struct Eq_n) 0x00;
+							Mem227[fp + ~0x67 + r11_n:word32] = 0x00;
+							Mem229[fp + ~0x67 + (r11_n + 0x04):word32] = 0x00;
+							Mem231[fp + ~0x67 + (r11_n + 0x08):word32] = 0x00;
 							r11_n = r11_n + 0x0C;
 						}
 						fn00404014(dwLoc8C);
-						r3_n = &fp->aFFFFFF98->dw0000;
+						r3_n = fp + ~0x67;
 						r2 = dwLoc8C;
 					}
 				}
 			}
-			if (r3_n == 0x00)
+			if (r3_n == null)
 			{
 				r26Out = dwLoc18;
 				r27Out = dwLoc14;
@@ -1895,8 +1895,8 @@ void fn00403070(struct Eq_n * r3, int32 r4, struct Eq_n * r5, struct Eq_n *** r6
 	r3->ptr0000 = r5;
 }
 
-// 00403104: void fn00403104(Register Eq_n r2, Register Eq_n r3)
-void fn00403104(Eq_n r2, Eq_n r3)
+// 00403104: void fn00403104(Register Eq_n r2, Register (ptr32 (arr (arr Eq_n))) r3)
+void fn00403104(Eq_n r2, Eq_n (* r3)[][])
 {
 	struct Eq_n * r8_n = *((word32) r2 + 228);
 	int32 r3_n = (int32) (int16) r3;
@@ -2280,11 +2280,11 @@ Eq_n fn00403744(Eq_n r2, Eq_n r3, struct Eq_n * r29, ptr32 r30, Eq_n r31, ptr32 
 			word32 ctr_n;
 			for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 			{
-				(&fp->aFFFFFFA0->dw0000)[r11_n] = (struct Eq_n) 0x00;
+				Mem79[fp + ~0x5F + r11_n:word32] = 0x00;
 				int32 r11_n = r11_n + 0x04;
-				(&fp->aFFFFFFA0->dw0000)[r11_n] = (struct Eq_n) 0x00;
-				(&fp->aFFFFFFA0->dw0000)[r11_n + 0x04] = (struct Eq_n) 0x00;
-				(&fp->aFFFFFFA0->dw0000)[r11_n + 0x08] = (struct Eq_n) 0x00;
+				Mem81[fp + ~0x5F + r11_n:word32] = 0x00;
+				Mem83[fp + ~0x5F + (r11_n + 0x04):word32] = 0x00;
+				Mem85[fp + ~0x5F + (r11_n + 0x08):word32] = 0x00;
 				r11_n = r11_n + 0x0C;
 			}
 			fn00403F54(r2);
@@ -2294,11 +2294,11 @@ Eq_n fn00403744(Eq_n r2, Eq_n r3, struct Eq_n * r29, ptr32 r30, Eq_n r31, ptr32 
 				word32 ctr_n;
 				for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 				{
-					(&fp->aFFFFFFA0->dw0000)[r11_n] = (struct Eq_n) 0x00;
+					Mem107[fp + ~0x5F + r11_n:word32] = 0x00;
 					int32 r11_n = r11_n + 0x04;
-					(&fp->aFFFFFFA0->dw0000)[r11_n] = (struct Eq_n) 0x00;
-					(&fp->aFFFFFFA0->dw0000)[r11_n + 0x04] = (struct Eq_n) 0x00;
-					(&fp->aFFFFFFA0->dw0000)[r11_n + 0x08] = (struct Eq_n) 0x00;
+					Mem109[fp + ~0x5F + r11_n:word32] = 0x00;
+					Mem111[fp + ~0x5F + (r11_n + 0x04):word32] = 0x00;
+					Mem113[fp + ~0x5F + (r11_n + 0x08):word32] = 0x00;
 					r11_n = r11_n + 0x0C;
 				}
 				fn00403F6C(dwLoc0184);
@@ -2313,7 +2313,7 @@ Eq_n fn00403744(Eq_n r2, Eq_n r3, struct Eq_n * r29, ptr32 r30, Eq_n r31, ptr32 
 			}
 			else
 			{
-				fn00403104(dwLoc0184, &fp->aFFFFFFA0->dw0000);
+				fn00403104(dwLoc0184, fp + ~0x5F);
 				r3Out = ~0x00;
 				r29Out = dwLoc10;
 				r30Out = dwLoc0C;
@@ -2338,7 +2338,7 @@ Eq_n fn00403898(Eq_n r2, struct Eq_n * r3, ptr32 r28, word32 r29, word32 r30, Eq
 	v5->dw0004 = r29;
 	v5->dw0008 = r30;
 	v5->t000C = r31;
-	Eq_n r3_n = 0x00;
+	Eq_n (* r3_n)[][] = null;
 	if (r4_n > r3)
 	{
 		Eq_n (* r28_n)[] = *((word32) r2 + 0x0078);
@@ -2356,7 +2356,7 @@ Eq_n fn00403898(Eq_n r2, struct Eq_n * r3, ptr32 r28, word32 r29, word32 r30, Eq
 					fn00403F24(r2);
 					if (fp != (struct Eq_n *) ~0x5F)
 					{
-						fn00403104(dwLoc84, &fp->aFFFFFFA0->dw0000);
+						fn00403104(dwLoc84, fp + ~0x5F);
 						r3Out = ~0x00;
 						&r28Out.u0->dw0000 = (struct Eq_n *) <invalid>;
 						&r29Out.u0->dw0000 = (struct Eq_n *) <invalid>;
@@ -2368,20 +2368,20 @@ Eq_n fn00403898(Eq_n r2, struct Eq_n * r3, ptr32 r28, word32 r29, word32 r30, Eq
 					word32 ctr_n;
 					for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 					{
-						(&fp->aFFFFFFA0->dw0000)[r11_n] = (struct Eq_n) 0x00;
+						Mem83[fp + ~0x5F + r11_n:word32] = 0x00;
 						int32 r11_n = r11_n + 0x04;
-						(&fp->aFFFFFFA0->dw0000)[r11_n] = (struct Eq_n) 0x00;
-						(&fp->aFFFFFFA0->dw0000)[r11_n + 0x04] = (struct Eq_n) 0x00;
-						(&fp->aFFFFFFA0->dw0000)[r11_n + 0x08] = (struct Eq_n) 0x00;
+						Mem85[fp + ~0x5F + r11_n:word32] = 0x00;
+						Mem87[fp + ~0x5F + (r11_n + 0x04):word32] = 0x00;
+						Mem89[fp + ~0x5F + (r11_n + 0x08):word32] = 0x00;
 						r11_n = r11_n + 0x0C;
 					}
 					fn00403F3C(dwLoc84);
-					r3_n = &fp->aFFFFFFA0->dw0000;
+					r3_n = fp + ~0x5F;
 					r2 = dwLoc84;
 				}
 			}
 			*r28_n = 0x00;
-			if (r3_n == 0x00)
+			if (r3_n == null)
 			{
 				r3Out = 0x00;
 				&r28Out.u0->dw0000 = (struct Eq_n *) <invalid>;

--- a/subjects/PE/m68k/hello_m68k.h
+++ b/subjects/PE/m68k/hello_m68k.h
@@ -87,7 +87,7 @@ Eq_337: (struct "Eq_337" 0001 (FFFFF800 up32 dwFFFFF800))
 	T_1422 (in a5Out : (ptr32 Eq_337))
 	T_1429 (in out a5 : ptr32)
 	T_1565 (in out a5_38 : ptr32)
-Eq_339: (struct "Eq_339" (0 Eq_712 t0000) (1 byte b0001) (2 word16 w0002) (4 Eq_712 t0004) (8 Eq_712 t0008) (C (ptr32 Eq_811) ptr000C) (E byte b000E) (F Eq_885 t000F) (1C int32 dw001C))
+Eq_339: (struct "Eq_339" (0 Eq_712 t0000) (1 byte b0001) (2 word16 w0002) (4 Eq_712 t0004) (8 Eq_712 t0008) (C (ptr32 Eq_811) ptr000C) (E byte b000E) (F byte b000F) (1C int32 dw001C))
 	T_339 (in dwArg08 : (ptr32 Eq_339))
 	T_365 (in dwArg04 : (ptr32 Eq_339))
 	T_491 (in d3 : (ptr32 Eq_339))
@@ -189,7 +189,7 @@ Eq_493: (union "Eq_493" (byte u0) (word32 u1))
 	T_493 (in bArg04 : Eq_493)
 	T_621 (in Mem44[a7_33 - 8<i32> + 0<32>:word32] : word32)
 	T_680 (in Mem52[a7_37 - 8<i32> + 0<32>:word32] : word32)
-Eq_494: (struct "Eq_494" (0 (ptr32 byte) ptr0000) (4 int32 dw0004) (8 (ptr32 byte) ptr0008) (C (ptr32 Eq_811) ptr000C) (F Eq_1136 t000F) (10 int32 dw0010) (18 word32 dw0018))
+Eq_494: (struct "Eq_494" (0 (ptr32 byte) ptr0000) (4 int32 dw0004) (8 (ptr32 byte) ptr0008) (C (ptr32 Eq_811) ptr000C) (F byte b000F) (10 int32 dw0010) (18 word32 dw0018))
 	T_494 (in dwArg08 : (ptr32 Eq_494))
 	T_524 (in dwArg08 : (ptr32 Eq_494))
 	T_626 (in Mem44[a7_33 - 4<i32> + 0<32>:word32] : word32)
@@ -420,22 +420,12 @@ Eq_811: (struct "Eq_811" (0 (ptr32 Eq_2242) ptr0000))
 Eq_839: (struct "Eq_839" (0 ptr32 ptr0000) (4 ptr32 ptr0004))
 	T_839 (in a7_88 : (ptr32 Eq_839))
 	T_841 (in a7_14 + 4<i32> : word32)
-Eq_883: (fn bool (Eq_885, word16, Eq_887))
+Eq_883: (fn bool (byte, word16, Eq_887))
 	T_883 (in __bset : ptr32)
 	T_884 (in signature of __bset : void)
 	T_1359 (in __bset : ptr32)
 	T_1464 (in __bset : ptr32)
 	T_1482 (in __bset : ptr32)
-Eq_885: (union "Eq_885" (byte u0) (word32 u1))
-	T_885 (in  : byte)
-	T_890 (in Mem48[a2_18 + 15<i32>:byte] : byte)
-	T_893 (in Mem48[a2_18 + 15<i32>:byte] : byte)
-	T_1362 (in Mem293[a2_121 + 3<i32>:byte] : byte)
-	T_1365 (in Mem293[a2_121 + 3<i32>:byte] : byte)
-	T_1467 (in Mem29[a2_21 + 15<i32>:byte] : byte)
-	T_1470 (in Mem29[a2_21 + 15<i32>:byte] : byte)
-	T_1485 (in Mem29[a2_21 + 15<i32>:byte] : byte)
-	T_1488 (in Mem29[a2_21 + 15<i32>:byte] : byte)
 Eq_887: (union "Eq_887" (byte u0) (ptr32 u1))
 	T_887 (in  : ptr32)
 	T_894 (in out Mem48[a2_18 + 15<i32>:byte] : ptr32)
@@ -472,7 +462,7 @@ Eq_1046: (struct "Eq_1046" (FFFFFFFF byte bFFFFFFFF) (0 ptr32 ptr0000) (8 ui32 d
 	T_1046 (in a6_119 : (ptr32 Eq_1046))
 	T_1049 (in fp - 4<32> : word32)
 	T_1187 (in a6 : (ptr32 Eq_1046))
-Eq_1058: (struct "Eq_1058" (0 word32 dw0000) (3 Eq_885 t0003))
+Eq_1058: (struct "Eq_1058" (0 word32 dw0000) (3 byte b0003))
 	T_1058 (in a2_121 : (ptr32 Eq_1058))
 	T_1059 (in dwArg08 + 12<i32> : word32)
 	T_1185 (in a2 : (ptr32 Eq_1058))
@@ -493,21 +483,15 @@ Eq_1114: (union "Eq_1114" (ui32 u0) (word16 u1))
 Eq_1115: (union "Eq_1115" (ui32 u0) (word16 u1))
 	T_1115 (in dwArg08->ptr000C & 0x10C<16> : word16)
 	T_1116 (in 0<16> : word16)
-Eq_1134: (fn bool (Eq_1136, byte, Eq_1138))
+Eq_1134: (fn bool (byte, byte, Eq_1138))
 	T_1134 (in __bclr : ptr32)
 	T_1135 (in signature of __bclr : void)
 	T_1677 (in __bclr : ptr32)
-Eq_1136: (union "Eq_1136" (ui32 u0) (byte u1))
-	T_1136 (in  : byte)
-	T_1141 (in Mem66[dwArg08 + 15<i32>:byte] : byte)
-	T_1145 (in Mem66[dwArg08 + 15<i32>:byte] : byte)
-	T_1680 (in Mem26[a2_31 + 15<i32>:byte] : byte)
-	T_1683 (in Mem26[a2_31 + 15<i32>:byte] : byte)
-Eq_1138: (union "Eq_1138" (ui32 u0) (byte u1) (ptr32 u2))
+Eq_1138: (union "Eq_1138" (byte u0) (ptr32 u1))
 	T_1138 (in  : ptr32)
 	T_1146 (in out Mem66[dwArg08 + 15<i32>:byte] : ptr32)
 	T_1684 (in out Mem26[a2_31 + 15<i32>:byte] : ptr32)
-Eq_1172: (struct "Eq_1172" (0 (ptr32 byte) ptr0000) (4 int32 dw0004) (8 (ptr32 byte) ptr0008) (C (ptr32 Eq_811) ptr000C) (F Eq_1136 t000F) (10 int32 dw0010))
+Eq_1172: (struct "Eq_1172" (0 (ptr32 byte) ptr0000) (4 int32 dw0004) (8 (ptr32 byte) ptr0008) (C (ptr32 Eq_811) ptr000C) (F byte b000F) (10 int32 dw0010))
 	T_1172 (in a5 + -2624<i32> : word32)
 Eq_1183: (fn (ptr32 Eq_1058) ((ptr32 Eq_1058), (ptr32 Eq_492), (ptr32 Eq_1046), (ptr32 Eq_494), ptr32, ptr32))
 	T_1183 (in fn00002014 : ptr32)
@@ -537,7 +521,7 @@ Eq_1434: (union "Eq_1434" (int32 u0) (up32 u1))
 	T_1434 (in 32<i32> : int32)
 Eq_1452: (struct "Eq_1452" (4 (ptr32 Eq_1058) ptr0004))
 	T_1452 (in a7_19 : (ptr32 Eq_1452))
-Eq_1454: (struct "Eq_1454" (0 ptr32 ptr0000) (4 int32 dw0004) (8 ptr32 ptr0008) (F Eq_885 t000F) (18 int32 dw0018))
+Eq_1454: (struct "Eq_1454" (0 ptr32 ptr0000) (4 int32 dw0004) (8 ptr32 ptr0008) (F byte b000F) (18 int32 dw0018))
 	T_1454 (in a2_21 : (ptr32 Eq_1454))
 Eq_1522: (struct "Eq_1522" (4 Eq_1392 t0004))
 	T_1522 (in a7_12 : (ptr32 Eq_1522))
@@ -552,9 +536,9 @@ Eq_1575: (fn (ptr32 Eq_1574) (ptr32, Eq_712, ptr32, ptr32))
 	T_1576 (in signature of fn000020F0 : void)
 Eq_1616: (struct "Eq_1616" (1C word32 dw001C))
 	T_1616 (in a2_96 : (ptr32 Eq_1616))
-Eq_1674: (struct "Eq_1674" (0 int32 dw0000) (4 int32 dw0004) (8 int32 dw0008) (F Eq_1136 t000F))
+Eq_1674: (struct "Eq_1674" (0 int32 dw0000) (4 int32 dw0004) (8 int32 dw0008) (F byte b000F))
 	T_1674 (in a2_31 : (ptr32 Eq_1674))
-Eq_1700: (struct "Eq_1700" (FFFFF958 (arr byte) aFFFFF958) (FFFFF998 (arr (ptr32 Eq_1701)) aFFFFF998) (FFFFFAA0 (ptr32 Eq_1704) ptrFFFFFAA0))
+Eq_1700: (struct "Eq_1700" (FFFFF958 (arr (arr byte)) aFFFFF958) (FFFFF998 (arr (ptr32 Eq_1701)) aFFFFF998) (FFFFFAA0 (ptr32 Eq_1704) ptrFFFFFAA0))
 	T_1700 (in a5 : (ptr32 Eq_1700))
 Eq_1701: (struct "Eq_1701" 0014 (4 (ptr32 word32) ptr0004) (8 (ptr32 (ptr32 Eq_1739)) ptr0008))
 	T_1701 (in d0_19 : (ptr32 Eq_1701))
@@ -689,7 +673,7 @@ Eq_2198: (struct "Eq_2198" (FFFFFD34 (ptr32 code) ptrFFFFFD34))
 Eq_2217: (fn word32 ((ptr32 Eq_2159), Eq_712, Eq_712, ptr32, (ptr32 Eq_2159), (ptr32 word32)))
 	T_2217 (in fn00002510 : ptr32)
 	T_2218 (in signature of fn00002510 : void)
-Eq_2236: (union "Eq_2236" ((ptr32 Eq_3934) u0) ((arr Eq_2236) u1) (Eq_3935 u2))
+Eq_2236: (union "Eq_2236" (word16 u0) ((ptr32 Eq_3933) u1) ((arr Eq_2236) u2) (Eq_3934 u3) (Eq_3935 u4))
 	T_2236 (in a0_25 : Eq_2236)
 	T_2284 (in a0 : Eq_2236)
 	T_2800 (in Mem106[a5 + -1316<i32>:word32] : word32)
@@ -704,25 +688,49 @@ Eq_2236: (union "Eq_2236" ((ptr32 Eq_3934) u0) ((arr Eq_2236) u1) (Eq_3935 u2))
 	T_2938 (in Mem133[a5 + -1316<i32>:word32] : word32)
 	T_2945 (in 0<32> : word32)
 	T_2949 (in Mem133[a5 + -1296<i32>:word32] : word32)
+	T_2952 (in Mem133[a0 + 0<32>:word16] : word16)
+	T_2953 (in 0<16> : word16)
 	T_2957 (in Mem189[a5 + -1316<i32>:word32] : word32)
+	T_2960 (in Mem189[Mem189[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
 	T_2966 (in Mem189[Mem189[a5 + -1316<i32>:word32] + 0<32>:word32] + (Mem189[a5 + -1312<i32>:word32] << 4<32>) : word32)
 	T_2974 (in Mem133[a5 + -1316<i32>:word32] : word32)
 	T_2975 (in 0<32> : word32)
 	T_2991 (in Mem185[a5 + -1316<i32>:word32] : word32)
+	T_2998 (in 0<i32> : int32)
+	T_3001 (in Mem201[a0 + 0<32>:word32] : word32)
 	T_3068 (in a0_202 + 60<i32> : word32)
 	T_3110 (in 0<32> : word32)
+	T_3113 (in a1_42 : Eq_2236)
 	T_3116 (in Mem16[a5 + -1316<i32>:word32] : word32)
+	T_3119 (in Mem16[Mem16[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
 	T_3127 (in a1_42[dwArg04 * 0x10<32>] : word32)
 	T_3135 (in SEQ(SLICE(a0 + 3<32>, word16, 16), SLICE(a0 + 3<32>, word16, 0) & 0xFFFC<16>) : uipr32)
 	T_3138 (in a1_42[dwArg04 * 0x10<32>] : word32)
 	T_3145 (in Mem78[a1_75 + 12<i32>:word32] : word32)
 	T_3186 (in Mem19[a5 + -1316<i32>:word32] : word32)
+	T_3189 (in Mem19[Mem19[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
 	T_3261 (in Mem19[a5 + -1316<i32>:word32] : word32)
+	T_3264 (in Mem19[Mem19[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
 	T_3269 (in Mem19[a5 + -1296<i32>:word32] : word32)
+	T_3272 (in Mem19[Mem19[a5 + -1296<i32>:word32] + 0<32>:word16] : word16)
+	T_3273 (in 0<16> : word16)
 	T_3319 (in Mem11[a5 + -1316<i32>:word32] : word32)
+	T_3322 (in Mem11[Mem11[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
+	T_3325 (in Mem11[Mem11[a5 + -1316<i32>:word32] + 0<32>:word32][dwArg04 * 0x10<32>] : word32)
+	T_3326 (in 0<32> : word32)
+	T_3328 (in a0_26 : Eq_2236)
 	T_3331 (in Mem11[a5 + -1316<i32>:word32] : word32)
+	T_3334 (in Mem11[Mem11[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
+	T_3335 (in 0<i32> : int32)
+	T_3338 (in a0_26[dwArg04 * 0x10<32>] : word32)
 	T_3917
 	T_3918
+	T_3919
+	T_3920
+	T_3921
+	T_3922
+	T_3923
+	T_3924
 Eq_2237: (struct "Eq_2237" (0 (ptr32 Eq_2242) ptr0000) (4 uipr32 dw0004))
 	T_2237 (in d0_23 : (ptr32 Eq_2237))
 	T_2244 (in fn000027B0(a5, dwArg04, out a0_25) : word32)
@@ -911,25 +919,12 @@ Eq_2829: (union "Eq_2829" (int32 u0) (ptr32 u1))
 	T_3287 (in d5 : word32)
 	T_3298 (in d5_114 : Eq_2829)
 	T_3301 (in Mem76[a7_111 + 4<i32>:word32] : word32)
-Eq_2879: (struct "Eq_2879" 0001 (0 (arr Eq_2879) a0000))
-	T_2879 (in Mem46[Mem46[Mem46[a5 + -1316<i32>:word32] + 0<32>:word32] + d7_119:word32] : word32)
-	T_2880 (in 0<32> : word32)
-	T_3919
-	T_3920
 Eq_2896: (fn int32 (Eq_2236, (ptr32 Eq_2159), ui32, up32, (ptr32 Eq_2159), ptr32))
 	T_2896 (in fn000029C8 : ptr32)
 	T_2897 (in signature of fn000029C8 : void)
-Eq_2998: (union "Eq_2998" (int32 u0) (word16 u1) ((arr Eq_2236) u2))
-	T_2998 (in 0<i32> : int32)
-	T_3001 (in Mem201[a0 + 0<32>:word32] : word32)
-Eq_3000: (union "Eq_3000" (word16 u0) ((arr Eq_2236) u1) (Eq_2998 u2))
-	T_3000 (in a0 + 0<32> : word32)
 Eq_3002: (struct "Eq_3002" (0 int32 dw0000) (4 int32 dw0004) (8 int32 dw0008) (C int32 dw000C) (10 int32 dw0010) (14 int32 dw0014) (18 int32 dw0018) (1C int32 dw001C) (20 int32 dw0020) (24 int32 dw0024) (28 int32 dw0028) (2C int32 dw002C) (30 int32 dw0030) (34 int32 dw0034) (38 int32 dw0038))
 	T_3002 (in a0_202 : (ptr32 Eq_3002))
 	T_3004 (in a0 + 4<i32> : word32)
-Eq_3113: (struct "Eq_3113" (0 (arr Eq_3921) a0000))
-	T_3113 (in a1_42 : (ptr32 Eq_3113))
-	T_3119 (in Mem16[Mem16[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
 Eq_3139: (struct "Eq_3139" (4 int32 dw0004) (8 up32 dw0008) (C Eq_2236 t000C))
 	T_3139 (in a1_75 : (ptr32 Eq_3139))
 	T_3142 (in a1_42 + (dwArg04 << 4<32>) : word32)
@@ -1002,15 +997,9 @@ Eq_3915: (struct "Eq_3915" 0008 (0 word32 dw0000) (4 (ptr32 byte) ptr0004))
 	T_3915
 Eq_3916: (struct "Eq_3916" 0008 (4 (ptr32 byte) ptr0004))
 	T_3916
-Eq_3921: (struct "Eq_3921" 0010 (0 Eq_2236 t0000))
-	T_3921
-	T_3922
-Eq_3923: (struct "Eq_3923" 0010 (0 int32 dw0000) (4 int32 dw0004) (8 int32 dw0008))
-	T_3923
-	T_3924
-Eq_3925: (struct "Eq_3925" 0010 (4 int32 dw0004))
+Eq_3925: (struct "Eq_3925" 0010 (0 int32 dw0000) (4 int32 dw0004))
 	T_3925
-Eq_3926: (struct "Eq_3926" 0010 (8 int32 dw0008))
+Eq_3926: (struct "Eq_3926" 0010 (4 int32 dw0004))
 	T_3926
 Eq_3928: (struct "Eq_3928" 0004 (0 word16 w0000))
 	T_3928
@@ -1022,11 +1011,11 @@ Eq_3931: (struct "Eq_3931" 0020 (C cui16 w000C) (F word32 dw000F))
 	T_3931
 Eq_3932: (struct "Eq_3932" (FFFFFAF8 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 code)))))) ptrFFFFFAF8) (FFFFFBB4 (arr Eq_3915) aFFFFFBB4) (FFFFFC0C (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 code)))))) ptrFFFFFC0C))
 	T_3932
-Eq_3933: (union "Eq_3933" (word16 u0) ((ptr32 (arr Eq_3923)) u1) ((ptr32 Eq_3113) u2) ((arr Eq_2236) u3) ((arr Eq_2879) u4) (Eq_2236 u5) (Eq_2998 u6))
+Eq_3933: (struct "Eq_3933" 0004 (0 (arr Eq_2236) a0000) (4 (arr Eq_3925) a0004))
 	T_3933
-Eq_3934: (struct "Eq_3934" 0004 (0 Eq_3933 t0000))
+Eq_3934: (struct "Eq_3934" 0001 (0 word32 dw0000))
 	T_3934
-Eq_3935: (struct "Eq_3935" 0001 (0 word32 dw0000))
+Eq_3935: (struct "Eq_3935" 0010 (0 Eq_2236 t0000))
 	T_3935
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
@@ -2219,8 +2208,8 @@ T_297: (in -2696<i32> : int32)
   OrigDataType: int32
 T_298: (in a5_27 + -2696<i32> : word32)
   Class: Eq_298
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_3898)
+  DataType: (ptr32 (arr word32))
+  OrigDataType: (ptr32 (arr T_3897))
 T_299: (in 4<i32> : int32)
   Class: Eq_299
   DataType: int32
@@ -2351,8 +2340,8 @@ T_330: (in -2696<i32> : int32)
   OrigDataType: int32
 T_331: (in a5_27 + -2696<i32> : word32)
   Class: Eq_331
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_3899)
+  DataType: (ptr32 (arr word32))
+  OrigDataType: (ptr32 (arr T_3897))
 T_332: (in 4<i32> : int32)
   Class: Eq_332
   DataType: int32
@@ -4567,7 +4556,7 @@ T_884: (in signature of __bset : void)
   OrigDataType: 
 T_885: (in  : byte)
   Class: Eq_885
-  DataType: Eq_885
+  DataType: byte
   OrigDataType: 
 T_886: (in  : word16)
   Class: Eq_886
@@ -4583,29 +4572,29 @@ T_888: (in 15<i32> : int32)
   OrigDataType: int32
 T_889: (in a2_18 + 15<i32> : word32)
   Class: Eq_889
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_890: (in Mem48[a2_18 + 15<i32>:byte] : byte)
   Class: Eq_885
-  DataType: Eq_885
-  OrigDataType: (union (byte u1) (word32 u0))
+  DataType: byte
+  OrigDataType: byte
 T_891: (in 5<16> : word16)
   Class: Eq_886
   DataType: word16
   OrigDataType: word16
 T_892: (in a2_18 + 15<i32> : word32)
   Class: Eq_892
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_893: (in Mem48[a2_18 + 15<i32>:byte] : byte)
   Class: Eq_885
-  DataType: Eq_885
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_894: (in out Mem48[a2_18 + 15<i32>:byte] : ptr32)
   Class: Eq_887
   DataType: Eq_887
-  OrigDataType: ptr32
-T_895: (in __bset(a2_18->t000F, 5<16>, out a2_18->t000F) : bool)
+  OrigDataType: (union (byte u0) (ptr32 u1))
+T_895: (in __bset(a2_18->b000F, 5<16>, out a2_18->b000F) : bool)
   Class: Eq_895
   DataType: bool
   OrigDataType: bool
@@ -5571,7 +5560,7 @@ T_1135: (in signature of __bclr : void)
   OrigDataType: 
 T_1136: (in  : byte)
   Class: Eq_1136
-  DataType: Eq_1136
+  DataType: byte
   OrigDataType: 
 T_1137: (in  : byte)
   Class: Eq_1137
@@ -5587,12 +5576,12 @@ T_1139: (in 15<i32> : int32)
   OrigDataType: int32
 T_1140: (in dwArg08 + 15<i32> : word32)
   Class: Eq_1140
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 ui32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_1141: (in Mem66[dwArg08 + 15<i32>:byte] : byte)
   Class: Eq_1136
-  DataType: Eq_1136
-  OrigDataType: (union (ui32 u0) (byte u1))
+  DataType: byte
+  OrigDataType: byte
 T_1142: (in 0<8> : byte)
   Class: Eq_1137
   DataType: byte
@@ -5603,17 +5592,17 @@ T_1143: (in 15<i32> : int32)
   OrigDataType: int32
 T_1144: (in dwArg08 + 15<i32> : word32)
   Class: Eq_1144
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 ui32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_1145: (in Mem66[dwArg08 + 15<i32>:byte] : byte)
   Class: Eq_1136
-  DataType: Eq_1136
-  OrigDataType: ui32
+  DataType: byte
+  OrigDataType: byte
 T_1146: (in out Mem66[dwArg08 + 15<i32>:byte] : ptr32)
   Class: Eq_1138
   DataType: Eq_1138
-  OrigDataType: (union (ui32 u0) (ptr32 u1))
-T_1147: (in __bclr(dwArg08->t000F, 0<8>, out dwArg08->t000F) : bool)
+  OrigDataType: (union (byte u0) (ptr32 u1))
+T_1147: (in __bclr(dwArg08->b000F, 0<8>, out dwArg08->b000F) : bool)
   Class: Eq_1147
   DataType: bool
   OrigDataType: bool
@@ -6471,29 +6460,29 @@ T_1360: (in 3<i32> : int32)
   OrigDataType: int32
 T_1361: (in a2_121 + 3<i32> : word32)
   Class: Eq_1361
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_1362: (in Mem293[a2_121 + 3<i32>:byte] : byte)
   Class: Eq_885
-  DataType: Eq_885
-  OrigDataType: (union (byte u1) (word32 u0))
+  DataType: byte
+  OrigDataType: byte
 T_1363: (in 5<16> : word16)
   Class: Eq_886
   DataType: word16
   OrigDataType: word16
 T_1364: (in a2_121 + 3<i32> : word32)
   Class: Eq_1364
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_1365: (in Mem293[a2_121 + 3<i32>:byte] : byte)
   Class: Eq_885
-  DataType: Eq_885
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_1366: (in out Mem293[a2_121 + 3<i32>:byte] : ptr32)
   Class: Eq_887
   DataType: Eq_887
-  OrigDataType: ptr32
-T_1367: (in __bset(a2_121->t0003, 5<16>, out a2_121->t0003) : bool)
+  OrigDataType: (union (byte u0) (ptr32 u1))
+T_1367: (in __bset(a2_121->b0003, 5<16>, out a2_121->b0003) : bool)
   Class: Eq_895
   DataType: bool
   OrigDataType: bool
@@ -6895,7 +6884,7 @@ T_1466: (in a2_21 + 15<i32> : word32)
   OrigDataType: ptr32
 T_1467: (in Mem29[a2_21 + 15<i32>:byte] : byte)
   Class: Eq_885
-  DataType: Eq_885
+  DataType: byte
   OrigDataType: byte
 T_1468: (in 2<16> : word16)
   Class: Eq_886
@@ -6907,13 +6896,13 @@ T_1469: (in a2_21 + 15<i32> : word32)
   OrigDataType: ptr32
 T_1470: (in Mem29[a2_21 + 15<i32>:byte] : byte)
   Class: Eq_885
-  DataType: Eq_885
+  DataType: byte
   OrigDataType: byte
 T_1471: (in out Mem29[a2_21 + 15<i32>:byte] : ptr32)
   Class: Eq_887
   DataType: Eq_887
   OrigDataType: (union (byte u0) (ptr32 u1))
-T_1472: (in __bset(a2_21->t000F, 2<16>, out a2_21->t000F) : bool)
+T_1472: (in __bset(a2_21->b000F, 2<16>, out a2_21->b000F) : bool)
   Class: Eq_895
   DataType: bool
   OrigDataType: bool
@@ -6967,7 +6956,7 @@ T_1484: (in a2_21 + 15<i32> : word32)
   OrigDataType: ptr32
 T_1485: (in Mem29[a2_21 + 15<i32>:byte] : byte)
   Class: Eq_885
-  DataType: Eq_885
+  DataType: byte
   OrigDataType: byte
 T_1486: (in 3<16> : word16)
   Class: Eq_886
@@ -6979,13 +6968,13 @@ T_1487: (in a2_21 + 15<i32> : word32)
   OrigDataType: ptr32
 T_1488: (in Mem29[a2_21 + 15<i32>:byte] : byte)
   Class: Eq_885
-  DataType: Eq_885
+  DataType: byte
   OrigDataType: byte
 T_1489: (in out Mem29[a2_21 + 15<i32>:byte] : ptr32)
   Class: Eq_887
   DataType: Eq_887
   OrigDataType: (union (byte u0) (ptr32 u1))
-T_1490: (in __bset(a2_21->t000F, 3<16>, out a2_21->t000F) : bool)
+T_1490: (in __bset(a2_21->b000F, 3<16>, out a2_21->b000F) : bool)
   Class: Eq_895
   DataType: bool
   OrigDataType: bool
@@ -7747,7 +7736,7 @@ T_1679: (in a2_31 + 15<i32> : word32)
   OrigDataType: word32
 T_1680: (in Mem26[a2_31 + 15<i32>:byte] : byte)
   Class: Eq_1136
-  DataType: Eq_1136
+  DataType: byte
   OrigDataType: byte
 T_1681: (in 3<8> : byte)
   Class: Eq_1137
@@ -7759,13 +7748,13 @@ T_1682: (in a2_31 + 15<i32> : word32)
   OrigDataType: word32
 T_1683: (in Mem26[a2_31 + 15<i32>:byte] : byte)
   Class: Eq_1136
-  DataType: Eq_1136
+  DataType: byte
   OrigDataType: byte
 T_1684: (in out Mem26[a2_31 + 15<i32>:byte] : ptr32)
   Class: Eq_1138
   DataType: Eq_1138
   OrigDataType: (union (byte u0) (ptr32 u1))
-T_1685: (in __bclr(a2_31->t000F, 3<8>, out a2_31->t000F) : bool)
+T_1685: (in __bclr(a2_31->b000F, 3<8>, out a2_31->b000F) : bool)
   Class: Eq_1147
   DataType: bool
   OrigDataType: bool
@@ -7897,14 +7886,14 @@ T_1717: (in 0x41<8> : byte)
   Class: Eq_1717
   DataType: byte
   OrigDataType: byte
-T_1718: (in a5->aFFFFF958[d1_27] | 0x41<8> : byte)
+T_1718: (in Mem30[a5 + -1704<i32> + d1_27:byte] | 0x41<8> : byte)
   Class: Eq_1716
   DataType: byte
   OrigDataType: byte
 T_1719: (in a5 + -1704<i32> : word32)
   Class: Eq_1719
-  DataType: (ptr32 (arr byte))
-  OrigDataType: (ptr32 (struct (0 (arr T_3907) a0000)))
+  DataType: (ptr32 (arr (arr byte)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr byte) a0000))))
 T_1720: (in a5 + -1704<i32> + d1_27 : word32)
   Class: Eq_1720
   DataType: (ptr32 byte)
@@ -7951,8 +7940,8 @@ T_1730: (in -1704<i32> : int32)
   OrigDataType: int32
 T_1731: (in a5 + -1704<i32> : word32)
   Class: Eq_1731
-  DataType: (ptr32 (arr byte))
-  OrigDataType: (ptr32 (struct (0 (arr T_3910) a0000)))
+  DataType: (ptr32 (arr (arr byte)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr byte) a0000))))
 T_1732: (in a5 + -1704<i32> + d1_27 : word32)
   Class: Eq_1732
   DataType: (ptr32 byte)
@@ -7965,14 +7954,14 @@ T_1734: (in 1<8> : byte)
   Class: Eq_1734
   DataType: byte
   OrigDataType: byte
-T_1735: (in a5->aFFFFF958[d1_27] | 1<8> : byte)
+T_1735: (in Mem30[a5 + -1704<i32> + d1_27:byte] | 1<8> : byte)
   Class: Eq_1716
   DataType: byte
   OrigDataType: byte
 T_1736: (in a5 + -1704<i32> : word32)
   Class: Eq_1736
-  DataType: (ptr32 (arr byte))
-  OrigDataType: (ptr32 (struct (0 (arr T_3912) a0000)))
+  DataType: (ptr32 (arr (arr byte)))
+  OrigDataType: (ptr32 (arr (struct (0 (arr byte) a0000))))
 T_1737: (in a5 + -1704<i32> + d1_27 : word32)
   Class: Eq_1737
   DataType: (ptr32 byte)
@@ -8031,8 +8020,8 @@ T_1750: (in SEQ(SLICE(a0_54, word16, 16), Mem52[a0_54 + 2<i32>:word16]) : uipr32
   OrigDataType: uipr32
 T_1751: (in a5 + -1640<i32> : word32)
   Class: Eq_1751
-  DataType: (ptr32 (ptr32 Eq_1701))
-  OrigDataType: (ptr32 T_3914)
+  DataType: (ptr32 (arr (ptr32 Eq_1701)))
+  OrigDataType: (ptr32 (arr T_3909))
 T_1752: (in 4<i32> : int32)
   Class: Eq_1752
   DataType: int32
@@ -12536,18 +12525,18 @@ T_2876: (in Mem46[a5 + -1316<i32>:word32] + 0<32> : word32)
 T_2877: (in Mem46[Mem46[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_2236
   DataType: Eq_2236
-  OrigDataType: (ptr32 (struct (0 (arr Eq_2879) a0000)))
+  OrigDataType: (ptr32 (struct (0 (arr T_3919) a0000)))
 T_2878: (in Mem46[Mem46[a5 + -1316<i32>:word32] + 0<32>:word32] + d7_119 : word32)
   Class: Eq_2878
-  DataType: (ptr32 Eq_2879)
+  DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_2879 t0000)))
 T_2879: (in Mem46[Mem46[Mem46[a5 + -1316<i32>:word32] + 0<32>:word32] + d7_119:word32] : word32)
-  Class: Eq_2879
-  DataType: Eq_2879
+  Class: Eq_2805
+  DataType: word32
   OrigDataType: word32
 T_2880: (in 0<32> : word32)
-  Class: Eq_2879
-  DataType: (struct "Eq_2879" 0001 (0 (arr Eq_2879) a0000))
+  Class: Eq_2805
+  DataType: word32
   OrigDataType: word32
 T_2881: (in *((word32) *a5->tFFFFFADC + d7_119) == 0<32> : bool)
   Class: Eq_2881
@@ -12743,7 +12732,7 @@ T_2928: (in Mem133[a5 + -1316<i32>:word32] : word32)
   OrigDataType: (ptr32 (struct (0 T_2803 t0000)))
 T_2929: (in 0<32> : word32)
   Class: Eq_2236
-  DataType: (ptr32 Eq_3934)
+  DataType: word16
   OrigDataType: word32
 T_2930: (in a5->tFFFFFADC == 0<32> : bool)
   Class: Eq_2930
@@ -12763,7 +12752,7 @@ T_2933: (in Mem133[a5 + -1316<i32>:word32] : word32)
   OrigDataType: (ptr32 (struct (0 T_2803 t0000)))
 T_2934: (in 0<32> : word32)
   Class: Eq_2236
-  DataType: (ptr32 Eq_3934)
+  DataType: word16
   OrigDataType: word32
 T_2935: (in a5->tFFFFFADC == 0<32> : bool)
   Class: Eq_2935
@@ -12807,7 +12796,7 @@ T_2944: (in __syscall(0xA122<16>) : void)
   OrigDataType: void
 T_2945: (in 0<32> : word32)
   Class: Eq_2236
-  DataType: (ptr32 Eq_3934)
+  DataType: word16
   OrigDataType: word32
 T_2946: (in a0 != 0<32> : bool)
   Class: Eq_2946
@@ -12831,14 +12820,14 @@ T_2950: (in 0<32> : word32)
   OrigDataType: word32
 T_2951: (in a0 + 0<32> : word32)
   Class: Eq_2951
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_2236))
+  OrigDataType: (ptr32 (arr T_2236))
 T_2952: (in Mem133[a0 + 0<32>:word16] : word16)
-  Class: Eq_2952
-  DataType: word16
-  OrigDataType: word16
+  Class: Eq_2236
+  DataType: Eq_2236
+  OrigDataType: (arr T_2236)
 T_2953: (in 0<16> : word16)
-  Class: Eq_2952
+  Class: Eq_2236
   DataType: word16
   OrigDataType: word16
 T_2954: (in *a0 == 0<16> : bool)
@@ -12866,8 +12855,8 @@ T_2959: (in Mem189[a5 + -1316<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_2960: (in Mem189[Mem189[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_2960
-  DataType: word32
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: word32
 T_2961: (in -1312<i32> : int32)
   Class: Eq_2961
@@ -12927,7 +12916,7 @@ T_2974: (in Mem133[a5 + -1316<i32>:word32] : word32)
   OrigDataType: word32
 T_2975: (in 0<32> : word32)
   Class: Eq_2236
-  DataType: (ptr32 Eq_3934)
+  DataType: word16
   OrigDataType: word32
 T_2976: (in a5->tFFFFFADC == 0<32> : bool)
   Class: Eq_2976
@@ -13018,8 +13007,8 @@ T_2997: (in __syscall(0xA023<16>) : void)
   DataType: void
   OrigDataType: void
 T_2998: (in 0<i32> : int32)
-  Class: Eq_2998
-  DataType: int32
+  Class: Eq_2236
+  DataType: word16
   OrigDataType: int32
 T_2999: (in 0<32> : word32)
   Class: Eq_2999
@@ -13027,12 +13016,12 @@ T_2999: (in 0<32> : word32)
   OrigDataType: word32
 T_3000: (in a0 + 0<32> : word32)
   Class: Eq_3000
-  DataType: (ptr32 Eq_3000)
-  OrigDataType: (ptr32 (union (int32 u4) (word16 u1) ((arr Eq_2236) u0) (word16 u2) (Eq_2998 u3)))
+  DataType: (ptr32 (arr Eq_2236))
+  OrigDataType: (ptr32 (arr T_2236))
 T_3001: (in Mem201[a0 + 0<32>:word32] : word32)
-  Class: Eq_2998
+  Class: Eq_2236
   DataType: Eq_2236
-  OrigDataType: int32
+  OrigDataType: word16
 T_3002: (in a0_202 : (ptr32 Eq_3002))
   Class: Eq_3002
   DataType: (ptr32 Eq_3002)
@@ -13467,7 +13456,7 @@ T_3109: (in __syscall(0xA11E<16>) : void)
   OrigDataType: void
 T_3110: (in 0<32> : word32)
   Class: Eq_2236
-  DataType: (ptr32 Eq_3934)
+  DataType: word16
   OrigDataType: word32
 T_3111: (in a0 == 0<32> : bool)
   Class: Eq_3111
@@ -13477,9 +13466,9 @@ T_3112: (in -1<i32> : int32)
   Class: Eq_2846
   DataType: int32
   OrigDataType: int32
-T_3113: (in a1_42 : (ptr32 Eq_3113))
-  Class: Eq_3113
-  DataType: (ptr32 Eq_3113)
+T_3113: (in a1_42 : Eq_2236)
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: (ptr32 (struct (0 (arr T_3921) a0000)))
 T_3114: (in -1316<i32> : int32)
   Class: Eq_3114
@@ -13502,8 +13491,8 @@ T_3118: (in Mem16[a5 + -1316<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3119: (in Mem16[Mem16[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_3113
-  DataType: (ptr32 Eq_3113)
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: word32
 T_3120: (in SLICE(a0, word16, 0) : word16)
   Class: Eq_3120
@@ -13782,8 +13771,8 @@ T_3188: (in Mem19[a5 + -1316<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3189: (in Mem19[Mem19[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_3189
-  DataType: word32
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: word32
 T_3190: (in 4<32> : word32)
   Class: Eq_3190
@@ -14067,7 +14056,7 @@ T_3259: (in -1316<i32> : int32)
   OrigDataType: int32
 T_3260: (in a5 + -1316<i32> : word32)
   Class: Eq_3260
-  DataType: (ptr32 (ptr32 word32))
+  DataType: (ptr32 (ptr32 Eq_2236))
   OrigDataType: (ptr32 (ptr32 (struct (0 T_3189 t0000))))
 T_3261: (in Mem19[a5 + -1316<i32>:word32] : word32)
   Class: Eq_2236
@@ -14082,8 +14071,8 @@ T_3263: (in Mem19[a5 + -1316<i32>:word32] + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_3264: (in Mem19[Mem19[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_3189
-  DataType: word32
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: word32
 T_3265: (in dwArg04 << 4<32> : word32)
   Class: Eq_3265
@@ -14114,11 +14103,11 @@ T_3271: (in Mem19[a5 + -1296<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3272: (in Mem19[Mem19[a5 + -1296<i32>:word32] + 0<32>:word16] : word16)
-  Class: Eq_3272
-  DataType: word16
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: word16
 T_3273: (in 0<16> : word16)
-  Class: Eq_3272
+  Class: Eq_2236
   DataType: word16
   OrigDataType: word16
 T_3274: (in *a5->tFFFFFAF0 == 0<16> : bool)
@@ -14314,8 +14303,8 @@ T_3321: (in Mem11[a5 + -1316<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_3322: (in Mem11[Mem11[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_3322
-  DataType: (ptr32 (arr Eq_3923))
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: (ptr32 (struct (0 (arr T_3923) a0000)))
 T_3323: (in 0x10<32> : ui32)
   Class: Eq_3323
@@ -14326,28 +14315,28 @@ T_3324: (in dwArg04 * 0x10<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3325: (in Mem11[Mem11[a5 + -1316<i32>:word32] + 0<32>:word32][dwArg04 * 0x10<32>] : word32)
-  Class: Eq_3325
-  DataType: int32
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: word32
 T_3326: (in 0<32> : word32)
-  Class: Eq_3325
-  DataType: int32
+  Class: Eq_2236
+  DataType: word16
   OrigDataType: word32
 T_3327: (in *((word32) *a5->tFFFFFADC + dwArg04 * 0x10<32>) == 0<32> : bool)
   Class: Eq_3327
   DataType: bool
   OrigDataType: bool
-T_3328: (in a0_26 : (arr Eq_3923))
-  Class: Eq_3322
-  DataType: (ptr32 (arr Eq_3923))
-  OrigDataType: (ptr32 (struct (0 (arr T_3923) a0000) (4 (arr Eq_3925) a0004) (8 (arr T_3926) a0008)))
+T_3328: (in a0_26 : Eq_2236)
+  Class: Eq_2236
+  DataType: Eq_2236
+  OrigDataType: (ptr32 (struct (0 (arr T_3923) a0000) (4 (arr T_3925) a0004) (8 (arr T_3926) a0008)))
 T_3329: (in -1316<i32> : int32)
   Class: Eq_3329
   DataType: int32
   OrigDataType: int32
 T_3330: (in a5 + -1316<i32> : word32)
   Class: Eq_3330
-  DataType: (ptr32 (ptr32 (ptr32 (arr Eq_3923))))
+  DataType: (ptr32 (ptr32 Eq_2236))
   OrigDataType: (ptr32 (ptr32 (struct (0 T_3322 t0000))))
 T_3331: (in Mem11[a5 + -1316<i32>:word32] : word32)
   Class: Eq_2236
@@ -14359,15 +14348,15 @@ T_3332: (in 0<32> : word32)
   OrigDataType: word32
 T_3333: (in Mem11[a5 + -1316<i32>:word32] + 0<32> : word32)
   Class: Eq_3333
-  DataType: (ptr32 (ptr32 (arr Eq_3923)))
+  DataType: (ptr32 (ptr32 (arr Eq_2236)))
   OrigDataType: (ptr32 (ptr32 (struct (0 (arr T_3923) a0000))))
 T_3334: (in Mem11[Mem11[a5 + -1316<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_3322
-  DataType: (ptr32 (arr Eq_3923))
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: (ptr32 (struct (0 (arr T_3923) a0000)))
 T_3335: (in 0<i32> : int32)
-  Class: Eq_3325
-  DataType: int32
+  Class: Eq_2236
+  DataType: word16
   OrigDataType: int32
 T_3336: (in 0x10<32> : ui32)
   Class: Eq_3336
@@ -14378,9 +14367,9 @@ T_3337: (in dwArg04 * 0x10<32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_3338: (in a0_26[dwArg04 * 0x10<32>] : word32)
-  Class: Eq_3325
-  DataType: int32
-  OrigDataType: word32
+  Class: Eq_2236
+  DataType: Eq_2236
+  OrigDataType: word16
 T_3339: (in 0<i32> : int32)
   Class: Eq_3339
   DataType: int32
@@ -14403,8 +14392,8 @@ T_3343: (in dwArg04 * 0x10<32> : word32)
   OrigDataType: ui32
 T_3344: (in (a0_26 + 4<i32>)[dwArg04 * 0x10<32>] : word32)
   Class: Eq_3339
-  DataType: int32
-  OrigDataType: word32
+  DataType: Eq_2236
+  OrigDataType: int32
 T_3345: (in 0<i32> : int32)
   Class: Eq_3345
   DataType: int32
@@ -14427,8 +14416,8 @@ T_3349: (in dwArg04 * 0x10<32> : word32)
   OrigDataType: ui32
 T_3350: (in (a0_26 + 8<i32>)[dwArg04 * 0x10<32>] : word32)
   Class: Eq_3345
-  DataType: int32
-  OrigDataType: word32
+  DataType: Eq_2236
+  OrigDataType: int32
 T_3351: (in __syscall : ptr32)
   Class: Eq_9
   DataType: (ptr32 Eq_9)
@@ -16651,15 +16640,15 @@ T_3905:
   OrigDataType: (struct 0001 (0 T_1716 t0000))
 T_3906:
   Class: Eq_3906
-  DataType: (arr byte)
-  OrigDataType: (arr T_3905)
+  DataType: (arr (arr byte))
+  OrigDataType: (arr (struct (0 (arr byte) a0000)))
 T_3907:
   Class: Eq_3905
   DataType: byte
   OrigDataType: (struct 0001 (0 T_1721 t0000))
 T_3908:
   Class: Eq_3906
-  DataType: (arr byte)
+  DataType: (arr (arr byte))
   OrigDataType: (arr T_3907)
 T_3909:
   Class: Eq_3909
@@ -16671,7 +16660,7 @@ T_3910:
   OrigDataType: (struct 0001 (0 T_1733 t0000))
 T_3911:
   Class: Eq_3906
-  DataType: (arr byte)
+  DataType: (arr (arr byte))
   OrigDataType: (arr T_3910)
 T_3912:
   Class: Eq_3905
@@ -16679,7 +16668,7 @@ T_3912:
   OrigDataType: (struct 0001 (0 T_1738 t0000))
 T_3913:
   Class: Eq_3906
-  DataType: (arr byte)
+  DataType: (arr (arr byte))
   OrigDataType: (arr T_3912)
 T_3914:
   Class: Eq_3909
@@ -16696,34 +16685,34 @@ T_3916:
 T_3917:
   Class: Eq_2236
   DataType: Eq_2236
-  OrigDataType: (struct "Eq_3935" 0001 (0 word32 dw0000))
+  OrigDataType: (struct 0001 (0 T_2805 t0000))
 T_3918:
   Class: Eq_2236
   DataType: Eq_2236
   OrigDataType: (arr Eq_2236)
 T_3919:
-  Class: Eq_2879
-  DataType: Eq_2879
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: (struct 0001 (0 T_2879 t0000))
 T_3920:
-  Class: Eq_2879
-  DataType: Eq_2879
-  OrigDataType: (arr Eq_2879)
+  Class: Eq_2236
+  DataType: Eq_2236
+  OrigDataType: (arr Eq_2236)
 T_3921:
-  Class: Eq_3921
-  DataType: Eq_3921
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: (struct 0010 (0 T_3127 t0000))
 T_3922:
-  Class: Eq_3921
-  DataType: Eq_3921
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: (struct 0010 (0 T_3138 t0000))
 T_3923:
-  Class: Eq_3923
-  DataType: Eq_3923
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: (struct 0010 (0 T_3325 t0000))
 T_3924:
-  Class: Eq_3923
-  DataType: Eq_3923
+  Class: Eq_2236
+  DataType: Eq_2236
   OrigDataType: (struct 0010 (0 T_3338 t0000))
 T_3925:
   Class: Eq_3925
@@ -16837,7 +16826,7 @@ typedef struct Eq_339 {
 	Eq_712 t0008;	// 8
 	struct Eq_811 * ptr000C;	// C
 	byte b000E;	// E
-	Eq_885 t000F;	// F
+	byte b000F;	// F
 	int32 dw001C;	// 1C
 } Eq_339;
 
@@ -16876,7 +16865,7 @@ typedef struct Eq_494 {
 	int32 dw0004;	// 4
 	byte * ptr0008;	// 8
 	struct Eq_811 * ptr000C;	// C
-	Eq_1136 t000F;	// F
+	byte b000F;	// F
 	int32 dw0010;	// 10
 	word32 dw0018;	// 18
 } Eq_494;
@@ -16924,12 +16913,7 @@ typedef struct Eq_839 {
 	ptr32 ptr0004;	// 4
 } Eq_839;
 
-typedef bool (Eq_883)(Eq_885, word16, Eq_887);
-
-typedef union Eq_885 {
-	byte u0;
-	word32 u1;
-} Eq_885;
+typedef bool (Eq_883)(byte, word16, Eq_887);
 
 typedef union Eq_887 {
 	byte u0;
@@ -16964,7 +16948,7 @@ typedef struct Eq_1046 {
 
 typedef struct Eq_1058 {
 	word32 dw0000;	// 0
-	Eq_885 t0003;	// 3
+	byte b0003;	// 3
 } Eq_1058;
 
 typedef bool (Eq_1066)(Eq_811 *, word16, ptr32);
@@ -16979,17 +16963,11 @@ typedef union Eq_1115 {
 	word16 u1;
 } Eq_1115;
 
-typedef bool (Eq_1134)(Eq_1136, byte, Eq_1138);
-
-typedef union Eq_1136 {
-	ui32 u0;
-	byte u1;
-} Eq_1136;
+typedef bool (Eq_1134)(byte, byte, Eq_1138);
 
 typedef union Eq_1138 {
-	ui32 u0;
-	byte u1;
-	ptr32 u2;
+	byte u0;
+	ptr32 u1;
 } Eq_1138;
 
 typedef struct Eq_1172 {
@@ -16997,7 +16975,7 @@ typedef struct Eq_1172 {
 	int32 dw0004;	// 4
 	byte * ptr0008;	// 8
 	struct Eq_811 * ptr000C;	// C
-	Eq_1136 t000F;	// F
+	byte b000F;	// F
 	int32 dw0010;	// 10
 } Eq_1172;
 
@@ -17042,7 +17020,7 @@ typedef struct Eq_1454 {
 	ptr32 ptr0000;	// 0
 	int32 dw0004;	// 4
 	ptr32 ptr0008;	// 8
-	Eq_885 t000F;	// F
+	byte b000F;	// F
 	int32 dw0018;	// 18
 } Eq_1454;
 
@@ -17064,11 +17042,11 @@ typedef struct Eq_1674 {
 	int32 dw0000;	// 0
 	int32 dw0004;	// 4
 	int32 dw0008;	// 8
-	Eq_1136 t000F;	// F
+	byte b000F;	// F
 } Eq_1674;
 
 typedef struct Eq_1700 {
-	byte aFFFFF958[];	// FFFFF958
+	byte aFFFFF958[][];	// FFFFF958
 	struct Eq_1701 * aFFFFF998[];	// FFFFF998
 	struct Eq_1704 * ptrFFFFFAA0;	// FFFFFAA0
 } Eq_1700;
@@ -17197,9 +17175,11 @@ typedef struct Eq_2198 {
 typedef word32 (Eq_2217)(Eq_2159 *, Eq_712, Eq_712, ptr32, Eq_2159 *, word32 *);
 
 typedef union Eq_2236 {
-	struct Eq_3934 * u0;
-	Eq_2236 u1[];
-	Eq_3935 u2;
+	word16 u0;
+	struct Eq_3933 * u1;
+	Eq_2236 u2[];
+	Eq_3934 u3;
+	Eq_3935 u4;
 } Eq_2236;
 
 typedef struct Eq_2237 {
@@ -17272,23 +17252,7 @@ typedef union Eq_2829 {
 	ptr32 u1;
 } Eq_2829;
 
-typedef struct Eq_2879 {	// size: 1 1
-	Eq_2879 a0000[];	// 0
-} Eq_2879;
-
 typedef int32 (Eq_2896)(Eq_2236, Eq_2159 *, ui32, up32, Eq_2159 *, ptr32);
-
-typedef union Eq_2998 {
-	int32 u0;
-	word16 u1;
-	Eq_2236 u2[];
-} Eq_2998;
-
-typedef union Eq_3000 {
-	word16 u0;
-	Eq_2236 u1[];
-	Eq_2998 u2;
-} Eq_3000;
 
 typedef struct Eq_3002 {
 	int32 dw0000;	// 0
@@ -17307,10 +17271,6 @@ typedef struct Eq_3002 {
 	int32 dw0034;	// 34
 	int32 dw0038;	// 38
 } Eq_3002;
-
-typedef struct Eq_3113 {
-	Eq_3921 a0000[];	// 0
-} Eq_3113;
 
 typedef struct Eq_3139 {
 	int32 dw0004;	// 4
@@ -17440,22 +17400,13 @@ typedef struct Eq_3916 {	// size: 8 8
 	byte * ptr0004;	// 4
 } Eq_3916;
 
-typedef struct Eq_3921 {	// size: 16 10
-	Eq_2236 t0000;	// 0
-} Eq_3921;
-
-typedef struct Eq_3923 {	// size: 16 10
-	int32 dw0000;	// 0
-	int32 dw0004;	// 4
-	int32 dw0008;	// 8
-} Eq_3923;
-
 typedef struct Eq_3925 {	// size: 16 10
+	int32 dw0000;	// 0
 	int32 dw0004;	// 4
 } Eq_3925;
 
 typedef struct Eq_3926 {	// size: 16 10
-	int32 dw0008;	// 8
+	int32 dw0004;	// 4
 } Eq_3926;
 
 typedef struct Eq_3928 {	// size: 4 4
@@ -17482,21 +17433,16 @@ typedef struct Eq_3932 {
 	<anonymous> ****** ptrFFFFFC0C;	// FFFFFC0C
 } Eq_3932;
 
-typedef union Eq_3933 {
-	word16 u0;
-	Eq_3923 (* u1)[];
-	struct Eq_3113 * u2;
-	Eq_2236 u3[];
-	Eq_2879 u4[];
-	Eq_2236 u5;
-	Eq_2998 u6;
+typedef struct Eq_3933 {	// size: 4 4
+	Eq_2236 a0000[];	// 0
+	Eq_3925 a0004[];	// 4
 } Eq_3933;
 
-typedef struct Eq_3934 {	// size: 4 4
-	Eq_3933 t0000;	// 0
+typedef struct Eq_3934 {	// size: 1 1
+	word32 dw0000;	// 0
 } Eq_3934;
 
-typedef struct Eq_3935 {	// size: 1 1
-	word32 dw0000;	// 0
+typedef struct Eq_3935 {	// size: 16 10
+	Eq_2236 t0000;	// 0
 } Eq_3935;
 

--- a/subjects/PE/m68k/hello_m68k_CRTHEAP.c
+++ b/subjects/PE/m68k/hello_m68k_CRTHEAP.c
@@ -377,7 +377,7 @@ l00002974:
 	int32 d0_n = 7;
 	do
 	{
-		*a0 = 0;
+		a0->u0 = 0;
 		struct Eq_n * a0_n = (word32) a0 + 4;
 		a0_n->dw0000 = 0;
 		a0_n->dw0004 = 0;
@@ -415,12 +415,12 @@ int32 fn000029C8(Eq_n a0, struct Eq_n * a5, ui32 dwArg04, up32 dwArg08, struct E
 	__syscall(0xA11E);
 	if (a0 != 0x00)
 	{
-		struct Eq_n * a1_n = *a5->tFFFFFADC;
+		Eq_n a1_n = *a5->tFFFFFADC;
 		if (((word16) a0 & 0x03) != 0x00)
-			a1_n[dwArg04 * 0x10] = (struct Eq_n) SEQ(SLICE((word32) a0 + 3, word16, 16), (word16) ((word32) a0 + 3) & ~0x03);
+			*((word32) a1_n + dwArg04 * 0x10) = SEQ(SLICE((word32) a0 + 3, word16, 16), (word16) ((word32) a0 + 3) & ~0x03);
 		else
-			a1_n[dwArg04 * 0x10] = (struct Eq_n) a0;
-		struct Eq_n * a1_n = a1_n + (dwArg04 << 0x04);
+			*((word32) a1_n + dwArg04 * 0x10) = a0;
+		struct Eq_n * a1_n = (word32) a1_n + (dwArg04 << 0x04);
 		a1_n->t000C = a0;
 		a1_n->dw0008 = d4_n;
 		a1_n->dw0004 = 0;
@@ -501,10 +501,10 @@ void fn00002AE0(struct Eq_n * a5, Eq_n dwArg04)
 {
 	if (*((word32) *a5->tFFFFFADC + dwArg04 * 0x10) != 0x00)
 		__syscall(0xA01F);
-	Eq_n a0_n[] = *a5->tFFFFFADC;
-	a0_n[dwArg04].dw0000 = 0;
-	a0_n[dwArg04].dw0004 = 0;
-	a0_n[dwArg04].dw0008 = 0;
+	Eq_n a0_n = *a5->tFFFFFADC;
+	((word32) a0_n + dwArg04 * 0x10)->u0 = 0;
+	*((word32) a0_n + (dwArg04 * 0x10 + 4)) = 0;
+	*((word32) a0_n + (dwArg04 * 0x10 + 8)) = 0;
 }
 
 // 00002B18: void fn00002B18(Register (ptr32 Eq_n) a5, Stack Eq_n dwArg04)

--- a/subjects/PE/m68k/hello_m68k_CRTSTART.c
+++ b/subjects/PE/m68k/hello_m68k_CRTSTART.c
@@ -19,14 +19,14 @@ void fn000021F0(struct Eq_n * a5)
 			{
 				if (d0_n == 0x46535953)
 				{
-					a5->aFFFFF958[d1_n] |= 0x01;
+					Mem52[a5 + -0x06A8 + d1_n:byte] = Mem30[a5 + -0x06A8 + d1_n:byte] | 0x01;
 					struct Eq_n * a0_n = *a1_n->ptr0008;
 					a5->aFFFFF998[d1_n] = SEQ(SLICE(a0_n, word16, 16), a0_n->w0002);
 				}
 			}
 			else
 			{
-				a5->aFFFFF958[d1_n] |= 0x41;
+				Mem41[a5 + -0x06A8 + d1_n:byte] = Mem30[a5 + -0x06A8 + d1_n:byte] | 0x41;
 				a5->aFFFFF998[d1_n] = a1_n;
 			}
 			++a1_n;

--- a/subjects/PE/m68k/hello_m68k_CRTSTDIO.c
+++ b/subjects/PE/m68k/hello_m68k_CRTSTDIO.c
@@ -330,7 +330,7 @@ int32 fn00001D80(struct Eq_n * a5, struct Eq_n * dwArg04, ptr32 & d3Out, ptr32 &
 			}
 			else
 			{
-				__bset(a2_n->t000F, 0x05, out a2_n->t000F);
+				__bset(a2_n->b000F, 0x05, out a2_n->b000F);
 				d3_n = -1;
 			}
 		}
@@ -527,7 +527,7 @@ l00001F1C:
 			}
 			else
 			{
-				__bset(a2_n->t0003, 0x05, out a2_n->t0003);
+				__bset(a2_n->b0003, 0x05, out a2_n->b0003);
 				struct Eq_n * a7_n = a7_n + 1;
 				ptr32 d4_n = a7_n->ptr0000;
 				ptr32 d5_n = a7_n->ptr0004;
@@ -545,7 +545,7 @@ l00001F1C:
 		if (!__btst((byte) d0_n, 0x04))
 		{
 			dwArg08->ptr0000 = dwArg08->ptr0008;
-			__bclr(dwArg08->t000F, 0x00, out dwArg08->t000F);
+			__bclr(dwArg08->b000F, 0x00, out dwArg08->b000F);
 			goto l00001EDA;
 		}
 	}
@@ -596,13 +596,13 @@ struct Eq_n * fn00002014(struct Eq_n * a2, struct Eq_n * a5, struct Eq_n * a6, s
 	a2_n->ptr0008 = d0_n;
 	if (d0_n != 0x00)
 	{
-		__bset(a2_n->t000F, 0x03, out a2_n->t000F);
+		__bset(a2_n->b000F, 0x03, out a2_n->b000F);
 		a2_n->dw0018 = 0x0200;
 	}
 	else
 	{
-		__bset(a2_n->t000F, 0x02, out a2_n->t000F);
-		a2_n->ptr0008 = (char *) &a2_n->t000F + 5;
+		__bset(a2_n->b000F, 0x02, out a2_n->b000F);
+		a2_n->ptr0008 = &a2_n->b000F + 5;
 		a2_n->dw0018 = 1;
 	}
 	a2_n->ptr0000 = a2_n->ptr0008;
@@ -704,7 +704,7 @@ word32 fn000020F0(ptr32 a5, Eq_n dwArg04, ptr32 & a5Out, ptr32 & a6Out)
 		word32 a7_n;
 		struct Eq_n * a2_n;
 		(a5 + 122)();
-		__bclr(a2_n->t000F, 0x03, out a2_n->t000F);
+		__bclr(a2_n->b000F, 0x03, out a2_n->b000F);
 		a2_n->dw0000 = 0;
 		a2_n->dw0008 = 0;
 		a2_n->dw0004 = 0;

--- a/subjects/PE/x86-64/varargs_test/varargs_test.reko/varargs_test.h
+++ b/subjects/PE/x86-64/varargs_test/varargs_test.reko/varargs_test.h
@@ -274,12 +274,12 @@ Eq_504: (fn void (Eq_469))
 	T_504 (in RtlCaptureContext : ptr64)
 	T_505 (in signature of RtlCaptureContext : void)
 	T_962 (in RtlCaptureContext : ptr64)
-Eq_508: (union "Eq_508" ((arr BYTE 512) u0) (ULONGLONG u1))
+Eq_508: (union "Eq_508" (DWORD u0) (ULONGLONG u1))
 	T_508 (in rsi_15 : Eq_508)
 	T_511 (in Mem11[rcx + 0xF8<64>:word64] : word64)
 	T_531 (in ControlPc : ULONGLONG)
 	T_968 (in qwLoc03E0 : word64)
-Eq_510: BYTE
+Eq_510: PCONTEXT
 	T_510 (in rcx + 0xF8<64> : word64)
 Eq_528: PVOID
 	T_528 (in rax_25 : Eq_528)
@@ -2489,19 +2489,19 @@ T_507: (in RtlCaptureContext(rcx) : void)
 T_508: (in rsi_15 : Eq_508)
   Class: Eq_508
   DataType: Eq_508
-  OrigDataType: (union (ULONGLONG u0) ((arr BYTE 512) u1))
+  OrigDataType: (union (ULONGLONG u0) (DWORD u1))
 T_509: (in 0xF8<64> : word64)
   Class: Eq_509
   DataType: word64
   OrigDataType: word64
 T_510: (in rcx + 0xF8<64> : word64)
   Class: Eq_510
-  DataType: (ptr64 (arr BYTE 512))
-  OrigDataType: (ptr64 (arr BYTE 512))
+  DataType: Eq_510
+  OrigDataType: PCONTEXT
 T_511: (in Mem11[rcx + 0xF8<64>:word64] : word64)
   Class: Eq_508
   DataType: Eq_508
-  OrigDataType: (arr BYTE 512)
+  OrigDataType: DWORD
 T_512: (in rdi_16 : uint64)
   Class: Eq_512
   DataType: uint64
@@ -6469,11 +6469,11 @@ typedef void (Eq_499)(_EXCEPTION_POINTERS *);
 typedef void (Eq_504)(PCONTEXT);
 
 typedef union Eq_508 {
-	BYTE u0[512];
+	DWORD u0;
 	ULONGLONG u1;
 } Eq_508;
 
-typedef BYTE Eq_510;
+typedef PCONTEXT Eq_510;
 
 typedef PVOID Eq_528;
 

--- a/subjects/PE/x86/VCExeSample/VCExeSample.reko/VCExeSample.globals.c
+++ b/subjects/PE/x86/VCExeSample/VCExeSample.reko/VCExeSample.globals.c
@@ -26,36 +26,13 @@ nested_structs_type g_gbl_nested_structs =
 		},
 		0,
 	};
-nested_structs_type g_t403020 = 
+nested_struct g_t403020 = 
 	{
 		0,
-		
-		{
-			0,
-			0,
-		},
 		0,
 	};
-nested_structs_type g_t403024 = 
-	{
-		0,
-		
-		{
-			0,
-			0,
-		},
-		0,
-	};
-nested_structs_type g_t403028 = 
-	{
-		0,
-		
-		{
-			0,
-			0,
-		},
-		0,
-	};
+int32 g_dw403024 = 0;
+int32 g_dw403028 = 0;
 uint32 g_dw40302C = 0x00;
 uint32 g_dw403030 = 0x00;
 thiscall_class * g_gbl_thiscall = null;

--- a/subjects/PE/x86/VCExeSample/VCExeSample.reko/VCExeSample.h
+++ b/subjects/PE/x86/VCExeSample/VCExeSample.reko/VCExeSample.h
@@ -4,7 +4,7 @@
 
 /*
 // Equivalence classes ////////////
-Eq_1: (struct "Globals" (4020C8 (str char) str4020C8) (4020D0 (str char) str4020D0) (4020DC (str char) str4020DC) (4020E0 (str char) str4020E0) (4020E4 (str char) str4020E4) (4020E8 (str char) str4020E8) (4020EC real32 r4020EC) (4020F0 real32 r4020F0) (4020F4 real32 r4020F4) (4020F8 real64 r4020F8) (402100 real64 r402100) (403018 cdecl_class_ptr gbl_c) (40301C nested_structs_type gbl_nested_structs) (403020 nested_structs_type t403020) (403024 nested_structs_type t403024) (403028 nested_structs_type t403028) (40302C uint32 dw40302C) (403030 uint32 dw403030) (403034 (ptr32 thiscall_class) gbl_thiscall))
+Eq_1: (struct "Globals" (4020C8 (str char) str4020C8) (4020D0 (str char) str4020D0) (4020DC (str char) str4020DC) (4020E0 (str char) str4020E0) (4020E4 (str char) str4020E4) (4020E8 (str char) str4020E8) (4020EC real32 r4020EC) (4020F0 real32 r4020F0) (4020F4 real32 r4020F4) (4020F8 real64 r4020F8) (402100 real64 r402100) (403018 cdecl_class_ptr gbl_c) (40301C nested_structs_type gbl_nested_structs) (403020 nested_struct t403020) (403024 int32 dw403024) (403028 int32 dw403028) (40302C uint32 dw40302C) (403030 uint32 dw403030) (403034 (ptr32 thiscall_class) gbl_thiscall))
 	globals_t (in globals : (ptr32 (struct "Globals")))
 Eq_5: (fn void ((ptr32 char), int32, (ptr32 char), real32))
 	T_5 (in test1 : ptr32)
@@ -181,12 +181,8 @@ Eq_260: (fn void ((ptr32 Eq_242)))
 	T_261 (in signature of nested_structs_test12 : void)
 Eq_265: nested_structs_type
 	T_265 (in 0040301C : ptr32)
-Eq_268: nested_structs_type
+Eq_268: nested_struct
 	T_268 (in 00403020 : ptr32)
-Eq_271: nested_structs_type
-	T_271 (in 00403024 : ptr32)
-Eq_274: nested_structs_type
-	T_274 (in 00403028 : ptr32)
 Eq_276: (struct "nested_struct" (0 int32 b) (4 int32 c))
 	T_276
 Eq_277: (struct "nested_structs_type" 0010 (0 int32 a) (4 nested_struct str) (C int32 d))
@@ -1265,7 +1261,7 @@ T_267: (in 6<32> : word32)
 T_268: (in 00403020 : ptr32)
   Class: Eq_268
   DataType: (ptr32 Eq_268)
-  OrigDataType: (ptr32 (union (nested_structs_type u1)))
+  OrigDataType: (ptr32 (union (nested_struct u1)))
 T_269: (in Mem8[0x00403020<p32>:word32] : word32)
   Class: Eq_267
   DataType: int32
@@ -1276,8 +1272,8 @@ T_270: (in 7<32> : word32)
   OrigDataType: word32
 T_271: (in 00403024 : ptr32)
   Class: Eq_271
-  DataType: (ptr32 Eq_271)
-  OrigDataType: (ptr32 (union (nested_structs_type u1)))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
 T_272: (in Mem9[0x00403024<p32>:word32] : word32)
   Class: Eq_270
   DataType: int32
@@ -1288,8 +1284,8 @@ T_273: (in 8<32> : word32)
   OrigDataType: word32
 T_274: (in 00403028 : ptr32)
   Class: Eq_274
-  DataType: (ptr32 Eq_274)
-  OrigDataType: (ptr32 (union (nested_structs_type u1)))
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
 T_275: (in Mem10[0x00403028<p32>:word32] : word32)
   Class: Eq_273
   DataType: int32
@@ -1321,9 +1317,9 @@ typedef struct Globals {
 	real64 r402100;	// 402100
 	cdecl_class_ptr gbl_c;	// 403018
 	nested_structs_type gbl_nested_structs;	// 40301C
-	nested_structs_type t403020;	// 403020
-	nested_structs_type t403024;	// 403024
-	nested_structs_type t403028;	// 403028
+	nested_struct t403020;	// 403020
+	int32 dw403024;	// 403024
+	int32 dw403028;	// 403028
 	uint32 dw40302C;	// 40302C
 	uint32 dw403030;	// 403030
 	thiscall_class * gbl_thiscall;	// 403034
@@ -1485,11 +1481,7 @@ typedef void (Eq_260)(nested_structs_type *);
 
 typedef nested_structs_type Eq_265;
 
-typedef nested_structs_type Eq_268;
-
-typedef nested_structs_type Eq_271;
-
-typedef nested_structs_type Eq_274;
+typedef nested_struct Eq_268;
 
 typedef struct nested_struct {
 	int32 b;	// 0

--- a/subjects/PE/x86/VCExeSample/VCExeSample.reko/VCExeSample_text.c
+++ b/subjects/PE/x86/VCExeSample/VCExeSample.reko/VCExeSample_text.c
@@ -127,8 +127,8 @@ void gbl_nested_structs_test14()
 	// gbl_nested_structs.str.b = 6
 	globals->t403020 = (Eq_n) 0x06;
 	// gbl_nested_structs.str.c = 7
-	globals->t403024 = (Eq_n) 0x07;
+	globals->dw403024 = 0x07;
 	// gbl_nested_structs.d = 8
-	globals->t403028 = (Eq_n) 0x08;
+	globals->dw403028 = 0x08;
 }
 

--- a/subjects/PE/x86/pySample/pySample.h
+++ b/subjects/PE/x86/pySample/pySample.h
@@ -73,7 +73,7 @@ Eq_110: PyObject
 Eq_111: PyObject
 	T_111 (in _Py_NoneStruct : PyObject)
 	T_121 (in _Py_NoneStruct : PyObject)
-Eq_123: (fn (ptr32 Eq_135) ((ptr32 char), (ptr32 Eq_126), (ptr32 char), (ptr32 Eq_128), int32))
+Eq_123: (fn (ptr32 Eq_135) ((ptr32 char), (ptr32 (arr PyMethodDef 5)), (ptr32 char), (ptr32 Eq_128), int32))
 	T_123 (in Py_InitModule4 : ptr32)
 	T_124 (in signature of Py_InitModule4 : void)
 Eq_126: PyMethodDef
@@ -896,7 +896,7 @@ T_125: (in ptrArg04 : (ptr32 char))
   OrigDataType: 
 T_126: (in ptrArg08 : (ptr32 PyMethodDef))
   Class: Eq_126
-  DataType: (ptr32 Eq_126)
+  DataType: (ptr32 (arr PyMethodDef 5))
   OrigDataType: 
 T_127: (in ptrArg0C : (ptr32 char))
   Class: Eq_127
@@ -916,8 +916,8 @@ T_130: (in 0x10002174<32> : word32)
   OrigDataType: (ptr32 char)
 T_131: (in 0x10003010<32> : word32)
   Class: Eq_126
-  DataType: (ptr32 Eq_126)
-  OrigDataType: (ptr32 PyMethodDef)
+  DataType: (ptr32 (arr PyMethodDef 5))
+  OrigDataType: (ptr32 (arr PyMethodDef 5))
 T_132: (in 0<32> : word32)
   Class: Eq_127
   DataType: (ptr32 char)
@@ -5547,7 +5547,7 @@ typedef PyObject Eq_110;
 
 typedef PyObject Eq_111;
 
-typedef PyObject * (Eq_123)(char *, PyMethodDef *, char *, PyObject *, int32);
+typedef PyObject * (Eq_123)(char *, PyMethodDef *[5], char *, PyObject *, int32);
 
 typedef PyMethodDef Eq_126;
 

--- a/subjects/VMS-vax/unzip.h
+++ b/subjects/VMS-vax/unzip.h
@@ -178,7 +178,7 @@ Eq_193: (union "Eq_193" (word16 u0) ((ptr64 Eq_23440) u1))
 	T_1103 (in 1<32> : word32)
 	T_1106 (in Mem42[sp_111 + 4<i32>:word32] : word32)
 	T_1109 (in Mem42[sp_111 + 16<i32>:word32] : word32)
-	T_1110 (in r4_45 : word32)
+	T_1110 (in r4_45 : Eq_193)
 	T_1113 (in Mem42[r3 + 4<i32>:word32] : word32)
 	T_1116 (in Mem42[r11 + 834<i32>:word32] : word32)
 	T_1120 (in Mem36[sp_111 + 16<i32>:word32] : word32)
@@ -497,8 +497,6 @@ Eq_1074: (struct "Eq_1074" (2 word16 w0002) (4 Eq_193 t0004) (8 Eq_193 t0008) (C
 Eq_1083: (union "Eq_1083" (int32 u0) (uint32 u1))
 	T_1083 (in (uint32) Mem18[r10 + 0xC656<32>:word16] : uint32)
 	T_1084 (in 0<32> : word32)
-Eq_1111: (struct "Eq_1111" (4 Eq_193 t0004))
-	T_1111 (in 4<i32> : int32)
 Eq_1127: (struct "Eq_1127" (C (ptr32 Eq_169) ptr000C) (10 (ptr32 Eq_200) ptr0010))
 	T_1127 (in sp_658 : (ptr32 Eq_1127))
 	T_1129 (in fp - 4<32> : word32)
@@ -508,7 +506,7 @@ Eq_1234: (fn Eq_193 ((ptr32 (ptr32 word32)), Eq_1237, (ptr32 Eq_170), (ptr32 byt
 	T_1234 (in fn0000CFBA : ptr32)
 	T_1235 (in signature of fn0000CFBA : void)
 	T_2152 (in fn0000CFBA : ptr32)
-Eq_1237: (union "Eq_1237" ((ptr32 Eq_23442) u0) ((ptr32 Eq_23445) u1))
+Eq_1237: (union "Eq_1237" ((ptr32 Eq_23442) u0) ((ptr32 Eq_23445) u1) ((arr Eq_21684) u2))
 	T_1237 (in ap : Eq_1237)
 	T_1245 (in r2_416 - 4<32> : word32)
 	T_2053 (in  : word32)
@@ -788,13 +786,9 @@ Eq_1240: (struct "Eq_1240" (400 word32 dw0400))
 	T_4641 (in (uint32) SLICE(r3_85, ui24, 8) ^ r0_16[((uint32) r2_35->b0006 ^ r3_85) & ~0xFFFFFF00<32>] : word32)
 	T_4682 (in (uint32) SLICE(r3_111, ui24, 8) ^ r0_16[((uint32) (*r2_106) ^ r3_111) & ~0xFFFFFF00<32>] : word32)
 	T_21666 (in Mem7[ap + 4<i32>:word32] : word32)
-Eq_1293: (struct "Eq_1293" (4 Eq_193 t0004))
-	T_1293 (in r3 + 4<i32> : word32)
 Eq_1327: (struct "Eq_1327" (C839 ptr32 ptrC839))
 	T_1327 (in r10_460 : (ptr32 Eq_1327))
 	T_1348 (in Mem481[sp_459 - 0xC<32> + 0<32>:word32] : word32)
-Eq_1397: (struct "Eq_1397" (4 Eq_193 t0004))
-	T_1397 (in r3 + 4<i32> : word32)
 Eq_1408: (union "Eq_1408" (int32 u0) (uint32 u1))
 	T_1408 (in r0_517 : Eq_1408)
 	T_1412 (in (uint32) Mem516[r6 + 0<32>:word16] : uint32)
@@ -803,7 +797,7 @@ Eq_1457: (union "Eq_1457" (int32 u0) (uint32 u1))
 	T_1457 (in 3<32> : word32)
 Eq_1458: (union "Eq_1458" (int32 u0) (uint32 u1))
 	T_1458 (in r0_517 - 3<32> : word32)
-Eq_1496: (fn Eq_193 ((ptr32 Eq_169), (ptr64 Eq_1499), (ptr32 word16), Eq_1501, (ptr32 Eq_1502)))
+Eq_1496: (fn Eq_193 ((ptr32 Eq_169), (ptr32 Eq_1499), (ptr32 word16), Eq_1501, (ptr32 Eq_1502)))
 	T_1496 (in fn0000AEF2 : ptr32)
 	T_1497 (in signature of fn0000AEF2 : void)
 	T_1545 (in fn0000AEF2 : ptr32)
@@ -813,7 +807,7 @@ Eq_1496: (fn Eq_193 ((ptr32 Eq_169), (ptr64 Eq_1499), (ptr32 word16), Eq_1501, (
 	T_1785 (in fn0000AEF2 : ptr32)
 	T_1828 (in fn0000AEF2 : ptr32)
 Eq_1499: (struct "Eq_1499" (4 Eq_193 t0004))
-	T_1499 (in r3Out : (ptr64 Eq_1499))
+	T_1499 (in r3Out : (ptr32 Eq_1499))
 	T_1503 (in out r3 : ptr32)
 	T_1546 (in out r3 : ptr32)
 	T_1606 (in out r3 : ptr32)
@@ -821,10 +815,10 @@ Eq_1499: (struct "Eq_1499" (4 Eq_193 t0004))
 	T_1726 (in out r3 : ptr32)
 	T_1786 (in out r3 : ptr32)
 	T_1829 (in out r3 : ptr32)
-	T_1948 (in r0_78 : (ptr64 Eq_1499))
+	T_1948 (in r0_78 : (ptr32 Eq_1499))
 	T_1957 (in 0<32> : word32)
 	T_1999 (in Mem105[sp_75 - 0xC<32> + 0<32>:word32] : word32)
-	T_2007 (in r3_136 : (ptr64 Eq_1499))
+	T_2007 (in r3_136 : (ptr32 Eq_1499))
 Eq_1501: (union "Eq_1501" (int32 u0) (ptr32 u1))
 	T_1501 (in apOut : Eq_1501)
 	T_1505 (in out ap : ptr32)
@@ -849,11 +843,6 @@ Eq_1502: (struct "Eq_1502" (8 (ptr32 Eq_169) ptr0008) (C (ptr32 Eq_200) ptr000C)
 	T_1964 (in fp_145 : (ptr32 Eq_1502))
 	T_1967 (in Mem70[fp_84 + 0xC<32>:word32] : word32)
 	T_2008 (in fp_137 : (ptr32 Eq_1502))
-Eq_1646: (union "Eq_1646" (word32 u0) ((ptr64 Eq_23446) u1))
-	T_1646 (in r2_356 + 4<i32> : word32)
-Eq_1844: (struct "Eq_1844" (4 Eq_193 t0004))
-	T_1844 (in r3 + 4<i32> : word32)
-	T_1849 (in Mem73[sp_70 - 4<32> + 0<32>:word32] : word32)
 Eq_1865: (struct "Eq_1865" (C839 ptr32 ptrC839))
 	T_1865 (in r10_86 : (ptr32 Eq_1865))
 	T_1886 (in Mem106[sp_85 - 0xC<32> + 0<32>:word32] : word32)
@@ -1282,7 +1271,7 @@ Eq_3479: (struct "Eq_3479" (C int32 dw000C))
 Eq_3485: (fn void ())
 	T_3485 (in fn0000F457 : ptr32)
 	T_3486 (in signature of fn0000F457 : void)
-Eq_3492: (struct "Eq_3492" (10CC0 (ptr32 byte) ptr10CC0) (10CC4 (ptr32 byte) ptr10CC4) (10CCC word64 qw10CCC) (10CD0 Eq_3801 t10CD0) (10CDC (ptr32 byte) ptr10CDC) (10CE8 word32 dw10CE8) (10CEC (ptr32 byte) ptr10CEC) (10CF0 word32 dw10CF0))
+Eq_3492: (struct "Eq_3492" (10CC0 (ptr32 byte) ptr10CC0) (10CC4 (ptr32 byte) ptr10CC4) (10CCC word64 qw10CCC) (10CD0 word32 dw10CD0) (10CDC (ptr32 byte) ptr10CDC) (10CE8 word32 dw10CE8) (10CEC (ptr32 byte) ptr10CEC) (10CF0 word32 dw10CF0))
 	T_3492 (in r6 : (ptr32 Eq_3492))
 Eq_3493: (union "Eq_3493" (int32 u0) (ptr32 u1))
 	T_3493 (in r7 : Eq_3493)
@@ -1310,7 +1299,7 @@ Eq_3631: (struct "Eq_3631" (5003 (ptr32 Eq_1237) ptr5003))
 	T_3631 (in r0_93 : (ptr32 Eq_3631))
 Eq_3632: (struct "Eq_3632" (50E87FFE (ptr32 Eq_2025) ptr50E87FFE))
 	T_3632 (in r2_94 : (ptr32 Eq_3632))
-Eq_3656: (struct "Eq_3656" (10CC0 (ptr32 Eq_3754) ptr10CC0) (10CC4 (ptr32 Eq_3754) ptr10CC4) (10CCC word64 qw10CCC) (10CD0 Eq_3831 t10CD0) (10CD8 Eq_3831 t10CD8) (10CDC (ptr32 Eq_3754) ptr10CDC) (10CE0 word32 dw10CE0) (10CE4 word32 dw10CE4) (10CE8 up32 dw10CE8) (10CEC (ptr32 Eq_3754) ptr10CEC))
+Eq_3656: (struct "Eq_3656" (10CC0 (ptr32 Eq_3754) ptr10CC0) (10CC4 (ptr32 Eq_3754) ptr10CC4) (10CCC word64 qw10CCC) (10CD0 word32 dw10CD0) (10CD8 word32 dw10CD8) (10CDC (ptr32 Eq_3754) ptr10CDC) (10CE0 word32 dw10CE0) (10CE4 word32 dw10CE4) (10CE8 up32 dw10CE8) (10CEC (ptr32 Eq_3754) ptr10CEC))
 	T_3656 (in r6_129 : (ptr32 Eq_3656))
 Eq_3678: (struct "Eq_3678" (4 (ptr32 Eq_4121) ptr0004))
 	T_3678 (in ap_218 : (ptr32 Eq_3678))
@@ -1331,14 +1320,6 @@ Eq_3788: (struct "Eq_3788" (10CF0 word32 dw10CF0))
 	T_3788 (in r6_394 : (ptr32 Eq_3788))
 Eq_3790: (struct "Eq_3790" (4 word32 dw0004))
 	T_3790 (in ap_391 : (ptr32 Eq_3790))
-Eq_3801: (union "Eq_3801" (word64 u0) (word32 u1))
-	T_3801 (in Mem374[r6 + 0x10CD0<32>:word32] : word32)
-	T_3802 (in 0<32> : word32)
-Eq_3831: (union "Eq_3831" (word64 u0) (word32 u1))
-	T_3831 (in v65_173 : Eq_3831)
-	T_3834 (in Mem172[r6_129 + 0x10CD8<32>:word32] : word32)
-	T_3837 (in Mem174[r6_129 + 0x10CD0<32>:word32] : word32)
-	T_3838 (in 0<32> : word32)
 Eq_3861: (fn word32 (Eq_3493, (ptr32 Eq_3495), (ptr32 Eq_3496), Eq_3866, Eq_3493, (ptr32 (arr ui32)), ptr32, ptr32))
 	T_3861 (in fn0000E2EA : ptr32)
 	T_3862 (in signature of fn0000E2EA : void)
@@ -1432,7 +1413,7 @@ Eq_5267: (struct "Eq_5267" (24 word32 dw0024) (90 word32 dw0090) (94 word32 dw00
 	T_5267 (in r2_16 : (ptr32 Eq_5267))
 Eq_5301: (struct "Eq_5301" (84 word32 dw0084) (C5F7 word32 dwC5F7) (C5FB int32 dwC5FB) (C849 int32 dwC849) (C84D word32 dwC84D))
 	T_5301 (in ap : (ptr32 Eq_5301))
-Eq_5419: (struct "Eq_5419" (0 (ptr32 word32) ptr0000) (4 word32 dw0004) (C word32 dw000C))
+Eq_5419: (struct "Eq_5419" (0 ptr32 ptr0000) (4 word32 dw0004) (C word32 dw000C))
 	T_5419 (in r0 : (ptr32 Eq_5419))
 	T_5423 (in r2Out : (ptr32 Eq_5419))
 	T_5428 (in r2_116 : (ptr32 Eq_5419))
@@ -1672,7 +1653,7 @@ Eq_5715: (struct "Eq_5715" (14 ui32 dw0014))
 Eq_5760: (struct "Eq_5760" (C (ptr32 Eq_5647) ptr000C) (10 (ptr32 Eq_5648) ptr0010))
 	T_5760 (in sp_222 : (ptr32 Eq_5760))
 	T_5762 (in fp - 4<32> : word32)
-Eq_5787: (struct "Eq_5787" (C5EB (ptr32 (arr word32)) ptrC5EB) (C809 ui32 dwC809) (C80A ui24 nC80A) (C80D ui32 dwC80D) (C810 word32 dwC810) (C811 ui32 dwC811) (C812 ui24 nC812))
+Eq_5787: (struct "Eq_5787" (C5EB (ptr32 (arr word32)) ptrC5EB) (C809 ui32 dwC809) (C80A ui24 nC80A) (C80D ui32 dwC80D) (C810 byte bC810) (C811 ui32 dwC811) (C812 ui24 nC812))
 	T_5787 (in r2_163 : (ptr32 Eq_5787))
 	T_5791 (in (uint32) Mem162[r3 + 0<32>:byte] : uint32)
 	T_5820 (in r2 : (ptr32 Eq_5787))
@@ -2058,7 +2039,7 @@ Eq_9098: (struct "Eq_9098" (C67A word32 dwC67A))
 	T_9098 (in r2_280 : (ptr32 Eq_9098))
 Eq_9112: (struct "Eq_9112" (C ptr32 ptr000C))
 	T_9112 (in fp_296 : (ptr32 Eq_9112))
-Eq_9234: (struct "Eq_9234" (C5EB (ptr32 (arr word32)) ptrC5EB) (C809 ui32 dwC809) (C80A word32 dwC80A) (C80D ui32 dwC80D) (C810 word32 dwC810) (C811 ui32 dwC811) (C812 word32 dwC812))
+Eq_9234: (struct "Eq_9234" (C5EB (ptr32 (arr word32)) ptrC5EB) (C809 ui32 dwC809) (C80A ui24 nC80A) (C80D ui32 dwC80D) (C810 byte bC810) (C811 ui32 dwC811) (C812 ui24 nC812))
 	T_9234 (in r2 : (ptr32 Eq_9234))
 	T_9244 (in r2 : (ptr32 Eq_9234))
 	T_9311 (in r2_97 : (ptr32 Eq_9234))
@@ -2077,7 +2058,7 @@ Eq_9284: (struct "Eq_9284" (C815 word32 dwC815))
 Eq_9312: (fn word32 ((ptr32 (arr Eq_6115)), (ptr32 Eq_6091), (ptr32 Eq_6092), ptr32, ptr32, ptr32))
 	T_9312 (in fn0000E2A6 : ptr32)
 	T_9313 (in signature of fn0000E2A6 : void)
-Eq_9453: (struct "Eq_9453" (84 (ptr32 (arr word32)) ptr0084) (5E7 (ptr32 Eq_9584) ptr05E7) (C5EB (ptr32 (arr word32)) ptrC5EB) (C5F7 (ptr32 byte) ptrC5F7) (C5FB (ptr32 (arr word32)) ptrC5FB) (C644 word16 wC644) (C64B byte bC64B) (C809 ui32 dwC809) (C80A ui24 nC80A) (C80D ui32 dwC80D) (C810 word32 dwC810) (C811 ui32 dwC811) (C812 ui32 dwC812))
+Eq_9453: (struct "Eq_9453" (84 (ptr32 (arr word32)) ptr0084) (5E7 (ptr32 Eq_9584) ptr05E7) (C5EB (ptr32 (arr word32)) ptrC5EB) (C5F7 (ptr32 byte) ptrC5F7) (C5FB (ptr32 (arr word32)) ptrC5FB) (C644 word16 wC644) (C64B byte bC64B) (C809 ui32 dwC809) (C80A ui24 nC80A) (C80D ui32 dwC80D) (C810 byte bC810) (C811 ui32 dwC811) (C812 ui24 nC812))
 	T_9453 (in r2_69 : (ptr32 Eq_9453))
 Eq_9454: (struct "Eq_9454" (FFFFFFFB byte bFFFFFFFB) (8 ptr32 ptr0008) (C ptr32 ptr000C))
 	T_9454 (in fp_74 : (ptr32 Eq_9454))
@@ -2106,7 +2087,7 @@ Eq_9968: (struct "Eq_9968" (0 word32 dw0000) (8 ptr32 ptr0008))
 Eq_10019: (struct "Eq_10019" (0 word32 dw0000) (8 ptr32 ptr0008))
 	T_10019 (in sp_98 : (ptr32 Eq_10019))
 	T_10021 (in sp_108 - 4<32> : word32)
-Eq_10156: (struct "Eq_10156" 0004 (0 (ptr32 Eq_23447) ptr0000) (4 (ptr32 byte) ptr0004))
+Eq_10156: (struct "Eq_10156" 0004 (0 (ptr32 Eq_23446) ptr0000) (4 (ptr32 byte) ptr0004))
 	T_10156 (in v22_17 : (ptr32 Eq_10156))
 	T_10162 (in Mem14[Mem14[ap + 8<i32>:word32] + 0<32>:word32] : word32)
 	T_10174 (in dwLoc0C_184 : (ptr32 Eq_10156))
@@ -2201,7 +2182,7 @@ Eq_11634: (struct "Eq_11634" (4 Eq_20387 t0004) (8 Eq_20387 t0008))
 	T_11743 (in ap : (ptr32 Eq_11634))
 Eq_11638: (struct "Eq_11638" (44 word32 dw0044) (64 int32 dw0064) (68 int32 dw0068) (90 (ptr32 (arr word32)) ptr0090) (94 (ptr32 (arr word32)) ptr0094))
 	T_11638 (in r3_631 : (ptr32 Eq_11638))
-Eq_11642: (struct "Eq_11642" (0 word32 dw0000) (2 word32 dw0002) (4 word32 dw0004))
+Eq_11642: (struct "Eq_11642" (0 word32 dw0000) (2 word16 w0002) (4 word32 dw0004))
 	T_11642 (in sp_626 : (ptr32 Eq_11642))
 Eq_11687: (struct "Eq_11687" (C670 word16 wC670))
 	T_11687 (in r3_216 : (ptr32 Eq_11687))
@@ -3028,20 +3009,49 @@ Eq_21635: (struct "Eq_21635" (2 word32 dw0002))
 	T_21646 (in Mem59[sp_20 - 4<32> + 0<32>:word32] : word32)
 Eq_21670: (struct "Eq_21670" (4 Eq_1237 t0004) (C (ptr32 Eq_2025) ptr000C))
 	T_21670 (in sp_38 : (ptr32 Eq_21670))
-Eq_21671: (struct "Eq_21671" (FFFFFA74 word32 dwFFFFFA74) (FFFFFFB8 (arr word32) aFFFFFFB8) (8 ptr32 ptr0008) (C ptr32 ptr000C))
+Eq_21671: (struct "Eq_21671" (FFFFFA74 word32 dwFFFFFA74) (FFFFFFB8 (arr Eq_21684) aFFFFFFB8) (8 ptr32 ptr0008) (C ptr32 ptr000C))
 	T_21671 (in fp_39 : (ptr32 Eq_21671))
-Eq_21672: (struct "Eq_21672" (4 (ptr32 Eq_18801) ptr0004) (8 word32 dw0008) (18 (ptr32 word32) ptr0018) (1C (ptr32 Eq_18801) ptr001C))
+Eq_21672: (struct "Eq_21672" (4 (ptr32 Eq_18801) ptr0004) (8 Eq_21684 t0008) (18 (ptr32 word32) ptr0018) (1C (ptr32 Eq_18801) ptr001C))
 	T_21672 (in ap_41 : (ptr32 Eq_21672))
+Eq_21684: (union "Eq_21684" (word32 u0) ((arr Eq_21684) u1))
+	T_21684 (in r11_54 : Eq_21684)
+	T_21687 (in Mem33[ap_41 + 8<i32>:word32] : word32)
+	T_21694 (in Mem59[fp_39 + -72<i32>:word32] : word32)
+	T_21696 (in Mem59[fp_39 + -72<i32>:word32] + 1<32> : word32)
+	T_21698 (in Mem63[fp_39 + -72<i32>:word32] : word32)
+	T_21702 (in r11_54 - 1<32> : word32)
+	T_21703 (in 0<32> : word32)
+	T_21707 (in Mem63[fp_39 + -72<i32>:word32] : word32)
+	T_21710 (in Mem63[ap_41 + 8<i32>:word32] : word32)
+	T_21846 (in Mem179[fp_39 + -72<i32>:word32] : word32)
+	T_21850 (in Mem179[fp_39 + -72<i32>:word32] + Mem179[sp_38 + 4<i32>:word32] : word32)
+	T_21852 (in Mem183[fp_39 + -72<i32>:word32] : word32)
+	T_23421
+	T_23422
+	T_23423
+	T_23424
 Eq_21745: (union "Eq_21745" (int32 u0) (up32 u1))
 	T_21745 (in 1<32> : word32)
 Eq_21832: (union "Eq_21832" (int32 u0) (up32 u1))
 	T_21832 (in 1<32> : word32)
-Eq_21900: (struct "Eq_21900" (FFFFFA6A int8 bFFFFFA6A) (FFFFFA6B int8 bFFFFFA6B) (FFFFFA6C Eq_22196 tFFFFFA6C) (FFFFFA70 (arr word32) aFFFFFA70) (FFFFFAB4 up32 dwFFFFFAB4) (FFFFFF34 (ptr32 Eq_18801) ptrFFFFFF34) (FFFFFFB8 (arr word32) aFFFFFFB8) (8 ptr32 ptr0008) (C ptr32 ptr000C))
+Eq_21900: (struct "Eq_21900" (FFFFFA6A int8 bFFFFFA6A) (FFFFFA6B int8 bFFFFFA6B) (FFFFFA6C Eq_22196 tFFFFFA6C) (FFFFFA70 (arr Eq_21944) aFFFFFA70) (FFFFFAB4 up32 dwFFFFFAB4) (FFFFFF34 (ptr32 Eq_18801) ptrFFFFFF34) (FFFFFFB8 (arr word32) aFFFFFFB8) (8 ptr32 ptr0008) (C ptr32 ptr000C))
 	T_21900 (in fp_237 : (ptr32 Eq_21900))
-Eq_21901: (struct "Eq_21901" 0004 (4 word32 dw0004) (8 (ptr32 ui32) ptr0008) (C int32 dw000C) (10 up32 dw0010) (18 word32 dw0018) (1C up32 dw001C) (20 up32 dw0020) (24 Eq_23448 t0024) (28 word32 dw0028) (2C up32 dw002C) (30 ui32 dw0030) (34 uint32 dw0034))
+Eq_21901: (struct "Eq_21901" 0004 (4 word32 dw0004) (8 (ptr32 ui32) ptr0008) (C int32 dw000C) (10 up32 dw0010) (18 word32 dw0018) (1C up32 dw001C) (20 up32 dw0020) (24 Eq_23447 t0024) (28 word32 dw0028) (2C up32 dw002C) (30 ui32 dw0030) (34 uint32 dw0034))
 	T_21901 (in sp_236 : (ptr32 Eq_21901))
 Eq_21902: (struct "Eq_21902" (4 (ptr32 word32) ptr0004) (8 up32 dw0008) (C uint32 dw000C) (10 (ptr32 (arr Eq_23430)) ptr0010) (14 (ptr32 (arr Eq_23429)) ptr0014) (18 (ptr32 word32) ptr0018) (1C (ptr32 (ptr32 Eq_2025)) ptr001C))
 	T_21902 (in ap_239 : (ptr32 Eq_21902))
+Eq_21944: (union "Eq_21944" (ui32 u0) ((arr Eq_21944) u1))
+	T_21944 (in Mem260[fp_237 + -1424<i32>:word32] : word32)
+	T_21946 (in Mem260[fp_237 + -1424<i32>:word32] + 1<32> : word32)
+	T_21948 (in Mem269[fp_237 + -1424<i32>:word32] : word32)
+	T_21978 (in 0<32> : word32)
+	T_21981 (in Mem294[fp_237 + -1424<i32>:word32] : word32)
+	T_22306 (in r11_451 : Eq_21944)
+	T_22423 (in Mem490[fp_237 + -1424<i32>:word32] : word32)
+	T_23425
+	T_23426
+Eq_21945: (union "Eq_21945" (word32 u0) ((arr Eq_21944) u1))
+	T_21945 (in 1<32> : word32)
 Eq_22162: (union "Eq_22162" (int32 u0) (up32 u1))
 	T_22162 (in r6_347 : word32)
 	T_22321 (in Mem417[sp_236 + 28<i32>:word32] : word32)
@@ -3276,7 +3286,7 @@ Eq_23438: (struct "Eq_23438" 0001 (FFFFFB7C word32 dwFFFFFB7C) (FFFFFFE4 int32 d
 	T_23438
 Eq_23439: (struct "Eq_23439" 0008 (FFFFFAEC word32 dwFFFFFAEC) (FFFFFFF0 word32 dwFFFFFFF0) (C word32 dw000C))
 	T_23439
-Eq_23440: (struct "Eq_23440" (4 Eq_193 t0004))
+Eq_23440: (struct "Eq_23440" (0 word16 w0000) (2 word16 w0002) (4 Eq_193 t0004) (24 Eq_193 t0024))
 	T_23440
 Eq_23441: (struct "Eq_23441" (4 Eq_193 t0004))
 	T_23441
@@ -3288,12 +3298,10 @@ Eq_23444: (struct "Eq_23444" 0008 (C5F7 word32 dwC5F7) (C5FB word32 dwC5FB) (C83
 	T_23444
 Eq_23445: (union "Eq_23445" (Eq_23443 u0) (Eq_23444 u1))
 	T_23445
-Eq_23446: (struct "Eq_23446" (4 Eq_193 t0004))
+Eq_23446: (struct "Eq_23446" (1 int8 b0001))
 	T_23446
-Eq_23447: (struct "Eq_23447" (1 int8 b0001))
+Eq_23447: (union "Eq_23447" ((ptr32 (ptr32 Eq_2025)) u0) ((arr (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 int32)))))))) u1) ((arr (ptr32 (ptr32 (ptr32 (ptr32 word32))))) u2) ((arr (ptr32 (ptr32 (ptr32 int8)))) u3) ((arr (ptr32 (ptr32 word32))) u4) (Eq_22288 u5))
 	T_23447
-Eq_23448: (union "Eq_23448" ((ptr32 (ptr32 Eq_2025)) u0) ((arr (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 (ptr32 int32)))))))) u1) ((arr (ptr32 (ptr32 (ptr32 (ptr32 word32))))) u2) ((arr (ptr32 (ptr32 (ptr32 int8)))) u3) ((arr (ptr32 (ptr32 word32))) u4) (Eq_22288 u5))
-	T_23448
 // Type Variables ////////////
 globals_t: (in globals : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -7670,7 +7678,7 @@ T_1093: (in Mem18[fp + 8<32>:word32] : word32)
 T_1094: (in r3 : word32)
   Class: Eq_193
   DataType: Eq_193
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  OrigDataType: (ptr32 (struct (4 T_1110 t0004)))
 T_1095: (in r6 : word32)
   Class: Eq_194
   DataType: (ptr32 word16)
@@ -7731,14 +7739,14 @@ T_1109: (in Mem42[sp_111 + 16<i32>:word32] : word32)
   Class: Eq_193
   DataType: Eq_193
   OrigDataType: word32
-T_1110: (in r4_45 : word32)
+T_1110: (in r4_45 : Eq_193)
   Class: Eq_193
   DataType: Eq_193
   OrigDataType: word32
 T_1111: (in 4<i32> : int32)
   Class: Eq_1111
-  DataType: (ptr64 Eq_1111)
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  DataType: int32
+  OrigDataType: int32
 T_1112: (in r3 + 4<i32> : word32)
   Class: Eq_1112
   DataType: word32
@@ -7945,12 +7953,12 @@ T_1162: (in 320<i32> : int32)
   OrigDataType: int32
 T_1163: (in r8 + 320<i32> : word32)
   Class: Eq_1163
-  DataType: (ptr32 word64)
-  OrigDataType: (ptr32 word64)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_1164: (in Mem608[r8 + 320<i32>:word32] : word32)
   Class: Eq_193
   DataType: Eq_193
-  OrigDataType: word64
+  OrigDataType: word32
 T_1165: (in 0<32> : word32)
   Class: Eq_193
   DataType: word16
@@ -8465,8 +8473,8 @@ T_1292: (in 4<i32> : int32)
   OrigDataType: int32
 T_1293: (in r3 + 4<i32> : word32)
   Class: Eq_1293
-  DataType: (ptr64 Eq_1293)
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_1294: (in Mem616[r3 + 4<i32>:word32] : word32)
   Class: Eq_193
   DataType: Eq_193
@@ -8477,12 +8485,12 @@ T_1295: (in 320<i32> : int32)
   OrigDataType: int32
 T_1296: (in r8 + 320<i32> : word32)
   Class: Eq_1296
-  DataType: (ptr32 word64)
-  OrigDataType: (ptr32 word64)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_1297: (in Mem616[r8 + 320<i32>:word32] : word32)
   Class: Eq_193
   DataType: Eq_193
-  OrigDataType: word64
+  OrigDataType: word32
 T_1298: (in 308<i32> : int32)
   Class: Eq_1298
   DataType: int32
@@ -8820,7 +8828,7 @@ T_1381: (in Mem36[sp_111 + 16<i32>:word32] + 0<32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1382: (in Mem36[Mem36[sp_111 + 16<i32>:word32] + 0<32>:word16] : word16)
-  Class: Eq_1123
+  Class: Eq_1382
   DataType: word16
   OrigDataType: word16
 T_1383: (in 831<i32> : int32)
@@ -8832,7 +8840,7 @@ T_1384: (in r11 + 831<i32> : word32)
   DataType: ptr32
   OrigDataType: ptr32
 T_1385: (in Mem36[r11 + 831<i32>:word16] : word16)
-  Class: Eq_1123
+  Class: Eq_1382
   DataType: word16
   OrigDataType: word16
 T_1386: (in *sp_111->t0010 == r11->w033F : bool)
@@ -8845,12 +8853,12 @@ T_1387: (in 344<i32> : int32)
   OrigDataType: int32
 T_1388: (in r8 + 344<i32> : word32)
   Class: Eq_1388
-  DataType: (ptr32 word64)
-  OrigDataType: (ptr32 word64)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_1389: (in Mem624[r8 + 344<i32>:word32] : word32)
   Class: Eq_193
   DataType: Eq_193
-  OrigDataType: word64
+  OrigDataType: word32
 T_1390: (in 308<i32> : int32)
   Class: Eq_1390
   DataType: int32
@@ -8881,8 +8889,8 @@ T_1396: (in 4<i32> : int32)
   OrigDataType: int32
 T_1397: (in r3 + 4<i32> : word32)
   Class: Eq_1397
-  DataType: (ptr64 Eq_1397)
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_1398: (in Mem632[r3 + 4<i32>:word32] : word32)
   Class: Eq_193
   DataType: Eq_193
@@ -9287,9 +9295,9 @@ T_1498: (in ap : (ptr32 Eq_169))
   Class: Eq_169
   DataType: (ptr32 Eq_169)
   OrigDataType: (ptr32 (struct (4 T_1903 t0004) (8 T_1932 t0008) (10 T_1899 t0010)))
-T_1499: (in r3Out : (ptr64 Eq_1499))
+T_1499: (in r3Out : (ptr32 Eq_1499))
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
+  DataType: (ptr32 Eq_1499)
   OrigDataType: ptr32
 T_1500: (in r6Out : (ptr32 word16))
   Class: Eq_1500
@@ -9305,8 +9313,8 @@ T_1502: (in fpOut : (ptr32 Eq_1502))
   OrigDataType: ptr32
 T_1503: (in out r3 : ptr32)
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  DataType: (ptr32 Eq_1499)
+  OrigDataType: (ptr32 (struct (4 T_1110 t0004)))
 T_1504: (in out r6 : ptr32)
   Class: Eq_1500
   DataType: (ptr32 word16)
@@ -9477,8 +9485,8 @@ T_1545: (in fn0000AEF2 : ptr32)
   OrigDataType: (ptr32 (fn T_1550 (T_191, T_1546, T_1547, T_1548, T_1549)))
 T_1546: (in out r3 : ptr32)
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  DataType: (ptr32 Eq_1499)
+  OrigDataType: (ptr32 (struct (4 T_1110 t0004)))
 T_1547: (in out r6 : ptr32)
   Class: Eq_1500
   DataType: (ptr32 word16)
@@ -9530,19 +9538,19 @@ T_1558: (in r8->t0154 != 0<32> : bool)
 T_1559: (in r2_356 : Eq_193)
   Class: Eq_193
   DataType: Eq_193
-  OrigDataType: (union ((ptr64 (struct (4 T_1647 t0004))) u1) (word32 u0))
+  OrigDataType: (ptr32 (struct (4 T_1647 t0004)))
 T_1560: (in 344<i32> : int32)
   Class: Eq_1560
   DataType: int32
   OrigDataType: int32
 T_1561: (in r8 + 344<i32> : word32)
   Class: Eq_1561
-  DataType: (ptr32 word64)
-  OrigDataType: (ptr32 word64)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_1562: (in Mem355[r8 + 344<i32>:word32] : word32)
   Class: Eq_193
   DataType: Eq_193
-  OrigDataType: word64
+  OrigDataType: word32
 T_1563: (in 0<32> : word32)
   Class: Eq_193
   DataType: word16
@@ -9717,8 +9725,8 @@ T_1605: (in fn0000AEF2 : ptr32)
   OrigDataType: (ptr32 (fn T_1610 (T_191, T_1606, T_1607, T_1608, T_1609)))
 T_1606: (in out r3 : ptr32)
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  DataType: (ptr32 Eq_1499)
+  OrigDataType: (ptr32 (struct (4 T_1110 t0004)))
 T_1607: (in out r6 : ptr32)
   Class: Eq_1500
   DataType: (ptr32 word16)
@@ -9877,8 +9885,8 @@ T_1645: (in 4<i32> : int32)
   OrigDataType: int32
 T_1646: (in r2_356 + 4<i32> : word32)
   Class: Eq_1646
-  DataType: Eq_1646
-  OrigDataType: (union ((ptr64 Eq_23446) u1) (word32 u0))
+  DataType: word32
+  OrigDataType: word32
 T_1647: (in Mem362[r2_356 + 4<i32>:word32] : word32)
   Class: Eq_193
   DataType: Eq_193
@@ -10025,8 +10033,8 @@ T_1682: (in fn0000AEF2 : ptr32)
   OrigDataType: (ptr32 (fn T_1687 (T_191, T_1683, T_1684, T_1685, T_1686)))
 T_1683: (in out r3 : ptr32)
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  DataType: (ptr32 Eq_1499)
+  OrigDataType: (ptr32 (struct (4 T_1110 t0004)))
 T_1684: (in out r6 : ptr32)
   Class: Eq_1500
   DataType: (ptr32 word16)
@@ -10197,8 +10205,8 @@ T_1725: (in fn0000AEF2 : ptr32)
   OrigDataType: (ptr32 (fn T_1730 (T_191, T_1726, T_1727, T_1728, T_1729)))
 T_1726: (in out r3 : ptr32)
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  DataType: (ptr32 Eq_1499)
+  OrigDataType: (ptr32 (struct (4 T_1110 t0004)))
 T_1727: (in out r6 : ptr32)
   Class: Eq_1500
   DataType: (ptr32 word16)
@@ -10437,8 +10445,8 @@ T_1785: (in fn0000AEF2 : ptr32)
   OrigDataType: (ptr32 (fn T_1790 (T_191, T_1786, T_1787, T_1788, T_1789)))
 T_1786: (in out r3 : ptr32)
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  DataType: (ptr32 Eq_1499)
+  OrigDataType: (ptr32 (struct (4 T_1110 t0004)))
 T_1787: (in out r6 : ptr32)
   Class: Eq_1500
   DataType: (ptr32 word16)
@@ -10609,8 +10617,8 @@ T_1828: (in fn0000AEF2 : ptr32)
   OrigDataType: (ptr32 (fn T_1833 (T_191, T_1829, T_1830, T_1831, T_1832)))
 T_1829: (in out r3 : ptr32)
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  DataType: (ptr32 Eq_1499)
+  OrigDataType: (ptr32 (struct (4 T_1110 t0004)))
 T_1830: (in out r6 : ptr32)
   Class: Eq_1500
   DataType: (ptr32 word16)
@@ -10633,12 +10641,12 @@ T_1834: (in 328<i32> : int32)
   OrigDataType: int32
 T_1835: (in r8 + 328<i32> : word32)
   Class: Eq_1835
-  DataType: (ptr32 word64)
-  OrigDataType: (ptr32 word64)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_1836: (in Mem155[r8 + 328<i32>:word32] : word32)
   Class: Eq_193
   DataType: Eq_193
-  OrigDataType: word64
+  OrigDataType: word32
 T_1837: (in sp_70 : (ptr32 word32))
   Class: Eq_1837
   DataType: (ptr32 word32)
@@ -10669,15 +10677,15 @@ T_1843: (in Mem71[sp_70 + 0<32>:word32] : word32)
   OrigDataType: word32
 T_1844: (in r3 + 4<i32> : word32)
   Class: Eq_1844
-  DataType: (ptr64 Eq_1844)
-  OrigDataType: (union ((ptr64 (struct (4 Eq_193 t0004))) u1) ((ptr32 (struct (4 Eq_193 t0004))) u0))
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
 T_1845: (in 4<32> : word32)
   Class: Eq_1845
   DataType: ui32
   OrigDataType: ui32
 T_1846: (in sp_70 - 4<32> : word32)
   Class: Eq_1846
-  DataType: (ptr32 (ptr64 Eq_1844))
+  DataType: (ptr32 (ptr32 word32))
   OrigDataType: (ptr32 (struct (0 T_1849 t0000)))
 T_1847: (in 0<32> : word32)
   Class: Eq_1847
@@ -10689,7 +10697,7 @@ T_1848: (in sp_70 - 4<32> + 0<32> : word32)
   OrigDataType: ptr32
 T_1849: (in Mem73[sp_70 - 4<32> + 0<32>:word32] : word32)
   Class: Eq_1844
-  DataType: (ptr64 Eq_1844)
+  DataType: (ptr32 word32)
   OrigDataType: word32
 T_1850: (in 874<i32> : int32)
   Class: Eq_1850
@@ -11083,9 +11091,9 @@ T_1947: (in sp_75 : ptr32)
   Class: Eq_1947
   DataType: ptr32
   OrigDataType: ptr32
-T_1948: (in r0_78 : (ptr64 Eq_1499))
+T_1948: (in r0_78 : (ptr32 Eq_1499))
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
+  DataType: (ptr32 Eq_1499)
   OrigDataType: word32
 T_1949: (in r4_82 : int32)
   Class: Eq_1949
@@ -11121,7 +11129,7 @@ T_1956: (in globals->ptr192B4 + 2<i32> : word32)
   OrigDataType: (ptr32 code)
 T_1957: (in 0<32> : word32)
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
+  DataType: (ptr32 Eq_1499)
   OrigDataType: word32
 T_1958: (in r0_78 != null : bool)
   Class: Eq_1958
@@ -11277,7 +11285,7 @@ T_1995: (in 0xC<32> : word32)
   OrigDataType: ui32
 T_1996: (in sp_75 - 0xC<32> : word32)
   Class: Eq_1996
-  DataType: (ptr32 (ptr64 Eq_1499))
+  DataType: (ptr32 (ptr32 Eq_1499))
   OrigDataType: (ptr32 (struct (0 T_1999 t0000)))
 T_1997: (in 0<32> : word32)
   Class: Eq_1997
@@ -11289,7 +11297,7 @@ T_1998: (in sp_75 - 0xC<32> + 0<32> : word32)
   OrigDataType: ptr32
 T_1999: (in Mem105[sp_75 - 0xC<32> + 0<32>:word32] : word32)
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
+  DataType: (ptr32 Eq_1499)
   OrigDataType: word32
 T_2000: (in 0001929C : ptr32)
   Class: Eq_2000
@@ -11319,9 +11327,9 @@ T_2006: (in r6_132 : (ptr32 word16))
   Class: Eq_1500
   DataType: (ptr32 word16)
   OrigDataType: word32
-T_2007: (in r3_136 : (ptr64 Eq_1499))
+T_2007: (in r3_136 : (ptr32 Eq_1499))
   Class: Eq_1499
-  DataType: (ptr64 Eq_1499)
+  DataType: (ptr32 Eq_1499)
   OrigDataType: word32
 T_2008: (in fp_137 : (ptr32 Eq_1502))
   Class: Eq_1502
@@ -18493,17 +18501,17 @@ T_3799: (in 0x10CD0<32> : word32)
   OrigDataType: word32
 T_3800: (in r6 + 0x10CD0<32> : word32)
   Class: Eq_3800
-  DataType: (ptr32 word64)
-  OrigDataType: (ptr32 word64)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3801: (in Mem374[r6 + 0x10CD0<32>:word32] : word32)
   Class: Eq_3801
-  DataType: Eq_3801
-  OrigDataType: word64
+  DataType: word32
+  OrigDataType: word32
 T_3802: (in 0<32> : word32)
   Class: Eq_3801
   DataType: word32
   OrigDataType: word32
-T_3803: (in r6->t10CD0 == 0<32> : bool)
+T_3803: (in r6->dw10CD0 == 0<32> : bool)
   Class: Eq_3803
   DataType: bool
   OrigDataType: bool
@@ -18615,9 +18623,9 @@ T_3830: (in Mem172[r6_129 + 0x10CE0<32>:word32] : word32)
   Class: Eq_3758
   DataType: word32
   OrigDataType: word32
-T_3831: (in v65_173 : Eq_3831)
+T_3831: (in v65_173 : word32)
   Class: Eq_3831
-  DataType: Eq_3831
+  DataType: word32
   OrigDataType: word32
 T_3832: (in 0x10CD8<32> : word32)
   Class: Eq_3832
@@ -18629,7 +18637,7 @@ T_3833: (in r6_129 + 0x10CD8<32> : word32)
   OrigDataType: ptr32
 T_3834: (in Mem172[r6_129 + 0x10CD8<32>:word32] : word32)
   Class: Eq_3831
-  DataType: Eq_3831
+  DataType: word32
   OrigDataType: word32
 T_3835: (in 0x10CD0<32> : word32)
   Class: Eq_3835
@@ -18637,12 +18645,12 @@ T_3835: (in 0x10CD0<32> : word32)
   OrigDataType: word32
 T_3836: (in r6_129 + 0x10CD0<32> : word32)
   Class: Eq_3836
-  DataType: (ptr32 word64)
-  OrigDataType: (ptr32 word64)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_3837: (in Mem174[r6_129 + 0x10CD0<32>:word32] : word32)
   Class: Eq_3831
-  DataType: Eq_3831
-  OrigDataType: word64
+  DataType: word32
+  OrigDataType: word32
 T_3838: (in 0<32> : word32)
   Class: Eq_3831
   DataType: word32
@@ -40129,12 +40137,12 @@ T_9208: (in 0xC810<32> : word32)
   OrigDataType: word32
 T_9209: (in r2 + 0xC810<32> : word32)
   Class: Eq_9209
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_9210: (in Mem19[r2 + 0xC810<32>:byte] : byte)
   Class: Eq_9210
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_9211: (in (uint32) Mem19[r2 + 0xC810<32>:byte] : uint32)
   Class: Eq_9211
   DataType: uint32
@@ -40151,7 +40159,7 @@ T_9214: (in Mem19[r2 + 0xC811<32>:word32] : word32)
   Class: Eq_9214
   DataType: ui32
   OrigDataType: word32
-T_9215: (in (uint32) r2->dwC810 ^ r2->dwC811 : word32)
+T_9215: (in (uint32) r2->bC810 ^ r2->dwC811 : word32)
   Class: Eq_9215
   DataType: ui32
   OrigDataType: ui32
@@ -40163,7 +40171,7 @@ T_9217: (in ~0xFFFFFF00<32> : word32)
   Class: Eq_9217
   DataType: ui32
   OrigDataType: ui32
-T_9218: (in ((uint32) r2->dwC810 ^ r2->dwC811) & ~0xFFFFFF00<32> : word32)
+T_9218: (in ((uint32) r2->bC810 ^ r2->dwC811) & ~0xFFFFFF00<32> : word32)
   Class: Eq_9218
   DataType: ui32
   OrigDataType: ui32
@@ -40171,7 +40179,7 @@ T_9219: (in 4<i32> : int32)
   Class: Eq_9219
   DataType: int32
   OrigDataType: int32
-T_9220: (in (((uint32) r2->dwC810 ^ r2->dwC811) & ~0xFFFFFF00<32>) * 4<i32> : word32)
+T_9220: (in (((uint32) r2->bC810 ^ r2->dwC811) & ~0xFFFFFF00<32>) * 4<i32> : word32)
   Class: Eq_9220
   DataType: ui32
   OrigDataType: ui32
@@ -40179,7 +40187,7 @@ T_9221: (in r3_23[(((uint32) Mem19[r2 + 0xC810<32>:byte] ^ Mem19[r2 + 0xC811<32>
   Class: Eq_9173
   DataType: word32
   OrigDataType: word32
-T_9222: (in (uint32) r2->nC812 ^ r3_23[((uint32) r2->dwC810 ^ r2->dwC811) & ~0xFFFFFF00<32>] : word32)
+T_9222: (in (uint32) r2->nC812 ^ r3_23[((uint32) r2->bC810 ^ r2->dwC811) & ~0xFFFFFF00<32>] : word32)
   Class: Eq_9214
   DataType: ui32
   OrigDataType: ui32
@@ -40793,12 +40801,12 @@ T_9374: (in 0xC80A<32> : word32)
   OrigDataType: word32
 T_9375: (in r2 + 0xC80A<32> : word32)
   Class: Eq_9375
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_9376: (in Mem19[r2 + 0xC80A<32>:ui24] : ui24)
   Class: Eq_9376
-  DataType: word32
-  OrigDataType: word32
+  DataType: ui24
+  OrigDataType: ui24
 T_9377: (in (uint32) Mem19[r2 + 0xC80A<32>:ui24] : uint32)
   Class: Eq_9377
   DataType: uint32
@@ -40871,7 +40879,7 @@ T_9394: (in Mem19[r2 + 0xC5EB<32>:word32][(((int32) Mem19[r4_18 + 0<32>:int8] ^ 
   Class: Eq_9394
   DataType: word32
   OrigDataType: word32
-T_9395: (in (uint32) r2->dwC80A ^ (r2->ptrC5EB)[((int32) (*r4_18) ^ r2->dwC809) & ~0xFFFFFF00<32>] : word32)
+T_9395: (in (uint32) r2->nC80A ^ (r2->ptrC5EB)[((int32) (*r4_18) ^ r2->dwC809) & ~0xFFFFFF00<32>] : word32)
   Class: Eq_9357
   DataType: ui32
   OrigDataType: ui32
@@ -40981,12 +40989,12 @@ T_9421: (in 0xC812<32> : word32)
   OrigDataType: word32
 T_9422: (in r2 + 0xC812<32> : word32)
   Class: Eq_9422
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_9423: (in Mem34[r2 + 0xC812<32>:ui24] : ui24)
   Class: Eq_9423
-  DataType: word32
-  OrigDataType: word32
+  DataType: ui24
+  OrigDataType: ui24
 T_9424: (in (uint32) Mem34[r2 + 0xC812<32>:ui24] : uint32)
   Class: Eq_9424
   DataType: uint32
@@ -41009,12 +41017,12 @@ T_9428: (in 0xC810<32> : word32)
   OrigDataType: word32
 T_9429: (in r2 + 0xC810<32> : word32)
   Class: Eq_9429
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_9430: (in Mem34[r2 + 0xC810<32>:byte] : byte)
   Class: Eq_9430
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_9431: (in (uint32) Mem34[r2 + 0xC810<32>:byte] : uint32)
   Class: Eq_9431
   DataType: uint32
@@ -41031,7 +41039,7 @@ T_9434: (in Mem34[r2 + 0xC811<32>:word32] : word32)
   Class: Eq_9365
   DataType: ui32
   OrigDataType: word32
-T_9435: (in (uint32) r2->dwC810 ^ r2->dwC811 : word32)
+T_9435: (in (uint32) r2->bC810 ^ r2->dwC811 : word32)
   Class: Eq_9435
   DataType: ui32
   OrigDataType: ui32
@@ -41043,7 +41051,7 @@ T_9437: (in ~0xFFFFFF00<32> : word32)
   Class: Eq_9437
   DataType: ui32
   OrigDataType: ui32
-T_9438: (in ((uint32) r2->dwC810 ^ r2->dwC811) & ~0xFFFFFF00<32> : word32)
+T_9438: (in ((uint32) r2->bC810 ^ r2->dwC811) & ~0xFFFFFF00<32> : word32)
   Class: Eq_9438
   DataType: ui32
   OrigDataType: ui32
@@ -41051,7 +41059,7 @@ T_9439: (in 4<i32> : int32)
   Class: Eq_9439
   DataType: int32
   OrigDataType: int32
-T_9440: (in (((uint32) r2->dwC810 ^ r2->dwC811) & ~0xFFFFFF00<32>) * 4<i32> : word32)
+T_9440: (in (((uint32) r2->bC810 ^ r2->dwC811) & ~0xFFFFFF00<32>) * 4<i32> : word32)
   Class: Eq_9440
   DataType: ui32
   OrigDataType: ui32
@@ -41059,7 +41067,7 @@ T_9441: (in Mem34[r2 + 0xC5EB<32>:word32][(((uint32) Mem34[r2 + 0xC810<32>:byte]
   Class: Eq_9394
   DataType: word32
   OrigDataType: word32
-T_9442: (in (uint32) r2->dwC812 ^ (r2->ptrC5EB)[((uint32) r2->dwC810 ^ r2->dwC811) & ~0xFFFFFF00<32>] : word32)
+T_9442: (in (uint32) r2->nC812 ^ (r2->ptrC5EB)[((uint32) r2->bC810 ^ r2->dwC811) & ~0xFFFFFF00<32>] : word32)
   Class: Eq_9365
   DataType: ui32
   OrigDataType: ui32
@@ -41473,12 +41481,12 @@ T_9544: (in 0xC812<32> : word32)
   OrigDataType: word32
 T_9545: (in r2_69 + 0xC812<32> : word32)
   Class: Eq_9545
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 ui32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_9546: (in Mem110[r2_69 + 0xC812<32>:ui24] : ui24)
   Class: Eq_9546
-  DataType: ui32
-  OrigDataType: ui32
+  DataType: ui24
+  OrigDataType: ui24
 T_9547: (in (uint32) Mem110[r2_69 + 0xC812<32>:ui24] : uint32)
   Class: Eq_9547
   DataType: uint32
@@ -41489,12 +41497,12 @@ T_9548: (in 0xC810<32> : word32)
   OrigDataType: word32
 T_9549: (in r2_69 + 0xC810<32> : word32)
   Class: Eq_9549
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_9550: (in Mem110[r2_69 + 0xC810<32>:byte] : byte)
   Class: Eq_9550
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_9551: (in (uint32) Mem110[r2_69 + 0xC810<32>:byte] : uint32)
   Class: Eq_9551
   DataType: uint32
@@ -41511,7 +41519,7 @@ T_9554: (in Mem110[r2_69 + 0xC811<32>:word32] : word32)
   Class: Eq_9468
   DataType: ui32
   OrigDataType: ui32
-T_9555: (in (uint32) r2_69->dwC810 ^ r2_69->dwC811 : word32)
+T_9555: (in (uint32) r2_69->bC810 ^ r2_69->dwC811 : word32)
   Class: Eq_9555
   DataType: ui32
   OrigDataType: ui32
@@ -41523,7 +41531,7 @@ T_9557: (in ~0xFFFFFF00<32> : word32)
   Class: Eq_9557
   DataType: ui32
   OrigDataType: ui32
-T_9558: (in ((uint32) r2_69->dwC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32> : word32)
+T_9558: (in ((uint32) r2_69->bC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32> : word32)
   Class: Eq_9558
   DataType: ui32
   OrigDataType: ui32
@@ -41531,7 +41539,7 @@ T_9559: (in 4<i32> : int32)
   Class: Eq_9559
   DataType: int32
   OrigDataType: int32
-T_9560: (in (((uint32) r2_69->dwC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32>) * 4<i32> : word32)
+T_9560: (in (((uint32) r2_69->bC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32>) * 4<i32> : word32)
   Class: Eq_9560
   DataType: ui32
   OrigDataType: ui32
@@ -41539,7 +41547,7 @@ T_9561: (in r3_114[(((uint32) Mem110[r2_69 + 0xC810<32>:byte] ^ Mem110[r2_69 + 0
   Class: Eq_9513
   DataType: word32
   OrigDataType: word32
-T_9562: (in (uint32) r2_69->dwC812 ^ r3_114[((uint32) r2_69->dwC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32>] : word32)
+T_9562: (in (uint32) r2_69->nC812 ^ r3_114[((uint32) r2_69->bC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32>] : word32)
   Class: Eq_9468
   DataType: ui32
   OrigDataType: ui32
@@ -42177,12 +42185,12 @@ T_9720: (in 0xC812<32> : word32)
   OrigDataType: word32
 T_9721: (in r2_69 + 0xC812<32> : word32)
   Class: Eq_9721
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 ui32)
+  DataType: (ptr32 ui24)
+  OrigDataType: (ptr32 ui24)
 T_9722: (in Mem197[r2_69 + 0xC812<32>:ui24] : ui24)
   Class: Eq_9546
-  DataType: ui32
-  OrigDataType: ui32
+  DataType: ui24
+  OrigDataType: ui24
 T_9723: (in (uint32) Mem197[r2_69 + 0xC812<32>:ui24] : uint32)
   Class: Eq_9723
   DataType: uint32
@@ -42193,12 +42201,12 @@ T_9724: (in 0xC810<32> : word32)
   OrigDataType: word32
 T_9725: (in r2_69 + 0xC810<32> : word32)
   Class: Eq_9725
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: (ptr32 byte)
+  OrigDataType: (ptr32 byte)
 T_9726: (in Mem197[r2_69 + 0xC810<32>:byte] : byte)
   Class: Eq_9550
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
 T_9727: (in (uint32) Mem197[r2_69 + 0xC810<32>:byte] : uint32)
   Class: Eq_9727
   DataType: uint32
@@ -42215,7 +42223,7 @@ T_9730: (in Mem197[r2_69 + 0xC811<32>:word32] : word32)
   Class: Eq_9468
   DataType: ui32
   OrigDataType: ui32
-T_9731: (in (uint32) r2_69->dwC810 ^ r2_69->dwC811 : word32)
+T_9731: (in (uint32) r2_69->bC810 ^ r2_69->dwC811 : word32)
   Class: Eq_9731
   DataType: ui32
   OrigDataType: ui32
@@ -42227,7 +42235,7 @@ T_9733: (in ~0xFFFFFF00<32> : word32)
   Class: Eq_9733
   DataType: ui32
   OrigDataType: ui32
-T_9734: (in ((uint32) r2_69->dwC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32> : word32)
+T_9734: (in ((uint32) r2_69->bC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32> : word32)
   Class: Eq_9734
   DataType: ui32
   OrigDataType: ui32
@@ -42235,7 +42243,7 @@ T_9735: (in 4<i32> : int32)
   Class: Eq_9735
   DataType: int32
   OrigDataType: int32
-T_9736: (in (((uint32) r2_69->dwC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32>) * 4<i32> : word32)
+T_9736: (in (((uint32) r2_69->bC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32>) * 4<i32> : word32)
   Class: Eq_9736
   DataType: ui32
   OrigDataType: ui32
@@ -42243,7 +42251,7 @@ T_9737: (in r3_162[(((uint32) Mem197[r2_69 + 0xC810<32>:byte] ^ Mem197[r2_69 + 0
   Class: Eq_9513
   DataType: word32
   OrigDataType: word32
-T_9738: (in (uint32) r2_69->dwC812 ^ r3_162[((uint32) r2_69->dwC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32>] : word32)
+T_9738: (in (uint32) r2_69->nC812 ^ r3_162[((uint32) r2_69->bC810 ^ r2_69->dwC811) & ~0xFFFFFF00<32>] : word32)
   Class: Eq_9468
   DataType: ui32
   OrigDataType: ui32
@@ -49273,7 +49281,7 @@ T_11494: (in r3->dw0064 <= 0<32> : bool)
   OrigDataType: bool
 T_11495: (in 0<32> : word32)
   Class: Eq_11495
-  DataType: (ptr32 word32)
+  DataType: ptr32
   OrigDataType: word32
 T_11496: (in 0<32> : word32)
   Class: Eq_11496
@@ -49285,7 +49293,7 @@ T_11497: (in r0 + 0<32> : word32)
   OrigDataType: word32
 T_11498: (in Mem45[r0 + 0<32>:word32] : word32)
   Class: Eq_11495
-  DataType: (ptr32 word32)
+  DataType: ptr32
   OrigDataType: word32
 T_11499: (in 1<32> : word32)
   Class: Eq_11499
@@ -49517,7 +49525,7 @@ T_11555: (in r3->dw0068 <= 0<32> : bool)
   OrigDataType: bool
 T_11556: (in 0<32> : word32)
   Class: Eq_11495
-  DataType: (ptr32 word32)
+  DataType: ptr32
   OrigDataType: word32
 T_11557: (in 0<32> : word32)
   Class: Eq_11557
@@ -49529,7 +49537,7 @@ T_11558: (in r0 + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_11559: (in Mem89[r0 + 0<32>:word32] : word32)
   Class: Eq_11495
-  DataType: (ptr32 word32)
+  DataType: ptr32
   OrigDataType: word32
 T_11560: (in 1<32> : word32)
   Class: Eq_11560
@@ -50913,12 +50921,12 @@ T_11904: (in 2<i32> : int32)
   OrigDataType: int32
 T_11905: (in sp_626 + 2<i32> : word32)
   Class: Eq_11905
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_11906: (in Mem762[sp_626 + 2<i32>:word16] : word16)
   Class: Eq_11906
-  DataType: word32
-  OrigDataType: word32
+  DataType: word16
+  OrigDataType: word16
 T_11907: (in (uint32) Mem762[sp_626 + 2<i32>:word16] : uint32)
   Class: Eq_11907
   DataType: uint32
@@ -50927,7 +50935,7 @@ T_11908: (in 0<32> : word32)
   Class: Eq_11907
   DataType: uint32
   OrigDataType: word32
-T_11909: (in (uint32) sp_626->dw0002 != 0<32> : bool)
+T_11909: (in (uint32) sp_626->w0002 != 0<32> : bool)
   Class: Eq_11909
   DataType: bool
   OrigDataType: bool
@@ -82145,7 +82153,7 @@ T_19712: (in Mem9[Mem0[ap + 4<i32>:word32] + 0<32>:word32] : word32)
   OrigDataType: word32
 T_19713: (in 0<32> : word32)
   Class: Eq_11495
-  DataType: (ptr32 word32)
+  DataType: ptr32
   OrigDataType: word32
 T_19714: (in 8<i32> : int32)
   Class: Eq_19714
@@ -82169,7 +82177,7 @@ T_19718: (in Mem9[ap + 8<i32>:word32] + 0<32> : word32)
   OrigDataType: word32
 T_19719: (in Mem11[Mem9[ap + 8<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_11495
-  DataType: (ptr32 word32)
+  DataType: ptr32
   OrigDataType: word32
 T_19720: (in -25<i32> : int32)
   Class: Eq_19720
@@ -84581,7 +84589,7 @@ T_20321: (in 8<i32> : int32)
   OrigDataType: int32
 T_20322: (in ap + 8<i32> : word32)
   Class: Eq_20322
-  DataType: (ptr32 (ptr32 (ptr32 word32)))
+  DataType: (ptr32 (ptr32 ptr32))
   OrigDataType: (ptr32 (ptr32 (struct (0 T_19719 t0000))))
 T_20323: (in Mem495[ap + 8<i32>:word32] : word32)
   Class: Eq_5419
@@ -84593,11 +84601,11 @@ T_20324: (in 1<32> : word32)
   OrigDataType: int32
 T_20325: (in Mem495[ap + 8<i32>:word32] + 1<32> : word32)
   Class: Eq_11495
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  DataType: ptr32
+  OrigDataType: ptr32
 T_20326: (in ap + 8<i32> : word32)
   Class: Eq_20326
-  DataType: (ptr32 (ptr32 (ptr32 word32)))
+  DataType: (ptr32 (ptr32 ptr32))
   OrigDataType: (ptr32 (ptr32 (struct (0 T_19719 t0000))))
 T_20327: (in Mem495[ap + 8<i32>:word32] : word32)
   Class: Eq_5419
@@ -84613,7 +84621,7 @@ T_20329: (in Mem495[ap + 8<i32>:word32] + 0<32> : word32)
   OrigDataType: (ptr32 word32)
 T_20330: (in Mem497[Mem495[ap + 8<i32>:word32] + 0<32>:word32] : word32)
   Class: Eq_11495
-  DataType: (ptr32 word32)
+  DataType: ptr32
   OrigDataType: word32
 T_20331: (in 0<32> : word32)
   Class: Eq_20331
@@ -90027,9 +90035,9 @@ T_21683: (in Mem33[ap_41 + 4<i32>:word32] : word32)
   Class: Eq_18801
   DataType: (ptr32 Eq_18801)
   OrigDataType: word32
-T_21684: (in r11_54 : word32)
+T_21684: (in r11_54 : Eq_21684)
   Class: Eq_21684
-  DataType: word32
+  DataType: Eq_21684
   OrigDataType: word32
 T_21685: (in 8<i32> : int32)
   Class: Eq_21685
@@ -90041,7 +90049,7 @@ T_21686: (in ap_41 + 8<i32> : word32)
   OrigDataType: ptr32
 T_21687: (in Mem33[ap_41 + 8<i32>:word32] : word32)
   Class: Eq_21684
-  DataType: word32
+  DataType: Eq_21684
   OrigDataType: word32
 T_21688: (in r3_60 : (ptr32 Eq_18801))
   Class: Eq_18801
@@ -90069,15 +90077,15 @@ T_21693: (in fp_39 + -72<i32> : word32)
   OrigDataType: word32
 T_21694: (in Mem59[fp_39 + -72<i32>:word32] : word32)
   Class: Eq_21684
-  DataType: word32
+  DataType: Eq_21684
   OrigDataType: word32
 T_21695: (in 1<32> : word32)
   Class: Eq_21695
   DataType: word32
   OrigDataType: word32
-T_21696: (in fp_39->aFFFFFFB8[0<i32>] + 1<32> : word32)
+T_21696: (in Mem59[fp_39 + -72<i32>:word32] + 1<32> : word32)
   Class: Eq_21684
-  DataType: word32
+  DataType: Eq_21684
   OrigDataType: word32
 T_21697: (in fp_39 + -72<i32> : word32)
   Class: Eq_21697
@@ -90085,7 +90093,7 @@ T_21697: (in fp_39 + -72<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_21698: (in Mem63[fp_39 + -72<i32>:word32] : word32)
   Class: Eq_21684
-  DataType: word32
+  DataType: Eq_21684
   OrigDataType: word32
 T_21699: (in 4<32> : word32)
   Class: Eq_21699
@@ -90101,7 +90109,7 @@ T_21701: (in 1<32> : word32)
   OrigDataType: word32
 T_21702: (in r11_54 - 1<32> : word32)
   Class: Eq_21684
-  DataType: word32
+  DataType: Eq_21684
   OrigDataType: word32
 T_21703: (in 0<32> : word32)
   Class: Eq_21684
@@ -90121,7 +90129,7 @@ T_21706: (in fp_39 + -72<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_21707: (in Mem63[fp_39 + -72<i32>:word32] : word32)
   Class: Eq_21684
-  DataType: word32
+  DataType: Eq_21684
   OrigDataType: word32
 T_21708: (in 8<i32> : int32)
   Class: Eq_21708
@@ -90133,9 +90141,9 @@ T_21709: (in ap_41 + 8<i32> : word32)
   OrigDataType: (ptr32 word32)
 T_21710: (in Mem63[ap_41 + 8<i32>:word32] : word32)
   Class: Eq_21684
-  DataType: word32
+  DataType: Eq_21684
   OrigDataType: word32
-T_21711: (in fp_39->aFFFFFFB8[0<i32>] != ap_41->dw0008 : bool)
+T_21711: (in fp_39->aFFFFFFB8[0<i32>] != ap_41->t0008 : bool)
   Class: Eq_21711
   DataType: bool
   OrigDataType: bool
@@ -90413,8 +90421,8 @@ T_21779: (in -72<i32> : int32)
   OrigDataType: int32
 T_21780: (in fp_39 + -72<i32> : word32)
   Class: Eq_21780
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_23422)
+  DataType: (ptr32 (arr Eq_21684))
+  OrigDataType: (ptr32 (arr T_21684))
 T_21781: (in 4<i32> : int32)
   Class: Eq_21781
   DataType: int32
@@ -90424,11 +90432,11 @@ T_21782: (in r11_101 * 4<i32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_21783: (in (fp_39 + -72<i32>)[r11_101 * 4<i32>] : word32)
-  Class: Eq_21783
+  Class: Eq_21753
   DataType: word32
   OrigDataType: word32
 T_21784: (in 0<32> : word32)
-  Class: Eq_21783
+  Class: Eq_21753
   DataType: word32
   OrigDataType: word32
 T_21785: (in fp_39->aFFFFFFB8[r11_101] != 0<32> : bool)
@@ -90497,8 +90505,8 @@ T_21800: (in -72<i32> : int32)
   OrigDataType: int32
 T_21801: (in fp_39 + -72<i32> : word32)
   Class: Eq_21801
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_23423)
+  DataType: (ptr32 (arr Eq_21684))
+  OrigDataType: (ptr32 (arr T_21684))
 T_21802: (in 4<i32> : int32)
   Class: Eq_21802
   DataType: int32
@@ -90508,7 +90516,7 @@ T_21803: (in r11_101 * 4<i32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_21804: (in (fp_39 + -72<i32>)[r11_101 * 4<i32>] : word32)
-  Class: Eq_21804
+  Class: Eq_21753
   DataType: word32
   OrigDataType: word32
 T_21805: (in sp_38->t0004 - (fp_39->aFFFFFFB8)[r11_101] : word32)
@@ -90553,8 +90561,8 @@ T_21814: (in -72<i32> : int32)
   OrigDataType: int32
 T_21815: (in fp_39 + -72<i32> : word32)
   Class: Eq_21815
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_23424)
+  DataType: (ptr32 (arr Eq_21684))
+  OrigDataType: (ptr32 (arr T_21684))
 T_21816: (in 4<i32> : int32)
   Class: Eq_21816
   DataType: int32
@@ -90564,7 +90572,7 @@ T_21817: (in r10_158 * 4<i32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_21818: (in (fp_39 + -72<i32>)[r10_158 * 4<i32>] : word32)
-  Class: Eq_21818
+  Class: Eq_21753
   DataType: word32
   OrigDataType: word32
 T_21819: (in sp_38->t0004 - (fp_39->aFFFFFFB8)[r10_158] : word32)
@@ -90673,12 +90681,12 @@ T_21844: (in -72<i32> : int32)
   OrigDataType: int32
 T_21845: (in fp_39 + -72<i32> : word32)
   Class: Eq_21845
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_21684))
+  OrigDataType: (ptr32 (arr Eq_21684))
 T_21846: (in Mem179[fp_39 + -72<i32>:word32] : word32)
   Class: Eq_21684
-  DataType: word32
-  OrigDataType: word32
+  DataType: Eq_21684
+  OrigDataType: (arr Eq_21684)
 T_21847: (in 4<i32> : int32)
   Class: Eq_21847
   DataType: int32
@@ -90690,19 +90698,19 @@ T_21848: (in sp_38 + 4<i32> : word32)
 T_21849: (in Mem179[sp_38 + 4<i32>:word32] : word32)
   Class: Eq_1237
   DataType: Eq_1237
-  OrigDataType: word32
+  OrigDataType: (union (word32 u0) ((arr Eq_21684) u1))
 T_21850: (in Mem179[fp_39 + -72<i32>:word32] + Mem179[sp_38 + 4<i32>:word32] : word32)
   Class: Eq_21684
-  DataType: word32
-  OrigDataType: word32
+  DataType: Eq_21684
+  OrigDataType: (arr Eq_21684)
 T_21851: (in fp_39 + -72<i32> : word32)
   Class: Eq_21851
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_21684))
+  OrigDataType: (ptr32 (arr Eq_21684))
 T_21852: (in Mem183[fp_39 + -72<i32>:word32] : word32)
   Class: Eq_21684
-  DataType: word32
-  OrigDataType: word32
+  DataType: Eq_21684
+  OrigDataType: (arr Eq_21684)
 T_21853: (in 0<32> : word32)
   Class: Eq_21853
   DataType: word32
@@ -90907,9 +90915,9 @@ T_21903: (in r5_245 : ptr32)
   Class: Eq_18804
   DataType: ptr32
   OrigDataType: word32
-T_21904: (in r3_240 : word32)
+T_21904: (in r3_240 : ui32)
   Class: Eq_21904
-  DataType: word32
+  DataType: ui32
   OrigDataType: word32
 T_21905: (in 0001927C : ptr32)
   Class: Eq_21905
@@ -91041,7 +91049,7 @@ T_21936: (in -1424<i32> : int32)
   OrigDataType: int32
 T_21937: (in fp_237 + -1424<i32> : word32)
   Class: Eq_21937
-  DataType: (ptr32 word32)
+  DataType: (ptr32 Eq_21944)
   OrigDataType: (ptr32 T_23425)
 T_21938: (in r10_261 : ui32)
   Class: Eq_21938
@@ -91057,7 +91065,7 @@ T_21940: (in r10_261 * 4<i32> : word32)
   OrigDataType: ui32
 T_21941: (in (fp_237 + -1424<i32>)[r10_261 * 4<i32>] : word32)
   Class: Eq_21904
-  DataType: word32
+  DataType: ui32
   OrigDataType: word32
 T_21942: (in -1424<i32> : int32)
   Class: Eq_21942
@@ -91065,27 +91073,27 @@ T_21942: (in -1424<i32> : int32)
   OrigDataType: int32
 T_21943: (in fp_237 + -1424<i32> : word32)
   Class: Eq_21943
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_21944))
+  OrigDataType: (ptr32 (arr Eq_21944))
 T_21944: (in Mem260[fp_237 + -1424<i32>:word32] : word32)
   Class: Eq_21944
-  DataType: word32
-  OrigDataType: word32
+  DataType: Eq_21944
+  OrigDataType: (arr Eq_21944)
 T_21945: (in 1<32> : word32)
   Class: Eq_21945
   DataType: word32
-  OrigDataType: word32
-T_21946: (in fp_237->aFFFFFA70[0<i32>] + 1<32> : word32)
+  OrigDataType: (union (word32 u0) ((arr Eq_21944) u1))
+T_21946: (in Mem260[fp_237 + -1424<i32>:word32] + 1<32> : word32)
   Class: Eq_21944
-  DataType: word32
-  OrigDataType: word32
+  DataType: Eq_21944
+  OrigDataType: (arr Eq_21944)
 T_21947: (in fp_237 + -1424<i32> : word32)
   Class: Eq_21947
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_21944))
+  OrigDataType: (ptr32 (arr Eq_21944))
 T_21948: (in Mem269[fp_237 + -1424<i32>:word32] : word32)
   Class: Eq_21944
-  DataType: word32
+  DataType: Eq_21944
   OrigDataType: word32
 T_21949: (in -1356<i32> : int32)
   Class: Eq_21949
@@ -91153,8 +91161,8 @@ T_21964: (in -1424<i32> : int32)
   OrigDataType: int32
 T_21965: (in fp_237 + -1424<i32> : word32)
   Class: Eq_21965
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 T_23426)
+  DataType: (ptr32 (arr Eq_21944))
+  OrigDataType: (ptr32 (arr T_21944))
 T_21966: (in 12<i32> : int32)
   Class: Eq_21966
   DataType: int32
@@ -91176,7 +91184,7 @@ T_21970: (in sp_236[3<i32>] * 4<i32> : word32)
   DataType: ui32
   OrigDataType: ui32
 T_21971: (in (fp_237 + -1424<i32>)[Mem287[sp_236 + 12<i32>:word32] * 4<i32>] : word32)
-  Class: Eq_21971
+  Class: Eq_21904
   DataType: ui32
   OrigDataType: word32
 T_21972: (in 8<i32> : int32)
@@ -91200,12 +91208,12 @@ T_21976: (in Mem287[sp_236 + 8<i32>:word32] + 0<32> : word32)
   DataType: word32
   OrigDataType: word32
 T_21977: (in Mem291[Mem287[sp_236 + 8<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_21971
+  Class: Eq_21904
   DataType: ui32
   OrigDataType: word32
 T_21978: (in 0<32> : word32)
   Class: Eq_21944
-  DataType: word32
+  DataType: ui32
   OrigDataType: word32
 T_21979: (in -1424<i32> : int32)
   Class: Eq_21979
@@ -91213,12 +91221,12 @@ T_21979: (in -1424<i32> : int32)
   OrigDataType: int32
 T_21980: (in fp_237 + -1424<i32> : word32)
   Class: Eq_21980
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_21944))
+  OrigDataType: (ptr32 (arr T_21944))
 T_21981: (in Mem294[fp_237 + -1424<i32>:word32] : word32)
   Class: Eq_21944
-  DataType: word32
-  OrigDataType: word32
+  DataType: Eq_21944
+  OrigDataType: ui32
 T_21982: (in 1<32> : word32)
   Class: Eq_21982
   DataType: word32
@@ -91700,7 +91708,7 @@ T_22101: (in Mem568[sp_236 + 8<i32>:word32] + 0<32> : word32)
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
 T_22102: (in Mem568[Mem568[sp_236 + 8<i32>:word32] + 0<32>:word32] : word32)
-  Class: Eq_21971
+  Class: Eq_21904
   DataType: ui32
   OrigDataType: ui32
 T_22103: (in 2<i8> : int8)
@@ -92249,8 +92257,8 @@ T_22238: (in -72<i32> : int32)
   OrigDataType: int32
 T_22239: (in fp_237 + -72<i32> : word32)
   Class: Eq_22239
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr word32))
+  OrigDataType: (ptr32 (arr T_23428))
 T_22240: (in (r9_244 << 2<i8>) + (fp_237 + -72<i32>) : word32)
   Class: Eq_22235
   DataType: (ptr32 up32)
@@ -92515,9 +92523,9 @@ T_22305: (in Mem436[sp_434 + 0<32>:word32] : word32)
   Class: Eq_22302
   DataType: ui32
   OrigDataType: word32
-T_22306: (in r11_451 : word32)
+T_22306: (in r11_451 : Eq_21944)
   Class: Eq_21944
-  DataType: word32
+  DataType: Eq_21944
   OrigDataType: word32
 T_22307: (in r0_452 : word32)
   Class: Eq_22307
@@ -92981,12 +92989,12 @@ T_22421: (in -1424<i32> : int32)
   OrigDataType: int32
 T_22422: (in fp_237 + -1424<i32> : word32)
   Class: Eq_22422
-  DataType: ptr32
-  OrigDataType: ptr32
+  DataType: (ptr32 (arr Eq_21944))
+  OrigDataType: (ptr32 (arr T_21944))
 T_22423: (in Mem490[fp_237 + -1424<i32>:word32] : word32)
   Class: Eq_21944
-  DataType: word32
-  OrigDataType: word32
+  DataType: Eq_21944
+  OrigDataType: (arr T_21944)
 T_22424: (in 36<i32> : int32)
   Class: Eq_22424
   DataType: int32
@@ -96977,27 +96985,27 @@ T_23420:
   OrigDataType: (arr T_23419)
 T_23421:
   Class: Eq_21684
-  DataType: word32
-  OrigDataType: (struct 0004 (0 word32 dw0000))
+  DataType: Eq_21684
+  OrigDataType: (struct 0004 (0 T_21753 t0000))
 T_23422:
   Class: Eq_21684
-  DataType: word32
+  DataType: Eq_21684
   OrigDataType: (struct 0004 (0 T_21783 t0000))
 T_23423:
   Class: Eq_21684
-  DataType: word32
+  DataType: Eq_21684
   OrigDataType: (struct 0004 (0 T_21804 t0000))
 T_23424:
   Class: Eq_21684
-  DataType: word32
+  DataType: Eq_21684
   OrigDataType: (struct 0004 (0 T_21818 t0000))
 T_23425:
   Class: Eq_21944
-  DataType: word32
-  OrigDataType: (struct 0004 (0 word32 dw0000))
+  DataType: Eq_21944
+  OrigDataType: (struct 0004 (0 T_21941 t0000))
 T_23426:
   Class: Eq_21944
-  DataType: word32
+  DataType: Eq_21944
   OrigDataType: (struct 0004 (0 T_21971 t0000))
 T_23427:
   Class: Eq_23427
@@ -97082,10 +97090,6 @@ T_23446:
 T_23447:
   Class: Eq_23447
   DataType: Eq_23447
-  OrigDataType: 
-T_23448:
-  Class: Eq_23448
-  DataType: Eq_23448
   OrigDataType: 
 */
 typedef struct Eq_20178;
@@ -97450,10 +97454,6 @@ typedef union Eq_1083 {
 	uint32 u1;
 } Eq_1083;
 
-typedef struct Eq_1111 {
-	Eq_193 t0004;	// 4
-} Eq_1111;
-
 typedef struct Eq_1127 {
 	struct Eq_169 * ptr000C;	// C
 	struct Eq_200 * ptr0010;	// 10
@@ -97469,23 +97469,16 @@ typedef Eq_193 (Eq_1234)(word32 * *, Eq_1237, Eq_170 *, byte *, Eq_1240 *, word3
 typedef union Eq_1237 {
 	struct Eq_23442 * u0;
 	union Eq_23445 * u1;
+	Eq_21684 u2[];
 } Eq_1237;
 
 typedef struct Eq_1240 {
 	word32 dw0400;	// 400
 } Eq_1240;
 
-typedef struct Eq_1293 {
-	Eq_193 t0004;	// 4
-} Eq_1293;
-
 typedef struct Eq_1327 {
 	ptr32 ptrC839;	// C839
 } Eq_1327;
-
-typedef struct Eq_1397 {
-	Eq_193 t0004;	// 4
-} Eq_1397;
 
 typedef union Eq_1408 {
 	int32 u0;
@@ -97517,15 +97510,6 @@ typedef struct Eq_1502 {
 	struct Eq_169 * ptr0008;	// 8
 	struct Eq_200 * ptr000C;	// C
 } Eq_1502;
-
-typedef union Eq_1646 {
-	word32 u0;
-	struct Eq_23446 * u1;
-} Eq_1646;
-
-typedef struct Eq_1844 {
-	Eq_193 t0004;	// 4
-} Eq_1844;
 
 typedef struct Eq_1865 {
 	ptr32 ptrC839;	// C839
@@ -97872,7 +97856,7 @@ typedef struct Eq_3492 {
 	byte * ptr10CC0;	// 10CC0
 	byte * ptr10CC4;	// 10CC4
 	word64 qw10CCC;	// 10CCC
-	Eq_3801 t10CD0;	// 10CD0
+	word32 dw10CD0;	// 10CD0
 	byte * ptr10CDC;	// 10CDC
 	word32 dw10CE8;	// 10CE8
 	byte * ptr10CEC;	// 10CEC
@@ -97920,8 +97904,8 @@ typedef struct Eq_3656 {
 	struct Eq_3754 * ptr10CC0;	// 10CC0
 	struct Eq_3754 * ptr10CC4;	// 10CC4
 	word64 qw10CCC;	// 10CCC
-	Eq_3831 t10CD0;	// 10CD0
-	Eq_3831 t10CD8;	// 10CD8
+	word32 dw10CD0;	// 10CD0
+	word32 dw10CD8;	// 10CD8
 	struct Eq_3754 * ptr10CDC;	// 10CDC
 	word32 dw10CE0;	// 10CE0
 	word32 dw10CE4;	// 10CE4
@@ -97953,16 +97937,6 @@ typedef struct Eq_3788 {
 typedef struct Eq_3790 {
 	word32 dw0004;	// 4
 } Eq_3790;
-
-typedef union Eq_3801 {
-	word64 u0;
-	word32 u1;
-} Eq_3801;
-
-typedef union Eq_3831 {
-	word64 u0;
-	word32 u1;
-} Eq_3831;
 
 typedef word32 (Eq_3861)(Eq_3493, Eq_3495 *, Eq_3496 *, Eq_3866, Eq_3493, ui32 *[], ptr32, ptr32);
 
@@ -98101,7 +98075,7 @@ typedef struct Eq_5301 {
 } Eq_5301;
 
 typedef struct Eq_5419 {
-	word32 * ptr0000;	// 0
+	ptr32 ptr0000;	// 0
 	word32 dw0004;	// 4
 	word32 dw000C;	// C
 } Eq_5419;
@@ -98177,7 +98151,7 @@ typedef struct Eq_5787 {
 	ui32 dwC809;	// C809
 	ui24 nC80A;	// C80A
 	ui32 dwC80D;	// C80D
-	word32 dwC810;	// C810
+	byte bC810;	// C810
 	ui32 dwC811;	// C811
 	ui24 nC812;	// C812
 } Eq_5787;
@@ -98711,11 +98685,11 @@ typedef struct Eq_9112 {
 typedef struct Eq_9234 {
 	word32 (* ptrC5EB)[];	// C5EB
 	ui32 dwC809;	// C809
-	word32 dwC80A;	// C80A
+	ui24 nC80A;	// C80A
 	ui32 dwC80D;	// C80D
-	word32 dwC810;	// C810
+	byte bC810;	// C810
 	ui32 dwC811;	// C811
-	word32 dwC812;	// C812
+	ui24 nC812;	// C812
 } Eq_9234;
 
 typedef struct Eq_9235 {
@@ -98746,9 +98720,9 @@ typedef struct Eq_9453 {
 	ui32 dwC809;	// C809
 	ui24 nC80A;	// C80A
 	ui32 dwC80D;	// C80D
-	word32 dwC810;	// C810
+	byte bC810;	// C810
 	ui32 dwC811;	// C811
-	ui32 dwC812;	// C812
+	ui24 nC812;	// C812
 } Eq_9453;
 
 typedef struct Eq_9454 {
@@ -98800,7 +98774,7 @@ typedef struct Eq_10019 {
 } Eq_10019;
 
 typedef struct Eq_10156 {	// size: 4 4
-	struct Eq_23447 * ptr0000;	// 0
+	struct Eq_23446 * ptr0000;	// 0
 	byte * ptr0004;	// 4
 } Eq_10156;
 
@@ -98954,7 +98928,7 @@ typedef struct Eq_11638 {
 
 typedef struct Eq_11642 {
 	word32 dw0000;	// 0
-	word32 dw0002;	// 2
+	word16 w0002;	// 2
 	word32 dw0004;	// 4
 } Eq_11642;
 
@@ -100147,17 +100121,22 @@ typedef struct Eq_21670 {
 
 typedef struct Eq_21671 {
 	word32 dwFFFFFA74;	// FFFFFA74
-	word32 aFFFFFFB8[];	// FFFFFFB8
+	Eq_21684 aFFFFFFB8[];	// FFFFFFB8
 	ptr32 ptr0008;	// 8
 	ptr32 ptr000C;	// C
 } Eq_21671;
 
 typedef struct Eq_21672 {
 	struct Eq_18801 * ptr0004;	// 4
-	word32 dw0008;	// 8
+	Eq_21684 t0008;	// 8
 	word32 * ptr0018;	// 18
 	struct Eq_18801 * ptr001C;	// 1C
 } Eq_21672;
+
+typedef union Eq_21684 {
+	word32 u0;
+	Eq_21684 u1[];
+} Eq_21684;
 
 typedef union Eq_21745 {
 	int32 u0;
@@ -100173,7 +100152,7 @@ typedef struct Eq_21900 {
 	int8 bFFFFFA6A;	// FFFFFA6A
 	int8 bFFFFFA6B;	// FFFFFA6B
 	Eq_22196 tFFFFFA6C;	// FFFFFA6C
-	word32 aFFFFFA70[];	// FFFFFA70
+	Eq_21944 aFFFFFA70[];	// FFFFFA70
 	up32 dwFFFFFAB4;	// FFFFFAB4
 	struct Eq_18801 * ptrFFFFFF34;	// FFFFFF34
 	word32 aFFFFFFB8[];	// FFFFFFB8
@@ -100189,7 +100168,7 @@ typedef struct Eq_21901 {	// size: 4 4
 	word32 dw0018;	// 18
 	up32 dw001C;	// 1C
 	up32 dw0020;	// 20
-	Eq_23448 t0024;	// 24
+	Eq_23447 t0024;	// 24
 	word32 dw0028;	// 28
 	up32 dw002C;	// 2C
 	ui32 dw0030;	// 30
@@ -100205,6 +100184,16 @@ typedef struct Eq_21902 {
 	word32 * ptr0018;	// 18
 	struct Eq_2025 ** ptr001C;	// 1C
 } Eq_21902;
+
+typedef union Eq_21944 {
+	ui32 u0;
+	Eq_21944 u1[];
+} Eq_21944;
+
+typedef union Eq_21945 {
+	word32 u0;
+	Eq_21944 u1[];
+} Eq_21945;
 
 typedef union Eq_22162 {
 	int32 u0;
@@ -100413,7 +100402,10 @@ typedef struct Eq_23439 {	// size: 8 8
 } Eq_23439;
 
 typedef struct Eq_23440 {
+	word16 w0000;	// 0
+	word16 w0002;	// 2
 	Eq_193 t0004;	// 4
+	Eq_193 t0024;	// 24
 } Eq_23440;
 
 typedef struct Eq_23441 {
@@ -100458,19 +100450,15 @@ typedef union Eq_23445 {
 } Eq_23445;
 
 typedef struct Eq_23446 {
-	Eq_193 t0004;	// 4
+	int8 b0001;	// 1
 } Eq_23446;
 
-typedef struct Eq_23447 {
-	int8 b0001;	// 1
-} Eq_23447;
-
-typedef union Eq_23448 {
+typedef union Eq_23447 {
 	struct Eq_2025 ** u0;
 	int32 ******* u1[];
 	word32 **** u2[];
 	int8 *** u3[];
 	word32 ** u4[];
 	Eq_22288 u5;
-} Eq_23448;
+} Eq_23447;
 

--- a/subjects/VMS-vax/unzip_code_0000.c
+++ b/subjects/VMS-vax/unzip_code_0000.c
@@ -537,7 +537,7 @@ Eq_n fn0000AA6A(struct Eq_n * r8, struct Eq_n * r10, struct Eq_n * r11, struct E
 				{
 					sp_n->t0004.u0 = 0x01;
 					r3 = sp_n->t0010;
-					word32 r4_n = Mem42[r3 + 4:word32];
+					Eq_n r4_n = *((word32) r3 + 4);
 					if (r4_n == r11->t0342)
 					{
 						uint32 * sp_n = sp_n - 0x04;
@@ -628,7 +628,7 @@ Eq_n fn0000AA6A(struct Eq_n * r8, struct Eq_n * r10, struct Eq_n * r11, struct E
 					{
 						word32 * sp_n = sp_n - 0x04;
 						*sp_n = 0x01;
-						Mem73[sp_n - 0x04 + 0x00:word32] = r3 + 4;
+						*(sp_n - 0x04) = (word32) r3 + 4;
 						*(sp_n - 0x08) = (char *) &r11->t0365 + 5;
 						*(sp_n - 0x0C) = (char *) r10 + 1515;
 						ptr32 sp_n;
@@ -717,7 +717,7 @@ Eq_n fn0000AA6A(struct Eq_n * r8, struct Eq_n * r10, struct Eq_n * r11, struct E
 	}
 }
 
-// 0000AEF2: Register word32 fn0000AEF2(Register (ptr32 Eq_n) ap, Register out (ptr64 Eq_n) r3Out, Register out (ptr32 word16) r6Out, Register out Eq_n apOut, Register out (ptr32 Eq_n) fpOut)
+// 0000AEF2: Register word32 fn0000AEF2(Register (ptr32 Eq_n) ap, Register out (ptr32 Eq_n) r3Out, Register out (ptr32 word16) r6Out, Register out Eq_n apOut, Register out (ptr32 Eq_n) fpOut)
 word32 fn0000AEF2(struct Eq_n * ap, struct Eq_n & r3Out, word16 & r6Out, union Eq_n & apOut, struct Eq_n & fpOut)
 {
 	Eq_n r2_n;
@@ -1419,8 +1419,8 @@ void fn0000C6FA(struct Eq_n * r6, Eq_n r7, word32 r8, struct Eq_n * ap, struct E
 		if (r6_n->dw10CE4 == 0x00)
 			r2_n = 0x01;
 		r6_n->dw10CE0 = r2_n;
-		Eq_n v65_n = r6_n->t10CD8;
-		r6_n->t10CD0 = v65_n;
+		word32 v65_n = r6_n->dw10CD8;
+		r6_n->dw10CD0 = v65_n;
 		if (v65_n != 0x00)
 			r6_n->ptr10CDC->bFFFFFFFF = 0x2E;
 		r6_n->ptr10CDC->b0000 = 0x00;
@@ -1439,7 +1439,7 @@ void fn0000C6FA(struct Eq_n * r6, Eq_n r7, word32 r8, struct Eq_n * ap, struct E
 				struct Eq_n * ap_n;
 				struct Eq_n * sp_n;
 				*r6->ptr10CDC = 0x00;
-				if (r6->t10CD0 != 0x00)
+				if (r6->dw10CD0 != 0x00)
 				{
 					*r6->ptr10CC4 = 0x5D;
 					sp_n = (struct Eq_n *) <invalid>;

--- a/subjects/VMS-vax/unzip_code_0001.c
+++ b/subjects/VMS-vax/unzip_code_0001.c
@@ -400,7 +400,7 @@ word32 fn00011F06(struct Eq_n * r2, struct Eq_n * ap, struct Eq_n * fp, word32 (
 	r2->dwC80D += r2->dwC809 & ~~0xFF;
 	r2->dwC80D = r2->dwC80D * 0x08088405 + 0x01;
 	word32 r3_n[] = r2->ptrC5EB;
-	r2->dwC811 = (uint32) r2->nC812 ^ r3_n[((uint32) r2->dwC810 ^ r2->dwC811) & ~~0xFF];
+	r2->dwC811 = (uint32) r2->nC812 ^ r3_n[((uint32) r2->bC810 ^ r2->dwC811) & ~~0xFF];
 	word32 r0_n = ap->dw0004;
 	struct Eq_n * fp_n = fp->ptr000C;
 	r3Out = r3_n;
@@ -463,10 +463,10 @@ word32 fn00012252(struct Eq_n * r2, struct Eq_n * ap, word32 fp, struct Eq_n & r
 	r2->dwC811 = 878082192;
 	while (*r4_n != 0x00)
 	{
-		r2->dwC809 = (uint32) r2->dwC80A ^ (r2->ptrC5EB)[((int32) (*r4_n) ^ r2->dwC809) & ~~0xFF];
+		r2->dwC809 = (uint32) r2->nC80A ^ (r2->ptrC5EB)[((int32) (*r4_n) ^ r2->dwC809) & ~~0xFF];
 		r2->dwC80D += r2->dwC809 & ~~0xFF;
 		r2->dwC80D = r2->dwC80D * 0x08088405 + 0x01;
-		r2->dwC811 = (uint32) r2->dwC812 ^ (r2->ptrC5EB)[((uint32) r2->dwC810 ^ r2->dwC811) & ~~0xFF];
+		r2->dwC811 = (uint32) r2->nC812 ^ (r2->ptrC5EB)[((uint32) r2->bC810 ^ r2->dwC811) & ~~0xFF];
 		++r4_n;
 	}
 	struct Eq_n * r2_n;
@@ -483,7 +483,7 @@ word32 fn00012252(struct Eq_n * r2, struct Eq_n * ap, word32 fp, struct Eq_n & r
 		r2_n->dwC80D += r2_n->dwC809 & ~~0xFF;
 		r2_n->dwC80D = r2_n->dwC80D * 0x08088405 + 0x01;
 		word32 r3_n[] = r2_n->ptrC5EB;
-		r2_n->dwC811 = (uint32) r2_n->dwC812 ^ r3_n[((uint32) r2_n->dwC810 ^ r2_n->dwC811) & ~~0xFF];
+		r2_n->dwC811 = (uint32) r2_n->nC812 ^ r3_n[((uint32) r2_n->bC810 ^ r2_n->dwC811) & ~~0xFF];
 		++r4_n;
 	}
 	Eq_n r4_n;
@@ -517,7 +517,7 @@ word32 fn00012252(struct Eq_n * r2, struct Eq_n * ap, word32 fp, struct Eq_n & r
 				r2_n->dwC80D += r2_n->dwC809 & ~~0xFF;
 				r2_n->dwC80D = r2_n->dwC80D * 0x08088405 + 0x01;
 				r3_n = r2_n->ptrC5EB;
-				r2_n->dwC811 = (uint32) r2_n->dwC812 ^ r3_n[((uint32) r2_n->dwC810 ^ r2_n->dwC811) & ~~0xFF];
+				r2_n->dwC811 = (uint32) r2_n->nC812 ^ r3_n[((uint32) r2_n->bC810 ^ r2_n->dwC811) & ~~0xFF];
 				++r5_n;
 				--r6_n;
 			} while (r6_n != 0x00);
@@ -1171,7 +1171,7 @@ void fn00012D86(struct Eq_n * r0, word32 r1, struct Eq_n * r3, word32 r4, struct
 			{
 				do
 				{
-					r0->ptr0000 = null;
+					r0->ptr0000 = 0x00;
 					++r2_n;
 				} while (r2_n < r3->dw0064);
 			}
@@ -1189,7 +1189,7 @@ void fn00012D86(struct Eq_n * r0, word32 r1, struct Eq_n * r3, word32 r4, struct
 			{
 				do
 				{
-					r0->ptr0000 = null;
+					r0->ptr0000 = 0x00;
 					++r2_n;
 				} while (r2_n < r3->dw0068);
 			}
@@ -1468,7 +1468,7 @@ void fn00012D86(struct Eq_n * r0, word32 r1, struct Eq_n * r3, word32 r4, struct
 				word32 r1_n;
 				(globals->ptr192B0 + 2)();
 			}
-			(uint32) sp_n->dw0002 != 0x00;
+			(uint32) sp_n->w0002 != 0x00;
 		}
 		else
 		{
@@ -4346,7 +4346,7 @@ void fn000167AA(word32 r0, struct Eq_n * r2, Eq_n r4, union Eq_n * fp, ptr32 * p
 void fn000173CA(struct Eq_n * r0, word32 r1, struct Eq_n * r3, struct Eq_n * r4, struct Eq_n * ap, struct Eq_n * fp)
 {
 	*ap->ptr0004 = (struct Eq_n **) null;
-	ap->ptr0008->ptr0000 = null;
+	ap->ptr0008->ptr0000 = 0x00;
 	r3->ptr05E7 = (struct Eq_n ***********) ((char *) fp - 25);
 	ptr32 sp_n = fp - 0x1C;
 	if ((uint32) r3->wC688 > 0x00)
@@ -4612,7 +4612,7 @@ l0001759B:
 					struct Eq_n ** r2_n = ap->ptr0004;
 					if (*r2_n < r0)
 						*r2_n = (struct Eq_n **) r0;
-					ap->ptr0008->ptr0000 = (word32 *) ((char *) &ap->ptr0008->ptr0000 + 1);
+					ap->ptr0008->ptr0000 = (char *) &ap->ptr0008->ptr0000 + 1;
 				}
 			}
 			word32 r1_n;
@@ -5377,15 +5377,15 @@ int32 fn0001878E(Eq_n ap, union Eq_n * fp, struct Eq_n & r2Out, struct Eq_n & r3
 	struct Eq_n * r4_n;
 	(globals->ptr1927C + 2)();
 	struct Eq_n * r2_n = ap_n->ptr0004;
-	word32 r11_n;
+	Eq_n r11_n;
 	do
 	{
 		struct Eq_n * r3_n = r2_n->dw0000;
-		++fp_n->aFFFFFFB8[0];
+		fp_n->aFFFFFFB8[0].u0 = (word32) fp_n->aFFFFFFB8[0] + 1;
 		++r2_n;
 		--r11_n;
 	} while (r11_n != 0x00);
-	if (fp_n->aFFFFFFB8[0] != ap_n->dw0008)
+	if (fp_n->aFFFFFFB8[0] != ap_n->t0008)
 	{
 		struct Eq_n * r10_n = (struct Eq_n *) 1;
 		while (fp_n->aFFFFFFB8[r10_n] == 0x00)
@@ -5436,7 +5436,7 @@ int32 fn0001878E(Eq_n ap, union Eq_n * fp, struct Eq_n & r2Out, struct Eq_n & r3
 		sp_n->t0004 = v32_n;
 		if (v32_n >= 0x00)
 		{
-			fp_n->aFFFFFFB8[0] = (word32) sp_n->t0004 + (fp_n->aFFFFFFB8)[0];
+			Mem183[fp_n + -72:word32] = Mem179[fp_n + -72:word32] + Mem179[sp_n + 4:word32];
 			fp_n->dwFFFFFA74 = 0x00;
 			word32 r10_n = 0x00;
 			word32 * r2_n = fp_n->aFFFFFFB8 + 1;
@@ -5458,7 +5458,7 @@ int32 fn0001878E(Eq_n ap, union Eq_n * fp, struct Eq_n & r2Out, struct Eq_n & r3
 			struct Eq_n * sp_n;
 			struct Eq_n * ap_n;
 			ptr32 r5_n;
-			word32 r3_n;
+			ui32 r3_n;
 			(globals->ptr1927C + 2)();
 			word32 * r2_n = ap_n->ptr0004;
 			up32 r11_n;
@@ -5468,15 +5468,15 @@ int32 fn0001878E(Eq_n ap, union Eq_n * fp, struct Eq_n & r2Out, struct Eq_n & r3
 				ui32 r10_n = *r2_n;
 				if (r10_n != 0x00)
 				{
-					r3_n = fp_n->aFFFFFA70[r10_n];
-					++fp_n->aFFFFFA70[0];
+					r3_n = (ui32) fp_n->aFFFFFA70[r10_n];
+					fp_n->aFFFFFA70[0] = (word32) fp_n->aFFFFFA70[0] + 1;
 					fp_n->dwFFFFFAB4 = r11_n;
 				}
 				++r11_n;
 			} while (r11_n < ap_n->dw0008);
 			sp_n[2] = (struct Eq_n) &ap_n->dw0008;
 			*sp_n[2] = (struct Eq_n) fp_n->aFFFFFA70[sp_n[3]];
-			fp_n->aFFFFFA70[0] = 0x00;
+			fp_n->aFFFFFA70[0].u0 = 0x00;
 			sp_n[0x0C] = (struct Eq_n) -0x01;
 			struct Eq_n * r2_n = sp_n[9];
 			r2_n->dwFFFFFFFC = 0x00;
@@ -5538,7 +5538,7 @@ int32 fn0001878E(Eq_n ap, union Eq_n * fp, struct Eq_n & r2Out, struct Eq_n & r3
 								uint32 r2_n = (word32) sp_n[11] + 1;
 								struct Eq_n * sp_n = sp_n - 0x04;
 								sp_n->dw0000 = r2_n * 0x06;
-								word32 r11_n;
+								Eq_n r11_n;
 								word32 r0_n;
 								word32 r10_n;
 								struct Eq_n * r4_n;

--- a/subjects/regressions/reko-90/PP.reko/PP_0800.c
+++ b/subjects/regressions/reko-90/PP.reko/PP_0800.c
@@ -13888,7 +13888,7 @@ Eq_n fn0800-9F02(Eq_n ax, struct Eq_n & dxOut)
 l0800_nF25:
 			word16 cx_n = seg0800->wFFFF9D37;
 			seg0800->wFFFF9D37 = (struct Eq_n **) dx_n;
-			dx_n->w0000 = ax;
+			dx_n->t0000 = ax;
 			dx_n->w0002 = cx_n;
 			dxOut = dx_n;
 			return 0x04;
@@ -13896,7 +13896,7 @@ l0800_nF25:
 		word16 dx_n;
 		if (fn0800_A215(ds_n, (uint32) (uint16) (-(ax_n & 0x0F) + 0x10), out dx_n) != ~0x00)
 		{
-			dx_n = (struct Eq_n *) ((char *) &dx_n->w0000 + 1);
+			dx_n = (struct Eq_n *) ((char *) &dx_n->t0000 + 1);
 			goto l0800_nF25;
 		}
 	}
@@ -14060,7 +14060,7 @@ void fn0800_A006(Eq_n bx, Eq_n ds)
 		while (true)
 		{
 			word16 Eq_n::* di_n = Eq_n::a0000;
-			word16 Eq_n::* si_n = &Eq_n::t0000;
+			word16 Eq_n::* si_n = Eq_n::a0000;
 			cu16 cx_n = dx_n;
 			if (dx_n > 0x1000)
 				cx_n = 0x1000;
@@ -14075,7 +14075,7 @@ void fn0800_A006(Eq_n bx, Eq_n ds)
 			if (dx_n <= 0x00)
 				break;
 			es_n = (struct Eq_n *) (es_n->a0000 + 0x0800);
-			ds_n = (struct Eq_n *) ((char *) &ds_n->t0000 + 0x00001000);
+			ds_n = (struct Eq_n *) (ds_n->a0000 + 0x0800);
 		}
 	}
 	struct Eq_n * ds_n;


### PR DESCRIPTION
- Create `ExpressionTypeAscender` test with second field access of global structure variable
```
Expected:
    DataType: (ptr32 real32)
```
but was:
```
    DataType: ptr32
```
- Make `ExpressionTypeAscender.GetPossibleFieldType` work with nested structures.
If we access beyond the start of the field, we need to check if field is
nested structure


