### PR TITLE
Create ExpressionSimplifier unit test for slice of large double value

### DIFF
--- a/src/UnitTests/Evaluation/ExpressionSimplifierTests.cs
+++ b/src/UnitTests/Evaluation/ExpressionSimplifierTests.cs
@@ -165,6 +165,20 @@ namespace Reko.UnitTests.Evaluation
         }
 
         [Test]
+        public void Exs_Slice32_LargeReal64()
+        {
+            Given_ExpressionSimplifier();
+            var expr = m.Slice(
+                PrimitiveType.Word32,
+                // 0x4415AF1D78B58C40
+                Constant.Real64(1e20),
+                0);
+            Assert.AreEqual(
+                "0x78B58C40<32>",
+                expr.Accept(simplifier).ToString());
+        }
+
+        [Test]
         public void Exs_CastCast()
         {
             Given_ExpressionSimplifier();


### PR DESCRIPTION
Create `ExpressionSimplifier` unit test for slice of large double value
`System.OverflowException` exception was thrown