### PR TITLE
Fix regressionTests.py to work with Python2 again

### DIFF
--- a/subjects/regressionTests.py
+++ b/subjects/regressionTests.py
@@ -5,6 +5,7 @@
 # * having a dcproject file associated with them or
 # * a subject.cmd file containing reko command lines to execute.
 
+from __future__ import print_function
 from optparse import OptionParser
 from threading import Thread
 from datetime import datetime


### PR DESCRIPTION
regressionTests.py work with Python2 again.

subjects/PE/x86/RussianText/RussianText.reko/RussianText.globals.c is incorrect so this will still break with Python3.
It declares a _char_ that's really the first half of a 2-byte utf-8 sequence and Python3 care about characters vs bytes.