### PR TITLE
Unicode BOM removal

### DIFF
--- a/src/UserInterfaces/WindowsForms/Controls/TextView.cs
+++ b/src/UserInterfaces/WindowsForms/Controls/TextView.cs
@@ -540,7 +540,7 @@ namespace Reko.UserInterfaces.WindowsForms.Controls
             var modelPos = model.CurrentPosition;
             try
             {
-                var writer = new StreamWriter(stream, Encoding.Unicode);
+                var writer = new StreamWriter(stream, new UnicodeEncoding(false, false));
                 var start = GetStartSelection();
                 var end = GetEndSelection();
                 if (layout.ComparePositions(start, end) == 0)

--- a/subjects/regressionTests.py
+++ b/subjects/regressionTests.py
@@ -81,12 +81,17 @@ def cmdline_split(s):
         a.append(sub)
     return a
 
+# On Windows file removal is asynchronous but renames are atomic
+def remove_file(file):
+    os.rename(file, '%s.rmtmp' % file)
+    os.remove('%s.rmtmp' % file)
+
 # Remove output files
 def clear_dir(dir_name, files):
     for pname in files:
         for ext in output_extensions:
             if pname.endswith(ext):
-                os.remove(os.path.join(dir_name, pname))
+                remove_file(os.path.join(dir_name, pname))
 
 def strip_id_nums(dirs):
     for dir in dirs:


### PR DESCRIPTION
Encoding.Unicode inserts a BOM when used with a StreamWriter. When selecting text in the GUI and copying it that BOM is still there breaking a lot of text editors (including Notepad++). This will create the same output but without the BOM.

Also a small fix related to regression tests. Removing files and directories on Windows (NTFS) is actually an asynchronous operation, the deletion is deferred until the handle is closed. And I believe that deletion is actually queued for processing too. This result in a race condition when you remove a file or directory and very quickly tries to create a new file or directory with the same name. The "correct" way to do this is to rename the file and remove the new name. The rename is atomic.

More info can be read here https://stackoverflow.com/questions/3764072/c-win32-how-to-wait-for-a-pending-delete-to-complete if you're interested :)