### PR TITLE
Added "Open in new tab" to context menu in CombinedCodeViewInteractor

### DIFF
--- a/src/Gui/decompiler-menus.xml
+++ b/src/Gui/decompiler-menus.xml
@@ -120,6 +120,7 @@
   <cmd id="ViewCfgCode" cmdSet="Reko" container="GrpCodeViewMode" priority="1">View _code</cmd>
   <cmd id="ViewCfgGraph" cmdSet="Reko" container="GrpCodeViewMode" priority="2">View control _graph</cmd>
   <cmd id="ViewPcRelative" cmdSet="Reko" container="GrpLowLevel">Show _PC relative addresses</cmd>
+  <cmd id="OpenInNewTab" cmdSet="Reko" container="GrpCodeView" priority="0">Open in new tab</cmd>
   <cmd id="EditDeclaration" cmdSet="Reko" container="GrpCodeView" priority="1">Edit declaration</cmd>
   <cmd id="EditComment" cmdSet="Reko" container="GrpCodeView" priority="2">Edit comment</cmd>
 

--- a/src/UserInterfaces/WindowsForms/CombinedCodeViewInteractor.cs
+++ b/src/UserInterfaces/WindowsForms/CombinedCodeViewInteractor.cs
@@ -309,6 +309,7 @@ namespace Reko.UserInterfaces.WindowsForms
                     case CmdIds.EditDeclaration:
                     case CmdIds.EditComment:
                     case CmdIds.ViewCfgGraph:
+                    case CmdIds.OpenInNewTab:
                         status.Status = MenuStatus.Visible;
                         return true;
                     }
@@ -335,6 +336,7 @@ namespace Reko.UserInterfaces.WindowsForms
                     return true;
                 case CmdIds.EditDeclaration:
                 case CmdIds.EditComment:
+                case CmdIds.OpenInNewTab:
                     status.Status = GetAnchorAddress() == null 
                         ? MenuStatus.Visible
                         : MenuStatus.Enabled | MenuStatus.Visible;
@@ -366,6 +368,9 @@ namespace Reko.UserInterfaces.WindowsForms
                     return true;
                 case CmdIds.EditComment:
                     EditComment();
+                    return true;
+                case CmdIds.OpenInNewTab:
+                    OpenInNewTab();
                     return true;
                 }
             }
@@ -469,6 +474,16 @@ namespace Reko.UserInterfaces.WindowsForms
             var anchorPt = FocusedTextView.GetAnchorTopPoint();
             var screenPoint = FocusedTextView.PointToScreen(anchorPt);
             commentFormInteractor.Show(screenPoint, program, addr);
+        }
+
+        private void OpenInNewTab()
+        {
+            var addr = GetAnchorAddress();
+            if (addr == null)
+                return;
+
+            if (program.Procedures.TryGetValue(addr, out var proc))
+                services.RequireService<ICodeViewerService>().DisplayProcedure(program, proc, program.NeedsScanning);
         }
 
         private void MixedCodeDataView_MouseDown(object sender, MouseEventArgs e)


### PR DESCRIPTION
Added a menu item for the context menu in CombinedCodeViewInteractor that opens the selected function in a new tab.

Not sure if this is the correct way to do it but "it worked on my machine<sup>TM</sup>"