### PR TITLE
Don't append <nBits> when saving registerValues

### DIFF
--- a/src/Core/Serialization/ProjectSaver.cs
+++ b/src/Core/Serialization/ProjectSaver.cs
@@ -119,7 +119,7 @@ namespace Reko.Core.Serialization
                     {
                         Address = sAddr,
                         Register = rv.Register.Name,
-                        Value = rv.Value.ToString().Replace("0x", ""),
+                        Value = string.Format($"{{0:X{rv.Register.DataType.Size * 2}}}", rv.Value.ToUInt64()),
                     });
                 }
             }

--- a/src/Gui/Forms/MainFormInteractor.cs
+++ b/src/Gui/Forms/MainFormInteractor.cs
@@ -721,10 +721,11 @@ namespace Reko.Gui.Forms
             }
 
             var fsSvc = Services.RequireService<IFileSystemService>();
+            var saver = new ProjectSaver(sc);
+            var sProject = saver.Serialize(ProjectFileName, decompilerSvc.Decompiler.Project);
+
             using (var xw = fsSvc.CreateXmlWriter(ProjectFileName))
             {
-                var saver = new ProjectSaver(sc);
-                var sProject = saver.Serialize(ProjectFileName, decompilerSvc.Decompiler.Project);
                 saver.Save(sProject, xw);
             }
             return true;

--- a/src/tests/Core/SudSaveProject.exp
+++ b/src/tests/Core/SudSaveProject.exp
@@ -40,8 +40,8 @@
         <dst>1000:05BA</dst>
       </jumpTable>
       <registerValues>
-        <assume addr="00012310" reg="eax" value="1231&lt;32&gt;" />
-        <assume addr="00012310" reg="ecx" value="42424711&lt;32&gt;" />
+        <assume addr="00012310" reg="eax" value="00001231" />
+        <assume addr="00012310" reg="ecx" value="42424711" />
       </registerValues>
       <outputFilePolicy>Segment</outputFilePolicy>
     </user>


### PR DESCRIPTION
- Removed <nBits> from the saved project for registerValues
- Delay opening the output file until the serialization is complete (prevents empty files if anything throws)