### PR TITLE
A small fix + a few enhancements.

### DIFF
--- a/src/Drivers/WebSite/reko.config
+++ b/src/Drivers/WebSite/reko.config
@@ -166,9 +166,6 @@
         <SignatureFiles>
           <SignatureFile Filename="amiga.flirtoid" Label="FlirtoidSignatures" />
         </SignatureFiles>      
-      </Environment>
-
-      <Environment Name="riscOS" Description="RISC OS" Type="Reko.Environments.RiscOS.RiscOSPlatform,Reko.Environments.RiscOS">
         <Options>
           <dict key="versionDependentLibraries">
             <list key="33">
@@ -181,6 +178,9 @@
             </list>  
           </dict>
         </Options>
+      </Environment>
+
+      <Environment Name="riscOS" Description="RISC OS" Type="Reko.Environments.RiscOS.RiscOSPlatform,Reko.Environments.RiscOS">
       </Environment>
 
       <Environment Name="zx81" Description="ZX81" Type="Reko.Environments.ZX81.ZX81Environment,Reko.Environments.ZX81">

--- a/src/Drivers/reko.config
+++ b/src/Drivers/reko.config
@@ -336,9 +336,6 @@
         <SignatureFiles>
           <SignatureFile Filename="amiga.flirtoid" Label="FlirtoidSignatures" />
         </SignatureFiles>
-      </Environment>
-
-      <Environment Name="riscOS" Description="RISC OS" Type="Reko.Environments.RiscOS.RiscOSPlatform,Reko.Environments.RiscOS">
         <Options>
           <dict key="versionDependentLibraries">
             <list key="33">
@@ -351,6 +348,9 @@
             </list>  
           </dict>
         </Options>
+      </Environment>
+
+      <Environment Name="riscOS" Description="RISC OS" Type="Reko.Environments.RiscOS.RiscOSPlatform,Reko.Environments.RiscOS">
       </Environment>
 
       <Environment Name="RT-11" Description="DEC RT-11" Type="Reko.Environments.RT11.RT11Platform,Reko.Environments.RT11">

--- a/src/Environments/AmigaOS.Design/AmigaOSProperties.Designer.cs
+++ b/src/Environments/AmigaOS.Design/AmigaOSProperties.Designer.cs
@@ -34,15 +34,17 @@
             this.cmbKickstartVersions = new System.Windows.Forms.ComboBox();
             this.lblUsedLibraries = new System.Windows.Forms.Label();
             this.lstLoadedLibs = new System.Windows.Forms.ListView();
-            this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader1 = new System.Windows.Forms.ColumnHeader();
+            this.btnImportLibraries = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // label1
             // 
             this.label1.Image = global::Reko.Environments.AmigaOS.Design.Properties.Resources.AmigaOS;
-            this.label1.Location = new System.Drawing.Point(3, 9);
+            this.label1.Location = new System.Drawing.Point(4, 10);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(132, 125);
+            this.label1.Size = new System.Drawing.Size(154, 144);
             this.label1.TabIndex = 0;
             // 
             // label2
@@ -50,36 +52,40 @@
             this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label2.BackColor = System.Drawing.Color.White;
-            this.label2.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(148, 9);
+            this.label2.Font = new System.Drawing.Font("Tahoma", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.label2.Location = new System.Drawing.Point(173, 10);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(588, 29);
+            this.label2.Size = new System.Drawing.Size(686, 33);
             this.label2.TabIndex = 1;
             this.label2.Text = "AmigaOS properties";
             // 
             // lblKickstart
             // 
             this.lblKickstart.AutoSize = true;
-            this.lblKickstart.Location = new System.Drawing.Point(145, 58);
+            this.lblKickstart.Location = new System.Drawing.Point(169, 67);
+            this.lblKickstart.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblKickstart.Name = "lblKickstart";
-            this.lblKickstart.Size = new System.Drawing.Size(118, 13);
+            this.lblKickstart.Size = new System.Drawing.Size(127, 15);
             this.lblKickstart.TabIndex = 2;
             this.lblKickstart.Text = "Select &Kickstart version";
             // 
             // cmbKickstartVersions
             // 
             this.cmbKickstartVersions.FormattingEnabled = true;
-            this.cmbKickstartVersions.Location = new System.Drawing.Point(148, 75);
+            this.cmbKickstartVersions.Location = new System.Drawing.Point(173, 87);
+            this.cmbKickstartVersions.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.cmbKickstartVersions.Name = "cmbKickstartVersions";
-            this.cmbKickstartVersions.Size = new System.Drawing.Size(182, 21);
+            this.cmbKickstartVersions.Size = new System.Drawing.Size(212, 23);
             this.cmbKickstartVersions.TabIndex = 3;
             // 
             // lblUsedLibraries
             // 
             this.lblUsedLibraries.AutoSize = true;
-            this.lblUsedLibraries.Location = new System.Drawing.Point(337, 58);
+            this.lblUsedLibraries.Location = new System.Drawing.Point(173, 113);
+            this.lblUsedLibraries.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblUsedLibraries.Name = "lblUsedLibraries";
-            this.lblUsedLibraries.Size = new System.Drawing.Size(47, 13);
+            this.lblUsedLibraries.Size = new System.Drawing.Size(51, 15);
             this.lblUsedLibraries.TabIndex = 4;
             this.lblUsedLibraries.Text = "Will use:";
             // 
@@ -87,9 +93,11 @@
             // 
             this.lstLoadedLibs.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader1});
-            this.lstLoadedLibs.Location = new System.Drawing.Point(337, 75);
+            this.lstLoadedLibs.HideSelection = false;
+            this.lstLoadedLibs.Location = new System.Drawing.Point(173, 131);
+            this.lstLoadedLibs.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.lstLoadedLibs.Name = "lstLoadedLibs";
-            this.lstLoadedLibs.Size = new System.Drawing.Size(187, 161);
+            this.lstLoadedLibs.Size = new System.Drawing.Size(212, 152);
             this.lstLoadedLibs.TabIndex = 5;
             this.lstLoadedLibs.UseCompatibleStateImageBehavior = false;
             this.lstLoadedLibs.View = System.Windows.Forms.View.Details;
@@ -99,18 +107,29 @@
             this.columnHeader1.Text = "Library";
             this.columnHeader1.Width = 144;
             // 
+            // btnImportLibraries
+            // 
+            this.btnImportLibraries.Location = new System.Drawing.Point(393, 87);
+            this.btnImportLibraries.Name = "btnImportLibraries";
+            this.btnImportLibraries.Size = new System.Drawing.Size(142, 23);
+            this.btnImportLibraries.TabIndex = 6;
+            this.btnImportLibraries.Text = "Import Libraries";
+            this.btnImportLibraries.UseVisualStyleBackColor = true;
+            // 
             // AmigaOSProperties
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.btnImportLibraries);
             this.Controls.Add(this.lstLoadedLibs);
             this.Controls.Add(this.lblUsedLibraries);
             this.Controls.Add(this.cmbKickstartVersions);
             this.Controls.Add(this.lblKickstart);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
+            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.Name = "AmigaOSProperties";
-            this.Size = new System.Drawing.Size(731, 271);
+            this.Size = new System.Drawing.Size(853, 313);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -125,5 +144,6 @@
         private System.Windows.Forms.Label lblUsedLibraries;
         private System.Windows.Forms.ListView lstLoadedLibs;
         private System.Windows.Forms.ColumnHeader columnHeader1;
+        private System.Windows.Forms.Button btnImportLibraries;
     }
 }

--- a/src/Environments/AmigaOS.Design/AmigaOSProperties.cs
+++ b/src/Environments/AmigaOS.Design/AmigaOSProperties.cs
@@ -37,10 +37,13 @@ namespace Reko.Environments.AmigaOS.Design
         {
             InitializeComponent();
             KickstartVersionList = new ComboBoxWrapper(cmbKickstartVersions);
+            ImportButton = new ButtonWrapper(btnImportLibraries);
             LoadedLibraryList = lstLoadedLibs;      //$TODO: no wrapper for ListView available yet.
         }
 
         public IComboBox KickstartVersionList { get; private set; }
+        public IButton ImportButton { get; private set; }
+
         public ListView LoadedLibraryList { get; private set; }
     }
 }

--- a/src/Environments/AmigaOS.Design/AmigaOSPropertiesInteractor.cs
+++ b/src/Environments/AmigaOS.Design/AmigaOSPropertiesInteractor.cs
@@ -64,7 +64,7 @@ namespace Reko.Environments.AmigaOS.Design
             PopulateLoadedLibraryList();
 
             this.Control.KickstartVersionList.SelectedIndexChanged += KickstartVersionList_SelectedIndexChanged;
-
+            this.Control.ImportButton.Click += ImportButton_Click;
             return Control;
         }
 
@@ -81,7 +81,10 @@ namespace Reko.Environments.AmigaOS.Design
         {
             PopulateLoadedLibraryList();
         }
-
+        private void ImportButton_Click(object sender, EventArgs e)
+        {
+            platform.SetKickstartVersion(33 + this.Control.KickstartVersionList.SelectedIndex);
+        }
         private void PopulateLoadedLibraryList()
         {
             var listOption = (ListOption)Control.KickstartVersionList.SelectedValue;


### PR DESCRIPTION
* Added `import` button to AmigaOS property control
Clicking the import button will currently call `SetKickstartVersion` based on the selected version.

* Small refactor for `EnsureTypeLibraries`
* Somehow reko.config moved AmigaOs kickstart versions to riscOS options.