### PR TITLE
Fix FpuStackStorage.OffsetOf

### DIFF
--- a/src/Core/Storage.cs
+++ b/src/Core/Storage.cs
@@ -340,7 +340,11 @@ namespace Reko.Core
 
         public override int OffsetOf(Storage stgSub)
         {
-            return -1;
+            if (!(stgSub is FpuStackStorage that))
+                return -1;
+            if (that.FpuStackOffset != this.FpuStackOffset)
+                return -1;
+            return 0;
         }
 
         public override bool OverlapsWith(Storage sThat)

--- a/src/UnitTests/Core/StorageTests.cs
+++ b/src/UnitTests/Core/StorageTests.cs
@@ -127,5 +127,13 @@ namespace Reko.UnitTests.Core
         {
             Assert.AreEqual(tmpWord32.BitSize, 32);
         }
+
+        [Test]
+        public void Stg_FpuStackStorageOffsetOf()
+        {
+            Assert.AreEqual(0, fpu0.OffsetOf(fpu0));
+            Assert.AreEqual(-1, fpu0.OffsetOf(fpu1));
+            Assert.AreEqual(-1, fpu1.OffsetOf(fpu0));
+        }
     }
 }


### PR DESCRIPTION
- Create unit test for `FpuStackStorage.OffsetOf`
`OffsetOf` for the same FPU storages:
```
Expected: 0
But was: -1
```