### PR TITLE
Mixed code data model null pointer exception

### DIFF
--- a/src/UserInterfaces/WindowsForms/Controls/MixedCodeDataModel.cs
+++ b/src/UserInterfaces/WindowsForms/Controls/MixedCodeDataModel.cs
@@ -73,10 +73,13 @@ namespace Reko.UserInterfaces.WindowsForms.Controls
         public MixedCodeDataModel(MixedCodeDataModel that)
         {
             this.program = that.program;
+            this.imageMap = that.imageMap;
             this.curPos = that.curPos;
+            this.StartPosition = that.StartPosition;
             this.endPos = that.endPos;
             this.instructions = that.instructions;
             this.LineCount = that.LineCount;
+            this.comments = that.comments;
         }
 
         public object CurrentPosition { get { return curPos; } }

--- a/src/UserInterfaces/WindowsForms/Controls/MixedCodeDataModel.cs
+++ b/src/UserInterfaces/WindowsForms/Controls/MixedCodeDataModel.cs
@@ -169,7 +169,7 @@ namespace Reko.UserInterfaces.WindowsForms.Controls
         /// </summary>
         private Dictionary<ImageMapBlock, MachineInstruction[]> CollectInstructions()
         {
-            Dictionary<ImageMapBlock, MachineInstruction[]> instructions = new Dictionary<ImageMapBlock, MachineInstruction[]>();
+            var instructions = new Dictionary<ImageMapBlock, MachineInstruction[]>();
             foreach (var bi in imageMap.Items.Values.OfType<ImageMapBlock>()
                 .ToList())
             {


### PR DESCRIPTION
MixedCodeDataModel threw a NullPointerException when hovering over references because some fields wasn't copied in the copy constructor.

Also marked read only fields as readonly.