### PR TITLE
Fix naming of 'scanf' format parser at windows characteristics files

### DIFF
--- a/src/Environments/Windows/win32characteristics.xml
+++ b/src/Environments/Windows/win32characteristics.xml
@@ -33,17 +33,17 @@
   
   <entry name="scanf">
     <characteristics>
-      <varargs>ScanfFormatParser,Reko.Libraries.Libc</varargs>
+      <varargs>Reko.Libraries.Libc.ScanfFormatParser,Reko.Libraries.Libc</varargs>
     </characteristics>
   </entry>
   <entry name="fscanf">
     <characteristics>
-      <varargs>ScanfFormatParser,Reko.Libraries.Libc</varargs>
+      <varargs>Reko.Libraries.Libc.ScanfFormatParser,Reko.Libraries.Libc</varargs>
     </characteristics>
   </entry>
   <entry name="sscanf">
     <characteristics>
-      <varargs>ScanfFormatParser,Reko.Libraries.Libc</varargs>
+      <varargs>Reko.Libraries.Libc.ScanfFormatParser,Reko.Libraries.Libc</varargs>
     </characteristics>
   </entry>
 

--- a/src/Environments/Windows/win64characteristics.xml
+++ b/src/Environments/Windows/win64characteristics.xml
@@ -28,17 +28,17 @@
 
   <entry name="scanf">
     <characteristics>
-      <varargs>ScanfFormatParser,Reko.Libraries.Libc</varargs>
+      <varargs>Reko.Libraries.Libc.ScanfFormatParser,Reko.Libraries.Libc</varargs>
     </characteristics>
   </entry>
   <entry name="fscanf">
     <characteristics>
-      <varargs>ScanfFormatParser,Reko.Libraries.Libc</varargs>
+      <varargs>Reko.Libraries.Libc.ScanfFormatParser,Reko.Libraries.Libc</varargs>
     </characteristics>
   </entry>
   <entry name="sscanf">
     <characteristics>
-      <varargs>ScanfFormatParser,Reko.Libraries.Libc</varargs>
+      <varargs>Reko.Libraries.Libc.ScanfFormatParser,Reko.Libraries.Libc</varargs>
     </characteristics>
   </entry>
 


### PR DESCRIPTION
Fix naming of `scanf` format parser at windows characteristics files. It caused exception during scanning phase.