### PR TITLE
Use ComplexExpresionBuilder to rewrite global variable

### DIFF
--- a/src/UnitTests/Typing/TypedConstantRewriterTests.cs
+++ b/src/UnitTests/Typing/TypedConstantRewriterTests.cs
@@ -175,6 +175,27 @@ namespace Reko.UnitTests.Typing
             Assert.AreEqual("&globals->t100100.r0004", e.ToString());
         }
 
+        [Test]
+        public void Tcr_RewriteDereferecedFirstStructField()
+        {
+            Given_TypedConstantRewriter();
+            var str = new StructureType
+            {
+                Fields =
+                {
+                    { 0, PrimitiveType.Int32 },
+                    { 4, PrimitiveType.Real32 },
+                },
+            };
+            Given_Global(0x00100100, str);
+            var c = Constant.Word32(0x00100100);
+            store.EnsureExpressionTypeVariable(factory, c);
+            c.TypeVariable.DataType = new Pointer(PrimitiveType.Word32, 32);
+            c.TypeVariable.OriginalDataType = PrimitiveType.Word32;
+            var e = tcr.Rewrite(c, true);
+            Assert.AreEqual("globals->t100100.dw0000", e.ToString());
+        }
+
         private void Given_String(string str, uint addr)
         {
             var w = new LeImageWriter(mem.Bytes, addr - (uint)mem.BaseAddress.ToLinear());

--- a/src/UnitTests/Typing/TypedConstantRewriterTests.cs
+++ b/src/UnitTests/Typing/TypedConstantRewriterTests.cs
@@ -63,8 +63,10 @@ namespace Reko.UnitTests.Typing
 			TypeVariable tvGlobals = store.EnsureExpressionTypeVariable(factory, globals);
 			EquivalenceClass eqGlobals = new EquivalenceClass(tvGlobals);
 			eqGlobals.DataType = s;
-			globals.TypeVariable.DataType = new Pointer(eqGlobals, 32);
-			globals.DataType = globals.TypeVariable.DataType;
+            var globalsPtr = new Pointer(eqGlobals, 32);
+            globals.TypeVariable.DataType = globalsPtr;
+            globals.TypeVariable.OriginalDataType = globalsPtr;
+            globals.DataType = globalsPtr;
 		}
 
         private void Given_TypedConstantRewriter()

--- a/subjects/Elf/AVR32/ls.reko/ls_seg00001000_0000.c
+++ b/subjects/Elf/AVR32/ls.reko/ls_seg00001000_0000.c
@@ -13439,7 +13439,7 @@ Eq_n fn0000CEEE(Eq_n r0, ptr32 r1, word32 * r10, <anonymous> * r11, Eq_n r12)
 		r10_n = (word32) ((word2) (r8_n / 100) == 0x01);
 	Eq_n dwLocA8_n;
 	word32 r2_n = *r10;
-	word32 r8_n = r5_n - 0x01 + (word32) (&((word32) globals->dwD1CE + 2))[((word32) r3_n + (r10_n * 0x0D + (((r3_n >> 0x1F) << 0x01) + (r3_n >> 0x1F) << 0x02))) * 0x02];
+	word32 r8_n = r5_n - 0x01 + (word32) ((char *) (&globals->dwD1CE) + 2)[((word32) r3_n + (r10_n * 0x0D + (((r3_n >> 0x1F) << 0x01) + (r3_n >> 0x1F) << 0x02))) * 0x02];
 	word32 dwLoc90_n = r2_n;
 	if (lr_n < 0x00)
 		dwLocA8_n.u0 = 0x00;

--- a/subjects/Elf/Msp430/a.reko/a.h
+++ b/subjects/Elf/Msp430/a.reko/a.h
@@ -3961,7 +3961,7 @@ T_461: (in 0<8> : byte)
   Class: Eq_178
   DataType: byte
   OrigDataType: byte
-T_462: (in globals->a0200 != 0<8> : bool)
+T_462: (in globals->a0200[0<i32>] != 0<8> : bool)
   Class: Eq_462
   DataType: bool
   OrigDataType: bool
@@ -4093,7 +4093,7 @@ T_494: (in out r15_12 : word16)
   Class: Eq_491
   DataType: Eq_491
   OrigDataType: (union (ptr16 u1) (word20 u0))
-T_495: (in xQueueReceive(sr, r14, r15, globals->a021C, out r15_12) : word20)
+T_495: (in xQueueReceive(sr, r14, r15, globals->a021C[0<i32>], out r15_12) : word20)
   Class: Eq_2
   DataType: ui20
   OrigDataType: word20
@@ -4437,7 +4437,7 @@ T_580: (in out r15_29 : word16)
   Class: Eq_570
   DataType: Eq_570
   OrigDataType: (union (ptr16 u1) (word20 u0))
-T_581: (in xQueueSendFromISR(sr, 0<16>, fp - 0xA<32>, globals->a021C, out r15_29) : word20)
+T_581: (in xQueueSendFromISR(sr, 0<16>, fp - 0xA<32>, globals->a021C[0<i32>], out r15_29) : word20)
   Class: Eq_2
   DataType: ui20
   OrigDataType: word20

--- a/subjects/Elf/Msp430/a.reko/a_text.c
+++ b/subjects/Elf/Msp430/a.reko/a_text.c
@@ -167,7 +167,7 @@ ui20 init_uart_isr(ui20 sr, Eq_n r13, Eq_n r14, Eq_n r15)
 	++globals->w0218;
 	Eq_n r15_n;
 	ui20 sr_n = xQueueCreate(sr & ~0x08, v17_n, out r15_n);
-	globals->a021C = r15_n;
+	globals->a021C[0] = r15_n;
 	Eq_n r15_n;
 	ui20 sr_n = xQueueCreate(sr_n, v17_n, out r15_n);
 	globals->t021E = r15_n;
@@ -203,7 +203,7 @@ void getchar(ui20 sr)
 //      fn00004000
 void uart_putchar_isr_mode(Eq_n r15)
 {
-	globals->a0200 = r15;
+	globals->a0200[0] = r15;
 }
 
 // 43A2: Register ui20 putchar(Register ui20 sr, Register Eq_n r15, Register out Eq_n r11Out)
@@ -218,7 +218,7 @@ ui20 putchar(ui20 sr, Eq_n r15, union Eq_n & r11Out)
 	if (r15 == 0x0A)
 		putchar(sr, 0x0D, out r11_n);
 	Eq_n r15_n;
-	if (globals->a0200 == 0x00)
+	if (globals->a0200[0] == 0x00)
 	{
 		do
 			;
@@ -238,7 +238,7 @@ ui20 putchar(ui20 sr, Eq_n r15, union Eq_n & r11Out)
 Eq_n x_getchar(ui20 sr, Eq_n r14, Eq_n r15)
 {
 	word20 r15_n;
-	xQueueReceive(sr, r14, r15, globals->a021C, out r15_n);
+	xQueueReceive(sr, r14, r15, globals->a021C[0], out r15_n);
 	if (r15_n == 0x00)
 		return 0x00;
 	return 0x01;
@@ -280,7 +280,7 @@ l00004420:
 void vRxISR(ui20 sr)
 {
 	word20 r15_n;
-	ui20 sr_n = xQueueSendFromISR(sr, 0x00, fp - 0x0A, globals->a021C, out r15_n);
+	ui20 sr_n = xQueueSendFromISR(sr, 0x00, fp - 0x0A, globals->a021C[0], out r15_n);
 	if (r15_n != 0x00)
 	{
 		word20 r11_n;

--- a/subjects/OpenRISC/sunxi/blob.reko/blob.c
+++ b/subjects/OpenRISC/sunxi/blob.reko/blob.c
@@ -3319,15 +3319,15 @@ Eq_n fn0000998C(Eq_n r15, word32 VR)
 		fn00009834(-1, -8, -3);
 		ui32 * r2_n = fn00009834(-1, -9, -3);
 		*r2_n |= 0x001A0000;
-		globals->a13938.u0 = -0x0011;
-		globals->a13934.u0 = -22;
+		globals->a13938[0].u0 = -0x0011;
+		globals->a13934[0].u0 = -22;
 		fn0000EDF4(-0x0F, &globals->t12C16, r15, VR);
 	}
 	else
 	{
 		globals->t134AC.u0 = -1;
-		globals->a13938 = r11_n;
-		globals->a13934.u0 = -0x0F;
+		globals->a13938[0] = r11_n;
+		globals->a13934[0].u0 = -0x0F;
 		word32 r22_n;
 		word32 r28_n;
 		fn0000D214(fp - 27, fp - 26, ~0x00, VR, out r22_n, out r28_n);
@@ -3750,7 +3750,7 @@ int32 fn0000A5D0(union Eq_n * r3)
 	union Eq_n * r4_n;
 	Eq_n r3_n;
 	Eq_n r4_n = *((char *) r3 + 40);
-	if (*((char *) r3 + 48) == &((word32) (globals->tFFFFFFFF).dw0000 + 2))
+	if (*((char *) r3 + 48) == (char *) (&(globals->tFFFFFFFF).dw0000) + 2)
 	{
 		r3_n = *((char *) r3 + 44);
 		globals->t1349C = r4_n;
@@ -4320,13 +4320,13 @@ l0000B84C:
 			{
 				int32 r14_n;
 				Eq_n r2_n;
-				if (r2_n == &((word32) (globals->tFFFFFFFF).dw0000 + 3))
+				if (r2_n == (char *) (&(globals->tFFFFFFFF).dw0000) + 3)
 				{
 					r14_n = -3;
 					r2_n = globals->t13098;
 					goto l0000B590;
 				}
-				if (r2_n > &((word32) (globals->tFFFFFFFF).dw0000 + 3))
+				if (r2_n > (char *) (&(globals->tFFFFFFFF).dw0000) + 3)
 				{
 					if (r2_n != &globals->dw0003)
 					{
@@ -4355,7 +4355,7 @@ l0000B5FC:
 				}
 				else
 				{
-					if (r2_n == &((word32) (globals->tFFFFFFFF).dw0000 + 2))
+					if (r2_n == (char *) (&(globals->tFFFFFFFF).dw0000) + 2)
 					{
 						r14_n = 0;
 						r2_n = globals->t1309C;
@@ -4569,9 +4569,9 @@ int32 fn0000BC28()
 //      fn00010570
 word32 fn0000BC38(word32 * r3)
 {
-	if (r3 > &globals->dw0021 || r3 < &((word32) globals->dw000B + 3))
+	if (r3 > &globals->dw0021 || r3 < (char *) (&globals->dw000B) + 3)
 		return dwLoc0C;
-	<anonymous> * r3_n = *((char *) globals->a12BA4 + (r3 - &((word32) globals->dw000B + 3)) * 0x04);
+	<anonymous> * r3_n = *((char *) globals->a12BA4 + (r3 - ((char *) (&globals->dw000B) + 3)) * 0x04);
 	word32 r2_n;
 	r3_n();
 	return r2_n;
@@ -7196,8 +7196,8 @@ word32 fn000101A8(Eq_n r15, word32 VR)
 	{
 		if ((globals->dw134D0 >> r18_n & 0x01) != 0x00)
 		{
-			Eq_n r2_n = globals->a13938;
-			while (r2_n <= globals->a13934)
+			Eq_n r2_n = globals->a13938[0];
+			while (r2_n <= (globals->a13934)[0])
 			{
 				if ((*r20_n >> r2_n & 0x01) != 0x00)
 				{
@@ -7224,8 +7224,8 @@ word32 fn000101A8(Eq_n r15, word32 VR)
 	{
 		if ((globals->dw134D4 >> r2_n & 0x01) == 0x00)
 		{
-			Eq_n r14_n = globals->a13938;
-			while (r14_n <= globals->a13934)
+			Eq_n r14_n = globals->a13938[0];
+			while (r14_n <= (globals->a13934)[0])
 			{
 				if ((*r16_n >> r14_n & 0x01) != 0x00)
 				{
@@ -7262,8 +7262,8 @@ word32 fn000103C0(Eq_n r15, word32 VR, ptr32 & r9Out, ptr32 & r18Out, ptr32 & r2
 	{
 		if ((globals->dw134D0 >> r16_n & 0x01) != 0x00 && *r20_n != 0x00)
 		{
-			Eq_n r2_n = globals->a13938;
-			while (r2_n <= globals->a13934)
+			Eq_n r2_n = globals->a13938[0];
+			while (r2_n <= (globals->a13934)[0])
 			{
 				if ((*r18_n >> r2_n & 0x01) != 0x00)
 				{
@@ -7286,8 +7286,8 @@ word32 fn000103C0(Eq_n r15, word32 VR, ptr32 & r9Out, ptr32 & r18Out, ptr32 & r2
 	{
 		if ((globals->dw134D4 >> r16_n & 0x01) == 0x00)
 		{
-			Eq_n r2_n = globals->a13938;
-			while (r2_n <= globals->a13934)
+			Eq_n r2_n = globals->a13938[0];
+			while (r2_n <= (globals->a13934)[0])
 			{
 				if ((*r14_n >> r2_n & 0x01) != 0x00 && (int32) (*((word64) r2_n + 0x00013744)) == 0x00)
 				{

--- a/subjects/OpenRISC/sunxi/blob.reko/blob.h
+++ b/subjects/OpenRISC/sunxi/blob.reko/blob.h
@@ -37787,7 +37787,7 @@ T_8074: (in 1<32> : word32)
   Class: Eq_3
   DataType: (ptr32 Eq_3)
   OrigDataType: word32
-T_8075: (in *((char *) r3 + 48<i32>) != &((word32) (globals->tFFFFFFFF).dw0000 + 2<i32>) : bool)
+T_8075: (in *((char *) r3 + 48<i32>) != (char *) (&(globals->tFFFFFFFF).dw0000) + 2<i32> : bool)
   Class: Eq_8075
   DataType: bool
   OrigDataType: bool
@@ -41567,7 +41567,7 @@ T_9019: (in 2<32> : word32)
   Class: Eq_6626
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_9020: (in r2_127 == &((word32) (globals->tFFFFFFFF).dw0000 + 3<i32>) : bool)
+T_9020: (in r2_127 == (char *) (&(globals->tFFFFFFFF).dw0000) + 3<i32> : bool)
   Class: Eq_9020
   DataType: bool
   OrigDataType: bool
@@ -41639,7 +41639,7 @@ T_9037: (in 2<32> : word32)
   Class: Eq_6626
   DataType: (ptr32 word32)
   OrigDataType: up32
-T_9038: (in r2_127 > &((word32) (globals->tFFFFFFFF).dw0000 + 3<i32>) : bool)
+T_9038: (in r2_127 > (char *) (&(globals->tFFFFFFFF).dw0000) + 3<i32> : bool)
   Class: Eq_9038
   DataType: bool
   OrigDataType: bool
@@ -41655,11 +41655,11 @@ T_9041: (in 1<32> : word32)
   Class: Eq_6626
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_9042: (in r2_127 == &((word32) (globals->tFFFFFFFF).dw0000 + 2<i32>) : bool)
+T_9042: (in r2_127 == (char *) (&(globals->tFFFFFFFF).dw0000) + 2<i32> : bool)
   Class: Eq_9042
   DataType: bool
   OrigDataType: bool
-T_9043: (in !(r2_127 == &((word32) (globals->tFFFFFFFF).dw0000 + 2<i32>)) : bool)
+T_9043: (in !(r2_127 == (char *) (&(globals->tFFFFFFFF).dw0000) + 2<i32>) : bool)
   Class: Eq_9043
   DataType: bool
   OrigDataType: bool
@@ -42795,11 +42795,11 @@ T_9326: (in 14<i32> : int32)
   Class: Eq_5788
   DataType: (ptr32 word32)
   OrigDataType: (union (int32 u0) (uint32 u1))
-T_9327: (in r3 < &((word32) globals->dw000B + 3<i32>) : bool)
+T_9327: (in r3 < (char *) (&globals->dw000B) + 3<i32> : bool)
   Class: Eq_9327
   DataType: bool
   OrigDataType: bool
-T_9328: (in r3 > &globals->dw0021 || r3 < &((word32) globals->dw000B + 3<i32>) : bool)
+T_9328: (in r3 > &globals->dw0021 || r3 < (char *) (&globals->dw000B) + 3<i32> : bool)
   Class: Eq_9328
   DataType: bool
   OrigDataType: bool
@@ -42815,7 +42815,7 @@ T_9331: (in 0x12BA4<32> : word32)
   Class: Eq_9331
   DataType: (ptr32 (arr (ptr32 code)))
   OrigDataType: (ptr32 (struct (0 (arr T_17976) a0000)))
-T_9332: (in r3 - &((word32) globals->dw000B + 3<i32>) : word32)
+T_9332: (in r3 - ((char *) (&globals->dw000B) + 3<i32>) : word32)
   Class: Eq_9332
   DataType: uint32
   OrigDataType: uint32
@@ -42823,7 +42823,7 @@ T_9333: (in 4<32> : ui32)
   Class: Eq_9333
   DataType: ui32
   OrigDataType: ui32
-T_9334: (in (r3 - &((word32) globals->dw000B + 3<i32>)) * 4<32> : word32)
+T_9334: (in (r3 - ((char *) (&globals->dw000B) + 3<i32>)) * 4<32> : word32)
   Class: Eq_9334
   DataType: ui32
   OrigDataType: ui32
@@ -60271,7 +60271,7 @@ T_13695: (in Mem78[0x13934<32>:word32] : word32)
   Class: Eq_6
   DataType: Eq_6
   OrigDataType: up32
-T_13696: (in r2_76 <= globals->a13934 : bool)
+T_13696: (in r2_76 <= (globals->a13934)[0<i32>] : bool)
   Class: Eq_13696
   DataType: bool
   OrigDataType: bool
@@ -60347,7 +60347,7 @@ T_13714: (in Mem258[0x13934<32>:word32] : word32)
   Class: Eq_6
   DataType: Eq_6
   OrigDataType: up32
-T_13715: (in r14_176 <= globals->a13934 : bool)
+T_13715: (in r14_176 <= (globals->a13934)[0<i32>] : bool)
   Class: Eq_13715
   DataType: bool
   OrigDataType: bool
@@ -60775,7 +60775,7 @@ T_13821: (in Mem29[0x13934<32>:word32] : word32)
   Class: Eq_6
   DataType: Eq_6
   OrigDataType: up32
-T_13822: (in r2_50 <= globals->a13934 : bool)
+T_13822: (in r2_50 <= (globals->a13934)[0<i32>] : bool)
   Class: Eq_13822
   DataType: bool
   OrigDataType: bool
@@ -60859,7 +60859,7 @@ T_13842: (in Mem29[0x13934<32>:word32] : word32)
   Class: Eq_6
   DataType: Eq_6
   OrigDataType: up32
-T_13843: (in r2_119 <= globals->a13934 : bool)
+T_13843: (in r2_119 <= (globals->a13934)[0<i32>] : bool)
   Class: Eq_13843
   DataType: bool
   OrigDataType: bool

--- a/subjects/PDP-11/lunar.reko/lunar.h
+++ b/subjects/PDP-11/lunar.reko/lunar.h
@@ -6684,7 +6684,7 @@ T_1427: (in 0x400<16> : word16)
   Class: Eq_19
   DataType: (ptr16 word16)
   OrigDataType: cup16
-T_1428: (in r4 > &(globals->t021C + 484<i32>) : bool)
+T_1428: (in r4 > (char *) (&globals->t021C) + 484<i32> : bool)
   Class: Eq_1428
   DataType: bool
   OrigDataType: bool
@@ -6712,7 +6712,7 @@ T_1434: (in 0x3FF<16> : word16)
   Class: Eq_19
   DataType: (ptr16 word16)
   OrigDataType: word16
-T_1435: (in globals->ptr0082 == &(globals->t021C + 483<i32>) : bool)
+T_1435: (in globals->ptr0082 == (char *) (&globals->t021C) + 483<i32> : bool)
   Class: Eq_1435
   DataType: bool
   OrigDataType: bool
@@ -8288,7 +8288,7 @@ T_1828: (in 0x400<16> : word16)
   Class: Eq_19
   DataType: (ptr16 word16)
   OrigDataType: cup16
-T_1829: (in r4_129 > &(globals->t021C + 484<i32>) : bool)
+T_1829: (in r4_129 > (char *) (&globals->t021C) + 484<i32> : bool)
   Class: Eq_1829
   DataType: bool
   OrigDataType: bool

--- a/subjects/PDP-11/lunar.reko/lunar_image.c
+++ b/subjects/PDP-11/lunar.reko/lunar_image.c
@@ -701,7 +701,7 @@ word16 fn0D3C(int16 r0, <anonymous> * ptrArg00)
 	globals->w00A0 = 225;
 	globals->w34DA = 0x00;
 	globals->w07BA = 0x00;
-	globals->a182A = 38996;
+	globals->a182A[0] = 38996;
 	globals->w182C = 0xF0A0;
 	globals->w182E = 0x00;
 	ptrArg00();
@@ -720,10 +720,10 @@ void fn0D66()
 cui16 * fn0D78(word16 * r4, cui16 * r5)
 {
 	cui16 wLoc02_n = 0x0200;
-	if (r4 <= &(globals->t021C + 484))
+	if (r4 <= (char *) (&globals->t021C) + 484)
 	{
-		r4 = (word16 *) &(globals->t021C + 483);
-		if (globals->ptr0082 == &(globals->t021C + 483))
+		r4 = (word16 *) ((char *) &globals->t021C + 483);
+		if (globals->ptr0082 == (char *) (&globals->t021C) + 483)
 			goto l0D9C;
 	}
 	if (r4 <= null)
@@ -892,8 +892,8 @@ void fn0F04(int16 r0)
 	word16 * r4_n = fn100C(*r0_n);
 	if (r4_n <= null)
 		r4_n = null;
-	else if (r4_n <= &(globals->t021C + 484))
-		r4_n = (word16 *) &(globals->t021C + 483);
+	else if (r4_n <= (char *) (&globals->t021C) + 484)
+		r4_n = (word16 *) ((char *) &globals->t021C + 483);
 	r5_n->ptr0000 = r4_n;
 	globals->ptr0082 = r4_n;
 	r5_n->w0002 = 0x8C50;

--- a/subjects/PE/x86/VCExeSample/VCExeSample.reko/VCExeSample_text.c
+++ b/subjects/PE/x86/VCExeSample/VCExeSample.reko/VCExeSample_text.c
@@ -134,9 +134,9 @@ void nested_structs_test13(nested_structs_type * str)
 void gbl_nested_structs_test14()
 {
 	// gbl_nested_structs.a = 5
-	globals->gbl_nested_structs = (Eq_n) 0x05;
+	globals->gbl_nested_structs.a = 0x05;
 	// gbl_nested_structs.str.b = 6
-	globals->gbl_nested_structs.str.b = (Eq_n) 0x06;
+	globals->gbl_nested_structs.str.b = 0x06;
 	// gbl_nested_structs.str.c = 7
 	globals->gbl_nested_structs.str.c = 0x07;
 	// gbl_nested_structs.d = 8


### PR DESCRIPTION
- Create `TypedConstantRewriter` test with dereferenced first struct field.

Expected:
```
        globals->t100100.dw0000
```
but was:
```
        globals->t100100
```