### PR TITLE
Fix: Support loading NE images without resources

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Eberhard Beilharz
 Phil Pemberton
 Marco Savelli
 Natalia Portillo (claunia)
+Sven Almgren (blindmatrix)

--- a/src/ImageLoaders/MzExe/NeImageLoader.cs
+++ b/src/ImageLoaders/MzExe/NeImageLoader.cs
@@ -254,7 +254,8 @@ namespace Reko.ImageLoaders.MzExe
                 case NE_TARGETOS.Windows:
                 case NE_TARGETOS.Windows386:
                     program.Resources.Name = "NE resources";
-                    program.Resources.Resources.AddRange(rsrcLoader.LoadResources());
+                    if (offRsrcTable != offResidentNameTable) // Some NE images contain no resources (indicated by offRsrcTable == offResidentNameTable)
+                        program.Resources.Resources.AddRange(rsrcLoader.LoadResources());
                     break;
                 case NE_TARGETOS.Os2:
                     program.Resources.Name = "OS/2 resources";


### PR DESCRIPTION
Some NE images don't contain resources, in which case `offRsrcTable == offResidentNameTable`