### PR TITLE
UserSignatureBuilder: keep user-defined procedure name if signature is not specified

### DIFF
--- a/src/Decompiler/Analysis/UserSignatureBuilder.cs
+++ b/src/Decompiler/Analysis/UserSignatureBuilder.cs
@@ -77,6 +77,7 @@ namespace Reko.Analysis
                         return;
                     }
                 }
+                proc.Name = userProc.Name ?? proc.Name;
             }
         }
 

--- a/src/UnitTests/Analysis/UserSignatureBuilderTests.cs
+++ b/src/UnitTests/Analysis/UserSignatureBuilderTests.cs
@@ -61,6 +61,16 @@ namespace Reko.UnitTests.Analysis
             });
         }
 
+        private void Given_UserName(uint address, string name)
+        {
+            program.User.Procedures.Add(
+                Address.Ptr32(address),
+                new Procedure_v1
+            {
+                Name = name
+            });
+        }
+
         private void Given_UserProcDecompileFlag(uint address, bool decompile)
         {
             program.User.Procedures[Address.Ptr32(address)].Decompile = decompile;
@@ -244,6 +254,16 @@ namespace Reko.UnitTests.Analysis
             usb.BuildSignature(Address.Ptr32(0x1000), proc);
             Assert.AreEqual("(fn void (word32))", proc.Signature.ToString());
             Assert.AreSame(PrimitiveType.Word32, proc.Signature.Parameters[0].DataType);
+        }
+
+        [Test]
+        public void Usb_NameWithoutSignature()
+        {
+            Given_Procedure(0x1000);
+            Given_UserName(0x1000, "usrName");
+            var usb = new UserSignatureBuilder(program);
+            usb.BuildSignature(Address.Ptr32(0x1000), proc);
+            Assert.AreEqual("usrName", proc.Name);
         }
     }
 }

--- a/src/tests/Analysis/RlTermination.exp
+++ b/src/tests/Analysis/RlTermination.exp
@@ -8,20 +8,20 @@ define fn0C00_0000
 fn0C00_0000_entry:
 	def ds
 l0C00_0000:
-	call fn0C00_0015 (retsize: 2;)
+	call maybeterminate (retsize: 2;)
 		uses: ax:0x20<16>,bx:0x3212<16>,ds:ds
 		defs: ax:ax_8
 	Mem14[ds:0x230<16>:word16] = ax_8
 	Mem15[ds:0x234<16>:word16] = 0x7B<16>
 	return
 fn0C00_0000_exit:
-// fn0C00_0015 /////////////////////
+// maybeterminate /////////////////////
 	LiveOut:   ax:[0..15]
 	BitsUsed:  ax:[0..15] bx:[0..15] ds:[0..15]
 	Trashed:   SCZO ax bx Top
 	Preserved: sp
-// fn0C00_0015
-define fn0C00_0015
+// maybeterminate
+define maybeterminate
 fn0C00_0015_entry:
 	def ax
 	def ds


### PR DESCRIPTION
- Create `UserSignatureBuilder` test with user-defined name without signature
```
Expected: "usrName"
 But was: "fnTest"
```
- `UserSignatureBuilder`: keep user-defined procedure name if signature is not specified

