### PR TITLE
Do not relocate global variable from one frame to another

### DIFF
--- a/src/Decompiler/Scanning/IdentifierRelocator.cs
+++ b/src/Decompiler/Scanning/IdentifierRelocator.cs
@@ -97,6 +97,8 @@ namespace Reko.Scanning
 
         public Identifier VisitTemporaryStorage(TemporaryStorage tmp)
         {
+            if (tmp is GlobalStorage)
+                return id!;
             return frameNew.CreateTemporary(id!.DataType);
         }
 

--- a/src/UnitTests/Scanning/IdentifierRelocatorTests.cs
+++ b/src/UnitTests/Scanning/IdentifierRelocatorTests.cs
@@ -1,0 +1,61 @@
+#region License
+/* 
+ * Copyright (C) 1999-2021 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using NUnit.Framework;
+using Reko.Core;
+using Reko.Core.Code;
+using Reko.Core.Expressions;
+using Reko.Core.Types;
+using Reko.Scanning;
+using Reko.UnitTests.Mocks;
+
+namespace Reko.UnitTests.Scanning
+{
+    [TestFixture]
+    public class IdentifierRelocatorTests
+    {
+        private ProcedureBuilder m;
+
+        [SetUp]
+        public void Setup()
+        {
+            m = new ProcedureBuilder();
+        }
+
+        private Instruction RunIdentifierRelocator(Instruction instr)
+        {
+            var frameNew = new Frame(PrimitiveType.Word32);
+            var replacer = new IdentifierRelocator(m.Frame, frameNew);
+            return replacer.ReplaceIdentifiers(instr);
+        }
+
+        [Test]
+        [Category(Categories.UnitTests)]
+        public void Ir_GlobalVariable()
+        {
+            var gbl_var = Identifier.Global("gbl_var", PrimitiveType.Int32);
+            Instruction instr = m.Assign(gbl_var, 123);
+
+            instr = RunIdentifierRelocator(instr);
+
+            Assert.AreEqual("gbl_var = 123<i32>", instr.ToString());
+        }
+    }
+}


### PR DESCRIPTION
- Create test with incorrect relocation of global variable from one frame to another

`IdentifierRelocator` creates temporary variable instead.

Expected:
```
gbl_var = 123<i32>
```
but was:
```
v2 = 123<i32>
```
- Do not relocate global variable from one frame to another