### PR TITLE
ComplexExpressionBuilder: correct type for '&' expression

### DIFF
--- a/src/Decompiler/Typing/ComplexExpressionBuilder.cs
+++ b/src/Decompiler/Typing/ComplexExpressionBuilder.cs
@@ -92,7 +92,8 @@ namespace Reko.Typing
             var exp = this.dtComplex.Accept(this);
             if (!dereferenced && dereferenceGenerated)
             {
-                exp = new UnaryExpression(Operator.AddrOf, dtComplex, exp);
+                var ptr = new Pointer(exp.DataType, dtComplex.BitSize);
+                exp = new UnaryExpression(Operator.AddrOf, ptr, exp);
             }
             if (dereferenced && !dereferenceGenerated)
             {

--- a/subjects/CPM-80/CB80_code.c
+++ b/subjects/CPM-80/CB80_code.c
@@ -96,7 +96,7 @@ byte fn045B()
 		return 0x00;
 	--globals->b0080;
 	struct Eq_n * hl_n = globals->ptr164E;
-	globals->ptr164E = &hl_n->b0001;
+	globals->ptr164E = (struct Eq_n *) &hl_n->b0001;
 	return hl_n->b0001;
 }
 
@@ -1105,7 +1105,7 @@ word16 fn1346(struct Eq_n * bc, struct Eq_n * de)
 bool fn1348(struct Eq_n * de, struct Eq_n * hl, ui8 & deOut, union Eq_n & hlOut)
 {
 	Eq_n a_a_n = SEQ(de->b0001, de->b0000) - SEQ(hl->b0001, hl->b0000);
-	deOut = (ui8 *) &de->b0001;
+	deOut = &de->b0001;
 	hlOut = a_a_n;
 	return (bool) cond(SLICE(a_a_n, byte, 8));
 }

--- a/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_text.c
+++ b/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_text.c
@@ -179,9 +179,9 @@ void vListInitialise(struct Eq_n * r0)
 {
 	r0->dw0008 = ~0x00;
 	r0->dw0000 = 0x00;
-	r0->ptr0004 = (word32 *) &r0->dw0008;
-	r0->ptr000C = (word32 *) &r0->dw0008;
-	r0->ptr0010 = (word32 *) &r0->dw0008;
+	r0->ptr0004 = &r0->dw0008;
+	r0->ptr000C = &r0->dw0008;
+	r0->ptr0010 = &r0->dw0008;
 }
 
 // 000082E8: void vListInitialiseItem(Register (ptr32 Eq_n) r0)

--- a/subjects/Elf/MIPS/redir/redir.reko/redir.h
+++ b/subjects/Elf/MIPS/redir/redir.reko/redir.h
@@ -18339,7 +18339,7 @@ T_4087: (in r2_52 != 0<32> : bool)
 T_4088: (in dwLoc48_539 : Eq_907)
   Class: Eq_907
   DataType: Eq_907
-  OrigDataType: (ptr32 Eq_4095)
+  OrigDataType: (ptr32 byte)
 T_4089: (in strcpy : ptr32)
   Class: Eq_4089
   DataType: (ptr32 Eq_4089)
@@ -19134,7 +19134,7 @@ T_4286: (in (dwLoc014C_568 * 0x14<32> - dwLoc014C_568) * 8<32> : word32)
   OrigDataType: ui32
 T_4287: (in (Mem367[0x10000A40<32>:word32] + 4<i32> + 144<i32>)[(dwLoc014C_568 * 0x14<32> - dwLoc014C_568) * 8<32>] : word32)
   Class: Eq_4274
-  DataType: Eq_4261
+  DataType: word32
   OrigDataType: word32
 T_4288: (in 1<i32> : int32)
   Class: Eq_4261
@@ -19302,7 +19302,7 @@ T_4328: (in (dwLoc014C_568 * 0x14<32> - dwLoc014C_568) * 8<32> : word32)
   OrigDataType: ui32
 T_4329: (in (Mem367[0x10000A40<32>:word32] + 4<i32> + 144<i32>)[(dwLoc014C_568 * 0x14<32> - dwLoc014C_568) * 8<32>] : word32)
   Class: Eq_4317
-  DataType: Eq_4261
+  DataType: word32
   OrigDataType: word32
 T_4330: (in r7_633 : word32)
   Class: Eq_4330
@@ -20230,7 +20230,7 @@ T_4560: (in (dwLoc24_383 * 0x14<32> - dwLoc24_383) * 8<32> : word32)
   OrigDataType: ui32
 T_4561: (in (Mem248[0x10000A40<32>:word32] + 4<i32> + 144<i32>)[(dwLoc24_383 * 0x14<32> - dwLoc24_383) * 8<32>] : word32)
   Class: Eq_4545
-  DataType: Eq_4261
+  DataType: word32
   OrigDataType: word32
 T_4562: (in 0x10008860<32> : word32)
   Class: Eq_4358

--- a/subjects/Elf/MIPS/redir/redir.reko/redir_text.c
+++ b/subjects/Elf/MIPS/redir/redir.reko/redir_text.c
@@ -1961,7 +1961,7 @@ void properties_load(Eq_n r4, Eq_n r5, word32 ra)
 								if ((word32) (r2_n < 1) == 0x00)
 								{
 									if (r2_n == 2)
-										globals->ptr10000A40->a0004->ptr0000.a0004[dwLoc014C_n * 0x14 - dwLoc014C_n + 0x0011].t0004 = (word32) (strchr("1yY", (word32) *r2_n) > null);
+										*((char *) &globals->ptr10000A40->a0004->ptr0000 + ((dwLoc014C_n * 0x14 - dwLoc014C_n) * 0x08 + 144)) = (word32) (strchr("1yY", (word32) *r2_n) > null);
 								}
 								else
 									strncpy((char *) &(globals->ptr10000A40->a0004 + 1)->ptr0000 + 1 + (dwLoc014C_n * 0x14 - dwLoc014C_n << 0x03), r2_n, 20);
@@ -1970,7 +1970,7 @@ void properties_load(Eq_n r4, Eq_n r5, word32 ra)
 							{
 								word32 r2_n;
 								globals->t4053F0();
-								globals->ptr10000A40->a0004->ptr0000.a0004[dwLoc014C_n * 0x14 - dwLoc014C_n + 0x0011].t0004 = r2_n;
+								*((char *) &globals->ptr10000A40->a0004->ptr0000 + ((dwLoc014C_n * 0x14 - dwLoc014C_n) * 0x08 + 144)) = r2_n;
 							}
 						}
 						++dwLoc014C_n;
@@ -2071,7 +2071,7 @@ Eq_n properties_parse_command_line(Eq_n r4, Eq_n r5[], word32 r16, word32 ra, un
 					word32 r6_n;
 					word32 r7_n;
 					(r25_n + 21488)();
-					globals->ptr10000A40->a0004->ptr0000.a0004[dwLoc24_n * 0x14 - dwLoc24_n + 0x0011].t0004 = r2_n;
+					*((char *) &globals->ptr10000A40->a0004->ptr0000 + ((dwLoc24_n * 0x14 - dwLoc24_n) * 0x08 + 144)) = r2_n;
 					r28_n = (struct Eq_n *) 0x10008860;
 				}
 l004061C8:

--- a/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize_text.c
+++ b/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize_text.c
@@ -784,7 +784,7 @@ l00012024:
 			word32 o3_n = (word32) o1_n->b0000;
 			if ((int32) o2_n->bFFFFFFFF == 0x2F)
 			{
-				o1_n = &o1_n->b0001;
+				o1_n = (struct Eq_n *) &o1_n->b0001;
 				goto l00012110;
 			}
 			Z_n = SLICE(cond(o3_n - 0x2E), bool, 2);
@@ -810,7 +810,7 @@ l00012024:
 		{
 			if (o0_n == 0x2F)
 			{
-				o1_n = &o1_n->b0002;
+				o1_n = (struct Eq_n *) &o1_n->b0002;
 				goto l00012110;
 			}
 			if (o0_n == 0x2E)
@@ -822,7 +822,7 @@ l00012024:
 					if (o0_n == 0x2F)
 						o0_n = o1_n + 1;
 					else
-						o0_n = &o1_n->b0002;
+						o0_n = (struct Eq_n *) &o1_n->b0002;
 					int8 * o2_n = (char *) o2_n - 2;
 					o1_n = o0_n;
 					while (true)
@@ -861,7 +861,7 @@ l00012110:
 				o0_n = (word32) o1_n->b0000;
 l00012104:
 			o2_n->b0000 = (byte) o0_n;
-			o1_n = &o1_n->b0001;
+			o1_n = (struct Eq_n *) &o1_n->b0001;
 			++o2_n;
 			goto l00012110;
 		}
@@ -870,7 +870,7 @@ l00012120:
 	if ((int32) o2_n->bFFFFFFFF == 0x2F)
 	{
 		o2_n->b0000 = 0x00;
-		o2_n = &o2_n->bFFFFFFFF;
+		o2_n = (struct Eq_n *) &o2_n->bFFFFFFFF;
 		o2_n->b0000 = 0x00;
 	}
 	else
@@ -1094,7 +1094,7 @@ word32 check_aux_info(word32 o0, ptr32 & i1Out)
 // 00012418: Register (ptr32 Eq_n) find_corresponding_lparen(Register (ptr32 Eq_n) o0)
 struct Eq_n * find_corresponding_lparen(struct Eq_n * o0)
 {
-	int8 * o0_n = &o0->bFFFFFFFF.bFFFFFFFF;
+	int8 * o0_n = &o0->bFFFFFFFF + -1;
 	word32 g3_n = 0x01;
 	int32 g2_n = (int32) o0->bFFFFFFFF;
 l00012424:
@@ -1245,7 +1245,7 @@ l00012688:
 						{
 							if (o0_n == 0x09)
 							{
-								i0_n = &i0_n->bFFFFFFFF;
+								i0_n = (struct Eq_n *) &i0_n->bFFFFFFFF;
 								continue;
 							}
 							else
@@ -1254,7 +1254,7 @@ l00012688:
 								goto l000127E4;
 							}
 						}
-						i0_n = &i0_n->bFFFFFFFF;
+						i0_n = (struct Eq_n *) &i0_n->bFFFFFFFF;
 					}
 					o0_n = (int32) i0_n->b0000;
 l000127E4:
@@ -4162,13 +4162,13 @@ word32 * __do_global_ctors_aux(word32 o3, word32 o4, word32 o5, word32 o7)
 	word32 o2_n = o1_n->dwFFFFFFFC;
 	if (o2_n != ~0x00)
 	{
-		l0_n = (word32 *) &o1_n->dwFFFFFFFC;
+		l0_n = &o1_n->dwFFFFFFFC;
 		do
 			fn00000014();
 		while (*l0_n != ~0x00);
 	}
 	else
-		l0_n = (word32 *) &o1_n->dwFFFFFFFC;
+		l0_n = &o1_n->dwFFFFFFFC;
 	return l0_n;
 }
 

--- a/subjects/Elf/x86-64/ls/ls.reko/ls.h
+++ b/subjects/Elf/x86-64/ls/ls.reko/ls.h
@@ -16445,7 +16445,7 @@ T_2505: (in 0<8> : byte)
   Class: Eq_2504
   DataType: byte
   OrigDataType: byte
-T_2506: (in (&rax_2759->t0014)[(uint64) (uint8) (rax_2759->t0014 == 0x2E<8>) / 24<i32>] == 0<8> : bool)
+T_2506: (in *((char *) &rax_2759->t0014 + (uint64) ((uint8) (rax_2759->t0014 == 0x2E<8>))) == 0<8> : bool)
   Class: Eq_2506
   DataType: bool
   OrigDataType: bool

--- a/subjects/Elf/x86-64/ls/ls.reko/ls_text.c
+++ b/subjects/Elf/x86-64/ls/ls.reko/ls_text.c
@@ -1219,7 +1219,7 @@ l00000000004035FF:
 												rax_n = globals->ptr61AF78;
 											}
 											rax_n->t0000 = globals->t61B018;
-											globals->ptr61AF78 = &globals->ptr61AF78->t0008;
+											globals->ptr61AF78 = (DIR *) &globals->ptr61AF78->t0008;
 										}
 									}
 									struct Eq_n * rdx_n = globals->ptr61B0E0;
@@ -1237,7 +1237,7 @@ l00000000004035FF:
 											rax_n = globals->ptr61AF78;
 										}
 										rax_n->t0000 = globals->t61B018;
-										globals->ptr61AF78 = &globals->ptr61AF78->t0008;
+										globals->ptr61AF78 = (DIR *) &globals->ptr61AF78->t0008;
 									}
 									fwrite_unlocked(4274491, 0x01, 0x02, globals->ptr61A610);
 									globals->t61B018 = (word32) globals->t61B018 + 2;
@@ -1267,7 +1267,7 @@ l00000000004036F0:
 												}
 											}
 										}
-										else if (eax_n == 0x00 || (&rax_n->t0014)[(uint64) ((uint8) (rax_n->t0014 == 0x2E)) / 24] == 0x00)
+										else if (eax_n == 0x00 || *((char *) (&rax_n->t0014) + (uint64) ((uint8) (rax_n->t0014 == 0x2E))) == 0x00)
 											goto l0000000000403770;
 									}
 									Eq_n r15_n = globals->t61B100;

--- a/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN_code.c
+++ b/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN_code.c
@@ -1168,7 +1168,7 @@ int32 fn00001E6C(Eq_n dwArg04, struct Eq_n * dwArg08, ui32 & a0Out, ptr32 & a1Ou
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg08->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg08->dw0018;
+			a0 = &dwArg08->dw0018;
 			d0_n = -1;
 l00001F7A:
 			a0Out = a0;
@@ -1225,7 +1225,7 @@ int32 fn00001F80(struct Eq_n * dwArg04, ui32 & a0Out, ptr32 & a1Out, ptr32 & a5O
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg04->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg04->dw0018;
+			a0 = &dwArg04->dw0018;
 			d0_n = -1;
 l0000200E:
 			a0Out = a0;
@@ -1237,7 +1237,7 @@ l0000200E:
 		dwArg04->dw0014 = dwArg04->dw001C;
 	}
 	dwArg04->dw0018 &= -4;
-	a0 = (ui32 *) &dwArg04->dw0018;
+	a0 = &dwArg04->dw0018;
 	d0_n = 0;
 	goto l0000200E;
 }

--- a/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG.h
+++ b/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG.h
@@ -6727,7 +6727,7 @@ T_1008: (in 105<i32> : int32)
 T_1009: (in a3_1222 : Eq_621)
   Class: Eq_621
   DataType: Eq_621
-  OrigDataType: (ptr32 Eq_932)
+  OrigDataType: (ptr32 word32)
 T_1010: (in 76<i32> : int32)
   Class: Eq_1010
   DataType: int32
@@ -13555,7 +13555,7 @@ T_2715: (in d0 : Eq_972)
 T_2716: (in a1_102 : Eq_974)
   Class: Eq_974
   DataType: Eq_974
-  OrigDataType: (ptr32 Eq_918)
+  OrigDataType: (ptr32 (ptr32 ui32))
 T_2717: (in a0_101 : (ptr32 ui32))
   Class: Eq_973
   DataType: (ptr32 ui32)

--- a/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG_code.c
+++ b/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG_code.c
@@ -1312,7 +1312,7 @@ int32 fn00001F9C(Eq_n dwArg04, struct Eq_n * dwArg08, ui32 & a0Out, ptr32 & a1Ou
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg08->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg08->dw0018;
+			a0 = &dwArg08->dw0018;
 			d0_n = -1;
 l000020AA:
 			a0Out = a0;
@@ -1369,7 +1369,7 @@ int32 fn000020B0(struct Eq_n * dwArg04, ui32 & a0Out, ptr32 & a1Out, ptr32 & a5O
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg04->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg04->dw0018;
+			a0 = &dwArg04->dw0018;
 			d0_n = -1;
 l0000213E:
 			a0Out = a0;
@@ -1381,7 +1381,7 @@ l0000213E:
 		dwArg04->dw0014 = dwArg04->dw001C;
 	}
 	dwArg04->dw0018 &= -4;
-	a0 = (ui32 *) &dwArg04->dw0018;
+	a0 = &dwArg04->dw0018;
 	d0_n = 0;
 	goto l0000213E;
 }

--- a/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL.h
+++ b/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL.h
@@ -8145,7 +8145,7 @@ T_1310: (in 105<i32> : int32)
 T_1311: (in a3_1222 : Eq_615)
   Class: Eq_615
   DataType: Eq_615
-  OrigDataType: (ptr32 Eq_1234)
+  OrigDataType: (ptr32 word32)
 T_1312: (in 76<i32> : int32)
   Class: Eq_1312
   DataType: int32
@@ -14973,7 +14973,7 @@ T_3017: (in d0 : Eq_622)
 T_3018: (in a1_102 : Eq_1276)
   Class: Eq_1276
   DataType: Eq_1276
-  OrigDataType: (ptr32 Eq_1220)
+  OrigDataType: (ptr32 (ptr32 ui32))
 T_3019: (in a0_101 : (ptr32 ui32))
   Class: Eq_1275
   DataType: (ptr32 ui32)

--- a/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL_code.c
+++ b/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL_code.c
@@ -1212,7 +1212,7 @@ int32 fn000020F4(Eq_n dwArg04, struct Eq_n * dwArg08, ui32 & a0Out, ptr32 & a1Ou
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg08->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg08->dw0018;
+			a0 = &dwArg08->dw0018;
 			d0_n = -1;
 l00002202:
 			a0Out = a0;
@@ -1269,7 +1269,7 @@ int32 fn00002208(struct Eq_n * dwArg04, ui32 & a0Out, ptr32 & a1Out, ptr32 & a5O
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg04->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg04->dw0018;
+			a0 = &dwArg04->dw0018;
 			d0_n = -1;
 l00002296:
 			a0Out = a0;
@@ -1281,7 +1281,7 @@ l00002296:
 		dwArg04->dw0014 = dwArg04->dw001C;
 	}
 	dwArg04->dw0018 &= -4;
-	a0 = (ui32 *) &dwArg04->dw0018;
+	a0 = &dwArg04->dw0018;
 	d0_n = 0;
 	goto l00002296;
 }

--- a/subjects/Hunk-m68k/BYTEOPS.reko/BYTEOPS_code.c
+++ b/subjects/Hunk-m68k/BYTEOPS.reko/BYTEOPS_code.c
@@ -1116,7 +1116,7 @@ int32 fn00001E34(Eq_n dwArg04, struct Eq_n * dwArg08, ui32 & a0Out, ptr32 & a5Ou
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg08->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg08->dw0018;
+			a0 = &dwArg08->dw0018;
 			d0_n = -1;
 l00001F42:
 			a0Out = a0;
@@ -1168,7 +1168,7 @@ int32 fn00001F48(struct Eq_n * dwArg04, ui32 & a0Out, ptr32 & a5Out)
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg04->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg04->dw0018;
+			a0 = &dwArg04->dw0018;
 			d0_n = -1;
 l00001FD6:
 			a0Out = a0;
@@ -1179,7 +1179,7 @@ l00001FD6:
 		dwArg04->dw0014 = dwArg04->dw001C;
 	}
 	dwArg04->dw0018 &= -4;
-	a0 = (ui32 *) &dwArg04->dw0018;
+	a0 = &dwArg04->dw0018;
 	d0_n = 0;
 	goto l00001FD6;
 }

--- a/subjects/Hunk-m68k/FIBO.reko/FIBO_code.c
+++ b/subjects/Hunk-m68k/FIBO.reko/FIBO_code.c
@@ -1146,7 +1146,7 @@ int32 fn00001E90(Eq_n dwArg04, struct Eq_n * dwArg08, ui32 & a0Out, ptr32 & a1Ou
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg08->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg08->dw0018;
+			a0 = &dwArg08->dw0018;
 			d0_n = -1;
 l00001F9E:
 			a0Out = a0;
@@ -1203,7 +1203,7 @@ int32 fn00001FA4(struct Eq_n * dwArg04, ui32 & a0Out, ptr32 & a1Out, ptr32 & a5O
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg04->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg04->dw0018;
+			a0 = &dwArg04->dw0018;
 			d0_n = -1;
 l00002032:
 			a0Out = a0;
@@ -1215,7 +1215,7 @@ l00002032:
 		dwArg04->dw0014 = dwArg04->dw001C;
 	}
 	dwArg04->dw0018 &= -4;
-	a0 = (ui32 *) &dwArg04->dw0018;
+	a0 = &dwArg04->dw0018;
 	d0_n = 0;
 	goto l00002032;
 }

--- a/subjects/Hunk-m68k/MATRIXMU.reko/MATRIXMU_code.c
+++ b/subjects/Hunk-m68k/MATRIXMU.reko/MATRIXMU_code.c
@@ -55,7 +55,7 @@ void fn00001000(int32 d0, byte * a0)
 			word32 a0_n;
 			d0_n->dw0000 = d0_n + 0x11;
 			d0_n->dw000C = d4_n - 0x01;
-			d0_n->ptr0008 = (byte *) (&d0_n->ptr0010 + d0_n / 20);
+			d0_n->ptr0008 = (char *) &d0_n->ptr0010 + d0_n;
 			null = null;
 			struct Eq_n * d0_n = d0_n->ptr00AC;
 			if (d0_n == null)

--- a/subjects/Hunk-m68k/MAX.reko/MAX.h
+++ b/subjects/Hunk-m68k/MAX.reko/MAX.h
@@ -24195,7 +24195,7 @@ T_5388: (in 105<i32> : int32)
 T_5389: (in a3_1222 : Eq_613)
   Class: Eq_613
   DataType: Eq_613
-  OrigDataType: (ptr32 Eq_5312)
+  OrigDataType: (ptr32 word32)
 T_5390: (in 76<i32> : int32)
   Class: Eq_5390
   DataType: int32
@@ -31023,7 +31023,7 @@ T_7095: (in d0 : Eq_5352)
 T_7096: (in a1_102 : Eq_5354)
   Class: Eq_5354
   DataType: Eq_5354
-  OrigDataType: (ptr32 Eq_5103)
+  OrigDataType: (ptr32 (ptr32 ui32))
 T_7097: (in a0_101 : (ptr32 ui32))
   Class: Eq_5159
   DataType: (ptr32 ui32)

--- a/subjects/Hunk-m68k/MAX.reko/MAX_code.c
+++ b/subjects/Hunk-m68k/MAX.reko/MAX_code.c
@@ -2073,7 +2073,7 @@ int32 fn00002B28(struct Eq_n * dwArg04, ui32 & a0Out, ptr32 & a1Out, ptr32 & a5O
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg04->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg04->dw0018;
+			a0 = &dwArg04->dw0018;
 			d0_n = -1;
 l00002BB6:
 			a0Out = a0;
@@ -2085,7 +2085,7 @@ l00002BB6:
 		dwArg04->dw0014 = dwArg04->dw001C;
 	}
 	dwArg04->dw0018 &= -4;
-	a0 = (ui32 *) &dwArg04->dw0018;
+	a0 = &dwArg04->dw0018;
 	d0_n = 0;
 	goto l00002BB6;
 }
@@ -2944,7 +2944,7 @@ int32 fn00003910(Eq_n dwArg04, struct Eq_n * dwArg08, ui32 & a0Out, ptr32 & a1Ou
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg08->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg08->dw0018;
+			a0 = &dwArg08->dw0018;
 			d0_n = -1;
 l00003A1E:
 			a0Out = a0;

--- a/subjects/Hunk-m68k/STRLEN.reko/STRLEN_code.c
+++ b/subjects/Hunk-m68k/STRLEN.reko/STRLEN_code.c
@@ -55,7 +55,7 @@ void fn00001000(int32 d0, byte * a0)
 			word32 a0_n;
 			d0_n->dw0000 = d0_n + 0x11;
 			d0_n->dw000C = d4_n - 0x01;
-			d0_n->ptr0008 = (byte *) (&d0_n->ptr0010 + d0_n / 20);
+			d0_n->ptr0008 = (char *) &d0_n->ptr0010 + d0_n;
 			null = null;
 			struct Eq_n * d0_n = d0_n->ptr00AC;
 			if (d0_n == null)

--- a/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG_code.c
+++ b/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG_code.c
@@ -1134,7 +1134,7 @@ int32 fn00001DF4(Eq_n dwArg04, struct Eq_n * dwArg08, ui32 & a0Out, ptr32 & a5Ou
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg08->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg08->dw0018;
+			a0 = &dwArg08->dw0018;
 			d0_n = -1;
 l00001F02:
 			a0Out = a0;
@@ -1188,7 +1188,7 @@ int32 fn00001F08(struct Eq_n * dwArg04, ui32 & a0Out, ptr32 & a1Out, ptr32 & a5O
 		if (d4_n - d0_n != 0x00)
 		{
 			dwArg04->dw0018 |= 16;
-			a0 = (ui32 *) &dwArg04->dw0018;
+			a0 = &dwArg04->dw0018;
 			d0_n = -1;
 l00001F96:
 			a0Out = a0;
@@ -1200,7 +1200,7 @@ l00001F96:
 		dwArg04->dw0014 = dwArg04->dw001C;
 	}
 	dwArg04->dw0018 &= -4;
-	a0 = (ui32 *) &dwArg04->dw0018;
+	a0 = &dwArg04->dw0018;
 	d0_n = 0;
 	goto l00001F96;
 }

--- a/subjects/OpenRISC/sunxi/blob.reko/blob.c
+++ b/subjects/OpenRISC/sunxi/blob.reko/blob.c
@@ -5850,12 +5850,12 @@ Eq_n fn0000EDF4(int32 r3, struct Eq_n * r4, Eq_n r15, word32 VR)
 			if (r4_n == 0x25)
 			{
 				int32 r18_n;
-				r16_n = &r16_n->bFFFFFFFF;
+				r16_n = (struct Eq_n *) &r16_n->bFFFFFFFF;
 				int32 r4_n = (int32) r16_n->b0000;
 				if ((r4_n - 49 & 0xFF) <= 0x08)
 				{
 					r18_n = r4_n - 48;
-					r16_n = &r16_n->bFFFFFFFF;
+					r16_n = (struct Eq_n *) &r16_n->bFFFFFFFF;
 					r4_n = (int32) r16_n->bFFFFFFFF;
 				}
 				else
@@ -5927,10 +5927,10 @@ l0000F00C:
 			else
 			{
 				r2_n->t0000 = (byte) r4_n;
-				r2_n = &r2_n->bFFFFFFFF;
+				r2_n = (struct Eq_n *) &r2_n->bFFFFFFFF;
 			}
 l0000F0B0:
-			r16_n = &r16_n->bFFFFFFFF;
+			r16_n = (struct Eq_n *) &r16_n->bFFFFFFFF;
 		}
 		if ((int32) r2_n->bFFFFFFFF == 0x0A)
 			globals->dw13154 = -1;

--- a/subjects/PDP-11/lunar.reko/lunar_image.c
+++ b/subjects/PDP-11/lunar.reko/lunar_image.c
@@ -509,7 +509,7 @@ void fn0A94(int16 r3, Eq_n r4, word16 * r5)
 			r5_n->w0000 = r0_n + 0x2040 & ~0xC000;
 			int16 v24_n = wLoc02_n - 0x01;
 			r4 = r4_n | 0x4000;
-			r5 = (word16 *) &r5_n->w0002;
+			r5 = &r5_n->w0002;
 			wLoc02_n = v24_n;
 		} while (v24_n > 0x00);
 		r5_n->w0002 = 0xF700;

--- a/subjects/PE/m68k/hello_m68k_CRTHEAP.c
+++ b/subjects/PE/m68k/hello_m68k_CRTHEAP.c
@@ -58,7 +58,7 @@ int32 fn00002510(struct Eq_n * a5, Eq_n dwArg04, union Eq_n & d3Out, ptr32 & d4O
 		a7_n->t0000 = d3_n;
 		word32 a0_n;
 		struct Eq_n * d0_n = fn000027B0(a5, a7_n->t0000, out a0_n);
-		a7_n = &a7_n->t0004;
+		a7_n = (struct Eq_n *) &a7_n->t0004;
 		a2_n = d0_n;
 		if (d0_n == null)
 		{
@@ -186,7 +186,7 @@ int32 fn0000275C(struct Eq_n * a0, struct Eq_n * a5, struct Eq_n & a0Out)
 			} while (&a0->dw0FF8 - d1_n > 0x00);
 		}
 		a0->dw0FF8 = 0;
-		a0Out = &a0->dw0FF8;
+		a0Out = (struct Eq_n *) &a0->dw0FF8;
 		return 1;
 	}
 	else

--- a/subjects/PE/m68k/hello_m68k_CRTSTDIO.c
+++ b/subjects/PE/m68k/hello_m68k_CRTSTDIO.c
@@ -496,7 +496,7 @@ l00001F1C:
 				a6_n->bFFFFFFFF = a6_n->b000B;
 				struct Eq_n * a7_n = a7_n - 4;
 				a7_n->dw0000 = 1;
-				a7_n->ptrFFFFFFFC = (byte *) &a6_n->bFFFFFFFF;
+				a7_n->ptrFFFFFFFC = &a6_n->bFFFFFFFF;
 				a7_n->dwFFFFFFF8 = d3_n;
 				word32 a7_n;
 				int32 d0_n;

--- a/subjects/PE/x86-64/varargs_test/varargs_test.reko/varargs_test_text.c
+++ b/subjects/PE/x86-64/varargs_test/varargs_test.reko/varargs_test_text.c
@@ -376,7 +376,7 @@ uint64 fn0000000140001718(<anonymous> ** rcx, <anonymous> & r8Out)
 			if (rcx_n->w0018 == 0x020B)
 			{
 				word32 eax_n = (word32) rcx_n->w0006;
-				struct Eq_n * rdx_n = &rcx_n->w0018 + (uint64) ((uint32) ((word32) rcx_n->w0014)) / 26;
+				struct Eq_n * rdx_n = &rcx_n->w0018 + (uint64) ((uint32) ((word32) rcx_n->w0014));
 				r8_n = rcx - 0x140000000;
 				struct Eq_n * r9_n = rdx_n + (uint64) ((uint32) eax_n);
 				uint56 rax_56_8_n = (uint56) (uint24) SLICE(eax_n, word24, 8);

--- a/subjects/VMS-vax/unzip.h
+++ b/subjects/VMS-vax/unzip.h
@@ -15882,7 +15882,7 @@ T_2870: (in sp_2 + -4<i32> : word32)
 T_2871: (in Mem7[sp_2 + -4<i32>:word32] : word32)
   Class: Eq_1223
   DataType: Eq_1223
-  OrigDataType: (ptr32 Eq_2791)
+  OrigDataType: (ptr32 up32)
 T_2872: (in sp_11 : (ptr32 Eq_2872))
   Class: Eq_2872
   DataType: (ptr32 Eq_2872)
@@ -68659,7 +68659,7 @@ T_16065: (in 0<8> : byte)
   Class: Eq_16064
   DataType: byte
   OrigDataType: byte
-T_16066: (in (&fp_1890->tFFFFFFEC)[r2_2008] == 0<8> : bool)
+T_16066: (in *((char *) &fp_1890->tFFFFFFEC + r2_2008) == 0<8> : bool)
   Class: Eq_16066
   DataType: bool
   OrigDataType: bool
@@ -78342,7 +78342,7 @@ T_18485: (in sp_137 + -4<i32> : word32)
 T_18486: (in Mem164[sp_137 + -4<i32>:word32] : word32)
   Class: Eq_1223
   DataType: Eq_1223
-  OrigDataType: (ptr32 Eq_18338)
+  OrigDataType: (ptr32 word32)
 T_18487: (in 0xC821<32> : word32)
   Class: Eq_18487
   DataType: int32
@@ -78362,7 +78362,7 @@ T_18490: (in sp_137 + -8<i32> : word32)
 T_18491: (in Mem167[sp_137 + -8<i32>:word32] : word32)
   Class: Eq_1223
   DataType: Eq_1223
-  OrigDataType: (ptr32 Eq_18338)
+  OrigDataType: (ptr32 word32)
 T_18492: (in 260<i32> : int32)
   Class: Eq_18492
   DataType: int32
@@ -83695,7 +83695,7 @@ T_19824: (in fp_237 + -1356<i32> + (Mem568[Mem568[sp_236 + 8<i32>:word32] + 0<32
   Class: Eq_19724
   DataType: (ptr32 word32)
   OrigDataType: ptr32
-T_19825: (in r8_295 < &fp_237->dwFFFFFAB4 + (*((word32) (sp_236)[2<i32>].dwFFFFFFFC + 4<i32>) << 2<i8>) / 16<i32> : bool)
+T_19825: (in r8_295 < &fp_237->dwFFFFFAB4 + (*((word32) (sp_236)[2<i32>].dwFFFFFFFC + 4<i32>) << 2<i8>) : bool)
   Class: Eq_19825
   DataType: bool
   OrigDataType: bool

--- a/subjects/VMS-vax/unzip_code_0000.c
+++ b/subjects/VMS-vax/unzip_code_0000.c
@@ -36,7 +36,7 @@ void fn0000802E(word32 r4)
 		r3_n = 0x01;
 	r2_n->dw0060 = r3_n;
 	sp_n->ptrFFFFFFFC = &ap_n->dw0004 + 1;
-	sp_n->ptrFFFFFFF8 = (word32 *) &ap_n->dw0004;
+	sp_n->ptrFFFFFFF8 = &ap_n->dw0004;
 	fn00008EC2(fp_n);
 }
 
@@ -165,8 +165,8 @@ word32 fn00009C8A(word32 r3, struct Eq_n * r6, struct Eq_n * r7, struct Eq_n * f
 		r6->ptr10175 = &r6->ptr10181;
 		r6->ptr10185 = &r6->b0168 + 0x00008001;
 		r6->dw10189 = 0x00;
-		r6->ptr10181 = (word32 *) &r6->ptr10175;
-		r6->ptr10190 = (word32 *) &r6->ptr10175;
+		r6->ptr10181 = &r6->ptr10175;
+		r6->ptr10190 = &r6->ptr10175;
 		if (r6->dw0160 != 0x00)
 			r6->b10174 = 0x00;
 		r6->ptr10194 = r3_n;
@@ -264,8 +264,8 @@ void fn0000A07A(struct Eq_n * r6, struct Eq_n * r7, word32 r8, word32 fp)
 			r6->ptr10175 = &r6->ptr10181;
 			r6->ptr10185 = &r6->b0168 + 0x00008001;
 			r6->dw10189 = 0x00;
-			r6->ptr10181 = (word32 *) &r6->ptr10175;
-			r6->ptr10190 = (word32 *) &r6->ptr10175;
+			r6->ptr10181 = &r6->ptr10175;
+			r6->ptr10190 = &r6->ptr10175;
 			if (r6->dw0160 == 0x00)
 				return;
 			Eq_n r0_n = (uint32) r6->b0168;
@@ -297,8 +297,8 @@ void fn0000A5B2(word32 r2, struct Eq_n * r5, struct Eq_n * r6, struct Eq_n * r7,
 			r6->ptr10175 = &r6->ptr10181;
 			r6->ptr10185 = (char *) r6 + 33129;
 			r6->dw10189 = 0x00;
-			r6->ptr10181 = (word32 *) &r6->ptr10175;
-			r6->ptr10190 = (word32 *) &r6->ptr10175;
+			r6->ptr10181 = &r6->ptr10175;
+			r6->ptr10190 = &r6->ptr10175;
 			if (r3_n > 0x06)
 				vax_subp4(0x00, 0x11, 0x2A, *r5->ptr1750);
 			else
@@ -1103,7 +1103,7 @@ word32 fn0000BC8A(struct Eq_n * r5, ptr32 & r1Out, struct Eq_n & r3Out, ptr32 & 
 	word32 r5_n;
 	(globals->ptr192A0 + 2)();
 	fp_n->dwFFFFFFF8 = r0_n;
-	sp_n->ptrFFFFFFFC = (word32 *) &fp_n->dwFFFFFFF8;
+	sp_n->ptrFFFFFFFC = &fp_n->dwFFFFFFF8;
 	struct Eq_n * sp_n;
 	struct Eq_n * r0_n;
 	struct Eq_n * fp_n;
@@ -1226,7 +1226,7 @@ word32 fn0000C022(struct Eq_n * r3, struct Eq_n * ap, struct Eq_n * fp, struct E
 		word32 r0_n = fp_n->dwFFFFFFF8;
 		r3_n->b105C5 = 0x00;
 		sp_n->dwFFFFFFFC = 0x01;
-		sp_n->ptrFFFFFFF8 = (byte *) &r3_n->b105C5;
+		sp_n->ptrFFFFFFF8 = &r3_n->b105C5;
 		sp_n->dwFFFFFFF4 = ap_n->dw0004;
 		sp_n->dwFFFFFFF0 = r4_n + 0x066A;
 		sp_n->dwFFFFFFEC = r2_n + 1515;
@@ -1373,7 +1373,7 @@ void fn0000C6FA(struct Eq_n * r6, Eq_n r7, word32 r8, struct Eq_n * ap, struct E
 			return;
 		sp_n->ptrFFFFFFFC = &fp_n->wFFFFFFD0 + 20;
 		sp_n->ptrFFFFFFF8 = &fp_n->wFFFFFFD0 + 4;
-		sp_n->ptrFFFFFFF4 = (word16 *) &fp_n->wFFFFFFD0;
+		sp_n->ptrFFFFFFF4 = &fp_n->wFFFFFFD0;
 		struct Eq_n * r0_n;
 		struct Eq_n * r2_n;
 		word32 r7_n;

--- a/subjects/VMS-vax/unzip_code_0001.c
+++ b/subjects/VMS-vax/unzip_code_0001.c
@@ -1298,7 +1298,7 @@ void fn00012D86(struct Eq_n * r0, word32 r1, struct Eq_n * r3, word32 r4, struct
 							}
 							break;
 						}
-						r2_n = (word32 *) &r2_n->dw0004;
+						r2_n = &r2_n->dw0004;
 						r8_n = r8_n;
 						ap = ap_n;
 						r1 = r1_n;
@@ -1334,7 +1334,7 @@ void fn00012D86(struct Eq_n * r0, word32 r1, struct Eq_n * r3, word32 r4, struct
 								}
 								break;
 							}
-							r2_n = (word32 *) &r2_n->dw0004;
+							r2_n = &r2_n->dw0004;
 							r8_n = r8_n;
 							ap = ap_n;
 							r1 = r1_n;
@@ -2315,9 +2315,9 @@ l000134E9:
 								int32 r1_n;
 								for (r1_n = 0x00; r1_n < 0x04; ++r1_n)
 								{
-									if ((&fp_n->tFFFFFFEC)[r2_n] != 0x00)
+									if (*((char *) &fp_n->tFFFFFFEC + r2_n) != 0x00)
 									{
-										*r3_n = (byte) (&fp_n->tFFFFFFEC)[r2_n];
+										*r3_n = (byte) *((char *) &fp_n->tFFFFFFEC + r2_n);
 										++r3_n;
 									}
 									++r2_n;
@@ -2347,7 +2347,7 @@ l000134E9:
 						byte * r3_n = r3_n - 0x01;
 						*r3_n = 0x29;
 						sp_n->dwFFFFFFFC = 0x00;
-						sp_n->ptrFFFFFFF8 = (byte *) &fp_n->bFFFFFFD6;
+						sp_n->ptrFFFFFFF8 = &fp_n->bFFFFFFD6;
 						sp_n->dwFFFFFFF4 = (uint32) sp_n->w000A;
 						sp_n->ptrFFFFFFF0 = r6_n + 3013;
 						sp_n->ptrFFFFFFEC = (char *) r5_n + 1515;
@@ -3095,7 +3095,7 @@ l00014154:
 											if (((uint32) r7_n->b0000 & 0x02) != 0x00)
 											{
 												struct Eq_n * sp_n = sp_n - 0x04;
-												sp_n->ptr0000 = (byte *) &fp_n->bFFFFFF66;
+												sp_n->ptr0000 = &fp_n->bFFFFFF66;
 												struct Eq_n * sp_n;
 												word32 ap_n;
 												word32 r5_n;
@@ -3123,7 +3123,7 @@ l00014154:
 											if (((uint32) r7_n->b0000 & 0x04) != 0x00)
 											{
 												struct Eq_n * sp_n = sp_n - 0x04;
-												sp_n->ptr0000 = (byte *) &fp_n->bFFFFFF66;
+												sp_n->ptr0000 = &fp_n->bFFFFFF66;
 												struct Eq_n * sp_n;
 												word32 ap_n;
 												word32 r5_n;
@@ -3158,7 +3158,7 @@ l00014154:
 												else
 													r3_n = r8_n + 0x00CF;
 												sp_n->ptrFFFFFFFC = r3_n;
-												sp_n->ptrFFFFFFF8 = (byte *) &fp_n->bFFFFFF66;
+												sp_n->ptrFFFFFFF8 = &fp_n->bFFFFFF66;
 												sp_n->dwFFFFFFF4 = &r6_n->b0004 + 4326;
 												sp_n->ptrFFFFFFF0 = (char *) r5_n + 1515;
 												struct Eq_n * sp_n;
@@ -3619,7 +3619,7 @@ l00013B30:
 							}
 							fp_n->bFFFFFFE0 = 0x00;
 							sp_n->dwFFFFFFFC = 0x00;
-							sp_n->ptrFFFFFFF8 = (byte *) &fp_n->bFFFFFFD6;
+							sp_n->ptrFFFFFFF8 = &fp_n->bFFFFFFD6;
 							sp_n->dwFFFFFFF4 = (uint32) sp_n->w000A;
 							sp_n->ptrFFFFFFF0 = r6_n + 3121;
 							sp_n->ptrFFFFFFEC = (char *) r5_n + 1515;
@@ -3705,7 +3705,7 @@ l00013994:
 							fp_n->bFFFFFFDE = (byte) r4_n;
 							fp_n->bFFFFFFDF = 0x00;
 							sp_n->dwFFFFFFFC = 0x00;
-							sp_n->ptrFFFFFFF8 = (byte *) &fp_n->bFFFFFFD6;
+							sp_n->ptrFFFFFFF8 = &fp_n->bFFFFFFD6;
 							sp_n->dwFFFFFFF4 = r7_n;
 							sp_n->ptrFFFFFFF0 = r6_n + 0x0BFB;
 							sp_n->ptrFFFFFFEC = (char *) r5_n + 1515;
@@ -3799,7 +3799,7 @@ void fn00014812(word32 r3, struct Eq_n * r4, word32 r6, word32 r8, word32 r9, wo
 	{
 		sp_n->dwFFFFFFFC = (uint32) r4_n->wC65E;
 		sp_n->dwFFFFFFF8 = r5_n + 0x00EC;
-		sp_n->ptrFFFFFFF4 = (byte *) &fp_n->bFFFFFFDC;
+		sp_n->ptrFFFFFFF4 = &fp_n->bFFFFFFDC;
 		(globals->ptr192D0 + 2)();
 	}
 	int32 ap_n;
@@ -4510,7 +4510,7 @@ void fn000173CA(struct Eq_n * r0, word32 r1, struct Eq_n * r3, struct Eq_n * r4,
 							r1 = r1_n;
 							break;
 						}
-						r2_n = (word32 *) &r2_n->dw0004;
+						r2_n = &r2_n->dw0004;
 						r9_n = r9_n;
 						r4 = r4_n;
 						r1 = r1_n;
@@ -4539,7 +4539,7 @@ void fn000173CA(struct Eq_n * r0, word32 r1, struct Eq_n * r3, struct Eq_n * r4,
 								r1 = r1_n;
 								break;
 							}
-							r2_n = (word32 *) &r2_n->dw0004;
+							r2_n = &r2_n->dw0004;
 							r9_n = r9_n;
 							r4 = r4_n;
 							r1 = r1_n;
@@ -5594,7 +5594,7 @@ int32 fn0001878E(Eq_n ap, union Eq_n * fp, struct Eq_n & r2Out, struct Eq_n & r3
 							} while (r9_n > r6_n + (&(*((char *) (&sp_n->t0024) + sp_n[0x0C] * 4))->dwFFFFFFFC)[1] / 51257);
 						}
 						fp_n->bFFFFFA6B = (int8) (r9_n - r6_n);
-						if (r8_n >= &fp_n->dwFFFFFAB4 + (*((word32) (sp_n)[2].dwFFFFFFFC + 4) << 2) / 16)
+						if (r8_n >= &fp_n->dwFFFFFAB4 + (*((word32) (sp_n)[2].dwFFFFFFFC + 4) << 2))
 							fp_n->bFFFFFA6A = 99;
 						else
 						{
@@ -6099,7 +6099,7 @@ word32 fn00018F22(struct Eq_n * ap, struct Eq_n * fp, ptr32 & apOut, ptr32 & fpO
 		struct Eq_n * r0_n = ap->ptr0004;
 		byte v11_n = r0_n->b0000;
 		if (v11_n == 0x5C && r0_n->b0001 != 0x00)
-			ap->ptr0004 = &r0_n->b0001;
+			ap->ptr0004 = (struct Eq_n *) &r0_n->b0001;
 		else if (v11_n == 0x25 || v11_n == 0x2A)
 		{
 			ptr32 fp_n = fp->ptr000C;
@@ -6107,7 +6107,7 @@ word32 fn00018F22(struct Eq_n * ap, struct Eq_n * fp, ptr32 & apOut, ptr32 & fpO
 			fpOut = fp_n;
 			return 0x01;
 		}
-		ap->ptr0004 = &ap->ptr0004->b0001;
+		ap->ptr0004 = (struct Eq_n *) &ap->ptr0004->b0001;
 	}
 	ptr32 fp_n = fp->ptr000C;
 	apOut = fp->ptr0008;

--- a/subjects/regressions/reko-90/PP.reko/PP_0800.c
+++ b/subjects/regressions/reko-90/PP.reko/PP_0800.c
@@ -12153,7 +12153,7 @@ l0800_nFCB:
 		si_n = ϕ(si_n, si_n, si_n);
 		Mem53 = ϕ(Mem968, Mem847, Mem49);
 		al_n = (ds->*si_n).b0000;
-		si_n = &&(SLICE(ptrArg02, selector, 16)->*(SLICE(ptrArg02, selector, 16)->*si_n).b0001);
+		si_n = (struct Eq_n Eq_n::*) &&(SLICE(ptrArg02, selector, 16)->*(SLICE(ptrArg02, selector, 16)->*si_n).b0001);
 		al_n = al_n;
 		if (al_n == 0x00)
 		{
@@ -12174,7 +12174,7 @@ l0800_nFCB:
 				di_n = ϕ(di_n, di_n, di_n, di_n, di_n, di_n, di_n, di_n, di_n, di_n);
 				Mem80 = ϕ(Mem77, Mem800, Mem482, Mem113, Mem117, Mem86, Mem478, Mem474, Mem787, Mem797);
 				si_n = ϕ(si_n, si_n, si_n, si_n, si_n, si_n, si_n, si_n, si_n, si_n);
-				si_n = &&(SLICE(ptrArg02, selector, 16)->*(SLICE(ptrArg02, selector, 16)->*si_n).b0001);
+				si_n = (struct Eq_n Eq_n::*) &&(SLICE(ptrArg02, selector, 16)->*(SLICE(ptrArg02, selector, 16)->*si_n).b0001);
 				ax_n.u0 = (int16) (ds->*si_n).b0000;
 				dh_n = SLICE(dx_n, byte, 8);
 				wArg0A_n = si_n;
@@ -12321,7 +12321,7 @@ l0800_nFCB:
 					v48_n = bLoc03_n & ~0x10;
 					es_n = psegArg0C;
 					al_n = (ds->*si_n).b0000;
-					si_n = &&(SLICE(ptrArg02, selector, 16)->*(SLICE(ptrArg02, selector, 16)->*si_n).b0001);
+					si_n = (struct Eq_n Eq_n::*) &&(SLICE(ptrArg02, selector, 16)->*(SLICE(ptrArg02, selector, 16)->*si_n).b0001);
 					bLoc03_n = v48_n;
 					if (al_n == 0x5E)
 					{
@@ -12350,7 +12350,7 @@ l0800_nD2:
 						Mem207 = ϕ(Mem202, Mem207, Mem435);
 						si_n = ϕ(si_n, si_n, si_n);
 						al_n = (ds->*si_n).b0000;
-						si_n = &&(ss->*(ss->*si_n).b0001);
+						si_n = (struct Eq_n Eq_n::*) &&(ss->*(ss->*si_n).b0001);
 						dx_n = SEQ(dh_n, dl_n);
 						if (al_n == 0x00)
 							break;
@@ -12440,7 +12440,7 @@ l0800_nE:
 						}
 						if (al_n != 0x2D || (dl_n > (psegArg0C->*si_n).b0000 || (psegArg0C->*si_n).b0000 == 0x5D))
 							goto l0800_nD2;
-						si_n = &&(ss->*(ss->*si_n).b0001);
+						si_n = (struct Eq_n Eq_n::*) &&(ss->*(ss->*si_n).b0001);
 						al_n = (ds->*si_n).b0000 - dl_n;
 						if (al_n != 0x00)
 						{

--- a/subjects/regressions/reko-90/PP.reko/PP_1483.c
+++ b/subjects/regressions/reko-90/PP.reko/PP_1483.c
@@ -482,7 +482,7 @@ void fn1483-1104(cup16 ax, byte dl, struct Eq_n Eq_n::* bx, struct Eq_n Eq_n::* 
 		(ss->*sp_n).ptr0000 = es;
 		word16 dx_n = SEQ(0x34, dl);
 		((char *) bp + 94)[si] = dx_n;
-		(&&(ds->*(ds->*(ds->*bx).a675E).w0000))[di / 26462] -= 0x7D;
+		ds->*((char *) (&(&(ds->*(ds->*(ds->*bx).a675E).w0000))) + di) -= 0x7D;
 		(ss->*sp_n).wFFFFFFFE = dx_n;
 		*((word32) Top_n + 1) *= lg2(*Top_n + 1.0);
 		Eq_n es_bx_n = ds->t9F59;


### PR DESCRIPTION
When rewriting `expression + offset` to `&complexExpression`, data type
of result should be pointer to `complexExpression.DataType`,
not `expression.DataType`