### PR TITLE
Core.csproj: ignore exit code for 'git rev-parse'

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -28,8 +28,15 @@
   <Target Name="GenerateGitHash" BeforeTargets="CoreCompile">
     <!-- names the obj/.../CustomAssemblyInfo.cs file -->
     <Exec Command="git rev-parse --short HEAD" ConsoleToMSBuild="true" IgnoreExitCode="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="SourceRevisionId" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitRevParseOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="GitRevParseExitCode" />
     </Exec>
+    <PropertyGroup Condition="$(GitRevParseExitCode)==0">
+      <SourceRevisionId>$(GitRevParseOutput)</SourceRevisionId>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(GitRevParseExitCode)!=0">
+      <SourceRevisionId>unknown</SourceRevisionId>
+    </PropertyGroup>
     <PropertyGroup>
       <CustomAssemblyInfoFile>$(IntermediateOutputPath)AssemblyData.Extra.cs</CustomAssemblyInfoFile>
     </PropertyGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -27,7 +27,7 @@
 
   <Target Name="GenerateGitHash" BeforeTargets="CoreCompile">
     <!-- names the obj/.../CustomAssemblyInfo.cs file -->
-    <Exec Command="git rev-parse --short HEAD" ConsoleToMSBuild="true">
+    <Exec Command="git rev-parse --short HEAD" ConsoleToMSBuild="true" IgnoreExitCode="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="SourceRevisionId" />
     </Exec>
     <PropertyGroup>


### PR DESCRIPTION
Make it build for users who have not added git to PATH