### PR TITLE
Add new Python scripting events

### DIFF
--- a/src/Core/Scripts/ScriptEvent.cs
+++ b/src/Core/Scripts/ScriptEvent.cs
@@ -29,5 +29,14 @@ namespace Reko.Core.Scripts
     {
         /// <summary>Fired when program was loaded to memory.</summary>
         OnProgramLoaded,
+        /// <summary>Fired before starting of program decompilation.</summary>
+        OnProgramDecompiling,
+        /// <summary>Fired when program was scanned.</summary>
+        OnProgramScanned,
+        /// <summary>
+        /// Fired when program was decompiled but before output files are
+        /// written.
+        /// </summary>
+        OnProgramDecompiled,
     }
 }

--- a/src/Decompiler/Decompiler.cs
+++ b/src/Decompiler/Decompiler.cs
@@ -572,12 +572,13 @@ namespace Reko
 		{
 			if (Project is null || Project.Programs.Count == 0)
 				throw new InvalidOperationException("Programs must be loaded first.");
-
+            Project.FireScriptEvent(ScriptEvent.OnProgramDecompiling);
             foreach (Program program in Project.Programs)
             {
                 ScanProgram(program);
             }
-		}
+            Project.FireScriptEvent(ScriptEvent.OnProgramScanned);
+        }
 
         private void ScanProgram(Program program)
         {
@@ -663,9 +664,10 @@ namespace Reko
                             "An error occurred while rewriting procedure to high-level language.");
                     }
                 }
-                WriteDecompilerProducts();
             }
-			eventListener.ShowStatus("Rewriting complete.");
+            project.FireScriptEvent(ScriptEvent.OnProgramDecompiled);
+            WriteDecompilerProducts();
+            eventListener.ShowStatus("Rewriting complete.");
 		}
 
 		public void WriteDecompilerProducts()

--- a/src/Scripts/Python/RekoEventsAPI.cs
+++ b/src/Scripts/Python/RekoEventsAPI.cs
@@ -39,6 +39,9 @@ namespace Reko.Scripts.Python
             events = new Dictionary<string, ScriptEvent>
             {
                 {"program_loaded", ScriptEvent.OnProgramLoaded},
+                {"program_decompiling", ScriptEvent.OnProgramDecompiling},
+                {"program_scanned", ScriptEvent.OnProgramScanned},
+                {"program_decompiled", ScriptEvent.OnProgramDecompiled},
             };
             handlers = new EventHandlersMap();
         }

--- a/src/Scripts/Python/RekoProgramAPI.cs
+++ b/src/Scripts/Python/RekoProgramAPI.cs
@@ -154,6 +154,10 @@ namespace Reko.Scripts.Python
             {
                 CSignature = CSignature,
             };
+            if (program.Procedures.TryGetValue(addr, out var proc))
+            {
+                proc.Name = name;
+            }
         }
 
         public bool GetProcedureDecompileFlag(ulong linearAddress)

--- a/subjects/scripting/pyFuncNames.reko/pySample_text.c
+++ b/subjects/scripting/pyFuncNames.reko/pySample_text.c
@@ -64,3 +64,8 @@ void initpySample()
 	Py_InitModule4("pySample", methods, null, null, 1007);
 }
 
+// 10001196: void empty_procedure_loaded_decompiling_scanned_decompiled()
+void empty_procedure_loaded_decompiling_scanned_decompiled()
+{
+}
+

--- a/subjects/scripting/py_func_names.py
+++ b/subjects/scripting/py_func_names.py
@@ -65,6 +65,7 @@ def on_program_loaded(program):
     program.comments[0x10001170] = "\n".join(comments)
     program.comments[0x10001183] = \
         'This is initialization of Python extension module'
+    program.procedures[0x10001196] = "empty_procedure_loaded"
 
 def exclude_dll_main(program):
     program.procedures[0x1000149E] = 'DllMain'
@@ -112,3 +113,13 @@ def bytes_to_list(numbers):
 
 # Subscribe to Reko events
 reko.on.program_loaded += on_program_loaded
+reko.on.program_decompiling += lambda program: add_event_name_to_procedure(
+    program, 0x10001196, 'decompiling')
+reko.on.program_scanned += lambda program: add_event_name_to_procedure(
+    program, 0x10001196, 'scanned')
+reko.on.program_decompiled += lambda program: add_event_name_to_procedure(
+    program, 0x10001196, 'decompiled')
+
+def add_event_name_to_procedure(program, address, event):
+    procedures = program.procedures
+    procedures[address] = '{}_{}'.format(procedures[address].name, event)


### PR DESCRIPTION
Following events are supported now:
- `program_loaded`. Fired when program was loaded to memory.
- `program_decompiling`. Fired before starting of program
decompilation.
- `program_scanned`. Fired when program was scanned.
- `program_decompiled`. Fired when program was decompiled but
before output files are written.

Also make procedure name defining work at later stages.