### PR TITLE
Debug: Added JIT Debugger Launcher

### DIFF
--- a/src/Core/DebugEx.cs
+++ b/src/Core/DebugEx.cs
@@ -65,11 +65,21 @@ namespace Reko.Core
             }
         }
 
+        /// <summary>
+        /// Launch the Debugger and Break
+        /// </summary>
+        /// <param name="launchIfTrue"></param>
+        /// <remarks>
+        /// Example usage: start reko with Ctrl+F5.
+        /// When this function is hit, the debugger will be started if <paramref name="launchIfTrue"/> is true.
+        /// Can be used with the result of a boolean expression as an alternative
+        /// to conventional breakpoints when debugging large executables
+        /// </remarks>
         [Conditional("DEBUG")]
-        public static void Break(bool cond = true)
+        public static void Break(bool launchIfTrue = true)
         {
             // should we break?
-            if (!cond) return;
+            if (!launchIfTrue) return;
 
             if (Debugger.IsAttached) {
                 // yes, but we're already attached. break instead
@@ -78,7 +88,12 @@ namespace Reko.Core
             }
 
             // yes, but we're not attached. launch & break
-            Debugger.Launch();
+            if (!Debugger.Launch())
+            {
+                // user clicked Cancel or this operation is not supported (e.g. Linux)
+                return;
+            }
+
             while (!Debugger.IsAttached)
             {
                 Thread.Sleep(200);

--- a/src/Core/DebugEx.cs
+++ b/src/Core/DebugEx.cs
@@ -66,15 +66,22 @@ namespace Reko.Core
         }
 
         [Conditional("DEBUG")]
-        public static void LauchDebugger()
+        public static void Break(bool cond = true)
         {
-            if (!Debugger.IsAttached)
+            // should we break?
+            if (!cond) return;
+
+            if (Debugger.IsAttached) {
+                // yes, but we're already attached. break instead
+                Debugger.Break();
+                return;
+            }
+
+            // yes, but we're not attached. launch & break
+            Debugger.Launch();
+            while (!Debugger.IsAttached)
             {
-                Debugger.Launch();
-                while (!Debugger.IsAttached)
-                {
-                    Thread.Sleep(200);
-                }
+                Thread.Sleep(200);
             }
         }
     }

--- a/src/Core/DebugEx.cs
+++ b/src/Core/DebugEx.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace Reko.Core
 {
@@ -61,6 +62,19 @@ namespace Reko.Core
             if (trace != null && trace.TraceVerbose)
             {
                 Debug.Print(message, args);
+            }
+        }
+
+        [Conditional("DEBUG")]
+        public static void LauchDebugger()
+        {
+            if (!Debugger.IsAttached)
+            {
+                Debugger.Launch();
+                while (!Debugger.IsAttached)
+                {
+                    Thread.Sleep(200);
+                }
             }
         }
     }


### PR DESCRIPTION
It's much faster to use when placing strategic breakpoints
This means there is less overhead (no debugger attached) while running
until we reach the point where we need to break and check