### PR TITLE
Win16Platform: Support __ prefix for calling conventions

### DIFF
--- a/src/Environments/Windows/Win16Platform.cs
+++ b/src/Environments/Windows/Win16Platform.cs
@@ -89,14 +89,17 @@ SP	top of stack
         {
             if (ccName == null)
                 ccName = "";
+
             switch (ccName)
             {
             case "":
             case "__cdecl":
             case "cdecl":
                 return new X86CallingConvention(4, 2, 4, true, false);
+            case "__pascal":
             case "pascal":
                 return new X86CallingConvention(4, 2, 4, false, true);
+            case "__stdcall":
             case "stdcall":
                 return new X86CallingConvention(4, 4, 4, false, false);
             }


### PR DESCRIPTION
Allow explicit __pascal calling convention in signatures