### PR TITLE
Cirrus CI: fix darwin build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,6 +33,9 @@ darwin_x64_task:
   macos_instance:
     image: big-sur-xcode-12.4
 
+  env:
+    PATH: $HOME/.dotnet:$PATH
+
   install_script:
     - brew install pkg-config cmake capstone p7zip
     - curl -L https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh | bash -s - --channel 3.1


### PR DESCRIPTION
As of today, we are using dotnet 5 on darwin with dotnet 3.1 on top of it
Due to the Symantec Root CA distrust, we need to use a dotnet 5 version
newer than 5.0.100, or it will fail certificates validation in dotnet restore
This is due to macOS removal of the Symantec certificate from the trusted store
Since we weren't updating the brew cache, an older dotnet 5 version was
being installed