### PR TITLE
Emit correct real values for type references

### DIFF
--- a/src/Decompiler/Evaluation/IdConstant.cs
+++ b/src/Decompiler/Evaluation/IdConstant.cs
@@ -71,10 +71,11 @@ namespace Reko.Evaluation
             if (this.pt != null)
             {
                 ctx.RemoveIdentifierUse(idDst!);
+                var pt = idDst!.DataType.ResolveAs<PrimitiveType>();
                 var cNew = src!.CloneExpression();
                 if (src.DataType.IsWord &&
-                    src is Constant cSrc && 
-                    idDst!.DataType is PrimitiveType pt &&
+                    src is Constant cSrc &&
+                    pt != null &&
                     pt.Domain == Domain.Real)
                 {
                     // Raw bitvector assigned to an real-valued register. We need to interpret the bitvector

--- a/src/UnitTests/Analysis/ValuePropagationTests.cs
+++ b/src/UnitTests/Analysis/ValuePropagationTests.cs
@@ -35,6 +35,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.IO;
+using System.Linq;
 
 namespace Reko.UnitTests.Analysis
 {
@@ -178,6 +179,12 @@ namespace Reko.UnitTests.Analysis
                 Console.WriteLine(sActual);
                 Assert.AreEqual(sExp, sActual);
             }
+        }
+
+        private void AssertLastStatement(string sExp)
+        {
+            var lastStatement = m.Ssa.Procedure.Statements.Last();
+            Assert.AreEqual(sExp, lastStatement.ToString());
         }
 
         private void RunValuePropagator()
@@ -1466,6 +1473,22 @@ SsaProcedureBuilder_exit:
 ";
             #endregion
             AssertStringsEqual(sExp, m.Ssa);
+        }
+
+        [Test]
+        [Category(Categories.UnitTests)]
+        public void VpTypeReferenceToReal64()
+        {
+            var c = Constant.Word64(0x4028000000000000); // 12.0
+            var doubleRef = new TypeReference("DOUBLE", PrimitiveType.Real64);
+            var v1 = m.Temp(doubleRef, "v1");
+            var v2 = m.Temp(doubleRef, "v2");
+            m.Assign(v1, c);
+            m.Assign(v2, v1);
+
+            RunValuePropagator();
+
+            AssertLastStatement("v2 = 12.0");
         }
     }
 }


### PR DESCRIPTION
- Create tests to reproduce incorrect emitting real values for type references

Expected:
```
v2 = 12.0
```
but was:
```
v2 = 4.622945017495814e+18
```