### PR TITLE
Do not throw exception when infinite recursion detected during Type Analysis

### DIFF
--- a/src/Core/Types/DataTypeComparer.cs
+++ b/src/Core/Types/DataTypeComparer.cs
@@ -90,7 +90,10 @@ namespace Reko.Core.Types
         public int CompareInternal(DataType x, DataType y, int count)
         {
             if (count > 20)
-                throw new ApplicationException("Way too deep");     //$BUG: discover why datatypes recurse so deep.
+            {
+                Debug.WriteLine("Way too deep");     //$BUG: discover why datatypes recurse so deep.
+                return 0;
+            }
             int prioX = x.Accept(this);
 			int prioY = y.Accept(this);
 			int dPrio = prioX - prioY;

--- a/src/Core/Types/Unifier.cs
+++ b/src/Core/Types/Unifier.cs
@@ -78,8 +78,11 @@ namespace Reko.Core.Types
 			if (a == null || b == null)
 				return false;
 
-			if (depth > 20)
-				throw new StackOverflowException("Way too deep");     //$BUG: discover why datatypes recurse so deep.
+            if (depth > 20)
+            {
+                trace.Error("Way too deep");     //$BUG: discover why datatypes recurse so deep.
+                return true;
+            }
 			
 			PrimitiveType? pa = a as PrimitiveType;
 			PrimitiveType? pb = b as PrimitiveType;


### PR DESCRIPTION
This is the work around infinite recursion which makes possible
to continue `Type Analysis` after such errors