### PR TITLE
Added support for pascal and stdcall calling conventions for MsdosPlatform

### DIFF
--- a/src/Environments/Msdos/MsdosPlatform.cs
+++ b/src/Environments/Msdos/MsdosPlatform.cs
@@ -90,12 +90,34 @@ namespace Reko.Environments.Msdos
 
         public override CallingConvention GetCallingConvention(string? ccName)
         {
-            return new X86CallingConvention(
-                4,      //$REVIEW: this is a far call, what about near calls?
-                2,
-                4,      //$REVIEW: this is a far ptr.
-                true,
-                false);
+            ccName = ccName?.TrimStart('_') ?? string.Empty; // Default to cdecl (same as empty string)
+
+            switch (ccName)
+            {
+            case "":
+            case "cdecl":
+                return new X86CallingConvention(
+                    4,      //$REVIEW: this is a far call, what about near calls?
+                    2,
+                    4,      //$REVIEW: this is a far ptr.
+                    true,
+                    false);
+            case "stdcall":
+                return new X86CallingConvention(
+                    4,      //$REVIEW: this is a far call, what about near calls?
+                    2,
+                    4,      //$REVIEW: this is a far ptr.
+                    false,
+                    false);
+            case "pascal":
+                return new X86CallingConvention(
+                    4,      //$REVIEW: this is a far call, what about near calls?
+                    2,
+                    4,      //$REVIEW: this is a far ptr.
+                    false,
+                    true);
+            }
+            throw new ArgumentOutOfRangeException(string.Format("Unknown calling convention '{0}'.", ccName));
         }
 
 

--- a/src/Environments/Windows/Win32Platform.cs
+++ b/src/Environments/Windows/Win32Platform.cs
@@ -126,18 +126,12 @@ namespace Reko.Environments.Windows
 
         public override CallingConvention GetCallingConvention(string? ccName)
         {
-            if (ccName == null)
-                return new X86CallingConvention(
-                    Architecture.PointerType.Size,
-                    Architecture.WordWidth.Size,
-                    Architecture.PointerType.Size,
-                    true,
-                    false);
+            ccName = ccName?.TrimStart('_') ?? string.Empty; // Default to cdecl (same as empty string)
+
             switch (ccName)
             {
             case "":
             case "cdecl":
-            case "__cdecl":
                 return new X86CallingConvention(
                     Architecture.PointerType.Size,
                     Architecture.WordWidth.Size,
@@ -145,7 +139,6 @@ namespace Reko.Environments.Windows
                     true,
                     false);
             case "stdcall":
-            case "__stdcall":
             case "stdapi":
                 return new X86CallingConvention(
                     Architecture.PointerType.Size,
@@ -160,12 +153,12 @@ namespace Reko.Environments.Windows
                     Architecture.PointerType.Size,
                     false,
                     true);
-            case "__thiscall":
+            case "thiscall":
                 return new ThisCallConvention(
                     Registers.ecx,
                     Architecture.WordWidth.Size,
                     Architecture.PointerType.Size);
-            case "__fastcall":
+            case "fastcall":
                 return new FastcallConvention(
                     Registers.ecx,
                     Registers.edx,


### PR DESCRIPTION
Added support for pascal and stdcall calling conventions for MsdosPlatform.

Also made underscore-prefixs optional for calling conventions for Win32Platform ("__pascal" should be treated the same as "pascal")