### PR TITLE
regressionTests.py sometime failed when output files were locked

### DIFF
--- a/subjects/regressionTests.py
+++ b/subjects/regressionTests.py
@@ -82,17 +82,23 @@ def cmdline_split(s):
         a.append(sub)
     return a
 
-# On Windows file removal is asynchronous but renames are atomic
-def remove_file(file):
-    os.rename(file, '%s.rmtmp' % file)
-    os.remove('%s.rmtmp' % file)
-
 # Remove output files
 def clear_dir(dir_name, files):
+    failedFiles = []
     for pname in files:
         for ext in output_extensions:
             if pname.endswith(ext):
-                remove_file(os.path.join(dir_name, pname))
+                filename = os.path.join(dir_name, pname)
+                try:
+                    os.remove(filename)
+                except:
+                    failedFiles.append(filename)
+    # Retry all failed files with a delay. Let the error propagate if persists.
+    if failedFiles:
+        time.sleep(1000)
+        for filename in failedFiles:
+            if os.exists(filename):
+                os.remove(filename)
 
 def strip_id_nums(dirs):
     for dir in dirs:


### PR DESCRIPTION
So I though I fixed the race condition in regressionTests.py, but I got it again today. The things I said about renaming before deletes in Windows is still true, but the chance of it happening is very small... I instead think that the output files might be locked by either Windows Search Indexer or a malware scanner.

I reverted the rename/remove thing I did last time and instead added a retry after a delay. The race condition is still there, but this time it should be less likely to cause an issue.