### PR TITLE
Read external procedure characteristics for user-defined metafiles

### DIFF
--- a/src/Core/ExternalProcedure.cs
+++ b/src/Core/ExternalProcedure.cs
@@ -33,15 +33,18 @@ namespace Reko.Core
     /// </summary>
 	public class ExternalProcedure : ProcedureBase
 	{
-        public ExternalProcedure(string name, FunctionType signature) : base(name)
+        public ExternalProcedure(
+            string name,
+            FunctionType signature,
+            ProcedureCharacteristics? chars = null) : base(name)
         {
-            this.Signature = signature ?? throw new ArgumentNullException(nameof(signature), $"External procedure {name} must have a signature.");
-        }
-
-        public ExternalProcedure(string name, FunctionType signature, ProcedureCharacteristics? chars) : base(name)
-        {
-            this.Signature = signature ?? throw new ArgumentNullException(nameof(signature));
-            this.Characteristics = chars;
+            this.Signature = signature ?? throw new ArgumentNullException(
+                nameof(signature),
+                $"External procedure {name} must have a signature.");
+            if (chars != null)
+            {
+                this.Characteristics = chars;
+            }
         }
 
 		public override FunctionType Signature { get; set; }

--- a/src/Core/ImportResolver.cs
+++ b/src/Core/ImportResolver.cs
@@ -124,7 +124,7 @@ namespace Reko.Core
             {
                 if (program.EnvironmentMetadata.Signatures.TryGetValue(importName, out var sig))
                 {
-                    var chr = platform.LookupCharacteristicsByName(importName);
+                    var chr = program.LookupCharacteristicsByName(importName);
                     return new ExternalProcedure(importName, sig, chr);
                 }
             }

--- a/src/Core/ImportResolver.cs
+++ b/src/Core/ImportResolver.cs
@@ -125,10 +125,7 @@ namespace Reko.Core
                 if (program.EnvironmentMetadata.Signatures.TryGetValue(importName, out var sig))
                 {
                     var chr = platform.LookupCharacteristicsByName(importName);
-                    if (chr != null)
-                        return new ExternalProcedure(importName, sig, chr);
-                    else
-                        return new ExternalProcedure(importName, sig);
+                    return new ExternalProcedure(importName, sig, chr);
                 }
             }
             if (project.LoadedMetadata.Signatures.TryGetValue(importName, out var signature))

--- a/src/Core/ProcedureBase.cs
+++ b/src/Core/ProcedureBase.cs
@@ -48,7 +48,7 @@ namespace Reko.Core
 
 		public abstract FunctionType Signature { get; set; }
 
-		public ProcedureCharacteristics? Characteristics { get; set; }
+		public ProcedureCharacteristics Characteristics { get; set; }
 
         /// <summary>
         /// If this is a member function of a class or struct, this property

--- a/src/Core/Program.cs
+++ b/src/Core/Program.cs
@@ -263,6 +263,16 @@ namespace Reko.Core
             return new TypeLibraryDeserializer(Platform, true, EnvironmentMetadata.Clone());
         }
 
+        public virtual ProcedureCharacteristics? LookupCharacteristicsByName(string procName)
+        {
+            if (EnvironmentMetadata.Characteristics.TryGetValue(
+                procName,
+                out var chr)
+            )
+                return chr;
+            return Platform.LookupCharacteristicsByName(procName);
+        }
+
         /// <summary>
         /// The processor architectures that exist in the Program. 
         /// </summary>

--- a/src/Core/TypeLibrary.cs
+++ b/src/Core/TypeLibrary.cs
@@ -19,6 +19,7 @@
 #endregion
 
 using Reko.Core.Output;
+using Reko.Core.Serialization;
 using Reko.Core.Types;
 using System;
 using System.Collections.Generic;
@@ -37,7 +38,9 @@ namespace Reko.Core
 		public TypeLibrary(bool caseInsensitive = false) : this(
             caseInsensitive,
             new Dictionary<string, DataType>(),
-            new Dictionary<string, FunctionType>(TypeLibrary.Comparer(caseInsensitive)),
+            new Dictionary<string, FunctionType>(Comparer(caseInsensitive)),
+            new Dictionary<string, ProcedureCharacteristics>(
+                Comparer(caseInsensitive)),
             new Dictionary<string, DataType>())
         {
         }
@@ -47,17 +50,24 @@ namespace Reko.Core
             bool caseInsensitive,
             IDictionary<string,DataType> types,
             IDictionary<string, FunctionType> procedures,
+            IDictionary<string, ProcedureCharacteristics> characteristics,
             IDictionary<string, DataType> globals)
         {
             this.isCaseInsensitive = caseInsensitive;
             this.Types = types;
             this.Signatures = procedures;
+            this.Characteristics = characteristics;
             this.Globals = globals;
             this.Modules = new Dictionary<string, ModuleDescriptor>();
         }
 
         public IDictionary<string, DataType> Types { get; private set; }
         public IDictionary<string, FunctionType> Signatures { get; private set; }
+        public IDictionary<string, ProcedureCharacteristics> Characteristics
+        {
+            get;
+            private set;
+        }
         public IDictionary<string, DataType> Globals { get; private set; }
         public IDictionary<string, ModuleDescriptor> Modules { get; private set; }
 

--- a/src/Core/TypeLibraryDeserializer.cs
+++ b/src/Core/TypeLibraryDeserializer.cs
@@ -115,11 +115,17 @@ namespace Reko.Core
         {
             try
             {
+                if (sp.Name is null)
+                    return;
+                if (sp.Characteristics != null)
+                {
+                    library.Characteristics[sp.Name] = sp.Characteristics;
+                }
                 var sser = new ProcedureSerializer(platform, this, this.defaultConvention ?? "");
                 var signature = sser.Deserialize(sp.Signature, platform.Architecture.CreateFrame());
-                if (sp.Name is null || signature is null)
+                if (signature is null)
                     return;
-                library.Signatures[sp.Name!] = signature;
+                library.Signatures[sp.Name] = signature;
                 var mod = EnsureModule(this.moduleName, this.library);
                 var svc = new SystemService
                 {

--- a/src/Decompiler/Scanning/BlockWorkitem.cs
+++ b/src/Decompiler/Scanning/BlockWorkitem.cs
@@ -426,7 +426,7 @@ namespace Reko.Scanning
                     var chr = impProc.Characteristics;
                     if (chr != null && chr.IsAlloca)
                         return ProcessAlloca(site, impProc);
-                    EmitCall(CreateProcedureConstant(impProc), sig, chr!, site);
+                    EmitCall(CreateProcedureConstant(impProc), sig, chr, site);
                     Emit(new ReturnInstruction());
                     blockCur!.Procedure.ControlGraph.AddEdge(blockCur, blockCur.Procedure.ExitBlock);
                     return false;
@@ -449,7 +449,7 @@ namespace Reko.Scanning
                     }
                     var sig = trampoline.Signature;
                     var chr = trampoline.Characteristics;
-                    EmitCall(CreateProcedureConstant(trampoline), sig, chr!, jmpSite);
+                    EmitCall(CreateProcedureConstant(trampoline), sig, chr, jmpSite);
                     Emit(new ReturnInstruction());
                     blockCur.Procedure.ControlGraph.AddEdge(blockCur, blockCur.Procedure.ExitBlock);
                     return false;
@@ -552,7 +552,7 @@ namespace Reko.Scanning
                 }
                 var pcCallee = CreateProcedureConstant(callee);
                 sig = callee.Signature;
-                chr = callee.Characteristics!;
+                chr = callee.Characteristics;
                 EmitCall(pcCallee, sig, chr, site);
                 if (callee is Procedure pCallee)
                 {
@@ -857,7 +857,7 @@ namespace Reko.Scanning
                 Emit(new SideEffect(side.Expression));
                 if (side.Expression is Application appl &&
                     appl.Procedure is ProcedureConstant fn &&
-                    fn.Procedure.Characteristics!.Terminates)
+                    fn.Procedure.Characteristics.Terminates)
                 {
                     scanner.TerminateBlock(blockCur!, ric!.Address + ric.Length);
                     return false;

--- a/src/Environments/Windows/win32characteristics.xml
+++ b/src/Environments/Windows/win32characteristics.xml
@@ -10,18 +10,6 @@
       <varargs>Reko.Environments.Windows.MsPrintfFormatParser,Reko.Environments.Windows</varargs>
     </characteristics>
   </entry>
-  <entry name="Py_BuildValue">
-    <!-- @ptomin This needs to be moved to a 'PythonCharacteristics.xml' file -->
-    <characteristics>
-      <varargs>Reko.Libraries.Python.PyBuildValueFormatParser,Reko.Libraries.Python</varargs>
-    </characteristics>
-  </entry>
-  <entry name="PyArg_ParseTuple">
-    <!-- @ptomin This needs to be moved to a 'PythonCharacteristics.xml' file -->
-    <characteristics>
-      <varargs>Reko.Libraries.Python.PyArgFormatParser,Reko.Libraries.Python</varargs>
-    </characteristics>
-  </entry>
   <entry name="exit">
     <characteristics>
       <terminates>true</terminates>

--- a/src/UnitTests/Core/Serialization/ProjectLoaderTests.cs
+++ b/src/UnitTests/Core/Serialization/ProjectLoaderTests.cs
@@ -390,14 +390,22 @@ namespace Reko.UnitTests.Core.Serialization
                 OsPath.Absolute("meta1.xml"),
                 this.platform.Object,
                 new TypeLibrary(
-                    false, types1, new Dictionary<string, FunctionType>(), new Dictionary<string, DataType>()
+                    false,
+                    types1,
+                    new Dictionary<string, FunctionType>(),
+                    new Dictionary<string, ProcedureCharacteristics>(),
+                    new Dictionary<string, DataType>()
                 )
             );
             mockFactory.CreateLoadMetadataStub(
                 OsPath.Absolute("meta2.xml"),
                 this.platform.Object,
                 new TypeLibrary(
-                    false, types2, new Dictionary<string, FunctionType>(), new Dictionary<string, DataType>()
+                    false,
+                    types2,
+                    new Dictionary<string, FunctionType>(),
+                    new Dictionary<string, ProcedureCharacteristics>(),
+                    new Dictionary<string, DataType>()
                 )
             );
 

--- a/src/UnitTests/Environments/Windows/Win32PlatformTests.cs
+++ b/src/UnitTests/Environments/Windows/Win32PlatformTests.cs
@@ -96,6 +96,7 @@ namespace Reko.UnitTests.Environments.Windows
                 false,
                 types, 
                 new Dictionary<string, FunctionType>(),
+                new Dictionary<string, ProcedureCharacteristics>(),
                 new Dictionary<string, DataType>());
 
             Expect_TypeLibraryLoaderService_LoadLibrary(

--- a/src/UnitTests/Mocks/MockFactory.cs
+++ b/src/UnitTests/Mocks/MockFactory.cs
@@ -90,7 +90,11 @@ namespace Reko.UnitTests.Mocks
         public void Given_PlatformTypes(Dictionary<string, DataType> types)
         {
             this.platformMetadata = new TypeLibrary(
-                false, types, new Dictionary<string, FunctionType>(), new Dictionary<string, DataType>()
+                false,
+                types,
+                new Dictionary<string, FunctionType>(),
+                new Dictionary<string, ProcedureCharacteristics>(),
+                new Dictionary<string, DataType>()
             );
         }
 
@@ -169,7 +173,12 @@ namespace Reko.UnitTests.Mocks
                 signatures = new Dictionary<string, FunctionType>();
             if (globals == null)
                 globals = new Dictionary<string, DataType>();
-            var loaderMetadata = new TypeLibrary(false, types, signatures, globals);
+            var loaderMetadata = new TypeLibrary(
+                false,
+                types,
+                signatures,
+                new Dictionary<string, ProcedureCharacteristics>(),
+                globals);
             if (module != null)
                 loaderMetadata.Modules.Add(moduleName, module);
 

--- a/subjects/PE/x86/pySample/python.xml
+++ b/subjects/PE/x86/pySample/python.xml
@@ -4115,6 +4115,9 @@
     </signature>
   </procedure>
   <procedure name="PyArg_ParseTuple">
+    <characteristics>
+      <varargs>Reko.Libraries.Python.PyArgFormatParser,Reko.Libraries.Python</varargs>
+    </characteristics>
     <signature>
       <return>
         <prim domain="SignedInt" size="4" />
@@ -4167,6 +4170,9 @@
     </signature>
   </procedure>
   <procedure name="Py_BuildValue">
+    <characteristics>
+      <varargs>Reko.Libraries.Python.PyBuildValueFormatParser,Reko.Libraries.Python</varargs>
+    </characteristics>
     <signature>
       <return>
         <ptr size="4">


### PR DESCRIPTION
- Move Python characteristics to user defined metadata (`python.xml`)
- Read external procedure characteristics from user-defined metafiles. Modify `TypeLibrary` to store procedure characteristics