### PR TITLE
Spring cleaning - Project version migrator

### DIFF
--- a/src/Core/Serialization/ProjectLoader.cs
+++ b/src/Core/Serialization/ProjectLoader.cs
@@ -163,11 +163,11 @@ namespace Reko.Core.Serialization
         public Project LoadProject(string filename, Project_v5 sp)
         {
             if (string.IsNullOrWhiteSpace(sp.ArchitectureName))
-                sp.ArchitectureName = GuessProjectProcessorArchitecture(filename, sp.Inputs.OfType<DecompilerInput_v5>());
+                sp.ArchitectureName = GuessProjectProcessorArchitecture(filename, sp.InputFiles);
             if (string.IsNullOrWhiteSpace(sp.ArchitectureName))
                 throw new ApplicationException("Missing <arch> in project file. Please specify.");
             if (string.IsNullOrWhiteSpace(sp.PlatformName))
-                sp.PlatformName = GuessProjectPlatform(filename, sp.Inputs.OfType<DecompilerInput_v5>());
+                sp.PlatformName = GuessProjectPlatform(filename, sp.InputFiles);
             var cfgSvc = Services.RequireService<IConfigurationService>();
             var arch = cfgSvc.GetArchitecture(sp.ArchitectureName);
             this.arch = arch ?? throw new ApplicationException(
@@ -180,9 +180,9 @@ namespace Reko.Core.Serialization
                         sp.PlatformName ?? "(null)"));
             this.platform = env.Load(Services, arch);
             this.project.LoadedMetadata = this.platform.CreateMetadata();
-            var typelibs = sp.Inputs.OfType<MetadataFile_v3>().Select(m => VisitMetadataFile(filename, m));
-            var programs = sp.Inputs.OfType<DecompilerInput_v5>().Select(s => VisitInputFile(filename, s));
-            sp.Inputs.OfType<AssemblerFile_v3>().Select(s => VisitAssemblerFile(s));
+            var typelibs = sp.MetadataFiles.Select(m => VisitMetadataFile(filename, m));
+            var programs = sp.InputFiles.Select(s => VisitInputFile(filename, s));
+            sp.AssemblerFiles.Select(s => VisitAssemblerFile(s));
             project.MetadataFiles.AddRange(typelibs);
             project.Programs.AddRange(programs);
             return this.project;
@@ -249,9 +249,9 @@ namespace Reko.Core.Serialization
                         sp.PlatformName ?? "(null)"));
             this.platform = env.Load(Services, arch);
             this.project.LoadedMetadata = this.platform.CreateMetadata();
-            var typelibs = sp.Inputs.OfType<MetadataFile_v3>().Select(m => VisitMetadataFile(filename, m));
-            var programs = sp.Inputs.OfType<DecompilerInput_v4>().Select(s => VisitInputFile(filename, s));
-            sp.Inputs.OfType<AssemblerFile_v3>().Select(s => VisitAssemblerFile(s));
+            var typelibs = sp.MetadataFiles.Select(m => VisitMetadataFile(filename, m));
+            var programs = sp.InputFiles.Select(s => VisitInputFile(filename, s));
+            sp.AssemblerFiles.Select(s => VisitAssemblerFile(s));
             project.MetadataFiles.AddRange(typelibs);
             project.Programs.AddRange(programs);
             return this.project;

--- a/src/Core/Serialization/ProjectSaver.cs
+++ b/src/Core/Serialization/ProjectSaver.cs
@@ -48,20 +48,23 @@ namespace Reko.Core.Serialization
         /// <returns></returns>
         public Project_v5 Serialize(string projectAbsPath, Project project)
         {
-            var inputs = new List<ProjectFile_v3>();
-            inputs.AddRange(project.Programs.Select(p => VisitProgram(projectAbsPath, p)));
-            inputs.AddRange(project.MetadataFiles.Select(m => VisitMetadataFile(projectAbsPath, m)));
+            var inputFiles = new List<DecompilerInput_v5>();
+            inputFiles.AddRange(project.Programs.Select(p => VisitProgram(projectAbsPath, p)));
+
+            var metadataFiles = new List<MetadataFile_v3>();
+            metadataFiles.AddRange(project.MetadataFiles.Select(m => VisitMetadataFile(projectAbsPath, m)));
             var sp = new Project_v5
             {
                 // ".Single()" because there can be only one Architecture and Platform, realistically.
                 ArchitectureName = project.Programs.Select(p => p.Architecture.Name).Distinct().SingleOrDefault(),
                 PlatformName = project.Programs.Select(p => p.Platform.Name).Distinct().SingleOrDefault(),   
-                Inputs = inputs
+                InputFiles = inputFiles,
+                MetadataFiles = metadataFiles,
             };
             return sp;
         }
 
-        public ProjectFile_v3 VisitProgram(string projectAbsPath, Program program)
+        public DecompilerInput_v5 VisitProgram(string projectAbsPath, Program program)
         {
             return new DecompilerInput_v5
             {
@@ -285,7 +288,7 @@ namespace Reko.Core.Serialization
             throw new NotSupportedException(value.GetType().Name);
         }
 
-        public ProjectFile_v3 VisitMetadataFile(string projectAbsPath, MetadataFile metadata)
+        public MetadataFile_v3 VisitMetadataFile(string projectAbsPath, MetadataFile metadata)
         {
             return new MetadataFile_v3
             {

--- a/src/Core/Serialization/ProjectVersionMigrator.cs
+++ b/src/Core/Serialization/ProjectVersionMigrator.cs
@@ -1,3 +1,23 @@
+#region License
+/*
+ * Copyright (C) 2021-2021 Sven Almgren.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -6,8 +26,14 @@ using System.Text;
 
 namespace Reko.Core.Serialization
 {
+    /// <summary>
+    /// ProjectVersionMigrator provides a set of methods to migrate older projects to later versions.
+    /// </summary>
     public static class ProjectVersionMigrator
     {
+        /// <summary>
+        /// Migrate Project_v4 to Project_v5.
+        /// </summary>
         public static Project_v5 MigrateProject(Project_v4 v4) => new Project_v5()
         {
             ArchitectureName = v4.ArchitectureName,
@@ -18,12 +44,13 @@ namespace Reko.Core.Serialization
         };
 
         /// <summary>
+        /// Migrate DecompilerInput_v4 to DecompilerInput_v5.
+        /// </summary>
+        /// <remarks>
         /// Ignored fields (They existed in v4 but are unused in current code):
         ///     IntermediateFilename
         ///     GlobalsFilename
-        /// </summary>
-        /// <param name="v4"></param>
-        /// <returns></returns>
+        /// </remarks>
         public static DecompilerInput_v5 MigrateDecompilerInput(DecompilerInput_v4 v4)
         {
             var v5 = new DecompilerInput_v5()

--- a/src/Core/Serialization/ProjectVersionMigrator.cs
+++ b/src/Core/Serialization/ProjectVersionMigrator.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Reko.Core.Serialization
+{
+    public static class ProjectVersionMigrator
+    {
+        public static Project_v5 MigrateProject(Project_v4 v4) => new Project_v5()
+        {
+            ArchitectureName = v4.ArchitectureName,
+            PlatformName = v4.PlatformName,
+            InputFiles = v4.InputFiles.Select(i => MigrateDecompilerInput(i)).ToList(),
+            MetadataFiles = v4.MetadataFiles,
+            AssemblerFiles = v4.AssemblerFiles,
+        };
+
+        /// <summary>
+        /// Ignored fields (They existed in v4 but are unused in current code):
+        ///     IntermediateFilename
+        ///     GlobalsFilename
+        /// </summary>
+        /// <param name="v4"></param>
+        /// <returns></returns>
+        public static DecompilerInput_v5 MigrateDecompilerInput(DecompilerInput_v4 v4)
+        {
+            var v5 = new DecompilerInput_v5()
+            {
+                Filename = v4.Filename,
+                Comment = v4.Comment,
+                DisassemblyDirectory = v4.DisassemblyFilename != null ? Path.GetDirectoryName(v4.DisassemblyFilename) : null,
+                SourceDirectory = v4.OutputFilename != null ? Path.GetDirectoryName(v4.OutputFilename) : null,
+                IncludeDirectory = v4.TypesFilename != null ? Path.GetDirectoryName(v4.TypesFilename) : null,
+                ResourcesDirectory = v4.ResourcesDirectory,
+                User = v4.User ?? new UserData_v4
+                {
+                    ExtractResources = true,
+                }
+            };
+
+            if (string.IsNullOrWhiteSpace(v5.User.OutputFilePolicy))
+                v5.User.OutputFilePolicy = Program.SingleFilePolicy;
+
+            return v5;
+        }
+    }
+}

--- a/src/Core/Serialization/Project_v3.cs
+++ b/src/Core/Serialization/Project_v3.cs
@@ -27,20 +27,17 @@ using System.Xml.Serialization;
 
 namespace Reko.Core.Serialization
 {
-    public abstract class ProjectFile_v3
-    {
-        [XmlElement("filename")]
-        public string? Filename;
-    }
-
     public class Heuristic_v3
     {
         [XmlAttribute("name")]
         public string? Name;
     }
 
-    public class MetadataFile_v3 : ProjectFile_v3
+    public class MetadataFile_v3
     {
+        [XmlElement("filename")]
+        public string? Filename;
+
         [XmlElement("loader")]
         public string? LoaderTypeName;
 
@@ -48,12 +45,14 @@ namespace Reko.Core.Serialization
         public string? ModuleName;
     }
 
-    public class AssemblerFile_v3 : ProjectFile_v3
+    public class AssemblerFile_v3
     {
+        [XmlElement("filename")]
+        public string? Filename;
+
         [XmlElement("assembler")]
         public string? Assembler;
     }
-
 
     public class Annotation_v3
     {

--- a/src/Core/Serialization/Project_v4.cs
+++ b/src/Core/Serialization/Project_v4.cs
@@ -43,7 +43,9 @@ namespace Reko.Core.Serialization
 
         public Project_v4()
         {
-            this.Inputs = new List<ProjectFile_v3>();
+            this.InputFiles = new List<DecompilerInput_v4>();
+            this.MetadataFiles = new List<MetadataFile_v3>();
+            this.AssemblerFiles = new List<AssemblerFile_v3>();
         }
 
         [XmlElement("arch")]
@@ -53,9 +55,13 @@ namespace Reko.Core.Serialization
         public string? PlatformName;
 
         [XmlElement("input", typeof(DecompilerInput_v4))]
+        public List<DecompilerInput_v4> InputFiles;
+
         [XmlElement("metadata", typeof(MetadataFile_v3))]
+        public List<MetadataFile_v3> MetadataFiles;
+        
         [XmlElement("asm", typeof(AssemblerFile_v3))]
-        public List<ProjectFile_v3> Inputs;
+        public List<AssemblerFile_v3> AssemblerFiles;
 
         public override T Accept<T>(ISerializedProjectVisitor<T> visitor)
         {
@@ -63,12 +69,15 @@ namespace Reko.Core.Serialization
         }
     }
 
-    public class DecompilerInput_v4 : ProjectFile_v3
+    public class DecompilerInput_v4
     {
         public DecompilerInput_v4()
         {
             User = new UserData_v4();
         }
+
+        [XmlElement("filename")]
+        public string? Filename;
 
         [XmlElement("comment")]
         public string? Comment;

--- a/src/Core/Serialization/Project_v5.cs
+++ b/src/Core/Serialization/Project_v5.cs
@@ -45,7 +45,9 @@ namespace Reko.Core.Serialization
 
         public Project_v5()
         {
-            this.Inputs = new List<ProjectFile_v3>();
+            this.InputFiles = new List<DecompilerInput_v5>();
+            this.MetadataFiles = new List<MetadataFile_v3>();
+            this.AssemblerFiles = new List<AssemblerFile_v3>();
         }
 
         [XmlElement("arch")]
@@ -55,9 +57,11 @@ namespace Reko.Core.Serialization
         public string? PlatformName;
 
         [XmlElement("input", typeof(DecompilerInput_v5))]
+        public List<DecompilerInput_v5> InputFiles;
         [XmlElement("metadata", typeof(MetadataFile_v3))]
+        public List<MetadataFile_v3> MetadataFiles;
         [XmlElement("asm", typeof(AssemblerFile_v3))]
-        public List<ProjectFile_v3> Inputs;
+        public List<AssemblerFile_v3> AssemblerFiles;
 
         public override T Accept<T>(ISerializedProjectVisitor<T> visitor)
         {
@@ -65,12 +69,15 @@ namespace Reko.Core.Serialization
         }
     }
 
-    public class DecompilerInput_v5 : ProjectFile_v3
+    public class DecompilerInput_v5
     {
         public DecompilerInput_v5()
         {
             User = new UserData_v4();
         }
+
+        [XmlElement("filename")]
+        public string? Filename;
 
         [XmlElement("comment")]
         public string? Comment;

--- a/src/UnitTests/Core/Serialization/ProjectLoaderTests.cs
+++ b/src/UnitTests/Core/Serialization/ProjectLoaderTests.cs
@@ -291,7 +291,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = "testArch",
                 PlatformName = "testOS",
-                Inputs =
+                InputFiles =
                 {
                     new DecompilerInput_v4
                     {
@@ -323,7 +323,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = "testArch",
                 PlatformName = "testOS",
-                Inputs =
+                InputFiles =
                 {
                     new DecompilerInput_v4
                     {
@@ -333,6 +333,8 @@ namespace Reko.UnitTests.Core.Serialization
                             LoadAddress = "00123400"
                         }
                     },
+                },
+                MetadataFiles = {
                     new MetadataFile_v3 {
                         Filename = "meta1.xml",
                     },
@@ -405,7 +407,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = "testArch",
                 PlatformName = "testOS",
-                Inputs =
+                InputFiles =
                 {
                     new DecompilerInput_v4
                     {
@@ -457,7 +459,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = "testArch",
                 PlatformName = "testOS",
-                Inputs =
+                InputFiles =
                 {
                     new DecompilerInput_v4
                     {
@@ -504,7 +506,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = "testArch",
                 PlatformName = "testOS",
-                Inputs =
+                InputFiles =
                 {
                     new DecompilerInput_v4
                     {
@@ -548,7 +550,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = "testArch",
                 PlatformName = "testOS",
-                Inputs =
+                InputFiles =
                 {
                     new DecompilerInput_v4
                     {
@@ -577,7 +579,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = "testArch",
                 PlatformName = "testOS",
-                Inputs =
+                InputFiles =
                 {
                     new DecompilerInput_v4
                     {
@@ -635,7 +637,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = "testArch",
                 PlatformName = "testOS",
-                Inputs =
+                InputFiles =
                 {
                     new DecompilerInput_v5
                     {

--- a/src/UnitTests/Core/Serialization/ProjectSerializerTests.cs
+++ b/src/UnitTests/Core/Serialization/ProjectSerializerTests.cs
@@ -129,7 +129,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = "testArch",
                 PlatformName = "testOS",
-                Inputs = {
+                InputFiles = {
                     new DecompilerInput_v4
                     {
                         Filename = "f.exe",
@@ -237,7 +237,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = "testArch",
                 PlatformName = "testOS",
-                Inputs = {
+                InputFiles = {
                     new DecompilerInput_v5
                     {
                         Filename = "f.exe",
@@ -338,7 +338,7 @@ namespace Reko.UnitTests.Core.Serialization
         {
             var sp = new Project_v5
             {
-                Inputs = {
+                InputFiles = {
                     new DecompilerInput_v5 {
                         Filename ="foo.exe",
                         User = new UserData_v4 {
@@ -347,6 +347,8 @@ namespace Reko.UnitTests.Core.Serialization
                             },
                         }
                     },
+                },
+                AssemblerFiles = {
                     new AssemblerFile_v3 { Filename="foo.asm", Assembler="x86-att" }
                 }
             };

--- a/src/UnitTests/Core/Serialization/SerializedLibraryTests.cs
+++ b/src/UnitTests/Core/Serialization/SerializedLibraryTests.cs
@@ -153,7 +153,7 @@ namespace Reko.UnitTests.Core.Serialization
         {
             var proj = new Project_v5
             {
-                Inputs = {
+                InputFiles = {
                     new DecompilerInput_v5 {
                         User = new UserData_v4
                         {
@@ -228,8 +228,8 @@ namespace Reko.UnitTests.Core.Serialization
             var rdr = new XmlTextReader(sr);
             var proj = (Project_v5)ser.Deserialize(rdr);
 
-            Assert.AreEqual(1, proj.Inputs.Count);
-            var input = (DecompilerInput_v5)proj.Inputs[0];
+            Assert.AreEqual(1, proj.InputFiles.Count);
+            var input = (DecompilerInput_v5)proj.InputFiles[0];
             Assert.AreEqual(1, input.User.GlobalData.Count);
             Assert.AreEqual("arr(ptr(code),10)", input.User.GlobalData[0].DataType.ToString());
         }

--- a/src/UnitTests/Core/Serialization/SerializedProjectTests.cs
+++ b/src/UnitTests/Core/Serialization/SerializedProjectTests.cs
@@ -103,7 +103,7 @@ namespace Reko.UnitTests.Core.Serialization
         {
             Project_v5 ud = new Project_v5
             {
-                Inputs =
+                InputFiles =
                 {
                     new DecompilerInput_v5
                     {
@@ -309,7 +309,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = arch.Object.Name,
                 PlatformName = platform.Object.Name,
-                Inputs = {
+                InputFiles = {
                     new DecompilerInput_v5 {
                         Filename = "foo.exe",
                         User = {
@@ -447,7 +447,7 @@ namespace Reko.UnitTests.Core.Serialization
             var sProject = new Project_v5 {
                 ArchitectureName = arch.Object.Name,
                 PlatformName = platform.Object.Name,
-                Inputs =
+                MetadataFiles =
                 {
                     new MetadataFile_v3
                     {
@@ -477,7 +477,7 @@ namespace Reko.UnitTests.Core.Serialization
             {
                 ArchitectureName = "testArch",
                 PlatformName = "testOS",
-                Inputs = 
+                InputFiles =
                 {
                     new DecompilerInput_v4
                     {
@@ -550,7 +550,7 @@ namespace Reko.UnitTests.Core.Serialization
             var saver = new ProjectSaver(sc);
             var sProj = new Project_v5
             {
-                Inputs = { saver.VisitProgram("foo.exe", program) }
+                InputFiles = { saver.VisitProgram("foo.exe", program) }
             };
             var writer = new FilteringXmlWriter(sw);
             writer.Formatting = System.Xml.Formatting.Indented;


### PR DESCRIPTION
Added code to migrate Project_v4 to Project_v5 as a separate process instead of having ProjectLoader deal with both versions internally. This simplifies the (already large) ProjectLoader and also makes it clearer what was changed between project versions (I think).

Also separated the different kinds of inputs to their own fields (and removed their common base class) as they didn't seem to share any functionality, which removed some LinQ .OfType<>() filters.