### PR TITLE
Create ExpressionSimplifier test: '(real32)0x1'

### DIFF
--- a/src/UnitTests/Evaluation/ExpressionSimplifierTests.cs
+++ b/src/UnitTests/Evaluation/ExpressionSimplifierTests.cs
@@ -368,6 +368,19 @@ namespace Reko.UnitTests.Evaluation
         }
 
         [Test]
+        public void Exs_Word32ConstantToReal32Convert()
+        {
+            Given_ExpressionSimplifier();
+            var value = Constant.Word32(0x1);
+            var exp = m.Convert(
+                value, PrimitiveType.Word32, PrimitiveType.Real32);
+
+            var result = exp.Accept(simplifier);
+
+            Assert.AreEqual("1.0F", result.ToString());
+        }
+
+        [Test]
         public void Exs_SegMem_Constants()
         {
             Given_SegmentedArchitecture();


### PR DESCRIPTION
John, I do not agree with simplification at 4971642. `Reko.Core.Expressions.Cast` is C-style cast and can't be used as reinterpret cast. So we should not transform `(real32) 1<32>` to `1.4013e-45`. It should be `1.0` instead
I have create `ExpressionSimplifier` test: '(real32)0x1
Expected:
```
    1.0F
```
but was:
```
    0.0F
```