### PR TITLE
Create EscapedFrameIntervalsFinder and ComplexStackVariableTransformer

### DIFF
--- a/src/Core/Expressions/ExpressionEmitter.cs
+++ b/src/Core/Expressions/ExpressionEmitter.cs
@@ -676,7 +676,7 @@ namespace Reko.Core.Expressions
         /// <returns>A memory access expression.</returns>
         public MemoryAccess Mem(DataType dt, Expression ea)
         {
-            return new MemoryAccess(MemoryIdentifier.GlobalMemory, ea, dt);
+            return Mem(MemoryIdentifier.GlobalMemory, dt, ea);
         }
 
         /// <summary>

--- a/src/Core/Expressions/ExpressionVisitor.cs
+++ b/src/Core/Expressions/ExpressionVisitor.cs
@@ -121,7 +121,7 @@ namespace Reko.Core.Expressions
         {
         }
 
-		public void VisitApplication(Application appl)
+		public virtual void VisitApplication(Application appl)
 		{
 			appl.Procedure.Accept(this);
 			for (int i = 0; i < appl.Arguments.Length; ++i)

--- a/src/Decompiler/Analysis/ComplexStackVariableTransformer.cs
+++ b/src/Decompiler/Analysis/ComplexStackVariableTransformer.cs
@@ -1,0 +1,149 @@
+#region License
+/* 
+ * Copyright (C) 1999-2022 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using Reko.Core;
+using Reko.Core.Code;
+using Reko.Core.Expressions;
+using Reko.Core.Lib;
+using Reko.Core.Operators;
+using Reko.Core.Services;
+using Reko.Core.Types;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+
+namespace Reko.Analysis
+{
+    /// <summary>
+    /// Rewrites expressions like <code>fp +/-offset</code> if offset is
+    /// inside of one of the specified intervals. In particular it rewrites
+    /// <code>fp - offset</code> to <code>&amp;tLoc_offset1 + offset2</code>
+    /// where <code>offset1 - offset2 = offset</code>
+    /// </summary>
+    public class ComplexStackVariableTransformer: InstructionTransformer
+    {
+        private readonly SsaState ssa;
+        private readonly IntervalTree<int, DataType> escapedFrameIntervals;
+        private readonly DecompilerEventListener eventListener;
+        private readonly Dictionary<int, SsaIdentifier> frameIds;
+        private Statement stmCur;
+        private readonly ExpressionEmitter m;
+
+        public ComplexStackVariableTransformer(
+            SsaState ssa,
+            IntervalTree<int, DataType> escapedFrameIntervals,
+            DecompilerEventListener eventListener)
+        {
+            this.ssa = ssa;
+            this.escapedFrameIntervals = escapedFrameIntervals;
+            this.eventListener = eventListener;
+            this.frameIds = new();
+            this.m = new();
+            this.stmCur = default!;
+        }
+
+        public void Transform()
+        {
+            var proc = ssa.Procedure;
+            foreach (var (interval, dt) in escapedFrameIntervals)
+            {
+                var id = proc.Frame.EnsureStackVariable(interval.Start, dt);
+                var sid = ssa.EnsureDefInstruction(id, proc.EntryBlock);
+                frameIds[interval.Start] = sid;
+            }
+            foreach (var stm in proc.Statements)
+            {
+                if (eventListener.IsCanceled())
+                    return;
+                this.stmCur = stm;
+                stm.Instruction = stm.Instruction.Accept(this);
+            }
+        }
+
+        #region IExpressionVisitor Members
+
+        public override Expression VisitBinaryExpression(BinaryExpression bin)
+        {
+            if (IsFrameAccess(bin, out var offset))
+            {
+                var bitSize = bin.DataType.BitSize;
+                if (TryRewriteFrameOffset(offset, bitSize, out var e))
+                    return e;
+                return bin;
+            }
+            var left = bin.Left.Accept(this);
+            var right = bin.Right.Accept(this);
+            return new BinaryExpression(bin.Operator, bin.DataType, left, right);
+        }
+
+        #endregion
+
+        private bool TryRewriteFrameOffset(
+            int offset,
+            int ptrBitSize,
+            [NotNullWhen(true)] out Expression? e)
+        {
+            var ints = escapedFrameIntervals.GetIntervalsOverlappingWith(
+                Interval.Create(offset, offset + 1));
+            if (ints.Count() == 0)
+            {
+                e = null;
+                return false;
+            }
+            var (i, _) = ints.First();
+            var id = frameIds[i.Start].Identifier;
+            var fp = ssa.Procedure.Frame.FramePointer;
+            ssa.Identifiers[fp].Uses.Remove(stmCur);
+            ssa.Identifiers[id].Uses.Add(stmCur);
+            var ptr = new Pointer(id.DataType, ptrBitSize);
+            e = m.AddSubSignedInt(m.AddrOf(ptr, id), offset - i.Start);
+            return true;
+        }
+
+        private bool IsFrameAccess(Expression e, out int offset)
+        {
+            offset = 0;
+            if (e == ssa.Procedure.Frame.FramePointer)
+            {
+                offset = 0;
+                return true;
+            }
+            if (e is not BinaryExpression bin)
+                return false;
+            if (bin.Left != ssa.Procedure.Frame.FramePointer)
+                return false;
+            if (bin.Right is not Constant c)
+                return false;
+            if (bin.Operator == Operator.ISub)
+            {
+                offset = -c.ToInt32();
+                return true;
+            }
+            if (bin.Operator == Operator.IAdd)
+            {
+                offset = c.ToInt32();
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Decompiler/Analysis/DataFlowAnalysis.cs
+++ b/src/Decompiler/Analysis/DataFlowAnalysis.cs
@@ -491,6 +491,16 @@ namespace Reko.Analysis
                 vp.Transform();
                 DumpWatchedProcedure("cce", "After CCE", ssa);
 
+                var efif = new EscapedFrameIntervalsFinder(
+                    program, ssa, eventListener);
+                var escapedFrameIntervals = efif.Find();
+                if (escapedFrameIntervals.Count > 0)
+                {
+                    var csvt = new ComplexStackVariableTransformer(
+                        ssa, escapedFrameIntervals, eventListener);
+                    csvt.Transform();
+                }
+
                 // Now compute SSA for the stack-based variables as well. That is:
                 // mem[fp - 30] becomes wLoc30, while 
                 // mem[fp + 30] becomes wArg30.

--- a/src/Decompiler/Analysis/EscapedFrameIntervalsFinder.cs
+++ b/src/Decompiler/Analysis/EscapedFrameIntervalsFinder.cs
@@ -1,0 +1,400 @@
+#region License
+/* 
+ * Copyright (C) 1999-2022 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using Reko.Core;
+using Reko.Core.Code;
+using Reko.Core.Expressions;
+using Reko.Core.Lib;
+using Reko.Core.Operators;
+using Reko.Core.Services;
+using Reko.Core.Types;
+using Reko.Evaluation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Reko.Analysis
+{
+    /// <summary>
+    /// Collect stack frame intervals which can be accessed during call to
+    /// other procedures. The intervals are obtained by merging of each
+    /// frame expression like <code>fp +/-offset</code> copied outside of
+    /// current procedure frame.
+    /// </summary>
+    public class EscapedFrameIntervalsFinder : ExpressionVisitorBase, InstructionVisitor
+    {
+        private Program program;
+        private SsaState ssa;
+        private DecompilerEventListener eventListener;
+        private Context ctx;
+        private ExpressionSimplifier eval;
+        private IntervalTree<int, DataType> intervals;
+
+        public EscapedFrameIntervalsFinder(
+            Program program,
+            SsaState ssa,
+            DecompilerEventListener eventListener)
+        {
+            this.program = program;
+            this.ssa = ssa;
+            this.eventListener = eventListener;
+            this.ctx = default!;
+            this.eval = default!;
+            this.intervals = default!;
+        }
+
+        private void CreateEvaluationContext()
+        {
+            this.ctx = new Context(ssa.Procedure.Architecture);
+            this.eval = new ExpressionSimplifier(
+                program.SegmentMap, ctx, eventListener);
+        }
+
+        public IntervalTree<int, DataType> Find()
+        {
+            this.intervals = new IntervalTree<int, DataType>();
+            foreach (var block in ssa.Procedure.ControlGraph.Blocks)
+            {
+                CreateEvaluationContext();
+                foreach (var stm in block.Statements)
+                {
+                    if (eventListener.IsCanceled())
+                        return intervals;
+                    stm.Instruction.Accept(this);
+                }
+            }
+            return intervals;
+        }
+
+        #region InstructionVisitor Members
+
+        public void VisitAssignment(Assignment ass)
+        {
+            var (e, _) = ass.Src.Accept(eval);
+            e.Accept(this);
+        }
+
+        public void VisitBranch(Branch branch)
+        {
+            var (e, _) = branch.Condition.Accept(eval);
+            e.Accept(this);
+        }
+
+        public void VisitCallInstruction(CallInstruction ci)
+        {
+        }
+
+        public void VisitComment(CodeComment code)
+        {
+        }
+
+        public void VisitDeclaration(Declaration decl)
+        {
+            if (decl.Expression is not null)
+            {
+                var (e, _) = decl.Expression.Accept(eval);
+                e.Accept(this);
+            }
+        }
+
+        public void VisitDefInstruction(DefInstruction def)
+        {
+        }
+
+        public void VisitGotoInstruction(GotoInstruction gotoInstruction)
+        {
+            if (gotoInstruction.Condition is not null)
+            {
+                var (e, _) = gotoInstruction.Condition.Accept(eval);
+                e.Accept(this);
+            }
+        }
+
+        public void VisitPhiAssignment(PhiAssignment phi)
+        {
+        }
+
+        public void VisitReturnInstruction(ReturnInstruction ret)
+        {
+            if (ret.Expression is not null)
+            {
+                var (e, _) = ret.Expression.Accept(eval);
+                e.Accept(this);
+            }
+        }
+
+        public void VisitSideEffect(SideEffect side)
+        {
+            var (e, _) = side.Expression.Accept(eval);
+            e.Accept(this);
+        }
+
+        public void VisitStore(Store store)
+        {
+            var (value, _) = store.Src.Accept(eval);
+            value.Accept(this);
+            if (store.Dst is MemoryAccess mem)
+            {
+                ctx.SetValueEa(mem.EffectiveAddress, value);
+            }
+        }
+
+        public void VisitSwitchInstruction(SwitchInstruction si)
+        {
+            var (e, _) = si.Expression.Accept(eval);
+            e.Accept(this);
+        }
+
+        public void VisitUseInstruction(UseInstruction use)
+        {
+        }
+
+        #endregion
+
+        #region IExpressionVisitor Members
+
+        public override void VisitApplication(Application appl)
+        {
+            appl.Procedure.Accept(this);
+            for (int i = 0; i < appl.Arguments.Length; ++i)
+            {
+                appl.Arguments[i].Accept(this);
+                var ptr = appl.Arguments[i].DataType.ResolveAs<Pointer>();
+                if (ptr is null)
+                    continue;
+                var pointee = ptr.Pointee;
+                if (IsFrameAccess(appl.Arguments[i], out var offset))
+                {
+                    AddInterval(offset, pointee);
+                }
+            }
+        }
+
+        #endregion
+
+        private void AddInterval(int offset, DataType dt)
+        {
+            var newInterval = Interval.Create(offset, offset + dt.Size);
+            var ints = intervals.GetIntervalsOverlappingWith(
+                newInterval).Select(de => de.Key).ToArray();
+            foreach(var interval in ints)
+            {
+                if (interval.Covers(newInterval))
+                {
+                    return;
+                }
+                else if (newInterval.Covers(interval))
+                {
+                    intervals.Delete(interval);
+                }
+                else
+                {
+                    int start = Math.Min(interval.Start, newInterval.Start);
+                    int end = Math.Max(interval.End, newInterval.End);
+                    AddInterval(start, new UnknownType(end - start));
+                    return;
+                }
+            }
+            intervals.Add(newInterval, dt);
+        }
+
+        private bool IsFrameAccess(Expression e, out int offset)
+        {
+            offset = 0;
+            if (e == ssa.Procedure.Frame.FramePointer)
+            {
+                offset = 0;
+                return true;
+            }
+            if (e is not BinaryExpression bin)
+                return false;
+            if (bin.Left != ssa.Procedure.Frame.FramePointer)
+                return false;
+            if (bin.Right is not Constant c)
+                return false;
+            if (bin.Operator == Operator.ISub)
+            {
+                offset = -c.ToInt32();
+                return true;
+            }
+            if (bin.Operator == Operator.IAdd)
+            {
+                offset = c.ToInt32();
+                return true;
+            }
+            return false;
+        }
+
+        private class Context : EvaluationContext
+        {
+            private readonly IProcessorArchitecture arch;
+            private Identifier? @base;
+            /// <summary>
+            /// Values at [base + offset] address.
+            /// </summary>
+            private readonly Dictionary<int, Expression> offsetValues;
+
+            public Context(IProcessorArchitecture arch)
+            {
+                this.arch = arch;
+                this.offsetValues = new();
+            }
+
+            public EndianServices Endianness => arch.Endianness;
+
+            public Expression? GetDefiningExpression(Identifier id)
+            {
+                return id;
+            }
+
+            public List<Statement> GetDefiningStatementClosure(Identifier id)
+            {
+                return new List<Statement>();
+            }
+
+            public Expression? GetValue(Identifier id)
+            {
+                return id;
+            }
+
+            public Expression GetValue(MemoryAccess access, SegmentMap segmentMap)
+            {
+                var ea = access.EffectiveAddress;
+                if (!IsIdentifierOffset(ea, out var @base, out var offset))
+                    return access;
+                if (this.@base != @base)
+                    return access;
+                if (!offsetValues.TryGetValue(offset, out var value))
+                    return access;
+                if (value.DataType.BitSize != access.DataType.BitSize)
+                    return access;
+                if (value is not Identifier)
+                {
+                    value = value.CloneExpression();
+                    value.DataType = access.DataType;
+                }
+                return value;
+            }
+
+            public Expression GetValue(SegmentedAccess access, SegmentMap segmentMap)
+            {
+                return access;
+            }
+
+            public Expression GetValue(Application appl)
+            {
+                return appl;
+            }
+
+            public bool IsUsedInPhi(Identifier id)
+            {
+                return false;
+            }
+
+            public Expression MakeSegmentedAddress(Constant seg, Constant off)
+            {
+                return arch.MakeSegmentedAddress(seg, off);
+            }
+
+            public Constant ReinterpretAsFloat(Constant rawBits)
+            {
+                return arch.ReinterpretAsFloat(rawBits);
+            }
+
+            public void RemoveExpressionUse(Expression expr)
+            {
+            }
+
+            public void RemoveIdentifierUse(Identifier id)
+            {
+            }
+
+            public void SetValue(Identifier id, Expression value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void SetValueEa(Expression ea, Expression value)
+            {
+                if (IsIdentifierOffset(ea, out var @base, out var offset))
+                {
+                    if (this.@base != @base)
+                    {
+                        // Base identifier was changed. All stored memory data
+                        // become invalid.
+                        this.@base = @base;
+                        offsetValues.Clear();
+                    }
+                    offsetValues[offset] = value;
+                    return;
+                }
+                else if (ea is Constant)
+                {
+                    // Constant memory access should not affect stored data
+                    return;
+                }
+                // Complex access can affect stored data
+                this.@base = null;
+                offsetValues.Clear();
+            }
+
+            public void SetValueEa(Expression basePointer, Expression ea, Expression value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void UseExpression(Expression expr)
+            {
+            }
+
+            private bool IsIdentifierOffset(
+                Expression ea, out Identifier? @base, out int offset)
+            {
+                if (ea is Identifier id)
+                {
+                    @base = id;
+                    offset = 0;
+                    return true;
+                }
+
+                if (
+                    ea is BinaryExpression bin &&
+                    (
+                        bin.Operator == Operator.IAdd ||
+                        bin.Operator == Operator.ISub) &&
+                    bin.Left is Identifier idLeft)
+                {
+                    if (bin.Right is Constant cOffset)
+                    {
+                        offset = cOffset.ToInt32();
+                        if (bin.Operator == Operator.ISub)
+                            offset = -offset;
+                        @base = idLeft;
+                        return true;
+                    }
+                }
+                @base = null;
+                offset = 0;
+                return false;
+            }
+        }
+    }
+}

--- a/src/UnitTests/Decompiler/Analysis/ComplexStackVariableTransformerTests.cs
+++ b/src/UnitTests/Decompiler/Analysis/ComplexStackVariableTransformerTests.cs
@@ -1,0 +1,123 @@
+#region License
+/* 
+ * Copyright (C) 1999-2022 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using NUnit.Framework;
+using Reko.Analysis;
+using Reko.Core;
+using Reko.Core.Expressions;
+using Reko.Core.Lib;
+using Reko.Core.Types;
+using Reko.UnitTests.Mocks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reko.UnitTests.Decompiler.Analysis
+{
+    [TestFixture]
+    public class ComplexStackVariableTransformerTests
+    {
+        private SsaProcedureBuilder m;
+        private Identifier fp;
+        private Program program;
+        private IntervalTree<int, DataType> intervals;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.m = new SsaProcedureBuilder();
+            var pb = new ProgramBuilder();
+            pb.Add(m);
+            this.program = pb.BuildProgram();
+            this.fp = m.FramePointer();
+            this.intervals = new();
+        }
+
+        private DataType Ptr32(DataType dt)
+        {
+            return new Pointer(dt, 32);
+        }
+
+        public void RunComplexStackVariableTransformer()
+        {
+            var eventListener = new FakeDecompilerEventListener();
+            var csvt = new ComplexStackVariableTransformer(
+                m.Ssa, intervals, eventListener);
+            csvt.Transform();
+            m.Ssa.Validate(s => Assert.Fail(s));
+        }
+
+        private void Given_FrameIntervals(
+            params (int offset, DataType dt)[] intervals)
+        {
+            foreach(var (offset, dt) in intervals)
+            {
+                this.intervals.Add(offset, offset + dt.Size, dt);
+            }
+        }
+
+        private void AssertProcedureCode(string expected)
+        {
+            ProcedureCodeVerifier.AssertCode(m.Ssa.Procedure, expected);
+        }
+
+        [Test]
+        public void Csvt_TwoApplicationCalls()
+        {
+            var ebp = m.Reg32("ebp");
+            var ebp_5 = m.Reg32("ebp_5");
+            var str = new StructureType("str", 8, true)
+            {
+                Fields =
+                {
+                    { 0, PrimitiveType.Int32 },
+                    { 4, PrimitiveType.Real32 },
+                },
+            };
+            var real32 = PrimitiveType.Real32;
+            m.MStore(m.ISub(fp, 4), ebp);
+            m.MStore(m.ISub(fp, 8), m.Word32(1));
+            m.MStore(m.ISub(fp, 12), m.Word32(2));
+            m.MStore(m.ISub(fp, 16), m.ISub(fp, 12));
+            m.SideEffect(m.Fn("func1", m.Mem(Ptr32(str), m.ISub(fp, 16))));
+            m.MStore(m.ISub(fp, 16), m.ISub(fp, 8));
+            m.SideEffect(m.Fn("func2", m.Mem(Ptr32(real32), m.ISub(fp, 16))));
+            m.Assign(ebp_5, m.Mem32(m.ISub(fp, 4)));
+            Given_FrameIntervals((-12, str));
+
+            RunComplexStackVariableTransformer();
+
+            var expected = @"
+def tLoc0C
+Mem3[fp - 4<32>:word32] = ebp
+Mem4[&tLoc0C + 4<i32>:word32] = 1<32>
+Mem5[&tLoc0C:word32] = 2<32>
+Mem6[fp - 0x10<32>:ptr32] = &tLoc0C
+func1(Mem7[fp - 0x10<32>:(ptr32 (struct ""str"" 0008))])
+Mem8[fp - 0x10<32>:ptr32] = &tLoc0C + 4<i32>
+func2(Mem9[fp - 0x10<32>:(ptr32 real32)])
+ebp_5 = Mem10[fp - 4<32>:word32]
+";
+            AssertProcedureCode(expected);
+        }
+    }
+}

--- a/src/UnitTests/Decompiler/Analysis/EscapedFrameIntervalsFinderTests.cs
+++ b/src/UnitTests/Decompiler/Analysis/EscapedFrameIntervalsFinderTests.cs
@@ -1,0 +1,108 @@
+#region License
+/* 
+ * Copyright (C) 1999-2022 Pavel Tomin.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#endregion
+
+using NUnit.Framework;
+using Reko.Analysis;
+using Reko.Core;
+using Reko.Core.Expressions;
+using Reko.Core.Lib;
+using Reko.Core.Types;
+using Reko.UnitTests.Mocks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reko.UnitTests.Decompiler.Analysis
+{
+    [TestFixture]
+    public class EscapedFrameIntervalsFinderTests
+    {
+        private SsaProcedureBuilder m;
+        private Identifier fp;
+        private Program program;
+        private IntervalTree<int, DataType> intervals;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.m = new SsaProcedureBuilder();
+            var pb = new ProgramBuilder();
+            pb.Add(m);
+            this.program = pb.BuildProgram();
+            this.fp = m.FramePointer();
+        }
+
+        private static DataType Ptr32(DataType dt)
+        {
+            return new Pointer(dt, 32);
+        }
+
+        private void RunEscapedFrameIntervalsFinder()
+        {
+            var eventListener = new FakeDecompilerEventListener();
+            var efif = new EscapedFrameIntervalsFinder(
+                program, m.Ssa, eventListener);
+            this.intervals = efif.Find();
+        }
+
+        private void AssertIntervals(string expected)
+        {
+            var actual = string.Join(Environment.NewLine, intervals);
+            actual = Environment.NewLine + actual;
+            if (actual != expected)
+            {
+                Console.WriteLine(actual);
+                Assert.AreEqual(expected, actual);
+            }
+        }
+
+        [Test]
+        public void Efif_TwoApplicationCalls()
+        {
+            var ebp = m.Reg32("ebp");
+            var ebp_5 = m.Reg32("ebp_5");
+            var str = new StructureType("str", 8, true)
+            {
+                Fields =
+                {
+                    { 0, PrimitiveType.Int32 },
+                    { 4, PrimitiveType.Real32 },
+                },
+            };
+            var real32 = PrimitiveType.Real32;
+            m.MStore(m.ISub(fp, 4), ebp);
+            m.MStore(m.ISub(fp, 8), m.Word32(1));
+            m.MStore(m.ISub(fp, 12), m.Word32(2));
+            m.MStore(m.ISub(fp, 16), m.ISub(fp, 12));
+            m.SideEffect(m.Fn("func1", m.Mem(Ptr32(str), m.ISub(fp, 16))));
+            m.MStore(m.ISub(fp, 16), m.ISub(fp, 8));
+            m.SideEffect(m.Fn("func2", m.Mem(Ptr32(real32), m.ISub(fp, 16))));
+            m.Assign(ebp_5, m.Mem32(m.ISub(fp, 4)));
+
+            RunEscapedFrameIntervalsFinder();
+
+            var expected = @"
+[[-12, -4], (struct ""str"" 0008 (0 int32 dw0000) (4 real32 r0004))]";
+            AssertIntervals(expected);
+        }
+    }
+}

--- a/subjects/PE/x86/ExeDll/Executable.reko/Executable.h
+++ b/subjects/PE/x86/ExeDll/Executable.reko/Executable.h
@@ -143,12 +143,12 @@ Eq_36: (struct "Eq_36" (FFFFFFF4 word32 dwFFFFFFF4) (FFFFFFF8 word32 dwFFFFFFF8)
 Eq_50: (struct "Eq_50" (0 ui32 dw0000) (4 word32 dw0004))
 	T_50 (in eax_30 @ 0040107A : (ptr32 Eq_50))
 	T_53 (in fn00401050() @ 0040107A : word32)
-	T_793 (in eax_4 @ 0040173F : (ptr32 Eq_50))
-	T_795 (in fn00401050() @ 0040173F : word32)
+	T_799 (in eax_4 @ 0040173F : (ptr32 Eq_50))
+	T_801 (in fn00401050() @ 0040173F : word32)
 Eq_51: (fn (ptr32 Eq_50) ())
 	T_51 (in fn00401050 @ 0040107A : ptr32)
 	T_52 (in signature of fn00401050 @ 00401050 : void)
-	T_794 (in fn00401050 @ 0040173F : ptr32)
+	T_800 (in fn00401050 @ 0040173F : ptr32)
 Eq_54: (fn void (ui32, word32))
 	T_54 (in _stdio_common_vfprintf @ 00401084 : ptr32)
 Eq_63: (union "Eq_63" (int32 u0) (DWORD u1))
@@ -164,9 +164,9 @@ Eq_63: (union "Eq_63" (int32 u0) (DWORD u1))
 	T_366 (in Mem293[esp_228 + -4<i32>:int32] @ 00401267 : int32)
 	T_727 (in GetCurrentThreadId() @ 004016B5 : DWORD)
 	T_730 (in GetCurrentProcessId() @ 004016B5 : DWORD)
-	T_835 (in ProcessorFeature @ 00401788 : DWORD)
-	T_836 (in 0x17<32> @ 00401788 : word32)
-	T_1015 (in 0xA<32> @ 00401A1E : word32)
+	T_841 (in ProcessorFeature @ 00401788 : DWORD)
+	T_842 (in 0x17<32> @ 00401788 : word32)
+	T_1021 (in 0xA<32> @ 00401A1E : word32)
 Eq_67: (fn void ())
 	T_67 (in fn00401663 @ 004012CE : ptr32)
 	T_68 (in signature of fn00401663 @ 00401663 : void)
@@ -181,7 +181,7 @@ Eq_71: (fn (ptr32 Eq_70) (word32, Eq_74, Eq_74, Eq_76, ui32))
 	T_71 (in fn00401980 @ 00401166 : ptr32)
 	T_72 (in signature of fn00401980 @ 00401980 : void)
 	T_587 (in fn00401980 @ 0040154B : ptr32)
-Eq_74: (union "Eq_74" (byte u0) ((ptr32 Eq_1202) u1))
+Eq_74: (union "Eq_74" (byte u0) ((ptr32 Eq_1208) u1))
 	T_74 (in esi @ 00401166 : Eq_74)
 	T_75 (in edi @ 00401166 : Eq_74)
 	T_78 (in esi @ 00401166 : word32)
@@ -214,8 +214,8 @@ Eq_74: (union "Eq_74" (byte u0) ((ptr32 Eq_1202) u1))
 	T_524 (in 1<32> @ 004014BE : word32)
 	T_560 (in 0<32> @ 004014CB : word32)
 	T_663 (in 0<8> @ 004015DE : byte)
-	T_967 (in Mem20[esp_14 + -8<i32>:word32] @ 0040199B : word32)
-	T_970 (in Mem23[esp_14 + -12<i32>:word32] @ 0040199C : word32)
+	T_973 (in Mem20[esp_14 + -8<i32>:word32] @ 0040199B : word32)
+	T_976 (in Mem23[esp_14 + -12<i32>:word32] @ 0040199C : word32)
 Eq_76: (union "Eq_76" (ui32 u0) (ptr32 u1))
 	T_76 (in dwArg00 @ 00401166 : Eq_76)
 	T_80 (in dwLoc0C @ 00401166 : word32)
@@ -226,10 +226,10 @@ Eq_76: (union "Eq_76" (ui32 u0) (ptr32 u1))
 	T_588 (in dwLoc0C @ 0040154B : word32)
 	T_634 (in eax_32 - 0x00400000<p32> @ 00000000 : word32)
 	T_654 (in out ebp_69 @ 004015C8 : ptr32)
-	T_981 (in Mem36[esp_14 + -20<i32>:word32] @ 004019AB : word32)
-	T_995 (in ebp_19 @ 004019D7 : Eq_76)
-	T_998 (in Mem8[ebp + 0<32>:word32] @ 004019D7 : word32)
-	T_1001 (in Mem22[ebp + 0<32>:word32] @ 004019D8 : word32)
+	T_987 (in Mem36[esp_14 + -20<i32>:word32] @ 004019AB : word32)
+	T_1001 (in ebp_19 @ 004019D7 : Eq_76)
+	T_1004 (in Mem8[ebp + 0<32>:word32] @ 004019D7 : word32)
+	T_1007 (in Mem22[ebp + 0<32>:word32] @ 004019D8 : word32)
 Eq_87: (fn byte (word32, word32))
 	T_87 (in fn00401474 @ 00401175 : ptr32)
 	T_88 (in signature of fn00401474 @ 00401474 : void)
@@ -240,7 +240,7 @@ Eq_125: (fn void (word32))
 	T_125 (in fn00401774 @ 00401179 : ptr32)
 	T_126 (in signature of fn00401774 @ 00401774 : void)
 	T_526 (in fn00401774 @ 0040153E : ptr32)
-	T_783 (in fn00401774 @ 00401733 : ptr32)
+	T_789 (in fn00401774 @ 00401733 : ptr32)
 Eq_133: (struct "Eq_133" (FFFFFFFC Eq_76 tFFFFFFFC))
 	T_133 (in esp_285 @ 0040119B : (ptr32 Eq_133))
 	T_157 (in esp_82 + 4<i32> @ 004011B5 : word32)
@@ -306,7 +306,7 @@ Eq_267: (struct "Eq_267" (FFFFFFDC Eq_74 tFFFFFFDC) (FFFFFFE7 byte bFFFFFFE7) (F
 Eq_293: (fn void ())
 	T_293 (in fn00401976 @ 00401216 : ptr32)
 	T_294 (in signature of fn00401976 @ 00401976 : void)
-	T_944 (in fn00401976 @ 00401939 : ptr32)
+	T_950 (in fn00401976 @ 00401939 : ptr32)
 Eq_297: (fn (ptr32 word32) ())
 	T_297 (in _p___argv @ 0040123B : ptr32)
 Eq_301: (fn (ptr32 word32) ())
@@ -346,28 +346,28 @@ Eq_392: (fn void ())
 Eq_395: (struct "_EXCEPTION_POINTERS" (0 PEXCEPTION_RECORD ExceptionRecord) (4 PCONTEXT ContextRecord))
 	T_395 (in dwArg04 @ 00401270 : (ptr32 Eq_395))
 	T_403 (in ExceptionInfo @ 004012E6 : (ptr32 (struct "_EXCEPTION_POINTERS")))
-	T_873 (in fp - 0xC<32> @ 00000000 : word32)
+	T_879 (in fp - 0xC<32> @ 00000000 : word32)
 Eq_396: (fn Eq_398 (Eq_398))
 	T_396 (in SetUnhandledExceptionFilter @ 004012DD : ptr32)
 	T_397 (in signature of SetUnhandledExceptionFilter @ 00000000 : void)
-	T_868 (in SetUnhandledExceptionFilter @ 00401868 : ptr32)
-	T_934 (in SetUnhandledExceptionFilter @ 004018D8 : ptr32)
+	T_874 (in SetUnhandledExceptionFilter @ 00401868 : ptr32)
+	T_940 (in SetUnhandledExceptionFilter @ 004018D8 : ptr32)
 Eq_398: LPTOP_LEVEL_EXCEPTION_FILTER
 	T_398 (in lpTopLevelExceptionFilter @ 004012DD : LPTOP_LEVEL_EXCEPTION_FILTER)
 	T_399 (in 0<32> @ 004012DD : word32)
 	T_400 (in SetUnhandledExceptionFilter(null) @ 004012DD : LPTOP_LEVEL_EXCEPTION_FILTER)
-	T_869 (in 0<32> @ 00401868 : word32)
-	T_870 (in SetUnhandledExceptionFilter(null) @ 00401868 : LPTOP_LEVEL_EXCEPTION_FILTER)
-	T_935 (in 0x4018DF<32> @ 004018D8 : word32)
-	T_936 (in SetUnhandledExceptionFilter(&g_t4018DF) @ 004018D8 : LPTOP_LEVEL_EXCEPTION_FILTER)
+	T_875 (in 0<32> @ 00401868 : word32)
+	T_876 (in SetUnhandledExceptionFilter(null) @ 00401868 : LPTOP_LEVEL_EXCEPTION_FILTER)
+	T_941 (in 0x4018DF<32> @ 004018D8 : word32)
+	T_942 (in SetUnhandledExceptionFilter(&g_t4018DF) @ 004018D8 : LPTOP_LEVEL_EXCEPTION_FILTER)
 Eq_401: (fn Eq_404 ((ptr32 Eq_395)))
 	T_401 (in UnhandledExceptionFilter @ 004012E6 : ptr32)
 	T_402 (in signature of UnhandledExceptionFilter @ 00000000 : void)
-	T_871 (in UnhandledExceptionFilter @ 0040187A : ptr32)
+	T_877 (in UnhandledExceptionFilter @ 0040187A : ptr32)
 Eq_404: LONG
 	T_404 (in UnhandledExceptionFilter(dwArg04) @ 004012E6 : LONG)
-	T_874 (in UnhandledExceptionFilter(fp - 0xC<32>) @ 0040187A : LONG)
-	T_875 (in 0<32> @ 0040187A : word32)
+	T_880 (in UnhandledExceptionFilter(fp - 0xC<32>) @ 0040187A : LONG)
+	T_881 (in 0<32> @ 0040187A : word32)
 Eq_405: (fn Eq_413 (Eq_407, Eq_408))
 	T_405 (in TerminateProcess @ 004012F8 : ptr32)
 	T_406 (in signature of TerminateProcess @ 00000000 : void)
@@ -382,13 +382,13 @@ Eq_409: (fn Eq_407 ())
 	T_410 (in signature of GetCurrentProcess @ 00000000 : void)
 Eq_413: BOOL
 	T_413 (in TerminateProcess(GetCurrentProcess(), 0xC0000409<32>) @ 004012F8 : BOOL)
-	T_737 (in QueryPerformanceCounter(fp - 0x18<32>) @ 004016BC : BOOL)
-	T_837 (in IsProcessorFeaturePresent(0x17<32>) @ 00401788 : BOOL)
-	T_838 (in 0<32> @ 00401788 : word32)
-	T_864 (in IsDebuggerPresent() @ 00401861 : BOOL)
-	T_865 (in 1<32> @ 00401861 : word32)
-	T_1016 (in IsProcessorFeaturePresent(0xA<32>) @ 00401A1E : BOOL)
-	T_1017 (in 0<32> @ 00401A1E : word32)
+	T_737 (in QueryPerformanceCounter(&tLoc18) @ 004016BC : BOOL)
+	T_843 (in IsProcessorFeaturePresent(0x17<32>) @ 00401788 : BOOL)
+	T_844 (in 0<32> @ 00401788 : word32)
+	T_870 (in IsDebuggerPresent() @ 00401861 : BOOL)
+	T_871 (in 1<32> @ 00401861 : word32)
+	T_1022 (in IsProcessorFeaturePresent(0xA<32>) @ 00401A1E : BOOL)
+	T_1023 (in 0<32> @ 00401A1E : word32)
 Eq_414: (struct "Eq_414" 0028 (8 up32 dw0008) (C up32 dw000C))
 	T_414 (in eax @ 004012FF : (ptr32 Eq_414))
 	T_417 (in edxOut @ 004012FF : (ptr32 Eq_414))
@@ -434,7 +434,7 @@ Eq_499: (fn byte ())
 Eq_529: (fn void ())
 	T_529 (in int3 @ 00401543 : ptr32)
 	T_530 (in signature of int3 @ 00000000 : void)
-	T_786 (in int3 @ 00401738 : ptr32)
+	T_792 (in int3 @ 00401738 : ptr32)
 Eq_533: (fn word32 (ui32, byte))
 	T_533 (in __ror<word32,byte> @ 0040150E : ptr32)
 	T_534 (in signature of __ror @ 00000000 : void)
@@ -448,12 +448,12 @@ Eq_540: (union "Eq_540" (ui32 u0) (byte u1))
 	T_714 (in Mem13[0x00403004<p32>:word32] @ 00401671 : word32)
 	T_715 (in 0xBB40E64E<32> @ 00401684 : word32)
 	T_738 (in ecx_55 @ 004016CE : Eq_540)
-	T_745 (in dwLoc14 ^ dwLoc18 ^ v14_43 ^ fp - 8<32> @ 00000000 : word32)
-	T_746 (in 0xBB40E64E<32> @ 004016D2 : word32)
-	T_759 (in 0xBB40E64F<32> @ 004016D4 : word32)
-	T_761 (in Mem71[0x00403004<p32>:word32] @ 004016EB : word32)
-	T_769 (in ecx_55 | (ecx_55 | 0x4711<32>) << 0x10<32> @ 00000000 : word32)
-	T_972 (in Mem23[0x00403004<p32>:word32] @ 004019A7 : word32)
+	T_751 (in tLoc18.dw0004 ^ tLoc18 ^ v14_43 ^ fp - 8<32> @ 00000000 : word32)
+	T_752 (in 0xBB40E64E<32> @ 004016D2 : word32)
+	T_765 (in 0xBB40E64F<32> @ 004016D4 : word32)
+	T_767 (in Mem71[0x00403004<p32>:word32] @ 004016EB : word32)
+	T_775 (in ecx_55 | (ecx_55 | 0x4711<32>) << 0x10<32> @ 00000000 : word32)
+	T_978 (in Mem23[0x00403004<p32>:word32] @ 004019A7 : word32)
 Eq_562: (fn word32 (word32))
 	T_562 (in initialize_onexit_table @ 004014DA : ptr32)
 Eq_568: (fn void (word32))
@@ -494,84 +494,90 @@ Eq_732: (fn Eq_413 ((ptr32 Eq_734)))
 	T_733 (in signature of QueryPerformanceCounter @ 00000000 : void)
 Eq_734: LARGE_INTEGER
 	T_734 (in lpPerformanceCount @ 004016BC : (ptr32 LARGE_INTEGER))
-	T_736 (in fp - 0x18<32> @ 00000000 : word32)
-Eq_770: (fn void (Eq_772))
-	T_770 (in InitializeSListHead @ 00401711 : ptr32)
-	T_771 (in signature of InitializeSListHead @ 00000000 : void)
-Eq_772: PSLIST_HEADER
-	T_772 (in ListHead @ 00401711 : PSLIST_HEADER)
-	T_773 (in 0x403358<32> @ 00401711 : word32)
-Eq_775: (fn word32 (word32, word32, word32))
-	T_775 (in controlfp_s @ 0040172E : ptr32)
-Eq_788: (fn (ptr32 Eq_790) ())
-	T_788 (in fn00401739 @ 00401738 : ptr32)
-	T_789 (in signature of fn00401739 @ 00401739 : void)
-	T_812 (in fn00401739 @ 0040174D : ptr32)
-Eq_790: (struct "Eq_790" (0 ui32 dw0000) (4 word32 dw0004))
-	T_790 (in fn00401739() @ 00401738 : word32)
-	T_811 (in eax_12 @ 0040174D : (ptr32 Eq_790))
-	T_813 (in fn00401739() @ 0040174D : word32)
-Eq_833: (fn Eq_413 (Eq_63))
-	T_833 (in IsProcessorFeaturePresent @ 00401788 : ptr32)
-	T_834 (in signature of IsProcessorFeaturePresent @ 00000000 : void)
-	T_1014 (in IsProcessorFeaturePresent @ 00401A1E : ptr32)
-Eq_843: (fn (ptr32 void) ((ptr32 void), int32, Eq_847))
-	T_843 (in memset @ 004017A4 : ptr32)
-	T_844 (in signature of memset @ 00000000 : void)
-	T_854 (in memset @ 0040182D : ptr32)
-Eq_847: size_t
-	T_847 (in _Size @ 004017A4 : size_t)
-	T_852 (in 0x2CC<32> @ 004017A4 : word32)
-	T_858 (in 0x50<32> @ 0040182D : word32)
-Eq_862: (fn Eq_413 ())
-	T_862 (in IsDebuggerPresent @ 00401861 : ptr32)
-	T_863 (in signature of IsDebuggerPresent @ 00000000 : void)
-Eq_866: (union "Eq_866" (bool u0) (byte u1))
-	T_866 (in IsDebuggerPresent() != 1<32> @ 00000000 : bool)
-Eq_877: (fn void (word32))
-	T_877 (in __fastfail @ 0040178D : ptr32)
-	T_878 (in signature of __fastfail @ 00000000 : void)
-Eq_888: (union "Eq_888" (bool u0) (ui32 u1))
-	T_888 (in (word32) (bl_90 + 1<8>) != 0<32> @ 00000000 : bool)
-Eq_894: HMODULE
-	T_894 (in eax_6 @ 00401891 : Eq_894)
-	T_899 (in GetModuleHandleW(null) @ 00401891 : HMODULE)
-	T_900 (in 0<32> @ 0040189B : word32)
-Eq_895: (fn Eq_894 (Eq_897))
-	T_895 (in GetModuleHandleW @ 00401891 : ptr32)
-	T_896 (in signature of GetModuleHandleW @ 00000000 : void)
-Eq_897: LPCWSTR
-	T_897 (in lpModuleName @ 00401891 : LPCWSTR)
-	T_898 (in 0<32> @ 00401891 : word32)
-Eq_904: (union "Eq_904" (int32 u0) (word16 u1))
-	T_904 (in Mem5[eax_6 + 0<32>:word16] @ 004018A8 : word16)
-	T_905 (in 0x5A4D<16> @ 004018A8 : word16)
-Eq_908: (struct "Eq_908" (0 word32 dw0000) (18 word16 w0018) (74 up32 dw0074) (E8 word32 dw00E8))
-	T_908 (in eax_17 @ 004018AD : (ptr32 Eq_908))
-	T_912 (in Mem5[eax_6 + 0x3C<32>:word32] + eax_6 @ 004018AD : word32)
-Eq_910: HMODULE
-	T_910 (in eax_6 + 0x3C<32> @ 004018AD : word32)
-Eq_946: (fn void ())
-	T_946 (in fn00000000 @ 0040193E : ptr32)
-Eq_957: (struct "Eq_957" (FFFFFFEC Eq_76 tFFFFFFEC) (FFFFFFF0 ui32 dwFFFFFFF0) (FFFFFFF4 Eq_74 tFFFFFFF4) (FFFFFFF8 Eq_74 tFFFFFFF8) (FFFFFFFC word32 dwFFFFFFFC))
-	T_957 (in esp_14 @ 00401998 : (ptr32 Eq_957))
-	T_961 (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
-Eq_984: (segment "Eq_984" (0 ptr32 ptr0000))
-	T_984 (in fs @ 004019BE : selector)
-Eq_992: (segment "Eq_992" (0 word32 dw0000))
-	T_992 (in fs @ 004019C9 : selector)
-Eq_993: (union "Eq_993" (ptr32 u0) ((memptr (ptr32 Eq_992) word32) u1))
-	T_993 (in 0x00000000<p32> @ 004019C9 : ptr32)
-Eq_1029: (fn void (word32, word32, (ptr32 word32), (ptr32 word32), (ptr32 word32), (ptr32 word32)))
-	T_1029 (in __cpuid @ 00401A3F : ptr32)
-	T_1030 (in signature of __cpuid @ 00000000 : void)
-	T_1047 (in __cpuid @ 00401A79 : ptr32)
-	T_1086 (in __cpuid @ 00401AEF : ptr32)
-Eq_1114: (fn word64 (word32))
-	T_1114 (in __xgetbv @ 00401B5C : ptr32)
-	T_1115 (in signature of __xgetbv @ 00000000 : void)
-Eq_1202: (struct "Eq_1202" (0 Eq_74 t0000))
-	T_1202
+	T_736 (in &tLoc18 @ 004016BC : (ptr32 LARGE_INTEGER))
+Eq_735: LARGE_INTEGER
+	T_735 (in tLoc18 @ 004016BC : LARGE_INTEGER)
+Eq_739: (struct "Eq_739" (0 LARGE_INTEGER t0000) (4 word32 dw0004))
+	T_739 (in &tLoc18 @ 004016CE : (ptr32 LARGE_INTEGER))
+Eq_743: LARGE_INTEGER
+	T_743 (in &tLoc18 @ 004016CE : (ptr32 LARGE_INTEGER))
+Eq_776: (fn void (Eq_778))
+	T_776 (in InitializeSListHead @ 00401711 : ptr32)
+	T_777 (in signature of InitializeSListHead @ 00000000 : void)
+Eq_778: PSLIST_HEADER
+	T_778 (in ListHead @ 00401711 : PSLIST_HEADER)
+	T_779 (in 0x403358<32> @ 00401711 : word32)
+Eq_781: (fn word32 (word32, word32, word32))
+	T_781 (in controlfp_s @ 0040172E : ptr32)
+Eq_794: (fn (ptr32 Eq_796) ())
+	T_794 (in fn00401739 @ 00401738 : ptr32)
+	T_795 (in signature of fn00401739 @ 00401739 : void)
+	T_818 (in fn00401739 @ 0040174D : ptr32)
+Eq_796: (struct "Eq_796" (0 ui32 dw0000) (4 word32 dw0004))
+	T_796 (in fn00401739() @ 00401738 : word32)
+	T_817 (in eax_12 @ 0040174D : (ptr32 Eq_796))
+	T_819 (in fn00401739() @ 0040174D : word32)
+Eq_839: (fn Eq_413 (Eq_63))
+	T_839 (in IsProcessorFeaturePresent @ 00401788 : ptr32)
+	T_840 (in signature of IsProcessorFeaturePresent @ 00000000 : void)
+	T_1020 (in IsProcessorFeaturePresent @ 00401A1E : ptr32)
+Eq_849: (fn (ptr32 void) ((ptr32 void), int32, Eq_853))
+	T_849 (in memset @ 004017A4 : ptr32)
+	T_850 (in signature of memset @ 00000000 : void)
+	T_860 (in memset @ 0040182D : ptr32)
+Eq_853: size_t
+	T_853 (in _Size @ 004017A4 : size_t)
+	T_858 (in 0x2CC<32> @ 004017A4 : word32)
+	T_864 (in 0x50<32> @ 0040182D : word32)
+Eq_868: (fn Eq_413 ())
+	T_868 (in IsDebuggerPresent @ 00401861 : ptr32)
+	T_869 (in signature of IsDebuggerPresent @ 00000000 : void)
+Eq_872: (union "Eq_872" (bool u0) (byte u1))
+	T_872 (in IsDebuggerPresent() != 1<32> @ 00000000 : bool)
+Eq_883: (fn void (word32))
+	T_883 (in __fastfail @ 0040178D : ptr32)
+	T_884 (in signature of __fastfail @ 00000000 : void)
+Eq_894: (union "Eq_894" (bool u0) (ui32 u1))
+	T_894 (in (word32) (bl_90 + 1<8>) != 0<32> @ 00000000 : bool)
+Eq_900: HMODULE
+	T_900 (in eax_6 @ 00401891 : Eq_900)
+	T_905 (in GetModuleHandleW(null) @ 00401891 : HMODULE)
+	T_906 (in 0<32> @ 0040189B : word32)
+Eq_901: (fn Eq_900 (Eq_903))
+	T_901 (in GetModuleHandleW @ 00401891 : ptr32)
+	T_902 (in signature of GetModuleHandleW @ 00000000 : void)
+Eq_903: LPCWSTR
+	T_903 (in lpModuleName @ 00401891 : LPCWSTR)
+	T_904 (in 0<32> @ 00401891 : word32)
+Eq_910: (union "Eq_910" (int32 u0) (word16 u1))
+	T_910 (in Mem5[eax_6 + 0<32>:word16] @ 004018A8 : word16)
+	T_911 (in 0x5A4D<16> @ 004018A8 : word16)
+Eq_914: (struct "Eq_914" (0 word32 dw0000) (18 word16 w0018) (74 up32 dw0074) (E8 word32 dw00E8))
+	T_914 (in eax_17 @ 004018AD : (ptr32 Eq_914))
+	T_918 (in Mem5[eax_6 + 0x3C<32>:word32] + eax_6 @ 004018AD : word32)
+Eq_916: HMODULE
+	T_916 (in eax_6 + 0x3C<32> @ 004018AD : word32)
+Eq_952: (fn void ())
+	T_952 (in fn00000000 @ 0040193E : ptr32)
+Eq_963: (struct "Eq_963" (FFFFFFEC Eq_76 tFFFFFFEC) (FFFFFFF0 ui32 dwFFFFFFF0) (FFFFFFF4 Eq_74 tFFFFFFF4) (FFFFFFF8 Eq_74 tFFFFFFF8) (FFFFFFFC word32 dwFFFFFFFC))
+	T_963 (in esp_14 @ 00401998 : (ptr32 Eq_963))
+	T_967 (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
+Eq_990: (segment "Eq_990" (0 ptr32 ptr0000))
+	T_990 (in fs @ 004019BE : selector)
+Eq_998: (segment "Eq_998" (0 word32 dw0000))
+	T_998 (in fs @ 004019C9 : selector)
+Eq_999: (union "Eq_999" (ptr32 u0) ((memptr (ptr32 Eq_998) word32) u1))
+	T_999 (in 0x00000000<p32> @ 004019C9 : ptr32)
+Eq_1035: (fn void (word32, word32, (ptr32 word32), (ptr32 word32), (ptr32 word32), (ptr32 word32)))
+	T_1035 (in __cpuid @ 00401A3F : ptr32)
+	T_1036 (in signature of __cpuid @ 00000000 : void)
+	T_1053 (in __cpuid @ 00401A79 : ptr32)
+	T_1092 (in __cpuid @ 00401AEF : ptr32)
+Eq_1120: (fn word64 (word32))
+	T_1120 (in __xgetbv @ 00401B5C : ptr32)
+	T_1121 (in signature of __xgetbv @ 00000000 : void)
+Eq_1208: (struct "Eq_1208" (0 Eq_74 t0000))
+	T_1208
 // Type Variables ////////////
 globals_t: (in globals @ 00000000 : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -1384,7 +1390,7 @@ T_202: (in signature of fn004019C6 @ 004019C6 : void)
 T_203: (in ebp @ 004012C8 : (ptr32 Eq_70))
   Class: Eq_70
   DataType: (ptr32 Eq_70)
-  OrigDataType: (ptr32 (struct (FFFFFFF0 T_991 tFFFFFFF0) (0 T_76 t0000)))
+  OrigDataType: (ptr32 (struct (FFFFFFF0 T_997 tFFFFFFF0) (0 T_76 t0000)))
 T_204: (in dwArg00 @ 004012C8 : Eq_76)
   Class: Eq_76
   DataType: Eq_76
@@ -3509,15 +3515,15 @@ T_734: (in lpPerformanceCount @ 004016BC : (ptr32 LARGE_INTEGER))
   Class: Eq_734
   DataType: (ptr32 Eq_734)
   OrigDataType: 
-T_735: (in 0x18<32> @ 004016BC : word32)
+T_735: (in tLoc18 @ 004016BC : LARGE_INTEGER)
   Class: Eq_735
-  DataType: ui32
-  OrigDataType: ui32
-T_736: (in fp - 0x18<32> @ 00000000 : word32)
+  DataType: Eq_735
+  OrigDataType: LARGE_INTEGER
+T_736: (in &tLoc18 @ 004016BC : (ptr32 LARGE_INTEGER))
   Class: Eq_734
   DataType: (ptr32 Eq_734)
   OrigDataType: (ptr32 LARGE_INTEGER)
-T_737: (in QueryPerformanceCounter(fp - 0x18<32>) @ 004016BC : BOOL)
+T_737: (in QueryPerformanceCounter(&tLoc18) @ 004016BC : BOOL)
   Class: Eq_413
   DataType: Eq_413
   OrigDataType: BOOL
@@ -3525,1698 +3531,1698 @@ T_738: (in ecx_55 @ 004016CE : Eq_540)
   Class: Eq_540
   DataType: Eq_540
   OrigDataType: ui32
-T_739: (in dwLoc14 @ 004016CE : word32)
+T_739: (in &tLoc18 @ 004016CE : (ptr32 LARGE_INTEGER))
   Class: Eq_739
-  DataType: word32
-  OrigDataType: word32
-T_740: (in dwLoc18 @ 004016CE : word32)
+  DataType: (ptr32 Eq_739)
+  OrigDataType: (ptr32 (struct (0 LARGE_INTEGER t0000) (4 T_742 t0004)))
+T_740: (in 4<i32> @ 004016CE : int32)
   Class: Eq_740
-  DataType: word32
-  OrigDataType: word32
-T_741: (in dwLoc14 ^ dwLoc18 @ 00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_741: (in &tLoc18 + 4<i32> @ 004016CE : word32)
   Class: Eq_741
-  DataType: ui32
-  OrigDataType: ui32
-T_742: (in dwLoc14 ^ dwLoc18 ^ v14_43 @ 00000000 : word32)
-  Class: Eq_742
-  DataType: ui32
-  OrigDataType: ui32
-T_743: (in 8<32> @ 004016CE : word32)
-  Class: Eq_743
-  DataType: ui32
-  OrigDataType: ui32
-T_744: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_744
   DataType: ptr32
   OrigDataType: ptr32
-T_745: (in dwLoc14 ^ dwLoc18 ^ v14_43 ^ fp - 8<32> @ 00000000 : word32)
-  Class: Eq_540
-  DataType: Eq_540
-  OrigDataType: ui32
-T_746: (in 0xBB40E64E<32> @ 004016D2 : word32)
-  Class: Eq_540
-  DataType: ui32
+T_742: (in Mem48[&tLoc18 + 4<i32>:word32] @ 004016CE : word32)
+  Class: Eq_742
+  DataType: word32
   OrigDataType: word32
-T_747: (in ecx_55 != 0xBB40E64E<32> @ 00000000 : bool)
+T_743: (in &tLoc18 @ 004016CE : (ptr32 LARGE_INTEGER))
+  Class: Eq_743
+  DataType: (ptr32 Eq_743)
+  OrigDataType: (ptr32 (struct (0 LARGE_INTEGER t0000)))
+T_744: (in 0<32> @ 004016CE : word32)
+  Class: Eq_744
+  DataType: word32
+  OrigDataType: word32
+T_745: (in &tLoc18 + 0<32> @ 004016CE : word32)
+  Class: Eq_745
+  DataType: ptr32
+  OrigDataType: ptr32
+T_746: (in Mem48[&tLoc18 + 0<32>:word32] @ 004016CE : word32)
+  Class: Eq_746
+  DataType: word32
+  OrigDataType: word32
+T_747: (in tLoc18.dw0004 ^ tLoc18 @ 00000000 : word32)
   Class: Eq_747
-  DataType: bool
-  OrigDataType: bool
-T_748: (in 0xFFFF0000<32> @ 00401688 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_748: (in tLoc18.dw0004 ^ tLoc18 ^ v14_43 @ 00000000 : word32)
   Class: Eq_748
   DataType: ui32
   OrigDataType: ui32
-T_749: (in eax_15 & 0xFFFF0000<32> @ 00000000 : word32)
+T_749: (in 8<32> @ 004016CE : word32)
   Class: Eq_749
   DataType: ui32
   OrigDataType: ui32
-T_750: (in 0<32> @ 00401688 : word32)
-  Class: Eq_749
+T_750: (in fp - 8<32> @ 00000000 : word32)
+  Class: Eq_750
+  DataType: ptr32
+  OrigDataType: ptr32
+T_751: (in tLoc18.dw0004 ^ tLoc18 ^ v14_43 ^ fp - 8<32> @ 00000000 : word32)
+  Class: Eq_540
+  DataType: Eq_540
+  OrigDataType: ui32
+T_752: (in 0xBB40E64E<32> @ 004016D2 : word32)
+  Class: Eq_540
   DataType: ui32
   OrigDataType: word32
-T_751: (in (eax_15 & 0xFFFF0000<32>) == 0<32> @ 00000000 : bool)
-  Class: Eq_751
+T_753: (in ecx_55 != 0xBB40E64E<32> @ 00000000 : bool)
+  Class: Eq_753
   DataType: bool
   OrigDataType: bool
-T_752: (in ~eax_15 @ 0040168C : word32)
-  Class: Eq_752
+T_754: (in 0xFFFF0000<32> @ 00401688 : word32)
+  Class: Eq_754
   DataType: ui32
   OrigDataType: ui32
-T_753: (in 00403000 @ 0040168C : ptr32)
-  Class: Eq_753
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_754 t0000)))
-T_754: (in Mem75[0x00403000<p32>:word32] @ 0040168C : word32)
-  Class: Eq_752
-  DataType: ui32
-  OrigDataType: word32
-T_755: (in 0xFFFF0000<32> @ 004016DD : word32)
+T_755: (in eax_15 & 0xFFFF0000<32> @ 00000000 : word32)
   Class: Eq_755
   DataType: ui32
   OrigDataType: ui32
-T_756: (in ecx_55 & 0xFFFF0000<32> @ 00000000 : word32)
-  Class: Eq_756
-  DataType: ui32
-  OrigDataType: ui32
-T_757: (in 0<32> @ 004016DD : word32)
-  Class: Eq_756
+T_756: (in 0<32> @ 00401688 : word32)
+  Class: Eq_755
   DataType: ui32
   OrigDataType: word32
-T_758: (in (ecx_55 & 0xFFFF0000<32>) != 0<32> @ 00000000 : bool)
-  Class: Eq_758
+T_757: (in (eax_15 & 0xFFFF0000<32>) == 0<32> @ 00000000 : bool)
+  Class: Eq_757
   DataType: bool
   OrigDataType: bool
-T_759: (in 0xBB40E64F<32> @ 004016D4 : word32)
+T_758: (in ~eax_15 @ 0040168C : word32)
+  Class: Eq_758
+  DataType: ui32
+  OrigDataType: ui32
+T_759: (in 00403000 @ 0040168C : ptr32)
+  Class: Eq_759
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_760 t0000)))
+T_760: (in Mem75[0x00403000<p32>:word32] @ 0040168C : word32)
+  Class: Eq_758
+  DataType: ui32
+  OrigDataType: word32
+T_761: (in 0xFFFF0000<32> @ 004016DD : word32)
+  Class: Eq_761
+  DataType: ui32
+  OrigDataType: ui32
+T_762: (in ecx_55 & 0xFFFF0000<32> @ 00000000 : word32)
+  Class: Eq_762
+  DataType: ui32
+  OrigDataType: ui32
+T_763: (in 0<32> @ 004016DD : word32)
+  Class: Eq_762
+  DataType: ui32
+  OrigDataType: word32
+T_764: (in (ecx_55 & 0xFFFF0000<32>) != 0<32> @ 00000000 : bool)
+  Class: Eq_764
+  DataType: bool
+  OrigDataType: bool
+T_765: (in 0xBB40E64F<32> @ 004016D4 : word32)
   Class: Eq_540
   DataType: ui32
   OrigDataType: word32
-T_760: (in 00403004 @ 004016EB : ptr32)
-  Class: Eq_760
+T_766: (in 00403004 @ 004016EB : ptr32)
+  Class: Eq_766
   DataType: (ptr32 Eq_540)
-  OrigDataType: (ptr32 (struct (0 T_761 t0000)))
-T_761: (in Mem71[0x00403004<p32>:word32] @ 004016EB : word32)
+  OrigDataType: (ptr32 (struct (0 T_767 t0000)))
+T_767: (in Mem71[0x00403004<p32>:word32] @ 004016EB : word32)
   Class: Eq_540
   DataType: Eq_540
   OrigDataType: word32
-T_762: (in ~ecx_55 @ 004016F3 : word32)
-  Class: Eq_752
+T_768: (in ~ecx_55 @ 004016F3 : word32)
+  Class: Eq_758
   DataType: ui32
   OrigDataType: ui32
-T_763: (in 00403000 @ 004016F3 : ptr32)
-  Class: Eq_763
+T_769: (in 00403000 @ 004016F3 : ptr32)
+  Class: Eq_769
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_764 t0000)))
-T_764: (in Mem73[0x00403000<p32>:word32] @ 004016F3 : word32)
-  Class: Eq_752
+  OrigDataType: (ptr32 (struct (0 T_770 t0000)))
+T_770: (in Mem73[0x00403000<p32>:word32] @ 004016F3 : word32)
+  Class: Eq_758
   DataType: ui32
   OrigDataType: word32
-T_765: (in 0x4711<32> @ 004016E9 : word32)
-  Class: Eq_765
+T_771: (in 0x4711<32> @ 004016E9 : word32)
+  Class: Eq_771
   DataType: ui32
   OrigDataType: ui32
-T_766: (in ecx_55 | 0x4711<32> @ 00000000 : word32)
-  Class: Eq_766
+T_772: (in ecx_55 | 0x4711<32> @ 00000000 : word32)
+  Class: Eq_772
   DataType: ui32
   OrigDataType: ui32
-T_767: (in 0x10<32> @ 004016E9 : word32)
-  Class: Eq_767
+T_773: (in 0x10<32> @ 004016E9 : word32)
+  Class: Eq_773
   DataType: word32
   OrigDataType: word32
-T_768: (in (ecx_55 | 0x4711<32>) << 0x10<32> @ 00000000 : word32)
-  Class: Eq_768
+T_774: (in (ecx_55 | 0x4711<32>) << 0x10<32> @ 00000000 : word32)
+  Class: Eq_774
   DataType: ui32
   OrigDataType: ui32
-T_769: (in ecx_55 | (ecx_55 | 0x4711<32>) << 0x10<32> @ 00000000 : word32)
+T_775: (in ecx_55 | (ecx_55 | 0x4711<32>) << 0x10<32> @ 00000000 : word32)
   Class: Eq_540
   DataType: Eq_540
   OrigDataType: ui32
-T_770: (in InitializeSListHead @ 00401711 : ptr32)
-  Class: Eq_770
-  DataType: (ptr32 Eq_770)
-  OrigDataType: (ptr32 (fn T_774 (T_773)))
-T_771: (in signature of InitializeSListHead @ 00000000 : void)
-  Class: Eq_770
-  DataType: (ptr32 Eq_770)
+T_776: (in InitializeSListHead @ 00401711 : ptr32)
+  Class: Eq_776
+  DataType: (ptr32 Eq_776)
+  OrigDataType: (ptr32 (fn T_780 (T_779)))
+T_777: (in signature of InitializeSListHead @ 00000000 : void)
+  Class: Eq_776
+  DataType: (ptr32 Eq_776)
   OrigDataType: 
-T_772: (in ListHead @ 00401711 : PSLIST_HEADER)
-  Class: Eq_772
-  DataType: Eq_772
+T_778: (in ListHead @ 00401711 : PSLIST_HEADER)
+  Class: Eq_778
+  DataType: Eq_778
   OrigDataType: 
-T_773: (in 0x403358<32> @ 00401711 : word32)
-  Class: Eq_772
-  DataType: Eq_772
+T_779: (in 0x403358<32> @ 00401711 : word32)
+  Class: Eq_778
+  DataType: Eq_778
   OrigDataType: PSLIST_HEADER
-T_774: (in InitializeSListHead(&g_u403358) @ 00401711 : void)
-  Class: Eq_774
+T_780: (in InitializeSListHead(&g_u403358) @ 00401711 : void)
+  Class: Eq_780
   DataType: void
   OrigDataType: void
-T_775: (in controlfp_s @ 0040172E : ptr32)
-  Class: Eq_775
-  DataType: (ptr32 Eq_775)
-  OrigDataType: (ptr32 (fn T_780 (T_777, T_778, T_779)))
-T_776: (in signature of controlfp_s @ 00000000 : void)
-  Class: Eq_776
-  DataType: Eq_776
+T_781: (in controlfp_s @ 0040172E : ptr32)
+  Class: Eq_781
+  DataType: (ptr32 Eq_781)
+  OrigDataType: (ptr32 (fn T_786 (T_783, T_784, T_785)))
+T_782: (in signature of controlfp_s @ 00000000 : void)
+  Class: Eq_782
+  DataType: Eq_782
   OrigDataType: 
-T_777: (in 0<32> @ 0040172E : word32)
-  Class: Eq_777
+T_783: (in 0<32> @ 0040172E : word32)
+  Class: Eq_783
   DataType: word32
   OrigDataType: word32
-T_778: (in 0x10000<32> @ 0040172E : word32)
-  Class: Eq_778
+T_784: (in 0x10000<32> @ 0040172E : word32)
+  Class: Eq_784
   DataType: word32
   OrigDataType: word32
-T_779: (in 0x30000<32> @ 0040172E : word32)
-  Class: Eq_779
+T_785: (in 0x30000<32> @ 0040172E : word32)
+  Class: Eq_785
   DataType: word32
   OrigDataType: word32
-T_780: (in controlfp_s(0<32>, 0x10000<32>, 0x30000<32>) @ 0040172E : void)
-  Class: Eq_780
+T_786: (in controlfp_s(0<32>, 0x10000<32>, 0x30000<32>) @ 0040172E : void)
+  Class: Eq_786
   DataType: word32
   OrigDataType: void
-T_781: (in 0<32> @ 0040172E : word32)
-  Class: Eq_780
+T_787: (in 0<32> @ 0040172E : word32)
+  Class: Eq_786
   DataType: word32
   OrigDataType: word32
-T_782: (in controlfp_s(0<32>, 0x10000<32>, 0x30000<32>) != 0<32> @ 00000000 : bool)
-  Class: Eq_782
+T_788: (in controlfp_s(0<32>, 0x10000<32>, 0x30000<32>) != 0<32> @ 00000000 : bool)
+  Class: Eq_788
   DataType: bool
   OrigDataType: bool
-T_783: (in fn00401774 @ 00401733 : ptr32)
+T_789: (in fn00401774 @ 00401733 : ptr32)
   Class: Eq_125
   DataType: (ptr32 Eq_125)
-  OrigDataType: (ptr32 (fn T_785 (T_784)))
-T_784: (in 7<32> @ 00401733 : word32)
+  OrigDataType: (ptr32 (fn T_791 (T_790)))
+T_790: (in 7<32> @ 00401733 : word32)
   Class: Eq_127
   DataType: word32
   OrigDataType: word32
-T_785: (in fn00401774(7<32>) @ 00401733 : void)
+T_791: (in fn00401774(7<32>) @ 00401733 : void)
   Class: Eq_131
   DataType: void
   OrigDataType: void
-T_786: (in int3 @ 00401738 : ptr32)
+T_792: (in int3 @ 00401738 : ptr32)
   Class: Eq_529
   DataType: (ptr32 Eq_529)
-  OrigDataType: (ptr32 (fn T_787 ()))
-T_787: (in int3() @ 00401738 : void)
+  OrigDataType: (ptr32 (fn T_793 ()))
+T_793: (in int3() @ 00401738 : void)
   Class: Eq_531
   DataType: void
   OrigDataType: void
-T_788: (in fn00401739 @ 00401738 : ptr32)
-  Class: Eq_788
-  DataType: (ptr32 Eq_788)
-  OrigDataType: (ptr32 (fn T_790 ()))
-T_789: (in signature of fn00401739 @ 00401739 : void)
-  Class: Eq_788
-  DataType: (ptr32 Eq_788)
+T_794: (in fn00401739 @ 00401738 : ptr32)
+  Class: Eq_794
+  DataType: (ptr32 Eq_794)
+  OrigDataType: (ptr32 (fn T_796 ()))
+T_795: (in signature of fn00401739 @ 00401739 : void)
+  Class: Eq_794
+  DataType: (ptr32 Eq_794)
   OrigDataType: 
-T_790: (in fn00401739() @ 00401738 : word32)
-  Class: Eq_790
-  DataType: (ptr32 Eq_790)
+T_796: (in fn00401739() @ 00401738 : word32)
+  Class: Eq_796
+  DataType: (ptr32 Eq_796)
   OrigDataType: word32
-T_791: (in eax @ 00401738 : ptr32)
-  Class: Eq_791
+T_797: (in eax @ 00401738 : ptr32)
+  Class: Eq_797
   DataType: ptr32
   OrigDataType: word32
-T_792: (in 0x00403360<p32> @ 0040173E : ptr32)
-  Class: Eq_791
+T_798: (in 0x00403360<p32> @ 0040173E : ptr32)
+  Class: Eq_797
   DataType: ptr32
   OrigDataType: ptr32
-T_793: (in eax_4 @ 0040173F : (ptr32 Eq_50))
+T_799: (in eax_4 @ 0040173F : (ptr32 Eq_50))
   Class: Eq_50
   DataType: (ptr32 Eq_50)
-  OrigDataType: (ptr32 (struct (0 T_802 t0000) (4 T_796 t0004)))
-T_794: (in fn00401050 @ 0040173F : ptr32)
+  OrigDataType: (ptr32 (struct (0 T_808 t0000) (4 T_802 t0004)))
+T_800: (in fn00401050 @ 0040173F : ptr32)
   Class: Eq_51
   DataType: (ptr32 Eq_51)
-  OrigDataType: (ptr32 (fn T_795 ()))
-T_795: (in fn00401050() @ 0040173F : word32)
+  OrigDataType: (ptr32 (fn T_801 ()))
+T_801: (in fn00401050() @ 0040173F : word32)
   Class: Eq_50
   DataType: (ptr32 Eq_50)
   OrigDataType: word32
-T_796: (in ecx_6 @ 00401744 : word32)
+T_802: (in ecx_6 @ 00401744 : word32)
   Class: Eq_61
   DataType: word32
   OrigDataType: word32
-T_797: (in 4<32> @ 00401744 : word32)
-  Class: Eq_797
-  DataType: word32
-  OrigDataType: word32
-T_798: (in eax_4 + 4<32> @ 00401744 : word32)
-  Class: Eq_798
-  DataType: word32
-  OrigDataType: word32
-T_799: (in Mem0[eax_4 + 4<32>:word32] @ 00401744 : word32)
-  Class: Eq_61
-  DataType: word32
-  OrigDataType: word32
-T_800: (in 0<32> @ 00401747 : word32)
-  Class: Eq_800
-  DataType: word32
-  OrigDataType: word32
-T_801: (in eax_4 + 0<32> @ 00401747 : word32)
-  Class: Eq_801
-  DataType: ptr32
-  OrigDataType: ptr32
-T_802: (in Mem0[eax_4 + 0<32>:word32] @ 00401747 : word32)
-  Class: Eq_58
-  DataType: ui32
-  OrigDataType: ui32
-T_803: (in 4<32> @ 00401747 : word32)
+T_803: (in 4<32> @ 00401744 : word32)
   Class: Eq_803
-  DataType: ui32
-  OrigDataType: ui32
-T_804: (in eax_4->dw0000 | 4<32> @ 00000000 : word32)
-  Class: Eq_58
-  DataType: ui32
-  OrigDataType: ui32
-T_805: (in 0<32> @ 00401747 : word32)
-  Class: Eq_805
   DataType: word32
   OrigDataType: word32
-T_806: (in eax_4 + 0<32> @ 00401747 : word32)
-  Class: Eq_806
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 ui32)
-T_807: (in Mem8[eax_4 + 0<32>:word32] @ 00401747 : word32)
-  Class: Eq_58
-  DataType: ui32
-  OrigDataType: ui32
-T_808: (in 4<32> @ 0040174A : word32)
-  Class: Eq_808
+T_804: (in eax_4 + 4<32> @ 00401744 : word32)
+  Class: Eq_804
   DataType: word32
   OrigDataType: word32
-T_809: (in eax_4 + 4<32> @ 0040174A : word32)
-  Class: Eq_809
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_810: (in Mem11[eax_4 + 4<32>:word32] @ 0040174A : word32)
+T_805: (in Mem0[eax_4 + 4<32>:word32] @ 00401744 : word32)
   Class: Eq_61
   DataType: word32
   OrigDataType: word32
-T_811: (in eax_12 @ 0040174D : (ptr32 Eq_790))
-  Class: Eq_790
-  DataType: (ptr32 Eq_790)
-  OrigDataType: (ptr32 (struct (0 T_820 t0000) (4 T_814 t0004)))
-T_812: (in fn00401739 @ 0040174D : ptr32)
-  Class: Eq_788
-  DataType: (ptr32 Eq_788)
-  OrigDataType: (ptr32 (fn T_813 ()))
-T_813: (in fn00401739() @ 0040174D : word32)
-  Class: Eq_790
-  DataType: (ptr32 Eq_790)
-  OrigDataType: word32
-T_814: (in ecx_13 @ 00401752 : word32)
-  Class: Eq_814
+T_806: (in 0<32> @ 00401747 : word32)
+  Class: Eq_806
   DataType: word32
   OrigDataType: word32
-T_815: (in 4<32> @ 00401752 : word32)
-  Class: Eq_815
-  DataType: word32
-  OrigDataType: word32
-T_816: (in eax_12 + 4<32> @ 00401752 : word32)
-  Class: Eq_816
-  DataType: word32
-  OrigDataType: word32
-T_817: (in Mem11[eax_12 + 4<32>:word32] @ 00401752 : word32)
-  Class: Eq_814
-  DataType: word32
-  OrigDataType: word32
-T_818: (in 0<32> @ 00401755 : word32)
-  Class: Eq_818
-  DataType: word32
-  OrigDataType: word32
-T_819: (in eax_12 + 0<32> @ 00401755 : word32)
-  Class: Eq_819
+T_807: (in eax_4 + 0<32> @ 00401747 : word32)
+  Class: Eq_807
   DataType: ptr32
   OrigDataType: ptr32
-T_820: (in Mem11[eax_12 + 0<32>:word32] @ 00401755 : word32)
-  Class: Eq_820
+T_808: (in Mem0[eax_4 + 0<32>:word32] @ 00401747 : word32)
+  Class: Eq_58
   DataType: ui32
   OrigDataType: ui32
-T_821: (in 2<32> @ 00401755 : word32)
-  Class: Eq_821
+T_809: (in 4<32> @ 00401747 : word32)
+  Class: Eq_809
   DataType: ui32
   OrigDataType: ui32
-T_822: (in eax_12->dw0000 | 2<32> @ 00000000 : word32)
-  Class: Eq_820
+T_810: (in eax_4->dw0000 | 4<32> @ 00000000 : word32)
+  Class: Eq_58
   DataType: ui32
   OrigDataType: ui32
-T_823: (in 0<32> @ 00401755 : word32)
-  Class: Eq_823
+T_811: (in 0<32> @ 00401747 : word32)
+  Class: Eq_811
   DataType: word32
   OrigDataType: word32
-T_824: (in eax_12 + 0<32> @ 00401755 : word32)
-  Class: Eq_824
+T_812: (in eax_4 + 0<32> @ 00401747 : word32)
+  Class: Eq_812
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 ui32)
-T_825: (in Mem15[eax_12 + 0<32>:word32] @ 00401755 : word32)
-  Class: Eq_820
+T_813: (in Mem8[eax_4 + 0<32>:word32] @ 00401747 : word32)
+  Class: Eq_58
   DataType: ui32
   OrigDataType: ui32
-T_826: (in 4<32> @ 00401758 : word32)
-  Class: Eq_826
-  DataType: word32
-  OrigDataType: word32
-T_827: (in eax_12 + 4<32> @ 00401758 : word32)
-  Class: Eq_827
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_828: (in Mem18[eax_12 + 4<32>:word32] @ 00401758 : word32)
+T_814: (in 4<32> @ 0040174A : word32)
   Class: Eq_814
   DataType: word32
   OrigDataType: word32
-T_829: (in eax @ 00401767 : ptr32)
-  Class: Eq_829
-  DataType: ptr32
+T_815: (in eax_4 + 4<32> @ 0040174A : word32)
+  Class: Eq_815
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_816: (in Mem11[eax_4 + 4<32>:word32] @ 0040174A : word32)
+  Class: Eq_61
+  DataType: word32
   OrigDataType: word32
-T_830: (in 0x00403388<p32> @ 0040176D : ptr32)
-  Class: Eq_829
+T_817: (in eax_12 @ 0040174D : (ptr32 Eq_796))
+  Class: Eq_796
+  DataType: (ptr32 Eq_796)
+  OrigDataType: (ptr32 (struct (0 T_826 t0000) (4 T_820 t0004)))
+T_818: (in fn00401739 @ 0040174D : ptr32)
+  Class: Eq_794
+  DataType: (ptr32 Eq_794)
+  OrigDataType: (ptr32 (fn T_819 ()))
+T_819: (in fn00401739() @ 0040174D : word32)
+  Class: Eq_796
+  DataType: (ptr32 Eq_796)
+  OrigDataType: word32
+T_820: (in ecx_13 @ 00401752 : word32)
+  Class: Eq_820
+  DataType: word32
+  OrigDataType: word32
+T_821: (in 4<32> @ 00401752 : word32)
+  Class: Eq_821
+  DataType: word32
+  OrigDataType: word32
+T_822: (in eax_12 + 4<32> @ 00401752 : word32)
+  Class: Eq_822
+  DataType: word32
+  OrigDataType: word32
+T_823: (in Mem11[eax_12 + 4<32>:word32] @ 00401752 : word32)
+  Class: Eq_820
+  DataType: word32
+  OrigDataType: word32
+T_824: (in 0<32> @ 00401755 : word32)
+  Class: Eq_824
+  DataType: word32
+  OrigDataType: word32
+T_825: (in eax_12 + 0<32> @ 00401755 : word32)
+  Class: Eq_825
   DataType: ptr32
   OrigDataType: ptr32
-T_831: (in eax @ 0040176D : ptr32)
-  Class: Eq_831
+T_826: (in Mem11[eax_12 + 0<32>:word32] @ 00401755 : word32)
+  Class: Eq_826
+  DataType: ui32
+  OrigDataType: ui32
+T_827: (in 2<32> @ 00401755 : word32)
+  Class: Eq_827
+  DataType: ui32
+  OrigDataType: ui32
+T_828: (in eax_12->dw0000 | 2<32> @ 00000000 : word32)
+  Class: Eq_826
+  DataType: ui32
+  OrigDataType: ui32
+T_829: (in 0<32> @ 00401755 : word32)
+  Class: Eq_829
+  DataType: word32
+  OrigDataType: word32
+T_830: (in eax_12 + 0<32> @ 00401755 : word32)
+  Class: Eq_830
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 ui32)
+T_831: (in Mem15[eax_12 + 0<32>:word32] @ 00401755 : word32)
+  Class: Eq_826
+  DataType: ui32
+  OrigDataType: ui32
+T_832: (in 4<32> @ 00401758 : word32)
+  Class: Eq_832
+  DataType: word32
+  OrigDataType: word32
+T_833: (in eax_12 + 4<32> @ 00401758 : word32)
+  Class: Eq_833
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_834: (in Mem18[eax_12 + 4<32>:word32] @ 00401758 : word32)
+  Class: Eq_820
+  DataType: word32
+  OrigDataType: word32
+T_835: (in eax @ 00401767 : ptr32)
+  Class: Eq_835
   DataType: ptr32
   OrigDataType: word32
-T_832: (in 0x00403384<p32> @ 00401773 : ptr32)
-  Class: Eq_831
+T_836: (in 0x00403388<p32> @ 0040176D : ptr32)
+  Class: Eq_835
   DataType: ptr32
   OrigDataType: ptr32
-T_833: (in IsProcessorFeaturePresent @ 00401788 : ptr32)
-  Class: Eq_833
-  DataType: (ptr32 Eq_833)
-  OrigDataType: (ptr32 (fn T_837 (T_836)))
-T_834: (in signature of IsProcessorFeaturePresent @ 00000000 : void)
-  Class: Eq_833
-  DataType: (ptr32 Eq_833)
+T_837: (in eax @ 0040176D : ptr32)
+  Class: Eq_837
+  DataType: ptr32
+  OrigDataType: word32
+T_838: (in 0x00403384<p32> @ 00401773 : ptr32)
+  Class: Eq_837
+  DataType: ptr32
+  OrigDataType: ptr32
+T_839: (in IsProcessorFeaturePresent @ 00401788 : ptr32)
+  Class: Eq_839
+  DataType: (ptr32 Eq_839)
+  OrigDataType: (ptr32 (fn T_843 (T_842)))
+T_840: (in signature of IsProcessorFeaturePresent @ 00000000 : void)
+  Class: Eq_839
+  DataType: (ptr32 Eq_839)
   OrigDataType: 
-T_835: (in ProcessorFeature @ 00401788 : DWORD)
+T_841: (in ProcessorFeature @ 00401788 : DWORD)
   Class: Eq_63
   DataType: Eq_63
   OrigDataType: 
-T_836: (in 0x17<32> @ 00401788 : word32)
+T_842: (in 0x17<32> @ 00401788 : word32)
   Class: Eq_63
   DataType: int32
   OrigDataType: DWORD
-T_837: (in IsProcessorFeaturePresent(0x17<32>) @ 00401788 : BOOL)
+T_843: (in IsProcessorFeaturePresent(0x17<32>) @ 00401788 : BOOL)
   Class: Eq_413
   DataType: Eq_413
   OrigDataType: BOOL
-T_838: (in 0<32> @ 00401788 : word32)
+T_844: (in 0<32> @ 00401788 : word32)
   Class: Eq_413
   DataType: Eq_413
   OrigDataType: word32
-T_839: (in IsProcessorFeaturePresent(0x17<32>) == 0<32> @ 00000000 : bool)
-  Class: Eq_839
+T_845: (in IsProcessorFeaturePresent(0x17<32>) == 0<32> @ 00000000 : bool)
+  Class: Eq_845
   DataType: bool
   OrigDataType: bool
-T_840: (in 0<32> @ 0040179E : word32)
-  Class: Eq_840
+T_846: (in 0<32> @ 0040179E : word32)
+  Class: Eq_846
   DataType: ui32
   OrigDataType: word32
-T_841: (in 00403368 @ 0040179E : ptr32)
-  Class: Eq_841
+T_847: (in 00403368 @ 0040179E : ptr32)
+  Class: Eq_847
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_842 t0000)))
-T_842: (in Mem30[0x00403368<p32>:word32] @ 0040179E : word32)
-  Class: Eq_840
+  OrigDataType: (ptr32 (struct (0 T_848 t0000)))
+T_848: (in Mem30[0x00403368<p32>:word32] @ 0040179E : word32)
+  Class: Eq_846
   DataType: ui32
   OrigDataType: word32
-T_843: (in memset @ 004017A4 : ptr32)
-  Class: Eq_843
-  DataType: (ptr32 Eq_843)
-  OrigDataType: (ptr32 (fn T_853 (T_850, T_851, T_852)))
-T_844: (in signature of memset @ 00000000 : void)
-  Class: Eq_843
-  DataType: (ptr32 Eq_843)
+T_849: (in memset @ 004017A4 : ptr32)
+  Class: Eq_849
+  DataType: (ptr32 Eq_849)
+  OrigDataType: (ptr32 (fn T_859 (T_856, T_857, T_858)))
+T_850: (in signature of memset @ 00000000 : void)
+  Class: Eq_849
+  DataType: (ptr32 Eq_849)
   OrigDataType: 
-T_845: (in _Dst @ 004017A4 : (ptr32 void))
-  Class: Eq_845
+T_851: (in _Dst @ 004017A4 : (ptr32 void))
+  Class: Eq_851
   DataType: (ptr32 void)
   OrigDataType: 
-T_846: (in _Val @ 004017A4 : int32)
-  Class: Eq_846
+T_852: (in _Val @ 004017A4 : int32)
+  Class: Eq_852
   DataType: int32
   OrigDataType: 
-T_847: (in _Size @ 004017A4 : size_t)
-  Class: Eq_847
-  DataType: Eq_847
+T_853: (in _Size @ 004017A4 : size_t)
+  Class: Eq_853
+  DataType: Eq_853
   OrigDataType: 
-T_848: (in fp @ 004017A4 : ptr32)
-  Class: Eq_848
+T_854: (in fp @ 004017A4 : ptr32)
+  Class: Eq_854
   DataType: ptr32
   OrigDataType: ptr32
-T_849: (in 0x328<32> @ 004017A4 : word32)
-  Class: Eq_849
-  DataType: ui32
-  OrigDataType: ui32
-T_850: (in fp - 0x328<32> @ 00000000 : word32)
-  Class: Eq_845
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_851: (in 0<32> @ 004017A4 : word32)
-  Class: Eq_846
-  DataType: int32
-  OrigDataType: int32
-T_852: (in 0x2CC<32> @ 004017A4 : word32)
-  Class: Eq_847
-  DataType: Eq_847
-  OrigDataType: size_t
-T_853: (in memset(fp - 0x328<32>, 0<32>, 0x2CC<32>) @ 004017A4 : (ptr32 void))
-  Class: Eq_853
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_854: (in memset @ 0040182D : ptr32)
-  Class: Eq_843
-  DataType: (ptr32 Eq_843)
-  OrigDataType: (ptr32 (fn T_859 (T_856, T_857, T_858)))
-T_855: (in 0x5C<32> @ 0040182D : word32)
+T_855: (in 0x328<32> @ 004017A4 : word32)
   Class: Eq_855
   DataType: ui32
   OrigDataType: ui32
-T_856: (in fp - 0x5C<32> @ 00000000 : word32)
-  Class: Eq_845
+T_856: (in fp - 0x328<32> @ 00000000 : word32)
+  Class: Eq_851
   DataType: (ptr32 void)
   OrigDataType: (ptr32 void)
-T_857: (in 0<32> @ 0040182D : word32)
-  Class: Eq_846
+T_857: (in 0<32> @ 004017A4 : word32)
+  Class: Eq_852
   DataType: int32
   OrigDataType: int32
-T_858: (in 0x50<32> @ 0040182D : word32)
-  Class: Eq_847
-  DataType: Eq_847
-  OrigDataType: size_t
-T_859: (in memset(fp - 0x5C<32>, 0<32>, 0x50<32>) @ 0040182D : (ptr32 void))
+T_858: (in 0x2CC<32> @ 004017A4 : word32)
   Class: Eq_853
+  DataType: Eq_853
+  OrigDataType: size_t
+T_859: (in memset(fp - 0x328<32>, 0<32>, 0x2CC<32>) @ 004017A4 : (ptr32 void))
+  Class: Eq_859
   DataType: (ptr32 void)
   OrigDataType: (ptr32 void)
-T_860: (in bl_90 @ 00401861 : byte)
-  Class: Eq_860
-  DataType: byte
-  OrigDataType: byte
-T_861: (in 0<8> @ 00401861 : byte)
+T_860: (in memset @ 0040182D : ptr32)
+  Class: Eq_849
+  DataType: (ptr32 Eq_849)
+  OrigDataType: (ptr32 (fn T_865 (T_862, T_863, T_864)))
+T_861: (in 0x5C<32> @ 0040182D : word32)
   Class: Eq_861
+  DataType: ui32
+  OrigDataType: ui32
+T_862: (in fp - 0x5C<32> @ 00000000 : word32)
+  Class: Eq_851
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_863: (in 0<32> @ 0040182D : word32)
+  Class: Eq_852
+  DataType: int32
+  OrigDataType: int32
+T_864: (in 0x50<32> @ 0040182D : word32)
+  Class: Eq_853
+  DataType: Eq_853
+  OrigDataType: size_t
+T_865: (in memset(fp - 0x5C<32>, 0<32>, 0x50<32>) @ 0040182D : (ptr32 void))
+  Class: Eq_859
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_866: (in bl_90 @ 00401861 : byte)
+  Class: Eq_866
   DataType: byte
   OrigDataType: byte
-T_862: (in IsDebuggerPresent @ 00401861 : ptr32)
-  Class: Eq_862
-  DataType: (ptr32 Eq_862)
-  OrigDataType: (ptr32 (fn T_864 ()))
-T_863: (in signature of IsDebuggerPresent @ 00000000 : void)
-  Class: Eq_862
-  DataType: (ptr32 Eq_862)
+T_867: (in 0<8> @ 00401861 : byte)
+  Class: Eq_867
+  DataType: byte
+  OrigDataType: byte
+T_868: (in IsDebuggerPresent @ 00401861 : ptr32)
+  Class: Eq_868
+  DataType: (ptr32 Eq_868)
+  OrigDataType: (ptr32 (fn T_870 ()))
+T_869: (in signature of IsDebuggerPresent @ 00000000 : void)
+  Class: Eq_868
+  DataType: (ptr32 Eq_868)
   OrigDataType: 
-T_864: (in IsDebuggerPresent() @ 00401861 : BOOL)
+T_870: (in IsDebuggerPresent() @ 00401861 : BOOL)
   Class: Eq_413
   DataType: Eq_413
   OrigDataType: BOOL
-T_865: (in 1<32> @ 00401861 : word32)
+T_871: (in 1<32> @ 00401861 : word32)
   Class: Eq_413
   DataType: Eq_413
   OrigDataType: word32
-T_866: (in IsDebuggerPresent() != 1<32> @ 00000000 : bool)
-  Class: Eq_866
-  DataType: Eq_866
+T_872: (in IsDebuggerPresent() != 1<32> @ 00000000 : bool)
+  Class: Eq_872
+  DataType: Eq_872
   OrigDataType: (union (bool u0) (byte u1))
-T_867: (in 0<8> - (IsDebuggerPresent() != 1<32>) @ 00000000 : byte)
-  Class: Eq_860
+T_873: (in 0<8> - (IsDebuggerPresent() != 1<32>) @ 00000000 : byte)
+  Class: Eq_866
   DataType: byte
   OrigDataType: byte
-T_868: (in SetUnhandledExceptionFilter @ 00401868 : ptr32)
+T_874: (in SetUnhandledExceptionFilter @ 00401868 : ptr32)
   Class: Eq_396
   DataType: (ptr32 Eq_396)
-  OrigDataType: (ptr32 (fn T_870 (T_869)))
-T_869: (in 0<32> @ 00401868 : word32)
+  OrigDataType: (ptr32 (fn T_876 (T_875)))
+T_875: (in 0<32> @ 00401868 : word32)
   Class: Eq_398
   DataType: Eq_398
   OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_870: (in SetUnhandledExceptionFilter(null) @ 00401868 : LPTOP_LEVEL_EXCEPTION_FILTER)
+T_876: (in SetUnhandledExceptionFilter(null) @ 00401868 : LPTOP_LEVEL_EXCEPTION_FILTER)
   Class: Eq_398
   DataType: Eq_398
   OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_871: (in UnhandledExceptionFilter @ 0040187A : ptr32)
+T_877: (in UnhandledExceptionFilter @ 0040187A : ptr32)
   Class: Eq_401
   DataType: (ptr32 Eq_401)
-  OrigDataType: (ptr32 (fn T_874 (T_873)))
-T_872: (in 0xC<32> @ 0040187A : word32)
-  Class: Eq_872
+  OrigDataType: (ptr32 (fn T_880 (T_879)))
+T_878: (in 0xC<32> @ 0040187A : word32)
+  Class: Eq_878
   DataType: ui32
   OrigDataType: ui32
-T_873: (in fp - 0xC<32> @ 00000000 : word32)
+T_879: (in fp - 0xC<32> @ 00000000 : word32)
   Class: Eq_395
   DataType: (ptr32 Eq_395)
   OrigDataType: (ptr32 (struct "_EXCEPTION_POINTERS"))
-T_874: (in UnhandledExceptionFilter(fp - 0xC<32>) @ 0040187A : LONG)
+T_880: (in UnhandledExceptionFilter(fp - 0xC<32>) @ 0040187A : LONG)
   Class: Eq_404
   DataType: Eq_404
   OrigDataType: LONG
-T_875: (in 0<32> @ 0040187A : word32)
+T_881: (in 0<32> @ 0040187A : word32)
   Class: Eq_404
   DataType: Eq_404
   OrigDataType: word32
-T_876: (in UnhandledExceptionFilter(fp - 0xC<32>) != 0<32> @ 00000000 : bool)
-  Class: Eq_876
+T_882: (in UnhandledExceptionFilter(fp - 0xC<32>) != 0<32> @ 00000000 : bool)
+  Class: Eq_882
   DataType: bool
   OrigDataType: bool
-T_877: (in __fastfail @ 0040178D : ptr32)
-  Class: Eq_877
-  DataType: (ptr32 Eq_877)
-  OrigDataType: (ptr32 (fn T_880 (T_127)))
-T_878: (in signature of __fastfail @ 00000000 : void)
-  Class: Eq_877
-  DataType: (ptr32 Eq_877)
+T_883: (in __fastfail @ 0040178D : ptr32)
+  Class: Eq_883
+  DataType: (ptr32 Eq_883)
+  OrigDataType: (ptr32 (fn T_886 (T_127)))
+T_884: (in signature of __fastfail @ 00000000 : void)
+  Class: Eq_883
+  DataType: (ptr32 Eq_883)
   OrigDataType: 
-T_879: (in ecx @ 0040178D : word32)
+T_885: (in ecx @ 0040178D : word32)
   Class: Eq_127
   DataType: word32
   OrigDataType: 
-T_880: (in __fastfail(dwArg04) @ 0040178D : void)
-  Class: Eq_880
+T_886: (in __fastfail(dwArg04) @ 0040178D : void)
+  Class: Eq_886
   DataType: void
   OrigDataType: void
-T_881: (in 00403368 @ 00401883 : ptr32)
-  Class: Eq_881
+T_887: (in 00403368 @ 00401883 : ptr32)
+  Class: Eq_887
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_882 t0000)))
-T_882: (in Mem97[0x00403368<p32>:word32] @ 00401883 : word32)
-  Class: Eq_840
+  OrigDataType: (ptr32 (struct (0 T_888 t0000)))
+T_888: (in Mem97[0x00403368<p32>:word32] @ 00401883 : word32)
+  Class: Eq_846
   DataType: ui32
   OrigDataType: ui32
-T_883: (in 0<32> @ 00401883 : word32)
-  Class: Eq_883
-  DataType: ui32
-  OrigDataType: ui32
-T_884: (in 1<8> @ 00401883 : byte)
-  Class: Eq_884
-  DataType: byte
-  OrigDataType: byte
-T_885: (in bl_90 + 1<8> @ 00000000 : byte)
-  Class: Eq_885
-  DataType: byte
-  OrigDataType: byte
-T_886: (in CONVERT(bl_90 + 1<8>, byte, word32) @ 00401883 : word32)
-  Class: Eq_886
-  DataType: word32
-  OrigDataType: word32
-T_887: (in 0<32> @ 00401883 : word32)
-  Class: Eq_886
-  DataType: word32
-  OrigDataType: word32
-T_888: (in (word32) (bl_90 + 1<8>) != 0<32> @ 00000000 : bool)
-  Class: Eq_888
-  DataType: Eq_888
-  OrigDataType: (union (bool u0) (ui32 u1))
-T_889: (in 0<32> - ((word32) (bl_90 + 1<8>) != 0<32>) @ 00000000 : word32)
+T_889: (in 0<32> @ 00401883 : word32)
   Class: Eq_889
   DataType: ui32
   OrigDataType: ui32
-T_890: (in g_dw403368 & 0<32> - ((word32) (bl_90 + 1<8>) != 0<32>) @ 00000000 : word32)
-  Class: Eq_840
+T_890: (in 1<8> @ 00401883 : byte)
+  Class: Eq_890
+  DataType: byte
+  OrigDataType: byte
+T_891: (in bl_90 + 1<8> @ 00000000 : byte)
+  Class: Eq_891
+  DataType: byte
+  OrigDataType: byte
+T_892: (in CONVERT(bl_90 + 1<8>, byte, word32) @ 00401883 : word32)
+  Class: Eq_892
+  DataType: word32
+  OrigDataType: word32
+T_893: (in 0<32> @ 00401883 : word32)
+  Class: Eq_892
+  DataType: word32
+  OrigDataType: word32
+T_894: (in (word32) (bl_90 + 1<8>) != 0<32> @ 00000000 : bool)
+  Class: Eq_894
+  DataType: Eq_894
+  OrigDataType: (union (bool u0) (ui32 u1))
+T_895: (in 0<32> - ((word32) (bl_90 + 1<8>) != 0<32>) @ 00000000 : word32)
+  Class: Eq_895
   DataType: ui32
   OrigDataType: ui32
-T_891: (in 00403368 @ 00401883 : ptr32)
-  Class: Eq_891
+T_896: (in g_dw403368 & 0<32> - ((word32) (bl_90 + 1<8>) != 0<32>) @ 00000000 : word32)
+  Class: Eq_846
+  DataType: ui32
+  OrigDataType: ui32
+T_897: (in 00403368 @ 00401883 : ptr32)
+  Class: Eq_897
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_892 t0000)))
-T_892: (in Mem108[0x00403368<p32>:word32] @ 00401883 : word32)
-  Class: Eq_840
+  OrigDataType: (ptr32 (struct (0 T_898 t0000)))
+T_898: (in Mem108[0x00403368<p32>:word32] @ 00401883 : word32)
+  Class: Eq_846
   DataType: ui32
   OrigDataType: word32
-T_893: (in al @ 00401883 : int8)
-  Class: Eq_893
+T_899: (in al @ 00401883 : int8)
+  Class: Eq_899
   DataType: int8
   OrigDataType: byte
-T_894: (in eax_6 @ 00401891 : Eq_894)
-  Class: Eq_894
-  DataType: Eq_894
+T_900: (in eax_6 @ 00401891 : Eq_900)
+  Class: Eq_900
+  DataType: Eq_900
   OrigDataType: HMODULE
-T_895: (in GetModuleHandleW @ 00401891 : ptr32)
-  Class: Eq_895
-  DataType: (ptr32 Eq_895)
-  OrigDataType: (ptr32 (fn T_899 (T_898)))
-T_896: (in signature of GetModuleHandleW @ 00000000 : void)
-  Class: Eq_895
-  DataType: (ptr32 Eq_895)
-  OrigDataType: 
-T_897: (in lpModuleName @ 00401891 : LPCWSTR)
-  Class: Eq_897
-  DataType: Eq_897
-  OrigDataType: 
-T_898: (in 0<32> @ 00401891 : word32)
-  Class: Eq_897
-  DataType: Eq_897
-  OrigDataType: LPCWSTR
-T_899: (in GetModuleHandleW(null) @ 00401891 : HMODULE)
-  Class: Eq_894
-  DataType: Eq_894
-  OrigDataType: HMODULE
-T_900: (in 0<32> @ 0040189B : word32)
-  Class: Eq_894
-  DataType: Eq_894
-  OrigDataType: word32
-T_901: (in eax_6 != null @ 00000000 : bool)
+T_901: (in GetModuleHandleW @ 00401891 : ptr32)
   Class: Eq_901
+  DataType: (ptr32 Eq_901)
+  OrigDataType: (ptr32 (fn T_905 (T_904)))
+T_902: (in signature of GetModuleHandleW @ 00000000 : void)
+  Class: Eq_901
+  DataType: (ptr32 Eq_901)
+  OrigDataType: 
+T_903: (in lpModuleName @ 00401891 : LPCWSTR)
+  Class: Eq_903
+  DataType: Eq_903
+  OrigDataType: 
+T_904: (in 0<32> @ 00401891 : word32)
+  Class: Eq_903
+  DataType: Eq_903
+  OrigDataType: LPCWSTR
+T_905: (in GetModuleHandleW(null) @ 00401891 : HMODULE)
+  Class: Eq_900
+  DataType: Eq_900
+  OrigDataType: HMODULE
+T_906: (in 0<32> @ 0040189B : word32)
+  Class: Eq_900
+  DataType: Eq_900
+  OrigDataType: word32
+T_907: (in eax_6 != null @ 00000000 : bool)
+  Class: Eq_907
   DataType: bool
   OrigDataType: bool
-T_902: (in 0<32> @ 004018A8 : word32)
-  Class: Eq_902
+T_908: (in 0<32> @ 004018A8 : word32)
+  Class: Eq_908
   DataType: word32
   OrigDataType: word32
-T_903: (in eax_6 + 0<32> @ 004018A8 : word32)
-  Class: Eq_903
+T_909: (in eax_6 + 0<32> @ 004018A8 : word32)
+  Class: Eq_909
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
-T_904: (in Mem5[eax_6 + 0<32>:word16] @ 004018A8 : word16)
-  Class: Eq_904
-  DataType: Eq_904
-  OrigDataType: int32
-T_905: (in 0x5A4D<16> @ 004018A8 : word16)
-  Class: Eq_904
-  DataType: word16
-  OrigDataType: word16
-T_906: (in eax_6->unused != 0x5A4D<16> @ 00000000 : bool)
-  Class: Eq_906
-  DataType: bool
-  OrigDataType: bool
-T_907: (in 0<8> @ 0040189F : byte)
-  Class: Eq_893
-  DataType: int8
-  OrigDataType: byte
-T_908: (in eax_17 @ 004018AD : (ptr32 Eq_908))
-  Class: Eq_908
-  DataType: (ptr32 Eq_908)
-  OrigDataType: (ptr32 (struct (0 T_915 t0000) (18 T_920 t0018) (74 T_925 t0074) (E8 T_930 t00E8)))
-T_909: (in 0x3C<32> @ 004018AD : word32)
-  Class: Eq_909
-  DataType: word32
-  OrigDataType: word32
-T_910: (in eax_6 + 0x3C<32> @ 004018AD : word32)
+T_910: (in Mem5[eax_6 + 0<32>:word16] @ 004018A8 : word16)
   Class: Eq_910
   DataType: Eq_910
-  OrigDataType: HMODULE
-T_911: (in Mem5[eax_6 + 0x3C<32>:word32] @ 004018AD : word32)
-  Class: Eq_911
-  DataType: int32
   OrigDataType: int32
-T_912: (in Mem5[eax_6 + 0x3C<32>:word32] + eax_6 @ 004018AD : word32)
-  Class: Eq_908
-  DataType: (ptr32 Eq_908)
-  OrigDataType: int32
-T_913: (in 0<32> @ 004018B5 : word32)
-  Class: Eq_913
-  DataType: word32
-  OrigDataType: word32
-T_914: (in eax_17 + 0<32> @ 004018B5 : word32)
+T_911: (in 0x5A4D<16> @ 004018A8 : word16)
+  Class: Eq_910
+  DataType: word16
+  OrigDataType: word16
+T_912: (in eax_6->unused != 0x5A4D<16> @ 00000000 : bool)
+  Class: Eq_912
+  DataType: bool
+  OrigDataType: bool
+T_913: (in 0<8> @ 0040189F : byte)
+  Class: Eq_899
+  DataType: int8
+  OrigDataType: byte
+T_914: (in eax_17 @ 004018AD : (ptr32 Eq_914))
   Class: Eq_914
+  DataType: (ptr32 Eq_914)
+  OrigDataType: (ptr32 (struct (0 T_921 t0000) (18 T_926 t0018) (74 T_931 t0074) (E8 T_936 t00E8)))
+T_915: (in 0x3C<32> @ 004018AD : word32)
+  Class: Eq_915
+  DataType: word32
+  OrigDataType: word32
+T_916: (in eax_6 + 0x3C<32> @ 004018AD : word32)
+  Class: Eq_916
+  DataType: Eq_916
+  OrigDataType: HMODULE
+T_917: (in Mem5[eax_6 + 0x3C<32>:word32] @ 004018AD : word32)
+  Class: Eq_917
   DataType: int32
   OrigDataType: int32
-T_915: (in Mem5[eax_17 + 0<32>:word32] @ 004018B5 : word32)
-  Class: Eq_915
-  DataType: word32
-  OrigDataType: word32
-T_916: (in 0x4550<32> @ 004018B5 : word32)
-  Class: Eq_915
-  DataType: word32
-  OrigDataType: word32
-T_917: (in eax_17->dw0000 != 0x4550<32> @ 00000000 : bool)
-  Class: Eq_917
-  DataType: bool
-  OrigDataType: bool
-T_918: (in 0x18<32> @ 004018C0 : word32)
-  Class: Eq_918
-  DataType: word32
-  OrigDataType: word32
-T_919: (in eax_17 + 0x18<32> @ 004018C0 : word32)
+T_918: (in Mem5[eax_6 + 0x3C<32>:word32] + eax_6 @ 004018AD : word32)
+  Class: Eq_914
+  DataType: (ptr32 Eq_914)
+  OrigDataType: int32
+T_919: (in 0<32> @ 004018B5 : word32)
   Class: Eq_919
-  DataType: ptr32
-  OrigDataType: ptr32
-T_920: (in Mem5[eax_17 + 0x18<32>:word16] @ 004018C0 : word16)
+  DataType: word32
+  OrigDataType: word32
+T_920: (in eax_17 + 0<32> @ 004018B5 : word32)
   Class: Eq_920
-  DataType: word16
-  OrigDataType: word16
-T_921: (in 0x10B<16> @ 004018C0 : word16)
-  Class: Eq_920
-  DataType: word16
-  OrigDataType: word16
-T_922: (in eax_17->w0018 != 0x10B<16> @ 00000000 : bool)
-  Class: Eq_922
-  DataType: bool
-  OrigDataType: bool
-T_923: (in 0x74<32> @ 004018C6 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_921: (in Mem5[eax_17 + 0<32>:word32] @ 004018B5 : word32)
+  Class: Eq_921
+  DataType: word32
+  OrigDataType: word32
+T_922: (in 0x4550<32> @ 004018B5 : word32)
+  Class: Eq_921
+  DataType: word32
+  OrigDataType: word32
+T_923: (in eax_17->dw0000 != 0x4550<32> @ 00000000 : bool)
   Class: Eq_923
-  DataType: word32
-  OrigDataType: word32
-T_924: (in eax_17 + 0x74<32> @ 004018C6 : word32)
+  DataType: bool
+  OrigDataType: bool
+T_924: (in 0x18<32> @ 004018C0 : word32)
   Class: Eq_924
+  DataType: word32
+  OrigDataType: word32
+T_925: (in eax_17 + 0x18<32> @ 004018C0 : word32)
+  Class: Eq_925
   DataType: ptr32
   OrigDataType: ptr32
-T_925: (in Mem5[eax_17 + 0x74<32>:word32] @ 004018C6 : word32)
-  Class: Eq_925
-  DataType: up32
-  OrigDataType: up32
-T_926: (in 0xE<32> @ 004018C6 : word32)
-  Class: Eq_925
-  DataType: up32
-  OrigDataType: up32
-T_927: (in eax_17->dw0074 <= 0xE<32> @ 00000000 : bool)
-  Class: Eq_927
-  DataType: bool
-  OrigDataType: bool
-T_928: (in 0xE8<32> @ 004018D2 : word32)
+T_926: (in Mem5[eax_17 + 0x18<32>:word16] @ 004018C0 : word16)
+  Class: Eq_926
+  DataType: word16
+  OrigDataType: word16
+T_927: (in 0x10B<16> @ 004018C0 : word16)
+  Class: Eq_926
+  DataType: word16
+  OrigDataType: word16
+T_928: (in eax_17->w0018 != 0x10B<16> @ 00000000 : bool)
   Class: Eq_928
-  DataType: word32
-  OrigDataType: word32
-T_929: (in eax_17 + 0xE8<32> @ 004018D2 : word32)
-  Class: Eq_929
-  DataType: ptr32
-  OrigDataType: ptr32
-T_930: (in Mem5[eax_17 + 0xE8<32>:word32] @ 004018D2 : word32)
-  Class: Eq_930
-  DataType: word32
-  OrigDataType: word32
-T_931: (in 0<32> @ 004018D2 : word32)
-  Class: Eq_930
-  DataType: word32
-  OrigDataType: word32
-T_932: (in eax_17->dw00E8 != 0<32> @ 00000000 : bool)
-  Class: Eq_932
   DataType: bool
   OrigDataType: bool
-T_933: (in CONVERT(Mem5[eax_17 + 0xE8<32>:word32] != 0<32>, bool, int8) @ 004018D2 : int8)
-  Class: Eq_893
+T_929: (in 0x74<32> @ 004018C6 : word32)
+  Class: Eq_929
+  DataType: word32
+  OrigDataType: word32
+T_930: (in eax_17 + 0x74<32> @ 004018C6 : word32)
+  Class: Eq_930
+  DataType: ptr32
+  OrigDataType: ptr32
+T_931: (in Mem5[eax_17 + 0x74<32>:word32] @ 004018C6 : word32)
+  Class: Eq_931
+  DataType: up32
+  OrigDataType: up32
+T_932: (in 0xE<32> @ 004018C6 : word32)
+  Class: Eq_931
+  DataType: up32
+  OrigDataType: up32
+T_933: (in eax_17->dw0074 <= 0xE<32> @ 00000000 : bool)
+  Class: Eq_933
+  DataType: bool
+  OrigDataType: bool
+T_934: (in 0xE8<32> @ 004018D2 : word32)
+  Class: Eq_934
+  DataType: word32
+  OrigDataType: word32
+T_935: (in eax_17 + 0xE8<32> @ 004018D2 : word32)
+  Class: Eq_935
+  DataType: ptr32
+  OrigDataType: ptr32
+T_936: (in Mem5[eax_17 + 0xE8<32>:word32] @ 004018D2 : word32)
+  Class: Eq_936
+  DataType: word32
+  OrigDataType: word32
+T_937: (in 0<32> @ 004018D2 : word32)
+  Class: Eq_936
+  DataType: word32
+  OrigDataType: word32
+T_938: (in eax_17->dw00E8 != 0<32> @ 00000000 : bool)
+  Class: Eq_938
+  DataType: bool
+  OrigDataType: bool
+T_939: (in CONVERT(Mem5[eax_17 + 0xE8<32>:word32] != 0<32>, bool, int8) @ 004018D2 : int8)
+  Class: Eq_899
   DataType: int8
   OrigDataType: int8
-T_934: (in SetUnhandledExceptionFilter @ 004018D8 : ptr32)
+T_940: (in SetUnhandledExceptionFilter @ 004018D8 : ptr32)
   Class: Eq_396
   DataType: (ptr32 Eq_396)
-  OrigDataType: (ptr32 (fn T_936 (T_935)))
-T_935: (in 0x4018DF<32> @ 004018D8 : word32)
+  OrigDataType: (ptr32 (fn T_942 (T_941)))
+T_941: (in 0x4018DF<32> @ 004018D8 : word32)
   Class: Eq_398
   DataType: Eq_398
   OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_936: (in SetUnhandledExceptionFilter(&g_t4018DF) @ 004018D8 : LPTOP_LEVEL_EXCEPTION_FILTER)
+T_942: (in SetUnhandledExceptionFilter(&g_t4018DF) @ 004018D8 : LPTOP_LEVEL_EXCEPTION_FILTER)
   Class: Eq_398
   DataType: Eq_398
   OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_937: (in esi_10 @ 00401922 : (ptr32 word32))
-  Class: Eq_937
+T_943: (in esi_10 @ 00401922 : (ptr32 word32))
+  Class: Eq_943
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
-T_938: (in 0x004024C8<p32> @ 00401922 : ptr32)
-  Class: Eq_937
+T_944: (in 0x004024C8<p32> @ 00401922 : ptr32)
+  Class: Eq_943
   DataType: (ptr32 word32)
   OrigDataType: ptr32
-T_939: (in true @ 0040192E : bool)
-  Class: Eq_939
+T_945: (in true @ 0040192E : bool)
+  Class: Eq_945
   DataType: bool
   OrigDataType: bool
-T_940: (in 4<32> @ 00401940 : word32)
-  Class: Eq_940
+T_946: (in 4<32> @ 00401940 : word32)
+  Class: Eq_946
   DataType: int32
   OrigDataType: int32
-T_941: (in esi_10 + 4<32> @ 00401940 : word32)
-  Class: Eq_937
-  DataType: (ptr32 word32)
-  OrigDataType: ptr32
-T_942: (in 0x004024C8<p32> @ 00401945 : ptr32)
-  Class: Eq_937
-  DataType: (ptr32 word32)
-  OrigDataType: ptr32
-T_943: (in esi_10 < g_a4024C8 @ 00000000 : bool)
+T_947: (in esi_10 + 4<32> @ 00401940 : word32)
   Class: Eq_943
+  DataType: (ptr32 word32)
+  OrigDataType: ptr32
+T_948: (in 0x004024C8<p32> @ 00401945 : ptr32)
+  Class: Eq_943
+  DataType: (ptr32 word32)
+  OrigDataType: ptr32
+T_949: (in esi_10 < g_a4024C8 @ 00000000 : bool)
+  Class: Eq_949
   DataType: bool
   OrigDataType: bool
-T_944: (in fn00401976 @ 00401939 : ptr32)
+T_950: (in fn00401976 @ 00401939 : ptr32)
   Class: Eq_293
   DataType: (ptr32 Eq_293)
-  OrigDataType: (ptr32 (fn T_945 ()))
-T_945: (in fn00401976() @ 00401939 : void)
+  OrigDataType: (ptr32 (fn T_951 ()))
+T_951: (in fn00401976() @ 00401939 : void)
   Class: Eq_295
   DataType: void
   OrigDataType: void
-T_946: (in fn00000000 @ 0040193E : ptr32)
-  Class: Eq_946
-  DataType: (ptr32 Eq_946)
-  OrigDataType: (ptr32 (fn T_948 ()))
-T_947: (in signature of fn00000000 @ 00000000 : void)
-  Class: Eq_947
-  DataType: Eq_947
+T_952: (in fn00000000 @ 0040193E : ptr32)
+  Class: Eq_952
+  DataType: (ptr32 Eq_952)
+  OrigDataType: (ptr32 (fn T_954 ()))
+T_953: (in signature of fn00000000 @ 00000000 : void)
+  Class: Eq_953
+  DataType: Eq_953
   OrigDataType: 
-T_948: (in fn00000000() @ 0040193E : void)
-  Class: Eq_948
+T_954: (in fn00000000() @ 0040193E : void)
+  Class: Eq_954
   DataType: void
   OrigDataType: void
-T_949: (in 0<32> @ 00401935 : word32)
-  Class: Eq_949
-  DataType: word32
-  OrigDataType: word32
-T_950: (in esi_10 + 0<32> @ 00401935 : word32)
-  Class: Eq_950
-  DataType: ptr32
-  OrigDataType: ptr32
-T_951: (in Mem16[esi_10 + 0<32>:word32] @ 00401935 : word32)
-  Class: Eq_951
-  DataType: word32
-  OrigDataType: word32
-T_952: (in 0<32> @ 00401935 : word32)
-  Class: Eq_951
-  DataType: word32
-  OrigDataType: word32
-T_953: (in *esi_10 == 0<32> @ 00000000 : bool)
-  Class: Eq_953
-  DataType: bool
-  OrigDataType: bool
-T_954: (in 004020D0 @ 00401976 : ptr32)
-  Class: Eq_954
-  DataType: (ptr32 (ptr32 code))
-  OrigDataType: (ptr32 (struct (0 T_955 t0000)))
-T_955: (in Mem0[0x004020D0<p32>:word32] @ 00401976 : word32)
+T_955: (in 0<32> @ 00401935 : word32)
   Class: Eq_955
-  DataType: (ptr32 code)
-  OrigDataType: (ptr32 code)
-T_956: (in ebp @ 00401976 : ptr32)
+  DataType: word32
+  OrigDataType: word32
+T_956: (in esi_10 + 0<32> @ 00401935 : word32)
   Class: Eq_956
   DataType: ptr32
-  OrigDataType: word32
-T_957: (in esp_14 @ 00401998 : (ptr32 Eq_957))
+  OrigDataType: ptr32
+T_957: (in Mem16[esi_10 + 0<32>:word32] @ 00401935 : word32)
   Class: Eq_957
-  DataType: (ptr32 Eq_957)
-  OrigDataType: (ptr32 (struct (FFFFFFEC T_981 tFFFFFFEC) (FFFFFFF0 T_978 tFFFFFFF0) (FFFFFFF4 T_970 tFFFFFFF4) (FFFFFFF8 T_967 tFFFFFFF8) (FFFFFFFC T_964 tFFFFFFFC)))
-T_958: (in fp @ 00401998 : ptr32)
-  Class: Eq_958
-  DataType: ptr32
-  OrigDataType: ptr32
-T_959: (in 8<i32> @ 00401998 : int32)
-  Class: Eq_959
-  DataType: int32
-  OrigDataType: int32
-T_960: (in fp - 8<i32> @ 00000000 : word32)
-  Class: Eq_960
-  DataType: ptr32
-  OrigDataType: ptr32
-T_961: (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
-  Class: Eq_957
-  DataType: (ptr32 Eq_957)
-  OrigDataType: ptr32
-T_962: (in -4<i32> @ 0040199A : int32)
-  Class: Eq_962
-  DataType: int32
-  OrigDataType: int32
-T_963: (in esp_14 + -4<i32> @ 0040199A : word32)
-  Class: Eq_963
-  DataType: ptr32
-  OrigDataType: ptr32
-T_964: (in Mem17[esp_14 + -4<i32>:word32] @ 0040199A : word32)
-  Class: Eq_65
   DataType: word32
   OrigDataType: word32
-T_965: (in -8<i32> @ 0040199B : int32)
+T_958: (in 0<32> @ 00401935 : word32)
+  Class: Eq_957
+  DataType: word32
+  OrigDataType: word32
+T_959: (in *esi_10 == 0<32> @ 00000000 : bool)
+  Class: Eq_959
+  DataType: bool
+  OrigDataType: bool
+T_960: (in 004020D0 @ 00401976 : ptr32)
+  Class: Eq_960
+  DataType: (ptr32 (ptr32 code))
+  OrigDataType: (ptr32 (struct (0 T_961 t0000)))
+T_961: (in Mem0[0x004020D0<p32>:word32] @ 00401976 : word32)
+  Class: Eq_961
+  DataType: (ptr32 code)
+  OrigDataType: (ptr32 code)
+T_962: (in ebp @ 00401976 : ptr32)
+  Class: Eq_962
+  DataType: ptr32
+  OrigDataType: word32
+T_963: (in esp_14 @ 00401998 : (ptr32 Eq_963))
+  Class: Eq_963
+  DataType: (ptr32 Eq_963)
+  OrigDataType: (ptr32 (struct (FFFFFFEC T_987 tFFFFFFEC) (FFFFFFF0 T_984 tFFFFFFF0) (FFFFFFF4 T_976 tFFFFFFF4) (FFFFFFF8 T_973 tFFFFFFF8) (FFFFFFFC T_970 tFFFFFFFC)))
+T_964: (in fp @ 00401998 : ptr32)
+  Class: Eq_964
+  DataType: ptr32
+  OrigDataType: ptr32
+T_965: (in 8<i32> @ 00401998 : int32)
   Class: Eq_965
   DataType: int32
   OrigDataType: int32
-T_966: (in esp_14 + -8<i32> @ 0040199B : word32)
+T_966: (in fp - 8<i32> @ 00000000 : word32)
   Class: Eq_966
   DataType: ptr32
   OrigDataType: ptr32
-T_967: (in Mem20[esp_14 + -8<i32>:word32] @ 0040199B : word32)
-  Class: Eq_74
-  DataType: Eq_74
-  OrigDataType: word32
-T_968: (in -12<i32> @ 0040199C : int32)
+T_967: (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
+  Class: Eq_963
+  DataType: (ptr32 Eq_963)
+  OrigDataType: ptr32
+T_968: (in -4<i32> @ 0040199A : int32)
   Class: Eq_968
   DataType: int32
   OrigDataType: int32
-T_969: (in esp_14 + -12<i32> @ 0040199C : word32)
+T_969: (in esp_14 + -4<i32> @ 0040199A : word32)
   Class: Eq_969
   DataType: ptr32
   OrigDataType: ptr32
-T_970: (in Mem23[esp_14 + -12<i32>:word32] @ 0040199C : word32)
+T_970: (in Mem17[esp_14 + -4<i32>:word32] @ 0040199A : word32)
+  Class: Eq_65
+  DataType: word32
+  OrigDataType: word32
+T_971: (in -8<i32> @ 0040199B : int32)
+  Class: Eq_971
+  DataType: int32
+  OrigDataType: int32
+T_972: (in esp_14 + -8<i32> @ 0040199B : word32)
+  Class: Eq_972
+  DataType: ptr32
+  OrigDataType: ptr32
+T_973: (in Mem20[esp_14 + -8<i32>:word32] @ 0040199B : word32)
   Class: Eq_74
   DataType: Eq_74
   OrigDataType: word32
-T_971: (in 00403004 @ 004019A7 : ptr32)
-  Class: Eq_971
+T_974: (in -12<i32> @ 0040199C : int32)
+  Class: Eq_974
+  DataType: int32
+  OrigDataType: int32
+T_975: (in esp_14 + -12<i32> @ 0040199C : word32)
+  Class: Eq_975
+  DataType: ptr32
+  OrigDataType: ptr32
+T_976: (in Mem23[esp_14 + -12<i32>:word32] @ 0040199C : word32)
+  Class: Eq_74
+  DataType: Eq_74
+  OrigDataType: word32
+T_977: (in 00403004 @ 004019A7 : ptr32)
+  Class: Eq_977
   DataType: (ptr32 Eq_540)
-  OrigDataType: (ptr32 (struct (0 T_972 t0000)))
-T_972: (in Mem23[0x00403004<p32>:word32] @ 004019A7 : word32)
+  OrigDataType: (ptr32 (struct (0 T_978 t0000)))
+T_978: (in Mem23[0x00403004<p32>:word32] @ 004019A7 : word32)
   Class: Eq_540
   DataType: Eq_540
   OrigDataType: word32
-T_973: (in 8<32> @ 004019A7 : word32)
-  Class: Eq_973
-  DataType: int32
-  OrigDataType: int32
-T_974: (in fp + 8<32> @ 00000000 : word32)
-  Class: Eq_974
-  DataType: ptr32
-  OrigDataType: ptr32
-T_975: (in g_t403004 ^ fp + 8<32> @ 00000000 : word32)
-  Class: Eq_975
-  DataType: ui32
-  OrigDataType: ui32
-T_976: (in -16<i32> @ 004019A7 : int32)
-  Class: Eq_976
-  DataType: int32
-  OrigDataType: int32
-T_977: (in esp_14 + -16<i32> @ 004019A7 : word32)
-  Class: Eq_977
-  DataType: ptr32
-  OrigDataType: ptr32
-T_978: (in Mem32[esp_14 + -16<i32>:word32] @ 004019A7 : word32)
-  Class: Eq_975
-  DataType: ui32
-  OrigDataType: word32
-T_979: (in -20<i32> @ 004019AB : int32)
+T_979: (in 8<32> @ 004019A7 : word32)
   Class: Eq_979
   DataType: int32
   OrigDataType: int32
-T_980: (in esp_14 + -20<i32> @ 004019AB : word32)
+T_980: (in fp + 8<32> @ 00000000 : word32)
   Class: Eq_980
   DataType: ptr32
   OrigDataType: ptr32
-T_981: (in Mem36[esp_14 + -20<i32>:word32] @ 004019AB : word32)
-  Class: Eq_76
-  DataType: Eq_76
-  OrigDataType: word32
-T_982: (in 8<32> @ 004019BE : word32)
-  Class: Eq_982
+T_981: (in g_t403004 ^ fp + 8<32> @ 00000000 : word32)
+  Class: Eq_981
   DataType: ui32
   OrigDataType: ui32
-T_983: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_983
-  DataType: ptr32
-  OrigDataType: ptr32
-T_984: (in fs @ 004019BE : selector)
-  Class: Eq_984
-  DataType: (ptr32 Eq_984)
-  OrigDataType: (ptr32 (segment (0 T_986 t0000)))
-T_985: (in 0<32> @ 004019BE : word32)
-  Class: Eq_985
-  DataType: (memptr (ptr32 Eq_984) ptr32)
-  OrigDataType: (memptr T_984 (struct (0 T_986 t0000)))
-T_986: (in Mem41[fs:0<32>:word32] @ 004019BE : word32)
-  Class: Eq_983
-  DataType: ptr32
-  OrigDataType: word32
-T_987: (in fp + 8<32> @ 00000000 : word32)
-  Class: Eq_956
-  DataType: ptr32
-  OrigDataType: ptr32
-T_988: (in ebx @ 004019C4 : word32)
-  Class: Eq_988
-  DataType: word32
-  OrigDataType: word32
-T_989: (in -16<i32> @ 004019C9 : int32)
-  Class: Eq_989
+T_982: (in -16<i32> @ 004019A7 : int32)
+  Class: Eq_982
   DataType: int32
   OrigDataType: int32
-T_990: (in ebp + -16<i32> @ 004019C9 : word32)
-  Class: Eq_990
-  DataType: word32
+T_983: (in esp_14 + -16<i32> @ 004019A7 : word32)
+  Class: Eq_983
+  DataType: ptr32
+  OrigDataType: ptr32
+T_984: (in Mem32[esp_14 + -16<i32>:word32] @ 004019A7 : word32)
+  Class: Eq_981
+  DataType: ui32
   OrigDataType: word32
-T_991: (in Mem0[ebp + -16<i32>:word32] @ 004019C9 : word32)
-  Class: Eq_991
-  DataType: word32
-  OrigDataType: word32
-T_992: (in fs @ 004019C9 : selector)
-  Class: Eq_992
-  DataType: (ptr32 Eq_992)
-  OrigDataType: (ptr32 (segment (0 T_994 t0000)))
-T_993: (in 0x00000000<p32> @ 004019C9 : ptr32)
-  Class: Eq_993
-  DataType: Eq_993
-  OrigDataType: (union (ptr32 u0) ((memptr T_992 (struct (0 word32 dw0000))) u1))
-T_994: (in Mem8[fs:0x00000000<p32>:word32] @ 004019C9 : word32)
-  Class: Eq_991
-  DataType: word32
-  OrigDataType: word32
-T_995: (in ebp_19 @ 004019D7 : Eq_76)
+T_985: (in -20<i32> @ 004019AB : int32)
+  Class: Eq_985
+  DataType: int32
+  OrigDataType: int32
+T_986: (in esp_14 + -20<i32> @ 004019AB : word32)
+  Class: Eq_986
+  DataType: ptr32
+  OrigDataType: ptr32
+T_987: (in Mem36[esp_14 + -20<i32>:word32] @ 004019AB : word32)
   Class: Eq_76
   DataType: Eq_76
   OrigDataType: word32
-T_996: (in 0<32> @ 004019D7 : word32)
+T_988: (in 8<32> @ 004019BE : word32)
+  Class: Eq_988
+  DataType: ui32
+  OrigDataType: ui32
+T_989: (in fp - 8<32> @ 00000000 : word32)
+  Class: Eq_989
+  DataType: ptr32
+  OrigDataType: ptr32
+T_990: (in fs @ 004019BE : selector)
+  Class: Eq_990
+  DataType: (ptr32 Eq_990)
+  OrigDataType: (ptr32 (segment (0 T_992 t0000)))
+T_991: (in 0<32> @ 004019BE : word32)
+  Class: Eq_991
+  DataType: (memptr (ptr32 Eq_990) ptr32)
+  OrigDataType: (memptr T_990 (struct (0 T_992 t0000)))
+T_992: (in Mem41[fs:0<32>:word32] @ 004019BE : word32)
+  Class: Eq_989
+  DataType: ptr32
+  OrigDataType: word32
+T_993: (in fp + 8<32> @ 00000000 : word32)
+  Class: Eq_962
+  DataType: ptr32
+  OrigDataType: ptr32
+T_994: (in ebx @ 004019C4 : word32)
+  Class: Eq_994
+  DataType: word32
+  OrigDataType: word32
+T_995: (in -16<i32> @ 004019C9 : int32)
+  Class: Eq_995
+  DataType: int32
+  OrigDataType: int32
+T_996: (in ebp + -16<i32> @ 004019C9 : word32)
   Class: Eq_996
   DataType: word32
   OrigDataType: word32
-T_997: (in ebp + 0<32> @ 004019D7 : word32)
+T_997: (in Mem0[ebp + -16<i32>:word32] @ 004019C9 : word32)
   Class: Eq_997
-  DataType: ptr32
-  OrigDataType: ptr32
-T_998: (in Mem8[ebp + 0<32>:word32] @ 004019D7 : word32)
-  Class: Eq_76
-  DataType: Eq_76
-  OrigDataType: word32
-T_999: (in 0<32> @ 004019D8 : word32)
-  Class: Eq_999
   DataType: word32
   OrigDataType: word32
-T_1000: (in ebp + 0<32> @ 004019D8 : word32)
-  Class: Eq_1000
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1001: (in Mem22[ebp + 0<32>:word32] @ 004019D8 : word32)
+T_998: (in fs @ 004019C9 : selector)
+  Class: Eq_998
+  DataType: (ptr32 Eq_998)
+  OrigDataType: (ptr32 (segment (0 T_1000 t0000)))
+T_999: (in 0x00000000<p32> @ 004019C9 : ptr32)
+  Class: Eq_999
+  DataType: Eq_999
+  OrigDataType: (union (ptr32 u0) ((memptr T_998 (struct (0 word32 dw0000))) u1))
+T_1000: (in Mem8[fs:0x00000000<p32>:word32] @ 004019C9 : word32)
+  Class: Eq_997
+  DataType: word32
+  OrigDataType: word32
+T_1001: (in ebp_19 @ 004019D7 : Eq_76)
   Class: Eq_76
   DataType: Eq_76
   OrigDataType: word32
-T_1002: (in dwArg0C @ 004019D9 : word32)
+T_1002: (in 0<32> @ 004019D7 : word32)
+  Class: Eq_1002
+  DataType: word32
+  OrigDataType: word32
+T_1003: (in ebp + 0<32> @ 004019D7 : word32)
+  Class: Eq_1003
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1004: (in Mem8[ebp + 0<32>:word32] @ 004019D7 : word32)
+  Class: Eq_76
+  DataType: Eq_76
+  OrigDataType: word32
+T_1005: (in 0<32> @ 004019D8 : word32)
+  Class: Eq_1005
+  DataType: word32
+  OrigDataType: word32
+T_1006: (in ebp + 0<32> @ 004019D8 : word32)
+  Class: Eq_1006
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1007: (in Mem22[ebp + 0<32>:word32] @ 004019D8 : word32)
+  Class: Eq_76
+  DataType: Eq_76
+  OrigDataType: word32
+T_1008: (in dwArg0C @ 004019D9 : word32)
   Class: Eq_206
   DataType: ptr32
   OrigDataType: word32
-T_1003: (in dwArg08 @ 004019D9 : word32)
+T_1009: (in dwArg08 @ 004019D9 : word32)
   Class: Eq_207
   DataType: ptr32
   OrigDataType: word32
-T_1004: (in dwArg10 @ 004019D9 : word32)
-  Class: Eq_988
+T_1010: (in dwArg10 @ 004019D9 : word32)
+  Class: Eq_994
   DataType: word32
   OrigDataType: word32
-T_1005: (in 0<32> @ 00401A01 : word32)
-  Class: Eq_1005
+T_1011: (in 0<32> @ 00401A01 : word32)
+  Class: Eq_1011
   DataType: word32
   OrigDataType: word32
-T_1006: (in 0040336C @ 00401A01 : ptr32)
-  Class: Eq_1006
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1007 t0000)))
-T_1007: (in Mem9[0x0040336C<p32>:word32] @ 00401A01 : word32)
-  Class: Eq_1005
-  DataType: word32
-  OrigDataType: word32
-T_1008: (in 00403010 @ 00401A0F : ptr32)
-  Class: Eq_1008
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1009 t0000)))
-T_1009: (in Mem14[0x00403010<p32>:word32] @ 00401A0F : word32)
-  Class: Eq_1009
-  DataType: ui32
-  OrigDataType: ui32
-T_1010: (in 1<32> @ 00401A0F : word32)
-  Class: Eq_1010
-  DataType: ui32
-  OrigDataType: ui32
-T_1011: (in g_dw403010 | 1<32> @ 00000000 : word32)
-  Class: Eq_1009
-  DataType: ui32
-  OrigDataType: ui32
-T_1012: (in 00403010 @ 00401A0F : ptr32)
+T_1012: (in 0040336C @ 00401A01 : ptr32)
   Class: Eq_1012
-  DataType: (ptr32 ui32)
+  DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_1013 t0000)))
-T_1013: (in Mem18[0x00403010<p32>:word32] @ 00401A0F : word32)
-  Class: Eq_1009
+T_1013: (in Mem9[0x0040336C<p32>:word32] @ 00401A01 : word32)
+  Class: Eq_1011
+  DataType: word32
+  OrigDataType: word32
+T_1014: (in 00403010 @ 00401A0F : ptr32)
+  Class: Eq_1014
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1015 t0000)))
+T_1015: (in Mem14[0x00403010<p32>:word32] @ 00401A0F : word32)
+  Class: Eq_1015
+  DataType: ui32
+  OrigDataType: ui32
+T_1016: (in 1<32> @ 00401A0F : word32)
+  Class: Eq_1016
+  DataType: ui32
+  OrigDataType: ui32
+T_1017: (in g_dw403010 | 1<32> @ 00000000 : word32)
+  Class: Eq_1015
+  DataType: ui32
+  OrigDataType: ui32
+T_1018: (in 00403010 @ 00401A0F : ptr32)
+  Class: Eq_1018
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1019 t0000)))
+T_1019: (in Mem18[0x00403010<p32>:word32] @ 00401A0F : word32)
+  Class: Eq_1015
   DataType: ui32
   OrigDataType: word32
-T_1014: (in IsProcessorFeaturePresent @ 00401A1E : ptr32)
-  Class: Eq_833
-  DataType: (ptr32 Eq_833)
-  OrigDataType: (ptr32 (fn T_1016 (T_1015)))
-T_1015: (in 0xA<32> @ 00401A1E : word32)
+T_1020: (in IsProcessorFeaturePresent @ 00401A1E : ptr32)
+  Class: Eq_839
+  DataType: (ptr32 Eq_839)
+  OrigDataType: (ptr32 (fn T_1022 (T_1021)))
+T_1021: (in 0xA<32> @ 00401A1E : word32)
   Class: Eq_63
   DataType: int32
   OrigDataType: DWORD
-T_1016: (in IsProcessorFeaturePresent(0xA<32>) @ 00401A1E : BOOL)
+T_1022: (in IsProcessorFeaturePresent(0xA<32>) @ 00401A1E : BOOL)
   Class: Eq_413
   DataType: Eq_413
   OrigDataType: BOOL
-T_1017: (in 0<32> @ 00401A1E : word32)
+T_1023: (in 0<32> @ 00401A1E : word32)
   Class: Eq_413
   DataType: Eq_413
   OrigDataType: word32
-T_1018: (in IsProcessorFeaturePresent(0xA<32>) == 0<32> @ 00000000 : bool)
-  Class: Eq_1018
+T_1024: (in IsProcessorFeaturePresent(0xA<32>) == 0<32> @ 00000000 : bool)
+  Class: Eq_1024
   DataType: bool
   OrigDataType: bool
-T_1019: (in edi_101 @ 00401A24 : ui32)
-  Class: Eq_1019
+T_1025: (in edi_101 @ 00401A24 : ui32)
+  Class: Eq_1025
   DataType: ui32
   OrigDataType: ui32
-T_1020: (in 00403010 @ 00401A2A : ptr32)
-  Class: Eq_1020
+T_1026: (in 00403010 @ 00401A2A : ptr32)
+  Class: Eq_1026
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1021 t0000)))
-T_1021: (in Mem28[0x00403010<p32>:word32] @ 00401A2A : word32)
-  Class: Eq_1009
+  OrigDataType: (ptr32 (struct (0 T_1027 t0000)))
+T_1027: (in Mem28[0x00403010<p32>:word32] @ 00401A2A : word32)
+  Class: Eq_1015
   DataType: ui32
   OrigDataType: ui32
-T_1022: (in 2<32> @ 00401A2A : word32)
-  Class: Eq_1022
+T_1028: (in 2<32> @ 00401A2A : word32)
+  Class: Eq_1028
   DataType: ui32
   OrigDataType: ui32
-T_1023: (in g_dw403010 | 2<32> @ 00000000 : word32)
-  Class: Eq_1009
+T_1029: (in g_dw403010 | 2<32> @ 00000000 : word32)
+  Class: Eq_1015
   DataType: ui32
   OrigDataType: ui32
-T_1024: (in 00403010 @ 00401A2A : ptr32)
-  Class: Eq_1024
+T_1030: (in 00403010 @ 00401A2A : ptr32)
+  Class: Eq_1030
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1025 t0000)))
-T_1025: (in Mem32[0x00403010<p32>:word32] @ 00401A2A : word32)
-  Class: Eq_1009
+  OrigDataType: (ptr32 (struct (0 T_1031 t0000)))
+T_1031: (in Mem32[0x00403010<p32>:word32] @ 00401A2A : word32)
+  Class: Eq_1015
   DataType: ui32
   OrigDataType: word32
-T_1026: (in 1<32> @ 00401A35 : word32)
-  Class: Eq_1005
+T_1032: (in 1<32> @ 00401A35 : word32)
+  Class: Eq_1011
   DataType: word32
   OrigDataType: word32
-T_1027: (in 0040336C @ 00401A35 : ptr32)
-  Class: Eq_1027
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1028 t0000)))
-T_1028: (in Mem41[0x0040336C<p32>:word32] @ 00401A35 : word32)
-  Class: Eq_1005
-  DataType: word32
-  OrigDataType: word32
-T_1029: (in __cpuid @ 00401A3F : ptr32)
-  Class: Eq_1029
-  DataType: (ptr32 Eq_1029)
-  OrigDataType: (ptr32 (fn T_1046 (T_1037, T_1038, T_1040, T_1042, T_1044, T_1045)))
-T_1030: (in signature of __cpuid @ 00000000 : void)
-  Class: Eq_1029
-  DataType: (ptr32 Eq_1029)
-  OrigDataType: 
-T_1031: (in p1 @ 00401A3F : word32)
-  Class: Eq_1031
-  DataType: word32
-  OrigDataType: 
-T_1032: (in p2 @ 00401A3F : word32)
-  Class: Eq_1032
-  DataType: word32
-  OrigDataType: 
-T_1033: (in p3 @ 00401A3F : word32)
+T_1033: (in 0040336C @ 00401A35 : ptr32)
   Class: Eq_1033
   DataType: (ptr32 word32)
-  OrigDataType: 
-T_1034: (in p4 @ 00401A3F : word32)
-  Class: Eq_1034
-  DataType: (ptr32 word32)
-  OrigDataType: 
-T_1035: (in p5 @ 00401A3F : word32)
+  OrigDataType: (ptr32 (struct (0 T_1034 t0000)))
+T_1034: (in Mem41[0x0040336C<p32>:word32] @ 00401A35 : word32)
+  Class: Eq_1011
+  DataType: word32
+  OrigDataType: word32
+T_1035: (in __cpuid @ 00401A3F : ptr32)
   Class: Eq_1035
-  DataType: (ptr32 word32)
+  DataType: (ptr32 Eq_1035)
+  OrigDataType: (ptr32 (fn T_1052 (T_1043, T_1044, T_1046, T_1048, T_1050, T_1051)))
+T_1036: (in signature of __cpuid @ 00000000 : void)
+  Class: Eq_1035
+  DataType: (ptr32 Eq_1035)
   OrigDataType: 
-T_1036: (in p6 @ 00401A3F : word32)
-  Class: Eq_1036
-  DataType: (ptr32 word32)
+T_1037: (in p1 @ 00401A3F : word32)
+  Class: Eq_1037
+  DataType: word32
   OrigDataType: 
-T_1037: (in 0<32> @ 00401A3F : word32)
-  Class: Eq_1031
+T_1038: (in p2 @ 00401A3F : word32)
+  Class: Eq_1038
   DataType: word32
-  OrigDataType: word32
-T_1038: (in 0<32> @ 00401A3F : word32)
-  Class: Eq_1032
-  DataType: word32
-  OrigDataType: word32
-T_1039: (in 0<32> @ 00401A3F : word32)
+  OrigDataType: 
+T_1039: (in p3 @ 00401A3F : word32)
   Class: Eq_1039
-  DataType: word32
-  OrigDataType: word32
-T_1040: (in &0<32> @ 00401A3F : ptr32)
-  Class: Eq_1033
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1041: (in 1<32> @ 00401A3F : word32)
+  OrigDataType: 
+T_1040: (in p4 @ 00401A3F : word32)
+  Class: Eq_1040
+  DataType: (ptr32 word32)
+  OrigDataType: 
+T_1041: (in p5 @ 00401A3F : word32)
   Class: Eq_1041
-  DataType: word32
-  OrigDataType: word32
-T_1042: (in &1<32> @ 00401A3F : ptr32)
-  Class: Eq_1034
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  OrigDataType: 
+T_1042: (in p6 @ 00401A3F : word32)
+  Class: Eq_1042
+  DataType: (ptr32 word32)
+  OrigDataType: 
 T_1043: (in 0<32> @ 00401A3F : word32)
-  Class: Eq_1043
+  Class: Eq_1037
   DataType: word32
   OrigDataType: word32
-T_1044: (in &0<32> @ 00401A3F : ptr32)
-  Class: Eq_1035
+T_1044: (in 0<32> @ 00401A3F : word32)
+  Class: Eq_1038
+  DataType: word32
+  OrigDataType: word32
+T_1045: (in 0<32> @ 00401A3F : word32)
+  Class: Eq_1045
+  DataType: word32
+  OrigDataType: word32
+T_1046: (in &0<32> @ 00401A3F : ptr32)
+  Class: Eq_1039
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_1045: (in &edx @ 00401A3F : ptr32)
-  Class: Eq_1036
+T_1047: (in 1<32> @ 00401A3F : word32)
+  Class: Eq_1047
+  DataType: word32
+  OrigDataType: word32
+T_1048: (in &1<32> @ 00401A3F : ptr32)
+  Class: Eq_1040
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_1046: (in __cpuid(0<32>, 0<32>, &0<32>, &1<32>, &0<32>, &edx) @ 00401A3F : void)
-  Class: Eq_1046
-  DataType: void
-  OrigDataType: void
-T_1047: (in __cpuid @ 00401A79 : ptr32)
-  Class: Eq_1029
-  DataType: (ptr32 Eq_1029)
-  OrigDataType: (ptr32 (fn T_1057 (T_1048, T_1049, T_1051, T_1053, T_1055, T_1056)))
-T_1048: (in 1<32> @ 00401A79 : word32)
-  Class: Eq_1031
+T_1049: (in 0<32> @ 00401A3F : word32)
+  Class: Eq_1049
   DataType: word32
   OrigDataType: word32
-T_1049: (in 0<32> @ 00401A79 : word32)
-  Class: Eq_1032
-  DataType: word32
-  OrigDataType: word32
-T_1050: (in 1<32> @ 00401A79 : word32)
-  Class: Eq_1050
-  DataType: word32
-  OrigDataType: word32
-T_1051: (in &1<32> @ 00401A79 : ptr32)
-  Class: Eq_1033
+T_1050: (in &0<32> @ 00401A3F : ptr32)
+  Class: Eq_1041
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_1052: (in 1<32> @ 00401A79 : word32)
+T_1051: (in &edx @ 00401A3F : ptr32)
+  Class: Eq_1042
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1052: (in __cpuid(0<32>, 0<32>, &0<32>, &1<32>, &0<32>, &edx) @ 00401A3F : void)
   Class: Eq_1052
-  DataType: word32
-  OrigDataType: word32
-T_1053: (in &1<32> @ 00401A79 : ptr32)
-  Class: Eq_1034
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1054: (in 0<32> @ 00401A79 : word32)
-  Class: Eq_1054
-  DataType: word32
-  OrigDataType: word32
-T_1055: (in &0<32> @ 00401A79 : ptr32)
-  Class: Eq_1035
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1056: (in &edx @ 00401A79 : ptr32)
-  Class: Eq_1036
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1057: (in __cpuid(1<32>, 0<32>, &1<32>, &1<32>, &0<32>, &edx) @ 00401A79 : void)
-  Class: Eq_1046
   DataType: void
   OrigDataType: void
-T_1058: (in bLoc14_257 @ 00401A24 : byte)
+T_1053: (in __cpuid @ 00401A79 : ptr32)
+  Class: Eq_1035
+  DataType: (ptr32 Eq_1035)
+  OrigDataType: (ptr32 (fn T_1063 (T_1054, T_1055, T_1057, T_1059, T_1061, T_1062)))
+T_1054: (in 1<32> @ 00401A79 : word32)
+  Class: Eq_1037
+  DataType: word32
+  OrigDataType: word32
+T_1055: (in 0<32> @ 00401A79 : word32)
+  Class: Eq_1038
+  DataType: word32
+  OrigDataType: word32
+T_1056: (in 1<32> @ 00401A79 : word32)
+  Class: Eq_1056
+  DataType: word32
+  OrigDataType: word32
+T_1057: (in &1<32> @ 00401A79 : ptr32)
+  Class: Eq_1039
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1058: (in 1<32> @ 00401A79 : word32)
   Class: Eq_1058
-  DataType: byte
-  OrigDataType: byte
-T_1059: (in 0<8> @ 00401A24 : byte)
-  Class: Eq_1058
-  DataType: byte
-  OrigDataType: byte
-T_1060: (in 0x49656E69<32> @ 00401A89 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_1059: (in &1<32> @ 00401A79 : ptr32)
+  Class: Eq_1040
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1060: (in 0<32> @ 00401A79 : word32)
   Class: Eq_1060
   DataType: word32
   OrigDataType: word32
-T_1061: (in edx ^ 0x49656E69<32> @ 00000000 : word32)
-  Class: Eq_1061
-  DataType: ui32
-  OrigDataType: ui32
-T_1062: (in 0x6C65746E<32> @ 00401A89 : word32)
-  Class: Eq_1062
-  DataType: ui32
-  OrigDataType: ui32
-T_1063: (in edx ^ 0x49656E69<32> | 0x6C65746E<32> @ 00000000 : word32)
-  Class: Eq_1063
-  DataType: ui32
-  OrigDataType: ui32
-T_1064: (in 0x756E6546<32> @ 00401A89 : word32)
+T_1061: (in &0<32> @ 00401A79 : ptr32)
+  Class: Eq_1041
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1062: (in &edx @ 00401A79 : ptr32)
+  Class: Eq_1042
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1063: (in __cpuid(1<32>, 0<32>, &1<32>, &1<32>, &0<32>, &edx) @ 00401A79 : void)
+  Class: Eq_1052
+  DataType: void
+  OrigDataType: void
+T_1064: (in bLoc14_257 @ 00401A24 : byte)
   Class: Eq_1064
-  DataType: ui32
-  OrigDataType: ui32
-T_1065: (in edx ^ 0x49656E69<32> | 0x6C65746E<32> | 0x756E6546<32> @ 00000000 : word32)
-  Class: Eq_1065
-  DataType: ui32
-  OrigDataType: ui32
-T_1066: (in 0<32> @ 00401A89 : word32)
-  Class: Eq_1065
-  DataType: ui32
+  DataType: byte
+  OrigDataType: byte
+T_1065: (in 0<8> @ 00401A24 : byte)
+  Class: Eq_1064
+  DataType: byte
+  OrigDataType: byte
+T_1066: (in 0x49656E69<32> @ 00401A89 : word32)
+  Class: Eq_1066
+  DataType: word32
   OrigDataType: word32
-T_1067: (in (edx ^ 0x49656E69<32> | 0x6C65746E<32> | 0x756E6546<32>) != 0<32> @ 00000000 : bool)
+T_1067: (in edx ^ 0x49656E69<32> @ 00000000 : word32)
   Class: Eq_1067
-  DataType: bool
-  OrigDataType: bool
-T_1068: (in 00403370 @ 00401ACE : ptr32)
+  DataType: ui32
+  OrigDataType: ui32
+T_1068: (in 0x6C65746E<32> @ 00401A89 : word32)
   Class: Eq_1068
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1069 t0000)))
-T_1069: (in Mem81[0x00403370<p32>:word32] @ 00401ACE : word32)
-  Class: Eq_1019
   DataType: ui32
-  OrigDataType: word32
-T_1070: (in false @ 00401A98 : bool)
+  OrigDataType: ui32
+T_1069: (in edx ^ 0x49656E69<32> | 0x6C65746E<32> @ 00000000 : word32)
+  Class: Eq_1069
+  DataType: ui32
+  OrigDataType: ui32
+T_1070: (in 0x756E6546<32> @ 00401A89 : word32)
   Class: Eq_1070
-  DataType: bool
-  OrigDataType: bool
-T_1071: (in edi_100 @ 00401ABD : ui32)
-  Class: Eq_1019
   DataType: ui32
   OrigDataType: ui32
-T_1072: (in 00403370 @ 00401ABD : ptr32)
-  Class: Eq_1072
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1073 t0000)))
-T_1073: (in Mem81[0x00403370<p32>:word32] @ 00401ABD : word32)
-  Class: Eq_1019
+T_1071: (in edx ^ 0x49656E69<32> | 0x6C65746E<32> | 0x756E6546<32> @ 00000000 : word32)
+  Class: Eq_1071
+  DataType: ui32
+  OrigDataType: ui32
+T_1072: (in 0<32> @ 00401A89 : word32)
+  Class: Eq_1071
   DataType: ui32
   OrigDataType: word32
-T_1074: (in 1<32> @ 00401AC6 : word32)
+T_1073: (in (edx ^ 0x49656E69<32> | 0x6C65746E<32> | 0x756E6546<32>) != 0<32> @ 00000000 : bool)
+  Class: Eq_1073
+  DataType: bool
+  OrigDataType: bool
+T_1074: (in 00403370 @ 00401ACE : ptr32)
   Class: Eq_1074
-  DataType: ui32
-  OrigDataType: ui32
-T_1075: (in edi_100 | 1<32> @ 00000000 : word32)
-  Class: Eq_1019
-  DataType: ui32
-  OrigDataType: ui32
-T_1076: (in 00403370 @ 00401AC6 : ptr32)
-  Class: Eq_1076
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1077 t0000)))
-T_1077: (in Mem104[0x00403370<p32>:word32] @ 00401AC6 : word32)
-  Class: Eq_1019
+  OrigDataType: (ptr32 (struct (0 T_1075 t0000)))
+T_1075: (in Mem81[0x00403370<p32>:word32] @ 00401ACE : word32)
+  Class: Eq_1025
   DataType: ui32
   OrigDataType: word32
-T_1078: (in edi_100 | 1<32> @ 00000000 : word32)
-  Class: Eq_1019
+T_1076: (in false @ 00401A98 : bool)
+  Class: Eq_1076
+  DataType: bool
+  OrigDataType: bool
+T_1077: (in edi_100 @ 00401ABD : ui32)
+  Class: Eq_1025
   DataType: ui32
   OrigDataType: ui32
-T_1079: (in false @ 00401A9F : bool)
-  Class: Eq_1079
-  DataType: bool
-  OrigDataType: bool
-T_1080: (in false @ 00401AA6 : bool)
+T_1078: (in 00403370 @ 00401ABD : ptr32)
+  Class: Eq_1078
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1079 t0000)))
+T_1079: (in Mem81[0x00403370<p32>:word32] @ 00401ABD : word32)
+  Class: Eq_1025
+  DataType: ui32
+  OrigDataType: word32
+T_1080: (in 1<32> @ 00401AC6 : word32)
   Class: Eq_1080
-  DataType: bool
-  OrigDataType: bool
-T_1081: (in false @ 00401AAD : bool)
-  Class: Eq_1081
-  DataType: bool
-  OrigDataType: bool
-T_1082: (in false @ 00401AB4 : bool)
+  DataType: ui32
+  OrigDataType: ui32
+T_1081: (in edi_100 | 1<32> @ 00000000 : word32)
+  Class: Eq_1025
+  DataType: ui32
+  OrigDataType: ui32
+T_1082: (in 00403370 @ 00401AC6 : ptr32)
   Class: Eq_1082
-  DataType: bool
-  OrigDataType: bool
-T_1083: (in true @ 00401ABB : bool)
-  Class: Eq_1083
-  DataType: bool
-  OrigDataType: bool
-T_1084: (in true @ 00401AE7 : bool)
-  Class: Eq_1084
-  DataType: bool
-  OrigDataType: bool
-T_1085: (in true @ 00401B22 : bool)
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1083 t0000)))
+T_1083: (in Mem104[0x00403370<p32>:word32] @ 00401AC6 : word32)
+  Class: Eq_1025
+  DataType: ui32
+  OrigDataType: word32
+T_1084: (in edi_100 | 1<32> @ 00000000 : word32)
+  Class: Eq_1025
+  DataType: ui32
+  OrigDataType: ui32
+T_1085: (in false @ 00401A9F : bool)
   Class: Eq_1085
   DataType: bool
   OrigDataType: bool
-T_1086: (in __cpuid @ 00401AEF : ptr32)
-  Class: Eq_1029
-  DataType: (ptr32 Eq_1029)
-  OrigDataType: (ptr32 (fn T_1096 (T_1087, T_1088, T_1090, T_1092, T_1094, T_1095)))
-T_1087: (in 7<32> @ 00401AEF : word32)
-  Class: Eq_1031
-  DataType: word32
-  OrigDataType: word32
-T_1088: (in 0<32> @ 00401AEF : word32)
-  Class: Eq_1032
-  DataType: word32
-  OrigDataType: word32
-T_1089: (in 7<32> @ 00401AEF : word32)
-  Class: Eq_1089
-  DataType: word32
-  OrigDataType: word32
-T_1090: (in &7<32> @ 00401AEF : ptr32)
-  Class: Eq_1033
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1091: (in 1<32> @ 00401AEF : word32)
-  Class: Eq_1091
-  DataType: word32
-  OrigDataType: word32
-T_1092: (in &1<32> @ 00401AEF : ptr32)
-  Class: Eq_1034
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1093: (in 0<32> @ 00401AEF : word32)
-  Class: Eq_1093
-  DataType: word32
-  OrigDataType: word32
-T_1094: (in &0<32> @ 00401AEF : ptr32)
-  Class: Eq_1035
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1095: (in &edx @ 00401AEF : ptr32)
-  Class: Eq_1036
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_1096: (in __cpuid(7<32>, 0<32>, &7<32>, &1<32>, &0<32>, &edx) @ 00401AEF : void)
-  Class: Eq_1046
-  DataType: void
-  OrigDataType: void
-T_1097: (in 1<8> @ 00401B0A : byte)
-  Class: Eq_1058
-  DataType: byte
-  OrigDataType: byte
-T_1098: (in true @ 00401B10 : bool)
-  Class: Eq_1098
+T_1086: (in false @ 00401AA6 : bool)
+  Class: Eq_1086
   DataType: bool
   OrigDataType: bool
-T_1099: (in 2<32> @ 00401B15 : word32)
-  Class: Eq_1099
-  DataType: ui32
-  OrigDataType: ui32
-T_1100: (in edi_101 | 2<32> @ 00000000 : word32)
-  Class: Eq_1019
-  DataType: ui32
-  OrigDataType: ui32
-T_1101: (in 00403370 @ 00401B15 : ptr32)
-  Class: Eq_1101
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1102 t0000)))
-T_1102: (in Mem150[0x00403370<p32>:word32] @ 00401B15 : word32)
-  Class: Eq_1019
-  DataType: ui32
+T_1087: (in false @ 00401AAD : bool)
+  Class: Eq_1087
+  DataType: bool
+  OrigDataType: bool
+T_1088: (in false @ 00401AB4 : bool)
+  Class: Eq_1088
+  DataType: bool
+  OrigDataType: bool
+T_1089: (in true @ 00401ABB : bool)
+  Class: Eq_1089
+  DataType: bool
+  OrigDataType: bool
+T_1090: (in true @ 00401AE7 : bool)
+  Class: Eq_1090
+  DataType: bool
+  OrigDataType: bool
+T_1091: (in true @ 00401B22 : bool)
+  Class: Eq_1091
+  DataType: bool
+  OrigDataType: bool
+T_1092: (in __cpuid @ 00401AEF : ptr32)
+  Class: Eq_1035
+  DataType: (ptr32 Eq_1035)
+  OrigDataType: (ptr32 (fn T_1102 (T_1093, T_1094, T_1096, T_1098, T_1100, T_1101)))
+T_1093: (in 7<32> @ 00401AEF : word32)
+  Class: Eq_1037
+  DataType: word32
   OrigDataType: word32
-T_1103: (in 00403010 @ 00401B24 : ptr32)
-  Class: Eq_1103
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1104 t0000)))
-T_1104: (in Mem152[0x00403010<p32>:word32] @ 00401B24 : word32)
-  Class: Eq_1009
-  DataType: ui32
-  OrigDataType: ui32
-T_1105: (in 4<32> @ 00401B24 : word32)
+T_1094: (in 0<32> @ 00401AEF : word32)
+  Class: Eq_1038
+  DataType: word32
+  OrigDataType: word32
+T_1095: (in 7<32> @ 00401AEF : word32)
+  Class: Eq_1095
+  DataType: word32
+  OrigDataType: word32
+T_1096: (in &7<32> @ 00401AEF : ptr32)
+  Class: Eq_1039
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1097: (in 1<32> @ 00401AEF : word32)
+  Class: Eq_1097
+  DataType: word32
+  OrigDataType: word32
+T_1098: (in &1<32> @ 00401AEF : ptr32)
+  Class: Eq_1040
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1099: (in 0<32> @ 00401AEF : word32)
+  Class: Eq_1099
+  DataType: word32
+  OrigDataType: word32
+T_1100: (in &0<32> @ 00401AEF : ptr32)
+  Class: Eq_1041
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1101: (in &edx @ 00401AEF : ptr32)
+  Class: Eq_1042
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_1102: (in __cpuid(7<32>, 0<32>, &7<32>, &1<32>, &0<32>, &edx) @ 00401AEF : void)
+  Class: Eq_1052
+  DataType: void
+  OrigDataType: void
+T_1103: (in 1<8> @ 00401B0A : byte)
+  Class: Eq_1064
+  DataType: byte
+  OrigDataType: byte
+T_1104: (in true @ 00401B10 : bool)
+  Class: Eq_1104
+  DataType: bool
+  OrigDataType: bool
+T_1105: (in 2<32> @ 00401B15 : word32)
   Class: Eq_1105
   DataType: ui32
   OrigDataType: ui32
-T_1106: (in g_dw403010 | 4<32> @ 00000000 : word32)
-  Class: Eq_1009
+T_1106: (in edi_101 | 2<32> @ 00000000 : word32)
+  Class: Eq_1025
   DataType: ui32
   OrigDataType: ui32
-T_1107: (in 00403010 @ 00401B24 : ptr32)
+T_1107: (in 00403370 @ 00401B15 : ptr32)
   Class: Eq_1107
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 (struct (0 T_1108 t0000)))
-T_1108: (in Mem162[0x00403010<p32>:word32] @ 00401B24 : word32)
-  Class: Eq_1009
+T_1108: (in Mem150[0x00403370<p32>:word32] @ 00401B15 : word32)
+  Class: Eq_1025
   DataType: ui32
   OrigDataType: word32
-T_1109: (in 2<32> @ 00401B2B : word32)
-  Class: Eq_1005
-  DataType: word32
-  OrigDataType: word32
-T_1110: (in 0040336C @ 00401B2B : ptr32)
-  Class: Eq_1110
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1111 t0000)))
-T_1111: (in Mem164[0x0040336C<p32>:word32] @ 00401B2B : word32)
-  Class: Eq_1005
-  DataType: word32
-  OrigDataType: word32
-T_1112: (in true @ 00401B3A : bool)
-  Class: Eq_1112
-  DataType: bool
-  OrigDataType: bool
-T_1113: (in true @ 00401B41 : bool)
+T_1109: (in 00403010 @ 00401B24 : ptr32)
+  Class: Eq_1109
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1110 t0000)))
+T_1110: (in Mem152[0x00403010<p32>:word32] @ 00401B24 : word32)
+  Class: Eq_1015
+  DataType: ui32
+  OrigDataType: ui32
+T_1111: (in 4<32> @ 00401B24 : word32)
+  Class: Eq_1111
+  DataType: ui32
+  OrigDataType: ui32
+T_1112: (in g_dw403010 | 4<32> @ 00000000 : word32)
+  Class: Eq_1015
+  DataType: ui32
+  OrigDataType: ui32
+T_1113: (in 00403010 @ 00401B24 : ptr32)
   Class: Eq_1113
-  DataType: bool
-  OrigDataType: bool
-T_1114: (in __xgetbv @ 00401B5C : ptr32)
-  Class: Eq_1114
-  DataType: (ptr32 Eq_1114)
-  OrigDataType: (ptr32 (fn T_1118 (T_1117)))
-T_1115: (in signature of __xgetbv @ 00000000 : void)
-  Class: Eq_1114
-  DataType: (ptr32 Eq_1114)
-  OrigDataType: 
-T_1116: (in p1 @ 00401B5C : word32)
-  Class: Eq_1116
-  DataType: word32
-  OrigDataType: 
-T_1117: (in 0<32> @ 00401B5C : word32)
-  Class: Eq_1116
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1114 t0000)))
+T_1114: (in Mem162[0x00403010<p32>:word32] @ 00401B24 : word32)
+  Class: Eq_1015
+  DataType: ui32
+  OrigDataType: word32
+T_1115: (in 2<32> @ 00401B2B : word32)
+  Class: Eq_1011
   DataType: word32
   OrigDataType: word32
-T_1118: (in __xgetbv(0<32>) @ 00401B5C : word64)
+T_1116: (in 0040336C @ 00401B2B : ptr32)
+  Class: Eq_1116
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_1117 t0000)))
+T_1117: (in Mem164[0x0040336C<p32>:word32] @ 00401B2B : word32)
+  Class: Eq_1011
+  DataType: word32
+  OrigDataType: word32
+T_1118: (in true @ 00401B3A : bool)
   Class: Eq_1118
+  DataType: bool
+  OrigDataType: bool
+T_1119: (in true @ 00401B41 : bool)
+  Class: Eq_1119
+  DataType: bool
+  OrigDataType: bool
+T_1120: (in __xgetbv @ 00401B5C : ptr32)
+  Class: Eq_1120
+  DataType: (ptr32 Eq_1120)
+  OrigDataType: (ptr32 (fn T_1124 (T_1123)))
+T_1121: (in signature of __xgetbv @ 00000000 : void)
+  Class: Eq_1120
+  DataType: (ptr32 Eq_1120)
+  OrigDataType: 
+T_1122: (in p1 @ 00401B5C : word32)
+  Class: Eq_1122
+  DataType: word32
+  OrigDataType: 
+T_1123: (in 0<32> @ 00401B5C : word32)
+  Class: Eq_1122
+  DataType: word32
+  OrigDataType: word32
+T_1124: (in __xgetbv(0<32>) @ 00401B5C : word64)
+  Class: Eq_1124
   DataType: word64
   OrigDataType: word64
-T_1119: (in SLICE(__xgetbv(0<32>), word32, 0) @ 00401B5C : word32)
-  Class: Eq_1119
+T_1125: (in SLICE(__xgetbv(0<32>), word32, 0) @ 00401B5C : word32)
+  Class: Eq_1125
   DataType: ui32
   OrigDataType: ui32
-T_1120: (in 6<32> @ 00401B5C : word32)
-  Class: Eq_1120
-  DataType: ui32
-  OrigDataType: ui32
-T_1121: (in (word32) __xgetbv(0<32>) & 6<32> @ 00000000 : word32)
-  Class: Eq_1121
-  DataType: ui32
-  OrigDataType: ui32
-T_1122: (in 6<32> @ 00401B5C : word32)
-  Class: Eq_1121
-  DataType: ui32
-  OrigDataType: word32
-T_1123: (in ((word32) __xgetbv(0<32>) & 6<32>) != 6<32> @ 00000000 : bool)
-  Class: Eq_1123
-  DataType: bool
-  OrigDataType: bool
-T_1124: (in false @ 00401B60 : bool)
-  Class: Eq_1124
-  DataType: bool
-  OrigDataType: bool
-T_1125: (in eax_187 @ 00401B62 : ui32)
-  Class: Eq_1009
-  DataType: ui32
-  OrigDataType: ui32
-T_1126: (in 00403010 @ 00401B62 : ptr32)
+T_1126: (in 6<32> @ 00401B5C : word32)
   Class: Eq_1126
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1127 t0000)))
-T_1127: (in Mem177[0x00403010<p32>:word32] @ 00401B62 : word32)
-  Class: Eq_1009
+  DataType: ui32
+  OrigDataType: ui32
+T_1127: (in (word32) __xgetbv(0<32>) & 6<32> @ 00000000 : word32)
+  Class: Eq_1127
+  DataType: ui32
+  OrigDataType: ui32
+T_1128: (in 6<32> @ 00401B5C : word32)
+  Class: Eq_1127
   DataType: ui32
   OrigDataType: word32
-T_1128: (in 3<32> @ 00401B6A : word32)
-  Class: Eq_1005
-  DataType: word32
-  OrigDataType: word32
-T_1129: (in 0040336C @ 00401B6A : ptr32)
+T_1129: (in ((word32) __xgetbv(0<32>) & 6<32>) != 6<32> @ 00000000 : bool)
   Class: Eq_1129
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1130 t0000)))
-T_1130: (in Mem189[0x0040336C<p32>:word32] @ 00401B6A : word32)
-  Class: Eq_1005
-  DataType: word32
-  OrigDataType: word32
-T_1131: (in 8<32> @ 00401B78 : word32)
-  Class: Eq_1131
-  DataType: ui32
-  OrigDataType: ui32
-T_1132: (in eax_187 | 8<32> @ 00000000 : word32)
-  Class: Eq_1009
-  DataType: ui32
-  OrigDataType: ui32
-T_1133: (in 00403010 @ 00401B78 : ptr32)
-  Class: Eq_1133
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1134 t0000)))
-T_1134: (in Mem192[0x00403010<p32>:word32] @ 00401B78 : word32)
-  Class: Eq_1009
-  DataType: ui32
-  OrigDataType: word32
-T_1135: (in 0x20<8> @ 00401B7D : byte)
-  Class: Eq_1135
-  DataType: byte
-  OrigDataType: byte
-T_1136: (in bLoc14_257 & 0x20<8> @ 00000000 : byte)
-  Class: Eq_1136
-  DataType: byte
-  OrigDataType: byte
-T_1137: (in 0<8> @ 00401B7D : byte)
-  Class: Eq_1136
-  DataType: byte
-  OrigDataType: byte
-T_1138: (in (bLoc14_257 & 0x20<8>) == 0<8> @ 00000000 : bool)
-  Class: Eq_1138
   DataType: bool
   OrigDataType: bool
-T_1139: (in 5<32> @ 00401B82 : word32)
-  Class: Eq_1005
-  DataType: word32
-  OrigDataType: word32
-T_1140: (in 0040336C @ 00401B82 : ptr32)
-  Class: Eq_1140
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1141 t0000)))
-T_1141: (in Mem197[0x0040336C<p32>:word32] @ 00401B82 : word32)
-  Class: Eq_1005
-  DataType: word32
-  OrigDataType: word32
-T_1142: (in eax_187 | 8<32> @ 00000000 : word32)
-  Class: Eq_1142
+T_1130: (in false @ 00401B60 : bool)
+  Class: Eq_1130
+  DataType: bool
+  OrigDataType: bool
+T_1131: (in eax_187 @ 00401B62 : ui32)
+  Class: Eq_1015
   DataType: ui32
   OrigDataType: ui32
-T_1143: (in 0x20<32> @ 00401B8C : word32)
-  Class: Eq_1143
-  DataType: ui32
-  OrigDataType: ui32
-T_1144: (in eax_187 | 8<32> | 0x20<32> @ 00000000 : word32)
-  Class: Eq_1009
-  DataType: ui32
-  OrigDataType: ui32
-T_1145: (in 00403010 @ 00401B8C : ptr32)
-  Class: Eq_1145
+T_1132: (in 00403010 @ 00401B62 : ptr32)
+  Class: Eq_1132
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1146 t0000)))
-T_1146: (in Mem198[0x00403010<p32>:word32] @ 00401B8C : word32)
-  Class: Eq_1009
+  OrigDataType: (ptr32 (struct (0 T_1133 t0000)))
+T_1133: (in Mem177[0x00403010<p32>:word32] @ 00401B62 : word32)
+  Class: Eq_1015
   DataType: ui32
   OrigDataType: word32
-T_1147: (in eax @ 00401B8C : uint32)
-  Class: Eq_1147
+T_1134: (in 3<32> @ 00401B6A : word32)
+  Class: Eq_1011
+  DataType: word32
+  OrigDataType: word32
+T_1135: (in 0040336C @ 00401B6A : ptr32)
+  Class: Eq_1135
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_1136 t0000)))
+T_1136: (in Mem189[0x0040336C<p32>:word32] @ 00401B6A : word32)
+  Class: Eq_1011
+  DataType: word32
+  OrigDataType: word32
+T_1137: (in 8<32> @ 00401B78 : word32)
+  Class: Eq_1137
+  DataType: ui32
+  OrigDataType: ui32
+T_1138: (in eax_187 | 8<32> @ 00000000 : word32)
+  Class: Eq_1015
+  DataType: ui32
+  OrigDataType: ui32
+T_1139: (in 00403010 @ 00401B78 : ptr32)
+  Class: Eq_1139
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1140 t0000)))
+T_1140: (in Mem192[0x00403010<p32>:word32] @ 00401B78 : word32)
+  Class: Eq_1015
+  DataType: ui32
+  OrigDataType: word32
+T_1141: (in 0x20<8> @ 00401B7D : byte)
+  Class: Eq_1141
+  DataType: byte
+  OrigDataType: byte
+T_1142: (in bLoc14_257 & 0x20<8> @ 00000000 : byte)
+  Class: Eq_1142
+  DataType: byte
+  OrigDataType: byte
+T_1143: (in 0<8> @ 00401B7D : byte)
+  Class: Eq_1142
+  DataType: byte
+  OrigDataType: byte
+T_1144: (in (bLoc14_257 & 0x20<8>) == 0<8> @ 00000000 : bool)
+  Class: Eq_1144
+  DataType: bool
+  OrigDataType: bool
+T_1145: (in 5<32> @ 00401B82 : word32)
+  Class: Eq_1011
+  DataType: word32
+  OrigDataType: word32
+T_1146: (in 0040336C @ 00401B82 : ptr32)
+  Class: Eq_1146
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_1147 t0000)))
+T_1147: (in Mem197[0x0040336C<p32>:word32] @ 00401B82 : word32)
+  Class: Eq_1011
+  DataType: word32
+  OrigDataType: word32
+T_1148: (in eax_187 | 8<32> @ 00000000 : word32)
+  Class: Eq_1148
+  DataType: ui32
+  OrigDataType: ui32
+T_1149: (in 0x20<32> @ 00401B8C : word32)
+  Class: Eq_1149
+  DataType: ui32
+  OrigDataType: ui32
+T_1150: (in eax_187 | 8<32> | 0x20<32> @ 00000000 : word32)
+  Class: Eq_1015
+  DataType: ui32
+  OrigDataType: ui32
+T_1151: (in 00403010 @ 00401B8C : ptr32)
+  Class: Eq_1151
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1152 t0000)))
+T_1152: (in Mem198[0x00403010<p32>:word32] @ 00401B8C : word32)
+  Class: Eq_1015
+  DataType: ui32
+  OrigDataType: word32
+T_1153: (in eax @ 00401B8C : uint32)
+  Class: Eq_1153
   DataType: uint32
   OrigDataType: word32
-T_1148: (in 00403014 @ 00401BA3 : ptr32)
-  Class: Eq_1148
+T_1154: (in 00403014 @ 00401BA3 : ptr32)
+  Class: Eq_1154
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_1149 t0000)))
-T_1149: (in Mem0[0x00403014<p32>:word32] @ 00401BA3 : word32)
-  Class: Eq_1149
+  OrigDataType: (ptr32 (struct (0 T_1155 t0000)))
+T_1155: (in Mem0[0x00403014<p32>:word32] @ 00401BA3 : word32)
+  Class: Eq_1155
   DataType: word32
   OrigDataType: word32
-T_1150: (in 0<32> @ 00401BA3 : word32)
-  Class: Eq_1149
+T_1156: (in 0<32> @ 00401BA3 : word32)
+  Class: Eq_1155
   DataType: word32
   OrigDataType: word32
-T_1151: (in g_dw403014 != 0<32> @ 00000000 : bool)
-  Class: Eq_1151
+T_1157: (in g_dw403014 != 0<32> @ 00000000 : bool)
+  Class: Eq_1157
   DataType: bool
   OrigDataType: bool
-T_1152: (in CONVERT(Mem0[0x00403014<p32>:word32] != 0<32>, bool, int8) @ 00401BA3 : int8)
-  Class: Eq_1152
+T_1158: (in CONVERT(Mem0[0x00403014<p32>:word32] != 0<32>, bool, int8) @ 00401BA3 : int8)
+  Class: Eq_1158
   DataType: int8
   OrigDataType: int8
-T_1153: (in CONVERT(CONVERT(Mem0[0x00403014<p32>:word32] != 0<32>, bool, int8), int8, uint32) @ 00401BA3 : uint32)
-  Class: Eq_1147
+T_1159: (in CONVERT(CONVERT(Mem0[0x00403014<p32>:word32] != 0<32>, bool, int8), int8, uint32) @ 00401BA3 : uint32)
+  Class: Eq_1153
   DataType: uint32
   OrigDataType: uint32
-T_1154: (in al @ 00401BA4 : byte)
-  Class: Eq_1154
-  DataType: byte
-  OrigDataType: byte
-T_1155: (in 1<8> @ 00401C4A : byte)
-  Class: Eq_1154
-  DataType: byte
-  OrigDataType: byte
-T_1156:
-  Class: Eq_1156
-  DataType: word32
-  OrigDataType: word32
-T_1157:
-  Class: Eq_1157
-  DataType: word32
-  OrigDataType: word32
-T_1158:
-  Class: Eq_1158
-  DataType: word32
-  OrigDataType: word32
-T_1159:
-  Class: Eq_1159
-  DataType: word32
-  OrigDataType: word32
-T_1160:
+T_1160: (in al @ 00401BA4 : byte)
   Class: Eq_1160
-  DataType: word32
-  OrigDataType: word32
-T_1161:
-  Class: Eq_1161
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
+T_1161: (in 1<8> @ 00401C4A : byte)
+  Class: Eq_1160
+  DataType: byte
+  OrigDataType: byte
 T_1162:
   Class: Eq_1162
   DataType: word32
@@ -5372,14 +5378,38 @@ T_1199:
 T_1200:
   Class: Eq_1200
   DataType: word32
-  OrigDataType: (struct 0004 (0 T_951 t0000))
+  OrigDataType: word32
 T_1201:
   Class: Eq_1201
-  DataType: (arr word32 1)
-  OrigDataType: (arr T_1200 1)
+  DataType: word32
+  OrigDataType: word32
 T_1202:
   Class: Eq_1202
-  DataType: Eq_1202
+  DataType: word32
+  OrigDataType: word32
+T_1203:
+  Class: Eq_1203
+  DataType: word32
+  OrigDataType: word32
+T_1204:
+  Class: Eq_1204
+  DataType: word32
+  OrigDataType: word32
+T_1205:
+  Class: Eq_1205
+  DataType: word32
+  OrigDataType: word32
+T_1206:
+  Class: Eq_1206
+  DataType: word32
+  OrigDataType: (struct 0004 (0 T_957 t0000))
+T_1207:
+  Class: Eq_1207
+  DataType: (arr word32 1)
+  OrigDataType: (arr T_1206 1)
+T_1208:
+  Class: Eq_1208
+  DataType: Eq_1208
   OrigDataType: 
 */
 typedef Eq_1struct _EXCEPTION_POINTERS;
@@ -5551,7 +5581,7 @@ typedef Eq_70 * (Eq_71)(word32, Eq_74, Eq_74, Eq_76, ui32);
 
 typedef union Eq_74 {
 	byte u0;
-	struct Eq_1202 * u1;
+	struct Eq_1208 * u1;
 } Eq_74;
 
 typedef union Eq_76 {
@@ -5748,87 +5778,96 @@ typedef BOOL (Eq_732)(LARGE_INTEGER *);
 
 typedef LARGE_INTEGER Eq_734;
 
-typedef void (Eq_770)(PSLIST_HEADER);
+typedef LARGE_INTEGER Eq_735;
 
-typedef PSLIST_HEADER Eq_772;
+typedef struct Eq_739 {
+	LARGE_INTEGER t0000;	// 0
+	word32 dw0004;	// 4
+} Eq_739;
 
-typedef word32 (Eq_775)(word32, word32, word32);
+typedef LARGE_INTEGER Eq_743;
 
-typedef Eq_790 * (Eq_788)();
+typedef void (Eq_776)(PSLIST_HEADER);
 
-typedef struct Eq_790 {
+typedef PSLIST_HEADER Eq_778;
+
+typedef word32 (Eq_781)(word32, word32, word32);
+
+typedef Eq_796 * (Eq_794)();
+
+typedef struct Eq_796 {
 	ui32 dw0000;	// 0
 	word32 dw0004;	// 4
-} Eq_790;
+} Eq_796;
 
-typedef BOOL (Eq_833)(Eq_63);
+typedef BOOL (Eq_839)(Eq_63);
 
-typedef void (Eq_843)(void, int32, size_t);
+typedef void (Eq_849)(void, int32, size_t);
 
-typedef size_t Eq_847;
+typedef size_t Eq_853;
 
-typedef BOOL (Eq_862)();
+typedef BOOL (Eq_868)();
 
-typedef union Eq_866 {
+typedef union Eq_872 {
 	bool u0;
 	byte u1;
-} Eq_866;
+} Eq_872;
 
-typedef void (Eq_877)(word32);
+typedef void (Eq_883)(word32);
 
-typedef union Eq_888 {
+typedef union Eq_894 {
 	bool u0;
 	ui32 u1;
-} Eq_888;
+} Eq_894;
 
-typedef HMODULE Eq_894;
+typedef HMODULE Eq_900;
 
-typedef HMODULE (Eq_895)(LPCWSTR);
+typedef HMODULE (Eq_901)(LPCWSTR);
 
-typedef LPCWSTR Eq_897;
+typedef LPCWSTR Eq_903;
 
-typedef union Eq_904 {
+typedef union Eq_910 {
 	int32 u0;
 	word16 u1;
-} Eq_904;
+} Eq_910;
 
-typedef struct Eq_908 {
+typedef struct Eq_914 {
 	word32 dw0000;	// 0
 	word16 w0018;	// 18
 	up32 dw0074;	// 74
 	word32 dw00E8;	// E8
-} Eq_908;
+} Eq_914;
 
-typedef HMODULE Eq_910;
+typedef HMODULE Eq_916;
 
-typedef void (Eq_946)();
+typedef void (Eq_952)();
 
-typedef struct Eq_957 {
+typedef struct Eq_963 {
 	Eq_76 tFFFFFFEC;	// FFFFFFEC
 	ui32 dwFFFFFFF0;	// FFFFFFF0
 	Eq_74 tFFFFFFF4;	// FFFFFFF4
 	Eq_74 tFFFFFFF8;	// FFFFFFF8
 	word32 dwFFFFFFFC;	// FFFFFFFC
-} Eq_957;
+} Eq_963;
 
-typedef struct Eq_984 {
+typedef struct Eq_990 {
 	ptr32 ptr0000;	// 0
-} Eq_984;
+} Eq_990;
 
-typedef struct Eq_992 {
+typedef struct Eq_998 {
 	word32 dw0000;	// 0
-} Eq_992;
+} Eq_998;
 
-typedef union Eq_993 {
+typedef union Eq_999 {
 	ptr32 u0;
-	word32 Eq_992::* u1;
-} Eq_993;
+	word32 Eq_998::* u1;
+} Eq_999;
 
-typedef void (Eq_1029)(word32, word32, word32 *, word32 *, word32 *, word32 *);
+typedef void (Eq_1035)(word32, word32, word32 *, word32 *, word32 *, word32 *);
 
-typedef word64 (Eq_1114)(word32);
+typedef word64 (Eq_1120)(word32);
 
-typedef struct Eq_1202 {
+typedef struct Eq_1208 {
 	Eq_74 t0000;	// 0
-} Eq_1202;
+} Eq_1208;
 

--- a/subjects/PE/x86/ExeDll/Executable.reko/Executable_text.c
+++ b/subjects/PE/x86/ExeDll/Executable.reko/Executable_text.c
@@ -348,8 +348,8 @@ void fn00401663()
 	{
 		GetSystemTimeAsFileTime(fp - 0x10);
 		ui32 v14_n = GetCurrentThreadId() ^ GetCurrentProcessId();
-		QueryPerformanceCounter(fp - 0x18);
-		Eq_n ecx_n = dwLoc14 ^ dwLoc18 ^ v14_n ^ fp - 0x08;
+		QueryPerformanceCounter(&tLoc18);
+		Eq_n ecx_n = tLoc18.dw0004 ^ tLoc18 ^ v14_n ^ fp - 0x08;
 		if (ecx_n == 0xBB40E64E)
 			ecx_n.u0 = ~0x44BF19B0;
 		else if ((ecx_n & 0xFFFF0000) == 0x00)

--- a/subjects/PE/x86/ExeDll/Executable.reko/Executable_text.dis
+++ b/subjects/PE/x86/ExeDll/Executable.reko/Executable_text.dis
@@ -476,8 +476,8 @@ l00401686:
 l00401693:
 	GetSystemTimeAsFileTime(fp - 0x10<32>)
 	word32 v14_43 = GetCurrentThreadId() ^ GetCurrentProcessId()
-	QueryPerformanceCounter(fp - 0x18<32>)
-	word32 ecx_55 = dwLoc14 ^ dwLoc18 ^ v14_43 ^ fp - 8<32>
+	QueryPerformanceCounter(&tLoc18)
+	word32 ecx_55 = Mem48[&tLoc18 + 4<i32>:word32] ^ Mem48[&tLoc18:word32] ^ v14_43 ^ fp - 8<32>
 	branch ecx_55 != 0xBB40E64E<32> l004016DB
 l004016DB:
 	branch (ecx_55 & 0xFFFF0000<32>) != 0<32> l004016EB

--- a/subjects/PE/x86/import-ordinals/main.h
+++ b/subjects/PE/x86/import-ordinals/main.h
@@ -152,9 +152,9 @@ Eq_89: (union "Eq_89" (int32 u0) (DWORD u1))
 	T_393 (in Mem293[esp_228 + -4<i32>:int32] @ 00401262 : int32)
 	T_632 (in GetCurrentThreadId() @ 004016B0 : DWORD)
 	T_635 (in GetCurrentProcessId() @ 004016B0 : DWORD)
-	T_681 (in ProcessorFeature @ 00401781 : DWORD)
-	T_682 (in 0x17<32> @ 00401781 : word32)
-	T_845 (in 0xA<32> @ 00401A1E : word32)
+	T_687 (in ProcessorFeature @ 00401781 : DWORD)
+	T_688 (in 0x17<32> @ 00401781 : word32)
+	T_851 (in 0xA<32> @ 00401A1E : word32)
 Eq_93: (fn void ())
 	T_93 (in fn0040165E @ 004012C9 : ptr32)
 	T_94 (in signature of fn0040165E @ 0040165E : void)
@@ -169,7 +169,7 @@ Eq_97: (fn (ptr32 Eq_96) (word32, Eq_100, Eq_100, Eq_102, ui32))
 	T_97 (in fn00401980 @ 00401161 : ptr32)
 	T_98 (in signature of fn00401980 @ 00401980 : void)
 	T_526 (in fn00401980 @ 00401546 : ptr32)
-Eq_100: (union "Eq_100" (byte u0) ((ptr32 Eq_1031) u1))
+Eq_100: (union "Eq_100" (byte u0) ((ptr32 Eq_1037) u1))
 	T_100 (in esi @ 00401161 : Eq_100)
 	T_101 (in edi @ 00401161 : Eq_100)
 	T_104 (in esi @ 00401161 : word32)
@@ -197,8 +197,8 @@ Eq_100: (union "Eq_100" (byte u0) ((ptr32 Eq_1031) u1))
 	T_314 (in Mem153[esp_107 + -8<i32>:word32] @ 0040120C : word32)
 	T_364 (in Mem173[esp_116 + -4<i32>:word32] @ 00401223 : word32)
 	T_602 (in 0<8> @ 004015D9 : byte)
-	T_797 (in Mem20[esp_14 + -8<i32>:word32] @ 0040199B : word32)
-	T_800 (in Mem23[esp_14 + -12<i32>:word32] @ 0040199C : word32)
+	T_803 (in Mem20[esp_14 + -8<i32>:word32] @ 0040199B : word32)
+	T_806 (in Mem23[esp_14 + -12<i32>:word32] @ 0040199C : word32)
 Eq_102: (union "Eq_102" (ui32 u0) (ptr32 u1))
 	T_102 (in dwArg00 @ 00401161 : Eq_102)
 	T_106 (in dwLoc0C @ 00401161 : word32)
@@ -209,10 +209,10 @@ Eq_102: (union "Eq_102" (ui32 u0) (ptr32 u1))
 	T_527 (in dwLoc0C @ 00401546 : word32)
 	T_573 (in eax_32 - 0x00400000<p32> @ 00000000 : word32)
 	T_593 (in out ebp_69 @ 004015C3 : ptr32)
-	T_811 (in Mem36[esp_14 + -20<i32>:word32] @ 004019AB : word32)
-	T_825 (in ebp_19 @ 004019D7 : Eq_102)
-	T_828 (in Mem8[ebp + 0<32>:word32] @ 004019D7 : word32)
-	T_831 (in Mem22[ebp + 0<32>:word32] @ 004019D8 : word32)
+	T_817 (in Mem36[esp_14 + -20<i32>:word32] @ 004019AB : word32)
+	T_831 (in ebp_19 @ 004019D7 : Eq_102)
+	T_834 (in Mem8[ebp + 0<32>:word32] @ 004019D7 : word32)
+	T_837 (in Mem22[ebp + 0<32>:word32] @ 004019D8 : word32)
 Eq_113: (fn byte (word32, word32))
 	T_113 (in fn0040146F @ 00401170 : ptr32)
 	T_114 (in signature of fn0040146F @ 0040146F : void)
@@ -391,90 +391,96 @@ Eq_637: (fn Eq_642 ((ptr32 Eq_639)))
 	T_638 (in signature of QueryPerformanceCounter @ 00000000 : void)
 Eq_639: LARGE_INTEGER
 	T_639 (in lpPerformanceCount @ 004016B7 : (ptr32 LARGE_INTEGER))
-	T_641 (in fp - 0x18<32> @ 00000000 : word32)
+	T_641 (in &tLoc18 @ 004016B7 : (ptr32 LARGE_INTEGER))
+Eq_640: LARGE_INTEGER
+	T_640 (in tLoc18 @ 004016B7 : LARGE_INTEGER)
 Eq_642: BOOL
-	T_642 (in QueryPerformanceCounter(fp - 0x18<32>) @ 004016B7 : BOOL)
-	T_683 (in IsProcessorFeaturePresent(0x17<32>) @ 00401781 : BOOL)
-	T_684 (in 0<32> @ 00401781 : word32)
-	T_710 (in IsDebuggerPresent() @ 0040185A : BOOL)
-	T_711 (in 1<32> @ 0040185A : word32)
-	T_846 (in IsProcessorFeaturePresent(0xA<32>) @ 00401A1E : BOOL)
-	T_847 (in 0<32> @ 00401A1E : word32)
-Eq_679: (fn Eq_642 (Eq_89))
-	T_679 (in IsProcessorFeaturePresent @ 00401781 : ptr32)
-	T_680 (in signature of IsProcessorFeaturePresent @ 00000000 : void)
-	T_844 (in IsProcessorFeaturePresent @ 00401A1E : ptr32)
-Eq_689: (fn (ptr32 void) ((ptr32 void), int32, Eq_693))
-	T_689 (in memset @ 0040179D : ptr32)
-	T_690 (in signature of memset @ 00000000 : void)
-	T_700 (in memset @ 00401826 : ptr32)
-Eq_693: size_t
-	T_693 (in _Size @ 0040179D : size_t)
-	T_698 (in 0x2CC<32> @ 0040179D : word32)
-	T_704 (in 0x50<32> @ 00401826 : word32)
-Eq_708: (fn Eq_642 ())
-	T_708 (in IsDebuggerPresent @ 0040185A : ptr32)
-	T_709 (in signature of IsDebuggerPresent @ 00000000 : void)
-Eq_712: (union "Eq_712" (bool u0) (byte u1))
-	T_712 (in IsDebuggerPresent() != 1<32> @ 00000000 : bool)
-Eq_714: (fn Eq_716 (Eq_716))
-	T_714 (in SetUnhandledExceptionFilter @ 00401861 : ptr32)
-	T_715 (in signature of SetUnhandledExceptionFilter @ 00000000 : void)
-Eq_716: LPTOP_LEVEL_EXCEPTION_FILTER
-	T_716 (in lpTopLevelExceptionFilter @ 00401861 : LPTOP_LEVEL_EXCEPTION_FILTER)
-	T_717 (in 0<32> @ 00401861 : word32)
-	T_718 (in SetUnhandledExceptionFilter(null) @ 00401861 : LPTOP_LEVEL_EXCEPTION_FILTER)
-Eq_719: (fn Eq_724 ((ptr32 Eq_721)))
-	T_719 (in UnhandledExceptionFilter @ 00401873 : ptr32)
-	T_720 (in signature of UnhandledExceptionFilter @ 00000000 : void)
-Eq_721: (struct "_EXCEPTION_POINTERS" (0 PEXCEPTION_RECORD ExceptionRecord) (4 PCONTEXT ContextRecord))
-	T_721 (in ExceptionInfo @ 00401873 : (ptr32 (struct "_EXCEPTION_POINTERS")))
-	T_723 (in fp - 0xC<32> @ 00000000 : word32)
-Eq_724: LONG
-	T_724 (in UnhandledExceptionFilter(fp - 0xC<32>) @ 00401873 : LONG)
-	T_725 (in 0<32> @ 00401873 : word32)
-Eq_727: (fn void (word32))
-	T_727 (in __fastfail @ 00401786 : ptr32)
-	T_728 (in signature of __fastfail @ 00000000 : void)
-Eq_738: (union "Eq_738" (bool u0) (ui32 u1))
-	T_738 (in (word32) (bl_90 + 1<8>) != 0<32> @ 00000000 : bool)
-Eq_744: HMODULE
-	T_744 (in eax_6 @ 0040188D : Eq_744)
-	T_749 (in GetModuleHandleW(null) @ 0040188D : HMODULE)
-	T_750 (in 0<32> @ 00401897 : word32)
-Eq_745: (fn Eq_744 (Eq_747))
-	T_745 (in GetModuleHandleW @ 0040188D : ptr32)
-	T_746 (in signature of GetModuleHandleW @ 00000000 : void)
-Eq_747: LPCWSTR
-	T_747 (in lpModuleName @ 0040188D : LPCWSTR)
-	T_748 (in 0<32> @ 0040188D : word32)
-Eq_754: (union "Eq_754" (int32 u0) (word16 u1))
-	T_754 (in Mem5[eax_6 + 0<32>:word16] @ 004018A4 : word16)
-	T_755 (in 0x5A4D<16> @ 004018A4 : word16)
-Eq_758: (struct "Eq_758" (0 word32 dw0000) (18 word16 w0018) (74 up32 dw0074) (E8 word32 dw00E8))
-	T_758 (in eax_17 @ 004018A9 : (ptr32 Eq_758))
-	T_762 (in Mem5[eax_6 + 0x3C<32>:word32] + eax_6 @ 004018A9 : word32)
-Eq_760: HMODULE
-	T_760 (in eax_6 + 0x3C<32> @ 004018A9 : word32)
-Eq_787: (struct "Eq_787" (FFFFFFEC Eq_102 tFFFFFFEC) (FFFFFFF0 ui32 dwFFFFFFF0) (FFFFFFF4 Eq_100 tFFFFFFF4) (FFFFFFF8 Eq_100 tFFFFFFF8) (FFFFFFFC word32 dwFFFFFFFC))
-	T_787 (in esp_14 @ 00401998 : (ptr32 Eq_787))
-	T_791 (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
-Eq_814: (segment "Eq_814" (0 ptr32 ptr0000))
-	T_814 (in fs @ 004019BE : selector)
-Eq_822: (segment "Eq_822" (0 word32 dw0000))
-	T_822 (in fs @ 004019C9 : selector)
-Eq_823: (union "Eq_823" (ptr32 u0) ((memptr (ptr32 Eq_822) word32) u1))
-	T_823 (in 0x00000000<p32> @ 004019C9 : ptr32)
-Eq_859: (fn void (word32, word32, (ptr32 word32), (ptr32 word32), (ptr32 word32), (ptr32 word32)))
-	T_859 (in __cpuid @ 00401A3F : ptr32)
-	T_860 (in signature of __cpuid @ 00000000 : void)
-	T_877 (in __cpuid @ 00401A79 : ptr32)
-	T_916 (in __cpuid @ 00401AEF : ptr32)
-Eq_944: (fn word64 (word32))
-	T_944 (in __xgetbv @ 00401B5C : ptr32)
-	T_945 (in signature of __xgetbv @ 00000000 : void)
-Eq_1031: (struct "Eq_1031" (0 Eq_100 t0000))
-	T_1031
+	T_642 (in QueryPerformanceCounter(&tLoc18) @ 004016B7 : BOOL)
+	T_689 (in IsProcessorFeaturePresent(0x17<32>) @ 00401781 : BOOL)
+	T_690 (in 0<32> @ 00401781 : word32)
+	T_716 (in IsDebuggerPresent() @ 0040185A : BOOL)
+	T_717 (in 1<32> @ 0040185A : word32)
+	T_852 (in IsProcessorFeaturePresent(0xA<32>) @ 00401A1E : BOOL)
+	T_853 (in 0<32> @ 00401A1E : word32)
+Eq_644: (struct "Eq_644" (0 LARGE_INTEGER t0000) (4 word32 dw0004))
+	T_644 (in &tLoc18 @ 004016C9 : (ptr32 LARGE_INTEGER))
+Eq_648: LARGE_INTEGER
+	T_648 (in &tLoc18 @ 004016C9 : (ptr32 LARGE_INTEGER))
+Eq_685: (fn Eq_642 (Eq_89))
+	T_685 (in IsProcessorFeaturePresent @ 00401781 : ptr32)
+	T_686 (in signature of IsProcessorFeaturePresent @ 00000000 : void)
+	T_850 (in IsProcessorFeaturePresent @ 00401A1E : ptr32)
+Eq_695: (fn (ptr32 void) ((ptr32 void), int32, Eq_699))
+	T_695 (in memset @ 0040179D : ptr32)
+	T_696 (in signature of memset @ 00000000 : void)
+	T_706 (in memset @ 00401826 : ptr32)
+Eq_699: size_t
+	T_699 (in _Size @ 0040179D : size_t)
+	T_704 (in 0x2CC<32> @ 0040179D : word32)
+	T_710 (in 0x50<32> @ 00401826 : word32)
+Eq_714: (fn Eq_642 ())
+	T_714 (in IsDebuggerPresent @ 0040185A : ptr32)
+	T_715 (in signature of IsDebuggerPresent @ 00000000 : void)
+Eq_718: (union "Eq_718" (bool u0) (byte u1))
+	T_718 (in IsDebuggerPresent() != 1<32> @ 00000000 : bool)
+Eq_720: (fn Eq_722 (Eq_722))
+	T_720 (in SetUnhandledExceptionFilter @ 00401861 : ptr32)
+	T_721 (in signature of SetUnhandledExceptionFilter @ 00000000 : void)
+Eq_722: LPTOP_LEVEL_EXCEPTION_FILTER
+	T_722 (in lpTopLevelExceptionFilter @ 00401861 : LPTOP_LEVEL_EXCEPTION_FILTER)
+	T_723 (in 0<32> @ 00401861 : word32)
+	T_724 (in SetUnhandledExceptionFilter(null) @ 00401861 : LPTOP_LEVEL_EXCEPTION_FILTER)
+Eq_725: (fn Eq_730 ((ptr32 Eq_727)))
+	T_725 (in UnhandledExceptionFilter @ 00401873 : ptr32)
+	T_726 (in signature of UnhandledExceptionFilter @ 00000000 : void)
+Eq_727: (struct "_EXCEPTION_POINTERS" (0 PEXCEPTION_RECORD ExceptionRecord) (4 PCONTEXT ContextRecord))
+	T_727 (in ExceptionInfo @ 00401873 : (ptr32 (struct "_EXCEPTION_POINTERS")))
+	T_729 (in fp - 0xC<32> @ 00000000 : word32)
+Eq_730: LONG
+	T_730 (in UnhandledExceptionFilter(fp - 0xC<32>) @ 00401873 : LONG)
+	T_731 (in 0<32> @ 00401873 : word32)
+Eq_733: (fn void (word32))
+	T_733 (in __fastfail @ 00401786 : ptr32)
+	T_734 (in signature of __fastfail @ 00000000 : void)
+Eq_744: (union "Eq_744" (bool u0) (ui32 u1))
+	T_744 (in (word32) (bl_90 + 1<8>) != 0<32> @ 00000000 : bool)
+Eq_750: HMODULE
+	T_750 (in eax_6 @ 0040188D : Eq_750)
+	T_755 (in GetModuleHandleW(null) @ 0040188D : HMODULE)
+	T_756 (in 0<32> @ 00401897 : word32)
+Eq_751: (fn Eq_750 (Eq_753))
+	T_751 (in GetModuleHandleW @ 0040188D : ptr32)
+	T_752 (in signature of GetModuleHandleW @ 00000000 : void)
+Eq_753: LPCWSTR
+	T_753 (in lpModuleName @ 0040188D : LPCWSTR)
+	T_754 (in 0<32> @ 0040188D : word32)
+Eq_760: (union "Eq_760" (int32 u0) (word16 u1))
+	T_760 (in Mem5[eax_6 + 0<32>:word16] @ 004018A4 : word16)
+	T_761 (in 0x5A4D<16> @ 004018A4 : word16)
+Eq_764: (struct "Eq_764" (0 word32 dw0000) (18 word16 w0018) (74 up32 dw0074) (E8 word32 dw00E8))
+	T_764 (in eax_17 @ 004018A9 : (ptr32 Eq_764))
+	T_768 (in Mem5[eax_6 + 0x3C<32>:word32] + eax_6 @ 004018A9 : word32)
+Eq_766: HMODULE
+	T_766 (in eax_6 + 0x3C<32> @ 004018A9 : word32)
+Eq_793: (struct "Eq_793" (FFFFFFEC Eq_102 tFFFFFFEC) (FFFFFFF0 ui32 dwFFFFFFF0) (FFFFFFF4 Eq_100 tFFFFFFF4) (FFFFFFF8 Eq_100 tFFFFFFF8) (FFFFFFFC word32 dwFFFFFFFC))
+	T_793 (in esp_14 @ 00401998 : (ptr32 Eq_793))
+	T_797 (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
+Eq_820: (segment "Eq_820" (0 ptr32 ptr0000))
+	T_820 (in fs @ 004019BE : selector)
+Eq_828: (segment "Eq_828" (0 word32 dw0000))
+	T_828 (in fs @ 004019C9 : selector)
+Eq_829: (union "Eq_829" (ptr32 u0) ((memptr (ptr32 Eq_828) word32) u1))
+	T_829 (in 0x00000000<p32> @ 004019C9 : ptr32)
+Eq_865: (fn void (word32, word32, (ptr32 word32), (ptr32 word32), (ptr32 word32), (ptr32 word32)))
+	T_865 (in __cpuid @ 00401A3F : ptr32)
+	T_866 (in signature of __cpuid @ 00000000 : void)
+	T_883 (in __cpuid @ 00401A79 : ptr32)
+	T_922 (in __cpuid @ 00401AEF : ptr32)
+Eq_950: (fn word64 (word32))
+	T_950 (in __xgetbv @ 00401B5C : ptr32)
+	T_951 (in signature of __xgetbv @ 00000000 : void)
+Eq_1037: (struct "Eq_1037" (0 Eq_100 t0000))
+	T_1037
 // Type Variables ////////////
 globals_t: (in globals @ 00000000 : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -1391,7 +1397,7 @@ T_228: (in signature of fn004019C6 @ 004019C6 : void)
 T_229: (in ebp @ 004012C3 : (ptr32 Eq_96))
   Class: Eq_96
   DataType: (ptr32 Eq_96)
-  OrigDataType: (ptr32 (struct (FFFFFFF0 T_821 tFFFFFFF0) (0 T_102 t0000)))
+  OrigDataType: (ptr32 (struct (FFFFFFF0 T_827 tFFFFFFF0) (0 T_102 t0000)))
 T_230: (in dwArg00 @ 004012C3 : Eq_102)
   Class: Eq_102
   DataType: Eq_102
@@ -3032,15 +3038,15 @@ T_639: (in lpPerformanceCount @ 004016B7 : (ptr32 LARGE_INTEGER))
   Class: Eq_639
   DataType: (ptr32 Eq_639)
   OrigDataType: 
-T_640: (in 0x18<32> @ 004016B7 : word32)
+T_640: (in tLoc18 @ 004016B7 : LARGE_INTEGER)
   Class: Eq_640
-  DataType: ui32
-  OrigDataType: ui32
-T_641: (in fp - 0x18<32> @ 00000000 : word32)
+  DataType: Eq_640
+  OrigDataType: LARGE_INTEGER
+T_641: (in &tLoc18 @ 004016B7 : (ptr32 LARGE_INTEGER))
   Class: Eq_639
   DataType: (ptr32 Eq_639)
   OrigDataType: (ptr32 LARGE_INTEGER)
-T_642: (in QueryPerformanceCounter(fp - 0x18<32>) @ 004016B7 : BOOL)
+T_642: (in QueryPerformanceCounter(&tLoc18) @ 004016B7 : BOOL)
   Class: Eq_642
   DataType: Eq_642
   OrigDataType: BOOL
@@ -3048,1398 +3054,1398 @@ T_643: (in ecx_55 @ 004016C9 : ui32)
   Class: Eq_617
   DataType: ui32
   OrigDataType: ui32
-T_644: (in dwLoc14 @ 004016C9 : word32)
+T_644: (in &tLoc18 @ 004016C9 : (ptr32 LARGE_INTEGER))
   Class: Eq_644
-  DataType: word32
-  OrigDataType: word32
-T_645: (in dwLoc18 @ 004016C9 : word32)
+  DataType: (ptr32 Eq_644)
+  OrigDataType: (ptr32 (struct (0 LARGE_INTEGER t0000) (4 T_647 t0004)))
+T_645: (in 4<i32> @ 004016C9 : int32)
   Class: Eq_645
-  DataType: word32
-  OrigDataType: word32
-T_646: (in dwLoc14 ^ dwLoc18 @ 00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_646: (in &tLoc18 + 4<i32> @ 004016C9 : word32)
   Class: Eq_646
-  DataType: ui32
-  OrigDataType: ui32
-T_647: (in dwLoc14 ^ dwLoc18 ^ v14_43 @ 00000000 : word32)
-  Class: Eq_647
-  DataType: ui32
-  OrigDataType: ui32
-T_648: (in 8<32> @ 004016C9 : word32)
-  Class: Eq_648
-  DataType: ui32
-  OrigDataType: ui32
-T_649: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_649
   DataType: ptr32
   OrigDataType: ptr32
-T_650: (in dwLoc14 ^ dwLoc18 ^ v14_43 ^ fp - 8<32> @ 00000000 : word32)
-  Class: Eq_617
+T_647: (in Mem48[&tLoc18 + 4<i32>:word32] @ 004016C9 : word32)
+  Class: Eq_647
+  DataType: word32
+  OrigDataType: word32
+T_648: (in &tLoc18 @ 004016C9 : (ptr32 LARGE_INTEGER))
+  Class: Eq_648
+  DataType: (ptr32 Eq_648)
+  OrigDataType: (ptr32 (struct (0 LARGE_INTEGER t0000)))
+T_649: (in 0<32> @ 004016C9 : word32)
+  Class: Eq_649
+  DataType: word32
+  OrigDataType: word32
+T_650: (in &tLoc18 + 0<32> @ 004016C9 : word32)
+  Class: Eq_650
+  DataType: ptr32
+  OrigDataType: ptr32
+T_651: (in Mem48[&tLoc18 + 0<32>:word32] @ 004016C9 : word32)
+  Class: Eq_651
+  DataType: word32
+  OrigDataType: word32
+T_652: (in tLoc18.dw0004 ^ tLoc18 @ 00000000 : word32)
+  Class: Eq_652
   DataType: ui32
   OrigDataType: ui32
-T_651: (in 0xBB40E64E<32> @ 004016CD : word32)
-  Class: Eq_617
-  DataType: ui32
-  OrigDataType: word32
-T_652: (in ecx_55 != 0xBB40E64E<32> @ 00000000 : bool)
-  Class: Eq_652
-  DataType: bool
-  OrigDataType: bool
-T_653: (in 0xFFFF0000<32> @ 00401683 : word32)
+T_653: (in tLoc18.dw0004 ^ tLoc18 ^ v14_43 @ 00000000 : word32)
   Class: Eq_653
   DataType: ui32
   OrigDataType: ui32
-T_654: (in eax_15 & 0xFFFF0000<32> @ 00000000 : word32)
+T_654: (in 8<32> @ 004016C9 : word32)
   Class: Eq_654
   DataType: ui32
   OrigDataType: ui32
-T_655: (in 0<32> @ 00401683 : word32)
-  Class: Eq_654
+T_655: (in fp - 8<32> @ 00000000 : word32)
+  Class: Eq_655
+  DataType: ptr32
+  OrigDataType: ptr32
+T_656: (in tLoc18.dw0004 ^ tLoc18 ^ v14_43 ^ fp - 8<32> @ 00000000 : word32)
+  Class: Eq_617
+  DataType: ui32
+  OrigDataType: ui32
+T_657: (in 0xBB40E64E<32> @ 004016CD : word32)
+  Class: Eq_617
   DataType: ui32
   OrigDataType: word32
-T_656: (in (eax_15 & 0xFFFF0000<32>) == 0<32> @ 00000000 : bool)
-  Class: Eq_656
+T_658: (in ecx_55 != 0xBB40E64E<32> @ 00000000 : bool)
+  Class: Eq_658
   DataType: bool
   OrigDataType: bool
-T_657: (in ~eax_15 @ 00401687 : word32)
-  Class: Eq_657
+T_659: (in 0xFFFF0000<32> @ 00401683 : word32)
+  Class: Eq_659
   DataType: ui32
   OrigDataType: ui32
-T_658: (in 00403000 @ 00401687 : ptr32)
-  Class: Eq_658
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_659 t0000)))
-T_659: (in Mem75[0x00403000<p32>:word32] @ 00401687 : word32)
-  Class: Eq_657
-  DataType: ui32
-  OrigDataType: word32
-T_660: (in 0xFFFF0000<32> @ 004016D8 : word32)
+T_660: (in eax_15 & 0xFFFF0000<32> @ 00000000 : word32)
   Class: Eq_660
   DataType: ui32
   OrigDataType: ui32
-T_661: (in ecx_55 & 0xFFFF0000<32> @ 00000000 : word32)
-  Class: Eq_661
-  DataType: ui32
-  OrigDataType: ui32
-T_662: (in 0<32> @ 004016D8 : word32)
-  Class: Eq_661
+T_661: (in 0<32> @ 00401683 : word32)
+  Class: Eq_660
   DataType: ui32
   OrigDataType: word32
-T_663: (in (ecx_55 & 0xFFFF0000<32>) != 0<32> @ 00000000 : bool)
-  Class: Eq_663
+T_662: (in (eax_15 & 0xFFFF0000<32>) == 0<32> @ 00000000 : bool)
+  Class: Eq_662
   DataType: bool
   OrigDataType: bool
-T_664: (in 0xBB40E64F<32> @ 004016CF : word32)
+T_663: (in ~eax_15 @ 00401687 : word32)
+  Class: Eq_663
+  DataType: ui32
+  OrigDataType: ui32
+T_664: (in 00403000 @ 00401687 : ptr32)
+  Class: Eq_664
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_665 t0000)))
+T_665: (in Mem75[0x00403000<p32>:word32] @ 00401687 : word32)
+  Class: Eq_663
+  DataType: ui32
+  OrigDataType: word32
+T_666: (in 0xFFFF0000<32> @ 004016D8 : word32)
+  Class: Eq_666
+  DataType: ui32
+  OrigDataType: ui32
+T_667: (in ecx_55 & 0xFFFF0000<32> @ 00000000 : word32)
+  Class: Eq_667
+  DataType: ui32
+  OrigDataType: ui32
+T_668: (in 0<32> @ 004016D8 : word32)
+  Class: Eq_667
+  DataType: ui32
+  OrigDataType: word32
+T_669: (in (ecx_55 & 0xFFFF0000<32>) != 0<32> @ 00000000 : bool)
+  Class: Eq_669
+  DataType: bool
+  OrigDataType: bool
+T_670: (in 0xBB40E64F<32> @ 004016CF : word32)
   Class: Eq_617
   DataType: ui32
   OrigDataType: word32
-T_665: (in 00403004 @ 004016E6 : ptr32)
-  Class: Eq_665
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_666 t0000)))
-T_666: (in Mem71[0x00403004<p32>:word32] @ 004016E6 : word32)
-  Class: Eq_617
-  DataType: ui32
-  OrigDataType: word32
-T_667: (in ~ecx_55 @ 004016EE : word32)
-  Class: Eq_657
-  DataType: ui32
-  OrigDataType: ui32
-T_668: (in 00403000 @ 004016EE : ptr32)
-  Class: Eq_668
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_669 t0000)))
-T_669: (in Mem73[0x00403000<p32>:word32] @ 004016EE : word32)
-  Class: Eq_657
-  DataType: ui32
-  OrigDataType: word32
-T_670: (in 0x4711<32> @ 004016E4 : word32)
-  Class: Eq_670
-  DataType: ui32
-  OrigDataType: ui32
-T_671: (in ecx_55 | 0x4711<32> @ 00000000 : word32)
+T_671: (in 00403004 @ 004016E6 : ptr32)
   Class: Eq_671
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_672 t0000)))
+T_672: (in Mem71[0x00403004<p32>:word32] @ 004016E6 : word32)
+  Class: Eq_617
+  DataType: ui32
+  OrigDataType: word32
+T_673: (in ~ecx_55 @ 004016EE : word32)
+  Class: Eq_663
   DataType: ui32
   OrigDataType: ui32
-T_672: (in 0x10<32> @ 004016E4 : word32)
-  Class: Eq_672
+T_674: (in 00403000 @ 004016EE : ptr32)
+  Class: Eq_674
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_675 t0000)))
+T_675: (in Mem73[0x00403000<p32>:word32] @ 004016EE : word32)
+  Class: Eq_663
+  DataType: ui32
+  OrigDataType: word32
+T_676: (in 0x4711<32> @ 004016E4 : word32)
+  Class: Eq_676
+  DataType: ui32
+  OrigDataType: ui32
+T_677: (in ecx_55 | 0x4711<32> @ 00000000 : word32)
+  Class: Eq_677
+  DataType: ui32
+  OrigDataType: ui32
+T_678: (in 0x10<32> @ 004016E4 : word32)
+  Class: Eq_678
   DataType: word32
   OrigDataType: word32
-T_673: (in (ecx_55 | 0x4711<32>) << 0x10<32> @ 00000000 : word32)
-  Class: Eq_673
+T_679: (in (ecx_55 | 0x4711<32>) << 0x10<32> @ 00000000 : word32)
+  Class: Eq_679
   DataType: ui32
   OrigDataType: ui32
-T_674: (in ecx_55 | (ecx_55 | 0x4711<32>) << 0x10<32> @ 00000000 : word32)
+T_680: (in ecx_55 | (ecx_55 | 0x4711<32>) << 0x10<32> @ 00000000 : word32)
   Class: Eq_617
   DataType: ui32
   OrigDataType: ui32
-T_675: (in eax @ 004016E4 : ptr32)
-  Class: Eq_675
+T_681: (in eax @ 004016E4 : ptr32)
+  Class: Eq_681
   DataType: ptr32
   OrigDataType: word32
-T_676: (in 0x00403384<p32> @ 00401766 : ptr32)
-  Class: Eq_675
+T_682: (in 0x00403384<p32> @ 00401766 : ptr32)
+  Class: Eq_681
   DataType: ptr32
   OrigDataType: ptr32
-T_677: (in eax @ 00401766 : ptr32)
-  Class: Eq_677
+T_683: (in eax @ 00401766 : ptr32)
+  Class: Eq_683
   DataType: ptr32
   OrigDataType: word32
-T_678: (in 0x00403380<p32> @ 0040176C : ptr32)
-  Class: Eq_677
+T_684: (in 0x00403380<p32> @ 0040176C : ptr32)
+  Class: Eq_683
   DataType: ptr32
   OrigDataType: ptr32
-T_679: (in IsProcessorFeaturePresent @ 00401781 : ptr32)
-  Class: Eq_679
-  DataType: (ptr32 Eq_679)
-  OrigDataType: (ptr32 (fn T_683 (T_682)))
-T_680: (in signature of IsProcessorFeaturePresent @ 00000000 : void)
-  Class: Eq_679
-  DataType: (ptr32 Eq_679)
+T_685: (in IsProcessorFeaturePresent @ 00401781 : ptr32)
+  Class: Eq_685
+  DataType: (ptr32 Eq_685)
+  OrigDataType: (ptr32 (fn T_689 (T_688)))
+T_686: (in signature of IsProcessorFeaturePresent @ 00000000 : void)
+  Class: Eq_685
+  DataType: (ptr32 Eq_685)
   OrigDataType: 
-T_681: (in ProcessorFeature @ 00401781 : DWORD)
+T_687: (in ProcessorFeature @ 00401781 : DWORD)
   Class: Eq_89
   DataType: Eq_89
   OrigDataType: 
-T_682: (in 0x17<32> @ 00401781 : word32)
+T_688: (in 0x17<32> @ 00401781 : word32)
   Class: Eq_89
   DataType: int32
   OrigDataType: DWORD
-T_683: (in IsProcessorFeaturePresent(0x17<32>) @ 00401781 : BOOL)
+T_689: (in IsProcessorFeaturePresent(0x17<32>) @ 00401781 : BOOL)
   Class: Eq_642
   DataType: Eq_642
   OrigDataType: BOOL
-T_684: (in 0<32> @ 00401781 : word32)
+T_690: (in 0<32> @ 00401781 : word32)
   Class: Eq_642
   DataType: Eq_642
   OrigDataType: word32
-T_685: (in IsProcessorFeaturePresent(0x17<32>) == 0<32> @ 00000000 : bool)
-  Class: Eq_685
+T_691: (in IsProcessorFeaturePresent(0x17<32>) == 0<32> @ 00000000 : bool)
+  Class: Eq_691
   DataType: bool
   OrigDataType: bool
-T_686: (in 0<32> @ 00401797 : word32)
-  Class: Eq_686
+T_692: (in 0<32> @ 00401797 : word32)
+  Class: Eq_692
   DataType: ui32
   OrigDataType: word32
-T_687: (in 00403368 @ 00401797 : ptr32)
-  Class: Eq_687
+T_693: (in 00403368 @ 00401797 : ptr32)
+  Class: Eq_693
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_688 t0000)))
-T_688: (in Mem30[0x00403368<p32>:word32] @ 00401797 : word32)
-  Class: Eq_686
+  OrigDataType: (ptr32 (struct (0 T_694 t0000)))
+T_694: (in Mem30[0x00403368<p32>:word32] @ 00401797 : word32)
+  Class: Eq_692
   DataType: ui32
   OrigDataType: word32
-T_689: (in memset @ 0040179D : ptr32)
-  Class: Eq_689
-  DataType: (ptr32 Eq_689)
-  OrigDataType: (ptr32 (fn T_699 (T_696, T_697, T_698)))
-T_690: (in signature of memset @ 00000000 : void)
-  Class: Eq_689
-  DataType: (ptr32 Eq_689)
+T_695: (in memset @ 0040179D : ptr32)
+  Class: Eq_695
+  DataType: (ptr32 Eq_695)
+  OrigDataType: (ptr32 (fn T_705 (T_702, T_703, T_704)))
+T_696: (in signature of memset @ 00000000 : void)
+  Class: Eq_695
+  DataType: (ptr32 Eq_695)
   OrigDataType: 
-T_691: (in _Dst @ 0040179D : (ptr32 void))
-  Class: Eq_691
+T_697: (in _Dst @ 0040179D : (ptr32 void))
+  Class: Eq_697
   DataType: (ptr32 void)
   OrigDataType: 
-T_692: (in _Val @ 0040179D : int32)
-  Class: Eq_692
+T_698: (in _Val @ 0040179D : int32)
+  Class: Eq_698
   DataType: int32
   OrigDataType: 
-T_693: (in _Size @ 0040179D : size_t)
-  Class: Eq_693
-  DataType: Eq_693
+T_699: (in _Size @ 0040179D : size_t)
+  Class: Eq_699
+  DataType: Eq_699
   OrigDataType: 
-T_694: (in fp @ 0040179D : ptr32)
-  Class: Eq_694
+T_700: (in fp @ 0040179D : ptr32)
+  Class: Eq_700
   DataType: ptr32
   OrigDataType: ptr32
-T_695: (in 0x328<32> @ 0040179D : word32)
-  Class: Eq_695
-  DataType: ui32
-  OrigDataType: ui32
-T_696: (in fp - 0x328<32> @ 00000000 : word32)
-  Class: Eq_691
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_697: (in 0<32> @ 0040179D : word32)
-  Class: Eq_692
-  DataType: int32
-  OrigDataType: int32
-T_698: (in 0x2CC<32> @ 0040179D : word32)
-  Class: Eq_693
-  DataType: Eq_693
-  OrigDataType: size_t
-T_699: (in memset(fp - 0x328<32>, 0<32>, 0x2CC<32>) @ 0040179D : (ptr32 void))
-  Class: Eq_699
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_700: (in memset @ 00401826 : ptr32)
-  Class: Eq_689
-  DataType: (ptr32 Eq_689)
-  OrigDataType: (ptr32 (fn T_705 (T_702, T_703, T_704)))
-T_701: (in 0x5C<32> @ 00401826 : word32)
+T_701: (in 0x328<32> @ 0040179D : word32)
   Class: Eq_701
   DataType: ui32
   OrigDataType: ui32
-T_702: (in fp - 0x5C<32> @ 00000000 : word32)
-  Class: Eq_691
+T_702: (in fp - 0x328<32> @ 00000000 : word32)
+  Class: Eq_697
   DataType: (ptr32 void)
   OrigDataType: (ptr32 void)
-T_703: (in 0<32> @ 00401826 : word32)
-  Class: Eq_692
+T_703: (in 0<32> @ 0040179D : word32)
+  Class: Eq_698
   DataType: int32
   OrigDataType: int32
-T_704: (in 0x50<32> @ 00401826 : word32)
-  Class: Eq_693
-  DataType: Eq_693
-  OrigDataType: size_t
-T_705: (in memset(fp - 0x5C<32>, 0<32>, 0x50<32>) @ 00401826 : (ptr32 void))
+T_704: (in 0x2CC<32> @ 0040179D : word32)
   Class: Eq_699
+  DataType: Eq_699
+  OrigDataType: size_t
+T_705: (in memset(fp - 0x328<32>, 0<32>, 0x2CC<32>) @ 0040179D : (ptr32 void))
+  Class: Eq_705
   DataType: (ptr32 void)
   OrigDataType: (ptr32 void)
-T_706: (in bl_90 @ 0040185A : byte)
-  Class: Eq_706
-  DataType: byte
-  OrigDataType: byte
-T_707: (in 0<8> @ 0040185A : byte)
+T_706: (in memset @ 00401826 : ptr32)
+  Class: Eq_695
+  DataType: (ptr32 Eq_695)
+  OrigDataType: (ptr32 (fn T_711 (T_708, T_709, T_710)))
+T_707: (in 0x5C<32> @ 00401826 : word32)
   Class: Eq_707
+  DataType: ui32
+  OrigDataType: ui32
+T_708: (in fp - 0x5C<32> @ 00000000 : word32)
+  Class: Eq_697
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_709: (in 0<32> @ 00401826 : word32)
+  Class: Eq_698
+  DataType: int32
+  OrigDataType: int32
+T_710: (in 0x50<32> @ 00401826 : word32)
+  Class: Eq_699
+  DataType: Eq_699
+  OrigDataType: size_t
+T_711: (in memset(fp - 0x5C<32>, 0<32>, 0x50<32>) @ 00401826 : (ptr32 void))
+  Class: Eq_705
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_712: (in bl_90 @ 0040185A : byte)
+  Class: Eq_712
   DataType: byte
   OrigDataType: byte
-T_708: (in IsDebuggerPresent @ 0040185A : ptr32)
-  Class: Eq_708
-  DataType: (ptr32 Eq_708)
-  OrigDataType: (ptr32 (fn T_710 ()))
-T_709: (in signature of IsDebuggerPresent @ 00000000 : void)
-  Class: Eq_708
-  DataType: (ptr32 Eq_708)
+T_713: (in 0<8> @ 0040185A : byte)
+  Class: Eq_713
+  DataType: byte
+  OrigDataType: byte
+T_714: (in IsDebuggerPresent @ 0040185A : ptr32)
+  Class: Eq_714
+  DataType: (ptr32 Eq_714)
+  OrigDataType: (ptr32 (fn T_716 ()))
+T_715: (in signature of IsDebuggerPresent @ 00000000 : void)
+  Class: Eq_714
+  DataType: (ptr32 Eq_714)
   OrigDataType: 
-T_710: (in IsDebuggerPresent() @ 0040185A : BOOL)
+T_716: (in IsDebuggerPresent() @ 0040185A : BOOL)
   Class: Eq_642
   DataType: Eq_642
   OrigDataType: BOOL
-T_711: (in 1<32> @ 0040185A : word32)
+T_717: (in 1<32> @ 0040185A : word32)
   Class: Eq_642
   DataType: Eq_642
   OrigDataType: word32
-T_712: (in IsDebuggerPresent() != 1<32> @ 00000000 : bool)
-  Class: Eq_712
-  DataType: Eq_712
+T_718: (in IsDebuggerPresent() != 1<32> @ 00000000 : bool)
+  Class: Eq_718
+  DataType: Eq_718
   OrigDataType: (union (bool u0) (byte u1))
-T_713: (in 0<8> - (IsDebuggerPresent() != 1<32>) @ 00000000 : byte)
-  Class: Eq_706
+T_719: (in 0<8> - (IsDebuggerPresent() != 1<32>) @ 00000000 : byte)
+  Class: Eq_712
   DataType: byte
   OrigDataType: byte
-T_714: (in SetUnhandledExceptionFilter @ 00401861 : ptr32)
-  Class: Eq_714
-  DataType: (ptr32 Eq_714)
-  OrigDataType: (ptr32 (fn T_718 (T_717)))
-T_715: (in signature of SetUnhandledExceptionFilter @ 00000000 : void)
-  Class: Eq_714
-  DataType: (ptr32 Eq_714)
-  OrigDataType: 
-T_716: (in lpTopLevelExceptionFilter @ 00401861 : LPTOP_LEVEL_EXCEPTION_FILTER)
-  Class: Eq_716
-  DataType: Eq_716
-  OrigDataType: 
-T_717: (in 0<32> @ 00401861 : word32)
-  Class: Eq_716
-  DataType: Eq_716
-  OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_718: (in SetUnhandledExceptionFilter(null) @ 00401861 : LPTOP_LEVEL_EXCEPTION_FILTER)
-  Class: Eq_716
-  DataType: Eq_716
-  OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
-T_719: (in UnhandledExceptionFilter @ 00401873 : ptr32)
-  Class: Eq_719
-  DataType: (ptr32 Eq_719)
+T_720: (in SetUnhandledExceptionFilter @ 00401861 : ptr32)
+  Class: Eq_720
+  DataType: (ptr32 Eq_720)
   OrigDataType: (ptr32 (fn T_724 (T_723)))
-T_720: (in signature of UnhandledExceptionFilter @ 00000000 : void)
-  Class: Eq_719
-  DataType: (ptr32 Eq_719)
+T_721: (in signature of SetUnhandledExceptionFilter @ 00000000 : void)
+  Class: Eq_720
+  DataType: (ptr32 Eq_720)
   OrigDataType: 
-T_721: (in ExceptionInfo @ 00401873 : (ptr32 (struct "_EXCEPTION_POINTERS")))
-  Class: Eq_721
-  DataType: (ptr32 Eq_721)
-  OrigDataType: 
-T_722: (in 0xC<32> @ 00401873 : word32)
+T_722: (in lpTopLevelExceptionFilter @ 00401861 : LPTOP_LEVEL_EXCEPTION_FILTER)
   Class: Eq_722
+  DataType: Eq_722
+  OrigDataType: 
+T_723: (in 0<32> @ 00401861 : word32)
+  Class: Eq_722
+  DataType: Eq_722
+  OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
+T_724: (in SetUnhandledExceptionFilter(null) @ 00401861 : LPTOP_LEVEL_EXCEPTION_FILTER)
+  Class: Eq_722
+  DataType: Eq_722
+  OrigDataType: LPTOP_LEVEL_EXCEPTION_FILTER
+T_725: (in UnhandledExceptionFilter @ 00401873 : ptr32)
+  Class: Eq_725
+  DataType: (ptr32 Eq_725)
+  OrigDataType: (ptr32 (fn T_730 (T_729)))
+T_726: (in signature of UnhandledExceptionFilter @ 00000000 : void)
+  Class: Eq_725
+  DataType: (ptr32 Eq_725)
+  OrigDataType: 
+T_727: (in ExceptionInfo @ 00401873 : (ptr32 (struct "_EXCEPTION_POINTERS")))
+  Class: Eq_727
+  DataType: (ptr32 Eq_727)
+  OrigDataType: 
+T_728: (in 0xC<32> @ 00401873 : word32)
+  Class: Eq_728
   DataType: ui32
   OrigDataType: ui32
-T_723: (in fp - 0xC<32> @ 00000000 : word32)
-  Class: Eq_721
-  DataType: (ptr32 Eq_721)
+T_729: (in fp - 0xC<32> @ 00000000 : word32)
+  Class: Eq_727
+  DataType: (ptr32 Eq_727)
   OrigDataType: (ptr32 (struct "_EXCEPTION_POINTERS"))
-T_724: (in UnhandledExceptionFilter(fp - 0xC<32>) @ 00401873 : LONG)
-  Class: Eq_724
-  DataType: Eq_724
+T_730: (in UnhandledExceptionFilter(fp - 0xC<32>) @ 00401873 : LONG)
+  Class: Eq_730
+  DataType: Eq_730
   OrigDataType: LONG
-T_725: (in 0<32> @ 00401873 : word32)
-  Class: Eq_724
-  DataType: Eq_724
+T_731: (in 0<32> @ 00401873 : word32)
+  Class: Eq_730
+  DataType: Eq_730
   OrigDataType: word32
-T_726: (in UnhandledExceptionFilter(fp - 0xC<32>) != 0<32> @ 00000000 : bool)
-  Class: Eq_726
+T_732: (in UnhandledExceptionFilter(fp - 0xC<32>) != 0<32> @ 00000000 : bool)
+  Class: Eq_732
   DataType: bool
   OrigDataType: bool
-T_727: (in __fastfail @ 00401786 : ptr32)
-  Class: Eq_727
-  DataType: (ptr32 Eq_727)
-  OrigDataType: (ptr32 (fn T_730 (T_153)))
-T_728: (in signature of __fastfail @ 00000000 : void)
-  Class: Eq_727
-  DataType: (ptr32 Eq_727)
+T_733: (in __fastfail @ 00401786 : ptr32)
+  Class: Eq_733
+  DataType: (ptr32 Eq_733)
+  OrigDataType: (ptr32 (fn T_736 (T_153)))
+T_734: (in signature of __fastfail @ 00000000 : void)
+  Class: Eq_733
+  DataType: (ptr32 Eq_733)
   OrigDataType: 
-T_729: (in ecx @ 00401786 : word32)
+T_735: (in ecx @ 00401786 : word32)
   Class: Eq_153
   DataType: word32
   OrigDataType: 
-T_730: (in __fastfail(dwArg04) @ 00401786 : void)
-  Class: Eq_730
+T_736: (in __fastfail(dwArg04) @ 00401786 : void)
+  Class: Eq_736
   DataType: void
   OrigDataType: void
-T_731: (in 00403368 @ 0040187C : ptr32)
-  Class: Eq_731
+T_737: (in 00403368 @ 0040187C : ptr32)
+  Class: Eq_737
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_732 t0000)))
-T_732: (in Mem97[0x00403368<p32>:word32] @ 0040187C : word32)
-  Class: Eq_686
+  OrigDataType: (ptr32 (struct (0 T_738 t0000)))
+T_738: (in Mem97[0x00403368<p32>:word32] @ 0040187C : word32)
+  Class: Eq_692
   DataType: ui32
   OrigDataType: ui32
-T_733: (in 0<32> @ 0040187C : word32)
-  Class: Eq_733
-  DataType: ui32
-  OrigDataType: ui32
-T_734: (in 1<8> @ 0040187C : byte)
-  Class: Eq_734
-  DataType: byte
-  OrigDataType: byte
-T_735: (in bl_90 + 1<8> @ 00000000 : byte)
-  Class: Eq_735
-  DataType: byte
-  OrigDataType: byte
-T_736: (in CONVERT(bl_90 + 1<8>, byte, word32) @ 0040187C : word32)
-  Class: Eq_736
-  DataType: word32
-  OrigDataType: word32
-T_737: (in 0<32> @ 0040187C : word32)
-  Class: Eq_736
-  DataType: word32
-  OrigDataType: word32
-T_738: (in (word32) (bl_90 + 1<8>) != 0<32> @ 00000000 : bool)
-  Class: Eq_738
-  DataType: Eq_738
-  OrigDataType: (union (bool u0) (ui32 u1))
-T_739: (in 0<32> - ((word32) (bl_90 + 1<8>) != 0<32>) @ 00000000 : word32)
+T_739: (in 0<32> @ 0040187C : word32)
   Class: Eq_739
   DataType: ui32
   OrigDataType: ui32
-T_740: (in g_dw403368 & 0<32> - ((word32) (bl_90 + 1<8>) != 0<32>) @ 00000000 : word32)
-  Class: Eq_686
+T_740: (in 1<8> @ 0040187C : byte)
+  Class: Eq_740
+  DataType: byte
+  OrigDataType: byte
+T_741: (in bl_90 + 1<8> @ 00000000 : byte)
+  Class: Eq_741
+  DataType: byte
+  OrigDataType: byte
+T_742: (in CONVERT(bl_90 + 1<8>, byte, word32) @ 0040187C : word32)
+  Class: Eq_742
+  DataType: word32
+  OrigDataType: word32
+T_743: (in 0<32> @ 0040187C : word32)
+  Class: Eq_742
+  DataType: word32
+  OrigDataType: word32
+T_744: (in (word32) (bl_90 + 1<8>) != 0<32> @ 00000000 : bool)
+  Class: Eq_744
+  DataType: Eq_744
+  OrigDataType: (union (bool u0) (ui32 u1))
+T_745: (in 0<32> - ((word32) (bl_90 + 1<8>) != 0<32>) @ 00000000 : word32)
+  Class: Eq_745
   DataType: ui32
   OrigDataType: ui32
-T_741: (in 00403368 @ 0040187C : ptr32)
-  Class: Eq_741
+T_746: (in g_dw403368 & 0<32> - ((word32) (bl_90 + 1<8>) != 0<32>) @ 00000000 : word32)
+  Class: Eq_692
+  DataType: ui32
+  OrigDataType: ui32
+T_747: (in 00403368 @ 0040187C : ptr32)
+  Class: Eq_747
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_742 t0000)))
-T_742: (in Mem108[0x00403368<p32>:word32] @ 0040187C : word32)
-  Class: Eq_686
+  OrigDataType: (ptr32 (struct (0 T_748 t0000)))
+T_748: (in Mem108[0x00403368<p32>:word32] @ 0040187C : word32)
+  Class: Eq_692
   DataType: ui32
   OrigDataType: word32
-T_743: (in al @ 0040187C : int8)
-  Class: Eq_743
+T_749: (in al @ 0040187C : int8)
+  Class: Eq_749
   DataType: int8
   OrigDataType: byte
-T_744: (in eax_6 @ 0040188D : Eq_744)
-  Class: Eq_744
-  DataType: Eq_744
+T_750: (in eax_6 @ 0040188D : Eq_750)
+  Class: Eq_750
+  DataType: Eq_750
   OrigDataType: HMODULE
-T_745: (in GetModuleHandleW @ 0040188D : ptr32)
-  Class: Eq_745
-  DataType: (ptr32 Eq_745)
-  OrigDataType: (ptr32 (fn T_749 (T_748)))
-T_746: (in signature of GetModuleHandleW @ 00000000 : void)
-  Class: Eq_745
-  DataType: (ptr32 Eq_745)
-  OrigDataType: 
-T_747: (in lpModuleName @ 0040188D : LPCWSTR)
-  Class: Eq_747
-  DataType: Eq_747
-  OrigDataType: 
-T_748: (in 0<32> @ 0040188D : word32)
-  Class: Eq_747
-  DataType: Eq_747
-  OrigDataType: LPCWSTR
-T_749: (in GetModuleHandleW(null) @ 0040188D : HMODULE)
-  Class: Eq_744
-  DataType: Eq_744
-  OrigDataType: HMODULE
-T_750: (in 0<32> @ 00401897 : word32)
-  Class: Eq_744
-  DataType: Eq_744
-  OrigDataType: word32
-T_751: (in eax_6 != null @ 00000000 : bool)
+T_751: (in GetModuleHandleW @ 0040188D : ptr32)
   Class: Eq_751
+  DataType: (ptr32 Eq_751)
+  OrigDataType: (ptr32 (fn T_755 (T_754)))
+T_752: (in signature of GetModuleHandleW @ 00000000 : void)
+  Class: Eq_751
+  DataType: (ptr32 Eq_751)
+  OrigDataType: 
+T_753: (in lpModuleName @ 0040188D : LPCWSTR)
+  Class: Eq_753
+  DataType: Eq_753
+  OrigDataType: 
+T_754: (in 0<32> @ 0040188D : word32)
+  Class: Eq_753
+  DataType: Eq_753
+  OrigDataType: LPCWSTR
+T_755: (in GetModuleHandleW(null) @ 0040188D : HMODULE)
+  Class: Eq_750
+  DataType: Eq_750
+  OrigDataType: HMODULE
+T_756: (in 0<32> @ 00401897 : word32)
+  Class: Eq_750
+  DataType: Eq_750
+  OrigDataType: word32
+T_757: (in eax_6 != null @ 00000000 : bool)
+  Class: Eq_757
   DataType: bool
   OrigDataType: bool
-T_752: (in 0<32> @ 004018A4 : word32)
-  Class: Eq_752
+T_758: (in 0<32> @ 004018A4 : word32)
+  Class: Eq_758
   DataType: word32
   OrigDataType: word32
-T_753: (in eax_6 + 0<32> @ 004018A4 : word32)
-  Class: Eq_753
+T_759: (in eax_6 + 0<32> @ 004018A4 : word32)
+  Class: Eq_759
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
-T_754: (in Mem5[eax_6 + 0<32>:word16] @ 004018A4 : word16)
-  Class: Eq_754
-  DataType: Eq_754
-  OrigDataType: int32
-T_755: (in 0x5A4D<16> @ 004018A4 : word16)
-  Class: Eq_754
-  DataType: word16
-  OrigDataType: word16
-T_756: (in eax_6->unused != 0x5A4D<16> @ 00000000 : bool)
-  Class: Eq_756
-  DataType: bool
-  OrigDataType: bool
-T_757: (in 0<8> @ 0040189B : byte)
-  Class: Eq_743
-  DataType: int8
-  OrigDataType: byte
-T_758: (in eax_17 @ 004018A9 : (ptr32 Eq_758))
-  Class: Eq_758
-  DataType: (ptr32 Eq_758)
-  OrigDataType: (ptr32 (struct (0 T_765 t0000) (18 T_770 t0018) (74 T_775 t0074) (E8 T_780 t00E8)))
-T_759: (in 0x3C<32> @ 004018A9 : word32)
-  Class: Eq_759
-  DataType: word32
-  OrigDataType: word32
-T_760: (in eax_6 + 0x3C<32> @ 004018A9 : word32)
+T_760: (in Mem5[eax_6 + 0<32>:word16] @ 004018A4 : word16)
   Class: Eq_760
   DataType: Eq_760
-  OrigDataType: HMODULE
-T_761: (in Mem5[eax_6 + 0x3C<32>:word32] @ 004018A9 : word32)
-  Class: Eq_761
-  DataType: int32
   OrigDataType: int32
-T_762: (in Mem5[eax_6 + 0x3C<32>:word32] + eax_6 @ 004018A9 : word32)
-  Class: Eq_758
-  DataType: (ptr32 Eq_758)
-  OrigDataType: int32
-T_763: (in 0<32> @ 004018B1 : word32)
-  Class: Eq_763
-  DataType: word32
-  OrigDataType: word32
-T_764: (in eax_17 + 0<32> @ 004018B1 : word32)
+T_761: (in 0x5A4D<16> @ 004018A4 : word16)
+  Class: Eq_760
+  DataType: word16
+  OrigDataType: word16
+T_762: (in eax_6->unused != 0x5A4D<16> @ 00000000 : bool)
+  Class: Eq_762
+  DataType: bool
+  OrigDataType: bool
+T_763: (in 0<8> @ 0040189B : byte)
+  Class: Eq_749
+  DataType: int8
+  OrigDataType: byte
+T_764: (in eax_17 @ 004018A9 : (ptr32 Eq_764))
   Class: Eq_764
+  DataType: (ptr32 Eq_764)
+  OrigDataType: (ptr32 (struct (0 T_771 t0000) (18 T_776 t0018) (74 T_781 t0074) (E8 T_786 t00E8)))
+T_765: (in 0x3C<32> @ 004018A9 : word32)
+  Class: Eq_765
+  DataType: word32
+  OrigDataType: word32
+T_766: (in eax_6 + 0x3C<32> @ 004018A9 : word32)
+  Class: Eq_766
+  DataType: Eq_766
+  OrigDataType: HMODULE
+T_767: (in Mem5[eax_6 + 0x3C<32>:word32] @ 004018A9 : word32)
+  Class: Eq_767
   DataType: int32
   OrigDataType: int32
-T_765: (in Mem5[eax_17 + 0<32>:word32] @ 004018B1 : word32)
-  Class: Eq_765
-  DataType: word32
-  OrigDataType: word32
-T_766: (in 0x4550<32> @ 004018B1 : word32)
-  Class: Eq_765
-  DataType: word32
-  OrigDataType: word32
-T_767: (in eax_17->dw0000 != 0x4550<32> @ 00000000 : bool)
-  Class: Eq_767
-  DataType: bool
-  OrigDataType: bool
-T_768: (in 0x18<32> @ 004018BC : word32)
-  Class: Eq_768
-  DataType: word32
-  OrigDataType: word32
-T_769: (in eax_17 + 0x18<32> @ 004018BC : word32)
+T_768: (in Mem5[eax_6 + 0x3C<32>:word32] + eax_6 @ 004018A9 : word32)
+  Class: Eq_764
+  DataType: (ptr32 Eq_764)
+  OrigDataType: int32
+T_769: (in 0<32> @ 004018B1 : word32)
   Class: Eq_769
-  DataType: ptr32
-  OrigDataType: ptr32
-T_770: (in Mem5[eax_17 + 0x18<32>:word16] @ 004018BC : word16)
+  DataType: word32
+  OrigDataType: word32
+T_770: (in eax_17 + 0<32> @ 004018B1 : word32)
   Class: Eq_770
-  DataType: word16
-  OrigDataType: word16
-T_771: (in 0x10B<16> @ 004018BC : word16)
-  Class: Eq_770
-  DataType: word16
-  OrigDataType: word16
-T_772: (in eax_17->w0018 != 0x10B<16> @ 00000000 : bool)
-  Class: Eq_772
-  DataType: bool
-  OrigDataType: bool
-T_773: (in 0x74<32> @ 004018C2 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_771: (in Mem5[eax_17 + 0<32>:word32] @ 004018B1 : word32)
+  Class: Eq_771
+  DataType: word32
+  OrigDataType: word32
+T_772: (in 0x4550<32> @ 004018B1 : word32)
+  Class: Eq_771
+  DataType: word32
+  OrigDataType: word32
+T_773: (in eax_17->dw0000 != 0x4550<32> @ 00000000 : bool)
   Class: Eq_773
-  DataType: word32
-  OrigDataType: word32
-T_774: (in eax_17 + 0x74<32> @ 004018C2 : word32)
+  DataType: bool
+  OrigDataType: bool
+T_774: (in 0x18<32> @ 004018BC : word32)
   Class: Eq_774
+  DataType: word32
+  OrigDataType: word32
+T_775: (in eax_17 + 0x18<32> @ 004018BC : word32)
+  Class: Eq_775
   DataType: ptr32
   OrigDataType: ptr32
-T_775: (in Mem5[eax_17 + 0x74<32>:word32] @ 004018C2 : word32)
-  Class: Eq_775
-  DataType: up32
-  OrigDataType: up32
-T_776: (in 0xE<32> @ 004018C2 : word32)
-  Class: Eq_775
-  DataType: up32
-  OrigDataType: up32
-T_777: (in eax_17->dw0074 <= 0xE<32> @ 00000000 : bool)
-  Class: Eq_777
-  DataType: bool
-  OrigDataType: bool
-T_778: (in 0xE8<32> @ 004018CE : word32)
+T_776: (in Mem5[eax_17 + 0x18<32>:word16] @ 004018BC : word16)
+  Class: Eq_776
+  DataType: word16
+  OrigDataType: word16
+T_777: (in 0x10B<16> @ 004018BC : word16)
+  Class: Eq_776
+  DataType: word16
+  OrigDataType: word16
+T_778: (in eax_17->w0018 != 0x10B<16> @ 00000000 : bool)
   Class: Eq_778
-  DataType: word32
-  OrigDataType: word32
-T_779: (in eax_17 + 0xE8<32> @ 004018CE : word32)
-  Class: Eq_779
-  DataType: ptr32
-  OrigDataType: ptr32
-T_780: (in Mem5[eax_17 + 0xE8<32>:word32] @ 004018CE : word32)
-  Class: Eq_780
-  DataType: word32
-  OrigDataType: word32
-T_781: (in 0<32> @ 004018CE : word32)
-  Class: Eq_780
-  DataType: word32
-  OrigDataType: word32
-T_782: (in eax_17->dw00E8 != 0<32> @ 00000000 : bool)
-  Class: Eq_782
   DataType: bool
   OrigDataType: bool
-T_783: (in CONVERT(Mem5[eax_17 + 0xE8<32>:word32] != 0<32>, bool, int8) @ 004018CE : int8)
-  Class: Eq_743
+T_779: (in 0x74<32> @ 004018C2 : word32)
+  Class: Eq_779
+  DataType: word32
+  OrigDataType: word32
+T_780: (in eax_17 + 0x74<32> @ 004018C2 : word32)
+  Class: Eq_780
+  DataType: ptr32
+  OrigDataType: ptr32
+T_781: (in Mem5[eax_17 + 0x74<32>:word32] @ 004018C2 : word32)
+  Class: Eq_781
+  DataType: up32
+  OrigDataType: up32
+T_782: (in 0xE<32> @ 004018C2 : word32)
+  Class: Eq_781
+  DataType: up32
+  OrigDataType: up32
+T_783: (in eax_17->dw0074 <= 0xE<32> @ 00000000 : bool)
+  Class: Eq_783
+  DataType: bool
+  OrigDataType: bool
+T_784: (in 0xE8<32> @ 004018CE : word32)
+  Class: Eq_784
+  DataType: word32
+  OrigDataType: word32
+T_785: (in eax_17 + 0xE8<32> @ 004018CE : word32)
+  Class: Eq_785
+  DataType: ptr32
+  OrigDataType: ptr32
+T_786: (in Mem5[eax_17 + 0xE8<32>:word32] @ 004018CE : word32)
+  Class: Eq_786
+  DataType: word32
+  OrigDataType: word32
+T_787: (in 0<32> @ 004018CE : word32)
+  Class: Eq_786
+  DataType: word32
+  OrigDataType: word32
+T_788: (in eax_17->dw00E8 != 0<32> @ 00000000 : bool)
+  Class: Eq_788
+  DataType: bool
+  OrigDataType: bool
+T_789: (in CONVERT(Mem5[eax_17 + 0xE8<32>:word32] != 0<32>, bool, int8) @ 004018CE : int8)
+  Class: Eq_749
   DataType: int8
   OrigDataType: int8
-T_784: (in 004020D4 @ 00401972 : ptr32)
-  Class: Eq_784
+T_790: (in 004020D4 @ 00401972 : ptr32)
+  Class: Eq_790
   DataType: (ptr32 (ptr32 code))
-  OrigDataType: (ptr32 (struct (0 T_785 t0000)))
-T_785: (in Mem0[0x004020D4<p32>:word32] @ 00401972 : word32)
-  Class: Eq_785
+  OrigDataType: (ptr32 (struct (0 T_791 t0000)))
+T_791: (in Mem0[0x004020D4<p32>:word32] @ 00401972 : word32)
+  Class: Eq_791
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_786: (in ebp @ 00401972 : ptr32)
-  Class: Eq_786
-  DataType: ptr32
-  OrigDataType: word32
-T_787: (in esp_14 @ 00401998 : (ptr32 Eq_787))
-  Class: Eq_787
-  DataType: (ptr32 Eq_787)
-  OrigDataType: (ptr32 (struct (FFFFFFEC T_811 tFFFFFFEC) (FFFFFFF0 T_808 tFFFFFFF0) (FFFFFFF4 T_800 tFFFFFFF4) (FFFFFFF8 T_797 tFFFFFFF8) (FFFFFFFC T_794 tFFFFFFFC)))
-T_788: (in fp @ 00401998 : ptr32)
-  Class: Eq_788
-  DataType: ptr32
-  OrigDataType: ptr32
-T_789: (in 8<i32> @ 00401998 : int32)
-  Class: Eq_789
-  DataType: int32
-  OrigDataType: int32
-T_790: (in fp - 8<i32> @ 00000000 : word32)
-  Class: Eq_790
-  DataType: ptr32
-  OrigDataType: ptr32
-T_791: (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
-  Class: Eq_787
-  DataType: (ptr32 Eq_787)
-  OrigDataType: ptr32
-T_792: (in -4<i32> @ 0040199A : int32)
+T_792: (in ebp @ 00401972 : ptr32)
   Class: Eq_792
-  DataType: int32
-  OrigDataType: int32
-T_793: (in esp_14 + -4<i32> @ 0040199A : word32)
+  DataType: ptr32
+  OrigDataType: word32
+T_793: (in esp_14 @ 00401998 : (ptr32 Eq_793))
   Class: Eq_793
+  DataType: (ptr32 Eq_793)
+  OrigDataType: (ptr32 (struct (FFFFFFEC T_817 tFFFFFFEC) (FFFFFFF0 T_814 tFFFFFFF0) (FFFFFFF4 T_806 tFFFFFFF4) (FFFFFFF8 T_803 tFFFFFFF8) (FFFFFFFC T_800 tFFFFFFFC)))
+T_794: (in fp @ 00401998 : ptr32)
+  Class: Eq_794
   DataType: ptr32
   OrigDataType: ptr32
-T_794: (in Mem17[esp_14 + -4<i32>:word32] @ 0040199A : word32)
-  Class: Eq_91
-  DataType: word32
-  OrigDataType: word32
-T_795: (in -8<i32> @ 0040199B : int32)
+T_795: (in 8<i32> @ 00401998 : int32)
   Class: Eq_795
   DataType: int32
   OrigDataType: int32
-T_796: (in esp_14 + -8<i32> @ 0040199B : word32)
+T_796: (in fp - 8<i32> @ 00000000 : word32)
   Class: Eq_796
   DataType: ptr32
   OrigDataType: ptr32
-T_797: (in Mem20[esp_14 + -8<i32>:word32] @ 0040199B : word32)
-  Class: Eq_100
-  DataType: Eq_100
-  OrigDataType: word32
-T_798: (in -12<i32> @ 0040199C : int32)
+T_797: (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
+  Class: Eq_793
+  DataType: (ptr32 Eq_793)
+  OrigDataType: ptr32
+T_798: (in -4<i32> @ 0040199A : int32)
   Class: Eq_798
   DataType: int32
   OrigDataType: int32
-T_799: (in esp_14 + -12<i32> @ 0040199C : word32)
+T_799: (in esp_14 + -4<i32> @ 0040199A : word32)
   Class: Eq_799
   DataType: ptr32
   OrigDataType: ptr32
-T_800: (in Mem23[esp_14 + -12<i32>:word32] @ 0040199C : word32)
+T_800: (in Mem17[esp_14 + -4<i32>:word32] @ 0040199A : word32)
+  Class: Eq_91
+  DataType: word32
+  OrigDataType: word32
+T_801: (in -8<i32> @ 0040199B : int32)
+  Class: Eq_801
+  DataType: int32
+  OrigDataType: int32
+T_802: (in esp_14 + -8<i32> @ 0040199B : word32)
+  Class: Eq_802
+  DataType: ptr32
+  OrigDataType: ptr32
+T_803: (in Mem20[esp_14 + -8<i32>:word32] @ 0040199B : word32)
   Class: Eq_100
   DataType: Eq_100
   OrigDataType: word32
-T_801: (in 00403004 @ 004019A7 : ptr32)
-  Class: Eq_801
+T_804: (in -12<i32> @ 0040199C : int32)
+  Class: Eq_804
+  DataType: int32
+  OrigDataType: int32
+T_805: (in esp_14 + -12<i32> @ 0040199C : word32)
+  Class: Eq_805
+  DataType: ptr32
+  OrigDataType: ptr32
+T_806: (in Mem23[esp_14 + -12<i32>:word32] @ 0040199C : word32)
+  Class: Eq_100
+  DataType: Eq_100
+  OrigDataType: word32
+T_807: (in 00403004 @ 004019A7 : ptr32)
+  Class: Eq_807
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_802 t0000)))
-T_802: (in Mem23[0x00403004<p32>:word32] @ 004019A7 : word32)
+  OrigDataType: (ptr32 (struct (0 T_808 t0000)))
+T_808: (in Mem23[0x00403004<p32>:word32] @ 004019A7 : word32)
   Class: Eq_617
   DataType: ui32
   OrigDataType: word32
-T_803: (in 8<32> @ 004019A7 : word32)
-  Class: Eq_803
-  DataType: int32
-  OrigDataType: int32
-T_804: (in fp + 8<32> @ 00000000 : word32)
-  Class: Eq_804
-  DataType: ptr32
-  OrigDataType: ptr32
-T_805: (in g_dw403004 ^ fp + 8<32> @ 00000000 : word32)
-  Class: Eq_805
-  DataType: ui32
-  OrigDataType: ui32
-T_806: (in -16<i32> @ 004019A7 : int32)
-  Class: Eq_806
-  DataType: int32
-  OrigDataType: int32
-T_807: (in esp_14 + -16<i32> @ 004019A7 : word32)
-  Class: Eq_807
-  DataType: ptr32
-  OrigDataType: ptr32
-T_808: (in Mem32[esp_14 + -16<i32>:word32] @ 004019A7 : word32)
-  Class: Eq_805
-  DataType: ui32
-  OrigDataType: word32
-T_809: (in -20<i32> @ 004019AB : int32)
+T_809: (in 8<32> @ 004019A7 : word32)
   Class: Eq_809
   DataType: int32
   OrigDataType: int32
-T_810: (in esp_14 + -20<i32> @ 004019AB : word32)
+T_810: (in fp + 8<32> @ 00000000 : word32)
   Class: Eq_810
   DataType: ptr32
   OrigDataType: ptr32
-T_811: (in Mem36[esp_14 + -20<i32>:word32] @ 004019AB : word32)
-  Class: Eq_102
-  DataType: Eq_102
-  OrigDataType: word32
-T_812: (in 8<32> @ 004019BE : word32)
-  Class: Eq_812
+T_811: (in g_dw403004 ^ fp + 8<32> @ 00000000 : word32)
+  Class: Eq_811
   DataType: ui32
   OrigDataType: ui32
-T_813: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_813
-  DataType: ptr32
-  OrigDataType: ptr32
-T_814: (in fs @ 004019BE : selector)
-  Class: Eq_814
-  DataType: (ptr32 Eq_814)
-  OrigDataType: (ptr32 (segment (0 T_816 t0000)))
-T_815: (in 0<32> @ 004019BE : word32)
-  Class: Eq_815
-  DataType: (memptr (ptr32 Eq_814) ptr32)
-  OrigDataType: (memptr T_814 (struct (0 T_816 t0000)))
-T_816: (in Mem41[fs:0<32>:word32] @ 004019BE : word32)
-  Class: Eq_813
-  DataType: ptr32
-  OrigDataType: word32
-T_817: (in fp + 8<32> @ 00000000 : word32)
-  Class: Eq_786
-  DataType: ptr32
-  OrigDataType: ptr32
-T_818: (in ebx @ 004019C4 : word32)
-  Class: Eq_818
-  DataType: word32
-  OrigDataType: word32
-T_819: (in -16<i32> @ 004019C9 : int32)
-  Class: Eq_819
+T_812: (in -16<i32> @ 004019A7 : int32)
+  Class: Eq_812
   DataType: int32
   OrigDataType: int32
-T_820: (in ebp + -16<i32> @ 004019C9 : word32)
-  Class: Eq_820
-  DataType: word32
+T_813: (in esp_14 + -16<i32> @ 004019A7 : word32)
+  Class: Eq_813
+  DataType: ptr32
+  OrigDataType: ptr32
+T_814: (in Mem32[esp_14 + -16<i32>:word32] @ 004019A7 : word32)
+  Class: Eq_811
+  DataType: ui32
   OrigDataType: word32
-T_821: (in Mem0[ebp + -16<i32>:word32] @ 004019C9 : word32)
-  Class: Eq_821
-  DataType: word32
-  OrigDataType: word32
-T_822: (in fs @ 004019C9 : selector)
-  Class: Eq_822
-  DataType: (ptr32 Eq_822)
-  OrigDataType: (ptr32 (segment (0 T_824 t0000)))
-T_823: (in 0x00000000<p32> @ 004019C9 : ptr32)
-  Class: Eq_823
-  DataType: Eq_823
-  OrigDataType: (union (ptr32 u0) ((memptr T_822 (struct (0 word32 dw0000))) u1))
-T_824: (in Mem8[fs:0x00000000<p32>:word32] @ 004019C9 : word32)
-  Class: Eq_821
-  DataType: word32
-  OrigDataType: word32
-T_825: (in ebp_19 @ 004019D7 : Eq_102)
+T_815: (in -20<i32> @ 004019AB : int32)
+  Class: Eq_815
+  DataType: int32
+  OrigDataType: int32
+T_816: (in esp_14 + -20<i32> @ 004019AB : word32)
+  Class: Eq_816
+  DataType: ptr32
+  OrigDataType: ptr32
+T_817: (in Mem36[esp_14 + -20<i32>:word32] @ 004019AB : word32)
   Class: Eq_102
   DataType: Eq_102
   OrigDataType: word32
-T_826: (in 0<32> @ 004019D7 : word32)
+T_818: (in 8<32> @ 004019BE : word32)
+  Class: Eq_818
+  DataType: ui32
+  OrigDataType: ui32
+T_819: (in fp - 8<32> @ 00000000 : word32)
+  Class: Eq_819
+  DataType: ptr32
+  OrigDataType: ptr32
+T_820: (in fs @ 004019BE : selector)
+  Class: Eq_820
+  DataType: (ptr32 Eq_820)
+  OrigDataType: (ptr32 (segment (0 T_822 t0000)))
+T_821: (in 0<32> @ 004019BE : word32)
+  Class: Eq_821
+  DataType: (memptr (ptr32 Eq_820) ptr32)
+  OrigDataType: (memptr T_820 (struct (0 T_822 t0000)))
+T_822: (in Mem41[fs:0<32>:word32] @ 004019BE : word32)
+  Class: Eq_819
+  DataType: ptr32
+  OrigDataType: word32
+T_823: (in fp + 8<32> @ 00000000 : word32)
+  Class: Eq_792
+  DataType: ptr32
+  OrigDataType: ptr32
+T_824: (in ebx @ 004019C4 : word32)
+  Class: Eq_824
+  DataType: word32
+  OrigDataType: word32
+T_825: (in -16<i32> @ 004019C9 : int32)
+  Class: Eq_825
+  DataType: int32
+  OrigDataType: int32
+T_826: (in ebp + -16<i32> @ 004019C9 : word32)
   Class: Eq_826
   DataType: word32
   OrigDataType: word32
-T_827: (in ebp + 0<32> @ 004019D7 : word32)
+T_827: (in Mem0[ebp + -16<i32>:word32] @ 004019C9 : word32)
   Class: Eq_827
-  DataType: ptr32
-  OrigDataType: ptr32
-T_828: (in Mem8[ebp + 0<32>:word32] @ 004019D7 : word32)
-  Class: Eq_102
-  DataType: Eq_102
-  OrigDataType: word32
-T_829: (in 0<32> @ 004019D8 : word32)
-  Class: Eq_829
   DataType: word32
   OrigDataType: word32
-T_830: (in ebp + 0<32> @ 004019D8 : word32)
-  Class: Eq_830
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_831: (in Mem22[ebp + 0<32>:word32] @ 004019D8 : word32)
+T_828: (in fs @ 004019C9 : selector)
+  Class: Eq_828
+  DataType: (ptr32 Eq_828)
+  OrigDataType: (ptr32 (segment (0 T_830 t0000)))
+T_829: (in 0x00000000<p32> @ 004019C9 : ptr32)
+  Class: Eq_829
+  DataType: Eq_829
+  OrigDataType: (union (ptr32 u0) ((memptr T_828 (struct (0 word32 dw0000))) u1))
+T_830: (in Mem8[fs:0x00000000<p32>:word32] @ 004019C9 : word32)
+  Class: Eq_827
+  DataType: word32
+  OrigDataType: word32
+T_831: (in ebp_19 @ 004019D7 : Eq_102)
   Class: Eq_102
   DataType: Eq_102
   OrigDataType: word32
-T_832: (in dwArg0C @ 004019D9 : word32)
+T_832: (in 0<32> @ 004019D7 : word32)
+  Class: Eq_832
+  DataType: word32
+  OrigDataType: word32
+T_833: (in ebp + 0<32> @ 004019D7 : word32)
+  Class: Eq_833
+  DataType: ptr32
+  OrigDataType: ptr32
+T_834: (in Mem8[ebp + 0<32>:word32] @ 004019D7 : word32)
+  Class: Eq_102
+  DataType: Eq_102
+  OrigDataType: word32
+T_835: (in 0<32> @ 004019D8 : word32)
+  Class: Eq_835
+  DataType: word32
+  OrigDataType: word32
+T_836: (in ebp + 0<32> @ 004019D8 : word32)
+  Class: Eq_836
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_837: (in Mem22[ebp + 0<32>:word32] @ 004019D8 : word32)
+  Class: Eq_102
+  DataType: Eq_102
+  OrigDataType: word32
+T_838: (in dwArg0C @ 004019D9 : word32)
   Class: Eq_232
   DataType: ptr32
   OrigDataType: word32
-T_833: (in dwArg08 @ 004019D9 : word32)
+T_839: (in dwArg08 @ 004019D9 : word32)
   Class: Eq_233
   DataType: ptr32
   OrigDataType: word32
-T_834: (in dwArg10 @ 004019D9 : word32)
-  Class: Eq_818
+T_840: (in dwArg10 @ 004019D9 : word32)
+  Class: Eq_824
   DataType: word32
   OrigDataType: word32
-T_835: (in 0<32> @ 00401A01 : word32)
-  Class: Eq_835
+T_841: (in 0<32> @ 00401A01 : word32)
+  Class: Eq_841
   DataType: word32
   OrigDataType: word32
-T_836: (in 0040336C @ 00401A01 : ptr32)
-  Class: Eq_836
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_837 t0000)))
-T_837: (in Mem9[0x0040336C<p32>:word32] @ 00401A01 : word32)
-  Class: Eq_835
-  DataType: word32
-  OrigDataType: word32
-T_838: (in 00403010 @ 00401A0F : ptr32)
-  Class: Eq_838
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_839 t0000)))
-T_839: (in Mem14[0x00403010<p32>:word32] @ 00401A0F : word32)
-  Class: Eq_839
-  DataType: ui32
-  OrigDataType: ui32
-T_840: (in 1<32> @ 00401A0F : word32)
-  Class: Eq_840
-  DataType: ui32
-  OrigDataType: ui32
-T_841: (in g_dw403010 | 1<32> @ 00000000 : word32)
-  Class: Eq_839
-  DataType: ui32
-  OrigDataType: ui32
-T_842: (in 00403010 @ 00401A0F : ptr32)
+T_842: (in 0040336C @ 00401A01 : ptr32)
   Class: Eq_842
-  DataType: (ptr32 ui32)
+  DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_843 t0000)))
-T_843: (in Mem18[0x00403010<p32>:word32] @ 00401A0F : word32)
-  Class: Eq_839
+T_843: (in Mem9[0x0040336C<p32>:word32] @ 00401A01 : word32)
+  Class: Eq_841
+  DataType: word32
+  OrigDataType: word32
+T_844: (in 00403010 @ 00401A0F : ptr32)
+  Class: Eq_844
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_845 t0000)))
+T_845: (in Mem14[0x00403010<p32>:word32] @ 00401A0F : word32)
+  Class: Eq_845
+  DataType: ui32
+  OrigDataType: ui32
+T_846: (in 1<32> @ 00401A0F : word32)
+  Class: Eq_846
+  DataType: ui32
+  OrigDataType: ui32
+T_847: (in g_dw403010 | 1<32> @ 00000000 : word32)
+  Class: Eq_845
+  DataType: ui32
+  OrigDataType: ui32
+T_848: (in 00403010 @ 00401A0F : ptr32)
+  Class: Eq_848
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_849 t0000)))
+T_849: (in Mem18[0x00403010<p32>:word32] @ 00401A0F : word32)
+  Class: Eq_845
   DataType: ui32
   OrigDataType: word32
-T_844: (in IsProcessorFeaturePresent @ 00401A1E : ptr32)
-  Class: Eq_679
-  DataType: (ptr32 Eq_679)
-  OrigDataType: (ptr32 (fn T_846 (T_845)))
-T_845: (in 0xA<32> @ 00401A1E : word32)
+T_850: (in IsProcessorFeaturePresent @ 00401A1E : ptr32)
+  Class: Eq_685
+  DataType: (ptr32 Eq_685)
+  OrigDataType: (ptr32 (fn T_852 (T_851)))
+T_851: (in 0xA<32> @ 00401A1E : word32)
   Class: Eq_89
   DataType: int32
   OrigDataType: DWORD
-T_846: (in IsProcessorFeaturePresent(0xA<32>) @ 00401A1E : BOOL)
+T_852: (in IsProcessorFeaturePresent(0xA<32>) @ 00401A1E : BOOL)
   Class: Eq_642
   DataType: Eq_642
   OrigDataType: BOOL
-T_847: (in 0<32> @ 00401A1E : word32)
+T_853: (in 0<32> @ 00401A1E : word32)
   Class: Eq_642
   DataType: Eq_642
   OrigDataType: word32
-T_848: (in IsProcessorFeaturePresent(0xA<32>) == 0<32> @ 00000000 : bool)
-  Class: Eq_848
+T_854: (in IsProcessorFeaturePresent(0xA<32>) == 0<32> @ 00000000 : bool)
+  Class: Eq_854
   DataType: bool
   OrigDataType: bool
-T_849: (in edi_101 @ 00401A24 : ui32)
-  Class: Eq_849
+T_855: (in edi_101 @ 00401A24 : ui32)
+  Class: Eq_855
   DataType: ui32
   OrigDataType: ui32
-T_850: (in 00403010 @ 00401A2A : ptr32)
-  Class: Eq_850
+T_856: (in 00403010 @ 00401A2A : ptr32)
+  Class: Eq_856
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_851 t0000)))
-T_851: (in Mem28[0x00403010<p32>:word32] @ 00401A2A : word32)
-  Class: Eq_839
+  OrigDataType: (ptr32 (struct (0 T_857 t0000)))
+T_857: (in Mem28[0x00403010<p32>:word32] @ 00401A2A : word32)
+  Class: Eq_845
   DataType: ui32
   OrigDataType: ui32
-T_852: (in 2<32> @ 00401A2A : word32)
-  Class: Eq_852
+T_858: (in 2<32> @ 00401A2A : word32)
+  Class: Eq_858
   DataType: ui32
   OrigDataType: ui32
-T_853: (in g_dw403010 | 2<32> @ 00000000 : word32)
-  Class: Eq_839
+T_859: (in g_dw403010 | 2<32> @ 00000000 : word32)
+  Class: Eq_845
   DataType: ui32
   OrigDataType: ui32
-T_854: (in 00403010 @ 00401A2A : ptr32)
-  Class: Eq_854
+T_860: (in 00403010 @ 00401A2A : ptr32)
+  Class: Eq_860
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_855 t0000)))
-T_855: (in Mem32[0x00403010<p32>:word32] @ 00401A2A : word32)
-  Class: Eq_839
+  OrigDataType: (ptr32 (struct (0 T_861 t0000)))
+T_861: (in Mem32[0x00403010<p32>:word32] @ 00401A2A : word32)
+  Class: Eq_845
   DataType: ui32
   OrigDataType: word32
-T_856: (in 1<32> @ 00401A35 : word32)
-  Class: Eq_835
+T_862: (in 1<32> @ 00401A35 : word32)
+  Class: Eq_841
   DataType: word32
   OrigDataType: word32
-T_857: (in 0040336C @ 00401A35 : ptr32)
-  Class: Eq_857
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_858 t0000)))
-T_858: (in Mem41[0x0040336C<p32>:word32] @ 00401A35 : word32)
-  Class: Eq_835
-  DataType: word32
-  OrigDataType: word32
-T_859: (in __cpuid @ 00401A3F : ptr32)
-  Class: Eq_859
-  DataType: (ptr32 Eq_859)
-  OrigDataType: (ptr32 (fn T_876 (T_867, T_868, T_870, T_872, T_874, T_875)))
-T_860: (in signature of __cpuid @ 00000000 : void)
-  Class: Eq_859
-  DataType: (ptr32 Eq_859)
-  OrigDataType: 
-T_861: (in p1 @ 00401A3F : word32)
-  Class: Eq_861
-  DataType: word32
-  OrigDataType: 
-T_862: (in p2 @ 00401A3F : word32)
-  Class: Eq_862
-  DataType: word32
-  OrigDataType: 
-T_863: (in p3 @ 00401A3F : word32)
+T_863: (in 0040336C @ 00401A35 : ptr32)
   Class: Eq_863
   DataType: (ptr32 word32)
-  OrigDataType: 
-T_864: (in p4 @ 00401A3F : word32)
-  Class: Eq_864
-  DataType: (ptr32 word32)
-  OrigDataType: 
-T_865: (in p5 @ 00401A3F : word32)
+  OrigDataType: (ptr32 (struct (0 T_864 t0000)))
+T_864: (in Mem41[0x0040336C<p32>:word32] @ 00401A35 : word32)
+  Class: Eq_841
+  DataType: word32
+  OrigDataType: word32
+T_865: (in __cpuid @ 00401A3F : ptr32)
   Class: Eq_865
-  DataType: (ptr32 word32)
+  DataType: (ptr32 Eq_865)
+  OrigDataType: (ptr32 (fn T_882 (T_873, T_874, T_876, T_878, T_880, T_881)))
+T_866: (in signature of __cpuid @ 00000000 : void)
+  Class: Eq_865
+  DataType: (ptr32 Eq_865)
   OrigDataType: 
-T_866: (in p6 @ 00401A3F : word32)
-  Class: Eq_866
-  DataType: (ptr32 word32)
+T_867: (in p1 @ 00401A3F : word32)
+  Class: Eq_867
+  DataType: word32
   OrigDataType: 
-T_867: (in 0<32> @ 00401A3F : word32)
-  Class: Eq_861
+T_868: (in p2 @ 00401A3F : word32)
+  Class: Eq_868
   DataType: word32
-  OrigDataType: word32
-T_868: (in 0<32> @ 00401A3F : word32)
-  Class: Eq_862
-  DataType: word32
-  OrigDataType: word32
-T_869: (in 0<32> @ 00401A3F : word32)
+  OrigDataType: 
+T_869: (in p3 @ 00401A3F : word32)
   Class: Eq_869
-  DataType: word32
-  OrigDataType: word32
-T_870: (in &0<32> @ 00401A3F : ptr32)
-  Class: Eq_863
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_871: (in 1<32> @ 00401A3F : word32)
+  OrigDataType: 
+T_870: (in p4 @ 00401A3F : word32)
+  Class: Eq_870
+  DataType: (ptr32 word32)
+  OrigDataType: 
+T_871: (in p5 @ 00401A3F : word32)
   Class: Eq_871
-  DataType: word32
-  OrigDataType: word32
-T_872: (in &1<32> @ 00401A3F : ptr32)
-  Class: Eq_864
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
+  OrigDataType: 
+T_872: (in p6 @ 00401A3F : word32)
+  Class: Eq_872
+  DataType: (ptr32 word32)
+  OrigDataType: 
 T_873: (in 0<32> @ 00401A3F : word32)
-  Class: Eq_873
+  Class: Eq_867
   DataType: word32
   OrigDataType: word32
-T_874: (in &0<32> @ 00401A3F : ptr32)
-  Class: Eq_865
+T_874: (in 0<32> @ 00401A3F : word32)
+  Class: Eq_868
+  DataType: word32
+  OrigDataType: word32
+T_875: (in 0<32> @ 00401A3F : word32)
+  Class: Eq_875
+  DataType: word32
+  OrigDataType: word32
+T_876: (in &0<32> @ 00401A3F : ptr32)
+  Class: Eq_869
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_875: (in &edx @ 00401A3F : ptr32)
-  Class: Eq_866
+T_877: (in 1<32> @ 00401A3F : word32)
+  Class: Eq_877
+  DataType: word32
+  OrigDataType: word32
+T_878: (in &1<32> @ 00401A3F : ptr32)
+  Class: Eq_870
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_876: (in __cpuid(0<32>, 0<32>, &0<32>, &1<32>, &0<32>, &edx) @ 00401A3F : void)
-  Class: Eq_876
-  DataType: void
-  OrigDataType: void
-T_877: (in __cpuid @ 00401A79 : ptr32)
-  Class: Eq_859
-  DataType: (ptr32 Eq_859)
-  OrigDataType: (ptr32 (fn T_887 (T_878, T_879, T_881, T_883, T_885, T_886)))
-T_878: (in 1<32> @ 00401A79 : word32)
-  Class: Eq_861
+T_879: (in 0<32> @ 00401A3F : word32)
+  Class: Eq_879
   DataType: word32
   OrigDataType: word32
-T_879: (in 0<32> @ 00401A79 : word32)
-  Class: Eq_862
-  DataType: word32
-  OrigDataType: word32
-T_880: (in 1<32> @ 00401A79 : word32)
-  Class: Eq_880
-  DataType: word32
-  OrigDataType: word32
-T_881: (in &1<32> @ 00401A79 : ptr32)
-  Class: Eq_863
+T_880: (in &0<32> @ 00401A3F : ptr32)
+  Class: Eq_871
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_882: (in 1<32> @ 00401A79 : word32)
+T_881: (in &edx @ 00401A3F : ptr32)
+  Class: Eq_872
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_882: (in __cpuid(0<32>, 0<32>, &0<32>, &1<32>, &0<32>, &edx) @ 00401A3F : void)
   Class: Eq_882
-  DataType: word32
-  OrigDataType: word32
-T_883: (in &1<32> @ 00401A79 : ptr32)
-  Class: Eq_864
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_884: (in 0<32> @ 00401A79 : word32)
-  Class: Eq_884
-  DataType: word32
-  OrigDataType: word32
-T_885: (in &0<32> @ 00401A79 : ptr32)
-  Class: Eq_865
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_886: (in &edx @ 00401A79 : ptr32)
-  Class: Eq_866
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_887: (in __cpuid(1<32>, 0<32>, &1<32>, &1<32>, &0<32>, &edx) @ 00401A79 : void)
-  Class: Eq_876
   DataType: void
   OrigDataType: void
-T_888: (in bLoc14_257 @ 00401A24 : byte)
+T_883: (in __cpuid @ 00401A79 : ptr32)
+  Class: Eq_865
+  DataType: (ptr32 Eq_865)
+  OrigDataType: (ptr32 (fn T_893 (T_884, T_885, T_887, T_889, T_891, T_892)))
+T_884: (in 1<32> @ 00401A79 : word32)
+  Class: Eq_867
+  DataType: word32
+  OrigDataType: word32
+T_885: (in 0<32> @ 00401A79 : word32)
+  Class: Eq_868
+  DataType: word32
+  OrigDataType: word32
+T_886: (in 1<32> @ 00401A79 : word32)
+  Class: Eq_886
+  DataType: word32
+  OrigDataType: word32
+T_887: (in &1<32> @ 00401A79 : ptr32)
+  Class: Eq_869
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_888: (in 1<32> @ 00401A79 : word32)
   Class: Eq_888
-  DataType: byte
-  OrigDataType: byte
-T_889: (in 0<8> @ 00401A24 : byte)
-  Class: Eq_888
-  DataType: byte
-  OrigDataType: byte
-T_890: (in 0x49656E69<32> @ 00401A89 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_889: (in &1<32> @ 00401A79 : ptr32)
+  Class: Eq_870
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_890: (in 0<32> @ 00401A79 : word32)
   Class: Eq_890
   DataType: word32
   OrigDataType: word32
-T_891: (in edx ^ 0x49656E69<32> @ 00000000 : word32)
-  Class: Eq_891
-  DataType: ui32
-  OrigDataType: ui32
-T_892: (in 0x6C65746E<32> @ 00401A89 : word32)
-  Class: Eq_892
-  DataType: ui32
-  OrigDataType: ui32
-T_893: (in edx ^ 0x49656E69<32> | 0x6C65746E<32> @ 00000000 : word32)
-  Class: Eq_893
-  DataType: ui32
-  OrigDataType: ui32
-T_894: (in 0x756E6546<32> @ 00401A89 : word32)
+T_891: (in &0<32> @ 00401A79 : ptr32)
+  Class: Eq_871
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_892: (in &edx @ 00401A79 : ptr32)
+  Class: Eq_872
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_893: (in __cpuid(1<32>, 0<32>, &1<32>, &1<32>, &0<32>, &edx) @ 00401A79 : void)
+  Class: Eq_882
+  DataType: void
+  OrigDataType: void
+T_894: (in bLoc14_257 @ 00401A24 : byte)
   Class: Eq_894
-  DataType: ui32
-  OrigDataType: ui32
-T_895: (in edx ^ 0x49656E69<32> | 0x6C65746E<32> | 0x756E6546<32> @ 00000000 : word32)
-  Class: Eq_895
-  DataType: ui32
-  OrigDataType: ui32
-T_896: (in 0<32> @ 00401A89 : word32)
-  Class: Eq_895
-  DataType: ui32
+  DataType: byte
+  OrigDataType: byte
+T_895: (in 0<8> @ 00401A24 : byte)
+  Class: Eq_894
+  DataType: byte
+  OrigDataType: byte
+T_896: (in 0x49656E69<32> @ 00401A89 : word32)
+  Class: Eq_896
+  DataType: word32
   OrigDataType: word32
-T_897: (in (edx ^ 0x49656E69<32> | 0x6C65746E<32> | 0x756E6546<32>) != 0<32> @ 00000000 : bool)
+T_897: (in edx ^ 0x49656E69<32> @ 00000000 : word32)
   Class: Eq_897
-  DataType: bool
-  OrigDataType: bool
-T_898: (in 00403370 @ 00401ACE : ptr32)
+  DataType: ui32
+  OrigDataType: ui32
+T_898: (in 0x6C65746E<32> @ 00401A89 : word32)
   Class: Eq_898
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_899 t0000)))
-T_899: (in Mem81[0x00403370<p32>:word32] @ 00401ACE : word32)
-  Class: Eq_849
   DataType: ui32
-  OrigDataType: word32
-T_900: (in false @ 00401A98 : bool)
+  OrigDataType: ui32
+T_899: (in edx ^ 0x49656E69<32> | 0x6C65746E<32> @ 00000000 : word32)
+  Class: Eq_899
+  DataType: ui32
+  OrigDataType: ui32
+T_900: (in 0x756E6546<32> @ 00401A89 : word32)
   Class: Eq_900
-  DataType: bool
-  OrigDataType: bool
-T_901: (in edi_100 @ 00401ABD : ui32)
-  Class: Eq_849
   DataType: ui32
   OrigDataType: ui32
-T_902: (in 00403370 @ 00401ABD : ptr32)
-  Class: Eq_902
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_903 t0000)))
-T_903: (in Mem81[0x00403370<p32>:word32] @ 00401ABD : word32)
-  Class: Eq_849
+T_901: (in edx ^ 0x49656E69<32> | 0x6C65746E<32> | 0x756E6546<32> @ 00000000 : word32)
+  Class: Eq_901
+  DataType: ui32
+  OrigDataType: ui32
+T_902: (in 0<32> @ 00401A89 : word32)
+  Class: Eq_901
   DataType: ui32
   OrigDataType: word32
-T_904: (in 1<32> @ 00401AC6 : word32)
+T_903: (in (edx ^ 0x49656E69<32> | 0x6C65746E<32> | 0x756E6546<32>) != 0<32> @ 00000000 : bool)
+  Class: Eq_903
+  DataType: bool
+  OrigDataType: bool
+T_904: (in 00403370 @ 00401ACE : ptr32)
   Class: Eq_904
-  DataType: ui32
-  OrigDataType: ui32
-T_905: (in edi_100 | 1<32> @ 00000000 : word32)
-  Class: Eq_849
-  DataType: ui32
-  OrigDataType: ui32
-T_906: (in 00403370 @ 00401AC6 : ptr32)
-  Class: Eq_906
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_907 t0000)))
-T_907: (in Mem104[0x00403370<p32>:word32] @ 00401AC6 : word32)
-  Class: Eq_849
+  OrigDataType: (ptr32 (struct (0 T_905 t0000)))
+T_905: (in Mem81[0x00403370<p32>:word32] @ 00401ACE : word32)
+  Class: Eq_855
   DataType: ui32
   OrigDataType: word32
-T_908: (in edi_100 | 1<32> @ 00000000 : word32)
-  Class: Eq_849
+T_906: (in false @ 00401A98 : bool)
+  Class: Eq_906
+  DataType: bool
+  OrigDataType: bool
+T_907: (in edi_100 @ 00401ABD : ui32)
+  Class: Eq_855
   DataType: ui32
   OrigDataType: ui32
-T_909: (in false @ 00401A9F : bool)
-  Class: Eq_909
-  DataType: bool
-  OrigDataType: bool
-T_910: (in false @ 00401AA6 : bool)
+T_908: (in 00403370 @ 00401ABD : ptr32)
+  Class: Eq_908
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_909 t0000)))
+T_909: (in Mem81[0x00403370<p32>:word32] @ 00401ABD : word32)
+  Class: Eq_855
+  DataType: ui32
+  OrigDataType: word32
+T_910: (in 1<32> @ 00401AC6 : word32)
   Class: Eq_910
-  DataType: bool
-  OrigDataType: bool
-T_911: (in false @ 00401AAD : bool)
-  Class: Eq_911
-  DataType: bool
-  OrigDataType: bool
-T_912: (in false @ 00401AB4 : bool)
+  DataType: ui32
+  OrigDataType: ui32
+T_911: (in edi_100 | 1<32> @ 00000000 : word32)
+  Class: Eq_855
+  DataType: ui32
+  OrigDataType: ui32
+T_912: (in 00403370 @ 00401AC6 : ptr32)
   Class: Eq_912
-  DataType: bool
-  OrigDataType: bool
-T_913: (in true @ 00401ABB : bool)
-  Class: Eq_913
-  DataType: bool
-  OrigDataType: bool
-T_914: (in true @ 00401AE7 : bool)
-  Class: Eq_914
-  DataType: bool
-  OrigDataType: bool
-T_915: (in true @ 00401B22 : bool)
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_913 t0000)))
+T_913: (in Mem104[0x00403370<p32>:word32] @ 00401AC6 : word32)
+  Class: Eq_855
+  DataType: ui32
+  OrigDataType: word32
+T_914: (in edi_100 | 1<32> @ 00000000 : word32)
+  Class: Eq_855
+  DataType: ui32
+  OrigDataType: ui32
+T_915: (in false @ 00401A9F : bool)
   Class: Eq_915
   DataType: bool
   OrigDataType: bool
-T_916: (in __cpuid @ 00401AEF : ptr32)
-  Class: Eq_859
-  DataType: (ptr32 Eq_859)
-  OrigDataType: (ptr32 (fn T_926 (T_917, T_918, T_920, T_922, T_924, T_925)))
-T_917: (in 7<32> @ 00401AEF : word32)
-  Class: Eq_861
-  DataType: word32
-  OrigDataType: word32
-T_918: (in 0<32> @ 00401AEF : word32)
-  Class: Eq_862
-  DataType: word32
-  OrigDataType: word32
-T_919: (in 7<32> @ 00401AEF : word32)
-  Class: Eq_919
-  DataType: word32
-  OrigDataType: word32
-T_920: (in &7<32> @ 00401AEF : ptr32)
-  Class: Eq_863
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_921: (in 1<32> @ 00401AEF : word32)
-  Class: Eq_921
-  DataType: word32
-  OrigDataType: word32
-T_922: (in &1<32> @ 00401AEF : ptr32)
-  Class: Eq_864
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_923: (in 0<32> @ 00401AEF : word32)
-  Class: Eq_923
-  DataType: word32
-  OrigDataType: word32
-T_924: (in &0<32> @ 00401AEF : ptr32)
-  Class: Eq_865
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_925: (in &edx @ 00401AEF : ptr32)
-  Class: Eq_866
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_926: (in __cpuid(7<32>, 0<32>, &7<32>, &1<32>, &0<32>, &edx) @ 00401AEF : void)
-  Class: Eq_876
-  DataType: void
-  OrigDataType: void
-T_927: (in 1<8> @ 00401B0A : byte)
-  Class: Eq_888
-  DataType: byte
-  OrigDataType: byte
-T_928: (in true @ 00401B10 : bool)
-  Class: Eq_928
+T_916: (in false @ 00401AA6 : bool)
+  Class: Eq_916
   DataType: bool
   OrigDataType: bool
-T_929: (in 2<32> @ 00401B15 : word32)
-  Class: Eq_929
-  DataType: ui32
-  OrigDataType: ui32
-T_930: (in edi_101 | 2<32> @ 00000000 : word32)
-  Class: Eq_849
-  DataType: ui32
-  OrigDataType: ui32
-T_931: (in 00403370 @ 00401B15 : ptr32)
-  Class: Eq_931
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_932 t0000)))
-T_932: (in Mem150[0x00403370<p32>:word32] @ 00401B15 : word32)
-  Class: Eq_849
-  DataType: ui32
+T_917: (in false @ 00401AAD : bool)
+  Class: Eq_917
+  DataType: bool
+  OrigDataType: bool
+T_918: (in false @ 00401AB4 : bool)
+  Class: Eq_918
+  DataType: bool
+  OrigDataType: bool
+T_919: (in true @ 00401ABB : bool)
+  Class: Eq_919
+  DataType: bool
+  OrigDataType: bool
+T_920: (in true @ 00401AE7 : bool)
+  Class: Eq_920
+  DataType: bool
+  OrigDataType: bool
+T_921: (in true @ 00401B22 : bool)
+  Class: Eq_921
+  DataType: bool
+  OrigDataType: bool
+T_922: (in __cpuid @ 00401AEF : ptr32)
+  Class: Eq_865
+  DataType: (ptr32 Eq_865)
+  OrigDataType: (ptr32 (fn T_932 (T_923, T_924, T_926, T_928, T_930, T_931)))
+T_923: (in 7<32> @ 00401AEF : word32)
+  Class: Eq_867
+  DataType: word32
   OrigDataType: word32
-T_933: (in 00403010 @ 00401B24 : ptr32)
-  Class: Eq_933
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_934 t0000)))
-T_934: (in Mem152[0x00403010<p32>:word32] @ 00401B24 : word32)
-  Class: Eq_839
-  DataType: ui32
-  OrigDataType: ui32
-T_935: (in 4<32> @ 00401B24 : word32)
+T_924: (in 0<32> @ 00401AEF : word32)
+  Class: Eq_868
+  DataType: word32
+  OrigDataType: word32
+T_925: (in 7<32> @ 00401AEF : word32)
+  Class: Eq_925
+  DataType: word32
+  OrigDataType: word32
+T_926: (in &7<32> @ 00401AEF : ptr32)
+  Class: Eq_869
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_927: (in 1<32> @ 00401AEF : word32)
+  Class: Eq_927
+  DataType: word32
+  OrigDataType: word32
+T_928: (in &1<32> @ 00401AEF : ptr32)
+  Class: Eq_870
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_929: (in 0<32> @ 00401AEF : word32)
+  Class: Eq_929
+  DataType: word32
+  OrigDataType: word32
+T_930: (in &0<32> @ 00401AEF : ptr32)
+  Class: Eq_871
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_931: (in &edx @ 00401AEF : ptr32)
+  Class: Eq_872
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_932: (in __cpuid(7<32>, 0<32>, &7<32>, &1<32>, &0<32>, &edx) @ 00401AEF : void)
+  Class: Eq_882
+  DataType: void
+  OrigDataType: void
+T_933: (in 1<8> @ 00401B0A : byte)
+  Class: Eq_894
+  DataType: byte
+  OrigDataType: byte
+T_934: (in true @ 00401B10 : bool)
+  Class: Eq_934
+  DataType: bool
+  OrigDataType: bool
+T_935: (in 2<32> @ 00401B15 : word32)
   Class: Eq_935
   DataType: ui32
   OrigDataType: ui32
-T_936: (in g_dw403010 | 4<32> @ 00000000 : word32)
-  Class: Eq_839
+T_936: (in edi_101 | 2<32> @ 00000000 : word32)
+  Class: Eq_855
   DataType: ui32
   OrigDataType: ui32
-T_937: (in 00403010 @ 00401B24 : ptr32)
+T_937: (in 00403370 @ 00401B15 : ptr32)
   Class: Eq_937
   DataType: (ptr32 ui32)
   OrigDataType: (ptr32 (struct (0 T_938 t0000)))
-T_938: (in Mem162[0x00403010<p32>:word32] @ 00401B24 : word32)
-  Class: Eq_839
+T_938: (in Mem150[0x00403370<p32>:word32] @ 00401B15 : word32)
+  Class: Eq_855
   DataType: ui32
   OrigDataType: word32
-T_939: (in 2<32> @ 00401B2B : word32)
-  Class: Eq_835
-  DataType: word32
-  OrigDataType: word32
-T_940: (in 0040336C @ 00401B2B : ptr32)
-  Class: Eq_940
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_941 t0000)))
-T_941: (in Mem164[0x0040336C<p32>:word32] @ 00401B2B : word32)
-  Class: Eq_835
-  DataType: word32
-  OrigDataType: word32
-T_942: (in true @ 00401B3A : bool)
-  Class: Eq_942
-  DataType: bool
-  OrigDataType: bool
-T_943: (in true @ 00401B41 : bool)
+T_939: (in 00403010 @ 00401B24 : ptr32)
+  Class: Eq_939
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_940 t0000)))
+T_940: (in Mem152[0x00403010<p32>:word32] @ 00401B24 : word32)
+  Class: Eq_845
+  DataType: ui32
+  OrigDataType: ui32
+T_941: (in 4<32> @ 00401B24 : word32)
+  Class: Eq_941
+  DataType: ui32
+  OrigDataType: ui32
+T_942: (in g_dw403010 | 4<32> @ 00000000 : word32)
+  Class: Eq_845
+  DataType: ui32
+  OrigDataType: ui32
+T_943: (in 00403010 @ 00401B24 : ptr32)
   Class: Eq_943
-  DataType: bool
-  OrigDataType: bool
-T_944: (in __xgetbv @ 00401B5C : ptr32)
-  Class: Eq_944
-  DataType: (ptr32 Eq_944)
-  OrigDataType: (ptr32 (fn T_948 (T_947)))
-T_945: (in signature of __xgetbv @ 00000000 : void)
-  Class: Eq_944
-  DataType: (ptr32 Eq_944)
-  OrigDataType: 
-T_946: (in p1 @ 00401B5C : word32)
-  Class: Eq_946
-  DataType: word32
-  OrigDataType: 
-T_947: (in 0<32> @ 00401B5C : word32)
-  Class: Eq_946
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_944 t0000)))
+T_944: (in Mem162[0x00403010<p32>:word32] @ 00401B24 : word32)
+  Class: Eq_845
+  DataType: ui32
+  OrigDataType: word32
+T_945: (in 2<32> @ 00401B2B : word32)
+  Class: Eq_841
   DataType: word32
   OrigDataType: word32
-T_948: (in __xgetbv(0<32>) @ 00401B5C : word64)
+T_946: (in 0040336C @ 00401B2B : ptr32)
+  Class: Eq_946
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_947 t0000)))
+T_947: (in Mem164[0x0040336C<p32>:word32] @ 00401B2B : word32)
+  Class: Eq_841
+  DataType: word32
+  OrigDataType: word32
+T_948: (in true @ 00401B3A : bool)
   Class: Eq_948
+  DataType: bool
+  OrigDataType: bool
+T_949: (in true @ 00401B41 : bool)
+  Class: Eq_949
+  DataType: bool
+  OrigDataType: bool
+T_950: (in __xgetbv @ 00401B5C : ptr32)
+  Class: Eq_950
+  DataType: (ptr32 Eq_950)
+  OrigDataType: (ptr32 (fn T_954 (T_953)))
+T_951: (in signature of __xgetbv @ 00000000 : void)
+  Class: Eq_950
+  DataType: (ptr32 Eq_950)
+  OrigDataType: 
+T_952: (in p1 @ 00401B5C : word32)
+  Class: Eq_952
+  DataType: word32
+  OrigDataType: 
+T_953: (in 0<32> @ 00401B5C : word32)
+  Class: Eq_952
+  DataType: word32
+  OrigDataType: word32
+T_954: (in __xgetbv(0<32>) @ 00401B5C : word64)
+  Class: Eq_954
   DataType: word64
   OrigDataType: word64
-T_949: (in SLICE(__xgetbv(0<32>), word32, 0) @ 00401B5C : word32)
-  Class: Eq_949
+T_955: (in SLICE(__xgetbv(0<32>), word32, 0) @ 00401B5C : word32)
+  Class: Eq_955
   DataType: ui32
   OrigDataType: ui32
-T_950: (in 6<32> @ 00401B5C : word32)
-  Class: Eq_950
-  DataType: ui32
-  OrigDataType: ui32
-T_951: (in (word32) __xgetbv(0<32>) & 6<32> @ 00000000 : word32)
-  Class: Eq_951
-  DataType: ui32
-  OrigDataType: ui32
-T_952: (in 6<32> @ 00401B5C : word32)
-  Class: Eq_951
-  DataType: ui32
-  OrigDataType: word32
-T_953: (in ((word32) __xgetbv(0<32>) & 6<32>) != 6<32> @ 00000000 : bool)
-  Class: Eq_953
-  DataType: bool
-  OrigDataType: bool
-T_954: (in false @ 00401B60 : bool)
-  Class: Eq_954
-  DataType: bool
-  OrigDataType: bool
-T_955: (in eax_187 @ 00401B62 : ui32)
-  Class: Eq_839
-  DataType: ui32
-  OrigDataType: ui32
-T_956: (in 00403010 @ 00401B62 : ptr32)
+T_956: (in 6<32> @ 00401B5C : word32)
   Class: Eq_956
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_957 t0000)))
-T_957: (in Mem177[0x00403010<p32>:word32] @ 00401B62 : word32)
-  Class: Eq_839
+  DataType: ui32
+  OrigDataType: ui32
+T_957: (in (word32) __xgetbv(0<32>) & 6<32> @ 00000000 : word32)
+  Class: Eq_957
+  DataType: ui32
+  OrigDataType: ui32
+T_958: (in 6<32> @ 00401B5C : word32)
+  Class: Eq_957
   DataType: ui32
   OrigDataType: word32
-T_958: (in 3<32> @ 00401B6A : word32)
-  Class: Eq_835
-  DataType: word32
-  OrigDataType: word32
-T_959: (in 0040336C @ 00401B6A : ptr32)
+T_959: (in ((word32) __xgetbv(0<32>) & 6<32>) != 6<32> @ 00000000 : bool)
   Class: Eq_959
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_960 t0000)))
-T_960: (in Mem189[0x0040336C<p32>:word32] @ 00401B6A : word32)
-  Class: Eq_835
-  DataType: word32
-  OrigDataType: word32
-T_961: (in 8<32> @ 00401B78 : word32)
-  Class: Eq_961
-  DataType: ui32
-  OrigDataType: ui32
-T_962: (in eax_187 | 8<32> @ 00000000 : word32)
-  Class: Eq_839
-  DataType: ui32
-  OrigDataType: ui32
-T_963: (in 00403010 @ 00401B78 : ptr32)
-  Class: Eq_963
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_964 t0000)))
-T_964: (in Mem192[0x00403010<p32>:word32] @ 00401B78 : word32)
-  Class: Eq_839
-  DataType: ui32
-  OrigDataType: word32
-T_965: (in 0x20<8> @ 00401B7D : byte)
-  Class: Eq_965
-  DataType: byte
-  OrigDataType: byte
-T_966: (in bLoc14_257 & 0x20<8> @ 00000000 : byte)
-  Class: Eq_966
-  DataType: byte
-  OrigDataType: byte
-T_967: (in 0<8> @ 00401B7D : byte)
-  Class: Eq_966
-  DataType: byte
-  OrigDataType: byte
-T_968: (in (bLoc14_257 & 0x20<8>) == 0<8> @ 00000000 : bool)
-  Class: Eq_968
   DataType: bool
   OrigDataType: bool
-T_969: (in 5<32> @ 00401B82 : word32)
-  Class: Eq_835
-  DataType: word32
-  OrigDataType: word32
-T_970: (in 0040336C @ 00401B82 : ptr32)
-  Class: Eq_970
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_971 t0000)))
-T_971: (in Mem197[0x0040336C<p32>:word32] @ 00401B82 : word32)
-  Class: Eq_835
-  DataType: word32
-  OrigDataType: word32
-T_972: (in eax_187 | 8<32> @ 00000000 : word32)
-  Class: Eq_972
+T_960: (in false @ 00401B60 : bool)
+  Class: Eq_960
+  DataType: bool
+  OrigDataType: bool
+T_961: (in eax_187 @ 00401B62 : ui32)
+  Class: Eq_845
   DataType: ui32
   OrigDataType: ui32
-T_973: (in 0x20<32> @ 00401B8C : word32)
-  Class: Eq_973
-  DataType: ui32
-  OrigDataType: ui32
-T_974: (in eax_187 | 8<32> | 0x20<32> @ 00000000 : word32)
-  Class: Eq_839
-  DataType: ui32
-  OrigDataType: ui32
-T_975: (in 00403010 @ 00401B8C : ptr32)
-  Class: Eq_975
+T_962: (in 00403010 @ 00401B62 : ptr32)
+  Class: Eq_962
   DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_976 t0000)))
-T_976: (in Mem198[0x00403010<p32>:word32] @ 00401B8C : word32)
-  Class: Eq_839
+  OrigDataType: (ptr32 (struct (0 T_963 t0000)))
+T_963: (in Mem177[0x00403010<p32>:word32] @ 00401B62 : word32)
+  Class: Eq_845
   DataType: ui32
   OrigDataType: word32
-T_977: (in eax @ 00401B8C : uint32)
-  Class: Eq_977
+T_964: (in 3<32> @ 00401B6A : word32)
+  Class: Eq_841
+  DataType: word32
+  OrigDataType: word32
+T_965: (in 0040336C @ 00401B6A : ptr32)
+  Class: Eq_965
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_966 t0000)))
+T_966: (in Mem189[0x0040336C<p32>:word32] @ 00401B6A : word32)
+  Class: Eq_841
+  DataType: word32
+  OrigDataType: word32
+T_967: (in 8<32> @ 00401B78 : word32)
+  Class: Eq_967
+  DataType: ui32
+  OrigDataType: ui32
+T_968: (in eax_187 | 8<32> @ 00000000 : word32)
+  Class: Eq_845
+  DataType: ui32
+  OrigDataType: ui32
+T_969: (in 00403010 @ 00401B78 : ptr32)
+  Class: Eq_969
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_970 t0000)))
+T_970: (in Mem192[0x00403010<p32>:word32] @ 00401B78 : word32)
+  Class: Eq_845
+  DataType: ui32
+  OrigDataType: word32
+T_971: (in 0x20<8> @ 00401B7D : byte)
+  Class: Eq_971
+  DataType: byte
+  OrigDataType: byte
+T_972: (in bLoc14_257 & 0x20<8> @ 00000000 : byte)
+  Class: Eq_972
+  DataType: byte
+  OrigDataType: byte
+T_973: (in 0<8> @ 00401B7D : byte)
+  Class: Eq_972
+  DataType: byte
+  OrigDataType: byte
+T_974: (in (bLoc14_257 & 0x20<8>) == 0<8> @ 00000000 : bool)
+  Class: Eq_974
+  DataType: bool
+  OrigDataType: bool
+T_975: (in 5<32> @ 00401B82 : word32)
+  Class: Eq_841
+  DataType: word32
+  OrigDataType: word32
+T_976: (in 0040336C @ 00401B82 : ptr32)
+  Class: Eq_976
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_977 t0000)))
+T_977: (in Mem197[0x0040336C<p32>:word32] @ 00401B82 : word32)
+  Class: Eq_841
+  DataType: word32
+  OrigDataType: word32
+T_978: (in eax_187 | 8<32> @ 00000000 : word32)
+  Class: Eq_978
+  DataType: ui32
+  OrigDataType: ui32
+T_979: (in 0x20<32> @ 00401B8C : word32)
+  Class: Eq_979
+  DataType: ui32
+  OrigDataType: ui32
+T_980: (in eax_187 | 8<32> | 0x20<32> @ 00000000 : word32)
+  Class: Eq_845
+  DataType: ui32
+  OrigDataType: ui32
+T_981: (in 00403010 @ 00401B8C : ptr32)
+  Class: Eq_981
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_982 t0000)))
+T_982: (in Mem198[0x00403010<p32>:word32] @ 00401B8C : word32)
+  Class: Eq_845
+  DataType: ui32
+  OrigDataType: word32
+T_983: (in eax @ 00401B8C : uint32)
+  Class: Eq_983
   DataType: uint32
   OrigDataType: word32
-T_978: (in 00403014 @ 00401BA3 : ptr32)
-  Class: Eq_978
+T_984: (in 00403014 @ 00401BA3 : ptr32)
+  Class: Eq_984
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_979 t0000)))
-T_979: (in Mem0[0x00403014<p32>:word32] @ 00401BA3 : word32)
-  Class: Eq_979
+  OrigDataType: (ptr32 (struct (0 T_985 t0000)))
+T_985: (in Mem0[0x00403014<p32>:word32] @ 00401BA3 : word32)
+  Class: Eq_985
   DataType: word32
   OrigDataType: word32
-T_980: (in 0<32> @ 00401BA3 : word32)
-  Class: Eq_979
+T_986: (in 0<32> @ 00401BA3 : word32)
+  Class: Eq_985
   DataType: word32
   OrigDataType: word32
-T_981: (in g_dw403014 != 0<32> @ 00000000 : bool)
-  Class: Eq_981
+T_987: (in g_dw403014 != 0<32> @ 00000000 : bool)
+  Class: Eq_987
   DataType: bool
   OrigDataType: bool
-T_982: (in CONVERT(Mem0[0x00403014<p32>:word32] != 0<32>, bool, int8) @ 00401BA3 : int8)
-  Class: Eq_982
+T_988: (in CONVERT(Mem0[0x00403014<p32>:word32] != 0<32>, bool, int8) @ 00401BA3 : int8)
+  Class: Eq_988
   DataType: int8
   OrigDataType: int8
-T_983: (in CONVERT(CONVERT(Mem0[0x00403014<p32>:word32] != 0<32>, bool, int8), int8, uint32) @ 00401BA3 : uint32)
-  Class: Eq_977
+T_989: (in CONVERT(CONVERT(Mem0[0x00403014<p32>:word32] != 0<32>, bool, int8), int8, uint32) @ 00401BA3 : uint32)
+  Class: Eq_983
   DataType: uint32
   OrigDataType: uint32
-T_984: (in al @ 00401BA3 : byte)
-  Class: Eq_984
-  DataType: byte
-  OrigDataType: byte
-T_985: (in 1<8> @ 00401C48 : byte)
-  Class: Eq_984
-  DataType: byte
-  OrigDataType: byte
-T_986:
-  Class: Eq_986
-  DataType: word32
-  OrigDataType: word32
-T_987:
-  Class: Eq_987
-  DataType: word32
-  OrigDataType: word32
-T_988:
-  Class: Eq_988
-  DataType: word32
-  OrigDataType: word32
-T_989:
-  Class: Eq_989
-  DataType: word32
-  OrigDataType: word32
-T_990:
+T_990: (in al @ 00401BA3 : byte)
   Class: Eq_990
-  DataType: word32
-  OrigDataType: word32
-T_991:
-  Class: Eq_991
-  DataType: word32
-  OrigDataType: word32
+  DataType: byte
+  OrigDataType: byte
+T_991: (in 1<8> @ 00401C48 : byte)
+  Class: Eq_990
+  DataType: byte
+  OrigDataType: byte
 T_992:
   Class: Eq_992
   DataType: word32
@@ -4598,7 +4604,31 @@ T_1030:
   OrigDataType: word32
 T_1031:
   Class: Eq_1031
-  DataType: Eq_1031
+  DataType: word32
+  OrigDataType: word32
+T_1032:
+  Class: Eq_1032
+  DataType: word32
+  OrigDataType: word32
+T_1033:
+  Class: Eq_1033
+  DataType: word32
+  OrigDataType: word32
+T_1034:
+  Class: Eq_1034
+  DataType: word32
+  OrigDataType: word32
+T_1035:
+  Class: Eq_1035
+  DataType: word32
+  OrigDataType: word32
+T_1036:
+  Class: Eq_1036
+  DataType: word32
+  OrigDataType: word32
+T_1037:
+  Class: Eq_1037
+  DataType: Eq_1037
   OrigDataType: 
 */
 typedef struct Globals {
@@ -4766,7 +4796,7 @@ typedef Eq_96 * (Eq_97)(word32, Eq_100, Eq_100, Eq_102, ui32);
 
 typedef union Eq_100 {
 	byte u0;
-	struct Eq_1031 * u1;
+	struct Eq_1037 * u1;
 } Eq_100;
 
 typedef union Eq_102 {
@@ -4921,87 +4951,96 @@ typedef BOOL (Eq_637)(LARGE_INTEGER *);
 
 typedef LARGE_INTEGER Eq_639;
 
+typedef LARGE_INTEGER Eq_640;
+
 typedef BOOL Eq_642;
 
-typedef BOOL (Eq_679)(Eq_89);
+typedef struct Eq_644 {
+	LARGE_INTEGER t0000;	// 0
+	word32 dw0004;	// 4
+} Eq_644;
 
-typedef void (Eq_689)(void, int32, size_t);
+typedef LARGE_INTEGER Eq_648;
 
-typedef size_t Eq_693;
+typedef BOOL (Eq_685)(Eq_89);
 
-typedef BOOL (Eq_708)();
+typedef void (Eq_695)(void, int32, size_t);
 
-typedef union Eq_712 {
+typedef size_t Eq_699;
+
+typedef BOOL (Eq_714)();
+
+typedef union Eq_718 {
 	bool u0;
 	byte u1;
-} Eq_712;
+} Eq_718;
 
-typedef LPTOP_LEVEL_EXCEPTION_FILTER (Eq_714)(LPTOP_LEVEL_EXCEPTION_FILTER);
+typedef LPTOP_LEVEL_EXCEPTION_FILTER (Eq_720)(LPTOP_LEVEL_EXCEPTION_FILTER);
 
-typedef LPTOP_LEVEL_EXCEPTION_FILTER Eq_716;
+typedef LPTOP_LEVEL_EXCEPTION_FILTER Eq_722;
 
-typedef LONG (Eq_719)(_EXCEPTION_POINTERS *);
+typedef LONG (Eq_725)(_EXCEPTION_POINTERS *);
 
 typedef struct _EXCEPTION_POINTERS {
 	PEXCEPTION_RECORD ExceptionRecord;	// 0
 	PCONTEXT ContextRecord;	// 4
-} Eq_721;
+} Eq_727;
 
-typedef LONG Eq_724;
+typedef LONG Eq_730;
 
-typedef void (Eq_727)(word32);
+typedef void (Eq_733)(word32);
 
-typedef union Eq_738 {
+typedef union Eq_744 {
 	bool u0;
 	ui32 u1;
-} Eq_738;
+} Eq_744;
 
-typedef HMODULE Eq_744;
+typedef HMODULE Eq_750;
 
-typedef HMODULE (Eq_745)(LPCWSTR);
+typedef HMODULE (Eq_751)(LPCWSTR);
 
-typedef LPCWSTR Eq_747;
+typedef LPCWSTR Eq_753;
 
-typedef union Eq_754 {
+typedef union Eq_760 {
 	int32 u0;
 	word16 u1;
-} Eq_754;
+} Eq_760;
 
-typedef struct Eq_758 {
+typedef struct Eq_764 {
 	word32 dw0000;	// 0
 	word16 w0018;	// 18
 	up32 dw0074;	// 74
 	word32 dw00E8;	// E8
-} Eq_758;
+} Eq_764;
 
-typedef HMODULE Eq_760;
+typedef HMODULE Eq_766;
 
-typedef struct Eq_787 {
+typedef struct Eq_793 {
 	Eq_102 tFFFFFFEC;	// FFFFFFEC
 	ui32 dwFFFFFFF0;	// FFFFFFF0
 	Eq_100 tFFFFFFF4;	// FFFFFFF4
 	Eq_100 tFFFFFFF8;	// FFFFFFF8
 	word32 dwFFFFFFFC;	// FFFFFFFC
-} Eq_787;
+} Eq_793;
 
-typedef struct Eq_814 {
+typedef struct Eq_820 {
 	ptr32 ptr0000;	// 0
-} Eq_814;
+} Eq_820;
 
-typedef struct Eq_822 {
+typedef struct Eq_828 {
 	word32 dw0000;	// 0
-} Eq_822;
+} Eq_828;
 
-typedef union Eq_823 {
+typedef union Eq_829 {
 	ptr32 u0;
-	word32 Eq_822::* u1;
-} Eq_823;
+	word32 Eq_828::* u1;
+} Eq_829;
 
-typedef void (Eq_859)(word32, word32, word32 *, word32 *, word32 *, word32 *);
+typedef void (Eq_865)(word32, word32, word32 *, word32 *, word32 *, word32 *);
 
-typedef word64 (Eq_944)(word32);
+typedef word64 (Eq_950)(word32);
 
-typedef struct Eq_1031 {
+typedef struct Eq_1037 {
 	Eq_100 t0000;	// 0
-} Eq_1031;
+} Eq_1037;
 

--- a/subjects/PE/x86/import-ordinals/main_text.c
+++ b/subjects/PE/x86/import-ordinals/main_text.c
@@ -287,8 +287,8 @@ void fn0040165E()
 	{
 		GetSystemTimeAsFileTime(fp - 0x10);
 		ui32 v14_n = GetCurrentThreadId() ^ GetCurrentProcessId();
-		QueryPerformanceCounter(fp - 0x18);
-		ui32 ecx_n = dwLoc14 ^ dwLoc18 ^ v14_n ^ fp - 0x08;
+		QueryPerformanceCounter(&tLoc18);
+		ui32 ecx_n = tLoc18.dw0004 ^ tLoc18 ^ v14_n ^ fp - 0x08;
 		if (ecx_n == 0xBB40E64E)
 			ecx_n = ~0x44BF19B0;
 		else if ((ecx_n & 0xFFFF0000) == 0x00)

--- a/subjects/PE/x86/import-ordinals/main_text.dis
+++ b/subjects/PE/x86/import-ordinals/main_text.dis
@@ -379,8 +379,8 @@ l00401681:
 l0040168E:
 	GetSystemTimeAsFileTime(fp - 0x10<32>)
 	word32 v14_43 = GetCurrentThreadId() ^ GetCurrentProcessId()
-	QueryPerformanceCounter(fp - 0x18<32>)
-	word32 ecx_55 = dwLoc14 ^ dwLoc18 ^ v14_43 ^ fp - 8<32>
+	QueryPerformanceCounter(&tLoc18)
+	word32 ecx_55 = Mem48[&tLoc18 + 4<i32>:word32] ^ Mem48[&tLoc18:word32] ^ v14_43 ^ fp - 8<32>
 	branch ecx_55 != 0xBB40E64E<32> l004016D6
 l004016D6:
 	branch (ecx_55 & 0xFFFF0000<32>) != 0<32> l004016E6

--- a/subjects/PE/x86/pySample/pySample.h
+++ b/subjects/PE/x86/pySample/pySample.h
@@ -5,7 +5,7 @@
 /*
 // Equivalence classes ////////////
 Eq_1: (struct "Globals"
-		(10000000 Eq_676 t10000000)
+		(10000000 Eq_696 t10000000)
 		(10002000 (ptr32 code) __imp__GetSystemTimeAsFileTime)
 		(10002004 (ptr32 code) __imp__GetCurrentProcessId)
 		(10002008 (ptr32 code) __imp__GetCurrentThreadId)
@@ -41,10 +41,10 @@ Eq_1: (struct "Globals"
 		(10002088 (ptr32 code) __imp__PyArg_ParseTuple)
 		(1000208C (ptr32 code) __imp___Py_NoneStruct)
 		(10002090 (ptr32 code) __imp__Py_BuildValue)
-		(10002098 Eq_293 t10002098)
-		(1000209C Eq_294 t1000209C)
-		(100020A0 Eq_239 t100020A0)
-		(100020A8 Eq_240 t100020A8)
+		(10002098 Eq_313 t10002098)
+		(1000209C Eq_314 t1000209C)
+		(100020A0 Eq_259 t100020A0)
+		(100020A8 Eq_260 t100020A8)
 		(100020CC word32 dw100020CC)
 		(100020E0 (str char) str100020E0)
 		(100020F4 (str char) str100020F4)
@@ -104,7 +104,7 @@ Eq_1: (struct "Globals"
 		(10003070 int32 dw10003070)
 		(100033A4 word32 dw100033A4)
 		(100033A8 word32 dw100033A8)
-		(100033AC Eq_185 t100033AC)
+		(100033AC Eq_205 t100033AC)
 		(100033B0 (ptr32 void) ptr100033B0)
 		(100033B4 (ptr32 void) ptr100033B4)
 		(100033B8 (ptr32 code) ptr100033B8))
@@ -112,407 +112,413 @@ Eq_1: (struct "Globals"
 Eq_2: PyObject
 	T_2 (in eax @ 00000000 : (ptr32 Eq_2))
 	T_5 (in eax_17 @ 10001016 : (ptr32 Eq_2))
-	T_18 (in PyArg_ParseTuple(ptrArg08, "ii:sum", fp - 4<32>, fp - 8<32>) @ 10001016 : int32)
-	T_19 (in 0<32> @ 10001021 : word32)
-	T_29 (in Py_BuildValue("i", dwLoc04 + dwLoc08) @ 10001042 : (ptr32 PyObject))
-	T_30 (in eax_17 @ 10001067 : (ptr32 Eq_2))
-	T_41 (in PyArg_ParseTuple(ptrArg08, "ii:dif", fp - 8<32>, fp - 4<32>) @ 10001067 : int32)
-	T_42 (in 0<32> @ 10001072 : word32)
-	T_51 (in Py_BuildValue("i", dwLoc08 - dwLoc04) @ 10001091 : (ptr32 PyObject))
-	T_52 (in eax_17 @ 100010B7 : (ptr32 Eq_2))
-	T_63 (in PyArg_ParseTuple(ptrArg08, "ii:div", fp - 8<32>, fp - 4<32>) @ 100010B7 : int32)
-	T_64 (in 0<32> @ 100010C2 : word32)
-	T_75 (in Py_BuildValue("i", (int32) ((int64) dwLoc08 /32 dwLoc04)) @ 100010E2 : (ptr32 PyObject))
-	T_76 (in eax_17 @ 10001107 : (ptr32 Eq_2))
-	T_87 (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", fp - 8<32>, fp - 4<32>) @ 10001107 : int32)
-	T_88 (in 0<32> @ 10001112 : word32)
-	T_99 (in Py_BuildValue("f", (real64) rLoc08 / (real64) rLoc04) @ 10001136 : (ptr32 PyObject))
+	T_17 (in PyArg_ParseTuple(ptrArg08, "ii:sum", &dwLoc04, &dwLoc08) @ 10001016 : int32)
+	T_18 (in 0<32> @ 10001021 : word32)
+	T_34 (in Py_BuildValue("i", dwLoc04 + dwLoc08) @ 10001042 : (ptr32 PyObject))
+	T_35 (in eax_17 @ 10001067 : (ptr32 Eq_2))
+	T_45 (in PyArg_ParseTuple(ptrArg08, "ii:dif", &dwLoc08, &dwLoc04) @ 10001067 : int32)
+	T_46 (in 0<32> @ 10001072 : word32)
+	T_61 (in Py_BuildValue("i", dwLoc08 - dwLoc04) @ 10001091 : (ptr32 PyObject))
+	T_62 (in eax_17 @ 100010B7 : (ptr32 Eq_2))
+	T_72 (in PyArg_ParseTuple(ptrArg08, "ii:div", &dwLoc08, &dwLoc04) @ 100010B7 : int32)
+	T_73 (in 0<32> @ 100010C2 : word32)
+	T_90 (in Py_BuildValue("i", (int32) ((int64) dwLoc08 /32 dwLoc04)) @ 100010E2 : (ptr32 PyObject))
+	T_91 (in eax_17 @ 10001107 : (ptr32 Eq_2))
+	T_101 (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", &rLoc08, &rLoc04) @ 10001107 : int32)
+	T_102 (in 0<32> @ 10001112 : word32)
+	T_119 (in Py_BuildValue("f", (real64) rLoc08 / (real64) rLoc04) @ 10001136 : (ptr32 PyObject))
 Eq_3: PyObject
 	T_3 (in ptrArg04 @ 00000000 : (ptr32 Eq_3))
 Eq_4: PyObject
 	T_4 (in ptrArg08 @ 00000000 : (ptr32 Eq_4))
 	T_8 (in ptrArg04 @ 10001016 : (ptr32 PyObject))
-	T_106 (in args @ 1000114A : (ptr32 PyObject))
+	T_126 (in args @ 1000114A : (ptr32 PyObject))
 Eq_6: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 int32), (ptr32 int32)))
 	T_6 (in PyArg_ParseTuple @ 10001016 : ptr32)
 	T_7 (in signature of PyArg_ParseTuple @ 00000000 : void)
-Eq_21: (fn (ptr32 Eq_2) ((ptr32 char), int32))
-	T_21 (in Py_BuildValue @ 10001042 : ptr32)
-	T_22 (in signature of Py_BuildValue @ 00000000 : void)
-Eq_31: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 int32), (ptr32 int32)))
-	T_31 (in PyArg_ParseTuple @ 10001067 : ptr32)
-	T_32 (in signature of PyArg_ParseTuple @ 00000000 : void)
-Eq_44: (fn (ptr32 Eq_2) ((ptr32 char), int32))
-	T_44 (in Py_BuildValue @ 10001091 : ptr32)
-	T_45 (in signature of Py_BuildValue @ 00000000 : void)
-Eq_53: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 int32), (ptr32 int32)))
-	T_53 (in PyArg_ParseTuple @ 100010B7 : ptr32)
-	T_54 (in signature of PyArg_ParseTuple @ 00000000 : void)
-Eq_66: (fn (ptr32 Eq_2) ((ptr32 char), int32))
-	T_66 (in Py_BuildValue @ 100010E2 : ptr32)
-	T_67 (in signature of Py_BuildValue @ 00000000 : void)
-Eq_77: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 real32), (ptr32 real32)))
-	T_77 (in PyArg_ParseTuple @ 10001107 : ptr32)
-	T_78 (in signature of PyArg_ParseTuple @ 00000000 : void)
-Eq_90: (fn (ptr32 Eq_2) ((ptr32 char), real64))
-	T_90 (in Py_BuildValue @ 10001136 : ptr32)
-	T_91 (in signature of Py_BuildValue @ 00000000 : void)
-Eq_100: PyObject
-	T_100 (in eax @ 10001117 : (ptr32 Eq_100))
-	T_103 (in eax_10 @ 1000114A : (ptr32 Eq_100))
-	T_108 (in PyArg_ParseTuple(args, ":unused") @ 1000114A : int32)
-	T_109 (in 0<32> @ 10001155 : word32)
-	T_123 (in &_Py_NoneStruct @ 10001165 : word32)
-Eq_101: PyObject
-	T_101 (in self @ 10001117 : (ptr32 Eq_101))
-Eq_102: PyObject
-	T_102 (in args @ 10001117 : (ptr32 Eq_102))
-Eq_104: (fn (ptr32 Eq_100) ((ptr32 Eq_4), (ptr32 char)))
-	T_104 (in PyArg_ParseTuple @ 1000114A : ptr32)
-	T_105 (in signature of PyArg_ParseTuple @ 00000000 : void)
-Eq_111: PyObject
-	T_111 (in eax_16 @ 10001158 : (ptr32 Eq_111))
-	T_113 (in &_Py_NoneStruct @ 10001158 : word32)
-Eq_112: PyObject
-	T_112 (in _Py_NoneStruct @ 10001158 : PyObject)
-	T_122 (in _Py_NoneStruct @ 10001165 : PyObject)
-Eq_124: (fn (ptr32 Eq_136) ((ptr32 char), (ptr32 (arr PyMethodDef 5)), (ptr32 char), (ptr32 Eq_129), int32))
-	T_124 (in Py_InitModule4 @ 10001183 : ptr32)
-	T_125 (in signature of Py_InitModule4 @ 00000000 : void)
-Eq_127: PyMethodDef
-	T_127 (in ptrArg08 @ 10001183 : (ptr32 PyMethodDef))
-	T_132 (in 0x10003010<32> @ 10001183 : word32)
-Eq_129: PyObject
-	T_129 (in ptrArg10 @ 10001183 : (ptr32 PyObject))
-	T_134 (in 0<32> @ 10001183 : word32)
-Eq_136: PyObject
-	T_136 (in Py_InitModule4("pySample", methods, null, null, 0x3EF<32>) @ 10001183 : (ptr32 PyObject))
-Eq_138: HMODULE
-	T_138 (in dwArg04 @ 1000118C : Eq_138)
-	T_402 (in ebx_113 @ 10001398 : Eq_138)
-	T_405 (in Mem7[ebp_13 + 8<32>:word32] @ 10001398 : word32)
-	T_478 (in Mem114[esp_106 + -8<i32>:word32] @ 100013FC : word32)
-	T_482 (in dwArg04 @ 100013FD : Eq_138)
-	T_486 (in Mem114[esp_106 + -8<i32>:word32] @ 100013FD : word32)
-	T_520 (in Mem88[esp_80 + -8<i32>:word32] @ 100013E9 : word32)
-	T_526 (in Mem88[esp_80 + -8<i32>:word32] @ 100013EA : word32)
-	T_556 (in Mem133[esp_106 + -8<i32>:word32] @ 10001410 : word32)
-	T_560 (in Mem133[esp_106 + -8<i32>:word32] @ 10001411 : word32)
-	T_574 (in Mem145[esp_106 + -8<i32>:word32] @ 10001419 : word32)
-	T_578 (in Mem145[esp_106 + -8<i32>:word32] @ 1000141A : word32)
-	T_610 (in Mem194[esp_184 + -8<i32>:word32] @ 10001439 : word32)
-	T_618 (in Mem194[esp_184 + -8<i32>:word32] @ 1000143A : word32)
-	T_765 (in eax_36 @ 10001762 : Eq_138)
-	T_768 (in Mem24[ebp_13 + 8<32>:word32] @ 10001762 : word32)
-	T_803 (in hLibModule @ 100017DA : HMODULE)
-Eq_139: DWORD
-	T_139 (in dwArg08 @ 1000118C : Eq_139)
-	T_147 (in 0<32> @ 100011F2 : word32)
-	T_160 (in 1<32> @ 10001216 : word32)
-	T_173 (in 0<32> @ 100012EA : word32)
-	T_208 (in dwMilliseconds @ 10001302 : DWORD)
-	T_209 (in 0x3E8<32> @ 10001302 : word32)
-	T_251 (in 0x3E8<32> @ 10001243 : word32)
-	T_385 (in eax @ 10001385 : Eq_139)
-	T_387 (in edx @ 10001385 : Eq_139)
-	T_406 (in 1<32> @ 1000139E : word32)
-	T_409 (in Mem25[ebp_13 + -28<i32>:word32] @ 1000139E : word32)
-	T_415 (in Mem28[0x10003008<p32>:word32] @ 100013A6 : word32)
-	T_425 (in esi_110 @ 10001396 : Eq_139)
-	T_426 (in 0<32> @ 100013B1 : word32)
-	T_428 (in 1<32> @ 100013C5 : word32)
-	T_434 (in 0<32> @ 100013BB : word32)
-	T_437 (in Mem248[ebp_13 + -28<i32>:word32] @ 100013BB : word32)
-	T_449 (in eax_257 @ 1000148A : Eq_139)
-	T_452 (in Mem256[ebp_13 + -28<i32>:word32] @ 1000148A : word32)
-	T_465 (in 2<32> @ 100013CA : word32)
-	T_475 (in Mem111[esp_106 + -4<i32>:word32] @ 100013FB : word32)
-	T_479 (in eax_115 @ 100013FD : Eq_139)
-	T_483 (in dwArg08 @ 100013FD : Eq_139)
-	T_489 (in Mem114[esp_106 + -4<i32>:word32] @ 100013FD : word32)
-	T_490 (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 100013FD : word32)
-	T_493 (in Mem122[ebp_13 + -28<i32>:word32] @ 10001402 : word32)
-	T_496 (in 1<32> @ 10001408 : word32)
-	T_500 (in Mem76[ebp_13 + -28<i32>:word32] @ 100013E1 : word32)
-	T_501 (in 0<32> @ 100013E1 : word32)
-	T_505 (in fn00000000(ebx_113, edx) @ 100013DA : void)
-	T_508 (in Mem74[ebp_13 + -28<i32>:word32] @ 100013DA : word32)
-	T_517 (in Mem85[esp_80 + -4<i32>:word32] @ 100013E8 : word32)
-	T_521 (in eax_90 @ 100013EA : Eq_139)
-	T_529 (in Mem88[esp_80 + -4<i32>:word32] @ 100013EA : word32)
-	T_536 (in fn100011E9(esp_80->tFFFFFFF8, esp_80->tFFFFFFFC, esp_80->t0000, out ebx_113, out esi_110, out edi_107) @ 100013EA : word32)
-	T_539 (in Mem101[ebp_13 + -28<i32>:word32] @ 100013EF : word32)
-	T_542 (in 0<32> @ 100013F4 : word32)
-	T_544 (in 0<32> @ 10001430 : word32)
-	T_546 (in 0<32> @ 1000140C : word32)
-	T_553 (in Mem131[esp_106 + -4<i32>:word32] @ 1000140F : word32)
-	T_563 (in Mem133[esp_106 + -4<i32>:word32] @ 10001411 : word32)
-	T_564 (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 10001411 : word32)
-	T_568 (in 0<32> @ 10001417 : word32)
-	T_571 (in Mem143[esp_106 + -4<i32>:word32] @ 10001417 : word32)
-	T_581 (in Mem145[esp_106 + -4<i32>:word32] @ 1000141A : word32)
-	T_588 (in fn100011E9(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC, esp_106->t0000, out ebx_113, out esi_110, out edi_107) @ 1000141A : word32)
-	T_607 (in Mem190[esp_184 + -4<i32>:word32] @ 10001438 : word32)
-	T_614 (in eax_197 @ 1000143A : Eq_139)
-	T_621 (in Mem194[esp_184 + -4<i32>:word32] @ 1000143A : word32)
-	T_628 (in fn100011E9(esp_184->tFFFFFFF8, esp_184->tFFFFFFFC, esp_184->t0000, out ebx_198, out esi_200, out edi_201) @ 1000143A : word32)
-	T_631 (in 0<32> @ 10001441 : word32)
-	T_633 (in 3<32> @ 10001435 : word32)
-	T_637 (in Mem218[ebp_13 + -28<i32>:word32] @ 1000144A : word32)
-	T_638 (in 0<32> @ 1000144A : word32)
-	T_642 (in Mem194[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
-	T_643 (in ebp_13->tFFFFFFE4 & eax_197 @ 00000000 : word32)
-	T_646 (in Mem214[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
-	T_653 (in fn00000000(ebx_198, esi_200, edi_201) @ 1000145A : void)
-	T_656 (in Mem247[ebp_13 + -28<i32>:word32] @ 1000145A : word32)
-	T_657 (in 0xFFFFFFFF<32> @ 10001493 : word32)
-	T_659 (in Mem4[0x10003008<p32>:word32] @ 10001493 : word32)
-	T_662 (in dwReason @ 1000149D : Eq_139)
-	T_664 (in 1<32> @ 100014A3 : word32)
-	T_794 (in 1<32> @ 100017CB : word32)
-	T_863 (in GetCurrentProcessId() @ 100018BB : DWORD)
-	T_866 (in GetCurrentThreadId() @ 100018BB : DWORD)
-	T_870 (in GetTickCount() @ 100018BB : DWORD)
-Eq_140: LPVOID
-	T_140 (in dwArg0C @ 1000118C : Eq_140)
-	T_386 (in ecx @ 10001385 : Eq_140)
-	T_424 (in edi_107 @ 10001394 : Eq_140)
-	T_472 (in Mem108[esp_106 + 0<32>:word32] @ 100013FA : word32)
-	T_514 (in Mem82[esp_80 + 0<32>:word32] @ 100013E7 : word32)
-	T_532 (in Mem88[esp_80 + 0<32>:word32] @ 100013EA : word32)
-	T_550 (in Mem129[esp_106 + 0<32>:word32] @ 1000140E : word32)
-	T_567 (in Mem141[esp_106 + 0<32>:word32] @ 10001416 : word32)
-	T_584 (in Mem145[esp_106 + 0<32>:word32] @ 1000141A : word32)
-	T_604 (in Mem187[esp_184 + 0<32>:word32] @ 10001437 : word32)
-	T_624 (in Mem194[esp_184 + 0<32>:word32] @ 1000143A : word32)
-	T_663 (in lpReserved @ 1000149D : Eq_140)
-Eq_145: LONG
-	T_145 (in ebp_145 @ 100011EE : Eq_145)
-	T_146 (in 0<32> @ 100011EE : word32)
-	T_175 (in edi_124 @ 10001222 : Eq_145)
-	T_181 (in Mem38[Mem38[fs:0x18<32>:word32] + 4<32>:word32] @ 10001222 : word32)
-	T_182 (in eax_136 @ 1000124D : Eq_145)
-	T_186 (in Exchange @ 1000124D : LONG)
-	T_187 (in Comperand @ 1000124D : LONG)
-	T_189 (in 0<32> @ 1000124D : word32)
-	T_190 (in InterlockedCompareExchange(&g_t100033AC, edi_124, 0<32>) @ 1000124D : LONG)
-	T_191 (in 0<32> @ 10001251 : word32)
-	T_196 (in 1<32> @ 10001310 : word32)
-	T_197 (in 0<32> @ 10001310 : word32)
-	T_198 (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) @ 10001310 : LONG)
-	T_199 (in 0<32> @ 10001310 : word32)
-	T_249 (in 1<32> @ 10001257 : word32)
-	T_256 (in 0<32> @ 1000136F : word32)
-	T_259 (in Mem111[esp_110 + 0<32>:word32] @ 1000136F : word32)
-	T_270 (in Value @ 10001378 : LONG)
-	T_276 (in Mem116[esp_110 + 0<32>:LONG] @ 10001378 : LONG)
-	T_277 (in InterlockedExchange(esp_110->ptrFFFFFFFC, esp_110->t0000) @ 10001378 : LONG)
-	T_301 (in 0<32> @ 100012AC : word32)
-	T_358 (in InterlockedExchange(&g_t100033AC, ebp_145) @ 100012B0 : LONG)
-Eq_176: (segment "Eq_176" (18 (ptr32 Eq_178) ptr0018))
-	T_176 (in fs @ 10001222 : selector)
-Eq_178: (struct "Eq_178" (4 Eq_145 t0004))
-	T_178 (in Mem38[fs:0x18<32>:word32] @ 10001222 : word32)
-Eq_183: (fn Eq_145 ((ptr32 Eq_185), Eq_145, Eq_145))
-	T_183 (in InterlockedCompareExchange @ 1000124D : ptr32)
-	T_184 (in signature of InterlockedCompareExchange @ 00000000 : void)
-	T_194 (in InterlockedCompareExchange @ 10001310 : ptr32)
-	T_370 (in ebx @ 100012CC : (ptr32 Eq_183))
-	T_374 (in InterlockedCompareExchange @ 100012CC : ptr32)
-	T_388 (in ebx @ 10001385 : (ptr32 Eq_183))
-	T_394 (in ebx @ 1000138F : (ptr32 Eq_183))
-	T_668 (in ebx @ 100014BC : word32)
-	T_813 (in Mem17[esp_14 + -4<i32>:word32] @ 10001802 : word32)
-Eq_185: LONG
-	T_185 (in Destination @ 1000124D : (ptr32 LONG))
-	T_188 (in 0x100033AC<p32> @ 1000124D : ptr32)
-	T_195 (in 0x100033AC<p32> @ 10001310 : ptr32)
-Eq_206: (fn void (Eq_139))
-	T_206 (in Sleep @ 10001302 : ptr32)
-	T_207 (in signature of Sleep @ 00000000 : void)
-	T_250 (in Sleep @ 10001243 : ptr32)
-Eq_216: (fn (ptr32 word32) ((ptr32 void)))
-	T_216 (in _decode_pointer @ 10001332 : ptr32)
-	T_217 (in signature of _decode_pointer @ 00000000 : void)
-	T_284 (in _decode_pointer @ 10001344 : ptr32)
-Eq_227: (fn void (int32))
-	T_227 (in _amsg_exit @ 1000131E : ptr32)
-	T_228 (in signature of _amsg_exit @ 00000000 : void)
-	T_246 (in _amsg_exit @ 10001266 : ptr32)
-Eq_237: (fn int32 ((ptr32 Eq_239), (ptr32 Eq_240)))
-	T_237 (in _initterm_e @ 1000128A : ptr32)
-	T_238 (in signature of _initterm_e @ 00000000 : void)
-Eq_239: PVFV
-	T_239 (in fStart @ 1000128A : (ptr32 PVFV))
-	T_241 (in 0x100020A0<32> @ 1000128A : word32)
-Eq_240: PVFV
-	T_240 (in fEnd @ 1000128A : (ptr32 PVFV))
-	T_242 (in 0x100020A8<32> @ 1000128A : word32)
-Eq_253: (struct "Eq_253" (FFFFFFFC (ptr32 Eq_260) ptrFFFFFFFC) (0 Eq_145 t0000))
-	T_253 (in esp_110 @ 1000136F : (ptr32 Eq_253))
-	T_255 (in esp_105 - 4<i32> @ 00000000 : word32)
-Eq_260: LONG
-	T_260 (in 0x100033AC<p32> @ 10001371 : ptr32)
-	T_263 (in Mem114[esp_110 + -4<i32>:word32] @ 10001371 : word32)
-	T_269 (in Target @ 10001378 : (ptr32 LONG))
-	T_273 (in Mem116[esp_110 + -4<i32>:(ptr32 LONG)] @ 10001378 : (ptr32 LONG))
-	T_357 (in 0x100033AC<p32> @ 100012B0 : ptr32)
-Eq_267: (fn Eq_145 ((ptr32 Eq_260), Eq_145))
-	T_267 (in InterlockedExchange @ 10001378 : ptr32)
-	T_268 (in signature of InterlockedExchange @ 00000000 : void)
-	T_356 (in InterlockedExchange @ 100012B0 : ptr32)
-Eq_291: (fn void ((ptr32 Eq_293), (ptr32 Eq_294)))
-	T_291 (in _initterm @ 1000129D : ptr32)
-	T_292 (in signature of _initterm @ 00000000 : void)
-Eq_293: PVFV
-	T_293 (in fStart @ 1000129D : (ptr32 PVFV))
-	T_295 (in 0x10002098<32> @ 1000129D : word32)
-Eq_294: PVFV
-	T_294 (in fEnd @ 1000129D : (ptr32 PVFV))
-	T_296 (in 0x1000209C<32> @ 1000129D : word32)
-Eq_304: (struct "Eq_304" (0 ptr32 ptr0000) (4 ptr32 ptr0004))
-	T_304 (in esp_261 @ 10001381 : (ptr32 Eq_304))
-	T_306 (in esp_118 + 4<i32> @ 10001381 : word32)
-Eq_331: (fn void ((ptr32 word32)))
-	T_331 (in free @ 10001358 : ptr32)
-	T_332 (in signature of free @ 00000000 : void)
-Eq_339: (fn (ptr32 void) ())
-	T_339 (in _encoded_null @ 1000135F : ptr32)
-	T_340 (in signature of _encoded_null @ 00000000 : void)
-Eq_368: (fn word32 ((ptr32 Eq_183), ptr32, word32, ptr32))
-	T_368 (in fn10001742 @ 100012CC : ptr32)
-	T_369 (in signature of fn10001742 @ 10001742 : void)
-Eq_391: (struct "Eq_391" (FFFFFFE4 Eq_139 tFFFFFFE4) (FFFFFFF0 word32 dwFFFFFFF0) (FFFFFFFC word32 dwFFFFFFFC) (0 Eq_456 t0000) (8 Eq_138 t0008))
-	T_391 (in ebp_13 @ 1000138F : (ptr32 Eq_391))
-	T_401 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10<32>) @ 1000138F : word32)
-	T_455 (in ebp @ 1000148D : (ptr32 Eq_391))
-	T_743 (in ebp_13 @ 10001749 : (ptr32 Eq_391))
-	T_747 (in fn100017E8(ebx, esi, edi, dwLoc0C, 8<32>) @ 10001749 : word32)
-Eq_392: (fn (ptr32 Eq_391) ((ptr32 Eq_183), ptr32, word32, word32, ui32))
-	T_392 (in fn100017E8 @ 1000138F : ptr32)
-	T_393 (in signature of fn100017E8 @ 100017E8 : void)
-	T_744 (in fn100017E8 @ 10001749 : ptr32)
-Eq_420: (struct "Eq_420" (FFFFFFFC Eq_456 tFFFFFFFC))
-	T_420 (in esp_100 @ 1000138A : (ptr32 Eq_420))
-	T_423 (in fp - 8<i32> @ 00000000 : word32)
-	T_495 (in esp_106 + 4<32> @ 100013FD : word32)
-	T_541 (in esp_80 + 4<32> @ 100013EA : word32)
-	T_590 (in esp_106 + 4<32> @ 1000141A : word32)
-	T_630 (in esp_184 + 4<32> @ 1000143A : word32)
-Eq_446: (fn void ())
-	T_446 (in fn10001493 @ 10001485 : ptr32)
-	T_447 (in signature of fn10001493 @ 10001493 : void)
-Eq_453: (fn ptr32 ((ptr32 Eq_391), Eq_456))
-	T_453 (in fn1000182D @ 1000148D : ptr32)
-	T_454 (in signature of fn1000182D @ 1000182D : void)
-	T_791 (in fn1000182D @ 100017AD : ptr32)
-Eq_456: (union "Eq_456" (ui32 u0) (ptr32 u1))
-	T_456 (in dwArg00 @ 1000148D : Eq_456)
-	T_459 (in Mem256[esp_100 + -4<i32>:word32] @ 1000148D : word32)
-	T_752 (in dwLoc0C_84 @ 10001757 : Eq_456)
-	T_753 (in 0x10000000<p32> @ 10001757 : ptr32)
-	T_770 (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
-	T_846 (in Mem22[ebp + 0<32>:word32] @ 1000183F : word32)
-Eq_467: (struct "Eq_467" (FFFFFFF8 Eq_138 tFFFFFFF8) (FFFFFFFC Eq_139 tFFFFFFFC) (0 Eq_140 t0000))
-	T_467 (in esp_106 @ 100013FA : (ptr32 Eq_467))
-	T_469 (in esp_100 - 4<i32> @ 00000000 : word32)
-Eq_480: (fn Eq_139 (Eq_138, Eq_139))
-	T_480 (in fn100017C6 @ 100013FD : ptr32)
-	T_481 (in signature of fn100017C6 @ 100017C6 : void)
-	T_557 (in fn100017C6 @ 10001411 : ptr32)
-Eq_503: (fn Eq_139 (Eq_138, Eq_139))
-	T_503 (in fn00000000 @ 100013DA : ptr32)
-Eq_509: (struct "Eq_509" (FFFFFFF8 Eq_138 tFFFFFFF8) (FFFFFFFC Eq_139 tFFFFFFFC) (0 Eq_140 t0000))
-	T_509 (in esp_80 @ 100013E7 : (ptr32 Eq_509))
-	T_511 (in esp_100 - 4<i32> @ 00000000 : word32)
-Eq_522: (fn Eq_139 (Eq_138, Eq_139, Eq_140, ptr32, ptr32, ptr32))
-	T_522 (in fn100011E9 @ 100013EA : ptr32)
-	T_523 (in signature of fn100011E9 @ 100011E9 : void)
-	T_575 (in fn100011E9 @ 1000141A : ptr32)
-	T_615 (in fn100011E9 @ 1000143A : ptr32)
-Eq_595: (fn void (Eq_138, word32, Eq_140))
-	T_595 (in fn00000000 @ 1000142C : ptr32)
-Eq_599: (struct "Eq_599" (FFFFFFF8 Eq_138 tFFFFFFF8) (FFFFFFFC Eq_139 tFFFFFFFC) (0 Eq_140 t0000))
-	T_599 (in esp_184 @ 10001437 : (ptr32 Eq_599))
-	T_601 (in esp_100 - 4<i32> @ 00000000 : word32)
-Eq_651: (fn Eq_139 (word32, word32, word32))
-	T_651 (in fn00000000 @ 1000145A : ptr32)
-Eq_660: BOOL
-	T_660 (in eax @ 1000149D : Eq_660)
-	T_671 (in fn10001388(lpReserved, dwReason, ebx, esi, edi) @ 100014BC : word32)
-	T_804 (in DisableThreadLibraryCalls(dwArg04) @ 100017DA : BOOL)
-	T_877 (in QueryPerformanceCounter(fp - 0x14<32>) @ 100018C1 : BOOL)
-Eq_661: HANDLE
-	T_661 (in hModule @ 1000149D : Eq_661)
-Eq_666: (fn Eq_660 (Eq_140, Eq_139, (ptr32 Eq_183), ptr32, word32))
-	T_666 (in fn10001388 @ 100014BC : ptr32)
-	T_667 (in signature of fn10001388 @ 10001388 : void)
-Eq_672: (fn void ())
-	T_672 (in fn10001864 @ 100014A5 : ptr32)
-	T_673 (in signature of fn10001864 @ 10001864 : void)
-Eq_676: (struct "Eq_676" (0 word16 w0000) (3C word32 dw003C))
-	T_676 (in dwArg04 @ 100014A5 : (ptr32 Eq_676))
-	T_756 (in 0x10000000<p32> @ 10001760 : ptr32)
-Eq_682: (struct "Eq_682" (0 word32 dw0000) (18 word16 w0018))
-	T_682 (in eax_9 @ 100016E1 : (ptr32 Eq_682))
-	T_686 (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 100016E1 : word32)
-Eq_700: (struct "Eq_700" 0028 (8 up32 dw0008) (C word32 dw000C))
-	T_700 (in eax @ 100016F8 : (ptr32 Eq_700))
-	T_715 (in eax_22 @ 10001718 : (ptr32 Eq_700))
-	T_722 (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) + 0x18<32> + ecx_7 @ 10001718 : word32)
-	T_725 (in 0<32> @ 1000173C : word32)
-	T_729 (in eax_22 + 0x28<32> @ 10001735 : word32)
-Eq_701: (struct "Eq_701" (3C word32 dw003C))
-	T_701 (in dwArg04 @ 100016F8 : (ptr32 Eq_701))
-	T_774 (in 0x10000000<p32> @ 10001769 : ptr32)
-Eq_703: (struct "Eq_703" (6 word16 w0006) (14 word16 w0014))
-	T_703 (in ecx_7 @ 10001707 : (ptr32 Eq_703))
-	T_707 (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 10001707 : word32)
-Eq_754: (fn word32 ((ptr32 Eq_676)))
-	T_754 (in fn100016D0 @ 10001760 : ptr32)
-	T_755 (in signature of fn100016D0 @ 100016D0 : void)
-Eq_769: (union "Eq_769" (ui32 u0) (ptr32 u1))
-	T_769 (in 0x10000000<p32> @ 10001767 : ptr32)
-Eq_771: (struct "Eq_771" (24 uint32 dw0024))
-	T_771 (in eax_43 @ 10001769 : (ptr32 Eq_771))
-	T_776 (in fn10001700(&g_t10000000, eax_36 - 0x10000000<p32>) @ 10001769 : word32)
-	T_777 (in 0<32> @ 10001772 : word32)
-Eq_772: (fn (ptr32 Eq_771) ((ptr32 Eq_701), uint32))
-	T_772 (in fn10001700 @ 10001769 : ptr32)
-	T_773 (in signature of fn10001700 @ 10001700 : void)
-Eq_801: (fn Eq_660 (Eq_138))
-	T_801 (in DisableThreadLibraryCalls @ 100017DA : ptr32)
-	T_802 (in signature of DisableThreadLibraryCalls @ 00000000 : void)
-Eq_806: (struct "Eq_806" (FFFFFFEC word32 dwFFFFFFEC) (FFFFFFF0 ui32 dwFFFFFFF0) (FFFFFFF4 word32 dwFFFFFFF4) (FFFFFFF8 ptr32 ptrFFFFFFF8) (FFFFFFFC (ptr32 Eq_183) ptrFFFFFFFC))
-	T_806 (in esp_14 @ 10001800 : (ptr32 Eq_806))
-	T_810 (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
-Eq_833: (segment "Eq_833" (0 ptr32 ptr0000))
-	T_833 (in fs @ 10001826 : selector)
-Eq_841: (segment "Eq_841" (0 word32 dw0000))
-	T_841 (in fs @ 10001830 : selector)
-Eq_842: (union "Eq_842" (ptr32 u0) ((memptr (ptr32 Eq_841) word32) u1))
-	T_842 (in 0x00000000<p32> @ 10001830 : ptr32)
-Eq_853: (fn void (Eq_855))
-	T_853 (in GetSystemTimeAsFileTime @ 10001899 : ptr32)
-	T_854 (in signature of GetSystemTimeAsFileTime @ 00000000 : void)
-Eq_855: LPFILETIME
-	T_855 (in lpSystemTimeAsFileTime @ 10001899 : LPFILETIME)
-	T_858 (in fp - 0xC<32> @ 00000000 : word32)
-Eq_861: (fn Eq_139 ())
-	T_861 (in GetCurrentProcessId @ 100018BB : ptr32)
-	T_862 (in signature of GetCurrentProcessId @ 00000000 : void)
-Eq_864: (fn Eq_139 ())
-	T_864 (in GetCurrentThreadId @ 100018BB : ptr32)
-	T_865 (in signature of GetCurrentThreadId @ 00000000 : void)
-Eq_868: (fn Eq_139 ())
-	T_868 (in GetTickCount @ 100018BB : ptr32)
-	T_869 (in signature of GetTickCount @ 00000000 : void)
-Eq_872: (fn Eq_660 ((ptr32 Eq_874)))
-	T_872 (in QueryPerformanceCounter @ 100018C1 : ptr32)
-	T_873 (in signature of QueryPerformanceCounter @ 00000000 : void)
-Eq_874: LARGE_INTEGER
-	T_874 (in lpPerformanceCount @ 100018C1 : (ptr32 LARGE_INTEGER))
-	T_876 (in fp - 0x14<32> @ 00000000 : word32)
+Eq_20: (fn (ptr32 Eq_2) ((ptr32 char), int32))
+	T_20 (in Py_BuildValue @ 10001042 : ptr32)
+	T_21 (in signature of Py_BuildValue @ 00000000 : void)
+Eq_36: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 int32), (ptr32 int32)))
+	T_36 (in PyArg_ParseTuple @ 10001067 : ptr32)
+	T_37 (in signature of PyArg_ParseTuple @ 00000000 : void)
+Eq_48: (fn (ptr32 Eq_2) ((ptr32 char), int32))
+	T_48 (in Py_BuildValue @ 10001091 : ptr32)
+	T_49 (in signature of Py_BuildValue @ 00000000 : void)
+Eq_63: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 int32), (ptr32 int32)))
+	T_63 (in PyArg_ParseTuple @ 100010B7 : ptr32)
+	T_64 (in signature of PyArg_ParseTuple @ 00000000 : void)
+Eq_75: (fn (ptr32 Eq_2) ((ptr32 char), int32))
+	T_75 (in Py_BuildValue @ 100010E2 : ptr32)
+	T_76 (in signature of Py_BuildValue @ 00000000 : void)
+Eq_92: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 real32), (ptr32 real32)))
+	T_92 (in PyArg_ParseTuple @ 10001107 : ptr32)
+	T_93 (in signature of PyArg_ParseTuple @ 00000000 : void)
+Eq_104: (fn (ptr32 Eq_2) ((ptr32 char), real64))
+	T_104 (in Py_BuildValue @ 10001136 : ptr32)
+	T_105 (in signature of Py_BuildValue @ 00000000 : void)
+Eq_120: PyObject
+	T_120 (in eax @ 10001117 : (ptr32 Eq_120))
+	T_123 (in eax_10 @ 1000114A : (ptr32 Eq_120))
+	T_128 (in PyArg_ParseTuple(args, ":unused") @ 1000114A : int32)
+	T_129 (in 0<32> @ 10001155 : word32)
+	T_143 (in &_Py_NoneStruct @ 10001165 : word32)
+Eq_121: PyObject
+	T_121 (in self @ 10001117 : (ptr32 Eq_121))
+Eq_122: PyObject
+	T_122 (in args @ 10001117 : (ptr32 Eq_122))
+Eq_124: (fn (ptr32 Eq_120) ((ptr32 Eq_4), (ptr32 char)))
+	T_124 (in PyArg_ParseTuple @ 1000114A : ptr32)
+	T_125 (in signature of PyArg_ParseTuple @ 00000000 : void)
+Eq_131: PyObject
+	T_131 (in eax_16 @ 10001158 : (ptr32 Eq_131))
+	T_133 (in &_Py_NoneStruct @ 10001158 : word32)
+Eq_132: PyObject
+	T_132 (in _Py_NoneStruct @ 10001158 : PyObject)
+	T_142 (in _Py_NoneStruct @ 10001165 : PyObject)
+Eq_144: (fn (ptr32 Eq_156) ((ptr32 char), (ptr32 (arr PyMethodDef 5)), (ptr32 char), (ptr32 Eq_149), int32))
+	T_144 (in Py_InitModule4 @ 10001183 : ptr32)
+	T_145 (in signature of Py_InitModule4 @ 00000000 : void)
+Eq_147: PyMethodDef
+	T_147 (in ptrArg08 @ 10001183 : (ptr32 PyMethodDef))
+	T_152 (in 0x10003010<32> @ 10001183 : word32)
+Eq_149: PyObject
+	T_149 (in ptrArg10 @ 10001183 : (ptr32 PyObject))
+	T_154 (in 0<32> @ 10001183 : word32)
+Eq_156: PyObject
+	T_156 (in Py_InitModule4("pySample", methods, null, null, 0x3EF<32>) @ 10001183 : (ptr32 PyObject))
+Eq_158: HMODULE
+	T_158 (in dwArg04 @ 1000118C : Eq_158)
+	T_422 (in ebx_113 @ 10001398 : Eq_158)
+	T_425 (in Mem7[ebp_13 + 8<32>:word32] @ 10001398 : word32)
+	T_498 (in Mem114[esp_106 + -8<i32>:word32] @ 100013FC : word32)
+	T_502 (in dwArg04 @ 100013FD : Eq_158)
+	T_506 (in Mem114[esp_106 + -8<i32>:word32] @ 100013FD : word32)
+	T_540 (in Mem88[esp_80 + -8<i32>:word32] @ 100013E9 : word32)
+	T_546 (in Mem88[esp_80 + -8<i32>:word32] @ 100013EA : word32)
+	T_576 (in Mem133[esp_106 + -8<i32>:word32] @ 10001410 : word32)
+	T_580 (in Mem133[esp_106 + -8<i32>:word32] @ 10001411 : word32)
+	T_594 (in Mem145[esp_106 + -8<i32>:word32] @ 10001419 : word32)
+	T_598 (in Mem145[esp_106 + -8<i32>:word32] @ 1000141A : word32)
+	T_630 (in Mem194[esp_184 + -8<i32>:word32] @ 10001439 : word32)
+	T_638 (in Mem194[esp_184 + -8<i32>:word32] @ 1000143A : word32)
+	T_785 (in eax_36 @ 10001762 : Eq_158)
+	T_788 (in Mem24[ebp_13 + 8<32>:word32] @ 10001762 : word32)
+	T_823 (in hLibModule @ 100017DA : HMODULE)
+Eq_159: DWORD
+	T_159 (in dwArg08 @ 1000118C : Eq_159)
+	T_167 (in 0<32> @ 100011F2 : word32)
+	T_180 (in 1<32> @ 10001216 : word32)
+	T_193 (in 0<32> @ 100012EA : word32)
+	T_228 (in dwMilliseconds @ 10001302 : DWORD)
+	T_229 (in 0x3E8<32> @ 10001302 : word32)
+	T_271 (in 0x3E8<32> @ 10001243 : word32)
+	T_405 (in eax @ 10001385 : Eq_159)
+	T_407 (in edx @ 10001385 : Eq_159)
+	T_426 (in 1<32> @ 1000139E : word32)
+	T_429 (in Mem25[ebp_13 + -28<i32>:word32] @ 1000139E : word32)
+	T_435 (in Mem28[0x10003008<p32>:word32] @ 100013A6 : word32)
+	T_445 (in esi_110 @ 10001396 : Eq_159)
+	T_446 (in 0<32> @ 100013B1 : word32)
+	T_448 (in 1<32> @ 100013C5 : word32)
+	T_454 (in 0<32> @ 100013BB : word32)
+	T_457 (in Mem248[ebp_13 + -28<i32>:word32] @ 100013BB : word32)
+	T_469 (in eax_257 @ 1000148A : Eq_159)
+	T_472 (in Mem256[ebp_13 + -28<i32>:word32] @ 1000148A : word32)
+	T_485 (in 2<32> @ 100013CA : word32)
+	T_495 (in Mem111[esp_106 + -4<i32>:word32] @ 100013FB : word32)
+	T_499 (in eax_115 @ 100013FD : Eq_159)
+	T_503 (in dwArg08 @ 100013FD : Eq_159)
+	T_509 (in Mem114[esp_106 + -4<i32>:word32] @ 100013FD : word32)
+	T_510 (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 100013FD : word32)
+	T_513 (in Mem122[ebp_13 + -28<i32>:word32] @ 10001402 : word32)
+	T_516 (in 1<32> @ 10001408 : word32)
+	T_520 (in Mem76[ebp_13 + -28<i32>:word32] @ 100013E1 : word32)
+	T_521 (in 0<32> @ 100013E1 : word32)
+	T_525 (in fn00000000(ebx_113, edx) @ 100013DA : void)
+	T_528 (in Mem74[ebp_13 + -28<i32>:word32] @ 100013DA : word32)
+	T_537 (in Mem85[esp_80 + -4<i32>:word32] @ 100013E8 : word32)
+	T_541 (in eax_90 @ 100013EA : Eq_159)
+	T_549 (in Mem88[esp_80 + -4<i32>:word32] @ 100013EA : word32)
+	T_556 (in fn100011E9(esp_80->tFFFFFFF8, esp_80->tFFFFFFFC, esp_80->t0000, out ebx_113, out esi_110, out edi_107) @ 100013EA : word32)
+	T_559 (in Mem101[ebp_13 + -28<i32>:word32] @ 100013EF : word32)
+	T_562 (in 0<32> @ 100013F4 : word32)
+	T_564 (in 0<32> @ 10001430 : word32)
+	T_566 (in 0<32> @ 1000140C : word32)
+	T_573 (in Mem131[esp_106 + -4<i32>:word32] @ 1000140F : word32)
+	T_583 (in Mem133[esp_106 + -4<i32>:word32] @ 10001411 : word32)
+	T_584 (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 10001411 : word32)
+	T_588 (in 0<32> @ 10001417 : word32)
+	T_591 (in Mem143[esp_106 + -4<i32>:word32] @ 10001417 : word32)
+	T_601 (in Mem145[esp_106 + -4<i32>:word32] @ 1000141A : word32)
+	T_608 (in fn100011E9(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC, esp_106->t0000, out ebx_113, out esi_110, out edi_107) @ 1000141A : word32)
+	T_627 (in Mem190[esp_184 + -4<i32>:word32] @ 10001438 : word32)
+	T_634 (in eax_197 @ 1000143A : Eq_159)
+	T_641 (in Mem194[esp_184 + -4<i32>:word32] @ 1000143A : word32)
+	T_648 (in fn100011E9(esp_184->tFFFFFFF8, esp_184->tFFFFFFFC, esp_184->t0000, out ebx_198, out esi_200, out edi_201) @ 1000143A : word32)
+	T_651 (in 0<32> @ 10001441 : word32)
+	T_653 (in 3<32> @ 10001435 : word32)
+	T_657 (in Mem218[ebp_13 + -28<i32>:word32] @ 1000144A : word32)
+	T_658 (in 0<32> @ 1000144A : word32)
+	T_662 (in Mem194[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
+	T_663 (in ebp_13->tFFFFFFE4 & eax_197 @ 00000000 : word32)
+	T_666 (in Mem214[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
+	T_673 (in fn00000000(ebx_198, esi_200, edi_201) @ 1000145A : void)
+	T_676 (in Mem247[ebp_13 + -28<i32>:word32] @ 1000145A : word32)
+	T_677 (in 0xFFFFFFFF<32> @ 10001493 : word32)
+	T_679 (in Mem4[0x10003008<p32>:word32] @ 10001493 : word32)
+	T_682 (in dwReason @ 1000149D : Eq_159)
+	T_684 (in 1<32> @ 100014A3 : word32)
+	T_814 (in 1<32> @ 100017CB : word32)
+	T_883 (in GetCurrentProcessId() @ 100018BB : DWORD)
+	T_886 (in GetCurrentThreadId() @ 100018BB : DWORD)
+	T_890 (in GetTickCount() @ 100018BB : DWORD)
+Eq_160: LPVOID
+	T_160 (in dwArg0C @ 1000118C : Eq_160)
+	T_406 (in ecx @ 10001385 : Eq_160)
+	T_444 (in edi_107 @ 10001394 : Eq_160)
+	T_492 (in Mem108[esp_106 + 0<32>:word32] @ 100013FA : word32)
+	T_534 (in Mem82[esp_80 + 0<32>:word32] @ 100013E7 : word32)
+	T_552 (in Mem88[esp_80 + 0<32>:word32] @ 100013EA : word32)
+	T_570 (in Mem129[esp_106 + 0<32>:word32] @ 1000140E : word32)
+	T_587 (in Mem141[esp_106 + 0<32>:word32] @ 10001416 : word32)
+	T_604 (in Mem145[esp_106 + 0<32>:word32] @ 1000141A : word32)
+	T_624 (in Mem187[esp_184 + 0<32>:word32] @ 10001437 : word32)
+	T_644 (in Mem194[esp_184 + 0<32>:word32] @ 1000143A : word32)
+	T_683 (in lpReserved @ 1000149D : Eq_160)
+Eq_165: LONG
+	T_165 (in ebp_145 @ 100011EE : Eq_165)
+	T_166 (in 0<32> @ 100011EE : word32)
+	T_195 (in edi_124 @ 10001222 : Eq_165)
+	T_201 (in Mem38[Mem38[fs:0x18<32>:word32] + 4<32>:word32] @ 10001222 : word32)
+	T_202 (in eax_136 @ 1000124D : Eq_165)
+	T_206 (in Exchange @ 1000124D : LONG)
+	T_207 (in Comperand @ 1000124D : LONG)
+	T_209 (in 0<32> @ 1000124D : word32)
+	T_210 (in InterlockedCompareExchange(&g_t100033AC, edi_124, 0<32>) @ 1000124D : LONG)
+	T_211 (in 0<32> @ 10001251 : word32)
+	T_216 (in 1<32> @ 10001310 : word32)
+	T_217 (in 0<32> @ 10001310 : word32)
+	T_218 (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) @ 10001310 : LONG)
+	T_219 (in 0<32> @ 10001310 : word32)
+	T_269 (in 1<32> @ 10001257 : word32)
+	T_276 (in 0<32> @ 1000136F : word32)
+	T_279 (in Mem111[esp_110 + 0<32>:word32] @ 1000136F : word32)
+	T_290 (in Value @ 10001378 : LONG)
+	T_296 (in Mem116[esp_110 + 0<32>:LONG] @ 10001378 : LONG)
+	T_297 (in InterlockedExchange(esp_110->ptrFFFFFFFC, esp_110->t0000) @ 10001378 : LONG)
+	T_321 (in 0<32> @ 100012AC : word32)
+	T_378 (in InterlockedExchange(&g_t100033AC, ebp_145) @ 100012B0 : LONG)
+Eq_196: (segment "Eq_196" (18 (ptr32 Eq_198) ptr0018))
+	T_196 (in fs @ 10001222 : selector)
+Eq_198: (struct "Eq_198" (4 Eq_165 t0004))
+	T_198 (in Mem38[fs:0x18<32>:word32] @ 10001222 : word32)
+Eq_203: (fn Eq_165 ((ptr32 Eq_205), Eq_165, Eq_165))
+	T_203 (in InterlockedCompareExchange @ 1000124D : ptr32)
+	T_204 (in signature of InterlockedCompareExchange @ 00000000 : void)
+	T_214 (in InterlockedCompareExchange @ 10001310 : ptr32)
+	T_390 (in ebx @ 100012CC : (ptr32 Eq_203))
+	T_394 (in InterlockedCompareExchange @ 100012CC : ptr32)
+	T_408 (in ebx @ 10001385 : (ptr32 Eq_203))
+	T_414 (in ebx @ 1000138F : (ptr32 Eq_203))
+	T_688 (in ebx @ 100014BC : word32)
+	T_833 (in Mem17[esp_14 + -4<i32>:word32] @ 10001802 : word32)
+Eq_205: LONG
+	T_205 (in Destination @ 1000124D : (ptr32 LONG))
+	T_208 (in 0x100033AC<p32> @ 1000124D : ptr32)
+	T_215 (in 0x100033AC<p32> @ 10001310 : ptr32)
+Eq_226: (fn void (Eq_159))
+	T_226 (in Sleep @ 10001302 : ptr32)
+	T_227 (in signature of Sleep @ 00000000 : void)
+	T_270 (in Sleep @ 10001243 : ptr32)
+Eq_236: (fn (ptr32 word32) ((ptr32 void)))
+	T_236 (in _decode_pointer @ 10001332 : ptr32)
+	T_237 (in signature of _decode_pointer @ 00000000 : void)
+	T_304 (in _decode_pointer @ 10001344 : ptr32)
+Eq_247: (fn void (int32))
+	T_247 (in _amsg_exit @ 1000131E : ptr32)
+	T_248 (in signature of _amsg_exit @ 00000000 : void)
+	T_266 (in _amsg_exit @ 10001266 : ptr32)
+Eq_257: (fn int32 ((ptr32 Eq_259), (ptr32 Eq_260)))
+	T_257 (in _initterm_e @ 1000128A : ptr32)
+	T_258 (in signature of _initterm_e @ 00000000 : void)
+Eq_259: PVFV
+	T_259 (in fStart @ 1000128A : (ptr32 PVFV))
+	T_261 (in 0x100020A0<32> @ 1000128A : word32)
+Eq_260: PVFV
+	T_260 (in fEnd @ 1000128A : (ptr32 PVFV))
+	T_262 (in 0x100020A8<32> @ 1000128A : word32)
+Eq_273: (struct "Eq_273" (FFFFFFFC (ptr32 Eq_280) ptrFFFFFFFC) (0 Eq_165 t0000))
+	T_273 (in esp_110 @ 1000136F : (ptr32 Eq_273))
+	T_275 (in esp_105 - 4<i32> @ 00000000 : word32)
+Eq_280: LONG
+	T_280 (in 0x100033AC<p32> @ 10001371 : ptr32)
+	T_283 (in Mem114[esp_110 + -4<i32>:word32] @ 10001371 : word32)
+	T_289 (in Target @ 10001378 : (ptr32 LONG))
+	T_293 (in Mem116[esp_110 + -4<i32>:(ptr32 LONG)] @ 10001378 : (ptr32 LONG))
+	T_377 (in 0x100033AC<p32> @ 100012B0 : ptr32)
+Eq_287: (fn Eq_165 ((ptr32 Eq_280), Eq_165))
+	T_287 (in InterlockedExchange @ 10001378 : ptr32)
+	T_288 (in signature of InterlockedExchange @ 00000000 : void)
+	T_376 (in InterlockedExchange @ 100012B0 : ptr32)
+Eq_311: (fn void ((ptr32 Eq_313), (ptr32 Eq_314)))
+	T_311 (in _initterm @ 1000129D : ptr32)
+	T_312 (in signature of _initterm @ 00000000 : void)
+Eq_313: PVFV
+	T_313 (in fStart @ 1000129D : (ptr32 PVFV))
+	T_315 (in 0x10002098<32> @ 1000129D : word32)
+Eq_314: PVFV
+	T_314 (in fEnd @ 1000129D : (ptr32 PVFV))
+	T_316 (in 0x1000209C<32> @ 1000129D : word32)
+Eq_324: (struct "Eq_324" (0 ptr32 ptr0000) (4 ptr32 ptr0004))
+	T_324 (in esp_261 @ 10001381 : (ptr32 Eq_324))
+	T_326 (in esp_118 + 4<i32> @ 10001381 : word32)
+Eq_351: (fn void ((ptr32 word32)))
+	T_351 (in free @ 10001358 : ptr32)
+	T_352 (in signature of free @ 00000000 : void)
+Eq_359: (fn (ptr32 void) ())
+	T_359 (in _encoded_null @ 1000135F : ptr32)
+	T_360 (in signature of _encoded_null @ 00000000 : void)
+Eq_388: (fn word32 ((ptr32 Eq_203), ptr32, word32, ptr32))
+	T_388 (in fn10001742 @ 100012CC : ptr32)
+	T_389 (in signature of fn10001742 @ 10001742 : void)
+Eq_411: (struct "Eq_411" (FFFFFFE4 Eq_159 tFFFFFFE4) (FFFFFFF0 word32 dwFFFFFFF0) (FFFFFFFC word32 dwFFFFFFFC) (0 Eq_476 t0000) (8 Eq_158 t0008))
+	T_411 (in ebp_13 @ 1000138F : (ptr32 Eq_411))
+	T_421 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10<32>) @ 1000138F : word32)
+	T_475 (in ebp @ 1000148D : (ptr32 Eq_411))
+	T_763 (in ebp_13 @ 10001749 : (ptr32 Eq_411))
+	T_767 (in fn100017E8(ebx, esi, edi, dwLoc0C, 8<32>) @ 10001749 : word32)
+Eq_412: (fn (ptr32 Eq_411) ((ptr32 Eq_203), ptr32, word32, word32, ui32))
+	T_412 (in fn100017E8 @ 1000138F : ptr32)
+	T_413 (in signature of fn100017E8 @ 100017E8 : void)
+	T_764 (in fn100017E8 @ 10001749 : ptr32)
+Eq_440: (struct "Eq_440" (FFFFFFFC Eq_476 tFFFFFFFC))
+	T_440 (in esp_100 @ 1000138A : (ptr32 Eq_440))
+	T_443 (in fp - 8<i32> @ 00000000 : word32)
+	T_515 (in esp_106 + 4<32> @ 100013FD : word32)
+	T_561 (in esp_80 + 4<32> @ 100013EA : word32)
+	T_610 (in esp_106 + 4<32> @ 1000141A : word32)
+	T_650 (in esp_184 + 4<32> @ 1000143A : word32)
+Eq_466: (fn void ())
+	T_466 (in fn10001493 @ 10001485 : ptr32)
+	T_467 (in signature of fn10001493 @ 10001493 : void)
+Eq_473: (fn ptr32 ((ptr32 Eq_411), Eq_476))
+	T_473 (in fn1000182D @ 1000148D : ptr32)
+	T_474 (in signature of fn1000182D @ 1000182D : void)
+	T_811 (in fn1000182D @ 100017AD : ptr32)
+Eq_476: (union "Eq_476" (ui32 u0) (ptr32 u1))
+	T_476 (in dwArg00 @ 1000148D : Eq_476)
+	T_479 (in Mem256[esp_100 + -4<i32>:word32] @ 1000148D : word32)
+	T_772 (in dwLoc0C_84 @ 10001757 : Eq_476)
+	T_773 (in 0x10000000<p32> @ 10001757 : ptr32)
+	T_790 (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
+	T_866 (in Mem22[ebp + 0<32>:word32] @ 1000183F : word32)
+Eq_487: (struct "Eq_487" (FFFFFFF8 Eq_158 tFFFFFFF8) (FFFFFFFC Eq_159 tFFFFFFFC) (0 Eq_160 t0000))
+	T_487 (in esp_106 @ 100013FA : (ptr32 Eq_487))
+	T_489 (in esp_100 - 4<i32> @ 00000000 : word32)
+Eq_500: (fn Eq_159 (Eq_158, Eq_159))
+	T_500 (in fn100017C6 @ 100013FD : ptr32)
+	T_501 (in signature of fn100017C6 @ 100017C6 : void)
+	T_577 (in fn100017C6 @ 10001411 : ptr32)
+Eq_523: (fn Eq_159 (Eq_158, Eq_159))
+	T_523 (in fn00000000 @ 100013DA : ptr32)
+Eq_529: (struct "Eq_529" (FFFFFFF8 Eq_158 tFFFFFFF8) (FFFFFFFC Eq_159 tFFFFFFFC) (0 Eq_160 t0000))
+	T_529 (in esp_80 @ 100013E7 : (ptr32 Eq_529))
+	T_531 (in esp_100 - 4<i32> @ 00000000 : word32)
+Eq_542: (fn Eq_159 (Eq_158, Eq_159, Eq_160, ptr32, ptr32, ptr32))
+	T_542 (in fn100011E9 @ 100013EA : ptr32)
+	T_543 (in signature of fn100011E9 @ 100011E9 : void)
+	T_595 (in fn100011E9 @ 1000141A : ptr32)
+	T_635 (in fn100011E9 @ 1000143A : ptr32)
+Eq_615: (fn void (Eq_158, word32, Eq_160))
+	T_615 (in fn00000000 @ 1000142C : ptr32)
+Eq_619: (struct "Eq_619" (FFFFFFF8 Eq_158 tFFFFFFF8) (FFFFFFFC Eq_159 tFFFFFFFC) (0 Eq_160 t0000))
+	T_619 (in esp_184 @ 10001437 : (ptr32 Eq_619))
+	T_621 (in esp_100 - 4<i32> @ 00000000 : word32)
+Eq_671: (fn Eq_159 (word32, word32, word32))
+	T_671 (in fn00000000 @ 1000145A : ptr32)
+Eq_680: BOOL
+	T_680 (in eax @ 1000149D : Eq_680)
+	T_691 (in fn10001388(lpReserved, dwReason, ebx, esi, edi) @ 100014BC : word32)
+	T_824 (in DisableThreadLibraryCalls(dwArg04) @ 100017DA : BOOL)
+	T_897 (in QueryPerformanceCounter(&tLoc14) @ 100018C1 : BOOL)
+Eq_681: HANDLE
+	T_681 (in hModule @ 1000149D : Eq_681)
+Eq_686: (fn Eq_680 (Eq_160, Eq_159, (ptr32 Eq_203), ptr32, word32))
+	T_686 (in fn10001388 @ 100014BC : ptr32)
+	T_687 (in signature of fn10001388 @ 10001388 : void)
+Eq_692: (fn void ())
+	T_692 (in fn10001864 @ 100014A5 : ptr32)
+	T_693 (in signature of fn10001864 @ 10001864 : void)
+Eq_696: (struct "Eq_696" (0 word16 w0000) (3C word32 dw003C))
+	T_696 (in dwArg04 @ 100014A5 : (ptr32 Eq_696))
+	T_776 (in 0x10000000<p32> @ 10001760 : ptr32)
+Eq_702: (struct "Eq_702" (0 word32 dw0000) (18 word16 w0018))
+	T_702 (in eax_9 @ 100016E1 : (ptr32 Eq_702))
+	T_706 (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 100016E1 : word32)
+Eq_720: (struct "Eq_720" 0028 (8 up32 dw0008) (C word32 dw000C))
+	T_720 (in eax @ 100016F8 : (ptr32 Eq_720))
+	T_735 (in eax_22 @ 10001718 : (ptr32 Eq_720))
+	T_742 (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) + 0x18<32> + ecx_7 @ 10001718 : word32)
+	T_745 (in 0<32> @ 1000173C : word32)
+	T_749 (in eax_22 + 0x28<32> @ 10001735 : word32)
+Eq_721: (struct "Eq_721" (3C word32 dw003C))
+	T_721 (in dwArg04 @ 100016F8 : (ptr32 Eq_721))
+	T_794 (in 0x10000000<p32> @ 10001769 : ptr32)
+Eq_723: (struct "Eq_723" (6 word16 w0006) (14 word16 w0014))
+	T_723 (in ecx_7 @ 10001707 : (ptr32 Eq_723))
+	T_727 (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 10001707 : word32)
+Eq_774: (fn word32 ((ptr32 Eq_696)))
+	T_774 (in fn100016D0 @ 10001760 : ptr32)
+	T_775 (in signature of fn100016D0 @ 100016D0 : void)
+Eq_789: (union "Eq_789" (ui32 u0) (ptr32 u1))
+	T_789 (in 0x10000000<p32> @ 10001767 : ptr32)
+Eq_791: (struct "Eq_791" (24 uint32 dw0024))
+	T_791 (in eax_43 @ 10001769 : (ptr32 Eq_791))
+	T_796 (in fn10001700(&g_t10000000, eax_36 - 0x10000000<p32>) @ 10001769 : word32)
+	T_797 (in 0<32> @ 10001772 : word32)
+Eq_792: (fn (ptr32 Eq_791) ((ptr32 Eq_721), uint32))
+	T_792 (in fn10001700 @ 10001769 : ptr32)
+	T_793 (in signature of fn10001700 @ 10001700 : void)
+Eq_821: (fn Eq_680 (Eq_158))
+	T_821 (in DisableThreadLibraryCalls @ 100017DA : ptr32)
+	T_822 (in signature of DisableThreadLibraryCalls @ 00000000 : void)
+Eq_826: (struct "Eq_826" (FFFFFFEC word32 dwFFFFFFEC) (FFFFFFF0 ui32 dwFFFFFFF0) (FFFFFFF4 word32 dwFFFFFFF4) (FFFFFFF8 ptr32 ptrFFFFFFF8) (FFFFFFFC (ptr32 Eq_203) ptrFFFFFFFC))
+	T_826 (in esp_14 @ 10001800 : (ptr32 Eq_826))
+	T_830 (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
+Eq_853: (segment "Eq_853" (0 ptr32 ptr0000))
+	T_853 (in fs @ 10001826 : selector)
+Eq_861: (segment "Eq_861" (0 word32 dw0000))
+	T_861 (in fs @ 10001830 : selector)
+Eq_862: (union "Eq_862" (ptr32 u0) ((memptr (ptr32 Eq_861) word32) u1))
+	T_862 (in 0x00000000<p32> @ 10001830 : ptr32)
+Eq_873: (fn void (Eq_875))
+	T_873 (in GetSystemTimeAsFileTime @ 10001899 : ptr32)
+	T_874 (in signature of GetSystemTimeAsFileTime @ 00000000 : void)
+Eq_875: LPFILETIME
+	T_875 (in lpSystemTimeAsFileTime @ 10001899 : LPFILETIME)
+	T_878 (in fp - 0xC<32> @ 00000000 : word32)
+Eq_881: (fn Eq_159 ())
+	T_881 (in GetCurrentProcessId @ 100018BB : ptr32)
+	T_882 (in signature of GetCurrentProcessId @ 00000000 : void)
+Eq_884: (fn Eq_159 ())
+	T_884 (in GetCurrentThreadId @ 100018BB : ptr32)
+	T_885 (in signature of GetCurrentThreadId @ 00000000 : void)
+Eq_888: (fn Eq_159 ())
+	T_888 (in GetTickCount @ 100018BB : ptr32)
+	T_889 (in signature of GetTickCount @ 00000000 : void)
+Eq_892: (fn Eq_680 ((ptr32 Eq_894)))
+	T_892 (in QueryPerformanceCounter @ 100018C1 : ptr32)
+	T_893 (in signature of QueryPerformanceCounter @ 00000000 : void)
+Eq_894: LARGE_INTEGER
+	T_894 (in lpPerformanceCount @ 100018C1 : (ptr32 LARGE_INTEGER))
+	T_896 (in &tLoc14 @ 100018C1 : (ptr32 LARGE_INTEGER))
+Eq_895: LARGE_INTEGER
+	T_895 (in tLoc14 @ 100018C1 : LARGE_INTEGER)
+Eq_899: (struct "Eq_899" (0 LARGE_INTEGER t0000) (4 word32 dw0004))
+	T_899 (in &tLoc14 @ 100018CD : (ptr32 LARGE_INTEGER))
+Eq_903: LARGE_INTEGER
+	T_903 (in &tLoc14 @ 100018CD : (ptr32 LARGE_INTEGER))
 // Type Variables ////////////
 globals_t: (in globals @ 00000000 : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -537,7 +543,7 @@ T_5: (in eax_17 @ 10001016 : (ptr32 Eq_2))
 T_6: (in PyArg_ParseTuple @ 10001016 : ptr32)
   Class: Eq_6
   DataType: (ptr32 Eq_6)
-  OrigDataType: (ptr32 (fn T_18 (T_4, T_12, T_15, T_17)))
+  OrigDataType: (ptr32 (fn T_17 (T_4, T_12, T_14, T_16)))
 T_7: (in signature of PyArg_ParseTuple @ 00000000 : void)
   Class: Eq_6
   DataType: (ptr32 Eq_6)
@@ -562,3678 +568,3678 @@ T_12: (in 0x10002144<32> @ 10001016 : word32)
   Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_13: (in fp @ 10001016 : ptr32)
+T_13: (in dwLoc04 @ 10001016 : int32)
   Class: Eq_13
-  DataType: ptr32
-  OrigDataType: ptr32
-T_14: (in 4<32> @ 10001016 : word32)
-  Class: Eq_14
-  DataType: ui32
-  OrigDataType: ui32
-T_15: (in fp - 4<32> @ 00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_14: (in &dwLoc04 @ 10001016 : (ptr32 int32))
   Class: Eq_10
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
-T_16: (in 8<32> @ 10001016 : word32)
-  Class: Eq_16
-  DataType: ui32
-  OrigDataType: ui32
-T_17: (in fp - 8<32> @ 00000000 : word32)
+T_15: (in dwLoc08 @ 10001016 : int32)
+  Class: Eq_15
+  DataType: int32
+  OrigDataType: int32
+T_16: (in &dwLoc08 @ 10001016 : (ptr32 int32))
   Class: Eq_11
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
-T_18: (in PyArg_ParseTuple(ptrArg08, "ii:sum", fp - 4<32>, fp - 8<32>) @ 10001016 : int32)
+T_17: (in PyArg_ParseTuple(ptrArg08, "ii:sum", &dwLoc04, &dwLoc08) @ 10001016 : int32)
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_19: (in 0<32> @ 10001021 : word32)
+T_18: (in 0<32> @ 10001021 : word32)
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: word32
-T_20: (in eax_17 != null @ 00000000 : bool)
-  Class: Eq_20
+T_19: (in eax_17 != null @ 00000000 : bool)
+  Class: Eq_19
   DataType: bool
   OrigDataType: bool
-T_21: (in Py_BuildValue @ 10001042 : ptr32)
-  Class: Eq_21
-  DataType: (ptr32 Eq_21)
-  OrigDataType: (ptr32 (fn T_29 (T_25, T_28)))
-T_22: (in signature of Py_BuildValue @ 00000000 : void)
-  Class: Eq_21
-  DataType: (ptr32 Eq_21)
+T_20: (in Py_BuildValue @ 10001042 : ptr32)
+  Class: Eq_20
+  DataType: (ptr32 Eq_20)
+  OrigDataType: (ptr32 (fn T_34 (T_24, T_33)))
+T_21: (in signature of Py_BuildValue @ 00000000 : void)
+  Class: Eq_20
+  DataType: (ptr32 Eq_20)
   OrigDataType: 
-T_23: (in ptrArg04 @ 10001042 : (ptr32 char))
-  Class: Eq_23
+T_22: (in ptrArg04 @ 10001042 : (ptr32 char))
+  Class: Eq_22
   DataType: (ptr32 char)
   OrigDataType: 
-T_24: (in  @ 10001042 : int32)
-  Class: Eq_24
+T_23: (in  @ 10001042 : int32)
+  Class: Eq_23
   DataType: int32
   OrigDataType: 
-T_25: (in 0x1000214C<32> @ 10001042 : word32)
-  Class: Eq_23
+T_24: (in 0x1000214C<32> @ 10001042 : word32)
+  Class: Eq_22
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_26: (in dwLoc04 @ 10001042 : word32)
+T_25: (in &dwLoc04 @ 10001042 : (ptr32 int32))
+  Class: Eq_25
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_26: (in 0<32> @ 10001042 : word32)
   Class: Eq_26
   DataType: word32
   OrigDataType: word32
-T_27: (in dwLoc08 @ 10001042 : word32)
+T_27: (in &dwLoc04 + 0<32> @ 10001042 : word32)
   Class: Eq_27
-  DataType: word32
-  OrigDataType: word32
-T_28: (in dwLoc04 + dwLoc08 @ 00000000 : word32)
-  Class: Eq_24
-  DataType: int32
-  OrigDataType: int32
-T_29: (in Py_BuildValue("i", dwLoc04 + dwLoc08) @ 10001042 : (ptr32 PyObject))
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: (ptr32 PyObject)
-T_30: (in eax_17 @ 10001067 : (ptr32 Eq_2))
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: int32
-T_31: (in PyArg_ParseTuple @ 10001067 : ptr32)
-  Class: Eq_31
-  DataType: (ptr32 Eq_31)
-  OrigDataType: (ptr32 (fn T_41 (T_4, T_35, T_38, T_40)))
-T_32: (in signature of PyArg_ParseTuple @ 00000000 : void)
-  Class: Eq_31
-  DataType: (ptr32 Eq_31)
-  OrigDataType: 
-T_33: (in  @ 10001067 : (ptr32 int32))
-  Class: Eq_33
-  DataType: (ptr32 int32)
-  OrigDataType: 
-T_34: (in  @ 10001067 : (ptr32 int32))
-  Class: Eq_34
-  DataType: (ptr32 int32)
-  OrigDataType: 
-T_35: (in 0x10002150<32> @ 10001067 : word32)
-  Class: Eq_9
-  DataType: (ptr32 char)
-  OrigDataType: (ptr32 char)
-T_36: (in fp @ 10001067 : ptr32)
-  Class: Eq_36
   DataType: ptr32
   OrigDataType: ptr32
-T_37: (in 8<32> @ 10001067 : word32)
-  Class: Eq_37
-  DataType: ui32
-  OrigDataType: ui32
-T_38: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_33
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_39: (in 4<32> @ 10001067 : word32)
-  Class: Eq_39
-  DataType: ui32
-  OrigDataType: ui32
-T_40: (in fp - 4<32> @ 00000000 : word32)
-  Class: Eq_34
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_41: (in PyArg_ParseTuple(ptrArg08, "ii:dif", fp - 8<32>, fp - 4<32>) @ 10001067 : int32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: int32
-T_42: (in 0<32> @ 10001072 : word32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
+T_28: (in Mem16[&dwLoc04 + 0<32>:word32] @ 10001042 : word32)
+  Class: Eq_28
+  DataType: word32
   OrigDataType: word32
-T_43: (in eax_17 != null @ 00000000 : bool)
-  Class: Eq_43
-  DataType: bool
-  OrigDataType: bool
-T_44: (in Py_BuildValue @ 10001091 : ptr32)
-  Class: Eq_44
-  DataType: (ptr32 Eq_44)
-  OrigDataType: (ptr32 (fn T_51 (T_47, T_50)))
-T_45: (in signature of Py_BuildValue @ 00000000 : void)
-  Class: Eq_44
-  DataType: (ptr32 Eq_44)
-  OrigDataType: 
-T_46: (in  @ 10001091 : int32)
-  Class: Eq_46
-  DataType: int32
-  OrigDataType: 
-T_47: (in 0x1000214C<32> @ 10001091 : word32)
+T_29: (in &dwLoc08 @ 10001042 : (ptr32 int32))
+  Class: Eq_29
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_30: (in 0<32> @ 10001042 : word32)
+  Class: Eq_30
+  DataType: word32
+  OrigDataType: word32
+T_31: (in &dwLoc08 + 0<32> @ 10001042 : word32)
+  Class: Eq_31
+  DataType: ptr32
+  OrigDataType: ptr32
+T_32: (in Mem16[&dwLoc08 + 0<32>:word32] @ 10001042 : word32)
+  Class: Eq_32
+  DataType: word32
+  OrigDataType: word32
+T_33: (in dwLoc04 + dwLoc08 @ 00000000 : word32)
   Class: Eq_23
-  DataType: (ptr32 char)
-  OrigDataType: (ptr32 char)
-T_48: (in dwLoc08 @ 10001091 : word32)
-  Class: Eq_48
-  DataType: word32
-  OrigDataType: word32
-T_49: (in dwLoc04 @ 10001091 : word32)
-  Class: Eq_49
-  DataType: word32
-  OrigDataType: word32
-T_50: (in dwLoc08 - dwLoc04 @ 00000000 : word32)
-  Class: Eq_46
   DataType: int32
   OrigDataType: int32
-T_51: (in Py_BuildValue("i", dwLoc08 - dwLoc04) @ 10001091 : (ptr32 PyObject))
+T_34: (in Py_BuildValue("i", dwLoc04 + dwLoc08) @ 10001042 : (ptr32 PyObject))
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: (ptr32 PyObject)
-T_52: (in eax_17 @ 100010B7 : (ptr32 Eq_2))
+T_35: (in eax_17 @ 10001067 : (ptr32 Eq_2))
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_53: (in PyArg_ParseTuple @ 100010B7 : ptr32)
-  Class: Eq_53
-  DataType: (ptr32 Eq_53)
-  OrigDataType: (ptr32 (fn T_63 (T_4, T_57, T_60, T_62)))
-T_54: (in signature of PyArg_ParseTuple @ 00000000 : void)
-  Class: Eq_53
-  DataType: (ptr32 Eq_53)
+T_36: (in PyArg_ParseTuple @ 10001067 : ptr32)
+  Class: Eq_36
+  DataType: (ptr32 Eq_36)
+  OrigDataType: (ptr32 (fn T_45 (T_4, T_40, T_42, T_44)))
+T_37: (in signature of PyArg_ParseTuple @ 00000000 : void)
+  Class: Eq_36
+  DataType: (ptr32 Eq_36)
   OrigDataType: 
-T_55: (in  @ 100010B7 : (ptr32 int32))
-  Class: Eq_55
+T_38: (in  @ 10001067 : (ptr32 int32))
+  Class: Eq_38
   DataType: (ptr32 int32)
   OrigDataType: 
-T_56: (in  @ 100010B7 : (ptr32 int32))
-  Class: Eq_56
+T_39: (in  @ 10001067 : (ptr32 int32))
+  Class: Eq_39
   DataType: (ptr32 int32)
   OrigDataType: 
-T_57: (in 0x10002158<32> @ 100010B7 : word32)
+T_40: (in 0x10002150<32> @ 10001067 : word32)
   Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_58: (in fp @ 100010B7 : ptr32)
+T_41: (in dwLoc08 @ 10001067 : int32)
+  Class: Eq_41
+  DataType: int32
+  OrigDataType: int32
+T_42: (in &dwLoc08 @ 10001067 : (ptr32 int32))
+  Class: Eq_38
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_43: (in dwLoc04 @ 10001067 : int32)
+  Class: Eq_43
+  DataType: int32
+  OrigDataType: int32
+T_44: (in &dwLoc04 @ 10001067 : (ptr32 int32))
+  Class: Eq_39
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_45: (in PyArg_ParseTuple(ptrArg08, "ii:dif", &dwLoc08, &dwLoc04) @ 10001067 : int32)
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
+  OrigDataType: int32
+T_46: (in 0<32> @ 10001072 : word32)
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
+  OrigDataType: word32
+T_47: (in eax_17 != null @ 00000000 : bool)
+  Class: Eq_47
+  DataType: bool
+  OrigDataType: bool
+T_48: (in Py_BuildValue @ 10001091 : ptr32)
+  Class: Eq_48
+  DataType: (ptr32 Eq_48)
+  OrigDataType: (ptr32 (fn T_61 (T_51, T_60)))
+T_49: (in signature of Py_BuildValue @ 00000000 : void)
+  Class: Eq_48
+  DataType: (ptr32 Eq_48)
+  OrigDataType: 
+T_50: (in  @ 10001091 : int32)
+  Class: Eq_50
+  DataType: int32
+  OrigDataType: 
+T_51: (in 0x1000214C<32> @ 10001091 : word32)
+  Class: Eq_22
+  DataType: (ptr32 char)
+  OrigDataType: (ptr32 char)
+T_52: (in &dwLoc08 @ 10001091 : (ptr32 int32))
+  Class: Eq_52
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_53: (in 0<32> @ 10001091 : word32)
+  Class: Eq_53
+  DataType: word32
+  OrigDataType: word32
+T_54: (in &dwLoc08 + 0<32> @ 10001091 : word32)
+  Class: Eq_54
+  DataType: ptr32
+  OrigDataType: ptr32
+T_55: (in Mem16[&dwLoc08 + 0<32>:word32] @ 10001091 : word32)
+  Class: Eq_55
+  DataType: word32
+  OrigDataType: word32
+T_56: (in &dwLoc04 @ 10001091 : (ptr32 int32))
+  Class: Eq_56
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_57: (in 0<32> @ 10001091 : word32)
+  Class: Eq_57
+  DataType: word32
+  OrigDataType: word32
+T_58: (in &dwLoc04 + 0<32> @ 10001091 : word32)
   Class: Eq_58
   DataType: ptr32
   OrigDataType: ptr32
-T_59: (in 8<32> @ 100010B7 : word32)
+T_59: (in Mem16[&dwLoc04 + 0<32>:word32] @ 10001091 : word32)
   Class: Eq_59
-  DataType: ui32
-  OrigDataType: ui32
-T_60: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_55
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_61: (in 4<32> @ 100010B7 : word32)
-  Class: Eq_61
-  DataType: ui32
-  OrigDataType: ui32
-T_62: (in fp - 4<32> @ 00000000 : word32)
-  Class: Eq_56
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_63: (in PyArg_ParseTuple(ptrArg08, "ii:div", fp - 8<32>, fp - 4<32>) @ 100010B7 : int32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: int32
-T_64: (in 0<32> @ 100010C2 : word32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: word32
-T_65: (in eax_17 != null @ 00000000 : bool)
-  Class: Eq_65
-  DataType: bool
-  OrigDataType: bool
-T_66: (in Py_BuildValue @ 100010E2 : ptr32)
-  Class: Eq_66
-  DataType: (ptr32 Eq_66)
-  OrigDataType: (ptr32 (fn T_75 (T_69, T_74)))
-T_67: (in signature of Py_BuildValue @ 00000000 : void)
-  Class: Eq_66
-  DataType: (ptr32 Eq_66)
-  OrigDataType: 
-T_68: (in  @ 100010E2 : int32)
-  Class: Eq_68
-  DataType: int32
-  OrigDataType: 
-T_69: (in 0x1000214C<32> @ 100010E2 : word32)
-  Class: Eq_23
-  DataType: (ptr32 char)
-  OrigDataType: (ptr32 char)
-T_70: (in dwLoc08 @ 100010E2 : word32)
-  Class: Eq_70
   DataType: word32
   OrigDataType: word32
-T_71: (in CONVERT(dwLoc08, word32, int64) @ 100010E2 : int64)
-  Class: Eq_71
-  DataType: int64
-  OrigDataType: int64
-T_72: (in dwLoc04 @ 100010E2 : word32)
-  Class: Eq_72
+T_60: (in dwLoc08 - dwLoc04 @ 00000000 : word32)
+  Class: Eq_50
   DataType: int32
   OrigDataType: int32
-T_73: (in (int64) dwLoc08 /32 dwLoc04 @ 00000000 : word32)
-  Class: Eq_73
-  DataType: int32
+T_61: (in Py_BuildValue("i", dwLoc08 - dwLoc04) @ 10001091 : (ptr32 PyObject))
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
+  OrigDataType: (ptr32 PyObject)
+T_62: (in eax_17 @ 100010B7 : (ptr32 Eq_2))
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_74: (in CONVERT(CONVERT(dwLoc08, word32, int64) /32 dwLoc04, word32, int32) @ 100010E2 : int32)
+T_63: (in PyArg_ParseTuple @ 100010B7 : ptr32)
+  Class: Eq_63
+  DataType: (ptr32 Eq_63)
+  OrigDataType: (ptr32 (fn T_72 (T_4, T_67, T_69, T_71)))
+T_64: (in signature of PyArg_ParseTuple @ 00000000 : void)
+  Class: Eq_63
+  DataType: (ptr32 Eq_63)
+  OrigDataType: 
+T_65: (in  @ 100010B7 : (ptr32 int32))
+  Class: Eq_65
+  DataType: (ptr32 int32)
+  OrigDataType: 
+T_66: (in  @ 100010B7 : (ptr32 int32))
+  Class: Eq_66
+  DataType: (ptr32 int32)
+  OrigDataType: 
+T_67: (in 0x10002158<32> @ 100010B7 : word32)
+  Class: Eq_9
+  DataType: (ptr32 char)
+  OrigDataType: (ptr32 char)
+T_68: (in dwLoc08 @ 100010B7 : int32)
   Class: Eq_68
   DataType: int32
   OrigDataType: int32
-T_75: (in Py_BuildValue("i", (int32) ((int64) dwLoc08 /32 dwLoc04)) @ 100010E2 : (ptr32 PyObject))
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: (ptr32 PyObject)
-T_76: (in eax_17 @ 10001107 : (ptr32 Eq_2))
+T_69: (in &dwLoc08 @ 100010B7 : (ptr32 int32))
+  Class: Eq_65
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_70: (in dwLoc04 @ 100010B7 : int32)
+  Class: Eq_70
+  DataType: int32
+  OrigDataType: int32
+T_71: (in &dwLoc04 @ 100010B7 : (ptr32 int32))
+  Class: Eq_66
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_72: (in PyArg_ParseTuple(ptrArg08, "ii:div", &dwLoc08, &dwLoc04) @ 100010B7 : int32)
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_77: (in PyArg_ParseTuple @ 10001107 : ptr32)
+T_73: (in 0<32> @ 100010C2 : word32)
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
+  OrigDataType: word32
+T_74: (in eax_17 != null @ 00000000 : bool)
+  Class: Eq_74
+  DataType: bool
+  OrigDataType: bool
+T_75: (in Py_BuildValue @ 100010E2 : ptr32)
+  Class: Eq_75
+  DataType: (ptr32 Eq_75)
+  OrigDataType: (ptr32 (fn T_90 (T_78, T_89)))
+T_76: (in signature of Py_BuildValue @ 00000000 : void)
+  Class: Eq_75
+  DataType: (ptr32 Eq_75)
+  OrigDataType: 
+T_77: (in  @ 100010E2 : int32)
   Class: Eq_77
-  DataType: (ptr32 Eq_77)
-  OrigDataType: (ptr32 (fn T_87 (T_4, T_81, T_84, T_86)))
-T_78: (in signature of PyArg_ParseTuple @ 00000000 : void)
-  Class: Eq_77
-  DataType: (ptr32 Eq_77)
+  DataType: int32
   OrigDataType: 
-T_79: (in  @ 10001107 : (ptr32 real32))
-  Class: Eq_79
-  DataType: (ptr32 real32)
-  OrigDataType: 
-T_80: (in  @ 10001107 : (ptr32 real32))
-  Class: Eq_80
-  DataType: (ptr32 real32)
-  OrigDataType: 
-T_81: (in 0x10002160<32> @ 10001107 : word32)
-  Class: Eq_9
+T_78: (in 0x1000214C<32> @ 100010E2 : word32)
+  Class: Eq_22
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_82: (in fp @ 10001107 : ptr32)
-  Class: Eq_82
+T_79: (in &dwLoc08 @ 100010E2 : (ptr32 int32))
+  Class: Eq_79
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_80: (in 0<32> @ 100010E2 : word32)
+  Class: Eq_80
+  DataType: word32
+  OrigDataType: word32
+T_81: (in &dwLoc08 + 0<32> @ 100010E2 : word32)
+  Class: Eq_81
   DataType: ptr32
   OrigDataType: ptr32
-T_83: (in 8<32> @ 10001107 : word32)
-  Class: Eq_83
-  DataType: ui32
-  OrigDataType: ui32
-T_84: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_79
-  DataType: (ptr32 real32)
-  OrigDataType: (ptr32 real32)
-T_85: (in 4<32> @ 10001107 : word32)
-  Class: Eq_85
-  DataType: ui32
-  OrigDataType: ui32
-T_86: (in fp - 4<32> @ 00000000 : word32)
-  Class: Eq_80
-  DataType: (ptr32 real32)
-  OrigDataType: (ptr32 real32)
-T_87: (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", fp - 8<32>, fp - 4<32>) @ 10001107 : int32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: int32
-T_88: (in 0<32> @ 10001112 : word32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
+T_82: (in Mem16[&dwLoc08 + 0<32>:word32] @ 100010E2 : word32)
+  Class: Eq_82
+  DataType: word32
   OrigDataType: word32
-T_89: (in eax_17 != null @ 00000000 : bool)
-  Class: Eq_89
-  DataType: bool
-  OrigDataType: bool
-T_90: (in Py_BuildValue @ 10001136 : ptr32)
-  Class: Eq_90
-  DataType: (ptr32 Eq_90)
-  OrigDataType: (ptr32 (fn T_99 (T_93, T_98)))
-T_91: (in signature of Py_BuildValue @ 00000000 : void)
-  Class: Eq_90
-  DataType: (ptr32 Eq_90)
-  OrigDataType: 
-T_92: (in  @ 10001136 : real64)
-  Class: Eq_92
-  DataType: real64
-  OrigDataType: 
-T_93: (in 0x10002168<32> @ 10001136 : word32)
-  Class: Eq_23
-  DataType: (ptr32 char)
-  OrigDataType: (ptr32 char)
-T_94: (in rLoc08 @ 10001136 : real32)
-  Class: Eq_94
-  DataType: real32
-  OrigDataType: real32
-T_95: (in CONVERT(rLoc08, real32, real64) @ 10001136 : real64)
-  Class: Eq_95
-  DataType: real64
-  OrigDataType: real64
-T_96: (in rLoc04 @ 10001136 : real32)
-  Class: Eq_96
-  DataType: real32
-  OrigDataType: real32
-T_97: (in CONVERT(rLoc04, real32, real64) @ 10001136 : real64)
-  Class: Eq_97
-  DataType: real64
-  OrigDataType: real64
-T_98: (in (real64) rLoc08 / (real64) rLoc04 @ 00000000 : real64)
-  Class: Eq_92
-  DataType: real64
-  OrigDataType: real64
-T_99: (in Py_BuildValue("f", (real64) rLoc08 / (real64) rLoc04) @ 10001136 : (ptr32 PyObject))
+T_83: (in CONVERT(Mem16[&dwLoc08 + 0<32>:word32], word32, int64) @ 100010E2 : int64)
+  Class: Eq_83
+  DataType: int64
+  OrigDataType: int64
+T_84: (in &dwLoc04 @ 100010E2 : (ptr32 int32))
+  Class: Eq_84
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_85: (in 0<32> @ 100010E2 : word32)
+  Class: Eq_85
+  DataType: word32
+  OrigDataType: word32
+T_86: (in &dwLoc04 + 0<32> @ 100010E2 : word32)
+  Class: Eq_86
+  DataType: ptr32
+  OrigDataType: ptr32
+T_87: (in Mem16[&dwLoc04 + 0<32>:word32] @ 100010E2 : word32)
+  Class: Eq_87
+  DataType: int32
+  OrigDataType: int32
+T_88: (in (int64) dwLoc08 /32 dwLoc04 @ 00000000 : word32)
+  Class: Eq_88
+  DataType: int32
+  OrigDataType: int32
+T_89: (in CONVERT(CONVERT(Mem16[&dwLoc08 + 0<32>:word32], word32, int64) /32 Mem16[&dwLoc04 + 0<32>:word32], word32, int32) @ 100010E2 : int32)
+  Class: Eq_77
+  DataType: int32
+  OrigDataType: int32
+T_90: (in Py_BuildValue("i", (int32) ((int64) dwLoc08 /32 dwLoc04)) @ 100010E2 : (ptr32 PyObject))
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: (ptr32 PyObject)
-T_100: (in eax @ 10001117 : (ptr32 Eq_100))
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
-  OrigDataType: (ptr32 PyObject)
-T_101: (in self @ 10001117 : (ptr32 Eq_101))
-  Class: Eq_101
-  DataType: (ptr32 Eq_101)
-  OrigDataType: (ptr32 PyObject)
-T_102: (in args @ 10001117 : (ptr32 Eq_102))
-  Class: Eq_102
-  DataType: (ptr32 Eq_102)
-  OrigDataType: (ptr32 PyObject)
-T_103: (in eax_10 @ 1000114A : (ptr32 Eq_100))
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+T_91: (in eax_17 @ 10001107 : (ptr32 Eq_2))
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_104: (in PyArg_ParseTuple @ 1000114A : ptr32)
-  Class: Eq_104
-  DataType: (ptr32 Eq_104)
-  OrigDataType: (ptr32 (fn T_108 (T_106, T_107)))
-T_105: (in signature of PyArg_ParseTuple @ 00000000 : void)
-  Class: Eq_104
-  DataType: (ptr32 Eq_104)
+T_92: (in PyArg_ParseTuple @ 10001107 : ptr32)
+  Class: Eq_92
+  DataType: (ptr32 Eq_92)
+  OrigDataType: (ptr32 (fn T_101 (T_4, T_96, T_98, T_100)))
+T_93: (in signature of PyArg_ParseTuple @ 00000000 : void)
+  Class: Eq_92
+  DataType: (ptr32 Eq_92)
   OrigDataType: 
-T_106: (in args @ 1000114A : (ptr32 PyObject))
-  Class: Eq_4
-  DataType: (ptr32 Eq_4)
-  OrigDataType: (ptr32 (union (PyObject u1)))
-T_107: (in 0x1000216C<32> @ 1000114A : word32)
+T_94: (in  @ 10001107 : (ptr32 real32))
+  Class: Eq_94
+  DataType: (ptr32 real32)
+  OrigDataType: 
+T_95: (in  @ 10001107 : (ptr32 real32))
+  Class: Eq_95
+  DataType: (ptr32 real32)
+  OrigDataType: 
+T_96: (in 0x10002160<32> @ 10001107 : word32)
   Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_108: (in PyArg_ParseTuple(args, ":unused") @ 1000114A : int32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+T_97: (in rLoc08 @ 10001107 : real32)
+  Class: Eq_97
+  DataType: real32
+  OrigDataType: real32
+T_98: (in &rLoc08 @ 10001107 : (ptr32 real32))
+  Class: Eq_94
+  DataType: (ptr32 real32)
+  OrigDataType: (ptr32 real32)
+T_99: (in rLoc04 @ 10001107 : real32)
+  Class: Eq_99
+  DataType: real32
+  OrigDataType: real32
+T_100: (in &rLoc04 @ 10001107 : (ptr32 real32))
+  Class: Eq_95
+  DataType: (ptr32 real32)
+  OrigDataType: (ptr32 real32)
+T_101: (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", &rLoc08, &rLoc04) @ 10001107 : int32)
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_109: (in 0<32> @ 10001155 : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+T_102: (in 0<32> @ 10001112 : word32)
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
   OrigDataType: word32
-T_110: (in eax_10 != null @ 00000000 : bool)
-  Class: Eq_110
+T_103: (in eax_17 != null @ 00000000 : bool)
+  Class: Eq_103
   DataType: bool
   OrigDataType: bool
-T_111: (in eax_16 @ 10001158 : (ptr32 Eq_111))
+T_104: (in Py_BuildValue @ 10001136 : ptr32)
+  Class: Eq_104
+  DataType: (ptr32 Eq_104)
+  OrigDataType: (ptr32 (fn T_119 (T_107, T_118)))
+T_105: (in signature of Py_BuildValue @ 00000000 : void)
+  Class: Eq_104
+  DataType: (ptr32 Eq_104)
+  OrigDataType: 
+T_106: (in  @ 10001136 : real64)
+  Class: Eq_106
+  DataType: real64
+  OrigDataType: 
+T_107: (in 0x10002168<32> @ 10001136 : word32)
+  Class: Eq_22
+  DataType: (ptr32 char)
+  OrigDataType: (ptr32 char)
+T_108: (in &rLoc08 @ 10001136 : (ptr32 real32))
+  Class: Eq_108
+  DataType: (ptr32 real32)
+  OrigDataType: (ptr32 (struct (0 real32 r0000)))
+T_109: (in 0<32> @ 10001136 : word32)
+  Class: Eq_109
+  DataType: word32
+  OrigDataType: word32
+T_110: (in &rLoc08 + 0<32> @ 10001136 : word32)
+  Class: Eq_110
+  DataType: ptr32
+  OrigDataType: ptr32
+T_111: (in Mem16[&rLoc08 + 0<32>:real32] @ 10001136 : real32)
   Class: Eq_111
-  DataType: (ptr32 Eq_111)
-  OrigDataType: (ptr32 PyObject)
-T_112: (in _Py_NoneStruct @ 10001158 : PyObject)
+  DataType: real32
+  OrigDataType: real32
+T_112: (in CONVERT(Mem16[&rLoc08 + 0<32>:real32], real32, real64) @ 10001136 : real64)
   Class: Eq_112
-  DataType: Eq_112
-  OrigDataType: PyObject
-T_113: (in &_Py_NoneStruct @ 10001158 : word32)
-  Class: Eq_111
-  DataType: (ptr32 Eq_111)
-  OrigDataType: (ptr32 PyObject)
-T_114: (in 0<32> @ 1000115D : word32)
+  DataType: real64
+  OrigDataType: real64
+T_113: (in &rLoc04 @ 10001136 : (ptr32 real32))
+  Class: Eq_113
+  DataType: (ptr32 real32)
+  OrigDataType: (ptr32 (struct (0 real32 r0000)))
+T_114: (in 0<32> @ 10001136 : word32)
   Class: Eq_114
   DataType: word32
   OrigDataType: word32
-T_115: (in eax_16 + 0<32> @ 1000115D : word32)
+T_115: (in &rLoc04 + 0<32> @ 10001136 : word32)
   Class: Eq_115
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_116: (in Mem9[eax_16 + 0<32>:word32] @ 1000115D : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_116: (in Mem16[&rLoc04 + 0<32>:real32] @ 10001136 : real32)
   Class: Eq_116
-  DataType: int32
-  OrigDataType: int32
-T_117: (in 1<32> @ 1000115D : word32)
+  DataType: real32
+  OrigDataType: real32
+T_117: (in CONVERT(Mem16[&rLoc04 + 0<32>:real32], real32, real64) @ 10001136 : real64)
   Class: Eq_117
-  DataType: word32
-  OrigDataType: word32
-T_118: (in eax_16->ob_refcnt + 1<32> @ 00000000 : word32)
-  Class: Eq_118
-  DataType: int32
-  OrigDataType: int32
-T_119: (in 0<32> @ 1000115D : word32)
-  Class: Eq_119
-  DataType: word32
-  OrigDataType: word32
-T_120: (in eax_16 + 0<32> @ 1000115D : word32)
-  Class: Eq_120
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_121: (in Mem18[eax_16 + 0<32>:word32] @ 1000115D : word32)
-  Class: Eq_118
-  DataType: int32
-  OrigDataType: int32
-T_122: (in _Py_NoneStruct @ 10001165 : PyObject)
-  Class: Eq_112
-  DataType: Eq_112
-  OrigDataType: PyObject
-T_123: (in &_Py_NoneStruct @ 10001165 : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+  DataType: real64
+  OrigDataType: real64
+T_118: (in (real64) rLoc08 / (real64) rLoc04 @ 00000000 : real64)
+  Class: Eq_106
+  DataType: real64
+  OrigDataType: real64
+T_119: (in Py_BuildValue("f", (real64) rLoc08 / (real64) rLoc04) @ 10001136 : (ptr32 PyObject))
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
   OrigDataType: (ptr32 PyObject)
-T_124: (in Py_InitModule4 @ 10001183 : ptr32)
+T_120: (in eax @ 10001117 : (ptr32 Eq_120))
+  Class: Eq_120
+  DataType: (ptr32 Eq_120)
+  OrigDataType: (ptr32 PyObject)
+T_121: (in self @ 10001117 : (ptr32 Eq_121))
+  Class: Eq_121
+  DataType: (ptr32 Eq_121)
+  OrigDataType: (ptr32 PyObject)
+T_122: (in args @ 10001117 : (ptr32 Eq_122))
+  Class: Eq_122
+  DataType: (ptr32 Eq_122)
+  OrigDataType: (ptr32 PyObject)
+T_123: (in eax_10 @ 1000114A : (ptr32 Eq_120))
+  Class: Eq_120
+  DataType: (ptr32 Eq_120)
+  OrigDataType: int32
+T_124: (in PyArg_ParseTuple @ 1000114A : ptr32)
   Class: Eq_124
   DataType: (ptr32 Eq_124)
-  OrigDataType: (ptr32 (fn T_136 (T_131, T_132, T_133, T_134, T_135)))
-T_125: (in signature of Py_InitModule4 @ 00000000 : void)
+  OrigDataType: (ptr32 (fn T_128 (T_126, T_127)))
+T_125: (in signature of PyArg_ParseTuple @ 00000000 : void)
   Class: Eq_124
   DataType: (ptr32 Eq_124)
   OrigDataType: 
-T_126: (in ptrArg04 @ 10001183 : (ptr32 char))
-  Class: Eq_126
-  DataType: (ptr32 char)
-  OrigDataType: 
-T_127: (in ptrArg08 @ 10001183 : (ptr32 PyMethodDef))
-  Class: Eq_127
-  DataType: (ptr32 (arr PyMethodDef 5))
-  OrigDataType: 
-T_128: (in ptrArg0C @ 10001183 : (ptr32 char))
-  Class: Eq_128
-  DataType: (ptr32 char)
-  OrigDataType: 
-T_129: (in ptrArg10 @ 10001183 : (ptr32 PyObject))
-  Class: Eq_129
-  DataType: (ptr32 Eq_129)
-  OrigDataType: 
-T_130: (in dwArg14 @ 10001183 : int32)
-  Class: Eq_130
-  DataType: int32
-  OrigDataType: 
-T_131: (in 0x10002174<32> @ 10001183 : word32)
-  Class: Eq_126
+T_126: (in args @ 1000114A : (ptr32 PyObject))
+  Class: Eq_4
+  DataType: (ptr32 Eq_4)
+  OrigDataType: (ptr32 (union (PyObject u1)))
+T_127: (in 0x1000216C<32> @ 1000114A : word32)
+  Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_132: (in 0x10003010<32> @ 10001183 : word32)
-  Class: Eq_127
+T_128: (in PyArg_ParseTuple(args, ":unused") @ 1000114A : int32)
+  Class: Eq_120
+  DataType: (ptr32 Eq_120)
+  OrigDataType: int32
+T_129: (in 0<32> @ 10001155 : word32)
+  Class: Eq_120
+  DataType: (ptr32 Eq_120)
+  OrigDataType: word32
+T_130: (in eax_10 != null @ 00000000 : bool)
+  Class: Eq_130
+  DataType: bool
+  OrigDataType: bool
+T_131: (in eax_16 @ 10001158 : (ptr32 Eq_131))
+  Class: Eq_131
+  DataType: (ptr32 Eq_131)
+  OrigDataType: (ptr32 PyObject)
+T_132: (in _Py_NoneStruct @ 10001158 : PyObject)
+  Class: Eq_132
+  DataType: Eq_132
+  OrigDataType: PyObject
+T_133: (in &_Py_NoneStruct @ 10001158 : word32)
+  Class: Eq_131
+  DataType: (ptr32 Eq_131)
+  OrigDataType: (ptr32 PyObject)
+T_134: (in 0<32> @ 1000115D : word32)
+  Class: Eq_134
+  DataType: word32
+  OrigDataType: word32
+T_135: (in eax_16 + 0<32> @ 1000115D : word32)
+  Class: Eq_135
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_136: (in Mem9[eax_16 + 0<32>:word32] @ 1000115D : word32)
+  Class: Eq_136
+  DataType: int32
+  OrigDataType: int32
+T_137: (in 1<32> @ 1000115D : word32)
+  Class: Eq_137
+  DataType: word32
+  OrigDataType: word32
+T_138: (in eax_16->ob_refcnt + 1<32> @ 00000000 : word32)
+  Class: Eq_138
+  DataType: int32
+  OrigDataType: int32
+T_139: (in 0<32> @ 1000115D : word32)
+  Class: Eq_139
+  DataType: word32
+  OrigDataType: word32
+T_140: (in eax_16 + 0<32> @ 1000115D : word32)
+  Class: Eq_140
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_141: (in Mem18[eax_16 + 0<32>:word32] @ 1000115D : word32)
+  Class: Eq_138
+  DataType: int32
+  OrigDataType: int32
+T_142: (in _Py_NoneStruct @ 10001165 : PyObject)
+  Class: Eq_132
+  DataType: Eq_132
+  OrigDataType: PyObject
+T_143: (in &_Py_NoneStruct @ 10001165 : word32)
+  Class: Eq_120
+  DataType: (ptr32 Eq_120)
+  OrigDataType: (ptr32 PyObject)
+T_144: (in Py_InitModule4 @ 10001183 : ptr32)
+  Class: Eq_144
+  DataType: (ptr32 Eq_144)
+  OrigDataType: (ptr32 (fn T_156 (T_151, T_152, T_153, T_154, T_155)))
+T_145: (in signature of Py_InitModule4 @ 00000000 : void)
+  Class: Eq_144
+  DataType: (ptr32 Eq_144)
+  OrigDataType: 
+T_146: (in ptrArg04 @ 10001183 : (ptr32 char))
+  Class: Eq_146
+  DataType: (ptr32 char)
+  OrigDataType: 
+T_147: (in ptrArg08 @ 10001183 : (ptr32 PyMethodDef))
+  Class: Eq_147
+  DataType: (ptr32 (arr PyMethodDef 5))
+  OrigDataType: 
+T_148: (in ptrArg0C @ 10001183 : (ptr32 char))
+  Class: Eq_148
+  DataType: (ptr32 char)
+  OrigDataType: 
+T_149: (in ptrArg10 @ 10001183 : (ptr32 PyObject))
+  Class: Eq_149
+  DataType: (ptr32 Eq_149)
+  OrigDataType: 
+T_150: (in dwArg14 @ 10001183 : int32)
+  Class: Eq_150
+  DataType: int32
+  OrigDataType: 
+T_151: (in 0x10002174<32> @ 10001183 : word32)
+  Class: Eq_146
+  DataType: (ptr32 char)
+  OrigDataType: (ptr32 char)
+T_152: (in 0x10003010<32> @ 10001183 : word32)
+  Class: Eq_147
   DataType: (ptr32 (arr PyMethodDef 5))
   OrigDataType: (ptr32 (arr PyMethodDef 5))
-T_133: (in 0<32> @ 10001183 : word32)
-  Class: Eq_128
+T_153: (in 0<32> @ 10001183 : word32)
+  Class: Eq_148
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_134: (in 0<32> @ 10001183 : word32)
-  Class: Eq_129
-  DataType: (ptr32 Eq_129)
-  OrigDataType: (ptr32 PyObject)
-T_135: (in 0x3EF<32> @ 10001183 : word32)
-  Class: Eq_130
-  DataType: int32
-  OrigDataType: int32
-T_136: (in Py_InitModule4("pySample", methods, null, null, 0x3EF<32>) @ 10001183 : (ptr32 PyObject))
-  Class: Eq_136
-  DataType: (ptr32 Eq_136)
-  OrigDataType: (ptr32 PyObject)
-T_137: (in eax @ 1000118C : word32)
-  Class: Eq_137
-  DataType: word32
-  OrigDataType: word32
-T_138: (in dwArg04 @ 1000118C : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_139: (in dwArg08 @ 1000118C : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_140: (in dwArg0C @ 1000118C : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_141: (in ebxOut @ 1000118C : ptr32)
-  Class: Eq_141
-  DataType: ptr32
-  OrigDataType: ptr32
-T_142: (in esiOut @ 1000118C : ptr32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: ptr32
-T_143: (in ediOut @ 1000118C : ptr32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: ptr32
-T_144: (in eax_14 @ 100011E9 : word32)
-  Class: Eq_137
-  DataType: word32
-  OrigDataType: word32
-T_145: (in ebp_145 @ 100011EE : Eq_145)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_146: (in 0<32> @ 100011EE : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_147: (in 0<32> @ 100011F2 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_148: (in dwArg08 != 0<32> @ 00000000 : bool)
-  Class: Eq_148
-  DataType: bool
-  OrigDataType: bool
-T_149: (in adjust_fdiv @ 10001210 : ptr32)
+T_154: (in 0<32> @ 10001183 : word32)
   Class: Eq_149
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_153 t0000)))
-T_150: (in signature of adjust_fdiv @ 00000000 : void)
+  DataType: (ptr32 Eq_149)
+  OrigDataType: (ptr32 PyObject)
+T_155: (in 0x3EF<32> @ 10001183 : word32)
   Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: 
-T_151: (in 0<32> @ 10001210 : word32)
-  Class: Eq_151
-  DataType: word32
-  OrigDataType: word32
-T_152: (in adjust_fdiv + 0<32> @ 10001210 : word32)
-  Class: Eq_152
-  DataType: ptr32
-  OrigDataType: ptr32
-T_153: (in Mem23[adjust_fdiv + 0<32>:word32] @ 10001210 : word32)
-  Class: Eq_153
-  DataType: word32
-  OrigDataType: word32
-T_154: (in 100033A4 @ 10001210 : ptr32)
-  Class: Eq_154
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_155 t0000)))
-T_155: (in Mem38[0x100033A4<p32>:word32] @ 10001210 : word32)
-  Class: Eq_153
-  DataType: word32
-  OrigDataType: word32
-T_156: (in esp_118 @ 1000120F : (ptr32 ptr32))
+  DataType: int32
+  OrigDataType: int32
+T_156: (in Py_InitModule4("pySample", methods, null, null, 0x3EF<32>) @ 10001183 : (ptr32 PyObject))
   Class: Eq_156
-  DataType: (ptr32 ptr32)
-  OrigDataType: (ptr32 (struct (0 T_309 t0000)))
-T_157: (in fp @ 1000120F : ptr32)
+  DataType: (ptr32 Eq_156)
+  OrigDataType: (ptr32 PyObject)
+T_157: (in eax @ 1000118C : word32)
   Class: Eq_157
-  DataType: ptr32
-  OrigDataType: ptr32
-T_158: (in 16<i32> @ 1000120F : int32)
+  DataType: word32
+  OrigDataType: word32
+T_158: (in dwArg04 @ 1000118C : Eq_158)
   Class: Eq_158
-  DataType: int32
-  OrigDataType: int32
-T_159: (in fp - 16<i32> @ 00000000 : word32)
-  Class: Eq_156
-  DataType: (ptr32 ptr32)
-  OrigDataType: ptr32
-T_160: (in 1<32> @ 10001216 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+  DataType: Eq_158
   OrigDataType: word32
-T_161: (in dwArg08 != 1<32> @ 00000000 : bool)
+T_159: (in dwArg08 @ 1000118C : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_160: (in dwArg0C @ 1000118C : Eq_160)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: word32
+T_161: (in ebxOut @ 1000118C : ptr32)
   Class: Eq_161
-  DataType: bool
-  OrigDataType: bool
-T_162: (in 10003070 @ 100011FA : ptr32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_162: (in esiOut @ 1000118C : ptr32)
   Class: Eq_162
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_163 t0000)))
-T_163: (in Mem8[0x10003070<p32>:word32] @ 100011FA : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_163: (in ediOut @ 1000118C : ptr32)
   Class: Eq_163
-  DataType: int32
-  OrigDataType: int32
-T_164: (in 0<32> @ 100011FA : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: int32
-T_165: (in g_dw10003070 <= 0<32> @ 00000000 : bool)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_164: (in eax_14 @ 100011E9 : word32)
+  Class: Eq_157
+  DataType: word32
+  OrigDataType: word32
+T_165: (in ebp_145 @ 100011EE : Eq_165)
   Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_166: (in 0<32> @ 100011EE : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_167: (in 0<32> @ 100011F2 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_168: (in dwArg08 != 0<32> @ 00000000 : bool)
+  Class: Eq_168
   DataType: bool
   OrigDataType: bool
-T_166: (in 0<32> @ 10001233 : word32)
-  Class: Eq_137
-  DataType: word32
-  OrigDataType: word32
-T_167: (in 10003070 @ 100011FC : ptr32)
-  Class: Eq_167
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_168 t0000)))
-T_168: (in Mem8[0x10003070<p32>:word32] @ 100011FC : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: word32
-T_169: (in 1<32> @ 100011FC : word32)
+T_169: (in adjust_fdiv @ 10001210 : ptr32)
   Class: Eq_169
-  DataType: word32
-  OrigDataType: word32
-T_170: (in g_dw10003070 - 1<32> @ 00000000 : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: word32
-T_171: (in 10003070 @ 100011FC : ptr32)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_173 t0000)))
+T_170: (in signature of adjust_fdiv @ 00000000 : void)
+  Class: Eq_170
+  DataType: Eq_170
+  OrigDataType: 
+T_171: (in 0<32> @ 10001210 : word32)
   Class: Eq_171
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_172 t0000)))
-T_172: (in Mem18[0x10003070<p32>:word32] @ 100011FC : word32)
-  Class: Eq_163
-  DataType: int32
+  DataType: word32
   OrigDataType: word32
-T_173: (in 0<32> @ 100012EA : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_172: (in adjust_fdiv + 0<32> @ 10001210 : word32)
+  Class: Eq_172
+  DataType: ptr32
+  OrigDataType: ptr32
+T_173: (in Mem23[adjust_fdiv + 0<32>:word32] @ 10001210 : word32)
+  Class: Eq_173
+  DataType: word32
   OrigDataType: word32
-T_174: (in dwArg08 != 0<32> @ 00000000 : bool)
+T_174: (in 100033A4 @ 10001210 : ptr32)
   Class: Eq_174
-  DataType: bool
-  OrigDataType: bool
-T_175: (in edi_124 @ 10001222 : Eq_145)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_176: (in fs @ 10001222 : selector)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_175 t0000)))
+T_175: (in Mem38[0x100033A4<p32>:word32] @ 10001210 : word32)
+  Class: Eq_173
+  DataType: word32
+  OrigDataType: word32
+T_176: (in esp_118 @ 1000120F : (ptr32 ptr32))
   Class: Eq_176
-  DataType: (ptr32 Eq_176)
-  OrigDataType: (ptr32 (segment (18 T_178 t0018)))
-T_177: (in 0x18<32> @ 10001222 : word32)
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_329 t0000)))
+T_177: (in fp @ 1000120F : ptr32)
   Class: Eq_177
-  DataType: (memptr (ptr32 Eq_176) (ptr32 Eq_178))
-  OrigDataType: (memptr T_176 (struct (0 T_178 t0000)))
-T_178: (in Mem38[fs:0x18<32>:word32] @ 10001222 : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_178: (in 16<i32> @ 1000120F : int32)
   Class: Eq_178
-  DataType: (ptr32 Eq_178)
-  OrigDataType: (ptr32 (struct (4 T_181 t0004)))
-T_179: (in 4<32> @ 10001222 : word32)
-  Class: Eq_179
-  DataType: word32
+  DataType: int32
+  OrigDataType: int32
+T_179: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_176
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
+T_180: (in 1<32> @ 10001216 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_180: (in Mem38[fs:0x18<32>:word32] + 4<32> @ 10001222 : word32)
-  Class: Eq_180
-  DataType: word32
-  OrigDataType: word32
-T_181: (in Mem38[Mem38[fs:0x18<32>:word32] + 4<32>:word32] @ 10001222 : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_182: (in eax_136 @ 1000124D : Eq_145)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_183: (in InterlockedCompareExchange @ 1000124D : ptr32)
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: (ptr32 (fn T_190 (T_188, T_175, T_189)))
-T_184: (in signature of InterlockedCompareExchange @ 00000000 : void)
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: 
-T_185: (in Destination @ 1000124D : (ptr32 LONG))
-  Class: Eq_185
-  DataType: (ptr32 Eq_185)
-  OrigDataType: 
-T_186: (in Exchange @ 1000124D : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: 
-T_187: (in Comperand @ 1000124D : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: 
-T_188: (in 0x100033AC<p32> @ 1000124D : ptr32)
-  Class: Eq_185
-  DataType: (ptr32 Eq_185)
-  OrigDataType: (ptr32 LONG)
-T_189: (in 0<32> @ 1000124D : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_190: (in InterlockedCompareExchange(&g_t100033AC, edi_124, 0<32>) @ 1000124D : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_191: (in 0<32> @ 10001251 : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_192: (in eax_136 != 0<32> @ 00000000 : bool)
-  Class: Eq_192
+T_181: (in dwArg08 != 1<32> @ 00000000 : bool)
+  Class: Eq_181
   DataType: bool
   OrigDataType: bool
-T_193: (in 1<32> @ 10001380 : word32)
-  Class: Eq_137
+T_182: (in 10003070 @ 100011FA : ptr32)
+  Class: Eq_182
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_183 t0000)))
+T_183: (in Mem8[0x10003070<p32>:word32] @ 100011FA : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: int32
+T_184: (in 0<32> @ 100011FA : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: int32
+T_185: (in g_dw10003070 <= 0<32> @ 00000000 : bool)
+  Class: Eq_185
+  DataType: bool
+  OrigDataType: bool
+T_186: (in 0<32> @ 10001233 : word32)
+  Class: Eq_157
   DataType: word32
   OrigDataType: word32
-T_194: (in InterlockedCompareExchange @ 10001310 : ptr32)
+T_187: (in 10003070 @ 100011FC : ptr32)
+  Class: Eq_187
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_188 t0000)))
+T_188: (in Mem8[0x10003070<p32>:word32] @ 100011FC : word32)
   Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: (ptr32 (fn T_198 (T_195, T_196, T_197)))
-T_195: (in 0x100033AC<p32> @ 10001310 : ptr32)
-  Class: Eq_185
-  DataType: (ptr32 Eq_185)
-  OrigDataType: (ptr32 LONG)
-T_196: (in 1<32> @ 10001310 : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_197: (in 0<32> @ 10001310 : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_198: (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) @ 10001310 : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_199: (in 0<32> @ 10001310 : word32)
-  Class: Eq_145
-  DataType: Eq_145
+  DataType: int32
   OrigDataType: word32
-T_200: (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) != 0<32> @ 00000000 : bool)
+T_189: (in 1<32> @ 100011FC : word32)
+  Class: Eq_189
+  DataType: word32
+  OrigDataType: word32
+T_190: (in g_dw10003070 - 1<32> @ 00000000 : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_191: (in 10003070 @ 100011FC : ptr32)
+  Class: Eq_191
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_192 t0000)))
+T_192: (in Mem18[0x10003070<p32>:word32] @ 100011FC : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_193: (in 0<32> @ 100012EA : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_194: (in dwArg08 != 0<32> @ 00000000 : bool)
+  Class: Eq_194
+  DataType: bool
+  OrigDataType: bool
+T_195: (in edi_124 @ 10001222 : Eq_165)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_196: (in fs @ 10001222 : selector)
+  Class: Eq_196
+  DataType: (ptr32 Eq_196)
+  OrigDataType: (ptr32 (segment (18 T_198 t0018)))
+T_197: (in 0x18<32> @ 10001222 : word32)
+  Class: Eq_197
+  DataType: (memptr (ptr32 Eq_196) (ptr32 Eq_198))
+  OrigDataType: (memptr T_196 (struct (0 T_198 t0000)))
+T_198: (in Mem38[fs:0x18<32>:word32] @ 10001222 : word32)
+  Class: Eq_198
+  DataType: (ptr32 Eq_198)
+  OrigDataType: (ptr32 (struct (4 T_201 t0004)))
+T_199: (in 4<32> @ 10001222 : word32)
+  Class: Eq_199
+  DataType: word32
+  OrigDataType: word32
+T_200: (in Mem38[fs:0x18<32>:word32] + 4<32> @ 10001222 : word32)
   Class: Eq_200
-  DataType: bool
-  OrigDataType: bool
-T_201: (in eax_136 == edi_124 @ 00000000 : bool)
-  Class: Eq_201
-  DataType: bool
-  OrigDataType: bool
-T_202: (in 100033A8 @ 10001262 : ptr32)
-  Class: Eq_202
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_203 t0000)))
-T_203: (in Mem135[0x100033A8<p32>:word32] @ 10001262 : word32)
-  Class: Eq_203
   DataType: word32
   OrigDataType: word32
-T_204: (in 0<32> @ 10001262 : word32)
-  Class: Eq_203
-  DataType: word32
+T_201: (in Mem38[Mem38[fs:0x18<32>:word32] + 4<32>:word32] @ 10001222 : word32)
+  Class: Eq_165
+  DataType: Eq_165
   OrigDataType: word32
-T_205: (in g_dw100033A8 == 0<32> @ 00000000 : bool)
+T_202: (in eax_136 @ 1000124D : Eq_165)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_203: (in InterlockedCompareExchange @ 1000124D : ptr32)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: (ptr32 (fn T_210 (T_208, T_195, T_209)))
+T_204: (in signature of InterlockedCompareExchange @ 00000000 : void)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: 
+T_205: (in Destination @ 1000124D : (ptr32 LONG))
   Class: Eq_205
-  DataType: bool
-  OrigDataType: bool
-T_206: (in Sleep @ 10001302 : ptr32)
-  Class: Eq_206
-  DataType: (ptr32 Eq_206)
-  OrigDataType: (ptr32 (fn T_210 (T_209)))
-T_207: (in signature of Sleep @ 00000000 : void)
-  Class: Eq_206
-  DataType: (ptr32 Eq_206)
+  DataType: (ptr32 Eq_205)
   OrigDataType: 
-T_208: (in dwMilliseconds @ 10001302 : DWORD)
-  Class: Eq_139
-  DataType: Eq_139
+T_206: (in Exchange @ 1000124D : LONG)
+  Class: Eq_165
+  DataType: Eq_165
   OrigDataType: 
-T_209: (in 0x3E8<32> @ 10001302 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_210: (in Sleep(0x3E8<32>) @ 10001302 : void)
-  Class: Eq_210
-  DataType: void
-  OrigDataType: void
-T_211: (in 100033A8 @ 1000131A : ptr32)
-  Class: Eq_211
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_212 t0000)))
-T_212: (in Mem53[0x100033A8<p32>:word32] @ 1000131A : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_213: (in 2<32> @ 1000131A : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_214: (in g_dw100033A8 == 2<32> @ 00000000 : bool)
-  Class: Eq_214
-  DataType: bool
-  OrigDataType: bool
-T_215: (in eax_69 @ 10001332 : (ptr32 word32))
-  Class: Eq_215
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 void)
-T_216: (in _decode_pointer @ 10001332 : ptr32)
-  Class: Eq_216
-  DataType: (ptr32 Eq_216)
-  OrigDataType: (ptr32 (fn T_221 (T_220)))
-T_217: (in signature of _decode_pointer @ 00000000 : void)
-  Class: Eq_216
-  DataType: (ptr32 Eq_216)
+T_207: (in Comperand @ 1000124D : LONG)
+  Class: Eq_165
+  DataType: Eq_165
   OrigDataType: 
-T_218: (in ptrArg04 @ 10001332 : (ptr32 void))
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: 
-T_219: (in 100033B4 @ 10001332 : ptr32)
-  Class: Eq_219
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_220 t0000)))
-T_220: (in Mem53[0x100033B4<p32>:word32] @ 10001332 : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_221: (in _decode_pointer(g_ptr100033B4) @ 10001332 : (ptr32 void))
-  Class: Eq_215
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 void)
-T_222: (in esp_105 @ 10001338 : ptr32)
-  Class: Eq_222
-  DataType: ptr32
-  OrigDataType: ptr32
-T_223: (in 16<i32> @ 10001338 : int32)
-  Class: Eq_223
-  DataType: int32
-  OrigDataType: int32
-T_224: (in fp - 16<i32> @ 00000000 : word32)
-  Class: Eq_222
-  DataType: ptr32
-  OrigDataType: ptr32
-T_225: (in 0<32> @ 10001339 : word32)
-  Class: Eq_215
-  DataType: (ptr32 word32)
-  OrigDataType: word32
-T_226: (in eax_69 == null @ 00000000 : bool)
-  Class: Eq_226
-  DataType: bool
-  OrigDataType: bool
-T_227: (in _amsg_exit @ 1000131E : ptr32)
-  Class: Eq_227
-  DataType: (ptr32 Eq_227)
-  OrigDataType: (ptr32 (fn T_231 (T_230)))
-T_228: (in signature of _amsg_exit @ 00000000 : void)
-  Class: Eq_227
-  DataType: (ptr32 Eq_227)
-  OrigDataType: 
-T_229: (in n @ 1000131E : int32)
-  Class: Eq_229
-  DataType: int32
-  OrigDataType: 
-T_230: (in 0x1F<32> @ 1000131E : word32)
-  Class: Eq_229
-  DataType: int32
-  OrigDataType: int32
-T_231: (in _amsg_exit(0x1F<32>) @ 1000131E : void)
-  Class: Eq_231
-  DataType: void
-  OrigDataType: void
-T_232: (in 1<32> @ 10001277 : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_233: (in 100033A8 @ 10001277 : ptr32)
-  Class: Eq_233
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_234 t0000)))
-T_234: (in Mem166[0x100033A8<p32>:word32] @ 10001277 : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_235: (in 16<i32> @ 10001289 : int32)
-  Class: Eq_235
-  DataType: int32
-  OrigDataType: int32
-T_236: (in fp - 16<i32> @ 00000000 : word32)
-  Class: Eq_156
-  DataType: (ptr32 ptr32)
-  OrigDataType: ptr32
-T_237: (in _initterm_e @ 1000128A : ptr32)
-  Class: Eq_237
-  DataType: (ptr32 Eq_237)
-  OrigDataType: (ptr32 (fn T_243 (T_241, T_242)))
-T_238: (in signature of _initterm_e @ 00000000 : void)
-  Class: Eq_237
-  DataType: (ptr32 Eq_237)
-  OrigDataType: 
-T_239: (in fStart @ 1000128A : (ptr32 PVFV))
-  Class: Eq_239
-  DataType: (ptr32 Eq_239)
-  OrigDataType: 
-T_240: (in fEnd @ 1000128A : (ptr32 PVFV))
-  Class: Eq_240
-  DataType: (ptr32 Eq_240)
-  OrigDataType: 
-T_241: (in 0x100020A0<32> @ 1000128A : word32)
-  Class: Eq_239
-  DataType: (ptr32 Eq_239)
-  OrigDataType: (ptr32 PVFV)
-T_242: (in 0x100020A8<32> @ 1000128A : word32)
-  Class: Eq_240
-  DataType: (ptr32 Eq_240)
-  OrigDataType: (ptr32 PVFV)
-T_243: (in _initterm_e(&g_t100020A0, &g_t100020A8) @ 1000128A : int32)
-  Class: Eq_243
-  DataType: int32
-  OrigDataType: int32
-T_244: (in 0<32> @ 1000128A : word32)
-  Class: Eq_243
-  DataType: int32
-  OrigDataType: word32
-T_245: (in _initterm_e(&g_t100020A0, &g_t100020A8) == 0<32> @ 00000000 : bool)
-  Class: Eq_245
-  DataType: bool
-  OrigDataType: bool
-T_246: (in _amsg_exit @ 10001266 : ptr32)
-  Class: Eq_227
-  DataType: (ptr32 Eq_227)
-  OrigDataType: (ptr32 (fn T_248 (T_247)))
-T_247: (in 0x1F<32> @ 10001266 : word32)
-  Class: Eq_229
-  DataType: int32
-  OrigDataType: int32
-T_248: (in _amsg_exit(0x1F<32>) @ 10001266 : void)
-  Class: Eq_231
-  DataType: void
-  OrigDataType: void
-T_249: (in 1<32> @ 10001257 : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_250: (in Sleep @ 10001243 : ptr32)
-  Class: Eq_206
-  DataType: (ptr32 Eq_206)
-  OrigDataType: (ptr32 (fn T_252 (T_251)))
-T_251: (in 0x3E8<32> @ 10001243 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_252: (in Sleep(0x3E8<32>) @ 10001243 : void)
-  Class: Eq_210
-  DataType: void
-  OrigDataType: void
-T_253: (in esp_110 @ 1000136F : (ptr32 Eq_253))
-  Class: Eq_253
-  DataType: (ptr32 Eq_253)
-  OrigDataType: (ptr32 (struct (FFFFFFFC T_260 tFFFFFFFC) (0 T_145 t0000)))
-T_254: (in 4<i32> @ 1000136F : int32)
-  Class: Eq_254
-  DataType: int32
-  OrigDataType: int32
-T_255: (in esp_105 - 4<i32> @ 00000000 : word32)
-  Class: Eq_253
-  DataType: (ptr32 Eq_253)
-  OrigDataType: ptr32
-T_256: (in 0<32> @ 1000136F : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_257: (in 0<32> @ 1000136F : word32)
-  Class: Eq_257
-  DataType: word32
-  OrigDataType: word32
-T_258: (in esp_110 + 0<32> @ 1000136F : word32)
-  Class: Eq_258
-  DataType: ptr32
-  OrigDataType: ptr32
-T_259: (in Mem111[esp_110 + 0<32>:word32] @ 1000136F : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_260: (in 0x100033AC<p32> @ 10001371 : ptr32)
-  Class: Eq_260
-  DataType: (ptr32 Eq_260)
-  OrigDataType: ptr32
-T_261: (in -4<i32> @ 10001371 : int32)
-  Class: Eq_261
-  DataType: int32
-  OrigDataType: int32
-T_262: (in esp_110 + -4<i32> @ 10001371 : word32)
-  Class: Eq_262
-  DataType: ptr32
-  OrigDataType: ptr32
-T_263: (in Mem114[esp_110 + -4<i32>:word32] @ 10001371 : word32)
-  Class: Eq_260
-  DataType: (ptr32 Eq_260)
-  OrigDataType: word32
-T_264: (in 0<32> @ 10001372 : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_265: (in 100033A8 @ 10001372 : ptr32)
-  Class: Eq_265
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_266 t0000)))
-T_266: (in Mem116[0x100033A8<p32>:word32] @ 10001372 : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_267: (in InterlockedExchange @ 10001378 : ptr32)
-  Class: Eq_267
-  DataType: (ptr32 Eq_267)
-  OrigDataType: (ptr32 (fn T_277 (T_273, T_276)))
-T_268: (in signature of InterlockedExchange @ 00000000 : void)
-  Class: Eq_267
-  DataType: (ptr32 Eq_267)
-  OrigDataType: 
-T_269: (in Target @ 10001378 : (ptr32 LONG))
-  Class: Eq_260
-  DataType: (ptr32 Eq_260)
-  OrigDataType: 
-T_270: (in Value @ 10001378 : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: 
-T_271: (in -4<i32> @ 10001378 : int32)
-  Class: Eq_271
-  DataType: int32
-  OrigDataType: int32
-T_272: (in esp_110 + -4<i32> @ 10001378 : word32)
-  Class: Eq_272
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_273: (in Mem116[esp_110 + -4<i32>:(ptr32 LONG)] @ 10001378 : (ptr32 LONG))
-  Class: Eq_260
-  DataType: (ptr32 Eq_260)
+T_208: (in 0x100033AC<p32> @ 1000124D : ptr32)
+  Class: Eq_205
+  DataType: (ptr32 Eq_205)
   OrigDataType: (ptr32 LONG)
-T_274: (in 0<32> @ 10001378 : word32)
-  Class: Eq_274
+T_209: (in 0<32> @ 1000124D : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_210: (in InterlockedCompareExchange(&g_t100033AC, edi_124, 0<32>) @ 1000124D : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_211: (in 0<32> @ 10001251 : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_212: (in eax_136 != 0<32> @ 00000000 : bool)
+  Class: Eq_212
+  DataType: bool
+  OrigDataType: bool
+T_213: (in 1<32> @ 10001380 : word32)
+  Class: Eq_157
   DataType: word32
   OrigDataType: word32
-T_275: (in esp_110 + 0<32> @ 10001378 : word32)
-  Class: Eq_275
+T_214: (in InterlockedCompareExchange @ 10001310 : ptr32)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: (ptr32 (fn T_218 (T_215, T_216, T_217)))
+T_215: (in 0x100033AC<p32> @ 10001310 : ptr32)
+  Class: Eq_205
+  DataType: (ptr32 Eq_205)
+  OrigDataType: (ptr32 LONG)
+T_216: (in 1<32> @ 10001310 : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_217: (in 0<32> @ 10001310 : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_218: (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) @ 10001310 : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_219: (in 0<32> @ 10001310 : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_220: (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) != 0<32> @ 00000000 : bool)
+  Class: Eq_220
+  DataType: bool
+  OrigDataType: bool
+T_221: (in eax_136 == edi_124 @ 00000000 : bool)
+  Class: Eq_221
+  DataType: bool
+  OrigDataType: bool
+T_222: (in 100033A8 @ 10001262 : ptr32)
+  Class: Eq_222
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_276: (in Mem116[esp_110 + 0<32>:LONG] @ 10001378 : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_277: (in InterlockedExchange(esp_110->ptrFFFFFFFC, esp_110->t0000) @ 10001378 : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_278: (in 4<32> @ 10001378 : word32)
-  Class: Eq_278
-  DataType: int32
-  OrigDataType: int32
-T_279: (in esp_110 + 4<32> @ 10001378 : word32)
-  Class: Eq_156
-  DataType: (ptr32 ptr32)
-  OrigDataType: ptr32
-T_280: (in esp_81 @ 10001343 : ptr32)
-  Class: Eq_280
+  OrigDataType: (ptr32 (struct (0 T_223 t0000)))
+T_223: (in Mem135[0x100033A8<p32>:word32] @ 10001262 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_224: (in 0<32> @ 10001262 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_225: (in g_dw100033A8 == 0<32> @ 00000000 : bool)
+  Class: Eq_225
+  DataType: bool
+  OrigDataType: bool
+T_226: (in Sleep @ 10001302 : ptr32)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
+  OrigDataType: (ptr32 (fn T_230 (T_229)))
+T_227: (in signature of Sleep @ 00000000 : void)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
+  OrigDataType: 
+T_228: (in dwMilliseconds @ 10001302 : DWORD)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: 
+T_229: (in 0x3E8<32> @ 10001302 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_230: (in Sleep(0x3E8<32>) @ 10001302 : void)
+  Class: Eq_230
+  DataType: void
+  OrigDataType: void
+T_231: (in 100033A8 @ 1000131A : ptr32)
+  Class: Eq_231
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_232 t0000)))
+T_232: (in Mem53[0x100033A8<p32>:word32] @ 1000131A : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_233: (in 2<32> @ 1000131A : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_234: (in g_dw100033A8 == 2<32> @ 00000000 : bool)
+  Class: Eq_234
+  DataType: bool
+  OrigDataType: bool
+T_235: (in eax_69 @ 10001332 : (ptr32 word32))
+  Class: Eq_235
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 void)
+T_236: (in _decode_pointer @ 10001332 : ptr32)
+  Class: Eq_236
+  DataType: (ptr32 Eq_236)
+  OrigDataType: (ptr32 (fn T_241 (T_240)))
+T_237: (in signature of _decode_pointer @ 00000000 : void)
+  Class: Eq_236
+  DataType: (ptr32 Eq_236)
+  OrigDataType: 
+T_238: (in ptrArg04 @ 10001332 : (ptr32 void))
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: 
+T_239: (in 100033B4 @ 10001332 : ptr32)
+  Class: Eq_239
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_240 t0000)))
+T_240: (in Mem53[0x100033B4<p32>:word32] @ 10001332 : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_241: (in _decode_pointer(g_ptr100033B4) @ 10001332 : (ptr32 void))
+  Class: Eq_235
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 void)
+T_242: (in esp_105 @ 10001338 : ptr32)
+  Class: Eq_242
   DataType: ptr32
   OrigDataType: ptr32
-T_281: (in 16<i32> @ 10001343 : int32)
+T_243: (in 16<i32> @ 10001338 : int32)
+  Class: Eq_243
+  DataType: int32
+  OrigDataType: int32
+T_244: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_242
+  DataType: ptr32
+  OrigDataType: ptr32
+T_245: (in 0<32> @ 10001339 : word32)
+  Class: Eq_235
+  DataType: (ptr32 word32)
+  OrigDataType: word32
+T_246: (in eax_69 == null @ 00000000 : bool)
+  Class: Eq_246
+  DataType: bool
+  OrigDataType: bool
+T_247: (in _amsg_exit @ 1000131E : ptr32)
+  Class: Eq_247
+  DataType: (ptr32 Eq_247)
+  OrigDataType: (ptr32 (fn T_251 (T_250)))
+T_248: (in signature of _amsg_exit @ 00000000 : void)
+  Class: Eq_247
+  DataType: (ptr32 Eq_247)
+  OrigDataType: 
+T_249: (in n @ 1000131E : int32)
+  Class: Eq_249
+  DataType: int32
+  OrigDataType: 
+T_250: (in 0x1F<32> @ 1000131E : word32)
+  Class: Eq_249
+  DataType: int32
+  OrigDataType: int32
+T_251: (in _amsg_exit(0x1F<32>) @ 1000131E : void)
+  Class: Eq_251
+  DataType: void
+  OrigDataType: void
+T_252: (in 1<32> @ 10001277 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_253: (in 100033A8 @ 10001277 : ptr32)
+  Class: Eq_253
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_254 t0000)))
+T_254: (in Mem166[0x100033A8<p32>:word32] @ 10001277 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_255: (in 16<i32> @ 10001289 : int32)
+  Class: Eq_255
+  DataType: int32
+  OrigDataType: int32
+T_256: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_176
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
+T_257: (in _initterm_e @ 1000128A : ptr32)
+  Class: Eq_257
+  DataType: (ptr32 Eq_257)
+  OrigDataType: (ptr32 (fn T_263 (T_261, T_262)))
+T_258: (in signature of _initterm_e @ 00000000 : void)
+  Class: Eq_257
+  DataType: (ptr32 Eq_257)
+  OrigDataType: 
+T_259: (in fStart @ 1000128A : (ptr32 PVFV))
+  Class: Eq_259
+  DataType: (ptr32 Eq_259)
+  OrigDataType: 
+T_260: (in fEnd @ 1000128A : (ptr32 PVFV))
+  Class: Eq_260
+  DataType: (ptr32 Eq_260)
+  OrigDataType: 
+T_261: (in 0x100020A0<32> @ 1000128A : word32)
+  Class: Eq_259
+  DataType: (ptr32 Eq_259)
+  OrigDataType: (ptr32 PVFV)
+T_262: (in 0x100020A8<32> @ 1000128A : word32)
+  Class: Eq_260
+  DataType: (ptr32 Eq_260)
+  OrigDataType: (ptr32 PVFV)
+T_263: (in _initterm_e(&g_t100020A0, &g_t100020A8) @ 1000128A : int32)
+  Class: Eq_263
+  DataType: int32
+  OrigDataType: int32
+T_264: (in 0<32> @ 1000128A : word32)
+  Class: Eq_263
+  DataType: int32
+  OrigDataType: word32
+T_265: (in _initterm_e(&g_t100020A0, &g_t100020A8) == 0<32> @ 00000000 : bool)
+  Class: Eq_265
+  DataType: bool
+  OrigDataType: bool
+T_266: (in _amsg_exit @ 10001266 : ptr32)
+  Class: Eq_247
+  DataType: (ptr32 Eq_247)
+  OrigDataType: (ptr32 (fn T_268 (T_267)))
+T_267: (in 0x1F<32> @ 10001266 : word32)
+  Class: Eq_249
+  DataType: int32
+  OrigDataType: int32
+T_268: (in _amsg_exit(0x1F<32>) @ 10001266 : void)
+  Class: Eq_251
+  DataType: void
+  OrigDataType: void
+T_269: (in 1<32> @ 10001257 : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_270: (in Sleep @ 10001243 : ptr32)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
+  OrigDataType: (ptr32 (fn T_272 (T_271)))
+T_271: (in 0x3E8<32> @ 10001243 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_272: (in Sleep(0x3E8<32>) @ 10001243 : void)
+  Class: Eq_230
+  DataType: void
+  OrigDataType: void
+T_273: (in esp_110 @ 1000136F : (ptr32 Eq_273))
+  Class: Eq_273
+  DataType: (ptr32 Eq_273)
+  OrigDataType: (ptr32 (struct (FFFFFFFC T_280 tFFFFFFFC) (0 T_165 t0000)))
+T_274: (in 4<i32> @ 1000136F : int32)
+  Class: Eq_274
+  DataType: int32
+  OrigDataType: int32
+T_275: (in esp_105 - 4<i32> @ 00000000 : word32)
+  Class: Eq_273
+  DataType: (ptr32 Eq_273)
+  OrigDataType: ptr32
+T_276: (in 0<32> @ 1000136F : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_277: (in 0<32> @ 1000136F : word32)
+  Class: Eq_277
+  DataType: word32
+  OrigDataType: word32
+T_278: (in esp_110 + 0<32> @ 1000136F : word32)
+  Class: Eq_278
+  DataType: ptr32
+  OrigDataType: ptr32
+T_279: (in Mem111[esp_110 + 0<32>:word32] @ 1000136F : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_280: (in 0x100033AC<p32> @ 10001371 : ptr32)
+  Class: Eq_280
+  DataType: (ptr32 Eq_280)
+  OrigDataType: ptr32
+T_281: (in -4<i32> @ 10001371 : int32)
   Class: Eq_281
   DataType: int32
   OrigDataType: int32
-T_282: (in fp - 16<i32> @ 00000000 : word32)
+T_282: (in esp_110 + -4<i32> @ 10001371 : word32)
+  Class: Eq_282
+  DataType: ptr32
+  OrigDataType: ptr32
+T_283: (in Mem114[esp_110 + -4<i32>:word32] @ 10001371 : word32)
   Class: Eq_280
-  DataType: ptr32
-  OrigDataType: ptr32
-T_283: (in edi_82 @ 10001344 : (ptr32 word32))
-  Class: Eq_215
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
-T_284: (in _decode_pointer @ 10001344 : ptr32)
-  Class: Eq_216
-  DataType: (ptr32 Eq_216)
-  OrigDataType: (ptr32 (fn T_287 (T_286)))
-T_285: (in 100033B0 @ 10001344 : ptr32)
+  DataType: (ptr32 Eq_280)
+  OrigDataType: word32
+T_284: (in 0<32> @ 10001372 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_285: (in 100033A8 @ 10001372 : ptr32)
   Class: Eq_285
-  DataType: (ptr32 (ptr32 void))
+  DataType: (ptr32 word32)
   OrigDataType: (ptr32 (struct (0 T_286 t0000)))
-T_286: (in Mem67[0x100033B0<p32>:word32] @ 10001344 : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_287: (in _decode_pointer(g_ptr100033B0) @ 10001344 : (ptr32 void))
-  Class: Eq_215
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 void)
-T_288: (in 4<32> @ 10001350 : word32)
-  Class: Eq_288
-  DataType: ui32
-  OrigDataType: ui32
-T_289: (in edi_82 - 4<32> @ 00000000 : word32)
-  Class: Eq_215
-  DataType: (ptr32 word32)
-  OrigDataType: ptr32
-T_290: (in edi_82 >= eax_69 @ 00000000 : bool)
-  Class: Eq_290
-  DataType: bool
-  OrigDataType: bool
-T_291: (in _initterm @ 1000129D : ptr32)
+T_286: (in Mem116[0x100033A8<p32>:word32] @ 10001372 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_287: (in InterlockedExchange @ 10001378 : ptr32)
+  Class: Eq_287
+  DataType: (ptr32 Eq_287)
+  OrigDataType: (ptr32 (fn T_297 (T_293, T_296)))
+T_288: (in signature of InterlockedExchange @ 00000000 : void)
+  Class: Eq_287
+  DataType: (ptr32 Eq_287)
+  OrigDataType: 
+T_289: (in Target @ 10001378 : (ptr32 LONG))
+  Class: Eq_280
+  DataType: (ptr32 Eq_280)
+  OrigDataType: 
+T_290: (in Value @ 10001378 : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: 
+T_291: (in -4<i32> @ 10001378 : int32)
   Class: Eq_291
-  DataType: (ptr32 Eq_291)
-  OrigDataType: (ptr32 (fn T_297 (T_295, T_296)))
-T_292: (in signature of _initterm @ 00000000 : void)
-  Class: Eq_291
-  DataType: (ptr32 Eq_291)
-  OrigDataType: 
-T_293: (in fStart @ 1000129D : (ptr32 PVFV))
-  Class: Eq_293
-  DataType: (ptr32 Eq_293)
-  OrigDataType: 
-T_294: (in fEnd @ 1000129D : (ptr32 PVFV))
-  Class: Eq_294
-  DataType: (ptr32 Eq_294)
-  OrigDataType: 
-T_295: (in 0x10002098<32> @ 1000129D : word32)
-  Class: Eq_293
-  DataType: (ptr32 Eq_293)
-  OrigDataType: (ptr32 PVFV)
-T_296: (in 0x1000209C<32> @ 1000129D : word32)
-  Class: Eq_294
-  DataType: (ptr32 Eq_294)
-  OrigDataType: (ptr32 PVFV)
-T_297: (in _initterm(&g_t10002098, &g_t1000209C) @ 1000129D : void)
-  Class: Eq_297
-  DataType: void
-  OrigDataType: void
-T_298: (in 2<32> @ 100012A3 : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_299: (in 100033A8 @ 100012A3 : ptr32)
-  Class: Eq_299
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_300 t0000)))
-T_300: (in Mem181[0x100033A8<p32>:word32] @ 100012A3 : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_301: (in 0<32> @ 100012AC : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_302: (in ebp_145 != 0<32> @ 00000000 : bool)
-  Class: Eq_302
-  DataType: bool
-  OrigDataType: bool
-T_303: (in 0<32> @ 1000128C : word32)
-  Class: Eq_137
-  DataType: word32
-  OrigDataType: word32
-T_304: (in esp_261 @ 10001381 : (ptr32 Eq_304))
-  Class: Eq_304
-  DataType: (ptr32 Eq_304)
-  OrigDataType: (ptr32 (struct (0 T_313 t0000) (4 T_317 t0004)))
-T_305: (in 4<i32> @ 10001381 : int32)
-  Class: Eq_305
   DataType: int32
   OrigDataType: int32
-T_306: (in esp_118 + 4<i32> @ 10001381 : word32)
-  Class: Eq_304
-  DataType: (ptr32 Eq_304)
-  OrigDataType: ptr32
-T_307: (in 0<32> @ 10001381 : word32)
-  Class: Eq_307
-  DataType: word32
-  OrigDataType: word32
-T_308: (in esp_118 + 0<32> @ 10001381 : word32)
-  Class: Eq_308
-  DataType: ptr32
-  OrigDataType: ptr32
-T_309: (in Mem258[esp_118 + 0<32>:word32] @ 10001381 : word32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: word32
-T_310: (in edi @ 10001381 : word32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: word32
-T_311: (in 0<32> @ 10001382 : word32)
-  Class: Eq_311
-  DataType: word32
-  OrigDataType: word32
-T_312: (in esp_261 + 0<32> @ 10001382 : word32)
-  Class: Eq_312
-  DataType: ptr32
-  OrigDataType: ptr32
-T_313: (in Mem258[esp_261 + 0<32>:word32] @ 10001382 : word32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: word32
-T_314: (in esi @ 10001382 : word32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: word32
-T_315: (in 4<i32> @ 10001383 : int32)
-  Class: Eq_315
-  DataType: int32
-  OrigDataType: int32
-T_316: (in esp_261 + 4<i32> @ 10001383 : word32)
-  Class: Eq_316
-  DataType: ptr32
-  OrigDataType: ptr32
-T_317: (in Mem258[esp_261 + 4<i32>:word32] @ 10001383 : word32)
-  Class: Eq_141
-  DataType: ptr32
-  OrigDataType: word32
-T_318: (in ebx @ 10001383 : word32)
-  Class: Eq_141
-  DataType: ptr32
-  OrigDataType: word32
-T_319: (in eax_89 @ 10001348 : (ptr32 code))
-  Class: Eq_319
-  DataType: (ptr32 code)
-  OrigDataType: (ptr32 code)
-T_320: (in 0<32> @ 10001348 : word32)
-  Class: Eq_320
-  DataType: word32
-  OrigDataType: word32
-T_321: (in edi_82 + 0<32> @ 10001348 : word32)
-  Class: Eq_321
-  DataType: ptr32
-  OrigDataType: ptr32
-T_322: (in Mem78[edi_82 + 0<32>:word32] @ 10001348 : word32)
-  Class: Eq_319
-  DataType: (ptr32 code)
-  OrigDataType: word32
-T_323: (in 0<32> @ 1000134C : word32)
-  Class: Eq_319
-  DataType: (ptr32 code)
-  OrigDataType: word32
-T_324: (in eax_89 == null @ 00000000 : bool)
-  Class: Eq_324
-  DataType: bool
-  OrigDataType: bool
-T_325: (in esp_102 @ 10001357 : (ptr32 (ptr32 word32)))
-  Class: Eq_325
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: (ptr32 (struct (0 T_215 t0000)))
-T_326: (in 4<i32> @ 10001357 : int32)
-  Class: Eq_326
-  DataType: int32
-  OrigDataType: int32
-T_327: (in esp_81 - 4<i32> @ 00000000 : word32)
-  Class: Eq_325
-  DataType: (ptr32 (ptr32 word32))
-  OrigDataType: ptr32
-T_328: (in 0<32> @ 10001357 : word32)
-  Class: Eq_328
-  DataType: word32
-  OrigDataType: word32
-T_329: (in esp_102 + 0<32> @ 10001357 : word32)
-  Class: Eq_329
-  DataType: ptr32
-  OrigDataType: ptr32
-T_330: (in Mem103[esp_102 + 0<32>:word32] @ 10001357 : word32)
-  Class: Eq_215
-  DataType: (ptr32 word32)
-  OrigDataType: word32
-T_331: (in free @ 10001358 : ptr32)
-  Class: Eq_331
-  DataType: (ptr32 Eq_331)
-  OrigDataType: (ptr32 (fn T_337 (T_336)))
-T_332: (in signature of free @ 00000000 : void)
-  Class: Eq_331
-  DataType: (ptr32 Eq_331)
-  OrigDataType: 
-T_333: (in ptrArg04 @ 10001358 : (ptr32 void))
-  Class: Eq_215
-  DataType: (ptr32 word32)
-  OrigDataType: 
-T_334: (in 0<32> @ 10001358 : word32)
-  Class: Eq_334
-  DataType: word32
-  OrigDataType: word32
-T_335: (in esp_102 + 0<32> @ 10001358 : word32)
-  Class: Eq_335
+T_292: (in esp_110 + -4<i32> @ 10001378 : word32)
+  Class: Eq_292
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_336: (in Mem103[esp_102 + 0<32>:(ptr32 void)] @ 10001358 : (ptr32 void))
-  Class: Eq_215
+T_293: (in Mem116[esp_110 + -4<i32>:(ptr32 LONG)] @ 10001378 : (ptr32 LONG))
+  Class: Eq_280
+  DataType: (ptr32 Eq_280)
+  OrigDataType: (ptr32 LONG)
+T_294: (in 0<32> @ 10001378 : word32)
+  Class: Eq_294
+  DataType: word32
+  OrigDataType: word32
+T_295: (in esp_110 + 0<32> @ 10001378 : word32)
+  Class: Eq_295
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_296: (in Mem116[esp_110 + 0<32>:LONG] @ 10001378 : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_297: (in InterlockedExchange(esp_110->ptrFFFFFFFC, esp_110->t0000) @ 10001378 : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_298: (in 4<32> @ 10001378 : word32)
+  Class: Eq_298
+  DataType: int32
+  OrigDataType: int32
+T_299: (in esp_110 + 4<32> @ 10001378 : word32)
+  Class: Eq_176
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
+T_300: (in esp_81 @ 10001343 : ptr32)
+  Class: Eq_300
+  DataType: ptr32
+  OrigDataType: ptr32
+T_301: (in 16<i32> @ 10001343 : int32)
+  Class: Eq_301
+  DataType: int32
+  OrigDataType: int32
+T_302: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_300
+  DataType: ptr32
+  OrigDataType: ptr32
+T_303: (in edi_82 @ 10001344 : (ptr32 word32))
+  Class: Eq_235
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
+T_304: (in _decode_pointer @ 10001344 : ptr32)
+  Class: Eq_236
+  DataType: (ptr32 Eq_236)
+  OrigDataType: (ptr32 (fn T_307 (T_306)))
+T_305: (in 100033B0 @ 10001344 : ptr32)
+  Class: Eq_305
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_306 t0000)))
+T_306: (in Mem67[0x100033B0<p32>:word32] @ 10001344 : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_307: (in _decode_pointer(g_ptr100033B0) @ 10001344 : (ptr32 void))
+  Class: Eq_235
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 void)
-T_337: (in free(*esp_102) @ 10001358 : void)
-  Class: Eq_337
+T_308: (in 4<32> @ 10001350 : word32)
+  Class: Eq_308
+  DataType: ui32
+  OrigDataType: ui32
+T_309: (in edi_82 - 4<32> @ 00000000 : word32)
+  Class: Eq_235
+  DataType: (ptr32 word32)
+  OrigDataType: ptr32
+T_310: (in edi_82 >= eax_69 @ 00000000 : bool)
+  Class: Eq_310
+  DataType: bool
+  OrigDataType: bool
+T_311: (in _initterm @ 1000129D : ptr32)
+  Class: Eq_311
+  DataType: (ptr32 Eq_311)
+  OrigDataType: (ptr32 (fn T_317 (T_315, T_316)))
+T_312: (in signature of _initterm @ 00000000 : void)
+  Class: Eq_311
+  DataType: (ptr32 Eq_311)
+  OrigDataType: 
+T_313: (in fStart @ 1000129D : (ptr32 PVFV))
+  Class: Eq_313
+  DataType: (ptr32 Eq_313)
+  OrigDataType: 
+T_314: (in fEnd @ 1000129D : (ptr32 PVFV))
+  Class: Eq_314
+  DataType: (ptr32 Eq_314)
+  OrigDataType: 
+T_315: (in 0x10002098<32> @ 1000129D : word32)
+  Class: Eq_313
+  DataType: (ptr32 Eq_313)
+  OrigDataType: (ptr32 PVFV)
+T_316: (in 0x1000209C<32> @ 1000129D : word32)
+  Class: Eq_314
+  DataType: (ptr32 Eq_314)
+  OrigDataType: (ptr32 PVFV)
+T_317: (in _initterm(&g_t10002098, &g_t1000209C) @ 1000129D : void)
+  Class: Eq_317
   DataType: void
   OrigDataType: void
-T_338: (in eax_106 @ 1000135F : (ptr32 void))
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_339: (in _encoded_null @ 1000135F : ptr32)
-  Class: Eq_339
-  DataType: (ptr32 Eq_339)
-  OrigDataType: (ptr32 (fn T_341 ()))
-T_340: (in signature of _encoded_null @ 00000000 : void)
-  Class: Eq_339
-  DataType: (ptr32 Eq_339)
-  OrigDataType: 
-T_341: (in _encoded_null() @ 1000135F : (ptr32 void))
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_342: (in 100033B0 @ 10001365 : ptr32)
-  Class: Eq_342
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_343 t0000)))
-T_343: (in Mem107[0x100033B0<p32>:word32] @ 10001365 : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
+T_318: (in 2<32> @ 100012A3 : word32)
+  Class: Eq_223
+  DataType: word32
   OrigDataType: word32
-T_344: (in 100033B4 @ 1000136A : ptr32)
+T_319: (in 100033A8 @ 100012A3 : ptr32)
+  Class: Eq_319
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_320 t0000)))
+T_320: (in Mem181[0x100033A8<p32>:word32] @ 100012A3 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_321: (in 0<32> @ 100012AC : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_322: (in ebp_145 != 0<32> @ 00000000 : bool)
+  Class: Eq_322
+  DataType: bool
+  OrigDataType: bool
+T_323: (in 0<32> @ 1000128C : word32)
+  Class: Eq_157
+  DataType: word32
+  OrigDataType: word32
+T_324: (in esp_261 @ 10001381 : (ptr32 Eq_324))
+  Class: Eq_324
+  DataType: (ptr32 Eq_324)
+  OrigDataType: (ptr32 (struct (0 T_333 t0000) (4 T_337 t0004)))
+T_325: (in 4<i32> @ 10001381 : int32)
+  Class: Eq_325
+  DataType: int32
+  OrigDataType: int32
+T_326: (in esp_118 + 4<i32> @ 10001381 : word32)
+  Class: Eq_324
+  DataType: (ptr32 Eq_324)
+  OrigDataType: ptr32
+T_327: (in 0<32> @ 10001381 : word32)
+  Class: Eq_327
+  DataType: word32
+  OrigDataType: word32
+T_328: (in esp_118 + 0<32> @ 10001381 : word32)
+  Class: Eq_328
+  DataType: ptr32
+  OrigDataType: ptr32
+T_329: (in Mem258[esp_118 + 0<32>:word32] @ 10001381 : word32)
+  Class: Eq_163
+  DataType: ptr32
+  OrigDataType: word32
+T_330: (in edi @ 10001381 : word32)
+  Class: Eq_163
+  DataType: ptr32
+  OrigDataType: word32
+T_331: (in 0<32> @ 10001382 : word32)
+  Class: Eq_331
+  DataType: word32
+  OrigDataType: word32
+T_332: (in esp_261 + 0<32> @ 10001382 : word32)
+  Class: Eq_332
+  DataType: ptr32
+  OrigDataType: ptr32
+T_333: (in Mem258[esp_261 + 0<32>:word32] @ 10001382 : word32)
+  Class: Eq_162
+  DataType: ptr32
+  OrigDataType: word32
+T_334: (in esi @ 10001382 : word32)
+  Class: Eq_162
+  DataType: ptr32
+  OrigDataType: word32
+T_335: (in 4<i32> @ 10001383 : int32)
+  Class: Eq_335
+  DataType: int32
+  OrigDataType: int32
+T_336: (in esp_261 + 4<i32> @ 10001383 : word32)
+  Class: Eq_336
+  DataType: ptr32
+  OrigDataType: ptr32
+T_337: (in Mem258[esp_261 + 4<i32>:word32] @ 10001383 : word32)
+  Class: Eq_161
+  DataType: ptr32
+  OrigDataType: word32
+T_338: (in ebx @ 10001383 : word32)
+  Class: Eq_161
+  DataType: ptr32
+  OrigDataType: word32
+T_339: (in eax_89 @ 10001348 : (ptr32 code))
+  Class: Eq_339
+  DataType: (ptr32 code)
+  OrigDataType: (ptr32 code)
+T_340: (in 0<32> @ 10001348 : word32)
+  Class: Eq_340
+  DataType: word32
+  OrigDataType: word32
+T_341: (in edi_82 + 0<32> @ 10001348 : word32)
+  Class: Eq_341
+  DataType: ptr32
+  OrigDataType: ptr32
+T_342: (in Mem78[edi_82 + 0<32>:word32] @ 10001348 : word32)
+  Class: Eq_339
+  DataType: (ptr32 code)
+  OrigDataType: word32
+T_343: (in 0<32> @ 1000134C : word32)
+  Class: Eq_339
+  DataType: (ptr32 code)
+  OrigDataType: word32
+T_344: (in eax_89 == null @ 00000000 : bool)
   Class: Eq_344
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_345 t0000)))
-T_345: (in Mem108[0x100033B4<p32>:word32] @ 1000136A : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: word32
-T_346: (in 4<i32> @ 1000135E : int32)
+  DataType: bool
+  OrigDataType: bool
+T_345: (in esp_102 @ 10001357 : (ptr32 (ptr32 word32)))
+  Class: Eq_345
+  DataType: (ptr32 (ptr32 word32))
+  OrigDataType: (ptr32 (struct (0 T_235 t0000)))
+T_346: (in 4<i32> @ 10001357 : int32)
   Class: Eq_346
   DataType: int32
   OrigDataType: int32
-T_347: (in esp_102 + 4<i32> @ 1000135E : word32)
-  Class: Eq_222
-  DataType: ptr32
+T_347: (in esp_81 - 4<i32> @ 00000000 : word32)
+  Class: Eq_345
+  DataType: (ptr32 (ptr32 word32))
   OrigDataType: ptr32
-T_348: (in ecx_99 @ 1000134E : word32)
+T_348: (in 0<32> @ 10001357 : word32)
   Class: Eq_348
   DataType: word32
   OrigDataType: word32
-T_349: (in edx_286 @ 1000134E : word32)
+T_349: (in esp_102 + 0<32> @ 10001357 : word32)
   Class: Eq_349
-  DataType: word32
-  OrigDataType: word32
-T_350: (in 16<i32> @ 100012B6 : int32)
-  Class: Eq_350
-  DataType: int32
-  OrigDataType: int32
-T_351: (in fp - 16<i32> @ 00000000 : word32)
-  Class: Eq_156
-  DataType: (ptr32 ptr32)
+  DataType: ptr32
   OrigDataType: ptr32
-T_352: (in 100033B8 @ 100012BD : ptr32)
-  Class: Eq_352
-  DataType: (ptr32 (ptr32 code))
-  OrigDataType: (ptr32 (struct (0 T_353 t0000)))
-T_353: (in Mem196[0x100033B8<p32>:word32] @ 100012BD : word32)
-  Class: Eq_353
-  DataType: (ptr32 code)
+T_350: (in Mem103[esp_102 + 0<32>:word32] @ 10001357 : word32)
+  Class: Eq_235
+  DataType: (ptr32 word32)
   OrigDataType: word32
-T_354: (in 0<32> @ 100012BD : word32)
-  Class: Eq_353
-  DataType: (ptr32 code)
-  OrigDataType: word32
-T_355: (in g_ptr100033B8 == null @ 00000000 : bool)
-  Class: Eq_355
-  DataType: bool
-  OrigDataType: bool
-T_356: (in InterlockedExchange @ 100012B0 : ptr32)
-  Class: Eq_267
-  DataType: (ptr32 Eq_267)
-  OrigDataType: (ptr32 (fn T_358 (T_357, T_145)))
-T_357: (in 0x100033AC<p32> @ 100012B0 : ptr32)
-  Class: Eq_260
-  DataType: (ptr32 Eq_260)
-  OrigDataType: (ptr32 LONG)
-T_358: (in InterlockedExchange(&g_t100033AC, ebp_145) @ 100012B0 : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_359: (in 10003070 @ 100012DD : ptr32)
-  Class: Eq_359
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_360 t0000)))
-T_360: (in Mem244[0x10003070<p32>:word32] @ 100012DD : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: word32
-T_361: (in 1<32> @ 100012DD : word32)
-  Class: Eq_361
-  DataType: word32
-  OrigDataType: word32
-T_362: (in g_dw10003070 + 1<32> @ 00000000 : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: word32
-T_363: (in 10003070 @ 100012DD : ptr32)
-  Class: Eq_363
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_364 t0000)))
-T_364: (in Mem246[0x10003070<p32>:word32] @ 100012DD : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: word32
-T_365: (in 16<i32> @ 100012CB : int32)
-  Class: Eq_365
-  DataType: int32
-  OrigDataType: int32
-T_366: (in fp - 16<i32> @ 00000000 : word32)
-  Class: Eq_156
-  DataType: (ptr32 ptr32)
-  OrigDataType: ptr32
-T_367: (in edi_214 @ 100012CC : word32)
-  Class: Eq_367
-  DataType: word32
-  OrigDataType: word32
-T_368: (in fn10001742 @ 100012CC : ptr32)
-  Class: Eq_368
-  DataType: (ptr32 Eq_368)
-  OrigDataType: (ptr32 (fn T_378 (T_374, T_375, T_376, T_377)))
-T_369: (in signature of fn10001742 @ 10001742 : void)
-  Class: Eq_368
-  DataType: (ptr32 Eq_368)
+T_351: (in free @ 10001358 : ptr32)
+  Class: Eq_351
+  DataType: (ptr32 Eq_351)
+  OrigDataType: (ptr32 (fn T_357 (T_356)))
+T_352: (in signature of free @ 00000000 : void)
+  Class: Eq_351
+  DataType: (ptr32 Eq_351)
   OrigDataType: 
-T_370: (in ebx @ 100012CC : (ptr32 Eq_183))
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
+T_353: (in ptrArg04 @ 10001358 : (ptr32 void))
+  Class: Eq_235
+  DataType: (ptr32 word32)
+  OrigDataType: 
+T_354: (in 0<32> @ 10001358 : word32)
+  Class: Eq_354
+  DataType: word32
   OrigDataType: word32
-T_371: (in esi @ 100012CC : ptr32)
-  Class: Eq_371
+T_355: (in esp_102 + 0<32> @ 10001358 : word32)
+  Class: Eq_355
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_356: (in Mem103[esp_102 + 0<32>:(ptr32 void)] @ 10001358 : (ptr32 void))
+  Class: Eq_235
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 void)
+T_357: (in free(*esp_102) @ 10001358 : void)
+  Class: Eq_357
+  DataType: void
+  OrigDataType: void
+T_358: (in eax_106 @ 1000135F : (ptr32 void))
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_359: (in _encoded_null @ 1000135F : ptr32)
+  Class: Eq_359
+  DataType: (ptr32 Eq_359)
+  OrigDataType: (ptr32 (fn T_361 ()))
+T_360: (in signature of _encoded_null @ 00000000 : void)
+  Class: Eq_359
+  DataType: (ptr32 Eq_359)
+  OrigDataType: 
+T_361: (in _encoded_null() @ 1000135F : (ptr32 void))
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_362: (in 100033B0 @ 10001365 : ptr32)
+  Class: Eq_362
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_363 t0000)))
+T_363: (in Mem107[0x100033B0<p32>:word32] @ 10001365 : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: word32
+T_364: (in 100033B4 @ 1000136A : ptr32)
+  Class: Eq_364
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_365 t0000)))
+T_365: (in Mem108[0x100033B4<p32>:word32] @ 1000136A : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: word32
+T_366: (in 4<i32> @ 1000135E : int32)
+  Class: Eq_366
+  DataType: int32
+  OrigDataType: int32
+T_367: (in esp_102 + 4<i32> @ 1000135E : word32)
+  Class: Eq_242
   DataType: ptr32
+  OrigDataType: ptr32
+T_368: (in ecx_99 @ 1000134E : word32)
+  Class: Eq_368
+  DataType: word32
   OrigDataType: word32
-T_372: (in edi @ 100012CC : word32)
+T_369: (in edx_286 @ 1000134E : word32)
+  Class: Eq_369
+  DataType: word32
+  OrigDataType: word32
+T_370: (in 16<i32> @ 100012B6 : int32)
+  Class: Eq_370
+  DataType: int32
+  OrigDataType: int32
+T_371: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_176
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
+T_372: (in 100033B8 @ 100012BD : ptr32)
   Class: Eq_372
-  DataType: word32
-  OrigDataType: word32
-T_373: (in ediOut @ 100012CC : ptr32)
+  DataType: (ptr32 (ptr32 code))
+  OrigDataType: (ptr32 (struct (0 T_373 t0000)))
+T_373: (in Mem196[0x100033B8<p32>:word32] @ 100012BD : word32)
   Class: Eq_373
-  DataType: ptr32
-  OrigDataType: ptr32
-T_374: (in InterlockedCompareExchange @ 100012CC : ptr32)
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: ptr32
-T_375: (in 0x100033AC<p32> @ 100012CC : ptr32)
-  Class: Eq_371
-  DataType: ptr32
-  OrigDataType: ptr32
-T_376: (in 2<32> @ 100012CC : word32)
-  Class: Eq_372
-  DataType: word32
+  DataType: (ptr32 code)
   OrigDataType: word32
-T_377: (in out edi_214 @ 100012CC : ptr32)
+T_374: (in 0<32> @ 100012BD : word32)
   Class: Eq_373
-  DataType: ptr32
-  OrigDataType: ptr32
-T_378: (in fn10001742(InterlockedCompareExchange, 0x100033AC<p32>, 2<32>, out edi_214) @ 100012CC : word32)
-  Class: Eq_378
-  DataType: word32
+  DataType: (ptr32 code)
   OrigDataType: word32
-T_379: (in 0<32> @ 100012CC : word32)
-  Class: Eq_378
-  DataType: word32
-  OrigDataType: word32
-T_380: (in fn10001742(InterlockedCompareExchange, 0x100033AC<p32>, 2<32>, out edi_214) == 0<32> @ 00000000 : bool)
-  Class: Eq_380
+T_375: (in g_ptr100033B8 == null @ 00000000 : bool)
+  Class: Eq_375
   DataType: bool
   OrigDataType: bool
-T_381: (in ecx_240 @ 100012D7 : word32)
+T_376: (in InterlockedExchange @ 100012B0 : ptr32)
+  Class: Eq_287
+  DataType: (ptr32 Eq_287)
+  OrigDataType: (ptr32 (fn T_378 (T_377, T_165)))
+T_377: (in 0x100033AC<p32> @ 100012B0 : ptr32)
+  Class: Eq_280
+  DataType: (ptr32 Eq_280)
+  OrigDataType: (ptr32 LONG)
+T_378: (in InterlockedExchange(&g_t100033AC, ebp_145) @ 100012B0 : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_379: (in 10003070 @ 100012DD : ptr32)
+  Class: Eq_379
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_380 t0000)))
+T_380: (in Mem244[0x10003070<p32>:word32] @ 100012DD : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_381: (in 1<32> @ 100012DD : word32)
   Class: Eq_381
   DataType: word32
   OrigDataType: word32
-T_382: (in edx_242 @ 100012D7 : word32)
-  Class: Eq_382
+T_382: (in g_dw10003070 + 1<32> @ 00000000 : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_383: (in 10003070 @ 100012DD : ptr32)
+  Class: Eq_383
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_384 t0000)))
+T_384: (in Mem246[0x10003070<p32>:word32] @ 100012DD : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_385: (in 16<i32> @ 100012CB : int32)
+  Class: Eq_385
+  DataType: int32
+  OrigDataType: int32
+T_386: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_176
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
+T_387: (in edi_214 @ 100012CC : word32)
+  Class: Eq_387
   DataType: word32
   OrigDataType: word32
-T_383: (in 100033B8 @ 100012D7 : ptr32)
-  Class: Eq_383
+T_388: (in fn10001742 @ 100012CC : ptr32)
+  Class: Eq_388
+  DataType: (ptr32 Eq_388)
+  OrigDataType: (ptr32 (fn T_398 (T_394, T_395, T_396, T_397)))
+T_389: (in signature of fn10001742 @ 10001742 : void)
+  Class: Eq_388
+  DataType: (ptr32 Eq_388)
+  OrigDataType: 
+T_390: (in ebx @ 100012CC : (ptr32 Eq_203))
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: word32
+T_391: (in esi @ 100012CC : ptr32)
+  Class: Eq_391
+  DataType: ptr32
+  OrigDataType: word32
+T_392: (in edi @ 100012CC : word32)
+  Class: Eq_392
+  DataType: word32
+  OrigDataType: word32
+T_393: (in ediOut @ 100012CC : ptr32)
+  Class: Eq_393
+  DataType: ptr32
+  OrigDataType: ptr32
+T_394: (in InterlockedCompareExchange @ 100012CC : ptr32)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: ptr32
+T_395: (in 0x100033AC<p32> @ 100012CC : ptr32)
+  Class: Eq_391
+  DataType: ptr32
+  OrigDataType: ptr32
+T_396: (in 2<32> @ 100012CC : word32)
+  Class: Eq_392
+  DataType: word32
+  OrigDataType: word32
+T_397: (in out edi_214 @ 100012CC : ptr32)
+  Class: Eq_393
+  DataType: ptr32
+  OrigDataType: ptr32
+T_398: (in fn10001742(InterlockedCompareExchange, 0x100033AC<p32>, 2<32>, out edi_214) @ 100012CC : word32)
+  Class: Eq_398
+  DataType: word32
+  OrigDataType: word32
+T_399: (in 0<32> @ 100012CC : word32)
+  Class: Eq_398
+  DataType: word32
+  OrigDataType: word32
+T_400: (in fn10001742(InterlockedCompareExchange, 0x100033AC<p32>, 2<32>, out edi_214) == 0<32> @ 00000000 : bool)
+  Class: Eq_400
+  DataType: bool
+  OrigDataType: bool
+T_401: (in ecx_240 @ 100012D7 : word32)
+  Class: Eq_401
+  DataType: word32
+  OrigDataType: word32
+T_402: (in edx_242 @ 100012D7 : word32)
+  Class: Eq_402
+  DataType: word32
+  OrigDataType: word32
+T_403: (in 100033B8 @ 100012D7 : ptr32)
+  Class: Eq_403
   DataType: (ptr32 (ptr32 code))
-  OrigDataType: (ptr32 (struct (0 T_384 t0000)))
-T_384: (in Mem233[0x100033B8<p32>:word32] @ 100012D7 : word32)
-  Class: Eq_353
+  OrigDataType: (ptr32 (struct (0 T_404 t0000)))
+T_404: (in Mem233[0x100033B8<p32>:word32] @ 100012D7 : word32)
+  Class: Eq_373
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_385: (in eax @ 10001385 : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
+T_405: (in eax @ 10001385 : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_386: (in ecx @ 10001385 : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
+T_406: (in ecx @ 10001385 : Eq_160)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_387: (in edx @ 10001385 : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
+T_407: (in edx @ 10001385 : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_388: (in ebx @ 10001385 : (ptr32 Eq_183))
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
+T_408: (in ebx @ 10001385 : (ptr32 Eq_203))
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
   OrigDataType: word32
-T_389: (in esi @ 10001385 : ptr32)
-  Class: Eq_371
-  DataType: ptr32
-  OrigDataType: word32
-T_390: (in edi @ 10001385 : word32)
-  Class: Eq_372
-  DataType: word32
-  OrigDataType: word32
-T_391: (in ebp_13 @ 1000138F : (ptr32 Eq_391))
+T_409: (in esi @ 10001385 : ptr32)
   Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: (ptr32 (struct (FFFFFFE4 T_139 tFFFFFFE4) (FFFFFFFC T_410 tFFFFFFFC) (8 T_405 t0008)))
-T_392: (in fn100017E8 @ 1000138F : ptr32)
-  Class: Eq_392
-  DataType: (ptr32 Eq_392)
-  OrigDataType: (ptr32 (fn T_401 (T_388, T_389, T_390, T_399, T_400)))
-T_393: (in signature of fn100017E8 @ 100017E8 : void)
-  Class: Eq_392
-  DataType: (ptr32 Eq_392)
-  OrigDataType: 
-T_394: (in ebx @ 1000138F : (ptr32 Eq_183))
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: word32
-T_395: (in esi @ 1000138F : ptr32)
-  Class: Eq_371
   DataType: ptr32
   OrigDataType: word32
-T_396: (in edi @ 1000138F : word32)
-  Class: Eq_372
+T_410: (in edi @ 10001385 : word32)
+  Class: Eq_392
   DataType: word32
   OrigDataType: word32
-T_397: (in dwArg00 @ 1000138F : word32)
-  Class: Eq_397
+T_411: (in ebp_13 @ 1000138F : (ptr32 Eq_411))
+  Class: Eq_411
+  DataType: (ptr32 Eq_411)
+  OrigDataType: (ptr32 (struct (FFFFFFE4 T_159 tFFFFFFE4) (FFFFFFFC T_430 tFFFFFFFC) (8 T_425 t0008)))
+T_412: (in fn100017E8 @ 1000138F : ptr32)
+  Class: Eq_412
+  DataType: (ptr32 Eq_412)
+  OrigDataType: (ptr32 (fn T_421 (T_408, T_409, T_410, T_419, T_420)))
+T_413: (in signature of fn100017E8 @ 100017E8 : void)
+  Class: Eq_412
+  DataType: (ptr32 Eq_412)
+  OrigDataType: 
+T_414: (in ebx @ 1000138F : (ptr32 Eq_203))
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: word32
+T_415: (in esi @ 1000138F : ptr32)
+  Class: Eq_391
+  DataType: ptr32
+  OrigDataType: word32
+T_416: (in edi @ 1000138F : word32)
+  Class: Eq_392
   DataType: word32
   OrigDataType: word32
-T_398: (in dwArg08 @ 1000138F : ui32)
-  Class: Eq_398
+T_417: (in dwArg00 @ 1000138F : word32)
+  Class: Eq_417
+  DataType: word32
+  OrigDataType: word32
+T_418: (in dwArg08 @ 1000138F : ui32)
+  Class: Eq_418
   DataType: ui32
   OrigDataType: ui32
-T_399: (in dwLoc0C @ 1000138F : word32)
-  Class: Eq_397
+T_419: (in dwLoc0C @ 1000138F : word32)
+  Class: Eq_417
   DataType: word32
   OrigDataType: word32
-T_400: (in 0x10<32> @ 1000138F : word32)
-  Class: Eq_398
+T_420: (in 0x10<32> @ 1000138F : word32)
+  Class: Eq_418
   DataType: ui32
   OrigDataType: word32
-T_401: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10<32>) @ 1000138F : word32)
-  Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: word32
-T_402: (in ebx_113 @ 10001398 : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_403: (in 8<32> @ 10001398 : word32)
-  Class: Eq_403
-  DataType: word32
-  OrigDataType: word32
-T_404: (in ebp_13 + 8<32> @ 10001398 : word32)
-  Class: Eq_404
-  DataType: word32
-  OrigDataType: word32
-T_405: (in Mem7[ebp_13 + 8<32>:word32] @ 10001398 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_406: (in 1<32> @ 1000139E : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_407: (in -28<i32> @ 1000139E : int32)
-  Class: Eq_407
-  DataType: int32
-  OrigDataType: int32
-T_408: (in ebp_13 + -28<i32> @ 1000139E : word32)
-  Class: Eq_408
-  DataType: ptr32
-  OrigDataType: ptr32
-T_409: (in Mem25[ebp_13 + -28<i32>:word32] @ 1000139E : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_410: (in 0<32> @ 100013A3 : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_411: (in -4<i32> @ 100013A3 : int32)
+T_421: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10<32>) @ 1000138F : word32)
   Class: Eq_411
-  DataType: int32
-  OrigDataType: int32
-T_412: (in ebp_13 + -4<i32> @ 100013A3 : word32)
-  Class: Eq_412
-  DataType: ptr32
-  OrigDataType: ptr32
-T_413: (in Mem27[ebp_13 + -4<i32>:word32] @ 100013A3 : word32)
-  Class: Eq_410
+  DataType: (ptr32 Eq_411)
+  OrigDataType: word32
+T_422: (in ebx_113 @ 10001398 : Eq_158)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_423: (in 8<32> @ 10001398 : word32)
+  Class: Eq_423
   DataType: word32
   OrigDataType: word32
-T_414: (in 10003008 @ 100013A6 : ptr32)
-  Class: Eq_414
-  DataType: (ptr32 Eq_139)
-  OrigDataType: (ptr32 (struct (0 T_415 t0000)))
-T_415: (in Mem28[0x10003008<p32>:word32] @ 100013A6 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_416: (in 1<32> @ 100013AC : word32)
-  Class: Eq_410
+T_424: (in ebp_13 + 8<32> @ 10001398 : word32)
+  Class: Eq_424
   DataType: word32
   OrigDataType: word32
-T_417: (in -4<i32> @ 100013AC : int32)
-  Class: Eq_417
-  DataType: int32
-  OrigDataType: int32
-T_418: (in ebp_13 + -4<i32> @ 100013AC : word32)
-  Class: Eq_418
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_419: (in Mem29[ebp_13 + -4<i32>:word32] @ 100013AC : word32)
-  Class: Eq_410
-  DataType: word32
+T_425: (in Mem7[ebp_13 + 8<32>:word32] @ 10001398 : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_420: (in esp_100 @ 1000138A : (ptr32 Eq_420))
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
-  OrigDataType: (ptr32 (struct (FFFFFFFC T_459 tFFFFFFFC)))
-T_421: (in fp @ 1000138A : ptr32)
-  Class: Eq_421
-  DataType: ptr32
-  OrigDataType: ptr32
-T_422: (in 8<i32> @ 1000138A : int32)
-  Class: Eq_422
-  DataType: int32
-  OrigDataType: int32
-T_423: (in fp - 8<i32> @ 00000000 : word32)
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
-  OrigDataType: ptr32
-T_424: (in edi_107 @ 10001394 : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
+T_426: (in 1<32> @ 1000139E : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_425: (in esi_110 @ 10001396 : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_426: (in 0<32> @ 100013B1 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_427: (in edx != 0<32> @ 00000000 : bool)
+T_427: (in -28<i32> @ 1000139E : int32)
   Class: Eq_427
-  DataType: bool
-  OrigDataType: bool
-T_428: (in 1<32> @ 100013C5 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+  DataType: int32
+  OrigDataType: int32
+T_428: (in ebp_13 + -28<i32> @ 1000139E : word32)
+  Class: Eq_428
+  DataType: ptr32
+  OrigDataType: ptr32
+T_429: (in Mem25[ebp_13 + -28<i32>:word32] @ 1000139E : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_429: (in edx == 1<32> @ 00000000 : bool)
-  Class: Eq_429
-  DataType: bool
-  OrigDataType: bool
-T_430: (in 10003070 @ 100013B9 : ptr32)
+T_430: (in 0<32> @ 100013A3 : word32)
   Class: Eq_430
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_431 t0000)))
-T_431: (in Mem29[0x10003070<p32>:word32] @ 100013B9 : word32)
-  Class: Eq_163
-  DataType: int32
+  DataType: word32
   OrigDataType: word32
-T_432: (in 0<32> @ 100013B9 : word32)
-  Class: Eq_163
+T_431: (in -4<i32> @ 100013A3 : int32)
+  Class: Eq_431
   DataType: int32
+  OrigDataType: int32
+T_432: (in ebp_13 + -4<i32> @ 100013A3 : word32)
+  Class: Eq_432
+  DataType: ptr32
+  OrigDataType: ptr32
+T_433: (in Mem27[ebp_13 + -4<i32>:word32] @ 100013A3 : word32)
+  Class: Eq_430
+  DataType: word32
   OrigDataType: word32
-T_433: (in g_dw10003070 != 0<32> @ 00000000 : bool)
-  Class: Eq_433
+T_434: (in 10003008 @ 100013A6 : ptr32)
+  Class: Eq_434
+  DataType: (ptr32 Eq_159)
+  OrigDataType: (ptr32 (struct (0 T_435 t0000)))
+T_435: (in Mem28[0x10003008<p32>:word32] @ 100013A6 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_436: (in 1<32> @ 100013AC : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_437: (in -4<i32> @ 100013AC : int32)
+  Class: Eq_437
+  DataType: int32
+  OrigDataType: int32
+T_438: (in ebp_13 + -4<i32> @ 100013AC : word32)
+  Class: Eq_438
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_439: (in Mem29[ebp_13 + -4<i32>:word32] @ 100013AC : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_440: (in esp_100 @ 1000138A : (ptr32 Eq_440))
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
+  OrigDataType: (ptr32 (struct (FFFFFFFC T_479 tFFFFFFFC)))
+T_441: (in fp @ 1000138A : ptr32)
+  Class: Eq_441
+  DataType: ptr32
+  OrigDataType: ptr32
+T_442: (in 8<i32> @ 1000138A : int32)
+  Class: Eq_442
+  DataType: int32
+  OrigDataType: int32
+T_443: (in fp - 8<i32> @ 00000000 : word32)
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
+  OrigDataType: ptr32
+T_444: (in edi_107 @ 10001394 : Eq_160)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: word32
+T_445: (in esi_110 @ 10001396 : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_446: (in 0<32> @ 100013B1 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_447: (in edx != 0<32> @ 00000000 : bool)
+  Class: Eq_447
   DataType: bool
   OrigDataType: bool
-T_434: (in 0<32> @ 100013BB : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_448: (in 1<32> @ 100013C5 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_435: (in -28<i32> @ 100013BB : int32)
-  Class: Eq_435
+T_449: (in edx == 1<32> @ 00000000 : bool)
+  Class: Eq_449
+  DataType: bool
+  OrigDataType: bool
+T_450: (in 10003070 @ 100013B9 : ptr32)
+  Class: Eq_450
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_451 t0000)))
+T_451: (in Mem29[0x10003070<p32>:word32] @ 100013B9 : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_452: (in 0<32> @ 100013B9 : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_453: (in g_dw10003070 != 0<32> @ 00000000 : bool)
+  Class: Eq_453
+  DataType: bool
+  OrigDataType: bool
+T_454: (in 0<32> @ 100013BB : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_455: (in -28<i32> @ 100013BB : int32)
+  Class: Eq_455
   DataType: int32
   OrigDataType: int32
-T_436: (in ebp_13 + -28<i32> @ 100013BB : word32)
-  Class: Eq_436
+T_456: (in ebp_13 + -28<i32> @ 100013BB : word32)
+  Class: Eq_456
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_437: (in Mem248[ebp_13 + -28<i32>:word32] @ 100013BB : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_457: (in Mem248[ebp_13 + -28<i32>:word32] @ 100013BB : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_438: (in 0<32> @ 1000147A : word32)
-  Class: Eq_410
+T_458: (in 0<32> @ 1000147A : word32)
+  Class: Eq_430
   DataType: word32
   OrigDataType: word32
-T_439: (in -4<i32> @ 1000147A : int32)
-  Class: Eq_439
+T_459: (in -4<i32> @ 1000147A : int32)
+  Class: Eq_459
   DataType: int32
   OrigDataType: int32
-T_440: (in ebp_13 + -4<i32> @ 1000147A : word32)
-  Class: Eq_440
+T_460: (in ebp_13 + -4<i32> @ 1000147A : word32)
+  Class: Eq_460
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_441: (in Mem253[ebp_13 + -4<i32>:word32] @ 1000147A : word32)
-  Class: Eq_410
+T_461: (in Mem253[ebp_13 + -4<i32>:word32] @ 1000147A : word32)
+  Class: Eq_430
   DataType: word32
   OrigDataType: word32
-T_442: (in 0xFFFFFFFE<32> @ 1000147E : word32)
-  Class: Eq_410
+T_462: (in 0xFFFFFFFE<32> @ 1000147E : word32)
+  Class: Eq_430
   DataType: word32
   OrigDataType: word32
-T_443: (in -4<i32> @ 1000147E : int32)
-  Class: Eq_443
+T_463: (in -4<i32> @ 1000147E : int32)
+  Class: Eq_463
   DataType: int32
   OrigDataType: int32
-T_444: (in ebp_13 + -4<i32> @ 1000147E : word32)
-  Class: Eq_444
+T_464: (in ebp_13 + -4<i32> @ 1000147E : word32)
+  Class: Eq_464
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_445: (in Mem256[ebp_13 + -4<i32>:word32] @ 1000147E : word32)
-  Class: Eq_410
+T_465: (in Mem256[ebp_13 + -4<i32>:word32] @ 1000147E : word32)
+  Class: Eq_430
   DataType: word32
   OrigDataType: word32
-T_446: (in fn10001493 @ 10001485 : ptr32)
-  Class: Eq_446
-  DataType: (ptr32 Eq_446)
-  OrigDataType: (ptr32 (fn T_448 ()))
-T_447: (in signature of fn10001493 @ 10001493 : void)
-  Class: Eq_446
-  DataType: (ptr32 Eq_446)
+T_466: (in fn10001493 @ 10001485 : ptr32)
+  Class: Eq_466
+  DataType: (ptr32 Eq_466)
+  OrigDataType: (ptr32 (fn T_468 ()))
+T_467: (in signature of fn10001493 @ 10001493 : void)
+  Class: Eq_466
+  DataType: (ptr32 Eq_466)
   OrigDataType: 
-T_448: (in fn10001493() @ 10001485 : void)
-  Class: Eq_448
+T_468: (in fn10001493() @ 10001485 : void)
+  Class: Eq_468
   DataType: void
   OrigDataType: void
-T_449: (in eax_257 @ 1000148A : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
+T_469: (in eax_257 @ 1000148A : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_450: (in -28<i32> @ 1000148A : int32)
-  Class: Eq_450
-  DataType: int32
-  OrigDataType: int32
-T_451: (in ebp_13 + -28<i32> @ 1000148A : word32)
-  Class: Eq_451
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_452: (in Mem256[ebp_13 + -28<i32>:word32] @ 1000148A : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_453: (in fn1000182D @ 1000148D : ptr32)
-  Class: Eq_453
-  DataType: (ptr32 Eq_453)
-  OrigDataType: (ptr32 (fn T_460 (T_391, T_459)))
-T_454: (in signature of fn1000182D @ 1000182D : void)
-  Class: Eq_453
-  DataType: (ptr32 Eq_453)
-  OrigDataType: 
-T_455: (in ebp @ 1000148D : (ptr32 Eq_391))
-  Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: (ptr32 (struct (FFFFFFF0 T_840 tFFFFFFF0) (0 T_846 t0000)))
-T_456: (in dwArg00 @ 1000148D : Eq_456)
-  Class: Eq_456
-  DataType: Eq_456
-  OrigDataType: word32
-T_457: (in -4<i32> @ 1000148D : int32)
-  Class: Eq_457
-  DataType: int32
-  OrigDataType: int32
-T_458: (in esp_100 + -4<i32> @ 1000148D : word32)
-  Class: Eq_458
-  DataType: ptr32
-  OrigDataType: ptr32
-T_459: (in Mem256[esp_100 + -4<i32>:word32] @ 1000148D : word32)
-  Class: Eq_456
-  DataType: Eq_456
-  OrigDataType: word32
-T_460: (in fn1000182D(ebp_13, esp_100->tFFFFFFFC) @ 1000148D : word32)
-  Class: Eq_373
-  DataType: ptr32
-  OrigDataType: word32
-T_461: (in 100020CC @ 100013D3 : ptr32)
-  Class: Eq_461
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_462 t0000)))
-T_462: (in Mem29[0x100020CC<p32>:word32] @ 100013D3 : word32)
-  Class: Eq_462
-  DataType: word32
-  OrigDataType: word32
-T_463: (in 0<32> @ 100013D3 : word32)
-  Class: Eq_462
-  DataType: word32
-  OrigDataType: word32
-T_464: (in g_dw100020CC == 0<32> @ 00000000 : bool)
-  Class: Eq_464
-  DataType: bool
-  OrigDataType: bool
-T_465: (in 2<32> @ 100013CA : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_466: (in edx != 2<32> @ 00000000 : bool)
-  Class: Eq_466
-  DataType: bool
-  OrigDataType: bool
-T_467: (in esp_106 @ 100013FA : (ptr32 Eq_467))
-  Class: Eq_467
-  DataType: (ptr32 Eq_467)
-  OrigDataType: (ptr32 (struct (FFFFFFF8 T_138 tFFFFFFF8) (FFFFFFFC T_139 tFFFFFFFC) (0 T_140 t0000)))
-T_468: (in 4<i32> @ 100013FA : int32)
-  Class: Eq_468
-  DataType: int32
-  OrigDataType: int32
-T_469: (in esp_100 - 4<i32> @ 00000000 : word32)
-  Class: Eq_467
-  DataType: (ptr32 Eq_467)
-  OrigDataType: ptr32
-T_470: (in 0<32> @ 100013FA : word32)
+T_470: (in -28<i32> @ 1000148A : int32)
   Class: Eq_470
-  DataType: word32
-  OrigDataType: word32
-T_471: (in esp_106 + 0<32> @ 100013FA : word32)
+  DataType: int32
+  OrigDataType: int32
+T_471: (in ebp_13 + -28<i32> @ 1000148A : word32)
   Class: Eq_471
-  DataType: ptr32
-  OrigDataType: ptr32
-T_472: (in Mem108[esp_106 + 0<32>:word32] @ 100013FA : word32)
-  Class: Eq_140
-  DataType: Eq_140
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_472: (in Mem256[ebp_13 + -28<i32>:word32] @ 1000148A : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_473: (in -4<i32> @ 100013FB : int32)
+T_473: (in fn1000182D @ 1000148D : ptr32)
   Class: Eq_473
-  DataType: int32
-  OrigDataType: int32
-T_474: (in esp_106 + -4<i32> @ 100013FB : word32)
-  Class: Eq_474
-  DataType: ptr32
-  OrigDataType: ptr32
-T_475: (in Mem111[esp_106 + -4<i32>:word32] @ 100013FB : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_476: (in -8<i32> @ 100013FC : int32)
+  DataType: (ptr32 Eq_473)
+  OrigDataType: (ptr32 (fn T_480 (T_411, T_479)))
+T_474: (in signature of fn1000182D @ 1000182D : void)
+  Class: Eq_473
+  DataType: (ptr32 Eq_473)
+  OrigDataType: 
+T_475: (in ebp @ 1000148D : (ptr32 Eq_411))
+  Class: Eq_411
+  DataType: (ptr32 Eq_411)
+  OrigDataType: (ptr32 (struct (FFFFFFF0 T_860 tFFFFFFF0) (0 T_866 t0000)))
+T_476: (in dwArg00 @ 1000148D : Eq_476)
   Class: Eq_476
+  DataType: Eq_476
+  OrigDataType: word32
+T_477: (in -4<i32> @ 1000148D : int32)
+  Class: Eq_477
   DataType: int32
   OrigDataType: int32
-T_477: (in esp_106 + -8<i32> @ 100013FC : word32)
-  Class: Eq_477
+T_478: (in esp_100 + -4<i32> @ 1000148D : word32)
+  Class: Eq_478
   DataType: ptr32
   OrigDataType: ptr32
-T_478: (in Mem114[esp_106 + -8<i32>:word32] @ 100013FC : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_479: (in Mem256[esp_100 + -4<i32>:word32] @ 1000148D : word32)
+  Class: Eq_476
+  DataType: Eq_476
   OrigDataType: word32
-T_479: (in eax_115 @ 100013FD : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
+T_480: (in fn1000182D(ebp_13, esp_100->tFFFFFFFC) @ 1000148D : word32)
+  Class: Eq_393
+  DataType: ptr32
   OrigDataType: word32
-T_480: (in fn100017C6 @ 100013FD : ptr32)
-  Class: Eq_480
-  DataType: (ptr32 Eq_480)
-  OrigDataType: (ptr32 (fn T_490 (T_486, T_489)))
-T_481: (in signature of fn100017C6 @ 100017C6 : void)
-  Class: Eq_480
-  DataType: (ptr32 Eq_480)
-  OrigDataType: 
-T_482: (in dwArg04 @ 100013FD : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: HMODULE
-T_483: (in dwArg08 @ 100013FD : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_484: (in -8<i32> @ 100013FD : int32)
-  Class: Eq_484
-  DataType: int32
-  OrigDataType: int32
-T_485: (in esp_106 + -8<i32> @ 100013FD : word32)
-  Class: Eq_485
+T_481: (in 100020CC @ 100013D3 : ptr32)
+  Class: Eq_481
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_486: (in Mem114[esp_106 + -8<i32>:word32] @ 100013FD : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_487: (in -4<i32> @ 100013FD : int32)
-  Class: Eq_487
-  DataType: int32
-  OrigDataType: int32
-T_488: (in esp_106 + -4<i32> @ 100013FD : word32)
-  Class: Eq_488
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_489: (in Mem114[esp_106 + -4<i32>:word32] @ 100013FD : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_490: (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 100013FD : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_491: (in -28<i32> @ 10001402 : int32)
-  Class: Eq_491
-  DataType: int32
-  OrigDataType: int32
-T_492: (in ebp_13 + -28<i32> @ 10001402 : word32)
-  Class: Eq_492
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_493: (in Mem122[ebp_13 + -28<i32>:word32] @ 10001402 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_494: (in 4<32> @ 100013FD : word32)
-  Class: Eq_494
-  DataType: int32
-  OrigDataType: int32
-T_495: (in esp_106 + 4<32> @ 100013FD : word32)
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
-  OrigDataType: ptr32
-T_496: (in 1<32> @ 10001408 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_497: (in esi_110 != 1<32> @ 00000000 : bool)
-  Class: Eq_497
-  DataType: bool
-  OrigDataType: bool
-T_498: (in -28<i32> @ 100013E1 : int32)
-  Class: Eq_498
-  DataType: int32
-  OrigDataType: int32
-T_499: (in ebp_13 + -28<i32> @ 100013E1 : word32)
-  Class: Eq_499
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_500: (in Mem76[ebp_13 + -28<i32>:word32] @ 100013E1 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_501: (in 0<32> @ 100013E1 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_502: (in ebp_13->tFFFFFFE4 == 0<32> @ 00000000 : bool)
-  Class: Eq_502
-  DataType: bool
-  OrigDataType: bool
-T_503: (in fn00000000 @ 100013DA : ptr32)
-  Class: Eq_503
-  DataType: (ptr32 Eq_503)
-  OrigDataType: (ptr32 (fn T_505 (T_402, T_387)))
-T_504: (in signature of fn00000000 @ 00000000 : void)
-  Class: Eq_504
-  DataType: Eq_504
-  OrigDataType: 
-T_505: (in fn00000000(ebx_113, edx) @ 100013DA : void)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: void
-T_506: (in -28<i32> @ 100013DA : int32)
-  Class: Eq_506
-  DataType: int32
-  OrigDataType: int32
-T_507: (in ebp_13 + -28<i32> @ 100013DA : word32)
-  Class: Eq_507
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_508: (in Mem74[ebp_13 + -28<i32>:word32] @ 100013DA : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_509: (in esp_80 @ 100013E7 : (ptr32 Eq_509))
-  Class: Eq_509
-  DataType: (ptr32 Eq_509)
-  OrigDataType: (ptr32 (struct (FFFFFFF8 T_138 tFFFFFFF8) (FFFFFFFC T_139 tFFFFFFFC) (0 T_140 t0000)))
-T_510: (in 4<i32> @ 100013E7 : int32)
-  Class: Eq_510
-  DataType: int32
-  OrigDataType: int32
-T_511: (in esp_100 - 4<i32> @ 00000000 : word32)
-  Class: Eq_509
-  DataType: (ptr32 Eq_509)
-  OrigDataType: ptr32
-T_512: (in 0<32> @ 100013E7 : word32)
-  Class: Eq_512
+  OrigDataType: (ptr32 (struct (0 T_482 t0000)))
+T_482: (in Mem29[0x100020CC<p32>:word32] @ 100013D3 : word32)
+  Class: Eq_482
   DataType: word32
   OrigDataType: word32
-T_513: (in esp_80 + 0<32> @ 100013E7 : word32)
-  Class: Eq_513
-  DataType: ptr32
-  OrigDataType: ptr32
-T_514: (in Mem82[esp_80 + 0<32>:word32] @ 100013E7 : word32)
-  Class: Eq_140
-  DataType: Eq_140
+T_483: (in 0<32> @ 100013D3 : word32)
+  Class: Eq_482
+  DataType: word32
   OrigDataType: word32
-T_515: (in -4<i32> @ 100013E8 : int32)
-  Class: Eq_515
+T_484: (in g_dw100020CC == 0<32> @ 00000000 : bool)
+  Class: Eq_484
+  DataType: bool
+  OrigDataType: bool
+T_485: (in 2<32> @ 100013CA : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_486: (in edx != 2<32> @ 00000000 : bool)
+  Class: Eq_486
+  DataType: bool
+  OrigDataType: bool
+T_487: (in esp_106 @ 100013FA : (ptr32 Eq_487))
+  Class: Eq_487
+  DataType: (ptr32 Eq_487)
+  OrigDataType: (ptr32 (struct (FFFFFFF8 T_158 tFFFFFFF8) (FFFFFFFC T_159 tFFFFFFFC) (0 T_160 t0000)))
+T_488: (in 4<i32> @ 100013FA : int32)
+  Class: Eq_488
   DataType: int32
   OrigDataType: int32
-T_516: (in esp_80 + -4<i32> @ 100013E8 : word32)
-  Class: Eq_516
+T_489: (in esp_100 - 4<i32> @ 00000000 : word32)
+  Class: Eq_487
+  DataType: (ptr32 Eq_487)
+  OrigDataType: ptr32
+T_490: (in 0<32> @ 100013FA : word32)
+  Class: Eq_490
+  DataType: word32
+  OrigDataType: word32
+T_491: (in esp_106 + 0<32> @ 100013FA : word32)
+  Class: Eq_491
   DataType: ptr32
   OrigDataType: ptr32
-T_517: (in Mem85[esp_80 + -4<i32>:word32] @ 100013E8 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_492: (in Mem108[esp_106 + 0<32>:word32] @ 100013FA : word32)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_518: (in -8<i32> @ 100013E9 : int32)
+T_493: (in -4<i32> @ 100013FB : int32)
+  Class: Eq_493
+  DataType: int32
+  OrigDataType: int32
+T_494: (in esp_106 + -4<i32> @ 100013FB : word32)
+  Class: Eq_494
+  DataType: ptr32
+  OrigDataType: ptr32
+T_495: (in Mem111[esp_106 + -4<i32>:word32] @ 100013FB : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_496: (in -8<i32> @ 100013FC : int32)
+  Class: Eq_496
+  DataType: int32
+  OrigDataType: int32
+T_497: (in esp_106 + -8<i32> @ 100013FC : word32)
+  Class: Eq_497
+  DataType: ptr32
+  OrigDataType: ptr32
+T_498: (in Mem114[esp_106 + -8<i32>:word32] @ 100013FC : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_499: (in eax_115 @ 100013FD : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_500: (in fn100017C6 @ 100013FD : ptr32)
+  Class: Eq_500
+  DataType: (ptr32 Eq_500)
+  OrigDataType: (ptr32 (fn T_510 (T_506, T_509)))
+T_501: (in signature of fn100017C6 @ 100017C6 : void)
+  Class: Eq_500
+  DataType: (ptr32 Eq_500)
+  OrigDataType: 
+T_502: (in dwArg04 @ 100013FD : Eq_158)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: HMODULE
+T_503: (in dwArg08 @ 100013FD : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_504: (in -8<i32> @ 100013FD : int32)
+  Class: Eq_504
+  DataType: int32
+  OrigDataType: int32
+T_505: (in esp_106 + -8<i32> @ 100013FD : word32)
+  Class: Eq_505
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_506: (in Mem114[esp_106 + -8<i32>:word32] @ 100013FD : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_507: (in -4<i32> @ 100013FD : int32)
+  Class: Eq_507
+  DataType: int32
+  OrigDataType: int32
+T_508: (in esp_106 + -4<i32> @ 100013FD : word32)
+  Class: Eq_508
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_509: (in Mem114[esp_106 + -4<i32>:word32] @ 100013FD : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_510: (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 100013FD : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_511: (in -28<i32> @ 10001402 : int32)
+  Class: Eq_511
+  DataType: int32
+  OrigDataType: int32
+T_512: (in ebp_13 + -28<i32> @ 10001402 : word32)
+  Class: Eq_512
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_513: (in Mem122[ebp_13 + -28<i32>:word32] @ 10001402 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_514: (in 4<32> @ 100013FD : word32)
+  Class: Eq_514
+  DataType: int32
+  OrigDataType: int32
+T_515: (in esp_106 + 4<32> @ 100013FD : word32)
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
+  OrigDataType: ptr32
+T_516: (in 1<32> @ 10001408 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_517: (in esi_110 != 1<32> @ 00000000 : bool)
+  Class: Eq_517
+  DataType: bool
+  OrigDataType: bool
+T_518: (in -28<i32> @ 100013E1 : int32)
   Class: Eq_518
   DataType: int32
   OrigDataType: int32
-T_519: (in esp_80 + -8<i32> @ 100013E9 : word32)
+T_519: (in ebp_13 + -28<i32> @ 100013E1 : word32)
   Class: Eq_519
-  DataType: ptr32
-  OrigDataType: ptr32
-T_520: (in Mem88[esp_80 + -8<i32>:word32] @ 100013E9 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_520: (in Mem76[ebp_13 + -28<i32>:word32] @ 100013E1 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_521: (in eax_90 @ 100013EA : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
+T_521: (in 0<32> @ 100013E1 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_522: (in fn100011E9 @ 100013EA : ptr32)
+T_522: (in ebp_13->tFFFFFFE4 == 0<32> @ 00000000 : bool)
   Class: Eq_522
-  DataType: (ptr32 Eq_522)
-  OrigDataType: (ptr32 (fn T_536 (T_526, T_529, T_532, T_533, T_534, T_535)))
-T_523: (in signature of fn100011E9 @ 100011E9 : void)
-  Class: Eq_522
-  DataType: (ptr32 Eq_522)
-  OrigDataType: 
-T_524: (in -8<i32> @ 100013EA : int32)
+  DataType: bool
+  OrigDataType: bool
+T_523: (in fn00000000 @ 100013DA : ptr32)
+  Class: Eq_523
+  DataType: (ptr32 Eq_523)
+  OrigDataType: (ptr32 (fn T_525 (T_422, T_407)))
+T_524: (in signature of fn00000000 @ 00000000 : void)
   Class: Eq_524
+  DataType: Eq_524
+  OrigDataType: 
+T_525: (in fn00000000(ebx_113, edx) @ 100013DA : void)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: void
+T_526: (in -28<i32> @ 100013DA : int32)
+  Class: Eq_526
   DataType: int32
   OrigDataType: int32
-T_525: (in esp_80 + -8<i32> @ 100013EA : word32)
-  Class: Eq_525
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_526: (in Mem88[esp_80 + -8<i32>:word32] @ 100013EA : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_527: (in -4<i32> @ 100013EA : int32)
+T_527: (in ebp_13 + -28<i32> @ 100013DA : word32)
   Class: Eq_527
-  DataType: int32
-  OrigDataType: int32
-T_528: (in esp_80 + -4<i32> @ 100013EA : word32)
-  Class: Eq_528
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_529: (in Mem88[esp_80 + -4<i32>:word32] @ 100013EA : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_528: (in Mem74[ebp_13 + -28<i32>:word32] @ 100013DA : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_530: (in 0<32> @ 100013EA : word32)
+T_529: (in esp_80 @ 100013E7 : (ptr32 Eq_529))
+  Class: Eq_529
+  DataType: (ptr32 Eq_529)
+  OrigDataType: (ptr32 (struct (FFFFFFF8 T_158 tFFFFFFF8) (FFFFFFFC T_159 tFFFFFFFC) (0 T_160 t0000)))
+T_530: (in 4<i32> @ 100013E7 : int32)
   Class: Eq_530
-  DataType: word32
-  OrigDataType: word32
-T_531: (in esp_80 + 0<32> @ 100013EA : word32)
-  Class: Eq_531
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_532: (in Mem88[esp_80 + 0<32>:word32] @ 100013EA : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_533: (in out ebx_113 @ 100013EA : ptr32)
-  Class: Eq_141
-  DataType: ptr32
-  OrigDataType: ptr32
-T_534: (in out esi_110 @ 100013EA : ptr32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: ptr32
-T_535: (in out edi_107 @ 100013EA : ptr32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: ptr32
-T_536: (in fn100011E9(esp_80->tFFFFFFF8, esp_80->tFFFFFFFC, esp_80->t0000, out ebx_113, out esi_110, out edi_107) @ 100013EA : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_537: (in -28<i32> @ 100013EF : int32)
-  Class: Eq_537
   DataType: int32
   OrigDataType: int32
-T_538: (in ebp_13 + -28<i32> @ 100013EF : word32)
+T_531: (in esp_100 - 4<i32> @ 00000000 : word32)
+  Class: Eq_529
+  DataType: (ptr32 Eq_529)
+  OrigDataType: ptr32
+T_532: (in 0<32> @ 100013E7 : word32)
+  Class: Eq_532
+  DataType: word32
+  OrigDataType: word32
+T_533: (in esp_80 + 0<32> @ 100013E7 : word32)
+  Class: Eq_533
+  DataType: ptr32
+  OrigDataType: ptr32
+T_534: (in Mem82[esp_80 + 0<32>:word32] @ 100013E7 : word32)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: word32
+T_535: (in -4<i32> @ 100013E8 : int32)
+  Class: Eq_535
+  DataType: int32
+  OrigDataType: int32
+T_536: (in esp_80 + -4<i32> @ 100013E8 : word32)
+  Class: Eq_536
+  DataType: ptr32
+  OrigDataType: ptr32
+T_537: (in Mem85[esp_80 + -4<i32>:word32] @ 100013E8 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_538: (in -8<i32> @ 100013E9 : int32)
   Class: Eq_538
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_539: (in Mem101[ebp_13 + -28<i32>:word32] @ 100013EF : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_540: (in 4<32> @ 100013EA : word32)
-  Class: Eq_540
   DataType: int32
   OrigDataType: int32
-T_541: (in esp_80 + 4<32> @ 100013EA : word32)
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
+T_539: (in esp_80 + -8<i32> @ 100013E9 : word32)
+  Class: Eq_539
+  DataType: ptr32
   OrigDataType: ptr32
-T_542: (in 0<32> @ 100013F4 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_540: (in Mem88[esp_80 + -8<i32>:word32] @ 100013E9 : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_543: (in eax_90 == 0<32> @ 00000000 : bool)
-  Class: Eq_543
-  DataType: bool
-  OrigDataType: bool
-T_544: (in 0<32> @ 10001430 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_541: (in eax_90 @ 100013EA : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_545: (in esi_110 == 0<32> @ 00000000 : bool)
+T_542: (in fn100011E9 @ 100013EA : ptr32)
+  Class: Eq_542
+  DataType: (ptr32 Eq_542)
+  OrigDataType: (ptr32 (fn T_556 (T_546, T_549, T_552, T_553, T_554, T_555)))
+T_543: (in signature of fn100011E9 @ 100011E9 : void)
+  Class: Eq_542
+  DataType: (ptr32 Eq_542)
+  OrigDataType: 
+T_544: (in -8<i32> @ 100013EA : int32)
+  Class: Eq_544
+  DataType: int32
+  OrigDataType: int32
+T_545: (in esp_80 + -8<i32> @ 100013EA : word32)
   Class: Eq_545
-  DataType: bool
-  OrigDataType: bool
-T_546: (in 0<32> @ 1000140C : word32)
-  Class: Eq_139
-  DataType: Eq_139
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_546: (in Mem88[esp_80 + -8<i32>:word32] @ 100013EA : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_547: (in eax_115 != 0<32> @ 00000000 : bool)
+T_547: (in -4<i32> @ 100013EA : int32)
   Class: Eq_547
+  DataType: int32
+  OrigDataType: int32
+T_548: (in esp_80 + -4<i32> @ 100013EA : word32)
+  Class: Eq_548
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_549: (in Mem88[esp_80 + -4<i32>:word32] @ 100013EA : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_550: (in 0<32> @ 100013EA : word32)
+  Class: Eq_550
+  DataType: word32
+  OrigDataType: word32
+T_551: (in esp_80 + 0<32> @ 100013EA : word32)
+  Class: Eq_551
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_552: (in Mem88[esp_80 + 0<32>:word32] @ 100013EA : word32)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: word32
+T_553: (in out ebx_113 @ 100013EA : ptr32)
+  Class: Eq_161
+  DataType: ptr32
+  OrigDataType: ptr32
+T_554: (in out esi_110 @ 100013EA : ptr32)
+  Class: Eq_162
+  DataType: ptr32
+  OrigDataType: ptr32
+T_555: (in out edi_107 @ 100013EA : ptr32)
+  Class: Eq_163
+  DataType: ptr32
+  OrigDataType: ptr32
+T_556: (in fn100011E9(esp_80->tFFFFFFF8, esp_80->tFFFFFFFC, esp_80->t0000, out ebx_113, out esi_110, out edi_107) @ 100013EA : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_557: (in -28<i32> @ 100013EF : int32)
+  Class: Eq_557
+  DataType: int32
+  OrigDataType: int32
+T_558: (in ebp_13 + -28<i32> @ 100013EF : word32)
+  Class: Eq_558
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_559: (in Mem101[ebp_13 + -28<i32>:word32] @ 100013EF : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_560: (in 4<32> @ 100013EA : word32)
+  Class: Eq_560
+  DataType: int32
+  OrigDataType: int32
+T_561: (in esp_80 + 4<32> @ 100013EA : word32)
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
+  OrigDataType: ptr32
+T_562: (in 0<32> @ 100013F4 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_563: (in eax_90 == 0<32> @ 00000000 : bool)
+  Class: Eq_563
   DataType: bool
   OrigDataType: bool
-T_548: (in 0<32> @ 1000140E : word32)
-  Class: Eq_548
-  DataType: word32
+T_564: (in 0<32> @ 10001430 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_549: (in esp_106 + 0<32> @ 1000140E : word32)
-  Class: Eq_549
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_550: (in Mem129[esp_106 + 0<32>:word32] @ 1000140E : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_551: (in -4<i32> @ 1000140F : int32)
-  Class: Eq_551
-  DataType: int32
-  OrigDataType: int32
-T_552: (in esp_106 + -4<i32> @ 1000140F : word32)
-  Class: Eq_552
-  DataType: ptr32
-  OrigDataType: ptr32
-T_553: (in Mem131[esp_106 + -4<i32>:word32] @ 1000140F : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_554: (in -8<i32> @ 10001410 : int32)
-  Class: Eq_554
-  DataType: int32
-  OrigDataType: int32
-T_555: (in esp_106 + -8<i32> @ 10001410 : word32)
-  Class: Eq_555
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_556: (in Mem133[esp_106 + -8<i32>:word32] @ 10001410 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_557: (in fn100017C6 @ 10001411 : ptr32)
-  Class: Eq_480
-  DataType: (ptr32 Eq_480)
-  OrigDataType: (ptr32 (fn T_564 (T_560, T_563)))
-T_558: (in -8<i32> @ 10001411 : int32)
-  Class: Eq_558
-  DataType: int32
-  OrigDataType: int32
-T_559: (in esp_106 + -8<i32> @ 10001411 : word32)
-  Class: Eq_559
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_560: (in Mem133[esp_106 + -8<i32>:word32] @ 10001411 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_561: (in -4<i32> @ 10001411 : int32)
-  Class: Eq_561
-  DataType: int32
-  OrigDataType: int32
-T_562: (in esp_106 + -4<i32> @ 10001411 : word32)
-  Class: Eq_562
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_563: (in Mem133[esp_106 + -4<i32>:word32] @ 10001411 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_564: (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 10001411 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_565: (in 0<32> @ 10001416 : word32)
+T_565: (in esi_110 == 0<32> @ 00000000 : bool)
   Class: Eq_565
+  DataType: bool
+  OrigDataType: bool
+T_566: (in 0<32> @ 1000140C : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_567: (in eax_115 != 0<32> @ 00000000 : bool)
+  Class: Eq_567
+  DataType: bool
+  OrigDataType: bool
+T_568: (in 0<32> @ 1000140E : word32)
+  Class: Eq_568
   DataType: word32
   OrigDataType: word32
-T_566: (in esp_106 + 0<32> @ 10001416 : word32)
-  Class: Eq_566
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_567: (in Mem141[esp_106 + 0<32>:word32] @ 10001416 : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_568: (in 0<32> @ 10001417 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_569: (in -4<i32> @ 10001417 : int32)
+T_569: (in esp_106 + 0<32> @ 1000140E : word32)
   Class: Eq_569
-  DataType: int32
-  OrigDataType: int32
-T_570: (in esp_106 + -4<i32> @ 10001417 : word32)
-  Class: Eq_570
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_571: (in Mem143[esp_106 + -4<i32>:word32] @ 10001417 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_570: (in Mem129[esp_106 + 0<32>:word32] @ 1000140E : word32)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_572: (in -8<i32> @ 10001419 : int32)
+T_571: (in -4<i32> @ 1000140F : int32)
+  Class: Eq_571
+  DataType: int32
+  OrigDataType: int32
+T_572: (in esp_106 + -4<i32> @ 1000140F : word32)
   Class: Eq_572
+  DataType: ptr32
+  OrigDataType: ptr32
+T_573: (in Mem131[esp_106 + -4<i32>:word32] @ 1000140F : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_574: (in -8<i32> @ 10001410 : int32)
+  Class: Eq_574
   DataType: int32
   OrigDataType: int32
-T_573: (in esp_106 + -8<i32> @ 10001419 : word32)
-  Class: Eq_573
+T_575: (in esp_106 + -8<i32> @ 10001410 : word32)
+  Class: Eq_575
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_574: (in Mem145[esp_106 + -8<i32>:word32] @ 10001419 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_576: (in Mem133[esp_106 + -8<i32>:word32] @ 10001410 : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_575: (in fn100011E9 @ 1000141A : ptr32)
-  Class: Eq_522
-  DataType: (ptr32 Eq_522)
-  OrigDataType: (ptr32 (fn T_588 (T_578, T_581, T_584, T_585, T_586, T_587)))
-T_576: (in -8<i32> @ 1000141A : int32)
-  Class: Eq_576
+T_577: (in fn100017C6 @ 10001411 : ptr32)
+  Class: Eq_500
+  DataType: (ptr32 Eq_500)
+  OrigDataType: (ptr32 (fn T_584 (T_580, T_583)))
+T_578: (in -8<i32> @ 10001411 : int32)
+  Class: Eq_578
   DataType: int32
   OrigDataType: int32
-T_577: (in esp_106 + -8<i32> @ 1000141A : word32)
-  Class: Eq_577
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_578: (in Mem145[esp_106 + -8<i32>:word32] @ 1000141A : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_579: (in -4<i32> @ 1000141A : int32)
+T_579: (in esp_106 + -8<i32> @ 10001411 : word32)
   Class: Eq_579
-  DataType: int32
-  OrigDataType: int32
-T_580: (in esp_106 + -4<i32> @ 1000141A : word32)
-  Class: Eq_580
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_581: (in Mem145[esp_106 + -4<i32>:word32] @ 1000141A : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_580: (in Mem133[esp_106 + -8<i32>:word32] @ 10001411 : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_582: (in 0<32> @ 1000141A : word32)
+T_581: (in -4<i32> @ 10001411 : int32)
+  Class: Eq_581
+  DataType: int32
+  OrigDataType: int32
+T_582: (in esp_106 + -4<i32> @ 10001411 : word32)
   Class: Eq_582
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_583: (in Mem133[esp_106 + -4<i32>:word32] @ 10001411 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_584: (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 10001411 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_585: (in 0<32> @ 10001416 : word32)
+  Class: Eq_585
   DataType: word32
   OrigDataType: word32
-T_583: (in esp_106 + 0<32> @ 1000141A : word32)
-  Class: Eq_583
+T_586: (in esp_106 + 0<32> @ 10001416 : word32)
+  Class: Eq_586
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_584: (in Mem145[esp_106 + 0<32>:word32] @ 1000141A : word32)
-  Class: Eq_140
-  DataType: Eq_140
+T_587: (in Mem141[esp_106 + 0<32>:word32] @ 10001416 : word32)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_585: (in out ebx_113 @ 1000141A : ptr32)
-  Class: Eq_141
-  DataType: ptr32
-  OrigDataType: ptr32
-T_586: (in out esi_110 @ 1000141A : ptr32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: ptr32
-T_587: (in out edi_107 @ 1000141A : ptr32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: ptr32
-T_588: (in fn100011E9(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC, esp_106->t0000, out ebx_113, out esi_110, out edi_107) @ 1000141A : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_588: (in 0<32> @ 10001417 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_589: (in 4<32> @ 1000141A : word32)
+T_589: (in -4<i32> @ 10001417 : int32)
   Class: Eq_589
   DataType: int32
   OrigDataType: int32
-T_590: (in esp_106 + 4<32> @ 1000141A : word32)
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
-  OrigDataType: ptr32
-T_591: (in 100020CC @ 10001426 : ptr32)
-  Class: Eq_591
+T_590: (in esp_106 + -4<i32> @ 10001417 : word32)
+  Class: Eq_590
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_592 t0000)))
-T_592: (in Mem145[0x100020CC<p32>:word32] @ 10001426 : word32)
-  Class: Eq_462
-  DataType: word32
+  OrigDataType: (ptr32 word32)
+T_591: (in Mem143[esp_106 + -4<i32>:word32] @ 10001417 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_593: (in 0<32> @ 10001426 : word32)
-  Class: Eq_462
-  DataType: word32
-  OrigDataType: word32
-T_594: (in g_dw100020CC == 0<32> @ 00000000 : bool)
-  Class: Eq_594
-  DataType: bool
-  OrigDataType: bool
-T_595: (in fn00000000 @ 1000142C : ptr32)
-  Class: Eq_595
-  DataType: (ptr32 Eq_595)
-  OrigDataType: (ptr32 (fn T_598 (T_402, T_597, T_424)))
-T_596: (in signature of fn00000000 @ 00000000 : void)
-  Class: Eq_596
-  DataType: Eq_596
-  OrigDataType: 
-T_597: (in 0<32> @ 1000142C : word32)
-  Class: Eq_597
-  DataType: word32
-  OrigDataType: word32
-T_598: (in fn00000000(ebx_113, 0<32>, edi_107) @ 1000142C : void)
-  Class: Eq_598
-  DataType: void
-  OrigDataType: void
-T_599: (in esp_184 @ 10001437 : (ptr32 Eq_599))
-  Class: Eq_599
-  DataType: (ptr32 Eq_599)
-  OrigDataType: (ptr32 (struct (FFFFFFF8 T_138 tFFFFFFF8) (FFFFFFFC T_139 tFFFFFFFC) (0 T_140 t0000)))
-T_600: (in 4<i32> @ 10001437 : int32)
-  Class: Eq_600
+T_592: (in -8<i32> @ 10001419 : int32)
+  Class: Eq_592
   DataType: int32
   OrigDataType: int32
-T_601: (in esp_100 - 4<i32> @ 00000000 : word32)
+T_593: (in esp_106 + -8<i32> @ 10001419 : word32)
+  Class: Eq_593
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_594: (in Mem145[esp_106 + -8<i32>:word32] @ 10001419 : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_595: (in fn100011E9 @ 1000141A : ptr32)
+  Class: Eq_542
+  DataType: (ptr32 Eq_542)
+  OrigDataType: (ptr32 (fn T_608 (T_598, T_601, T_604, T_605, T_606, T_607)))
+T_596: (in -8<i32> @ 1000141A : int32)
+  Class: Eq_596
+  DataType: int32
+  OrigDataType: int32
+T_597: (in esp_106 + -8<i32> @ 1000141A : word32)
+  Class: Eq_597
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_598: (in Mem145[esp_106 + -8<i32>:word32] @ 1000141A : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_599: (in -4<i32> @ 1000141A : int32)
   Class: Eq_599
-  DataType: (ptr32 Eq_599)
-  OrigDataType: ptr32
-T_602: (in 0<32> @ 10001437 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_600: (in esp_106 + -4<i32> @ 1000141A : word32)
+  Class: Eq_600
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_601: (in Mem145[esp_106 + -4<i32>:word32] @ 1000141A : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_602: (in 0<32> @ 1000141A : word32)
   Class: Eq_602
   DataType: word32
   OrigDataType: word32
-T_603: (in esp_184 + 0<32> @ 10001437 : word32)
+T_603: (in esp_106 + 0<32> @ 1000141A : word32)
   Class: Eq_603
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_604: (in Mem145[esp_106 + 0<32>:word32] @ 1000141A : word32)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: word32
+T_605: (in out ebx_113 @ 1000141A : ptr32)
+  Class: Eq_161
   DataType: ptr32
   OrigDataType: ptr32
-T_604: (in Mem187[esp_184 + 0<32>:word32] @ 10001437 : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_605: (in -4<i32> @ 10001438 : int32)
-  Class: Eq_605
-  DataType: int32
-  OrigDataType: int32
-T_606: (in esp_184 + -4<i32> @ 10001438 : word32)
-  Class: Eq_606
+T_606: (in out esi_110 @ 1000141A : ptr32)
+  Class: Eq_162
   DataType: ptr32
   OrigDataType: ptr32
-T_607: (in Mem190[esp_184 + -4<i32>:word32] @ 10001438 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_607: (in out edi_107 @ 1000141A : ptr32)
+  Class: Eq_163
+  DataType: ptr32
+  OrigDataType: ptr32
+T_608: (in fn100011E9(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC, esp_106->t0000, out ebx_113, out esi_110, out edi_107) @ 1000141A : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_608: (in -8<i32> @ 10001439 : int32)
-  Class: Eq_608
-  DataType: int32
-  OrigDataType: int32
-T_609: (in esp_184 + -8<i32> @ 10001439 : word32)
+T_609: (in 4<32> @ 1000141A : word32)
   Class: Eq_609
-  DataType: ptr32
+  DataType: int32
+  OrigDataType: int32
+T_610: (in esp_106 + 4<32> @ 1000141A : word32)
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
   OrigDataType: ptr32
-T_610: (in Mem194[esp_184 + -8<i32>:word32] @ 10001439 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_611: (in ebx_198 @ 1000143A : word32)
+T_611: (in 100020CC @ 10001426 : ptr32)
   Class: Eq_611
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_612 t0000)))
+T_612: (in Mem145[0x100020CC<p32>:word32] @ 10001426 : word32)
+  Class: Eq_482
   DataType: word32
   OrigDataType: word32
-T_612: (in esi_200 @ 1000143A : word32)
-  Class: Eq_612
+T_613: (in 0<32> @ 10001426 : word32)
+  Class: Eq_482
   DataType: word32
   OrigDataType: word32
-T_613: (in edi_201 @ 1000143A : word32)
-  Class: Eq_613
-  DataType: word32
-  OrigDataType: word32
-T_614: (in eax_197 @ 1000143A : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: ui32
-T_615: (in fn100011E9 @ 1000143A : ptr32)
-  Class: Eq_522
-  DataType: (ptr32 Eq_522)
-  OrigDataType: (ptr32 (fn T_628 (T_618, T_621, T_624, T_625, T_626, T_627)))
-T_616: (in -8<i32> @ 1000143A : int32)
+T_614: (in g_dw100020CC == 0<32> @ 00000000 : bool)
+  Class: Eq_614
+  DataType: bool
+  OrigDataType: bool
+T_615: (in fn00000000 @ 1000142C : ptr32)
+  Class: Eq_615
+  DataType: (ptr32 Eq_615)
+  OrigDataType: (ptr32 (fn T_618 (T_422, T_617, T_444)))
+T_616: (in signature of fn00000000 @ 00000000 : void)
   Class: Eq_616
-  DataType: int32
-  OrigDataType: int32
-T_617: (in esp_184 + -8<i32> @ 1000143A : word32)
+  DataType: Eq_616
+  OrigDataType: 
+T_617: (in 0<32> @ 1000142C : word32)
   Class: Eq_617
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_618: (in Mem194[esp_184 + -8<i32>:word32] @ 1000143A : word32)
-  Class: Eq_138
-  DataType: Eq_138
+  DataType: word32
   OrigDataType: word32
-T_619: (in -4<i32> @ 1000143A : int32)
+T_618: (in fn00000000(ebx_113, 0<32>, edi_107) @ 1000142C : void)
+  Class: Eq_618
+  DataType: void
+  OrigDataType: void
+T_619: (in esp_184 @ 10001437 : (ptr32 Eq_619))
   Class: Eq_619
+  DataType: (ptr32 Eq_619)
+  OrigDataType: (ptr32 (struct (FFFFFFF8 T_158 tFFFFFFF8) (FFFFFFFC T_159 tFFFFFFFC) (0 T_160 t0000)))
+T_620: (in 4<i32> @ 10001437 : int32)
+  Class: Eq_620
   DataType: int32
   OrigDataType: int32
-T_620: (in esp_184 + -4<i32> @ 1000143A : word32)
-  Class: Eq_620
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_621: (in Mem194[esp_184 + -4<i32>:word32] @ 1000143A : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_622: (in 0<32> @ 1000143A : word32)
+T_621: (in esp_100 - 4<i32> @ 00000000 : word32)
+  Class: Eq_619
+  DataType: (ptr32 Eq_619)
+  OrigDataType: ptr32
+T_622: (in 0<32> @ 10001437 : word32)
   Class: Eq_622
   DataType: word32
   OrigDataType: word32
-T_623: (in esp_184 + 0<32> @ 1000143A : word32)
+T_623: (in esp_184 + 0<32> @ 10001437 : word32)
   Class: Eq_623
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_624: (in Mem194[esp_184 + 0<32>:word32] @ 1000143A : word32)
-  Class: Eq_140
-  DataType: Eq_140
+  DataType: ptr32
+  OrigDataType: ptr32
+T_624: (in Mem187[esp_184 + 0<32>:word32] @ 10001437 : word32)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_625: (in out ebx_198 @ 1000143A : ptr32)
-  Class: Eq_141
+T_625: (in -4<i32> @ 10001438 : int32)
+  Class: Eq_625
+  DataType: int32
+  OrigDataType: int32
+T_626: (in esp_184 + -4<i32> @ 10001438 : word32)
+  Class: Eq_626
   DataType: ptr32
   OrigDataType: ptr32
-T_626: (in out esi_200 @ 1000143A : ptr32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: ptr32
-T_627: (in out edi_201 @ 1000143A : ptr32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: ptr32
-T_628: (in fn100011E9(esp_184->tFFFFFFF8, esp_184->tFFFFFFFC, esp_184->t0000, out ebx_198, out esi_200, out edi_201) @ 1000143A : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_627: (in Mem190[esp_184 + -4<i32>:word32] @ 10001438 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_629: (in 4<32> @ 1000143A : word32)
+T_628: (in -8<i32> @ 10001439 : int32)
+  Class: Eq_628
+  DataType: int32
+  OrigDataType: int32
+T_629: (in esp_184 + -8<i32> @ 10001439 : word32)
   Class: Eq_629
-  DataType: int32
-  OrigDataType: int32
-T_630: (in esp_184 + 4<32> @ 1000143A : word32)
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
+  DataType: ptr32
   OrigDataType: ptr32
-T_631: (in 0<32> @ 10001441 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_630: (in Mem194[esp_184 + -8<i32>:word32] @ 10001439 : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_632: (in eax_197 != 0<32> @ 00000000 : bool)
+T_631: (in ebx_198 @ 1000143A : word32)
+  Class: Eq_631
+  DataType: word32
+  OrigDataType: word32
+T_632: (in esi_200 @ 1000143A : word32)
   Class: Eq_632
-  DataType: bool
-  OrigDataType: bool
-T_633: (in 3<32> @ 10001435 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+  DataType: word32
   OrigDataType: word32
-T_634: (in esi_110 != 3<32> @ 00000000 : bool)
-  Class: Eq_634
-  DataType: bool
-  OrigDataType: bool
-T_635: (in -28<i32> @ 1000144A : int32)
-  Class: Eq_635
-  DataType: int32
-  OrigDataType: int32
-T_636: (in ebp_13 + -28<i32> @ 1000144A : word32)
+T_633: (in edi_201 @ 1000143A : word32)
+  Class: Eq_633
+  DataType: word32
+  OrigDataType: word32
+T_634: (in eax_197 @ 1000143A : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: ui32
+T_635: (in fn100011E9 @ 1000143A : ptr32)
+  Class: Eq_542
+  DataType: (ptr32 Eq_542)
+  OrigDataType: (ptr32 (fn T_648 (T_638, T_641, T_644, T_645, T_646, T_647)))
+T_636: (in -8<i32> @ 1000143A : int32)
   Class: Eq_636
+  DataType: int32
+  OrigDataType: int32
+T_637: (in esp_184 + -8<i32> @ 1000143A : word32)
+  Class: Eq_637
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_637: (in Mem218[ebp_13 + -28<i32>:word32] @ 1000144A : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_638: (in Mem194[esp_184 + -8<i32>:word32] @ 1000143A : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_638: (in 0<32> @ 1000144A : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_639: (in ebp_13->tFFFFFFE4 == 0<32> @ 00000000 : bool)
+T_639: (in -4<i32> @ 1000143A : int32)
   Class: Eq_639
-  DataType: bool
-  OrigDataType: bool
-T_640: (in -28<i32> @ 10001443 : int32)
+  DataType: int32
+  OrigDataType: int32
+T_640: (in esp_184 + -4<i32> @ 1000143A : word32)
   Class: Eq_640
-  DataType: int32
-  OrigDataType: int32
-T_641: (in ebp_13 + -28<i32> @ 10001443 : word32)
-  Class: Eq_641
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_642: (in Mem194[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: ui32
-T_643: (in ebp_13->tFFFFFFE4 & eax_197 @ 00000000 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: ui32
-T_644: (in -28<i32> @ 10001443 : int32)
-  Class: Eq_644
-  DataType: int32
-  OrigDataType: int32
-T_645: (in ebp_13 + -28<i32> @ 10001443 : word32)
-  Class: Eq_645
+T_641: (in Mem194[esp_184 + -4<i32>:word32] @ 1000143A : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_642: (in 0<32> @ 1000143A : word32)
+  Class: Eq_642
+  DataType: word32
+  OrigDataType: word32
+T_643: (in esp_184 + 0<32> @ 1000143A : word32)
+  Class: Eq_643
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_646: (in Mem214[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_644: (in Mem194[esp_184 + 0<32>:word32] @ 1000143A : word32)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_647: (in 100020CC @ 10001453 : ptr32)
-  Class: Eq_647
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_648 t0000)))
-T_648: (in Mem218[0x100020CC<p32>:word32] @ 10001453 : word32)
-  Class: Eq_462
-  DataType: word32
+T_645: (in out ebx_198 @ 1000143A : ptr32)
+  Class: Eq_161
+  DataType: ptr32
+  OrigDataType: ptr32
+T_646: (in out esi_200 @ 1000143A : ptr32)
+  Class: Eq_162
+  DataType: ptr32
+  OrigDataType: ptr32
+T_647: (in out edi_201 @ 1000143A : ptr32)
+  Class: Eq_163
+  DataType: ptr32
+  OrigDataType: ptr32
+T_648: (in fn100011E9(esp_184->tFFFFFFF8, esp_184->tFFFFFFFC, esp_184->t0000, out ebx_198, out esi_200, out edi_201) @ 1000143A : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_649: (in 0<32> @ 10001453 : word32)
-  Class: Eq_462
-  DataType: word32
+T_649: (in 4<32> @ 1000143A : word32)
+  Class: Eq_649
+  DataType: int32
+  OrigDataType: int32
+T_650: (in esp_184 + 4<32> @ 1000143A : word32)
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
+  OrigDataType: ptr32
+T_651: (in 0<32> @ 10001441 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_650: (in g_dw100020CC == 0<32> @ 00000000 : bool)
-  Class: Eq_650
-  DataType: bool
-  OrigDataType: bool
-T_651: (in fn00000000 @ 1000145A : ptr32)
-  Class: Eq_651
-  DataType: (ptr32 Eq_651)
-  OrigDataType: (ptr32 (fn T_653 (T_611, T_612, T_613)))
-T_652: (in signature of fn00000000 @ 00000000 : void)
+T_652: (in eax_197 != 0<32> @ 00000000 : bool)
   Class: Eq_652
-  DataType: Eq_652
-  OrigDataType: 
-T_653: (in fn00000000(ebx_198, esi_200, edi_201) @ 1000145A : void)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: void
-T_654: (in -28<i32> @ 1000145A : int32)
-  Class: Eq_654
-  DataType: int32
-  OrigDataType: int32
-T_655: (in ebp_13 + -28<i32> @ 1000145A : word32)
-  Class: Eq_655
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_656: (in Mem247[ebp_13 + -28<i32>:word32] @ 1000145A : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_657: (in 0xFFFFFFFF<32> @ 10001493 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_658: (in 10003008 @ 10001493 : ptr32)
-  Class: Eq_658
-  DataType: (ptr32 Eq_139)
-  OrigDataType: (ptr32 (struct (0 T_659 t0000)))
-T_659: (in Mem4[0x10003008<p32>:word32] @ 10001493 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_660: (in eax @ 1000149D : Eq_660)
-  Class: Eq_660
-  DataType: Eq_660
-  OrigDataType: BOOL
-T_661: (in hModule @ 1000149D : Eq_661)
-  Class: Eq_661
-  DataType: Eq_661
-  OrigDataType: HANDLE
-T_662: (in dwReason @ 1000149D : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_663: (in lpReserved @ 1000149D : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: LPVOID
-T_664: (in 1<32> @ 100014A3 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_665: (in dwReason != 1<32> @ 00000000 : bool)
-  Class: Eq_665
   DataType: bool
   OrigDataType: bool
-T_666: (in fn10001388 @ 100014BC : ptr32)
-  Class: Eq_666
-  DataType: (ptr32 Eq_666)
-  OrigDataType: (ptr32 (fn T_671 (T_663, T_662, T_668, T_669, T_670)))
-T_667: (in signature of fn10001388 @ 10001388 : void)
-  Class: Eq_666
-  DataType: (ptr32 Eq_666)
-  OrigDataType: 
-T_668: (in ebx @ 100014BC : word32)
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
+T_653: (in 3<32> @ 10001435 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_669: (in esi @ 100014BC : word32)
-  Class: Eq_371
+T_654: (in esi_110 != 3<32> @ 00000000 : bool)
+  Class: Eq_654
+  DataType: bool
+  OrigDataType: bool
+T_655: (in -28<i32> @ 1000144A : int32)
+  Class: Eq_655
+  DataType: int32
+  OrigDataType: int32
+T_656: (in ebp_13 + -28<i32> @ 1000144A : word32)
+  Class: Eq_656
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_657: (in Mem218[ebp_13 + -28<i32>:word32] @ 1000144A : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_658: (in 0<32> @ 1000144A : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_659: (in ebp_13->tFFFFFFE4 == 0<32> @ 00000000 : bool)
+  Class: Eq_659
+  DataType: bool
+  OrigDataType: bool
+T_660: (in -28<i32> @ 10001443 : int32)
+  Class: Eq_660
+  DataType: int32
+  OrigDataType: int32
+T_661: (in ebp_13 + -28<i32> @ 10001443 : word32)
+  Class: Eq_661
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_662: (in Mem194[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: ui32
+T_663: (in ebp_13->tFFFFFFE4 & eax_197 @ 00000000 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: ui32
+T_664: (in -28<i32> @ 10001443 : int32)
+  Class: Eq_664
+  DataType: int32
+  OrigDataType: int32
+T_665: (in ebp_13 + -28<i32> @ 10001443 : word32)
+  Class: Eq_665
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_666: (in Mem214[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_667: (in 100020CC @ 10001453 : ptr32)
+  Class: Eq_667
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_668 t0000)))
+T_668: (in Mem218[0x100020CC<p32>:word32] @ 10001453 : word32)
+  Class: Eq_482
+  DataType: word32
+  OrigDataType: word32
+T_669: (in 0<32> @ 10001453 : word32)
+  Class: Eq_482
+  DataType: word32
+  OrigDataType: word32
+T_670: (in g_dw100020CC == 0<32> @ 00000000 : bool)
+  Class: Eq_670
+  DataType: bool
+  OrigDataType: bool
+T_671: (in fn00000000 @ 1000145A : ptr32)
+  Class: Eq_671
+  DataType: (ptr32 Eq_671)
+  OrigDataType: (ptr32 (fn T_673 (T_631, T_632, T_633)))
+T_672: (in signature of fn00000000 @ 00000000 : void)
+  Class: Eq_672
+  DataType: Eq_672
+  OrigDataType: 
+T_673: (in fn00000000(ebx_198, esi_200, edi_201) @ 1000145A : void)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: void
+T_674: (in -28<i32> @ 1000145A : int32)
+  Class: Eq_674
+  DataType: int32
+  OrigDataType: int32
+T_675: (in ebp_13 + -28<i32> @ 1000145A : word32)
+  Class: Eq_675
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_676: (in Mem247[ebp_13 + -28<i32>:word32] @ 1000145A : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_677: (in 0xFFFFFFFF<32> @ 10001493 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_678: (in 10003008 @ 10001493 : ptr32)
+  Class: Eq_678
+  DataType: (ptr32 Eq_159)
+  OrigDataType: (ptr32 (struct (0 T_679 t0000)))
+T_679: (in Mem4[0x10003008<p32>:word32] @ 10001493 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_680: (in eax @ 1000149D : Eq_680)
+  Class: Eq_680
+  DataType: Eq_680
+  OrigDataType: BOOL
+T_681: (in hModule @ 1000149D : Eq_681)
+  Class: Eq_681
+  DataType: Eq_681
+  OrigDataType: HANDLE
+T_682: (in dwReason @ 1000149D : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_683: (in lpReserved @ 1000149D : Eq_160)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: LPVOID
+T_684: (in 1<32> @ 100014A3 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_685: (in dwReason != 1<32> @ 00000000 : bool)
+  Class: Eq_685
+  DataType: bool
+  OrigDataType: bool
+T_686: (in fn10001388 @ 100014BC : ptr32)
+  Class: Eq_686
+  DataType: (ptr32 Eq_686)
+  OrigDataType: (ptr32 (fn T_691 (T_683, T_682, T_688, T_689, T_690)))
+T_687: (in signature of fn10001388 @ 10001388 : void)
+  Class: Eq_686
+  DataType: (ptr32 Eq_686)
+  OrigDataType: 
+T_688: (in ebx @ 100014BC : word32)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: word32
+T_689: (in esi @ 100014BC : word32)
+  Class: Eq_391
   DataType: ptr32
   OrigDataType: word32
-T_670: (in edi @ 100014BC : word32)
-  Class: Eq_372
+T_690: (in edi @ 100014BC : word32)
+  Class: Eq_392
   DataType: word32
   OrigDataType: word32
-T_671: (in fn10001388(lpReserved, dwReason, ebx, esi, edi) @ 100014BC : word32)
-  Class: Eq_660
-  DataType: Eq_660
+T_691: (in fn10001388(lpReserved, dwReason, ebx, esi, edi) @ 100014BC : word32)
+  Class: Eq_680
+  DataType: Eq_680
   OrigDataType: word32
-T_672: (in fn10001864 @ 100014A5 : ptr32)
-  Class: Eq_672
-  DataType: (ptr32 Eq_672)
-  OrigDataType: (ptr32 (fn T_674 ()))
-T_673: (in signature of fn10001864 @ 10001864 : void)
-  Class: Eq_672
-  DataType: (ptr32 Eq_672)
+T_692: (in fn10001864 @ 100014A5 : ptr32)
+  Class: Eq_692
+  DataType: (ptr32 Eq_692)
+  OrigDataType: (ptr32 (fn T_694 ()))
+T_693: (in signature of fn10001864 @ 10001864 : void)
+  Class: Eq_692
+  DataType: (ptr32 Eq_692)
   OrigDataType: 
-T_674: (in fn10001864() @ 100014A5 : void)
-  Class: Eq_674
+T_694: (in fn10001864() @ 100014A5 : void)
+  Class: Eq_694
   DataType: void
   OrigDataType: void
-T_675: (in eax @ 100014A5 : uint32)
-  Class: Eq_675
+T_695: (in eax @ 100014A5 : uint32)
+  Class: Eq_695
   DataType: uint32
   OrigDataType: word32
-T_676: (in dwArg04 @ 100014A5 : (ptr32 Eq_676))
-  Class: Eq_676
-  DataType: (ptr32 Eq_676)
-  OrigDataType: (ptr32 (struct (0 T_679 t0000) (3C T_685 t003C)))
-T_677: (in 0<32> @ 100016D9 : word32)
-  Class: Eq_677
-  DataType: word32
-  OrigDataType: word32
-T_678: (in dwArg04 + 0<32> @ 100016D9 : word32)
-  Class: Eq_678
-  DataType: word32
-  OrigDataType: word32
-T_679: (in Mem0[dwArg04 + 0<32>:word16] @ 100016D9 : word16)
-  Class: Eq_679
-  DataType: word16
-  OrigDataType: word16
-T_680: (in 0x5A4D<16> @ 100016D9 : word16)
-  Class: Eq_679
-  DataType: word16
-  OrigDataType: word16
-T_681: (in dwArg04->w0000 == 0x5A4D<16> @ 00000000 : bool)
-  Class: Eq_681
-  DataType: bool
-  OrigDataType: bool
-T_682: (in eax_9 @ 100016E1 : (ptr32 Eq_682))
-  Class: Eq_682
-  DataType: (ptr32 Eq_682)
-  OrigDataType: (ptr32 (struct (0 T_689 t0000) (18 T_695 t0018)))
-T_683: (in 0x3C<32> @ 100016E1 : word32)
-  Class: Eq_683
-  DataType: word32
-  OrigDataType: word32
-T_684: (in dwArg04 + 0x3C<32> @ 100016E1 : word32)
-  Class: Eq_684
-  DataType: ptr32
-  OrigDataType: ptr32
-T_685: (in Mem0[dwArg04 + 0x3C<32>:word32] @ 100016E1 : word32)
-  Class: Eq_685
-  DataType: word32
-  OrigDataType: word32
-T_686: (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 100016E1 : word32)
-  Class: Eq_682
-  DataType: (ptr32 Eq_682)
-  OrigDataType: word32
-T_687: (in 0<32> @ 100016E9 : word32)
-  Class: Eq_687
-  DataType: word32
-  OrigDataType: word32
-T_688: (in eax_9 + 0<32> @ 100016E9 : word32)
-  Class: Eq_688
-  DataType: word32
-  OrigDataType: word32
-T_689: (in Mem0[eax_9 + 0<32>:word32] @ 100016E9 : word32)
-  Class: Eq_689
-  DataType: word32
-  OrigDataType: word32
-T_690: (in 0x4550<32> @ 100016E9 : word32)
-  Class: Eq_689
-  DataType: word32
-  OrigDataType: word32
-T_691: (in eax_9->dw0000 != 0x4550<32> @ 00000000 : bool)
-  Class: Eq_691
-  DataType: bool
-  OrigDataType: bool
-T_692: (in 0<32> @ 100016DD : word32)
-  Class: Eq_675
-  DataType: uint32
-  OrigDataType: word32
-T_693: (in 0x18<32> @ 100016F8 : word32)
-  Class: Eq_693
-  DataType: word32
-  OrigDataType: word32
-T_694: (in eax_9 + 0x18<32> @ 100016F8 : word32)
-  Class: Eq_694
-  DataType: ptr32
-  OrigDataType: ptr32
-T_695: (in Mem0[eax_9 + 0x18<32>:word16] @ 100016F8 : word16)
-  Class: Eq_695
-  DataType: word16
-  OrigDataType: word16
-T_696: (in 0x10B<16> @ 100016F8 : word16)
-  Class: Eq_695
-  DataType: word16
-  OrigDataType: word16
-T_697: (in eax_9->w0018 == 0x10B<16> @ 00000000 : bool)
+T_696: (in dwArg04 @ 100014A5 : (ptr32 Eq_696))
+  Class: Eq_696
+  DataType: (ptr32 Eq_696)
+  OrigDataType: (ptr32 (struct (0 T_699 t0000) (3C T_705 t003C)))
+T_697: (in 0<32> @ 100016D9 : word32)
   Class: Eq_697
-  DataType: bool
-  OrigDataType: bool
-T_698: (in CONVERT(Mem0[eax_9 + 0x18<32>:word16] == 0x10B<16>, bool, int8) @ 100016F8 : int8)
-  Class: Eq_698
-  DataType: int8
-  OrigDataType: int8
-T_699: (in CONVERT(CONVERT(Mem0[eax_9 + 0x18<32>:word16] == 0x10B<16>, bool, int8), int8, uint32) @ 100016F8 : uint32)
-  Class: Eq_675
-  DataType: uint32
-  OrigDataType: uint32
-T_700: (in eax @ 100016F8 : (ptr32 Eq_700))
-  Class: Eq_700
-  DataType: (ptr32 Eq_700)
-  OrigDataType: word32
-T_701: (in dwArg04 @ 100016F8 : (ptr32 Eq_701))
-  Class: Eq_701
-  DataType: (ptr32 Eq_701)
-  OrigDataType: (ptr32 (struct (3C T_706 t003C)))
-T_702: (in dwArg08 @ 100016F8 : uint32)
-  Class: Eq_702
-  DataType: uint32
-  OrigDataType: up32
-T_703: (in ecx_7 @ 10001707 : (ptr32 Eq_703))
-  Class: Eq_703
-  DataType: (ptr32 Eq_703)
-  OrigDataType: (ptr32 (struct (6 T_711 t0006) (14 T_718 t0014)))
-T_704: (in 0x3C<32> @ 10001707 : word32)
-  Class: Eq_704
   DataType: word32
   OrigDataType: word32
-T_705: (in dwArg04 + 0x3C<32> @ 10001707 : word32)
+T_698: (in dwArg04 + 0<32> @ 100016D9 : word32)
+  Class: Eq_698
+  DataType: word32
+  OrigDataType: word32
+T_699: (in Mem0[dwArg04 + 0<32>:word16] @ 100016D9 : word16)
+  Class: Eq_699
+  DataType: word16
+  OrigDataType: word16
+T_700: (in 0x5A4D<16> @ 100016D9 : word16)
+  Class: Eq_699
+  DataType: word16
+  OrigDataType: word16
+T_701: (in dwArg04->w0000 == 0x5A4D<16> @ 00000000 : bool)
+  Class: Eq_701
+  DataType: bool
+  OrigDataType: bool
+T_702: (in eax_9 @ 100016E1 : (ptr32 Eq_702))
+  Class: Eq_702
+  DataType: (ptr32 Eq_702)
+  OrigDataType: (ptr32 (struct (0 T_709 t0000) (18 T_715 t0018)))
+T_703: (in 0x3C<32> @ 100016E1 : word32)
+  Class: Eq_703
+  DataType: word32
+  OrigDataType: word32
+T_704: (in dwArg04 + 0x3C<32> @ 100016E1 : word32)
+  Class: Eq_704
+  DataType: ptr32
+  OrigDataType: ptr32
+T_705: (in Mem0[dwArg04 + 0x3C<32>:word32] @ 100016E1 : word32)
   Class: Eq_705
   DataType: word32
   OrigDataType: word32
-T_706: (in Mem0[dwArg04 + 0x3C<32>:word32] @ 10001707 : word32)
-  Class: Eq_706
+T_706: (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 100016E1 : word32)
+  Class: Eq_702
+  DataType: (ptr32 Eq_702)
+  OrigDataType: word32
+T_707: (in 0<32> @ 100016E9 : word32)
+  Class: Eq_707
   DataType: word32
   OrigDataType: word32
-T_707: (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 10001707 : word32)
-  Class: Eq_703
-  DataType: (ptr32 Eq_703)
-  OrigDataType: word32
-T_708: (in esi_15 @ 1000170F : up32)
+T_708: (in eax_9 + 0<32> @ 100016E9 : word32)
   Class: Eq_708
-  DataType: up32
-  OrigDataType: up32
-T_709: (in 6<32> @ 1000170F : word32)
+  DataType: word32
+  OrigDataType: word32
+T_709: (in Mem0[eax_9 + 0<32>:word32] @ 100016E9 : word32)
   Class: Eq_709
   DataType: word32
   OrigDataType: word32
-T_710: (in ecx_7 + 6<32> @ 1000170F : word32)
-  Class: Eq_710
+T_710: (in 0x4550<32> @ 100016E9 : word32)
+  Class: Eq_709
   DataType: word32
   OrigDataType: word32
-T_711: (in Mem14[ecx_7 + 6<32>:word16] @ 1000170F : word16)
+T_711: (in eax_9->dw0000 != 0x4550<32> @ 00000000 : bool)
   Class: Eq_711
-  DataType: word16
-  OrigDataType: word16
-T_712: (in CONVERT(Mem14[ecx_7 + 6<32>:word16], word16, word32) @ 1000170F : word32)
-  Class: Eq_708
-  DataType: up32
-  OrigDataType: word32
-T_713: (in edx_16 @ 10001713 : up32)
-  Class: Eq_708
-  DataType: up32
-  OrigDataType: up32
-T_714: (in 0<32> @ 10001713 : word32)
-  Class: Eq_708
-  DataType: up32
-  OrigDataType: word32
-T_715: (in eax_22 @ 10001718 : (ptr32 Eq_700))
-  Class: Eq_700
-  DataType: (ptr32 Eq_700)
-  OrigDataType: (ptr32 (struct 0028 (8 up32 dw0008) (C word32 dw000C)))
-T_716: (in 0x14<32> @ 10001718 : word32)
-  Class: Eq_716
-  DataType: word32
-  OrigDataType: word32
-T_717: (in ecx_7 + 0x14<32> @ 10001718 : word32)
-  Class: Eq_717
-  DataType: ptr32
-  OrigDataType: ptr32
-T_718: (in Mem0[ecx_7 + 0x14<32>:word16] @ 10001718 : word16)
-  Class: Eq_718
-  DataType: word16
-  OrigDataType: word16
-T_719: (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) @ 10001718 : word32)
-  Class: Eq_719
-  DataType: word32
-  OrigDataType: word32
-T_720: (in 0x18<32> @ 10001718 : word32)
-  Class: Eq_720
-  DataType: word32
-  OrigDataType: word32
-T_721: (in (word32) ecx_7->w0014 + 0x18<32> @ 00000000 : word32)
-  Class: Eq_721
-  DataType: word32
-  OrigDataType: word32
-T_722: (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) + 0x18<32> + ecx_7 @ 10001718 : word32)
-  Class: Eq_700
-  DataType: (ptr32 Eq_700)
-  OrigDataType: word32
-T_723: (in 0<32> @ 1000171C : word32)
-  Class: Eq_708
-  DataType: up32
-  OrigDataType: up32
-T_724: (in esi_15 <= 0<32> @ 00000000 : bool)
-  Class: Eq_724
   DataType: bool
   OrigDataType: bool
-T_725: (in 0<32> @ 1000173C : word32)
-  Class: Eq_700
-  DataType: (ptr32 Eq_700)
+T_712: (in 0<32> @ 100016DD : word32)
+  Class: Eq_695
+  DataType: uint32
   OrigDataType: word32
-T_726: (in 1<32> @ 10001732 : word32)
+T_713: (in 0x18<32> @ 100016F8 : word32)
+  Class: Eq_713
+  DataType: word32
+  OrigDataType: word32
+T_714: (in eax_9 + 0x18<32> @ 100016F8 : word32)
+  Class: Eq_714
+  DataType: ptr32
+  OrigDataType: ptr32
+T_715: (in Mem0[eax_9 + 0x18<32>:word16] @ 100016F8 : word16)
+  Class: Eq_715
+  DataType: word16
+  OrigDataType: word16
+T_716: (in 0x10B<16> @ 100016F8 : word16)
+  Class: Eq_715
+  DataType: word16
+  OrigDataType: word16
+T_717: (in eax_9->w0018 == 0x10B<16> @ 00000000 : bool)
+  Class: Eq_717
+  DataType: bool
+  OrigDataType: bool
+T_718: (in CONVERT(Mem0[eax_9 + 0x18<32>:word16] == 0x10B<16>, bool, int8) @ 100016F8 : int8)
+  Class: Eq_718
+  DataType: int8
+  OrigDataType: int8
+T_719: (in CONVERT(CONVERT(Mem0[eax_9 + 0x18<32>:word16] == 0x10B<16>, bool, int8), int8, uint32) @ 100016F8 : uint32)
+  Class: Eq_695
+  DataType: uint32
+  OrigDataType: uint32
+T_720: (in eax @ 100016F8 : (ptr32 Eq_720))
+  Class: Eq_720
+  DataType: (ptr32 Eq_720)
+  OrigDataType: word32
+T_721: (in dwArg04 @ 100016F8 : (ptr32 Eq_721))
+  Class: Eq_721
+  DataType: (ptr32 Eq_721)
+  OrigDataType: (ptr32 (struct (3C T_726 t003C)))
+T_722: (in dwArg08 @ 100016F8 : uint32)
+  Class: Eq_722
+  DataType: uint32
+  OrigDataType: up32
+T_723: (in ecx_7 @ 10001707 : (ptr32 Eq_723))
+  Class: Eq_723
+  DataType: (ptr32 Eq_723)
+  OrigDataType: (ptr32 (struct (6 T_731 t0006) (14 T_738 t0014)))
+T_724: (in 0x3C<32> @ 10001707 : word32)
+  Class: Eq_724
+  DataType: word32
+  OrigDataType: word32
+T_725: (in dwArg04 + 0x3C<32> @ 10001707 : word32)
+  Class: Eq_725
+  DataType: word32
+  OrigDataType: word32
+T_726: (in Mem0[dwArg04 + 0x3C<32>:word32] @ 10001707 : word32)
   Class: Eq_726
   DataType: word32
   OrigDataType: word32
-T_727: (in edx_16 + 1<32> @ 00000000 : word32)
-  Class: Eq_708
-  DataType: up32
+T_727: (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 10001707 : word32)
+  Class: Eq_723
+  DataType: (ptr32 Eq_723)
   OrigDataType: word32
-T_728: (in 0x28<32> @ 10001735 : word32)
+T_728: (in esi_15 @ 1000170F : up32)
   Class: Eq_728
-  DataType: word32
-  OrigDataType: word32
-T_729: (in eax_22 + 0x28<32> @ 10001735 : word32)
-  Class: Eq_700
-  DataType: (ptr32 Eq_700)
-  OrigDataType: word32
-T_730: (in edx_16 < esi_15 @ 00000000 : bool)
-  Class: Eq_730
-  DataType: bool
-  OrigDataType: bool
-T_731: (in 8<32> @ 10001730 : word32)
-  Class: Eq_731
-  DataType: word32
-  OrigDataType: word32
-T_732: (in eax_22 + 8<32> @ 10001730 : word32)
-  Class: Eq_732
-  DataType: word32
-  OrigDataType: word32
-T_733: (in Mem21[eax_22 + 8<32>:word32] @ 10001730 : word32)
-  Class: Eq_733
   DataType: up32
   OrigDataType: up32
-T_734: (in ecx_28 @ 10001730 : uint32)
-  Class: Eq_702
-  DataType: uint32
+T_729: (in 6<32> @ 1000170F : word32)
+  Class: Eq_729
+  DataType: word32
+  OrigDataType: word32
+T_730: (in ecx_7 + 6<32> @ 1000170F : word32)
+  Class: Eq_730
+  DataType: word32
+  OrigDataType: word32
+T_731: (in Mem14[ecx_7 + 6<32>:word16] @ 1000170F : word16)
+  Class: Eq_731
+  DataType: word16
+  OrigDataType: word16
+T_732: (in CONVERT(Mem14[ecx_7 + 6<32>:word16], word16, word32) @ 1000170F : word32)
+  Class: Eq_728
+  DataType: up32
+  OrigDataType: word32
+T_733: (in edx_16 @ 10001713 : up32)
+  Class: Eq_728
+  DataType: up32
   OrigDataType: up32
-T_735: (in eax_22->dw0008 + ecx_28 @ 00000000 : word32)
-  Class: Eq_702
-  DataType: uint32
-  OrigDataType: up32
-T_736: (in dwArg08 < eax_22->dw0008 + ecx_28 @ 00000000 : bool)
+T_734: (in 0<32> @ 10001713 : word32)
+  Class: Eq_728
+  DataType: up32
+  OrigDataType: word32
+T_735: (in eax_22 @ 10001718 : (ptr32 Eq_720))
+  Class: Eq_720
+  DataType: (ptr32 Eq_720)
+  OrigDataType: (ptr32 (struct 0028 (8 up32 dw0008) (C word32 dw000C)))
+T_736: (in 0x14<32> @ 10001718 : word32)
   Class: Eq_736
-  DataType: bool
-  OrigDataType: bool
-T_737: (in 0xC<32> @ 10001722 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_737: (in ecx_7 + 0x14<32> @ 10001718 : word32)
   Class: Eq_737
-  DataType: word32
-  OrigDataType: word32
-T_738: (in eax_22 + 0xC<32> @ 10001722 : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_738: (in Mem0[ecx_7 + 0x14<32>:word16] @ 10001718 : word16)
   Class: Eq_738
-  DataType: ptr32
-  OrigDataType: ptr32
-T_739: (in Mem21[eax_22 + 0xC<32>:word32] @ 10001722 : word32)
-  Class: Eq_702
-  DataType: uint32
+  DataType: word16
+  OrigDataType: word16
+T_739: (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) @ 10001718 : word32)
+  Class: Eq_739
+  DataType: word32
   OrigDataType: word32
-T_740: (in dwArg08 < ecx_28 @ 00000000 : bool)
+T_740: (in 0x18<32> @ 10001718 : word32)
   Class: Eq_740
+  DataType: word32
+  OrigDataType: word32
+T_741: (in (word32) ecx_7->w0014 + 0x18<32> @ 00000000 : word32)
+  Class: Eq_741
+  DataType: word32
+  OrigDataType: word32
+T_742: (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) + 0x18<32> + ecx_7 @ 10001718 : word32)
+  Class: Eq_720
+  DataType: (ptr32 Eq_720)
+  OrigDataType: word32
+T_743: (in 0<32> @ 1000171C : word32)
+  Class: Eq_728
+  DataType: up32
+  OrigDataType: up32
+T_744: (in esi_15 <= 0<32> @ 00000000 : bool)
+  Class: Eq_744
   DataType: bool
   OrigDataType: bool
-T_741: (in eax @ 10001727 : ui32)
-  Class: Eq_741
-  DataType: ui32
+T_745: (in 0<32> @ 1000173C : word32)
+  Class: Eq_720
+  DataType: (ptr32 Eq_720)
   OrigDataType: word32
-T_742: (in eax_59 @ 10001742 : ui32)
-  Class: Eq_741
-  DataType: ui32
-  OrigDataType: ui32
-T_743: (in ebp_13 @ 10001749 : (ptr32 Eq_391))
-  Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: (ptr32 (struct (FFFFFFFC T_748 tFFFFFFFC) (8 T_768 t0008)))
-T_744: (in fn100017E8 @ 10001749 : ptr32)
-  Class: Eq_392
-  DataType: (ptr32 Eq_392)
-  OrigDataType: (ptr32 (fn T_747 (T_370, T_371, T_372, T_745, T_746)))
-T_745: (in dwLoc0C @ 10001749 : word32)
-  Class: Eq_397
+T_746: (in 1<32> @ 10001732 : word32)
+  Class: Eq_746
   DataType: word32
   OrigDataType: word32
-T_746: (in 8<32> @ 10001749 : word32)
-  Class: Eq_398
-  DataType: ui32
+T_747: (in edx_16 + 1<32> @ 00000000 : word32)
+  Class: Eq_728
+  DataType: up32
   OrigDataType: word32
-T_747: (in fn100017E8(ebx, esi, edi, dwLoc0C, 8<32>) @ 10001749 : word32)
-  Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: word32
-T_748: (in 0<32> @ 1000174E : word32)
-  Class: Eq_410
+T_748: (in 0x28<32> @ 10001735 : word32)
+  Class: Eq_748
   DataType: word32
   OrigDataType: word32
-T_749: (in -4<i32> @ 1000174E : int32)
-  Class: Eq_749
-  DataType: int32
-  OrigDataType: int32
-T_750: (in ebp_13 + -4<i32> @ 1000174E : word32)
+T_749: (in eax_22 + 0x28<32> @ 10001735 : word32)
+  Class: Eq_720
+  DataType: (ptr32 Eq_720)
+  OrigDataType: word32
+T_750: (in edx_16 < esi_15 @ 00000000 : bool)
   Class: Eq_750
-  DataType: word32
-  OrigDataType: word32
-T_751: (in Mem19[ebp_13 + -4<i32>:word32] @ 1000174E : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_752: (in dwLoc0C_84 @ 10001757 : Eq_456)
-  Class: Eq_456
-  DataType: Eq_456
-  OrigDataType: (union (ui32 u0) (ptr32 u1))
-T_753: (in 0x10000000<p32> @ 10001757 : ptr32)
-  Class: Eq_456
-  DataType: ptr32
-  OrigDataType: ptr32
-T_754: (in fn100016D0 @ 10001760 : ptr32)
-  Class: Eq_754
-  DataType: (ptr32 Eq_754)
-  OrigDataType: (ptr32 (fn T_757 (T_756)))
-T_755: (in signature of fn100016D0 @ 100016D0 : void)
-  Class: Eq_754
-  DataType: (ptr32 Eq_754)
-  OrigDataType: 
-T_756: (in 0x10000000<p32> @ 10001760 : ptr32)
-  Class: Eq_676
-  DataType: (ptr32 Eq_676)
-  OrigDataType: ptr32
-T_757: (in fn100016D0(&g_t10000000) @ 10001760 : word32)
-  Class: Eq_757
-  DataType: word32
-  OrigDataType: word32
-T_758: (in 0<32> @ 10001760 : word32)
-  Class: Eq_757
-  DataType: word32
-  OrigDataType: word32
-T_759: (in fn100016D0(&g_t10000000) == 0<32> @ 00000000 : bool)
-  Class: Eq_759
   DataType: bool
   OrigDataType: bool
-T_760: (in 0xFFFFFFFE<32> @ 1000179F : word32)
-  Class: Eq_410
+T_751: (in 8<32> @ 10001730 : word32)
+  Class: Eq_751
   DataType: word32
   OrigDataType: word32
-T_761: (in -4<i32> @ 1000179F : int32)
+T_752: (in eax_22 + 8<32> @ 10001730 : word32)
+  Class: Eq_752
+  DataType: word32
+  OrigDataType: word32
+T_753: (in Mem21[eax_22 + 8<32>:word32] @ 10001730 : word32)
+  Class: Eq_753
+  DataType: up32
+  OrigDataType: up32
+T_754: (in ecx_28 @ 10001730 : uint32)
+  Class: Eq_722
+  DataType: uint32
+  OrigDataType: up32
+T_755: (in eax_22->dw0008 + ecx_28 @ 00000000 : word32)
+  Class: Eq_722
+  DataType: uint32
+  OrigDataType: up32
+T_756: (in dwArg08 < eax_22->dw0008 + ecx_28 @ 00000000 : bool)
+  Class: Eq_756
+  DataType: bool
+  OrigDataType: bool
+T_757: (in 0xC<32> @ 10001722 : word32)
+  Class: Eq_757
+  DataType: word32
+  OrigDataType: word32
+T_758: (in eax_22 + 0xC<32> @ 10001722 : word32)
+  Class: Eq_758
+  DataType: ptr32
+  OrigDataType: ptr32
+T_759: (in Mem21[eax_22 + 0xC<32>:word32] @ 10001722 : word32)
+  Class: Eq_722
+  DataType: uint32
+  OrigDataType: word32
+T_760: (in dwArg08 < ecx_28 @ 00000000 : bool)
+  Class: Eq_760
+  DataType: bool
+  OrigDataType: bool
+T_761: (in eax @ 10001727 : ui32)
   Class: Eq_761
-  DataType: int32
-  OrigDataType: int32
-T_762: (in ebp_13 + -4<i32> @ 1000179F : word32)
-  Class: Eq_762
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_763: (in Mem58[ebp_13 + -4<i32>:word32] @ 1000179F : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_764: (in 0<32> @ 100017A6 : word32)
-  Class: Eq_741
   DataType: ui32
   OrigDataType: word32
-T_765: (in eax_36 @ 10001762 : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
+T_762: (in eax_59 @ 10001742 : ui32)
+  Class: Eq_761
+  DataType: ui32
   OrigDataType: ui32
-T_766: (in 8<32> @ 10001762 : word32)
-  Class: Eq_766
+T_763: (in ebp_13 @ 10001749 : (ptr32 Eq_411))
+  Class: Eq_411
+  DataType: (ptr32 Eq_411)
+  OrigDataType: (ptr32 (struct (FFFFFFFC T_768 tFFFFFFFC) (8 T_788 t0008)))
+T_764: (in fn100017E8 @ 10001749 : ptr32)
+  Class: Eq_412
+  DataType: (ptr32 Eq_412)
+  OrigDataType: (ptr32 (fn T_767 (T_390, T_391, T_392, T_765, T_766)))
+T_765: (in dwLoc0C @ 10001749 : word32)
+  Class: Eq_417
   DataType: word32
   OrigDataType: word32
-T_767: (in ebp_13 + 8<32> @ 10001762 : word32)
-  Class: Eq_767
+T_766: (in 8<32> @ 10001749 : word32)
+  Class: Eq_418
+  DataType: ui32
+  OrigDataType: word32
+T_767: (in fn100017E8(ebx, esi, edi, dwLoc0C, 8<32>) @ 10001749 : word32)
+  Class: Eq_411
+  DataType: (ptr32 Eq_411)
+  OrigDataType: word32
+T_768: (in 0<32> @ 1000174E : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_769: (in -4<i32> @ 1000174E : int32)
+  Class: Eq_769
+  DataType: int32
+  OrigDataType: int32
+T_770: (in ebp_13 + -4<i32> @ 1000174E : word32)
+  Class: Eq_770
+  DataType: word32
+  OrigDataType: word32
+T_771: (in Mem19[ebp_13 + -4<i32>:word32] @ 1000174E : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_772: (in dwLoc0C_84 @ 10001757 : Eq_476)
+  Class: Eq_476
+  DataType: Eq_476
+  OrigDataType: (union (ui32 u0) (ptr32 u1))
+T_773: (in 0x10000000<p32> @ 10001757 : ptr32)
+  Class: Eq_476
   DataType: ptr32
   OrigDataType: ptr32
-T_768: (in Mem24[ebp_13 + 8<32>:word32] @ 10001762 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_774: (in fn100016D0 @ 10001760 : ptr32)
+  Class: Eq_774
+  DataType: (ptr32 Eq_774)
+  OrigDataType: (ptr32 (fn T_777 (T_776)))
+T_775: (in signature of fn100016D0 @ 100016D0 : void)
+  Class: Eq_774
+  DataType: (ptr32 Eq_774)
+  OrigDataType: 
+T_776: (in 0x10000000<p32> @ 10001760 : ptr32)
+  Class: Eq_696
+  DataType: (ptr32 Eq_696)
+  OrigDataType: ptr32
+T_777: (in fn100016D0(&g_t10000000) @ 10001760 : word32)
+  Class: Eq_777
+  DataType: word32
   OrigDataType: word32
-T_769: (in 0x10000000<p32> @ 10001767 : ptr32)
-  Class: Eq_769
+T_778: (in 0<32> @ 10001760 : word32)
+  Class: Eq_777
+  DataType: word32
+  OrigDataType: word32
+T_779: (in fn100016D0(&g_t10000000) == 0<32> @ 00000000 : bool)
+  Class: Eq_779
+  DataType: bool
+  OrigDataType: bool
+T_780: (in 0xFFFFFFFE<32> @ 1000179F : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_781: (in -4<i32> @ 1000179F : int32)
+  Class: Eq_781
+  DataType: int32
+  OrigDataType: int32
+T_782: (in ebp_13 + -4<i32> @ 1000179F : word32)
+  Class: Eq_782
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_783: (in Mem58[ebp_13 + -4<i32>:word32] @ 1000179F : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_784: (in 0<32> @ 100017A6 : word32)
+  Class: Eq_761
+  DataType: ui32
+  OrigDataType: word32
+T_785: (in eax_36 @ 10001762 : Eq_158)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: ui32
+T_786: (in 8<32> @ 10001762 : word32)
+  Class: Eq_786
+  DataType: word32
+  OrigDataType: word32
+T_787: (in ebp_13 + 8<32> @ 10001762 : word32)
+  Class: Eq_787
+  DataType: ptr32
+  OrigDataType: ptr32
+T_788: (in Mem24[ebp_13 + 8<32>:word32] @ 10001762 : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_789: (in 0x10000000<p32> @ 10001767 : ptr32)
+  Class: Eq_789
   DataType: ui32
   OrigDataType: (union (ui32 u0) (ptr32 u1))
-T_770: (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
-  Class: Eq_456
-  DataType: Eq_456
+T_790: (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
+  Class: Eq_476
+  DataType: Eq_476
   OrigDataType: ui32
-T_771: (in eax_43 @ 10001769 : (ptr32 Eq_771))
-  Class: Eq_771
-  DataType: (ptr32 Eq_771)
-  OrigDataType: (ptr32 (struct (24 T_781 t0024)))
-T_772: (in fn10001700 @ 10001769 : ptr32)
-  Class: Eq_772
-  DataType: (ptr32 Eq_772)
-  OrigDataType: (ptr32 (fn T_776 (T_774, T_775)))
-T_773: (in signature of fn10001700 @ 10001700 : void)
-  Class: Eq_772
-  DataType: (ptr32 Eq_772)
+T_791: (in eax_43 @ 10001769 : (ptr32 Eq_791))
+  Class: Eq_791
+  DataType: (ptr32 Eq_791)
+  OrigDataType: (ptr32 (struct (24 T_801 t0024)))
+T_792: (in fn10001700 @ 10001769 : ptr32)
+  Class: Eq_792
+  DataType: (ptr32 Eq_792)
+  OrigDataType: (ptr32 (fn T_796 (T_794, T_795)))
+T_793: (in signature of fn10001700 @ 10001700 : void)
+  Class: Eq_792
+  DataType: (ptr32 Eq_792)
   OrigDataType: 
-T_774: (in 0x10000000<p32> @ 10001769 : ptr32)
-  Class: Eq_701
-  DataType: (ptr32 Eq_701)
+T_794: (in 0x10000000<p32> @ 10001769 : ptr32)
+  Class: Eq_721
+  DataType: (ptr32 Eq_721)
   OrigDataType: ptr32
-T_775: (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
-  Class: Eq_702
+T_795: (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
+  Class: Eq_722
   DataType: uint32
   OrigDataType: ui32
-T_776: (in fn10001700(&g_t10000000, eax_36 - 0x10000000<p32>) @ 10001769 : word32)
-  Class: Eq_771
-  DataType: (ptr32 Eq_771)
+T_796: (in fn10001700(&g_t10000000, eax_36 - 0x10000000<p32>) @ 10001769 : word32)
+  Class: Eq_791
+  DataType: (ptr32 Eq_791)
   OrigDataType: word32
-T_777: (in 0<32> @ 10001772 : word32)
-  Class: Eq_771
-  DataType: (ptr32 Eq_771)
+T_797: (in 0<32> @ 10001772 : word32)
+  Class: Eq_791
+  DataType: (ptr32 Eq_791)
   OrigDataType: word32
-T_778: (in eax_43 == null @ 00000000 : bool)
-  Class: Eq_778
+T_798: (in eax_43 == null @ 00000000 : bool)
+  Class: Eq_798
   DataType: bool
   OrigDataType: bool
-T_779: (in 0x24<32> @ 1000177C : word32)
-  Class: Eq_779
+T_799: (in 0x24<32> @ 1000177C : word32)
+  Class: Eq_799
   DataType: word32
   OrigDataType: word32
-T_780: (in eax_43 + 0x24<32> @ 1000177C : word32)
-  Class: Eq_780
-  DataType: word32
-  OrigDataType: word32
-T_781: (in Mem42[eax_43 + 0x24<32>:word32] @ 1000177C : word32)
-  Class: Eq_781
-  DataType: uint32
-  OrigDataType: uint32
-T_782: (in 0x1F<32> @ 1000177C : word32)
-  Class: Eq_782
-  DataType: word32
-  OrigDataType: word32
-T_783: (in eax_43->dw0024 >> 0x1F<32> @ 00000000 : word32)
-  Class: Eq_783
-  DataType: uint32
-  OrigDataType: uint32
-T_784: (in ~(eax_43->dw0024 >> 0x1F<32>) @ 1000177C : word32)
-  Class: Eq_784
-  DataType: uint32
-  OrigDataType: uint32
-T_785: (in 1<32> @ 1000177C : word32)
-  Class: Eq_785
-  DataType: ui32
-  OrigDataType: ui32
-T_786: (in ~(eax_43->dw0024 >> 0x1F<32>) & 1<32> @ 00000000 : word32)
-  Class: Eq_741
-  DataType: ui32
-  OrigDataType: ui32
-T_787: (in 0xFFFFFFFE<32> @ 1000177F : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_788: (in -4<i32> @ 1000177F : int32)
-  Class: Eq_788
-  DataType: int32
-  OrigDataType: int32
-T_789: (in ebp_13 + -4<i32> @ 1000177F : word32)
-  Class: Eq_789
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_790: (in Mem68[ebp_13 + -4<i32>:word32] @ 1000177F : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_791: (in fn1000182D @ 100017AD : ptr32)
-  Class: Eq_453
-  DataType: (ptr32 Eq_453)
-  OrigDataType: (ptr32 (fn T_792 (T_743, T_752)))
-T_792: (in fn1000182D(ebp_13, dwLoc0C_84) @ 100017AD : word32)
-  Class: Eq_373
-  DataType: ptr32
-  OrigDataType: word32
-T_793: (in eax @ 100017AD : word32)
-  Class: Eq_793
-  DataType: word32
-  OrigDataType: word32
-T_794: (in 1<32> @ 100017CB : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_795: (in dwArg08 != 1<32> @ 00000000 : bool)
-  Class: Eq_795
-  DataType: bool
-  OrigDataType: bool
-T_796: (in 1<32> @ 100017E3 : word32)
-  Class: Eq_793
-  DataType: word32
-  OrigDataType: word32
-T_797: (in 100020CC @ 100017D4 : ptr32)
-  Class: Eq_797
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_798 t0000)))
-T_798: (in Mem0[0x100020CC<p32>:word32] @ 100017D4 : word32)
-  Class: Eq_462
-  DataType: word32
-  OrigDataType: word32
-T_799: (in 0<32> @ 100017D4 : word32)
-  Class: Eq_462
-  DataType: word32
-  OrigDataType: word32
-T_800: (in g_dw100020CC != 0<32> @ 00000000 : bool)
+T_800: (in eax_43 + 0x24<32> @ 1000177C : word32)
   Class: Eq_800
-  DataType: bool
-  OrigDataType: bool
-T_801: (in DisableThreadLibraryCalls @ 100017DA : ptr32)
-  Class: Eq_801
-  DataType: (ptr32 Eq_801)
-  OrigDataType: (ptr32 (fn T_804 (T_482)))
-T_802: (in signature of DisableThreadLibraryCalls @ 00000000 : void)
-  Class: Eq_801
-  DataType: (ptr32 Eq_801)
-  OrigDataType: 
-T_803: (in hLibModule @ 100017DA : HMODULE)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: 
-T_804: (in DisableThreadLibraryCalls(dwArg04) @ 100017DA : BOOL)
-  Class: Eq_660
-  DataType: Eq_660
-  OrigDataType: BOOL
-T_805: (in ebp @ 100017DA : ptr32)
-  Class: Eq_805
-  DataType: ptr32
+  DataType: word32
   OrigDataType: word32
-T_806: (in esp_14 @ 10001800 : (ptr32 Eq_806))
-  Class: Eq_806
-  DataType: (ptr32 Eq_806)
-  OrigDataType: (ptr32 (struct (FFFFFFEC T_830 tFFFFFFEC) (FFFFFFF0 T_827 tFFFFFFF0) (FFFFFFF4 T_819 tFFFFFFF4) (FFFFFFF8 T_816 tFFFFFFF8) (FFFFFFFC T_813 tFFFFFFFC)))
-T_807: (in fp @ 10001800 : ptr32)
-  Class: Eq_807
-  DataType: ptr32
-  OrigDataType: ptr32
-T_808: (in 8<i32> @ 10001800 : int32)
+T_801: (in Mem42[eax_43 + 0x24<32>:word32] @ 1000177C : word32)
+  Class: Eq_801
+  DataType: uint32
+  OrigDataType: uint32
+T_802: (in 0x1F<32> @ 1000177C : word32)
+  Class: Eq_802
+  DataType: word32
+  OrigDataType: word32
+T_803: (in eax_43->dw0024 >> 0x1F<32> @ 00000000 : word32)
+  Class: Eq_803
+  DataType: uint32
+  OrigDataType: uint32
+T_804: (in ~(eax_43->dw0024 >> 0x1F<32>) @ 1000177C : word32)
+  Class: Eq_804
+  DataType: uint32
+  OrigDataType: uint32
+T_805: (in 1<32> @ 1000177C : word32)
+  Class: Eq_805
+  DataType: ui32
+  OrigDataType: ui32
+T_806: (in ~(eax_43->dw0024 >> 0x1F<32>) & 1<32> @ 00000000 : word32)
+  Class: Eq_761
+  DataType: ui32
+  OrigDataType: ui32
+T_807: (in 0xFFFFFFFE<32> @ 1000177F : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_808: (in -4<i32> @ 1000177F : int32)
   Class: Eq_808
   DataType: int32
   OrigDataType: int32
-T_809: (in fp - 8<i32> @ 00000000 : word32)
+T_809: (in ebp_13 + -4<i32> @ 1000177F : word32)
   Class: Eq_809
-  DataType: ptr32
-  OrigDataType: ptr32
-T_810: (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
-  Class: Eq_806
-  DataType: (ptr32 Eq_806)
-  OrigDataType: ptr32
-T_811: (in -4<i32> @ 10001802 : int32)
-  Class: Eq_811
-  DataType: int32
-  OrigDataType: int32
-T_812: (in esp_14 + -4<i32> @ 10001802 : word32)
-  Class: Eq_812
-  DataType: ptr32
-  OrigDataType: ptr32
-T_813: (in Mem17[esp_14 + -4<i32>:word32] @ 10001802 : word32)
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: word32
-T_814: (in -8<i32> @ 10001803 : int32)
-  Class: Eq_814
-  DataType: int32
-  OrigDataType: int32
-T_815: (in esp_14 + -8<i32> @ 10001803 : word32)
-  Class: Eq_815
-  DataType: ptr32
-  OrigDataType: ptr32
-T_816: (in Mem20[esp_14 + -8<i32>:word32] @ 10001803 : word32)
-  Class: Eq_371
-  DataType: ptr32
-  OrigDataType: word32
-T_817: (in -12<i32> @ 10001804 : int32)
-  Class: Eq_817
-  DataType: int32
-  OrigDataType: int32
-T_818: (in esp_14 + -12<i32> @ 10001804 : word32)
-  Class: Eq_818
-  DataType: ptr32
-  OrigDataType: ptr32
-T_819: (in Mem23[esp_14 + -12<i32>:word32] @ 10001804 : word32)
-  Class: Eq_372
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_810: (in Mem68[ebp_13 + -4<i32>:word32] @ 1000177F : word32)
+  Class: Eq_430
   DataType: word32
   OrigDataType: word32
-T_820: (in 10003000 @ 1000180F : ptr32)
+T_811: (in fn1000182D @ 100017AD : ptr32)
+  Class: Eq_473
+  DataType: (ptr32 Eq_473)
+  OrigDataType: (ptr32 (fn T_812 (T_763, T_772)))
+T_812: (in fn1000182D(ebp_13, dwLoc0C_84) @ 100017AD : word32)
+  Class: Eq_393
+  DataType: ptr32
+  OrigDataType: word32
+T_813: (in eax @ 100017AD : word32)
+  Class: Eq_813
+  DataType: word32
+  OrigDataType: word32
+T_814: (in 1<32> @ 100017CB : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_815: (in dwArg08 != 1<32> @ 00000000 : bool)
+  Class: Eq_815
+  DataType: bool
+  OrigDataType: bool
+T_816: (in 1<32> @ 100017E3 : word32)
+  Class: Eq_813
+  DataType: word32
+  OrigDataType: word32
+T_817: (in 100020CC @ 100017D4 : ptr32)
+  Class: Eq_817
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_818 t0000)))
+T_818: (in Mem0[0x100020CC<p32>:word32] @ 100017D4 : word32)
+  Class: Eq_482
+  DataType: word32
+  OrigDataType: word32
+T_819: (in 0<32> @ 100017D4 : word32)
+  Class: Eq_482
+  DataType: word32
+  OrigDataType: word32
+T_820: (in g_dw100020CC != 0<32> @ 00000000 : bool)
   Class: Eq_820
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_821 t0000)))
-T_821: (in Mem23[0x10003000<p32>:word32] @ 1000180F : word32)
+  DataType: bool
+  OrigDataType: bool
+T_821: (in DisableThreadLibraryCalls @ 100017DA : ptr32)
   Class: Eq_821
-  DataType: ui32
-  OrigDataType: word32
-T_822: (in 8<32> @ 1000180F : word32)
-  Class: Eq_822
-  DataType: int32
-  OrigDataType: int32
-T_823: (in fp + 8<32> @ 00000000 : word32)
-  Class: Eq_823
-  DataType: ptr32
-  OrigDataType: ptr32
-T_824: (in g_dw10003000 ^ fp + 8<32> @ 00000000 : word32)
-  Class: Eq_824
-  DataType: ui32
-  OrigDataType: ui32
-T_825: (in -16<i32> @ 1000180F : int32)
+  DataType: (ptr32 Eq_821)
+  OrigDataType: (ptr32 (fn T_824 (T_502)))
+T_822: (in signature of DisableThreadLibraryCalls @ 00000000 : void)
+  Class: Eq_821
+  DataType: (ptr32 Eq_821)
+  OrigDataType: 
+T_823: (in hLibModule @ 100017DA : HMODULE)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: 
+T_824: (in DisableThreadLibraryCalls(dwArg04) @ 100017DA : BOOL)
+  Class: Eq_680
+  DataType: Eq_680
+  OrigDataType: BOOL
+T_825: (in ebp @ 100017DA : ptr32)
   Class: Eq_825
-  DataType: int32
-  OrigDataType: int32
-T_826: (in esp_14 + -16<i32> @ 1000180F : word32)
+  DataType: ptr32
+  OrigDataType: word32
+T_826: (in esp_14 @ 10001800 : (ptr32 Eq_826))
   Class: Eq_826
+  DataType: (ptr32 Eq_826)
+  OrigDataType: (ptr32 (struct (FFFFFFEC T_850 tFFFFFFEC) (FFFFFFF0 T_847 tFFFFFFF0) (FFFFFFF4 T_839 tFFFFFFF4) (FFFFFFF8 T_836 tFFFFFFF8) (FFFFFFFC T_833 tFFFFFFFC)))
+T_827: (in fp @ 10001800 : ptr32)
+  Class: Eq_827
   DataType: ptr32
   OrigDataType: ptr32
-T_827: (in Mem32[esp_14 + -16<i32>:word32] @ 1000180F : word32)
-  Class: Eq_824
-  DataType: ui32
-  OrigDataType: word32
-T_828: (in -20<i32> @ 10001813 : int32)
+T_828: (in 8<i32> @ 10001800 : int32)
   Class: Eq_828
   DataType: int32
   OrigDataType: int32
-T_829: (in esp_14 + -20<i32> @ 10001813 : word32)
+T_829: (in fp - 8<i32> @ 00000000 : word32)
   Class: Eq_829
   DataType: ptr32
   OrigDataType: ptr32
-T_830: (in Mem36[esp_14 + -20<i32>:word32] @ 10001813 : word32)
-  Class: Eq_397
-  DataType: word32
-  OrigDataType: word32
-T_831: (in 8<32> @ 10001826 : word32)
+T_830: (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
+  Class: Eq_826
+  DataType: (ptr32 Eq_826)
+  OrigDataType: ptr32
+T_831: (in -4<i32> @ 10001802 : int32)
   Class: Eq_831
-  DataType: ui32
-  OrigDataType: ui32
-T_832: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_832
-  DataType: ptr32
-  OrigDataType: ptr32
-T_833: (in fs @ 10001826 : selector)
-  Class: Eq_833
-  DataType: (ptr32 Eq_833)
-  OrigDataType: (ptr32 (segment (0 T_835 t0000)))
-T_834: (in 0<32> @ 10001826 : word32)
-  Class: Eq_834
-  DataType: (memptr (ptr32 Eq_833) ptr32)
-  OrigDataType: (memptr T_833 (struct (0 T_835 t0000)))
-T_835: (in Mem41[fs:0<32>:word32] @ 10001826 : word32)
-  Class: Eq_832
-  DataType: ptr32
-  OrigDataType: word32
-T_836: (in fp + 8<32> @ 00000000 : word32)
-  Class: Eq_805
-  DataType: ptr32
-  OrigDataType: ptr32
-T_837: (in edi @ 1000182C : word32)
-  Class: Eq_837
-  DataType: word32
-  OrigDataType: word32
-T_838: (in -16<i32> @ 10001830 : int32)
-  Class: Eq_838
   DataType: int32
   OrigDataType: int32
-T_839: (in ebp + -16<i32> @ 10001830 : word32)
-  Class: Eq_839
-  DataType: word32
-  OrigDataType: word32
-T_840: (in Mem0[ebp + -16<i32>:word32] @ 10001830 : word32)
-  Class: Eq_840
-  DataType: word32
-  OrigDataType: word32
-T_841: (in fs @ 10001830 : selector)
-  Class: Eq_841
-  DataType: (ptr32 Eq_841)
-  OrigDataType: (ptr32 (segment (0 T_843 t0000)))
-T_842: (in 0x00000000<p32> @ 10001830 : ptr32)
-  Class: Eq_842
-  DataType: Eq_842
-  OrigDataType: (union (ptr32 u0) ((memptr T_841 (struct (0 word32 dw0000))) u1))
-T_843: (in Mem8[fs:0x00000000<p32>:word32] @ 10001830 : word32)
-  Class: Eq_840
-  DataType: word32
-  OrigDataType: word32
-T_844: (in 0<32> @ 1000183F : word32)
-  Class: Eq_844
-  DataType: word32
-  OrigDataType: word32
-T_845: (in ebp + 0<32> @ 1000183F : word32)
-  Class: Eq_845
+T_832: (in esp_14 + -4<i32> @ 10001802 : word32)
+  Class: Eq_832
   DataType: ptr32
   OrigDataType: ptr32
-T_846: (in Mem22[ebp + 0<32>:word32] @ 1000183F : word32)
-  Class: Eq_456
-  DataType: Eq_456
+T_833: (in Mem17[esp_14 + -4<i32>:word32] @ 10001802 : word32)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
   OrigDataType: word32
-T_847: (in dwArg08 @ 10001840 : word32)
+T_834: (in -8<i32> @ 10001803 : int32)
+  Class: Eq_834
+  DataType: int32
+  OrigDataType: int32
+T_835: (in esp_14 + -8<i32> @ 10001803 : word32)
+  Class: Eq_835
+  DataType: ptr32
+  OrigDataType: ptr32
+T_836: (in Mem20[esp_14 + -8<i32>:word32] @ 10001803 : word32)
+  Class: Eq_391
+  DataType: ptr32
+  OrigDataType: word32
+T_837: (in -12<i32> @ 10001804 : int32)
   Class: Eq_837
+  DataType: int32
+  OrigDataType: int32
+T_838: (in esp_14 + -12<i32> @ 10001804 : word32)
+  Class: Eq_838
+  DataType: ptr32
+  OrigDataType: ptr32
+T_839: (in Mem23[esp_14 + -12<i32>:word32] @ 10001804 : word32)
+  Class: Eq_392
   DataType: word32
   OrigDataType: word32
-T_848: (in eax_9 @ 1000186A : ui32)
-  Class: Eq_821
+T_840: (in 10003000 @ 1000180F : ptr32)
+  Class: Eq_840
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_841 t0000)))
+T_841: (in Mem23[0x10003000<p32>:word32] @ 1000180F : word32)
+  Class: Eq_841
+  DataType: ui32
+  OrigDataType: word32
+T_842: (in 8<32> @ 1000180F : word32)
+  Class: Eq_842
+  DataType: int32
+  OrigDataType: int32
+T_843: (in fp + 8<32> @ 00000000 : word32)
+  Class: Eq_843
+  DataType: ptr32
+  OrigDataType: ptr32
+T_844: (in g_dw10003000 ^ fp + 8<32> @ 00000000 : word32)
+  Class: Eq_844
   DataType: ui32
   OrigDataType: ui32
-T_849: (in 10003000 @ 1000186A : ptr32)
+T_845: (in -16<i32> @ 1000180F : int32)
+  Class: Eq_845
+  DataType: int32
+  OrigDataType: int32
+T_846: (in esp_14 + -16<i32> @ 1000180F : word32)
+  Class: Eq_846
+  DataType: ptr32
+  OrigDataType: ptr32
+T_847: (in Mem32[esp_14 + -16<i32>:word32] @ 1000180F : word32)
+  Class: Eq_844
+  DataType: ui32
+  OrigDataType: word32
+T_848: (in -20<i32> @ 10001813 : int32)
+  Class: Eq_848
+  DataType: int32
+  OrigDataType: int32
+T_849: (in esp_14 + -20<i32> @ 10001813 : word32)
   Class: Eq_849
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_850 t0000)))
-T_850: (in Mem6[0x10003000<p32>:word32] @ 1000186A : word32)
-  Class: Eq_821
-  DataType: ui32
+  DataType: ptr32
+  OrigDataType: ptr32
+T_850: (in Mem36[esp_14 + -20<i32>:word32] @ 10001813 : word32)
+  Class: Eq_417
+  DataType: word32
   OrigDataType: word32
-T_851: (in 0xBB40E64E<32> @ 10001885 : word32)
-  Class: Eq_821
+T_851: (in 8<32> @ 10001826 : word32)
+  Class: Eq_851
   DataType: ui32
-  OrigDataType: word32
-T_852: (in eax_9 == 0xBB40E64E<32> @ 00000000 : bool)
+  OrigDataType: ui32
+T_852: (in fp - 8<32> @ 00000000 : word32)
   Class: Eq_852
+  DataType: ptr32
+  OrigDataType: ptr32
+T_853: (in fs @ 10001826 : selector)
+  Class: Eq_853
+  DataType: (ptr32 Eq_853)
+  OrigDataType: (ptr32 (segment (0 T_855 t0000)))
+T_854: (in 0<32> @ 10001826 : word32)
+  Class: Eq_854
+  DataType: (memptr (ptr32 Eq_853) ptr32)
+  OrigDataType: (memptr T_853 (struct (0 T_855 t0000)))
+T_855: (in Mem41[fs:0<32>:word32] @ 10001826 : word32)
+  Class: Eq_852
+  DataType: ptr32
+  OrigDataType: word32
+T_856: (in fp + 8<32> @ 00000000 : word32)
+  Class: Eq_825
+  DataType: ptr32
+  OrigDataType: ptr32
+T_857: (in edi @ 1000182C : word32)
+  Class: Eq_857
+  DataType: word32
+  OrigDataType: word32
+T_858: (in -16<i32> @ 10001830 : int32)
+  Class: Eq_858
+  DataType: int32
+  OrigDataType: int32
+T_859: (in ebp + -16<i32> @ 10001830 : word32)
+  Class: Eq_859
+  DataType: word32
+  OrigDataType: word32
+T_860: (in Mem0[ebp + -16<i32>:word32] @ 10001830 : word32)
+  Class: Eq_860
+  DataType: word32
+  OrigDataType: word32
+T_861: (in fs @ 10001830 : selector)
+  Class: Eq_861
+  DataType: (ptr32 Eq_861)
+  OrigDataType: (ptr32 (segment (0 T_863 t0000)))
+T_862: (in 0x00000000<p32> @ 10001830 : ptr32)
+  Class: Eq_862
+  DataType: Eq_862
+  OrigDataType: (union (ptr32 u0) ((memptr T_861 (struct (0 word32 dw0000))) u1))
+T_863: (in Mem8[fs:0x00000000<p32>:word32] @ 10001830 : word32)
+  Class: Eq_860
+  DataType: word32
+  OrigDataType: word32
+T_864: (in 0<32> @ 1000183F : word32)
+  Class: Eq_864
+  DataType: word32
+  OrigDataType: word32
+T_865: (in ebp + 0<32> @ 1000183F : word32)
+  Class: Eq_865
+  DataType: ptr32
+  OrigDataType: ptr32
+T_866: (in Mem22[ebp + 0<32>:word32] @ 1000183F : word32)
+  Class: Eq_476
+  DataType: Eq_476
+  OrigDataType: word32
+T_867: (in dwArg08 @ 10001840 : word32)
+  Class: Eq_857
+  DataType: word32
+  OrigDataType: word32
+T_868: (in eax_9 @ 1000186A : ui32)
+  Class: Eq_841
+  DataType: ui32
+  OrigDataType: ui32
+T_869: (in 10003000 @ 1000186A : ptr32)
+  Class: Eq_869
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_870 t0000)))
+T_870: (in Mem6[0x10003000<p32>:word32] @ 1000186A : word32)
+  Class: Eq_841
+  DataType: ui32
+  OrigDataType: word32
+T_871: (in 0xBB40E64E<32> @ 10001885 : word32)
+  Class: Eq_841
+  DataType: ui32
+  OrigDataType: word32
+T_872: (in eax_9 == 0xBB40E64E<32> @ 00000000 : bool)
+  Class: Eq_872
   DataType: bool
   OrigDataType: bool
-T_853: (in GetSystemTimeAsFileTime @ 10001899 : ptr32)
-  Class: Eq_853
-  DataType: (ptr32 Eq_853)
-  OrigDataType: (ptr32 (fn T_859 (T_858)))
-T_854: (in signature of GetSystemTimeAsFileTime @ 00000000 : void)
-  Class: Eq_853
-  DataType: (ptr32 Eq_853)
+T_873: (in GetSystemTimeAsFileTime @ 10001899 : ptr32)
+  Class: Eq_873
+  DataType: (ptr32 Eq_873)
+  OrigDataType: (ptr32 (fn T_879 (T_878)))
+T_874: (in signature of GetSystemTimeAsFileTime @ 00000000 : void)
+  Class: Eq_873
+  DataType: (ptr32 Eq_873)
   OrigDataType: 
-T_855: (in lpSystemTimeAsFileTime @ 10001899 : LPFILETIME)
-  Class: Eq_855
-  DataType: Eq_855
+T_875: (in lpSystemTimeAsFileTime @ 10001899 : LPFILETIME)
+  Class: Eq_875
+  DataType: Eq_875
   OrigDataType: 
-T_856: (in fp @ 10001899 : ptr32)
-  Class: Eq_856
+T_876: (in fp @ 10001899 : ptr32)
+  Class: Eq_876
   DataType: ptr32
   OrigDataType: ptr32
-T_857: (in 0xC<32> @ 10001899 : word32)
-  Class: Eq_857
+T_877: (in 0xC<32> @ 10001899 : word32)
+  Class: Eq_877
   DataType: ui32
   OrigDataType: ui32
-T_858: (in fp - 0xC<32> @ 00000000 : word32)
-  Class: Eq_855
-  DataType: Eq_855
+T_878: (in fp - 0xC<32> @ 00000000 : word32)
+  Class: Eq_875
+  DataType: Eq_875
   OrigDataType: LPFILETIME
-T_859: (in GetSystemTimeAsFileTime(fp - 0xC<32>) @ 10001899 : void)
-  Class: Eq_859
+T_879: (in GetSystemTimeAsFileTime(fp - 0xC<32>) @ 10001899 : void)
+  Class: Eq_879
   DataType: void
   OrigDataType: void
-T_860: (in esi_46 @ 100018BB : ui32)
-  Class: Eq_860
-  DataType: ui32
-  OrigDataType: ui32
-T_861: (in GetCurrentProcessId @ 100018BB : ptr32)
-  Class: Eq_861
-  DataType: (ptr32 Eq_861)
-  OrigDataType: (ptr32 (fn T_863 ()))
-T_862: (in signature of GetCurrentProcessId @ 00000000 : void)
-  Class: Eq_861
-  DataType: (ptr32 Eq_861)
-  OrigDataType: 
-T_863: (in GetCurrentProcessId() @ 100018BB : DWORD)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_864: (in GetCurrentThreadId @ 100018BB : ptr32)
-  Class: Eq_864
-  DataType: (ptr32 Eq_864)
-  OrigDataType: (ptr32 (fn T_866 ()))
-T_865: (in signature of GetCurrentThreadId @ 00000000 : void)
-  Class: Eq_864
-  DataType: (ptr32 Eq_864)
-  OrigDataType: 
-T_866: (in GetCurrentThreadId() @ 100018BB : DWORD)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_867: (in GetCurrentProcessId() ^ GetCurrentThreadId() @ 00000000 : word32)
-  Class: Eq_867
-  DataType: ui32
-  OrigDataType: ui32
-T_868: (in GetTickCount @ 100018BB : ptr32)
-  Class: Eq_868
-  DataType: (ptr32 Eq_868)
-  OrigDataType: (ptr32 (fn T_870 ()))
-T_869: (in signature of GetTickCount @ 00000000 : void)
-  Class: Eq_868
-  DataType: (ptr32 Eq_868)
-  OrigDataType: 
-T_870: (in GetTickCount() @ 100018BB : DWORD)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_871: (in GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount() @ 00000000 : word32)
-  Class: Eq_860
-  DataType: ui32
-  OrigDataType: ui32
-T_872: (in QueryPerformanceCounter @ 100018C1 : ptr32)
-  Class: Eq_872
-  DataType: (ptr32 Eq_872)
-  OrigDataType: (ptr32 (fn T_877 (T_876)))
-T_873: (in signature of QueryPerformanceCounter @ 00000000 : void)
-  Class: Eq_872
-  DataType: (ptr32 Eq_872)
-  OrigDataType: 
-T_874: (in lpPerformanceCount @ 100018C1 : (ptr32 LARGE_INTEGER))
-  Class: Eq_874
-  DataType: (ptr32 Eq_874)
-  OrigDataType: 
-T_875: (in 0x14<32> @ 100018C1 : word32)
-  Class: Eq_875
-  DataType: ui32
-  OrigDataType: ui32
-T_876: (in fp - 0x14<32> @ 00000000 : word32)
-  Class: Eq_874
-  DataType: (ptr32 Eq_874)
-  OrigDataType: (ptr32 LARGE_INTEGER)
-T_877: (in QueryPerformanceCounter(fp - 0x14<32>) @ 100018C1 : BOOL)
-  Class: Eq_660
-  DataType: Eq_660
-  OrigDataType: BOOL
-T_878: (in esi_54 @ 100018CD : ui32)
-  Class: Eq_821
-  DataType: ui32
-  OrigDataType: ui32
-T_879: (in dwLoc10 @ 100018CD : word32)
-  Class: Eq_879
-  DataType: word32
-  OrigDataType: word32
-T_880: (in dwLoc14 @ 100018CD : word32)
+T_880: (in esi_46 @ 100018BB : ui32)
   Class: Eq_880
-  DataType: word32
-  OrigDataType: word32
-T_881: (in dwLoc10 ^ dwLoc14 @ 00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_881: (in GetCurrentProcessId @ 100018BB : ptr32)
   Class: Eq_881
-  DataType: ui32
-  OrigDataType: ui32
-T_882: (in esi_46 ^ (dwLoc10 ^ dwLoc14) @ 00000000 : word32)
-  Class: Eq_821
-  DataType: ui32
-  OrigDataType: ui32
-T_883: (in 0xBB40E64E<32> @ 100018D1 : word32)
-  Class: Eq_821
-  DataType: ui32
-  OrigDataType: word32
-T_884: (in esi_54 != 0xBB40E64E<32> @ 00000000 : bool)
+  DataType: (ptr32 Eq_881)
+  OrigDataType: (ptr32 (fn T_883 ()))
+T_882: (in signature of GetCurrentProcessId @ 00000000 : void)
+  Class: Eq_881
+  DataType: (ptr32 Eq_881)
+  OrigDataType: 
+T_883: (in GetCurrentProcessId() @ 100018BB : DWORD)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_884: (in GetCurrentThreadId @ 100018BB : ptr32)
   Class: Eq_884
-  DataType: bool
-  OrigDataType: bool
-T_885: (in 0xFFFF0000<32> @ 10001889 : word32)
-  Class: Eq_885
+  DataType: (ptr32 Eq_884)
+  OrigDataType: (ptr32 (fn T_886 ()))
+T_885: (in signature of GetCurrentThreadId @ 00000000 : void)
+  Class: Eq_884
+  DataType: (ptr32 Eq_884)
+  OrigDataType: 
+T_886: (in GetCurrentThreadId() @ 100018BB : DWORD)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_887: (in GetCurrentProcessId() ^ GetCurrentThreadId() @ 00000000 : word32)
+  Class: Eq_887
   DataType: ui32
   OrigDataType: ui32
-T_886: (in eax_9 & 0xFFFF0000<32> @ 00000000 : word32)
-  Class: Eq_886
-  DataType: ui32
-  OrigDataType: ui32
-T_887: (in 0<32> @ 10001889 : word32)
-  Class: Eq_886
-  DataType: ui32
-  OrigDataType: word32
-T_888: (in (eax_9 & 0xFFFF0000<32>) == 0<32> @ 00000000 : bool)
+T_888: (in GetTickCount @ 100018BB : ptr32)
   Class: Eq_888
-  DataType: bool
-  OrigDataType: bool
-T_889: (in ~eax_9 @ 1000188D : word32)
-  Class: Eq_889
+  DataType: (ptr32 Eq_888)
+  OrigDataType: (ptr32 (fn T_890 ()))
+T_889: (in signature of GetTickCount @ 00000000 : void)
+  Class: Eq_888
+  DataType: (ptr32 Eq_888)
+  OrigDataType: 
+T_890: (in GetTickCount() @ 100018BB : DWORD)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_891: (in GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount() @ 00000000 : word32)
+  Class: Eq_880
   DataType: ui32
   OrigDataType: ui32
-T_890: (in 10003004 @ 1000188D : ptr32)
-  Class: Eq_890
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_891 t0000)))
-T_891: (in Mem76[0x10003004<p32>:word32] @ 1000188D : word32)
-  Class: Eq_889
-  DataType: ui32
-  OrigDataType: word32
-T_892: (in 0xFFFF0000<32> @ 100018DC : word32)
+T_892: (in QueryPerformanceCounter @ 100018C1 : ptr32)
   Class: Eq_892
-  DataType: ui32
-  OrigDataType: ui32
-T_893: (in esi_54 & 0xFFFF0000<32> @ 00000000 : word32)
-  Class: Eq_893
-  DataType: ui32
-  OrigDataType: ui32
-T_894: (in 0<32> @ 100018DC : word32)
-  Class: Eq_893
-  DataType: ui32
-  OrigDataType: word32
-T_895: (in (esi_54 & 0xFFFF0000<32>) != 0<32> @ 00000000 : bool)
+  DataType: (ptr32 Eq_892)
+  OrigDataType: (ptr32 (fn T_897 (T_896)))
+T_893: (in signature of QueryPerformanceCounter @ 00000000 : void)
+  Class: Eq_892
+  DataType: (ptr32 Eq_892)
+  OrigDataType: 
+T_894: (in lpPerformanceCount @ 100018C1 : (ptr32 LARGE_INTEGER))
+  Class: Eq_894
+  DataType: (ptr32 Eq_894)
+  OrigDataType: 
+T_895: (in tLoc14 @ 100018C1 : LARGE_INTEGER)
   Class: Eq_895
-  DataType: bool
-  OrigDataType: bool
-T_896: (in 0xBB40E64F<32> @ 100018D3 : word32)
-  Class: Eq_821
-  DataType: ui32
-  OrigDataType: word32
-T_897: (in 10003000 @ 100018E5 : ptr32)
-  Class: Eq_897
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_898 t0000)))
-T_898: (in Mem69[0x10003000<p32>:word32] @ 100018E5 : word32)
-  Class: Eq_821
-  DataType: ui32
-  OrigDataType: word32
-T_899: (in ~esi_54 @ 100018ED : word32)
-  Class: Eq_889
+  DataType: Eq_895
+  OrigDataType: LARGE_INTEGER
+T_896: (in &tLoc14 @ 100018C1 : (ptr32 LARGE_INTEGER))
+  Class: Eq_894
+  DataType: (ptr32 Eq_894)
+  OrigDataType: (ptr32 LARGE_INTEGER)
+T_897: (in QueryPerformanceCounter(&tLoc14) @ 100018C1 : BOOL)
+  Class: Eq_680
+  DataType: Eq_680
+  OrigDataType: BOOL
+T_898: (in esi_54 @ 100018CD : ui32)
+  Class: Eq_841
   DataType: ui32
   OrigDataType: ui32
-T_900: (in 10003004 @ 100018ED : ptr32)
+T_899: (in &tLoc14 @ 100018CD : (ptr32 LARGE_INTEGER))
+  Class: Eq_899
+  DataType: (ptr32 Eq_899)
+  OrigDataType: (ptr32 (struct (0 LARGE_INTEGER t0000) (4 T_902 t0004)))
+T_900: (in 4<i32> @ 100018CD : int32)
   Class: Eq_900
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_901 t0000)))
-T_901: (in Mem71[0x10003004<p32>:word32] @ 100018ED : word32)
-  Class: Eq_889
-  DataType: ui32
-  OrigDataType: word32
-T_902: (in 0x10<32> @ 100018E3 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_901: (in &tLoc14 + 4<i32> @ 100018CD : word32)
+  Class: Eq_901
+  DataType: ptr32
+  OrigDataType: ptr32
+T_902: (in Mem49[&tLoc14 + 4<i32>:word32] @ 100018CD : word32)
   Class: Eq_902
   DataType: word32
   OrigDataType: word32
-T_903: (in esi_54 << 0x10<32> @ 00000000 : word32)
+T_903: (in &tLoc14 @ 100018CD : (ptr32 LARGE_INTEGER))
   Class: Eq_903
-  DataType: ui32
-  OrigDataType: ui32
-T_904: (in esi_54 | esi_54 << 0x10<32> @ 00000000 : word32)
-  Class: Eq_821
-  DataType: ui32
-  OrigDataType: ui32
-T_905:
-  Class: Eq_905
+  DataType: (ptr32 Eq_903)
+  OrigDataType: (ptr32 (struct (0 LARGE_INTEGER t0000)))
+T_904: (in 0<32> @ 100018CD : word32)
+  Class: Eq_904
   DataType: word32
   OrigDataType: word32
-T_906:
+T_905: (in &tLoc14 + 0<32> @ 100018CD : word32)
+  Class: Eq_905
+  DataType: ptr32
+  OrigDataType: ptr32
+T_906: (in Mem49[&tLoc14 + 0<32>:word32] @ 100018CD : word32)
   Class: Eq_906
   DataType: word32
   OrigDataType: word32
-T_907:
+T_907: (in tLoc14.dw0004 ^ tLoc14 @ 00000000 : word32)
   Class: Eq_907
-  DataType: word32
+  DataType: ui32
+  OrigDataType: ui32
+T_908: (in esi_46 ^ (tLoc14.dw0004 ^ tLoc14) @ 00000000 : word32)
+  Class: Eq_841
+  DataType: ui32
+  OrigDataType: ui32
+T_909: (in 0xBB40E64E<32> @ 100018D1 : word32)
+  Class: Eq_841
+  DataType: ui32
   OrigDataType: word32
-T_908:
-  Class: Eq_908
-  DataType: word32
-  OrigDataType: word32
-T_909:
-  Class: Eq_909
-  DataType: word32
-  OrigDataType: word32
-T_910:
+T_910: (in esi_54 != 0xBB40E64E<32> @ 00000000 : bool)
   Class: Eq_910
-  DataType: word32
-  OrigDataType: word32
-T_911:
+  DataType: bool
+  OrigDataType: bool
+T_911: (in 0xFFFF0000<32> @ 10001889 : word32)
   Class: Eq_911
-  DataType: word32
-  OrigDataType: word32
-T_912:
+  DataType: ui32
+  OrigDataType: ui32
+T_912: (in eax_9 & 0xFFFF0000<32> @ 00000000 : word32)
   Class: Eq_912
-  DataType: word32
+  DataType: ui32
+  OrigDataType: ui32
+T_913: (in 0<32> @ 10001889 : word32)
+  Class: Eq_912
+  DataType: ui32
   OrigDataType: word32
-T_913:
-  Class: Eq_913
-  DataType: word32
-  OrigDataType: word32
-T_914:
+T_914: (in (eax_9 & 0xFFFF0000<32>) == 0<32> @ 00000000 : bool)
   Class: Eq_914
-  DataType: word32
-  OrigDataType: word32
-T_915:
+  DataType: bool
+  OrigDataType: bool
+T_915: (in ~eax_9 @ 1000188D : word32)
   Class: Eq_915
-  DataType: word32
-  OrigDataType: word32
-T_916:
+  DataType: ui32
+  OrigDataType: ui32
+T_916: (in 10003004 @ 1000188D : ptr32)
   Class: Eq_916
-  DataType: word32
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_917 t0000)))
+T_917: (in Mem76[0x10003004<p32>:word32] @ 1000188D : word32)
+  Class: Eq_915
+  DataType: ui32
   OrigDataType: word32
-T_917:
-  Class: Eq_917
-  DataType: word32
-  OrigDataType: word32
-T_918:
+T_918: (in 0xFFFF0000<32> @ 100018DC : word32)
   Class: Eq_918
-  DataType: word32
-  OrigDataType: word32
-T_919:
+  DataType: ui32
+  OrigDataType: ui32
+T_919: (in esi_54 & 0xFFFF0000<32> @ 00000000 : word32)
   Class: Eq_919
-  DataType: word32
+  DataType: ui32
+  OrigDataType: ui32
+T_920: (in 0<32> @ 100018DC : word32)
+  Class: Eq_919
+  DataType: ui32
   OrigDataType: word32
-T_920:
-  Class: Eq_920
-  DataType: word32
-  OrigDataType: word32
-T_921:
+T_921: (in (esi_54 & 0xFFFF0000<32>) != 0<32> @ 00000000 : bool)
   Class: Eq_921
-  DataType: word32
+  DataType: bool
+  OrigDataType: bool
+T_922: (in 0xBB40E64F<32> @ 100018D3 : word32)
+  Class: Eq_841
+  DataType: ui32
   OrigDataType: word32
-T_922:
-  Class: Eq_922
-  DataType: word32
-  OrigDataType: word32
-T_923:
+T_923: (in 10003000 @ 100018E5 : ptr32)
   Class: Eq_923
-  DataType: word32
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_924 t0000)))
+T_924: (in Mem69[0x10003000<p32>:word32] @ 100018E5 : word32)
+  Class: Eq_841
+  DataType: ui32
   OrigDataType: word32
-T_924:
-  Class: Eq_924
-  DataType: word32
-  OrigDataType: word32
-T_925:
-  Class: Eq_925
-  DataType: word32
-  OrigDataType: word32
-T_926:
+T_925: (in ~esi_54 @ 100018ED : word32)
+  Class: Eq_915
+  DataType: ui32
+  OrigDataType: ui32
+T_926: (in 10003004 @ 100018ED : ptr32)
   Class: Eq_926
-  DataType: word32
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_927 t0000)))
+T_927: (in Mem71[0x10003004<p32>:word32] @ 100018ED : word32)
+  Class: Eq_915
+  DataType: ui32
   OrigDataType: word32
-T_927:
-  Class: Eq_927
-  DataType: word32
-  OrigDataType: word32
-T_928:
+T_928: (in 0x10<32> @ 100018E3 : word32)
   Class: Eq_928
   DataType: word32
   OrigDataType: word32
-T_929:
+T_929: (in esi_54 << 0x10<32> @ 00000000 : word32)
   Class: Eq_929
-  DataType: word32
-  OrigDataType: word32
-T_930:
-  Class: Eq_930
-  DataType: word32
-  OrigDataType: word32
+  DataType: ui32
+  OrigDataType: ui32
+T_930: (in esi_54 | esi_54 << 0x10<32> @ 00000000 : word32)
+  Class: Eq_841
+  DataType: ui32
+  OrigDataType: ui32
 T_931:
   Class: Eq_931
   DataType: word32
@@ -4270,9 +4276,113 @@ T_939:
   Class: Eq_939
   DataType: word32
   OrigDataType: word32
+T_940:
+  Class: Eq_940
+  DataType: word32
+  OrigDataType: word32
+T_941:
+  Class: Eq_941
+  DataType: word32
+  OrigDataType: word32
+T_942:
+  Class: Eq_942
+  DataType: word32
+  OrigDataType: word32
+T_943:
+  Class: Eq_943
+  DataType: word32
+  OrigDataType: word32
+T_944:
+  Class: Eq_944
+  DataType: word32
+  OrigDataType: word32
+T_945:
+  Class: Eq_945
+  DataType: word32
+  OrigDataType: word32
+T_946:
+  Class: Eq_946
+  DataType: word32
+  OrigDataType: word32
+T_947:
+  Class: Eq_947
+  DataType: word32
+  OrigDataType: word32
+T_948:
+  Class: Eq_948
+  DataType: word32
+  OrigDataType: word32
+T_949:
+  Class: Eq_949
+  DataType: word32
+  OrigDataType: word32
+T_950:
+  Class: Eq_950
+  DataType: word32
+  OrigDataType: word32
+T_951:
+  Class: Eq_951
+  DataType: word32
+  OrigDataType: word32
+T_952:
+  Class: Eq_952
+  DataType: word32
+  OrigDataType: word32
+T_953:
+  Class: Eq_953
+  DataType: word32
+  OrigDataType: word32
+T_954:
+  Class: Eq_954
+  DataType: word32
+  OrigDataType: word32
+T_955:
+  Class: Eq_955
+  DataType: word32
+  OrigDataType: word32
+T_956:
+  Class: Eq_956
+  DataType: word32
+  OrigDataType: word32
+T_957:
+  Class: Eq_957
+  DataType: word32
+  OrigDataType: word32
+T_958:
+  Class: Eq_958
+  DataType: word32
+  OrigDataType: word32
+T_959:
+  Class: Eq_959
+  DataType: word32
+  OrigDataType: word32
+T_960:
+  Class: Eq_960
+  DataType: word32
+  OrigDataType: word32
+T_961:
+  Class: Eq_961
+  DataType: word32
+  OrigDataType: word32
+T_962:
+  Class: Eq_962
+  DataType: word32
+  OrigDataType: word32
+T_963:
+  Class: Eq_963
+  DataType: word32
+  OrigDataType: word32
+T_964:
+  Class: Eq_964
+  DataType: word32
+  OrigDataType: word32
+T_965:
+  Class: Eq_965
+  DataType: word32
+  OrigDataType: word32
 */
 typedef struct Globals {
-	Eq_676 t10000000;	// 10000000
+	Eq_696 t10000000;	// 10000000
 	<anonymous> * __imp__GetSystemTimeAsFileTime;	// 10002000
 	<anonymous> * __imp__GetCurrentProcessId;	// 10002004
 	<anonymous> * __imp__GetCurrentThreadId;	// 10002008
@@ -4308,10 +4418,10 @@ typedef struct Globals {
 	<anonymous> * __imp__PyArg_ParseTuple;	// 10002088
 	<anonymous> * __imp___Py_NoneStruct;	// 1000208C
 	<anonymous> * __imp__Py_BuildValue;	// 10002090
-	Eq_293 t10002098;	// 10002098
-	Eq_294 t1000209C;	// 1000209C
-	Eq_239 t100020A0;	// 100020A0
-	Eq_240 t100020A8;	// 100020A8
+	Eq_313 t10002098;	// 10002098
+	Eq_314 t1000209C;	// 1000209C
+	Eq_259 t100020A0;	// 100020A0
+	Eq_260 t100020A8;	// 100020A8
 	word32 dw100020CC;	// 100020CC
 	char str100020E0[];	// 100020E0
 	char str100020F4[];	// 100020F4
@@ -4371,7 +4481,7 @@ typedef struct Globals {
 	int32 dw10003070;	// 10003070
 	word32 dw100033A4;	// 100033A4
 	word32 dw100033A8;	// 100033A8
-	Eq_185 t100033AC;	// 100033AC
+	Eq_205 t100033AC;	// 100033AC
 	void * ptr100033B0;	// 100033B0
 	void * ptr100033B4;	// 100033B4
 	<anonymous> * ptr100033B8;	// 100033B8
@@ -4385,228 +4495,237 @@ typedef PyObject Eq_4;
 
 typedef PyObject * (Eq_6)(PyObject *, char *, int32 *, int32 *);
 
-typedef PyObject * (Eq_21)(char *, int32);
+typedef PyObject * (Eq_20)(char *, int32);
 
-typedef PyObject * (Eq_31)(PyObject *, char *, int32 *, int32 *);
+typedef PyObject * (Eq_36)(PyObject *, char *, int32 *, int32 *);
 
-typedef PyObject * (Eq_44)(char *, int32);
+typedef PyObject * (Eq_48)(char *, int32);
 
-typedef PyObject * (Eq_53)(PyObject *, char *, int32 *, int32 *);
+typedef PyObject * (Eq_63)(PyObject *, char *, int32 *, int32 *);
 
-typedef PyObject * (Eq_66)(char *, int32);
+typedef PyObject * (Eq_75)(char *, int32);
 
-typedef PyObject * (Eq_77)(PyObject *, char *, real32 *, real32 *);
+typedef PyObject * (Eq_92)(PyObject *, char *, real32 *, real32 *);
 
-typedef PyObject * (Eq_90)(char *, real64);
+typedef PyObject * (Eq_104)(char *, real64);
 
-typedef PyObject Eq_100;
+typedef PyObject Eq_120;
 
-typedef PyObject Eq_101;
+typedef PyObject Eq_121;
 
-typedef PyObject Eq_102;
+typedef PyObject Eq_122;
 
-typedef PyObject * (Eq_104)(PyObject *, char *);
+typedef PyObject * (Eq_124)(PyObject *, char *);
 
-typedef PyObject Eq_111;
+typedef PyObject Eq_131;
 
-typedef PyObject Eq_112;
+typedef PyObject Eq_132;
 
-typedef PyObject * (Eq_124)(char *, PyMethodDef *[5], char *, PyObject *, int32);
+typedef PyObject * (Eq_144)(char *, PyMethodDef *[5], char *, PyObject *, int32);
 
-typedef PyMethodDef Eq_127;
+typedef PyMethodDef Eq_147;
 
-typedef PyObject Eq_129;
+typedef PyObject Eq_149;
 
-typedef PyObject Eq_136;
+typedef PyObject Eq_156;
 
-typedef HMODULE Eq_138;
+typedef HMODULE Eq_158;
 
-typedef DWORD Eq_139;
+typedef DWORD Eq_159;
 
-typedef LPVOID Eq_140;
+typedef LPVOID Eq_160;
 
-typedef LONG Eq_145;
+typedef LONG Eq_165;
 
-typedef struct Eq_176 {
-	struct Eq_178 * ptr0018;	// 18
-} Eq_176;
+typedef struct Eq_196 {
+	struct Eq_198 * ptr0018;	// 18
+} Eq_196;
 
-typedef struct Eq_178 {
-	Eq_145 t0004;	// 4
-} Eq_178;
+typedef struct Eq_198 {
+	Eq_165 t0004;	// 4
+} Eq_198;
 
-typedef LONG (Eq_183)(LONG *, LONG, LONG);
+typedef LONG (Eq_203)(LONG *, LONG, LONG);
 
-typedef LONG Eq_185;
+typedef LONG Eq_205;
 
-typedef void (Eq_206)(DWORD);
+typedef void (Eq_226)(DWORD);
 
-typedef word32 * (Eq_216)(void);
+typedef word32 * (Eq_236)(void);
 
-typedef void (Eq_227)(int32);
+typedef void (Eq_247)(int32);
 
-typedef int32 (Eq_237)(PVFV *, PVFV *);
+typedef int32 (Eq_257)(PVFV *, PVFV *);
 
-typedef PVFV Eq_239;
+typedef PVFV Eq_259;
 
-typedef PVFV Eq_240;
+typedef PVFV Eq_260;
 
-typedef struct Eq_253 {
+typedef struct Eq_273 {
 	LONG * ptrFFFFFFFC;	// FFFFFFFC
-	Eq_145 t0000;	// 0
-} Eq_253;
+	Eq_165 t0000;	// 0
+} Eq_273;
 
-typedef LONG Eq_260;
+typedef LONG Eq_280;
 
-typedef LONG (Eq_267)(LONG *, LONG);
+typedef LONG (Eq_287)(LONG *, LONG);
 
-typedef void (Eq_291)(PVFV *, PVFV *);
+typedef void (Eq_311)(PVFV *, PVFV *);
 
-typedef PVFV Eq_293;
+typedef PVFV Eq_313;
 
-typedef PVFV Eq_294;
+typedef PVFV Eq_314;
 
-typedef struct Eq_304 {
+typedef struct Eq_324 {
 	ptr32 ptr0000;	// 0
 	ptr32 ptr0004;	// 4
-} Eq_304;
+} Eq_324;
 
-typedef void (Eq_331)(word32 *);
+typedef void (Eq_351)(word32 *);
 
-typedef void (Eq_339)();
+typedef void (Eq_359)();
 
-typedef word32 (Eq_368)( *, ptr32, word32, ptr32);
+typedef word32 (Eq_388)( *, ptr32, word32, ptr32);
 
-typedef struct Eq_391 {
-	Eq_139 tFFFFFFE4;	// FFFFFFE4
+typedef struct Eq_411 {
+	Eq_159 tFFFFFFE4;	// FFFFFFE4
 	word32 dwFFFFFFF0;	// FFFFFFF0
 	word32 dwFFFFFFFC;	// FFFFFFFC
-	Eq_456 t0000;	// 0
-	Eq_138 t0008;	// 8
-} Eq_391;
+	Eq_476 t0000;	// 0
+	Eq_158 t0008;	// 8
+} Eq_411;
 
-typedef Eq_391 * (Eq_392)( *, ptr32, word32, word32, ui32);
+typedef Eq_411 * (Eq_412)( *, ptr32, word32, word32, ui32);
 
-typedef struct Eq_420 {
-	Eq_456 tFFFFFFFC;	// FFFFFFFC
-} Eq_420;
+typedef struct Eq_440 {
+	Eq_476 tFFFFFFFC;	// FFFFFFFC
+} Eq_440;
 
-typedef void (Eq_446)();
+typedef void (Eq_466)();
 
-typedef ptr32 (Eq_453)(Eq_391 *, Eq_456);
+typedef ptr32 (Eq_473)(Eq_411 *, Eq_476);
 
-typedef union Eq_456 {
+typedef union Eq_476 {
 	ui32 u0;
 	ptr32 u1;
-} Eq_456;
+} Eq_476;
 
-typedef struct Eq_467 {
-	Eq_138 tFFFFFFF8;	// FFFFFFF8
-	Eq_139 tFFFFFFFC;	// FFFFFFFC
-	Eq_140 t0000;	// 0
-} Eq_467;
+typedef struct Eq_487 {
+	Eq_158 tFFFFFFF8;	// FFFFFFF8
+	Eq_159 tFFFFFFFC;	// FFFFFFFC
+	Eq_160 t0000;	// 0
+} Eq_487;
 
-typedef DWORD (Eq_480)(HMODULE, DWORD);
+typedef DWORD (Eq_500)(HMODULE, DWORD);
 
-typedef DWORD (Eq_503)(HMODULE, DWORD);
+typedef DWORD (Eq_523)(HMODULE, DWORD);
 
-typedef struct Eq_509 {
-	Eq_138 tFFFFFFF8;	// FFFFFFF8
-	Eq_139 tFFFFFFFC;	// FFFFFFFC
-	Eq_140 t0000;	// 0
-} Eq_509;
+typedef struct Eq_529 {
+	Eq_158 tFFFFFFF8;	// FFFFFFF8
+	Eq_159 tFFFFFFFC;	// FFFFFFFC
+	Eq_160 t0000;	// 0
+} Eq_529;
 
-typedef DWORD (Eq_522)(HMODULE, DWORD, LPVOID, ptr32, ptr32, ptr32);
+typedef DWORD (Eq_542)(HMODULE, DWORD, LPVOID, ptr32, ptr32, ptr32);
 
-typedef void (Eq_595)(HMODULE, word32, LPVOID);
+typedef void (Eq_615)(HMODULE, word32, LPVOID);
 
-typedef struct Eq_599 {
-	Eq_138 tFFFFFFF8;	// FFFFFFF8
-	Eq_139 tFFFFFFFC;	// FFFFFFFC
-	Eq_140 t0000;	// 0
-} Eq_599;
+typedef struct Eq_619 {
+	Eq_158 tFFFFFFF8;	// FFFFFFF8
+	Eq_159 tFFFFFFFC;	// FFFFFFFC
+	Eq_160 t0000;	// 0
+} Eq_619;
 
-typedef DWORD (Eq_651)(word32, word32, word32);
+typedef DWORD (Eq_671)(word32, word32, word32);
 
-typedef BOOL Eq_660;
+typedef BOOL Eq_680;
 
-typedef HANDLE Eq_661;
+typedef HANDLE Eq_681;
 
-typedef BOOL (Eq_666)(LPVOID, DWORD,  *, ptr32, word32);
+typedef BOOL (Eq_686)(LPVOID, DWORD,  *, ptr32, word32);
 
-typedef void (Eq_672)();
+typedef void (Eq_692)();
 
-typedef struct Eq_676 {
+typedef struct Eq_696 {
 	word16 w0000;	// 0
 	word32 dw003C;	// 3C
-} Eq_676;
+} Eq_696;
 
-typedef struct Eq_682 {
+typedef struct Eq_702 {
 	word32 dw0000;	// 0
 	word16 w0018;	// 18
-} Eq_682;
+} Eq_702;
 
-typedef struct Eq_700 {	// size: 40 28
+typedef struct Eq_720 {	// size: 40 28
 	up32 dw0008;	// 8
 	word32 dw000C;	// C
-} Eq_700;
+} Eq_720;
 
-typedef struct Eq_701 {
+typedef struct Eq_721 {
 	word32 dw003C;	// 3C
-} Eq_701;
+} Eq_721;
 
-typedef struct Eq_703 {
+typedef struct Eq_723 {
 	word16 w0006;	// 6
 	word16 w0014;	// 14
-} Eq_703;
+} Eq_723;
 
-typedef word32 (Eq_754)(Eq_676 *);
+typedef word32 (Eq_774)(Eq_696 *);
 
-typedef union Eq_769 {
+typedef union Eq_789 {
 	ui32 u0;
 	ptr32 u1;
-} Eq_769;
+} Eq_789;
 
-typedef struct Eq_771 {
+typedef struct Eq_791 {
 	uint32 dw0024;	// 24
-} Eq_771;
+} Eq_791;
 
-typedef Eq_771 * (Eq_772)(Eq_701 *, uint32);
+typedef Eq_791 * (Eq_792)(Eq_721 *, uint32);
 
-typedef BOOL (Eq_801)(HMODULE);
+typedef BOOL (Eq_821)(HMODULE);
 
-typedef struct Eq_806 {
+typedef struct Eq_826 {
 	word32 dwFFFFFFEC;	// FFFFFFEC
 	ui32 dwFFFFFFF0;	// FFFFFFF0
 	word32 dwFFFFFFF4;	// FFFFFFF4
 	ptr32 ptrFFFFFFF8;	// FFFFFFF8
-	Eq_145 (* ptrFFFFFFFC)(LONG *, Eq_145, Eq_145);	// FFFFFFFC
-} Eq_806;
+	Eq_165 (* ptrFFFFFFFC)(LONG *, Eq_165, Eq_165);	// FFFFFFFC
+} Eq_826;
 
-typedef struct Eq_833 {
+typedef struct Eq_853 {
 	ptr32 ptr0000;	// 0
-} Eq_833;
+} Eq_853;
 
-typedef struct Eq_841 {
+typedef struct Eq_861 {
 	word32 dw0000;	// 0
-} Eq_841;
+} Eq_861;
 
-typedef union Eq_842 {
+typedef union Eq_862 {
 	ptr32 u0;
-	word32 Eq_841::* u1;
-} Eq_842;
+	word32 Eq_861::* u1;
+} Eq_862;
 
-typedef void (Eq_853)(LPFILETIME);
+typedef void (Eq_873)(LPFILETIME);
 
-typedef LPFILETIME Eq_855;
+typedef LPFILETIME Eq_875;
 
-typedef DWORD (Eq_861)();
+typedef DWORD (Eq_881)();
 
-typedef DWORD (Eq_864)();
+typedef DWORD (Eq_884)();
 
-typedef DWORD (Eq_868)();
+typedef DWORD (Eq_888)();
 
-typedef BOOL (Eq_872)(LARGE_INTEGER *);
+typedef BOOL (Eq_892)(LARGE_INTEGER *);
 
-typedef LARGE_INTEGER Eq_874;
+typedef LARGE_INTEGER Eq_894;
+
+typedef LARGE_INTEGER Eq_895;
+
+typedef struct Eq_899 {
+	LARGE_INTEGER t0000;	// 0
+	word32 dw0004;	// 4
+} Eq_899;
+
+typedef LARGE_INTEGER Eq_903;
 

--- a/subjects/PE/x86/pySample/pySample_text.c
+++ b/subjects/PE/x86/pySample/pySample_text.c
@@ -7,7 +7,7 @@
 // 10001000: Register (ptr32 Eq_n) fn10001000(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * fn10001000(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:sum", fp - 0x04, fp - 0x08);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:sum", &dwLoc04, &dwLoc08);
 	if (eax_n != null)
 		return Py_BuildValue("i", dwLoc04 + dwLoc08);
 	return eax_n;
@@ -16,7 +16,7 @@ PyObject * fn10001000(PyObject * ptrArg04, PyObject * ptrArg08)
 // 10001050: Register (ptr32 Eq_n) fn10001050(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * fn10001050(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:dif", fp - 0x08, fp - 0x04);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:dif", &dwLoc08, &dwLoc04);
 	if (eax_n != null)
 		return Py_BuildValue("i", dwLoc08 - dwLoc04);
 	return eax_n;
@@ -25,7 +25,7 @@ PyObject * fn10001050(PyObject * ptrArg04, PyObject * ptrArg08)
 // 100010A0: Register (ptr32 Eq_n) fn100010A0(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * fn100010A0(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:div", fp - 0x08, fp - 0x04);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:div", &dwLoc08, &dwLoc04);
 	if (eax_n != null)
 		return Py_BuildValue("i", (int32) ((int64) dwLoc08 /32 dwLoc04));
 	return eax_n;
@@ -34,7 +34,7 @@ PyObject * fn100010A0(PyObject * ptrArg04, PyObject * ptrArg08)
 // 100010F0: Register (ptr32 Eq_n) fn100010F0(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * fn100010F0(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ff:fdiv", fp - 0x08, fp - 0x04);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ff:fdiv", &rLoc08, &rLoc04);
 	if (eax_n != null)
 		return Py_BuildValue("f", (real64) rLoc08 / (real64) rLoc04);
 	return eax_n;
@@ -372,8 +372,8 @@ void fn10001864()
 	{
 		GetSystemTimeAsFileTime(fp - 0x0C);
 		ui32 esi_n = GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount();
-		QueryPerformanceCounter(fp - 0x14);
-		ui32 esi_n = esi_n ^ (dwLoc10 ^ dwLoc14);
+		QueryPerformanceCounter(&tLoc14);
+		ui32 esi_n = esi_n ^ (tLoc14.dw0004 ^ tLoc14);
 		if (esi_n == 0xBB40E64E)
 			esi_n = ~0x44BF19B0;
 		else if ((esi_n & 0xFFFF0000) == 0x00)

--- a/subjects/PE/x86/pySample/pySample_text.dis
+++ b/subjects/PE/x86/pySample/pySample_text.dis
@@ -7,10 +7,10 @@ PyObject * fn10001000(PyObject * ptrArg04, PyObject * ptrArg08)
 // Preserved:
 fn10001000_entry:
 l10001000:
-	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002144<32>, fp - 4<32>, fp - 8<32>)
+	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002144<32>, &dwLoc04, &dwLoc08)
 	branch eax_17 != 0<32> l10001027
 l10001027:
-	return Py_BuildValue(0x1000214C<32>, dwLoc04 + dwLoc08)
+	return Py_BuildValue(0x1000214C<32>, Mem16[&dwLoc04:word32] + Mem16[&dwLoc08:word32])
 l10001023:
 	return eax_17
 fn10001000_exit:
@@ -25,10 +25,10 @@ PyObject * fn10001050(PyObject * ptrArg04, PyObject * ptrArg08)
 // Preserved:
 fn10001050_entry:
 l10001050:
-	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002150<32>, fp - 8<32>, fp - 4<32>)
+	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002150<32>, &dwLoc08, &dwLoc04)
 	branch eax_17 != 0<32> l10001078
 l10001078:
-	return Py_BuildValue(0x1000214C<32>, dwLoc08 - dwLoc04)
+	return Py_BuildValue(0x1000214C<32>, Mem16[&dwLoc08:word32] - Mem16[&dwLoc04:word32])
 l10001074:
 	return eax_17
 fn10001050_exit:
@@ -43,10 +43,10 @@ PyObject * fn100010A0(PyObject * ptrArg04, PyObject * ptrArg08)
 // Preserved:
 fn100010A0_entry:
 l100010A0:
-	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002158<32>, fp - 8<32>, fp - 4<32>)
+	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002158<32>, &dwLoc08, &dwLoc04)
 	branch eax_17 != 0<32> l100010C8
 l100010C8:
-	return Py_BuildValue(0x1000214C<32>, CONVERT(CONVERT(dwLoc08, word32, int64) /32 dwLoc04, word32, int32))
+	return Py_BuildValue(0x1000214C<32>, CONVERT(CONVERT(Mem16[&dwLoc08:word32], word32, int64) /32 Mem16[&dwLoc04:word32], word32, int32))
 l100010C4:
 	return eax_17
 fn100010A0_exit:
@@ -61,10 +61,10 @@ PyObject * fn100010F0(PyObject * ptrArg04, PyObject * ptrArg08)
 // Preserved:
 fn100010F0_entry:
 l100010F0:
-	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002160<32>, fp - 8<32>, fp - 4<32>)
+	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002160<32>, &rLoc08, &rLoc04)
 	branch eax_17 != 0<32> l10001118
 l10001118:
-	return Py_BuildValue(0x10002168<32>, CONVERT(rLoc08, real32, real64) / CONVERT(rLoc04, real32, real64))
+	return Py_BuildValue(0x10002168<32>, CONVERT(Mem16[&rLoc08:real32], real32, real64) / CONVERT(Mem16[&rLoc04:real32], real32, real64))
 l10001114:
 	return eax_17
 fn100010F0_exit:
@@ -513,8 +513,8 @@ l10001887:
 l10001894:
 	GetSystemTimeAsFileTime(fp - 0xC<32>)
 	word32 esi_46 = GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount()
-	QueryPerformanceCounter(fp - 0x14<32>)
-	word32 esi_54 = esi_46 ^ (dwLoc10 ^ dwLoc14)
+	QueryPerformanceCounter(&tLoc14)
+	word32 esi_54 = esi_46 ^ (Mem49[&tLoc14 + 4<i32>:word32] ^ Mem49[&tLoc14:word32])
 	branch esi_54 != 0xBB40E64E<32> l100018DA
 l100018DA:
 	branch (esi_54 & 0xFFFF0000<32>) != 0<32> l100018E5

--- a/subjects/PE/x86/pySample/shingledPySample.reko/pySample.h
+++ b/subjects/PE/x86/pySample/shingledPySample.reko/pySample.h
@@ -5,7 +5,7 @@
 /*
 // Equivalence classes ////////////
 Eq_1: (struct "Globals"
-		(10000000 Eq_825 t10000000)
+		(10000000 Eq_845 t10000000)
 		(10002000 (ptr32 code) __imp__GetSystemTimeAsFileTime)
 		(10002004 (ptr32 code) __imp__GetCurrentProcessId)
 		(10002008 (ptr32 code) __imp__GetCurrentThreadId)
@@ -41,10 +41,10 @@ Eq_1: (struct "Globals"
 		(10002088 (ptr32 code) __imp__PyArg_ParseTuple)
 		(1000208C (ptr32 code) __imp___Py_NoneStruct)
 		(10002090 (ptr32 code) __imp__Py_BuildValue)
-		(10002098 Eq_293 t10002098)
-		(1000209C Eq_294 t1000209C)
-		(100020A0 Eq_239 t100020A0)
-		(100020A8 Eq_240 t100020A8)
+		(10002098 Eq_313 t10002098)
+		(1000209C Eq_314 t1000209C)
+		(100020A0 Eq_259 t100020A0)
+		(100020A8 Eq_260 t100020A8)
 		(100020CC word32 dw100020CC)
 		(100020E0 (str char) str100020E0)
 		(100020F4 (str char) str100020F4)
@@ -100,12 +100,12 @@ Eq_1: (struct "Globals"
 		(1000232C word32 dw1000232C)
 		(10003000 ui32 dw10003000)
 		(10003004 ui32 dw10003004)
-		(10003008 Eq_1091 t10003008)
+		(10003008 Eq_1117 t10003008)
 		(10003010 (arr PyMethodDef 5) methods)
 		(10003070 int32 dw10003070)
 		(100033A4 word32 dw100033A4)
 		(100033A8 word32 dw100033A8)
-		(100033AC Eq_185 t100033AC)
+		(100033AC Eq_205 t100033AC)
 		(100033B0 (ptr32 void) ptr100033B0)
 		(100033B4 (ptr32 void) ptr100033B4)
 		(100033B8 (ptr32 code) ptr100033B8))
@@ -113,491 +113,497 @@ Eq_1: (struct "Globals"
 Eq_2: PyObject
 	T_2 (in eax @ 00000000 : (ptr32 Eq_2))
 	T_5 (in eax_17 @ 10001016 : (ptr32 Eq_2))
-	T_18 (in PyArg_ParseTuple(ptrArg08, "ii:sum", fp - 4<32>, fp - 8<32>) @ 10001016 : int32)
-	T_19 (in 0<32> @ 10001021 : word32)
-	T_29 (in Py_BuildValue("i", dwLoc04 + dwLoc08) @ 10001042 : (ptr32 PyObject))
-	T_30 (in eax_17 @ 10001067 : (ptr32 Eq_2))
-	T_41 (in PyArg_ParseTuple(ptrArg08, "ii:dif", fp - 8<32>, fp - 4<32>) @ 10001067 : int32)
-	T_42 (in 0<32> @ 10001072 : word32)
-	T_51 (in Py_BuildValue("i", dwLoc08 - dwLoc04) @ 10001091 : (ptr32 PyObject))
-	T_52 (in eax_17 @ 100010B7 : (ptr32 Eq_2))
-	T_63 (in PyArg_ParseTuple(ptrArg08, "ii:div", fp - 8<32>, fp - 4<32>) @ 100010B7 : int32)
-	T_64 (in 0<32> @ 100010C2 : word32)
-	T_75 (in Py_BuildValue("i", (int32) ((int64) dwLoc08 /32 dwLoc04)) @ 100010E2 : (ptr32 PyObject))
-	T_76 (in eax_17 @ 10001107 : (ptr32 Eq_2))
-	T_87 (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", fp - 8<32>, fp - 4<32>) @ 10001107 : int32)
-	T_88 (in 0<32> @ 10001112 : word32)
-	T_99 (in Py_BuildValue("f", (real64) rLoc08 / (real64) rLoc04) @ 10001136 : (ptr32 PyObject))
+	T_17 (in PyArg_ParseTuple(ptrArg08, "ii:sum", &dwLoc04, &dwLoc08) @ 10001016 : int32)
+	T_18 (in 0<32> @ 10001021 : word32)
+	T_34 (in Py_BuildValue("i", dwLoc04 + dwLoc08) @ 10001042 : (ptr32 PyObject))
+	T_35 (in eax_17 @ 10001067 : (ptr32 Eq_2))
+	T_45 (in PyArg_ParseTuple(ptrArg08, "ii:dif", &dwLoc08, &dwLoc04) @ 10001067 : int32)
+	T_46 (in 0<32> @ 10001072 : word32)
+	T_61 (in Py_BuildValue("i", dwLoc08 - dwLoc04) @ 10001091 : (ptr32 PyObject))
+	T_62 (in eax_17 @ 100010B7 : (ptr32 Eq_2))
+	T_72 (in PyArg_ParseTuple(ptrArg08, "ii:div", &dwLoc08, &dwLoc04) @ 100010B7 : int32)
+	T_73 (in 0<32> @ 100010C2 : word32)
+	T_90 (in Py_BuildValue("i", (int32) ((int64) dwLoc08 /32 dwLoc04)) @ 100010E2 : (ptr32 PyObject))
+	T_91 (in eax_17 @ 10001107 : (ptr32 Eq_2))
+	T_101 (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", &rLoc08, &rLoc04) @ 10001107 : int32)
+	T_102 (in 0<32> @ 10001112 : word32)
+	T_119 (in Py_BuildValue("f", (real64) rLoc08 / (real64) rLoc04) @ 10001136 : (ptr32 PyObject))
 Eq_3: PyObject
 	T_3 (in ptrArg04 @ 00000000 : (ptr32 Eq_3))
 Eq_4: PyObject
 	T_4 (in ptrArg08 @ 00000000 : (ptr32 Eq_4))
 	T_8 (in ptrArg04 @ 10001016 : (ptr32 PyObject))
-	T_106 (in args @ 1000114A : (ptr32 PyObject))
+	T_126 (in args @ 1000114A : (ptr32 PyObject))
 Eq_6: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 int32), (ptr32 int32)))
 	T_6 (in PyArg_ParseTuple @ 10001016 : ptr32)
 	T_7 (in signature of PyArg_ParseTuple @ 00000000 : void)
-Eq_21: (fn (ptr32 Eq_2) ((ptr32 char), int32))
-	T_21 (in Py_BuildValue @ 10001042 : ptr32)
-	T_22 (in signature of Py_BuildValue @ 00000000 : void)
-Eq_31: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 int32), (ptr32 int32)))
-	T_31 (in PyArg_ParseTuple @ 10001067 : ptr32)
-	T_32 (in signature of PyArg_ParseTuple @ 00000000 : void)
-Eq_44: (fn (ptr32 Eq_2) ((ptr32 char), int32))
-	T_44 (in Py_BuildValue @ 10001091 : ptr32)
-	T_45 (in signature of Py_BuildValue @ 00000000 : void)
-Eq_53: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 int32), (ptr32 int32)))
-	T_53 (in PyArg_ParseTuple @ 100010B7 : ptr32)
-	T_54 (in signature of PyArg_ParseTuple @ 00000000 : void)
-Eq_66: (fn (ptr32 Eq_2) ((ptr32 char), int32))
-	T_66 (in Py_BuildValue @ 100010E2 : ptr32)
-	T_67 (in signature of Py_BuildValue @ 00000000 : void)
-Eq_77: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 real32), (ptr32 real32)))
-	T_77 (in PyArg_ParseTuple @ 10001107 : ptr32)
-	T_78 (in signature of PyArg_ParseTuple @ 00000000 : void)
-Eq_90: (fn (ptr32 Eq_2) ((ptr32 char), real64))
-	T_90 (in Py_BuildValue @ 10001136 : ptr32)
-	T_91 (in signature of Py_BuildValue @ 00000000 : void)
-Eq_100: PyObject
-	T_100 (in eax @ 10001117 : (ptr32 Eq_100))
-	T_103 (in eax_10 @ 1000114A : (ptr32 Eq_100))
-	T_108 (in PyArg_ParseTuple(args, ":unused") @ 1000114A : int32)
-	T_109 (in 0<32> @ 10001155 : word32)
-	T_123 (in &_Py_NoneStruct @ 10001165 : word32)
-Eq_101: PyObject
-	T_101 (in self @ 10001117 : (ptr32 Eq_101))
-Eq_102: PyObject
-	T_102 (in args @ 10001117 : (ptr32 Eq_102))
-Eq_104: (fn (ptr32 Eq_100) ((ptr32 Eq_4), (ptr32 char)))
-	T_104 (in PyArg_ParseTuple @ 1000114A : ptr32)
-	T_105 (in signature of PyArg_ParseTuple @ 00000000 : void)
-Eq_111: PyObject
-	T_111 (in eax_16 @ 10001158 : (ptr32 Eq_111))
-	T_113 (in &_Py_NoneStruct @ 10001158 : word32)
-Eq_112: PyObject
-	T_112 (in _Py_NoneStruct @ 10001158 : PyObject)
-	T_122 (in _Py_NoneStruct @ 10001165 : PyObject)
-Eq_124: (fn (ptr32 Eq_136) ((ptr32 char), (ptr32 (arr PyMethodDef 5)), (ptr32 char), (ptr32 Eq_129), int32))
-	T_124 (in Py_InitModule4 @ 10001183 : ptr32)
-	T_125 (in signature of Py_InitModule4 @ 00000000 : void)
-Eq_127: PyMethodDef
-	T_127 (in ptrArg08 @ 10001183 : (ptr32 PyMethodDef))
-	T_132 (in 0x10003010<32> @ 10001183 : word32)
-Eq_129: PyObject
-	T_129 (in ptrArg10 @ 10001183 : (ptr32 PyObject))
-	T_134 (in 0<32> @ 10001183 : word32)
-Eq_136: PyObject
-	T_136 (in Py_InitModule4("pySample", methods, null, null, 0x3EF<32>) @ 10001183 : (ptr32 PyObject))
-Eq_138: (union "Eq_138" (_onexit_t u0) (HMODULE u1))
-	T_138 (in dwArg04 @ 1000118C : Eq_138)
-	T_402 (in ebx_113 @ 10001398 : Eq_138)
-	T_405 (in Mem7[ebp_13 + 8<32>:word32] @ 10001398 : word32)
-	T_478 (in Mem114[esp_106 + -8<i32>:word32] @ 100013FC : word32)
-	T_482 (in dwArg04 @ 100013FD : Eq_138)
-	T_486 (in Mem114[esp_106 + -8<i32>:word32] @ 100013FD : word32)
-	T_520 (in Mem88[esp_80 + -8<i32>:word32] @ 100013E9 : word32)
-	T_526 (in Mem88[esp_80 + -8<i32>:word32] @ 100013EA : word32)
-	T_556 (in Mem133[esp_106 + -8<i32>:word32] @ 10001410 : word32)
-	T_560 (in Mem133[esp_106 + -8<i32>:word32] @ 10001411 : word32)
-	T_574 (in Mem145[esp_106 + -8<i32>:word32] @ 10001419 : word32)
-	T_578 (in Mem145[esp_106 + -8<i32>:word32] @ 1000141A : word32)
-	T_610 (in Mem194[esp_184 + -8<i32>:word32] @ 10001439 : word32)
-	T_618 (in Mem194[esp_184 + -8<i32>:word32] @ 1000143A : word32)
-	T_675 (in eax @ 100014A5 : Eq_138)
-	T_679 (in eax_111 @ 100015CF : Eq_138)
-	T_731 (in v16_57 @ 10001628 : Eq_138)
-	T_734 (in Mem56[ebp_13 + 8<32>:word32] @ 10001628 : word32)
-	T_737 (in func @ 10001630 : _onexit_t)
-	T_742 (in Mem59[esp_30 + -16<i32>:_onexit_t] @ 10001630 : _onexit_t)
-	T_749 (in __dllonexit(esp_30->tFFFFFFF0, esp_30->ptrFFFFFFF4, esp_30->ptrFFFFFFF8) @ 10001630 : _onexit_t)
-	T_752 (in Mem61[ebp_13 + -36<i32>:word32] @ 10001630 : word32)
-	T_784 (in Mem83[ebp_13 + -36<i32>:word32] @ 1000165C : word32)
-	T_787 (in _Func @ 100015F5 : _onexit_t)
-	T_790 (in Mem25[ebp_13 + 8<32>:word32] @ 100015F5 : word32)
-	T_791 (in _onexit(ebp_13->t0008) @ 100015F5 : _onexit_t)
-	T_914 (in eax_36 @ 10001762 : Eq_138)
-	T_917 (in Mem24[ebp_13 + 8<32>:word32] @ 10001762 : word32)
-	T_952 (in hLibModule @ 100017DA : HMODULE)
-Eq_139: DWORD
-	T_139 (in dwArg08 @ 1000118C : Eq_139)
-	T_147 (in 0<32> @ 100011F2 : word32)
-	T_160 (in 1<32> @ 10001216 : word32)
-	T_173 (in 0<32> @ 100012EA : word32)
-	T_208 (in dwMilliseconds @ 10001302 : DWORD)
-	T_209 (in 0x3E8<32> @ 10001302 : word32)
-	T_215 (in eax_69 @ 10001332 : Eq_139)
-	T_221 (in _decode_pointer(g_ptr100033B4) @ 10001332 : (ptr32 void))
-	T_225 (in 0<32> @ 10001339 : word32)
-	T_251 (in 0x3E8<32> @ 10001243 : word32)
-	T_283 (in edi_82 @ 10001344 : DWORD)
-	T_287 (in _decode_pointer(g_ptr100033B0) @ 10001344 : (ptr32 void))
-	T_289 (in edi_82 - 4<32> @ 00000000 : word32)
-	T_330 (in Mem103[esp_102 + 0<32>:word32] @ 10001357 : word32)
-	T_333 (in ptrArg04 @ 10001358 : (ptr32 void))
-	T_336 (in Mem103[esp_102 + 0<32>:(ptr32 void)] @ 10001358 : (ptr32 void))
-	T_385 (in eax @ 10001385 : Eq_139)
-	T_387 (in edx @ 10001385 : Eq_139)
-	T_406 (in 1<32> @ 1000139E : word32)
-	T_409 (in Mem25[ebp_13 + -28<i32>:word32] @ 1000139E : word32)
-	T_415 (in Mem28[0x10003008<p32>:word32] @ 100013A6 : word32)
-	T_425 (in esi_110 @ 10001396 : Eq_139)
-	T_426 (in 0<32> @ 100013B1 : word32)
-	T_428 (in 1<32> @ 100013C5 : word32)
-	T_434 (in 0<32> @ 100013BB : word32)
-	T_437 (in Mem248[ebp_13 + -28<i32>:word32] @ 100013BB : word32)
-	T_449 (in eax_257 @ 1000148A : Eq_139)
-	T_452 (in Mem256[ebp_13 + -28<i32>:word32] @ 1000148A : word32)
-	T_465 (in 2<32> @ 100013CA : word32)
-	T_475 (in Mem111[esp_106 + -4<i32>:word32] @ 100013FB : word32)
-	T_479 (in eax_115 @ 100013FD : Eq_139)
-	T_483 (in dwArg08 @ 100013FD : Eq_139)
-	T_489 (in Mem114[esp_106 + -4<i32>:word32] @ 100013FD : word32)
-	T_490 (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 100013FD : word32)
-	T_493 (in Mem122[ebp_13 + -28<i32>:word32] @ 10001402 : word32)
-	T_496 (in 1<32> @ 10001408 : word32)
-	T_500 (in Mem76[ebp_13 + -28<i32>:word32] @ 100013E1 : word32)
-	T_501 (in 0<32> @ 100013E1 : word32)
-	T_505 (in fn00000000(ebx_113, edx) @ 100013DA : void)
-	T_508 (in Mem74[ebp_13 + -28<i32>:word32] @ 100013DA : word32)
-	T_517 (in Mem85[esp_80 + -4<i32>:word32] @ 100013E8 : word32)
-	T_521 (in eax_90 @ 100013EA : Eq_139)
-	T_529 (in Mem88[esp_80 + -4<i32>:word32] @ 100013EA : word32)
-	T_536 (in fn100011E9(esp_80->tFFFFFFF8, esp_80->tFFFFFFFC, esp_80->t0000, out ebx_113, out esi_110, out edi_107) @ 100013EA : word32)
-	T_539 (in Mem101[ebp_13 + -28<i32>:word32] @ 100013EF : word32)
-	T_542 (in 0<32> @ 100013F4 : word32)
-	T_544 (in 0<32> @ 10001430 : word32)
-	T_546 (in 0<32> @ 1000140C : word32)
-	T_553 (in Mem131[esp_106 + -4<i32>:word32] @ 1000140F : word32)
-	T_563 (in Mem133[esp_106 + -4<i32>:word32] @ 10001411 : word32)
-	T_564 (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 10001411 : word32)
-	T_568 (in 0<32> @ 10001417 : word32)
-	T_571 (in Mem143[esp_106 + -4<i32>:word32] @ 10001417 : word32)
-	T_581 (in Mem145[esp_106 + -4<i32>:word32] @ 1000141A : word32)
-	T_588 (in fn100011E9(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC, esp_106->t0000, out ebx_113, out esi_110, out edi_107) @ 1000141A : word32)
-	T_607 (in Mem190[esp_184 + -4<i32>:word32] @ 10001438 : word32)
-	T_614 (in eax_197 @ 1000143A : Eq_139)
-	T_621 (in Mem194[esp_184 + -4<i32>:word32] @ 1000143A : word32)
-	T_628 (in fn100011E9(esp_184->tFFFFFFF8, esp_184->tFFFFFFFC, esp_184->t0000, out ebx_198, out esi_200, out edi_201) @ 1000143A : word32)
-	T_631 (in 0<32> @ 10001441 : word32)
-	T_633 (in 3<32> @ 10001435 : word32)
-	T_637 (in Mem218[ebp_13 + -28<i32>:word32] @ 1000144A : word32)
-	T_638 (in 0<32> @ 1000144A : word32)
-	T_642 (in Mem194[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
-	T_643 (in ebp_13->tFFFFFFE4 & eax_197 @ 00000000 : word32)
-	T_646 (in Mem214[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
-	T_653 (in fn00000000(ebx_198, esi_200, edi_201) @ 1000145A : void)
-	T_656 (in Mem247[ebp_13 + -28<i32>:word32] @ 1000145A : word32)
-	T_657 (in 0xFFFFFFFF<32> @ 10001493 : word32)
-	T_659 (in Mem4[0x10003008<p32>:word32] @ 10001493 : word32)
-	T_662 (in dwReason @ 1000149D : Eq_139)
-	T_664 (in 1<32> @ 100014A3 : word32)
-	T_686 (in eax_22 @ 100015E7 : Eq_139)
-	T_690 (in _decode_pointer(g_ptr100033B4) @ 100015E7 : (ptr32 void))
-	T_693 (in Mem25[ebp_13 + -28<i32>:word32] @ 100015EA : word32)
-	T_694 (in 0xFFFFFFFF<32> @ 100015F0 : word32)
-	T_716 (in _decode_pointer(esp_30->ptr0000) @ 10001612 : (ptr32 void))
-	T_719 (in Mem45[ebp_13 + -28<i32>:word32] @ 10001612 : word32)
-	T_727 (in _decode_pointer(esp_30->ptrFFFFFFFC) @ 1000161D : (ptr32 void))
-	T_730 (in Mem50[ebp_13 + -32<i32>:word32] @ 1000161D : word32)
-	T_757 (in Mem61[ebp_13 + -28<i32>:word32] @ 1000163E : word32)
-	T_768 (in Mem71[ebp_13 + -32<i32>:word32] @ 1000164B : word32)
-	T_943 (in 1<32> @ 100017CB : word32)
-	T_1012 (in GetCurrentProcessId() @ 100018BB : DWORD)
-	T_1015 (in GetCurrentThreadId() @ 100018BB : DWORD)
-	T_1019 (in GetTickCount() @ 100018BB : DWORD)
-Eq_140: LPVOID
-	T_140 (in dwArg0C @ 1000118C : Eq_140)
-	T_386 (in ecx @ 10001385 : Eq_140)
-	T_424 (in edi_107 @ 10001394 : Eq_140)
-	T_472 (in Mem108[esp_106 + 0<32>:word32] @ 100013FA : word32)
-	T_514 (in Mem82[esp_80 + 0<32>:word32] @ 100013E7 : word32)
-	T_532 (in Mem88[esp_80 + 0<32>:word32] @ 100013EA : word32)
-	T_550 (in Mem129[esp_106 + 0<32>:word32] @ 1000140E : word32)
-	T_567 (in Mem141[esp_106 + 0<32>:word32] @ 10001416 : word32)
-	T_584 (in Mem145[esp_106 + 0<32>:word32] @ 1000141A : word32)
-	T_604 (in Mem187[esp_184 + 0<32>:word32] @ 10001437 : word32)
-	T_624 (in Mem194[esp_184 + 0<32>:word32] @ 1000143A : word32)
-	T_663 (in lpReserved @ 1000149D : Eq_140)
-Eq_145: LONG
-	T_145 (in ebp_145 @ 100011EE : Eq_145)
-	T_146 (in 0<32> @ 100011EE : word32)
-	T_175 (in edi_124 @ 10001222 : Eq_145)
-	T_181 (in Mem38[Mem38[fs:0x18<32>:word32] + 4<32>:word32] @ 10001222 : word32)
-	T_182 (in eax_136 @ 1000124D : Eq_145)
-	T_186 (in Exchange @ 1000124D : LONG)
-	T_187 (in Comperand @ 1000124D : LONG)
-	T_189 (in 0<32> @ 1000124D : word32)
-	T_190 (in InterlockedCompareExchange(&g_t100033AC, edi_124, 0<32>) @ 1000124D : LONG)
-	T_191 (in 0<32> @ 10001251 : word32)
-	T_196 (in 1<32> @ 10001310 : word32)
-	T_197 (in 0<32> @ 10001310 : word32)
-	T_198 (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) @ 10001310 : LONG)
-	T_199 (in 0<32> @ 10001310 : word32)
-	T_249 (in 1<32> @ 10001257 : word32)
-	T_256 (in 0<32> @ 1000136F : word32)
-	T_259 (in Mem111[esp_110 + 0<32>:word32] @ 1000136F : word32)
-	T_270 (in Value @ 10001378 : LONG)
-	T_276 (in Mem116[esp_110 + 0<32>:LONG] @ 10001378 : LONG)
-	T_277 (in InterlockedExchange(esp_110->ptrFFFFFFFC, esp_110->t0000) @ 10001378 : LONG)
-	T_301 (in 0<32> @ 100012AC : word32)
-	T_358 (in InterlockedExchange(&g_t100033AC, ebp_145) @ 100012B0 : LONG)
-Eq_176: (segment "Eq_176" (18 (ptr32 Eq_178) ptr0018))
-	T_176 (in fs @ 10001222 : selector)
-Eq_178: (struct "Eq_178" (4 Eq_145 t0004))
-	T_178 (in Mem38[fs:0x18<32>:word32] @ 10001222 : word32)
-Eq_183: (fn Eq_145 ((ptr32 Eq_185), Eq_145, Eq_145))
-	T_183 (in InterlockedCompareExchange @ 1000124D : ptr32)
-	T_184 (in signature of InterlockedCompareExchange @ 00000000 : void)
-	T_194 (in InterlockedCompareExchange @ 10001310 : ptr32)
-	T_370 (in ebx @ 100012CC : (ptr32 Eq_183))
-	T_374 (in InterlockedCompareExchange @ 100012CC : ptr32)
-	T_388 (in ebx @ 10001385 : (ptr32 Eq_183))
-	T_394 (in ebx @ 1000138F : (ptr32 Eq_183))
-	T_668 (in ebx @ 100014BC : word32)
-	T_676 (in ebx @ 100014A5 : (ptr32 Eq_183))
-	T_803 (in ebx @ 1000166D : (ptr32 Eq_183))
-	T_962 (in Mem17[esp_14 + -4<i32>:word32] @ 10001802 : word32)
-Eq_185: LONG
-	T_185 (in Destination @ 1000124D : (ptr32 LONG))
-	T_188 (in 0x100033AC<p32> @ 1000124D : ptr32)
-	T_195 (in 0x100033AC<p32> @ 10001310 : ptr32)
-Eq_206: (fn void (Eq_139))
-	T_206 (in Sleep @ 10001302 : ptr32)
-	T_207 (in signature of Sleep @ 00000000 : void)
-	T_250 (in Sleep @ 10001243 : ptr32)
-Eq_216: (fn Eq_139 ((ptr32 void)))
-	T_216 (in _decode_pointer @ 10001332 : ptr32)
-	T_217 (in signature of _decode_pointer @ 00000000 : void)
-	T_284 (in _decode_pointer @ 10001344 : ptr32)
-	T_687 (in _decode_pointer @ 100015E7 : ptr32)
-	T_712 (in _decode_pointer @ 10001612 : ptr32)
-	T_723 (in _decode_pointer @ 1000161D : ptr32)
-Eq_227: (fn void (int32))
-	T_227 (in _amsg_exit @ 1000131E : ptr32)
-	T_228 (in signature of _amsg_exit @ 00000000 : void)
-	T_246 (in _amsg_exit @ 10001266 : ptr32)
-Eq_237: (fn int32 ((ptr32 Eq_239), (ptr32 Eq_240)))
-	T_237 (in _initterm_e @ 1000128A : ptr32)
-	T_238 (in signature of _initterm_e @ 00000000 : void)
-Eq_239: PVFV
-	T_239 (in fStart @ 1000128A : (ptr32 PVFV))
-	T_241 (in 0x100020A0<32> @ 1000128A : word32)
-Eq_240: PVFV
-	T_240 (in fEnd @ 1000128A : (ptr32 PVFV))
-	T_242 (in 0x100020A8<32> @ 1000128A : word32)
-Eq_253: (struct "Eq_253" (FFFFFFFC (ptr32 Eq_260) ptrFFFFFFFC) (0 Eq_145 t0000))
-	T_253 (in esp_110 @ 1000136F : (ptr32 Eq_253))
-	T_255 (in esp_105 - 4<i32> @ 00000000 : word32)
-Eq_260: LONG
-	T_260 (in 0x100033AC<p32> @ 10001371 : ptr32)
-	T_263 (in Mem114[esp_110 + -4<i32>:word32] @ 10001371 : word32)
-	T_269 (in Target @ 10001378 : (ptr32 LONG))
-	T_273 (in Mem116[esp_110 + -4<i32>:(ptr32 LONG)] @ 10001378 : (ptr32 LONG))
-	T_357 (in 0x100033AC<p32> @ 100012B0 : ptr32)
-Eq_267: (fn Eq_145 ((ptr32 Eq_260), Eq_145))
-	T_267 (in InterlockedExchange @ 10001378 : ptr32)
-	T_268 (in signature of InterlockedExchange @ 00000000 : void)
-	T_356 (in InterlockedExchange @ 100012B0 : ptr32)
-Eq_291: (fn void ((ptr32 Eq_293), (ptr32 Eq_294)))
-	T_291 (in _initterm @ 1000129D : ptr32)
-	T_292 (in signature of _initterm @ 00000000 : void)
-Eq_293: PVFV
-	T_293 (in fStart @ 1000129D : (ptr32 PVFV))
-	T_295 (in 0x10002098<32> @ 1000129D : word32)
-Eq_294: PVFV
-	T_294 (in fEnd @ 1000129D : (ptr32 PVFV))
-	T_296 (in 0x1000209C<32> @ 1000129D : word32)
-Eq_304: (struct "Eq_304" (0 ptr32 ptr0000) (4 ptr32 ptr0004))
-	T_304 (in esp_261 @ 10001381 : (ptr32 Eq_304))
-	T_306 (in esp_118 + 4<i32> @ 10001381 : word32)
-Eq_331: (fn void (Eq_139))
-	T_331 (in free @ 10001358 : ptr32)
-	T_332 (in signature of free @ 00000000 : void)
-Eq_339: (fn (ptr32 void) ())
-	T_339 (in _encoded_null @ 1000135F : ptr32)
-	T_340 (in signature of _encoded_null @ 00000000 : void)
-Eq_368: (fn word32 ((ptr32 Eq_183), ptr32, word32, ptr32))
-	T_368 (in fn10001742 @ 100012CC : ptr32)
-	T_369 (in signature of fn10001742 @ 10001742 : void)
-Eq_391: (struct "Eq_391"
-		(FFFFFFDC Eq_138 tFFFFFFDC)
-		(FFFFFFE0 Eq_139 tFFFFFFE0)
-		(FFFFFFE4 Eq_139 tFFFFFFE4)
+Eq_20: (fn (ptr32 Eq_2) ((ptr32 char), int32))
+	T_20 (in Py_BuildValue @ 10001042 : ptr32)
+	T_21 (in signature of Py_BuildValue @ 00000000 : void)
+Eq_36: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 int32), (ptr32 int32)))
+	T_36 (in PyArg_ParseTuple @ 10001067 : ptr32)
+	T_37 (in signature of PyArg_ParseTuple @ 00000000 : void)
+Eq_48: (fn (ptr32 Eq_2) ((ptr32 char), int32))
+	T_48 (in Py_BuildValue @ 10001091 : ptr32)
+	T_49 (in signature of Py_BuildValue @ 00000000 : void)
+Eq_63: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 int32), (ptr32 int32)))
+	T_63 (in PyArg_ParseTuple @ 100010B7 : ptr32)
+	T_64 (in signature of PyArg_ParseTuple @ 00000000 : void)
+Eq_75: (fn (ptr32 Eq_2) ((ptr32 char), int32))
+	T_75 (in Py_BuildValue @ 100010E2 : ptr32)
+	T_76 (in signature of Py_BuildValue @ 00000000 : void)
+Eq_92: (fn (ptr32 Eq_2) ((ptr32 Eq_4), (ptr32 char), (ptr32 real32), (ptr32 real32)))
+	T_92 (in PyArg_ParseTuple @ 10001107 : ptr32)
+	T_93 (in signature of PyArg_ParseTuple @ 00000000 : void)
+Eq_104: (fn (ptr32 Eq_2) ((ptr32 char), real64))
+	T_104 (in Py_BuildValue @ 10001136 : ptr32)
+	T_105 (in signature of Py_BuildValue @ 00000000 : void)
+Eq_120: PyObject
+	T_120 (in eax @ 10001117 : (ptr32 Eq_120))
+	T_123 (in eax_10 @ 1000114A : (ptr32 Eq_120))
+	T_128 (in PyArg_ParseTuple(args, ":unused") @ 1000114A : int32)
+	T_129 (in 0<32> @ 10001155 : word32)
+	T_143 (in &_Py_NoneStruct @ 10001165 : word32)
+Eq_121: PyObject
+	T_121 (in self @ 10001117 : (ptr32 Eq_121))
+Eq_122: PyObject
+	T_122 (in args @ 10001117 : (ptr32 Eq_122))
+Eq_124: (fn (ptr32 Eq_120) ((ptr32 Eq_4), (ptr32 char)))
+	T_124 (in PyArg_ParseTuple @ 1000114A : ptr32)
+	T_125 (in signature of PyArg_ParseTuple @ 00000000 : void)
+Eq_131: PyObject
+	T_131 (in eax_16 @ 10001158 : (ptr32 Eq_131))
+	T_133 (in &_Py_NoneStruct @ 10001158 : word32)
+Eq_132: PyObject
+	T_132 (in _Py_NoneStruct @ 10001158 : PyObject)
+	T_142 (in _Py_NoneStruct @ 10001165 : PyObject)
+Eq_144: (fn (ptr32 Eq_156) ((ptr32 char), (ptr32 (arr PyMethodDef 5)), (ptr32 char), (ptr32 Eq_149), int32))
+	T_144 (in Py_InitModule4 @ 10001183 : ptr32)
+	T_145 (in signature of Py_InitModule4 @ 00000000 : void)
+Eq_147: PyMethodDef
+	T_147 (in ptrArg08 @ 10001183 : (ptr32 PyMethodDef))
+	T_152 (in 0x10003010<32> @ 10001183 : word32)
+Eq_149: PyObject
+	T_149 (in ptrArg10 @ 10001183 : (ptr32 PyObject))
+	T_154 (in 0<32> @ 10001183 : word32)
+Eq_156: PyObject
+	T_156 (in Py_InitModule4("pySample", methods, null, null, 0x3EF<32>) @ 10001183 : (ptr32 PyObject))
+Eq_158: (union "Eq_158" (_onexit_t u0) (HMODULE u1))
+	T_158 (in dwArg04 @ 1000118C : Eq_158)
+	T_422 (in ebx_113 @ 10001398 : Eq_158)
+	T_425 (in Mem7[ebp_13 + 8<32>:word32] @ 10001398 : word32)
+	T_498 (in Mem114[esp_106 + -8<i32>:word32] @ 100013FC : word32)
+	T_502 (in dwArg04 @ 100013FD : Eq_158)
+	T_506 (in Mem114[esp_106 + -8<i32>:word32] @ 100013FD : word32)
+	T_540 (in Mem88[esp_80 + -8<i32>:word32] @ 100013E9 : word32)
+	T_546 (in Mem88[esp_80 + -8<i32>:word32] @ 100013EA : word32)
+	T_576 (in Mem133[esp_106 + -8<i32>:word32] @ 10001410 : word32)
+	T_580 (in Mem133[esp_106 + -8<i32>:word32] @ 10001411 : word32)
+	T_594 (in Mem145[esp_106 + -8<i32>:word32] @ 10001419 : word32)
+	T_598 (in Mem145[esp_106 + -8<i32>:word32] @ 1000141A : word32)
+	T_630 (in Mem194[esp_184 + -8<i32>:word32] @ 10001439 : word32)
+	T_638 (in Mem194[esp_184 + -8<i32>:word32] @ 1000143A : word32)
+	T_695 (in eax @ 100014A5 : Eq_158)
+	T_699 (in eax_111 @ 100015CF : Eq_158)
+	T_751 (in v16_57 @ 10001628 : Eq_158)
+	T_754 (in Mem56[ebp_13 + 8<32>:word32] @ 10001628 : word32)
+	T_757 (in func @ 10001630 : _onexit_t)
+	T_762 (in Mem59[esp_30 + -16<i32>:_onexit_t] @ 10001630 : _onexit_t)
+	T_769 (in __dllonexit(esp_30->tFFFFFFF0, esp_30->ptrFFFFFFF4, esp_30->ptrFFFFFFF8) @ 10001630 : _onexit_t)
+	T_772 (in Mem61[ebp_13 + -36<i32>:word32] @ 10001630 : word32)
+	T_804 (in Mem83[ebp_13 + -36<i32>:word32] @ 1000165C : word32)
+	T_807 (in _Func @ 100015F5 : _onexit_t)
+	T_810 (in Mem25[ebp_13 + 8<32>:word32] @ 100015F5 : word32)
+	T_811 (in _onexit(ebp_13->t0008) @ 100015F5 : _onexit_t)
+	T_934 (in eax_36 @ 10001762 : Eq_158)
+	T_937 (in Mem24[ebp_13 + 8<32>:word32] @ 10001762 : word32)
+	T_972 (in hLibModule @ 100017DA : HMODULE)
+Eq_159: DWORD
+	T_159 (in dwArg08 @ 1000118C : Eq_159)
+	T_167 (in 0<32> @ 100011F2 : word32)
+	T_180 (in 1<32> @ 10001216 : word32)
+	T_193 (in 0<32> @ 100012EA : word32)
+	T_228 (in dwMilliseconds @ 10001302 : DWORD)
+	T_229 (in 0x3E8<32> @ 10001302 : word32)
+	T_235 (in eax_69 @ 10001332 : Eq_159)
+	T_241 (in _decode_pointer(g_ptr100033B4) @ 10001332 : (ptr32 void))
+	T_245 (in 0<32> @ 10001339 : word32)
+	T_271 (in 0x3E8<32> @ 10001243 : word32)
+	T_303 (in edi_82 @ 10001344 : DWORD)
+	T_307 (in _decode_pointer(g_ptr100033B0) @ 10001344 : (ptr32 void))
+	T_309 (in edi_82 - 4<32> @ 00000000 : word32)
+	T_350 (in Mem103[esp_102 + 0<32>:word32] @ 10001357 : word32)
+	T_353 (in ptrArg04 @ 10001358 : (ptr32 void))
+	T_356 (in Mem103[esp_102 + 0<32>:(ptr32 void)] @ 10001358 : (ptr32 void))
+	T_405 (in eax @ 10001385 : Eq_159)
+	T_407 (in edx @ 10001385 : Eq_159)
+	T_426 (in 1<32> @ 1000139E : word32)
+	T_429 (in Mem25[ebp_13 + -28<i32>:word32] @ 1000139E : word32)
+	T_435 (in Mem28[0x10003008<p32>:word32] @ 100013A6 : word32)
+	T_445 (in esi_110 @ 10001396 : Eq_159)
+	T_446 (in 0<32> @ 100013B1 : word32)
+	T_448 (in 1<32> @ 100013C5 : word32)
+	T_454 (in 0<32> @ 100013BB : word32)
+	T_457 (in Mem248[ebp_13 + -28<i32>:word32] @ 100013BB : word32)
+	T_469 (in eax_257 @ 1000148A : Eq_159)
+	T_472 (in Mem256[ebp_13 + -28<i32>:word32] @ 1000148A : word32)
+	T_485 (in 2<32> @ 100013CA : word32)
+	T_495 (in Mem111[esp_106 + -4<i32>:word32] @ 100013FB : word32)
+	T_499 (in eax_115 @ 100013FD : Eq_159)
+	T_503 (in dwArg08 @ 100013FD : Eq_159)
+	T_509 (in Mem114[esp_106 + -4<i32>:word32] @ 100013FD : word32)
+	T_510 (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 100013FD : word32)
+	T_513 (in Mem122[ebp_13 + -28<i32>:word32] @ 10001402 : word32)
+	T_516 (in 1<32> @ 10001408 : word32)
+	T_520 (in Mem76[ebp_13 + -28<i32>:word32] @ 100013E1 : word32)
+	T_521 (in 0<32> @ 100013E1 : word32)
+	T_525 (in fn00000000(ebx_113, edx) @ 100013DA : void)
+	T_528 (in Mem74[ebp_13 + -28<i32>:word32] @ 100013DA : word32)
+	T_537 (in Mem85[esp_80 + -4<i32>:word32] @ 100013E8 : word32)
+	T_541 (in eax_90 @ 100013EA : Eq_159)
+	T_549 (in Mem88[esp_80 + -4<i32>:word32] @ 100013EA : word32)
+	T_556 (in fn100011E9(esp_80->tFFFFFFF8, esp_80->tFFFFFFFC, esp_80->t0000, out ebx_113, out esi_110, out edi_107) @ 100013EA : word32)
+	T_559 (in Mem101[ebp_13 + -28<i32>:word32] @ 100013EF : word32)
+	T_562 (in 0<32> @ 100013F4 : word32)
+	T_564 (in 0<32> @ 10001430 : word32)
+	T_566 (in 0<32> @ 1000140C : word32)
+	T_573 (in Mem131[esp_106 + -4<i32>:word32] @ 1000140F : word32)
+	T_583 (in Mem133[esp_106 + -4<i32>:word32] @ 10001411 : word32)
+	T_584 (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 10001411 : word32)
+	T_588 (in 0<32> @ 10001417 : word32)
+	T_591 (in Mem143[esp_106 + -4<i32>:word32] @ 10001417 : word32)
+	T_601 (in Mem145[esp_106 + -4<i32>:word32] @ 1000141A : word32)
+	T_608 (in fn100011E9(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC, esp_106->t0000, out ebx_113, out esi_110, out edi_107) @ 1000141A : word32)
+	T_627 (in Mem190[esp_184 + -4<i32>:word32] @ 10001438 : word32)
+	T_634 (in eax_197 @ 1000143A : Eq_159)
+	T_641 (in Mem194[esp_184 + -4<i32>:word32] @ 1000143A : word32)
+	T_648 (in fn100011E9(esp_184->tFFFFFFF8, esp_184->tFFFFFFFC, esp_184->t0000, out ebx_198, out esi_200, out edi_201) @ 1000143A : word32)
+	T_651 (in 0<32> @ 10001441 : word32)
+	T_653 (in 3<32> @ 10001435 : word32)
+	T_657 (in Mem218[ebp_13 + -28<i32>:word32] @ 1000144A : word32)
+	T_658 (in 0<32> @ 1000144A : word32)
+	T_662 (in Mem194[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
+	T_663 (in ebp_13->tFFFFFFE4 & eax_197 @ 00000000 : word32)
+	T_666 (in Mem214[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
+	T_673 (in fn00000000(ebx_198, esi_200, edi_201) @ 1000145A : void)
+	T_676 (in Mem247[ebp_13 + -28<i32>:word32] @ 1000145A : word32)
+	T_677 (in 0xFFFFFFFF<32> @ 10001493 : word32)
+	T_679 (in Mem4[0x10003008<p32>:word32] @ 10001493 : word32)
+	T_682 (in dwReason @ 1000149D : Eq_159)
+	T_684 (in 1<32> @ 100014A3 : word32)
+	T_706 (in eax_22 @ 100015E7 : Eq_159)
+	T_710 (in _decode_pointer(g_ptr100033B4) @ 100015E7 : (ptr32 void))
+	T_713 (in Mem25[ebp_13 + -28<i32>:word32] @ 100015EA : word32)
+	T_714 (in 0xFFFFFFFF<32> @ 100015F0 : word32)
+	T_736 (in _decode_pointer(esp_30->ptr0000) @ 10001612 : (ptr32 void))
+	T_739 (in Mem45[ebp_13 + -28<i32>:word32] @ 10001612 : word32)
+	T_747 (in _decode_pointer(esp_30->ptrFFFFFFFC) @ 1000161D : (ptr32 void))
+	T_750 (in Mem50[ebp_13 + -32<i32>:word32] @ 1000161D : word32)
+	T_777 (in Mem61[ebp_13 + -28<i32>:word32] @ 1000163E : word32)
+	T_788 (in Mem71[ebp_13 + -32<i32>:word32] @ 1000164B : word32)
+	T_963 (in 1<32> @ 100017CB : word32)
+	T_1032 (in GetCurrentProcessId() @ 100018BB : DWORD)
+	T_1035 (in GetCurrentThreadId() @ 100018BB : DWORD)
+	T_1039 (in GetTickCount() @ 100018BB : DWORD)
+Eq_160: LPVOID
+	T_160 (in dwArg0C @ 1000118C : Eq_160)
+	T_406 (in ecx @ 10001385 : Eq_160)
+	T_444 (in edi_107 @ 10001394 : Eq_160)
+	T_492 (in Mem108[esp_106 + 0<32>:word32] @ 100013FA : word32)
+	T_534 (in Mem82[esp_80 + 0<32>:word32] @ 100013E7 : word32)
+	T_552 (in Mem88[esp_80 + 0<32>:word32] @ 100013EA : word32)
+	T_570 (in Mem129[esp_106 + 0<32>:word32] @ 1000140E : word32)
+	T_587 (in Mem141[esp_106 + 0<32>:word32] @ 10001416 : word32)
+	T_604 (in Mem145[esp_106 + 0<32>:word32] @ 1000141A : word32)
+	T_624 (in Mem187[esp_184 + 0<32>:word32] @ 10001437 : word32)
+	T_644 (in Mem194[esp_184 + 0<32>:word32] @ 1000143A : word32)
+	T_683 (in lpReserved @ 1000149D : Eq_160)
+Eq_165: LONG
+	T_165 (in ebp_145 @ 100011EE : Eq_165)
+	T_166 (in 0<32> @ 100011EE : word32)
+	T_195 (in edi_124 @ 10001222 : Eq_165)
+	T_201 (in Mem38[Mem38[fs:0x18<32>:word32] + 4<32>:word32] @ 10001222 : word32)
+	T_202 (in eax_136 @ 1000124D : Eq_165)
+	T_206 (in Exchange @ 1000124D : LONG)
+	T_207 (in Comperand @ 1000124D : LONG)
+	T_209 (in 0<32> @ 1000124D : word32)
+	T_210 (in InterlockedCompareExchange(&g_t100033AC, edi_124, 0<32>) @ 1000124D : LONG)
+	T_211 (in 0<32> @ 10001251 : word32)
+	T_216 (in 1<32> @ 10001310 : word32)
+	T_217 (in 0<32> @ 10001310 : word32)
+	T_218 (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) @ 10001310 : LONG)
+	T_219 (in 0<32> @ 10001310 : word32)
+	T_269 (in 1<32> @ 10001257 : word32)
+	T_276 (in 0<32> @ 1000136F : word32)
+	T_279 (in Mem111[esp_110 + 0<32>:word32] @ 1000136F : word32)
+	T_290 (in Value @ 10001378 : LONG)
+	T_296 (in Mem116[esp_110 + 0<32>:LONG] @ 10001378 : LONG)
+	T_297 (in InterlockedExchange(esp_110->ptrFFFFFFFC, esp_110->t0000) @ 10001378 : LONG)
+	T_321 (in 0<32> @ 100012AC : word32)
+	T_378 (in InterlockedExchange(&g_t100033AC, ebp_145) @ 100012B0 : LONG)
+Eq_196: (segment "Eq_196" (18 (ptr32 Eq_198) ptr0018))
+	T_196 (in fs @ 10001222 : selector)
+Eq_198: (struct "Eq_198" (4 Eq_165 t0004))
+	T_198 (in Mem38[fs:0x18<32>:word32] @ 10001222 : word32)
+Eq_203: (fn Eq_165 ((ptr32 Eq_205), Eq_165, Eq_165))
+	T_203 (in InterlockedCompareExchange @ 1000124D : ptr32)
+	T_204 (in signature of InterlockedCompareExchange @ 00000000 : void)
+	T_214 (in InterlockedCompareExchange @ 10001310 : ptr32)
+	T_390 (in ebx @ 100012CC : (ptr32 Eq_203))
+	T_394 (in InterlockedCompareExchange @ 100012CC : ptr32)
+	T_408 (in ebx @ 10001385 : (ptr32 Eq_203))
+	T_414 (in ebx @ 1000138F : (ptr32 Eq_203))
+	T_688 (in ebx @ 100014BC : word32)
+	T_696 (in ebx @ 100014A5 : (ptr32 Eq_203))
+	T_823 (in ebx @ 1000166D : (ptr32 Eq_203))
+	T_982 (in Mem17[esp_14 + -4<i32>:word32] @ 10001802 : word32)
+Eq_205: LONG
+	T_205 (in Destination @ 1000124D : (ptr32 LONG))
+	T_208 (in 0x100033AC<p32> @ 1000124D : ptr32)
+	T_215 (in 0x100033AC<p32> @ 10001310 : ptr32)
+Eq_226: (fn void (Eq_159))
+	T_226 (in Sleep @ 10001302 : ptr32)
+	T_227 (in signature of Sleep @ 00000000 : void)
+	T_270 (in Sleep @ 10001243 : ptr32)
+Eq_236: (fn Eq_159 ((ptr32 void)))
+	T_236 (in _decode_pointer @ 10001332 : ptr32)
+	T_237 (in signature of _decode_pointer @ 00000000 : void)
+	T_304 (in _decode_pointer @ 10001344 : ptr32)
+	T_707 (in _decode_pointer @ 100015E7 : ptr32)
+	T_732 (in _decode_pointer @ 10001612 : ptr32)
+	T_743 (in _decode_pointer @ 1000161D : ptr32)
+Eq_247: (fn void (int32))
+	T_247 (in _amsg_exit @ 1000131E : ptr32)
+	T_248 (in signature of _amsg_exit @ 00000000 : void)
+	T_266 (in _amsg_exit @ 10001266 : ptr32)
+Eq_257: (fn int32 ((ptr32 Eq_259), (ptr32 Eq_260)))
+	T_257 (in _initterm_e @ 1000128A : ptr32)
+	T_258 (in signature of _initterm_e @ 00000000 : void)
+Eq_259: PVFV
+	T_259 (in fStart @ 1000128A : (ptr32 PVFV))
+	T_261 (in 0x100020A0<32> @ 1000128A : word32)
+Eq_260: PVFV
+	T_260 (in fEnd @ 1000128A : (ptr32 PVFV))
+	T_262 (in 0x100020A8<32> @ 1000128A : word32)
+Eq_273: (struct "Eq_273" (FFFFFFFC (ptr32 Eq_280) ptrFFFFFFFC) (0 Eq_165 t0000))
+	T_273 (in esp_110 @ 1000136F : (ptr32 Eq_273))
+	T_275 (in esp_105 - 4<i32> @ 00000000 : word32)
+Eq_280: LONG
+	T_280 (in 0x100033AC<p32> @ 10001371 : ptr32)
+	T_283 (in Mem114[esp_110 + -4<i32>:word32] @ 10001371 : word32)
+	T_289 (in Target @ 10001378 : (ptr32 LONG))
+	T_293 (in Mem116[esp_110 + -4<i32>:(ptr32 LONG)] @ 10001378 : (ptr32 LONG))
+	T_377 (in 0x100033AC<p32> @ 100012B0 : ptr32)
+Eq_287: (fn Eq_165 ((ptr32 Eq_280), Eq_165))
+	T_287 (in InterlockedExchange @ 10001378 : ptr32)
+	T_288 (in signature of InterlockedExchange @ 00000000 : void)
+	T_376 (in InterlockedExchange @ 100012B0 : ptr32)
+Eq_311: (fn void ((ptr32 Eq_313), (ptr32 Eq_314)))
+	T_311 (in _initterm @ 1000129D : ptr32)
+	T_312 (in signature of _initterm @ 00000000 : void)
+Eq_313: PVFV
+	T_313 (in fStart @ 1000129D : (ptr32 PVFV))
+	T_315 (in 0x10002098<32> @ 1000129D : word32)
+Eq_314: PVFV
+	T_314 (in fEnd @ 1000129D : (ptr32 PVFV))
+	T_316 (in 0x1000209C<32> @ 1000129D : word32)
+Eq_324: (struct "Eq_324" (0 ptr32 ptr0000) (4 ptr32 ptr0004))
+	T_324 (in esp_261 @ 10001381 : (ptr32 Eq_324))
+	T_326 (in esp_118 + 4<i32> @ 10001381 : word32)
+Eq_351: (fn void (Eq_159))
+	T_351 (in free @ 10001358 : ptr32)
+	T_352 (in signature of free @ 00000000 : void)
+Eq_359: (fn (ptr32 void) ())
+	T_359 (in _encoded_null @ 1000135F : ptr32)
+	T_360 (in signature of _encoded_null @ 00000000 : void)
+Eq_388: (fn word32 ((ptr32 Eq_203), ptr32, word32, ptr32))
+	T_388 (in fn10001742 @ 100012CC : ptr32)
+	T_389 (in signature of fn10001742 @ 10001742 : void)
+Eq_411: (struct "Eq_411"
+		(FFFFFFDC Eq_158 tFFFFFFDC)
+		(FFFFFFE0 Eq_159 tFFFFFFE0)
+		(FFFFFFE4 Eq_159 tFFFFFFE4)
 		(FFFFFFF0 word32 dwFFFFFFF0)
 		(FFFFFFFC word32 dwFFFFFFFC)
-		(0 Eq_456 t0000)
-		(8 Eq_138 t0008))
-	T_391 (in ebp_13 @ 1000138F : (ptr32 Eq_391))
-	T_401 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10<32>) @ 1000138F : word32)
-	T_455 (in ebp @ 1000148D : (ptr32 Eq_391))
-	T_681 (in ebp_13 @ 100015D6 : (ptr32 Eq_391))
-	T_685 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x14<32>) @ 100015D6 : word32)
-	T_892 (in ebp_13 @ 10001749 : (ptr32 Eq_391))
-	T_896 (in fn100017E8(ebx, esi, edi, dwLoc0C, 8<32>) @ 10001749 : word32)
-Eq_392: (fn (ptr32 Eq_391) ((ptr32 Eq_183), ptr32, word32, word32, ui32))
-	T_392 (in fn100017E8 @ 1000138F : ptr32)
-	T_393 (in signature of fn100017E8 @ 100017E8 : void)
-	T_682 (in fn100017E8 @ 100015D6 : ptr32)
-	T_893 (in fn100017E8 @ 10001749 : ptr32)
-Eq_420: (struct "Eq_420" (FFFFFFFC Eq_456 tFFFFFFFC))
-	T_420 (in esp_100 @ 1000138A : (ptr32 Eq_420))
-	T_423 (in fp - 8<i32> @ 00000000 : word32)
-	T_495 (in esp_106 + 4<32> @ 100013FD : word32)
-	T_541 (in esp_80 + 4<32> @ 100013EA : word32)
-	T_590 (in esp_106 + 4<32> @ 1000141A : word32)
-	T_630 (in esp_184 + 4<32> @ 1000143A : word32)
-Eq_446: (fn void ())
-	T_446 (in fn10001493 @ 10001485 : ptr32)
-	T_447 (in signature of fn10001493 @ 10001493 : void)
-Eq_453: (fn ptr32 ((ptr32 Eq_391), Eq_456))
-	T_453 (in fn1000182D @ 1000148D : ptr32)
-	T_454 (in signature of fn1000182D @ 1000182D : void)
-	T_795 (in fn1000182D @ 1000165F : ptr32)
-	T_940 (in fn1000182D @ 100017AD : ptr32)
-Eq_456: (union "Eq_456" (ui32 u0) (ptr32 u1))
-	T_456 (in dwArg00 @ 1000148D : Eq_456)
-	T_459 (in Mem256[esp_100 + -4<i32>:word32] @ 1000148D : word32)
-	T_798 (in Mem95[esp_80 + -4<i32>:word32] @ 1000165F : word32)
-	T_901 (in dwLoc0C_84 @ 10001757 : Eq_456)
-	T_902 (in 0x10000000<p32> @ 10001757 : ptr32)
-	T_919 (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
-	T_995 (in Mem22[ebp + 0<32>:word32] @ 1000183F : word32)
-Eq_467: (struct "Eq_467" (FFFFFFF8 Eq_138 tFFFFFFF8) (FFFFFFFC Eq_139 tFFFFFFFC) (0 Eq_140 t0000))
-	T_467 (in esp_106 @ 100013FA : (ptr32 Eq_467))
-	T_469 (in esp_100 - 4<i32> @ 00000000 : word32)
-Eq_480: (fn Eq_139 (Eq_138, Eq_139))
-	T_480 (in fn100017C6 @ 100013FD : ptr32)
-	T_481 (in signature of fn100017C6 @ 100017C6 : void)
-	T_557 (in fn100017C6 @ 10001411 : ptr32)
-Eq_503: (fn Eq_139 (Eq_138, Eq_139))
-	T_503 (in fn00000000 @ 100013DA : ptr32)
-Eq_509: (struct "Eq_509" (FFFFFFF8 Eq_138 tFFFFFFF8) (FFFFFFFC Eq_139 tFFFFFFFC) (0 Eq_140 t0000))
-	T_509 (in esp_80 @ 100013E7 : (ptr32 Eq_509))
-	T_511 (in esp_100 - 4<i32> @ 00000000 : word32)
-Eq_522: (fn Eq_139 (Eq_138, Eq_139, Eq_140, ptr32, ptr32, ptr32))
-	T_522 (in fn100011E9 @ 100013EA : ptr32)
-	T_523 (in signature of fn100011E9 @ 100011E9 : void)
-	T_575 (in fn100011E9 @ 1000141A : ptr32)
-	T_615 (in fn100011E9 @ 1000143A : ptr32)
-Eq_595: (fn void (Eq_138, word32, Eq_140))
-	T_595 (in fn00000000 @ 1000142C : ptr32)
-Eq_599: (struct "Eq_599" (FFFFFFF8 Eq_138 tFFFFFFF8) (FFFFFFFC Eq_139 tFFFFFFFC) (0 Eq_140 t0000))
-	T_599 (in esp_184 @ 10001437 : (ptr32 Eq_599))
-	T_601 (in esp_100 - 4<i32> @ 00000000 : word32)
-Eq_651: (fn Eq_139 (word32, word32, word32))
-	T_651 (in fn00000000 @ 1000145A : ptr32)
-Eq_660: BOOL
-	T_660 (in eax @ 1000149D : Eq_660)
-	T_671 (in fn10001388(lpReserved, dwReason, ebx, esi, edi) @ 100014BC : word32)
-	T_953 (in DisableThreadLibraryCalls(dwArg04) @ 100017DA : BOOL)
-	T_1026 (in QueryPerformanceCounter(fp - 0x14<32>) @ 100018C1 : BOOL)
-Eq_661: HANDLE
-	T_661 (in hModule @ 1000149D : Eq_661)
-Eq_666: (fn Eq_660 (Eq_140, Eq_139, (ptr32 Eq_183), ptr32, word32))
-	T_666 (in fn10001388 @ 100014BC : ptr32)
-	T_667 (in signature of fn10001388 @ 10001388 : void)
-Eq_672: (fn void ())
-	T_672 (in fn10001864 @ 100014A5 : ptr32)
-	T_673 (in signature of fn10001864 @ 10001864 : void)
-Eq_680: (struct "Eq_680" (FFFFFFFC Eq_456 tFFFFFFFC))
-	T_680 (in esp_80 @ 100015CF : (ptr32 Eq_680))
-	T_781 (in esp_75 + 0x1C<32> @ 00000000 : word32)
-	T_794 (in fp - 8<i32> @ 00000000 : word32)
-Eq_696: (fn void (word32))
-	T_696 (in lock @ 10001600 : ptr32)
-Eq_701: (struct "Eq_701" (FFFFFFF0 Eq_138 tFFFFFFF0) (FFFFFFF4 (ptr32 (ptr32 Eq_738)) ptrFFFFFFF4) (FFFFFFF8 (ptr32 (ptr32 Eq_739)) ptrFFFFFFF8) (FFFFFFFC (ptr32 void) ptrFFFFFFFC) (0 (ptr32 void) ptr0000))
-	T_701 (in esp_30 @ 10001605 : word32)
-Eq_735: (fn Eq_138 (Eq_138, (ptr32 (ptr32 Eq_738)), (ptr32 (ptr32 Eq_739))))
-	T_735 (in __dllonexit @ 10001630 : ptr32)
-	T_736 (in signature of __dllonexit @ 00000000 : void)
-Eq_738: PVFV
-	T_738 (in pbegin @ 10001630 : (ptr32 (ptr32 PVFV)))
-	T_745 (in Mem59[esp_30 + -12<i32>:(ptr32 (ptr32 PVFV))] @ 10001630 : (ptr32 (ptr32 PVFV)))
-Eq_739: PVFV
-	T_739 (in pend @ 10001630 : (ptr32 (ptr32 PVFV)))
-	T_748 (in Mem59[esp_30 + -8<i32>:(ptr32 (ptr32 PVFV))] @ 10001630 : (ptr32 (ptr32 PVFV)))
-Eq_753: (fn (ptr32 void) ((ptr32 void), Eq_139, Eq_138, ptr32, ptr32, (ptr32 void), (ptr32 void)))
-	T_753 (in encode_pointer @ 1000163E : ptr32)
-Eq_765: (fn (ptr32 void) (Eq_139))
-	T_765 (in encode_pointer @ 1000164B : ptr32)
-Eq_776: (fn void ())
-	T_776 (in fn10001665 @ 10001657 : ptr32)
-	T_777 (in signature of fn10001665 @ 10001665 : void)
-Eq_785: (fn Eq_138 (Eq_138))
-	T_785 (in _onexit @ 100015F5 : ptr32)
-	T_786 (in signature of _onexit @ 00000000 : void)
-Eq_800: (fn void ())
-	T_800 (in unlock @ 10001667 : ptr32)
-Eq_806: (fn word32 ((ptr32 Eq_183), ptr32, word32))
-	T_806 (in fn100015CF @ 10001672 : ptr32)
-	T_807 (in signature of fn100015CF @ 100015CF : void)
-Eq_821: (fn void ())
-	T_821 (in fn00000000 @ 10001698 : ptr32)
-Eq_825: (struct "Eq_825" (0 word16 w0000) (3C word32 dw003C))
-	T_825 (in dwArg04 @ 10001698 : (ptr32 Eq_825))
-	T_905 (in 0x10000000<p32> @ 10001760 : ptr32)
-Eq_831: (struct "Eq_831" (0 word32 dw0000) (18 word16 w0018))
-	T_831 (in eax_9 @ 100016E1 : (ptr32 Eq_831))
-	T_835 (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 100016E1 : word32)
-Eq_849: (struct "Eq_849" 0028 (8 up32 dw0008) (C word32 dw000C))
-	T_849 (in eax @ 100016F8 : (ptr32 Eq_849))
-	T_864 (in eax_22 @ 10001718 : (ptr32 Eq_849))
-	T_871 (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) + 0x18<32> + ecx_7 @ 10001718 : word32)
-	T_874 (in 0<32> @ 1000173C : word32)
-	T_878 (in eax_22 + 0x28<32> @ 10001735 : word32)
-Eq_850: (struct "Eq_850" (3C word32 dw003C))
-	T_850 (in dwArg04 @ 100016F8 : (ptr32 Eq_850))
-	T_923 (in 0x10000000<p32> @ 10001769 : ptr32)
-Eq_852: (struct "Eq_852" (6 word16 w0006) (14 word16 w0014))
-	T_852 (in ecx_7 @ 10001707 : (ptr32 Eq_852))
-	T_856 (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 10001707 : word32)
-Eq_903: (fn word32 ((ptr32 Eq_825)))
-	T_903 (in fn100016D0 @ 10001760 : ptr32)
-	T_904 (in signature of fn100016D0 @ 100016D0 : void)
-Eq_918: (union "Eq_918" (ui32 u0) (ptr32 u1))
-	T_918 (in 0x10000000<p32> @ 10001767 : ptr32)
-Eq_920: (struct "Eq_920" (24 uint32 dw0024))
-	T_920 (in eax_43 @ 10001769 : (ptr32 Eq_920))
-	T_925 (in fn10001700(&g_t10000000, eax_36 - 0x10000000<p32>) @ 10001769 : word32)
-	T_926 (in 0<32> @ 10001772 : word32)
-Eq_921: (fn (ptr32 Eq_920) ((ptr32 Eq_850), uint32))
-	T_921 (in fn10001700 @ 10001769 : ptr32)
-	T_922 (in signature of fn10001700 @ 10001700 : void)
-Eq_950: (fn Eq_660 (Eq_138))
-	T_950 (in DisableThreadLibraryCalls @ 100017DA : ptr32)
-	T_951 (in signature of DisableThreadLibraryCalls @ 00000000 : void)
-Eq_955: (struct "Eq_955" (FFFFFFEC word32 dwFFFFFFEC) (FFFFFFF0 ui32 dwFFFFFFF0) (FFFFFFF4 word32 dwFFFFFFF4) (FFFFFFF8 ptr32 ptrFFFFFFF8) (FFFFFFFC (ptr32 Eq_183) ptrFFFFFFFC))
-	T_955 (in esp_14 @ 10001800 : (ptr32 Eq_955))
-	T_959 (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
-Eq_982: (segment "Eq_982" (0 ptr32 ptr0000))
-	T_982 (in fs @ 10001826 : selector)
-Eq_990: (segment "Eq_990" (0 word32 dw0000))
-	T_990 (in fs @ 10001830 : selector)
-Eq_991: (union "Eq_991" (ptr32 u0) ((memptr (ptr32 Eq_990) word32) u1))
-	T_991 (in 0x00000000<p32> @ 10001830 : ptr32)
-Eq_1002: (fn void (Eq_1004))
-	T_1002 (in GetSystemTimeAsFileTime @ 10001899 : ptr32)
-	T_1003 (in signature of GetSystemTimeAsFileTime @ 00000000 : void)
-Eq_1004: LPFILETIME
-	T_1004 (in lpSystemTimeAsFileTime @ 10001899 : LPFILETIME)
-	T_1007 (in fp - 0xC<32> @ 00000000 : word32)
-Eq_1010: (fn Eq_139 ())
-	T_1010 (in GetCurrentProcessId @ 100018BB : ptr32)
-	T_1011 (in signature of GetCurrentProcessId @ 00000000 : void)
-Eq_1013: (fn Eq_139 ())
-	T_1013 (in GetCurrentThreadId @ 100018BB : ptr32)
-	T_1014 (in signature of GetCurrentThreadId @ 00000000 : void)
-Eq_1017: (fn Eq_139 ())
-	T_1017 (in GetTickCount @ 100018BB : ptr32)
-	T_1018 (in signature of GetTickCount @ 00000000 : void)
-Eq_1021: (fn Eq_660 ((ptr32 Eq_1023)))
-	T_1021 (in QueryPerformanceCounter @ 100018C1 : ptr32)
-	T_1022 (in signature of QueryPerformanceCounter @ 00000000 : void)
-Eq_1023: LARGE_INTEGER
-	T_1023 (in lpPerformanceCount @ 100018C1 : (ptr32 LARGE_INTEGER))
-	T_1025 (in fp - 0x14<32> @ 00000000 : word32)
-Eq_1091: DWORD
-	T_1091
+		(0 Eq_476 t0000)
+		(8 Eq_158 t0008))
+	T_411 (in ebp_13 @ 1000138F : (ptr32 Eq_411))
+	T_421 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10<32>) @ 1000138F : word32)
+	T_475 (in ebp @ 1000148D : (ptr32 Eq_411))
+	T_701 (in ebp_13 @ 100015D6 : (ptr32 Eq_411))
+	T_705 (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x14<32>) @ 100015D6 : word32)
+	T_912 (in ebp_13 @ 10001749 : (ptr32 Eq_411))
+	T_916 (in fn100017E8(ebx, esi, edi, dwLoc0C, 8<32>) @ 10001749 : word32)
+Eq_412: (fn (ptr32 Eq_411) ((ptr32 Eq_203), ptr32, word32, word32, ui32))
+	T_412 (in fn100017E8 @ 1000138F : ptr32)
+	T_413 (in signature of fn100017E8 @ 100017E8 : void)
+	T_702 (in fn100017E8 @ 100015D6 : ptr32)
+	T_913 (in fn100017E8 @ 10001749 : ptr32)
+Eq_440: (struct "Eq_440" (FFFFFFFC Eq_476 tFFFFFFFC))
+	T_440 (in esp_100 @ 1000138A : (ptr32 Eq_440))
+	T_443 (in fp - 8<i32> @ 00000000 : word32)
+	T_515 (in esp_106 + 4<32> @ 100013FD : word32)
+	T_561 (in esp_80 + 4<32> @ 100013EA : word32)
+	T_610 (in esp_106 + 4<32> @ 1000141A : word32)
+	T_650 (in esp_184 + 4<32> @ 1000143A : word32)
+Eq_466: (fn void ())
+	T_466 (in fn10001493 @ 10001485 : ptr32)
+	T_467 (in signature of fn10001493 @ 10001493 : void)
+Eq_473: (fn ptr32 ((ptr32 Eq_411), Eq_476))
+	T_473 (in fn1000182D @ 1000148D : ptr32)
+	T_474 (in signature of fn1000182D @ 1000182D : void)
+	T_815 (in fn1000182D @ 1000165F : ptr32)
+	T_960 (in fn1000182D @ 100017AD : ptr32)
+Eq_476: (union "Eq_476" (ui32 u0) (ptr32 u1))
+	T_476 (in dwArg00 @ 1000148D : Eq_476)
+	T_479 (in Mem256[esp_100 + -4<i32>:word32] @ 1000148D : word32)
+	T_818 (in Mem95[esp_80 + -4<i32>:word32] @ 1000165F : word32)
+	T_921 (in dwLoc0C_84 @ 10001757 : Eq_476)
+	T_922 (in 0x10000000<p32> @ 10001757 : ptr32)
+	T_939 (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
+	T_1015 (in Mem22[ebp + 0<32>:word32] @ 1000183F : word32)
+Eq_487: (struct "Eq_487" (FFFFFFF8 Eq_158 tFFFFFFF8) (FFFFFFFC Eq_159 tFFFFFFFC) (0 Eq_160 t0000))
+	T_487 (in esp_106 @ 100013FA : (ptr32 Eq_487))
+	T_489 (in esp_100 - 4<i32> @ 00000000 : word32)
+Eq_500: (fn Eq_159 (Eq_158, Eq_159))
+	T_500 (in fn100017C6 @ 100013FD : ptr32)
+	T_501 (in signature of fn100017C6 @ 100017C6 : void)
+	T_577 (in fn100017C6 @ 10001411 : ptr32)
+Eq_523: (fn Eq_159 (Eq_158, Eq_159))
+	T_523 (in fn00000000 @ 100013DA : ptr32)
+Eq_529: (struct "Eq_529" (FFFFFFF8 Eq_158 tFFFFFFF8) (FFFFFFFC Eq_159 tFFFFFFFC) (0 Eq_160 t0000))
+	T_529 (in esp_80 @ 100013E7 : (ptr32 Eq_529))
+	T_531 (in esp_100 - 4<i32> @ 00000000 : word32)
+Eq_542: (fn Eq_159 (Eq_158, Eq_159, Eq_160, ptr32, ptr32, ptr32))
+	T_542 (in fn100011E9 @ 100013EA : ptr32)
+	T_543 (in signature of fn100011E9 @ 100011E9 : void)
+	T_595 (in fn100011E9 @ 1000141A : ptr32)
+	T_635 (in fn100011E9 @ 1000143A : ptr32)
+Eq_615: (fn void (Eq_158, word32, Eq_160))
+	T_615 (in fn00000000 @ 1000142C : ptr32)
+Eq_619: (struct "Eq_619" (FFFFFFF8 Eq_158 tFFFFFFF8) (FFFFFFFC Eq_159 tFFFFFFFC) (0 Eq_160 t0000))
+	T_619 (in esp_184 @ 10001437 : (ptr32 Eq_619))
+	T_621 (in esp_100 - 4<i32> @ 00000000 : word32)
+Eq_671: (fn Eq_159 (word32, word32, word32))
+	T_671 (in fn00000000 @ 1000145A : ptr32)
+Eq_680: BOOL
+	T_680 (in eax @ 1000149D : Eq_680)
+	T_691 (in fn10001388(lpReserved, dwReason, ebx, esi, edi) @ 100014BC : word32)
+	T_973 (in DisableThreadLibraryCalls(dwArg04) @ 100017DA : BOOL)
+	T_1046 (in QueryPerformanceCounter(&tLoc14) @ 100018C1 : BOOL)
+Eq_681: HANDLE
+	T_681 (in hModule @ 1000149D : Eq_681)
+Eq_686: (fn Eq_680 (Eq_160, Eq_159, (ptr32 Eq_203), ptr32, word32))
+	T_686 (in fn10001388 @ 100014BC : ptr32)
+	T_687 (in signature of fn10001388 @ 10001388 : void)
+Eq_692: (fn void ())
+	T_692 (in fn10001864 @ 100014A5 : ptr32)
+	T_693 (in signature of fn10001864 @ 10001864 : void)
+Eq_700: (struct "Eq_700" (FFFFFFFC Eq_476 tFFFFFFFC))
+	T_700 (in esp_80 @ 100015CF : (ptr32 Eq_700))
+	T_801 (in esp_75 + 0x1C<32> @ 00000000 : word32)
+	T_814 (in fp - 8<i32> @ 00000000 : word32)
+Eq_716: (fn void (word32))
+	T_716 (in lock @ 10001600 : ptr32)
+Eq_721: (struct "Eq_721" (FFFFFFF0 Eq_158 tFFFFFFF0) (FFFFFFF4 (ptr32 (ptr32 Eq_758)) ptrFFFFFFF4) (FFFFFFF8 (ptr32 (ptr32 Eq_759)) ptrFFFFFFF8) (FFFFFFFC (ptr32 void) ptrFFFFFFFC) (0 (ptr32 void) ptr0000))
+	T_721 (in esp_30 @ 10001605 : word32)
+Eq_755: (fn Eq_158 (Eq_158, (ptr32 (ptr32 Eq_758)), (ptr32 (ptr32 Eq_759))))
+	T_755 (in __dllonexit @ 10001630 : ptr32)
+	T_756 (in signature of __dllonexit @ 00000000 : void)
+Eq_758: PVFV
+	T_758 (in pbegin @ 10001630 : (ptr32 (ptr32 PVFV)))
+	T_765 (in Mem59[esp_30 + -12<i32>:(ptr32 (ptr32 PVFV))] @ 10001630 : (ptr32 (ptr32 PVFV)))
+Eq_759: PVFV
+	T_759 (in pend @ 10001630 : (ptr32 (ptr32 PVFV)))
+	T_768 (in Mem59[esp_30 + -8<i32>:(ptr32 (ptr32 PVFV))] @ 10001630 : (ptr32 (ptr32 PVFV)))
+Eq_773: (fn (ptr32 void) ((ptr32 void), Eq_159, Eq_158, ptr32, ptr32, (ptr32 void), (ptr32 void)))
+	T_773 (in encode_pointer @ 1000163E : ptr32)
+Eq_785: (fn (ptr32 void) (Eq_159))
+	T_785 (in encode_pointer @ 1000164B : ptr32)
+Eq_796: (fn void ())
+	T_796 (in fn10001665 @ 10001657 : ptr32)
+	T_797 (in signature of fn10001665 @ 10001665 : void)
+Eq_805: (fn Eq_158 (Eq_158))
+	T_805 (in _onexit @ 100015F5 : ptr32)
+	T_806 (in signature of _onexit @ 00000000 : void)
+Eq_820: (fn void ())
+	T_820 (in unlock @ 10001667 : ptr32)
+Eq_826: (fn word32 ((ptr32 Eq_203), ptr32, word32))
+	T_826 (in fn100015CF @ 10001672 : ptr32)
+	T_827 (in signature of fn100015CF @ 100015CF : void)
+Eq_841: (fn void ())
+	T_841 (in fn00000000 @ 10001698 : ptr32)
+Eq_845: (struct "Eq_845" (0 word16 w0000) (3C word32 dw003C))
+	T_845 (in dwArg04 @ 10001698 : (ptr32 Eq_845))
+	T_925 (in 0x10000000<p32> @ 10001760 : ptr32)
+Eq_851: (struct "Eq_851" (0 word32 dw0000) (18 word16 w0018))
+	T_851 (in eax_9 @ 100016E1 : (ptr32 Eq_851))
+	T_855 (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 100016E1 : word32)
+Eq_869: (struct "Eq_869" 0028 (8 up32 dw0008) (C word32 dw000C))
+	T_869 (in eax @ 100016F8 : (ptr32 Eq_869))
+	T_884 (in eax_22 @ 10001718 : (ptr32 Eq_869))
+	T_891 (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) + 0x18<32> + ecx_7 @ 10001718 : word32)
+	T_894 (in 0<32> @ 1000173C : word32)
+	T_898 (in eax_22 + 0x28<32> @ 10001735 : word32)
+Eq_870: (struct "Eq_870" (3C word32 dw003C))
+	T_870 (in dwArg04 @ 100016F8 : (ptr32 Eq_870))
+	T_943 (in 0x10000000<p32> @ 10001769 : ptr32)
+Eq_872: (struct "Eq_872" (6 word16 w0006) (14 word16 w0014))
+	T_872 (in ecx_7 @ 10001707 : (ptr32 Eq_872))
+	T_876 (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 10001707 : word32)
+Eq_923: (fn word32 ((ptr32 Eq_845)))
+	T_923 (in fn100016D0 @ 10001760 : ptr32)
+	T_924 (in signature of fn100016D0 @ 100016D0 : void)
+Eq_938: (union "Eq_938" (ui32 u0) (ptr32 u1))
+	T_938 (in 0x10000000<p32> @ 10001767 : ptr32)
+Eq_940: (struct "Eq_940" (24 uint32 dw0024))
+	T_940 (in eax_43 @ 10001769 : (ptr32 Eq_940))
+	T_945 (in fn10001700(&g_t10000000, eax_36 - 0x10000000<p32>) @ 10001769 : word32)
+	T_946 (in 0<32> @ 10001772 : word32)
+Eq_941: (fn (ptr32 Eq_940) ((ptr32 Eq_870), uint32))
+	T_941 (in fn10001700 @ 10001769 : ptr32)
+	T_942 (in signature of fn10001700 @ 10001700 : void)
+Eq_970: (fn Eq_680 (Eq_158))
+	T_970 (in DisableThreadLibraryCalls @ 100017DA : ptr32)
+	T_971 (in signature of DisableThreadLibraryCalls @ 00000000 : void)
+Eq_975: (struct "Eq_975" (FFFFFFEC word32 dwFFFFFFEC) (FFFFFFF0 ui32 dwFFFFFFF0) (FFFFFFF4 word32 dwFFFFFFF4) (FFFFFFF8 ptr32 ptrFFFFFFF8) (FFFFFFFC (ptr32 Eq_203) ptrFFFFFFFC))
+	T_975 (in esp_14 @ 10001800 : (ptr32 Eq_975))
+	T_979 (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
+Eq_1002: (segment "Eq_1002" (0 ptr32 ptr0000))
+	T_1002 (in fs @ 10001826 : selector)
+Eq_1010: (segment "Eq_1010" (0 word32 dw0000))
+	T_1010 (in fs @ 10001830 : selector)
+Eq_1011: (union "Eq_1011" (ptr32 u0) ((memptr (ptr32 Eq_1010) word32) u1))
+	T_1011 (in 0x00000000<p32> @ 10001830 : ptr32)
+Eq_1022: (fn void (Eq_1024))
+	T_1022 (in GetSystemTimeAsFileTime @ 10001899 : ptr32)
+	T_1023 (in signature of GetSystemTimeAsFileTime @ 00000000 : void)
+Eq_1024: LPFILETIME
+	T_1024 (in lpSystemTimeAsFileTime @ 10001899 : LPFILETIME)
+	T_1027 (in fp - 0xC<32> @ 00000000 : word32)
+Eq_1030: (fn Eq_159 ())
+	T_1030 (in GetCurrentProcessId @ 100018BB : ptr32)
+	T_1031 (in signature of GetCurrentProcessId @ 00000000 : void)
+Eq_1033: (fn Eq_159 ())
+	T_1033 (in GetCurrentThreadId @ 100018BB : ptr32)
+	T_1034 (in signature of GetCurrentThreadId @ 00000000 : void)
+Eq_1037: (fn Eq_159 ())
+	T_1037 (in GetTickCount @ 100018BB : ptr32)
+	T_1038 (in signature of GetTickCount @ 00000000 : void)
+Eq_1041: (fn Eq_680 ((ptr32 Eq_1043)))
+	T_1041 (in QueryPerformanceCounter @ 100018C1 : ptr32)
+	T_1042 (in signature of QueryPerformanceCounter @ 00000000 : void)
+Eq_1043: LARGE_INTEGER
+	T_1043 (in lpPerformanceCount @ 100018C1 : (ptr32 LARGE_INTEGER))
+	T_1045 (in &tLoc14 @ 100018C1 : (ptr32 LARGE_INTEGER))
+Eq_1044: LARGE_INTEGER
+	T_1044 (in tLoc14 @ 100018C1 : LARGE_INTEGER)
+Eq_1048: (struct "Eq_1048" (0 LARGE_INTEGER t0000) (4 word32 dw0004))
+	T_1048 (in &tLoc14 @ 100018CD : (ptr32 LARGE_INTEGER))
+Eq_1052: LARGE_INTEGER
+	T_1052 (in &tLoc14 @ 100018CD : (ptr32 LARGE_INTEGER))
+Eq_1117: DWORD
+	T_1117
 // Type Variables ////////////
 globals_t: (in globals @ 00000000 : (ptr32 (struct "Globals")))
   Class: Eq_1
@@ -622,7 +628,7 @@ T_5: (in eax_17 @ 10001016 : (ptr32 Eq_2))
 T_6: (in PyArg_ParseTuple @ 10001016 : ptr32)
   Class: Eq_6
   DataType: (ptr32 Eq_6)
-  OrigDataType: (ptr32 (fn T_18 (T_4, T_12, T_15, T_17)))
+  OrigDataType: (ptr32 (fn T_17 (T_4, T_12, T_14, T_16)))
 T_7: (in signature of PyArg_ParseTuple @ 00000000 : void)
   Class: Eq_6
   DataType: (ptr32 Eq_6)
@@ -647,4274 +653,4274 @@ T_12: (in 0x10002144<32> @ 10001016 : word32)
   Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_13: (in fp @ 10001016 : ptr32)
+T_13: (in dwLoc04 @ 10001016 : int32)
   Class: Eq_13
-  DataType: ptr32
-  OrigDataType: ptr32
-T_14: (in 4<32> @ 10001016 : word32)
-  Class: Eq_14
-  DataType: ui32
-  OrigDataType: ui32
-T_15: (in fp - 4<32> @ 00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_14: (in &dwLoc04 @ 10001016 : (ptr32 int32))
   Class: Eq_10
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
-T_16: (in 8<32> @ 10001016 : word32)
-  Class: Eq_16
-  DataType: ui32
-  OrigDataType: ui32
-T_17: (in fp - 8<32> @ 00000000 : word32)
+T_15: (in dwLoc08 @ 10001016 : int32)
+  Class: Eq_15
+  DataType: int32
+  OrigDataType: int32
+T_16: (in &dwLoc08 @ 10001016 : (ptr32 int32))
   Class: Eq_11
   DataType: (ptr32 int32)
   OrigDataType: (ptr32 int32)
-T_18: (in PyArg_ParseTuple(ptrArg08, "ii:sum", fp - 4<32>, fp - 8<32>) @ 10001016 : int32)
+T_17: (in PyArg_ParseTuple(ptrArg08, "ii:sum", &dwLoc04, &dwLoc08) @ 10001016 : int32)
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_19: (in 0<32> @ 10001021 : word32)
+T_18: (in 0<32> @ 10001021 : word32)
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: word32
-T_20: (in eax_17 != null @ 00000000 : bool)
-  Class: Eq_20
+T_19: (in eax_17 != null @ 00000000 : bool)
+  Class: Eq_19
   DataType: bool
   OrigDataType: bool
-T_21: (in Py_BuildValue @ 10001042 : ptr32)
-  Class: Eq_21
-  DataType: (ptr32 Eq_21)
-  OrigDataType: (ptr32 (fn T_29 (T_25, T_28)))
-T_22: (in signature of Py_BuildValue @ 00000000 : void)
-  Class: Eq_21
-  DataType: (ptr32 Eq_21)
+T_20: (in Py_BuildValue @ 10001042 : ptr32)
+  Class: Eq_20
+  DataType: (ptr32 Eq_20)
+  OrigDataType: (ptr32 (fn T_34 (T_24, T_33)))
+T_21: (in signature of Py_BuildValue @ 00000000 : void)
+  Class: Eq_20
+  DataType: (ptr32 Eq_20)
   OrigDataType: 
-T_23: (in ptrArg04 @ 10001042 : (ptr32 char))
-  Class: Eq_23
+T_22: (in ptrArg04 @ 10001042 : (ptr32 char))
+  Class: Eq_22
   DataType: (ptr32 char)
   OrigDataType: 
-T_24: (in  @ 10001042 : int32)
-  Class: Eq_24
+T_23: (in  @ 10001042 : int32)
+  Class: Eq_23
   DataType: int32
   OrigDataType: 
-T_25: (in 0x1000214C<32> @ 10001042 : word32)
-  Class: Eq_23
+T_24: (in 0x1000214C<32> @ 10001042 : word32)
+  Class: Eq_22
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_26: (in dwLoc04 @ 10001042 : word32)
+T_25: (in &dwLoc04 @ 10001042 : (ptr32 int32))
+  Class: Eq_25
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_26: (in 0<32> @ 10001042 : word32)
   Class: Eq_26
   DataType: word32
   OrigDataType: word32
-T_27: (in dwLoc08 @ 10001042 : word32)
+T_27: (in &dwLoc04 + 0<32> @ 10001042 : word32)
   Class: Eq_27
-  DataType: word32
-  OrigDataType: word32
-T_28: (in dwLoc04 + dwLoc08 @ 00000000 : word32)
-  Class: Eq_24
-  DataType: int32
-  OrigDataType: int32
-T_29: (in Py_BuildValue("i", dwLoc04 + dwLoc08) @ 10001042 : (ptr32 PyObject))
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: (ptr32 PyObject)
-T_30: (in eax_17 @ 10001067 : (ptr32 Eq_2))
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: int32
-T_31: (in PyArg_ParseTuple @ 10001067 : ptr32)
-  Class: Eq_31
-  DataType: (ptr32 Eq_31)
-  OrigDataType: (ptr32 (fn T_41 (T_4, T_35, T_38, T_40)))
-T_32: (in signature of PyArg_ParseTuple @ 00000000 : void)
-  Class: Eq_31
-  DataType: (ptr32 Eq_31)
-  OrigDataType: 
-T_33: (in  @ 10001067 : (ptr32 int32))
-  Class: Eq_33
-  DataType: (ptr32 int32)
-  OrigDataType: 
-T_34: (in  @ 10001067 : (ptr32 int32))
-  Class: Eq_34
-  DataType: (ptr32 int32)
-  OrigDataType: 
-T_35: (in 0x10002150<32> @ 10001067 : word32)
-  Class: Eq_9
-  DataType: (ptr32 char)
-  OrigDataType: (ptr32 char)
-T_36: (in fp @ 10001067 : ptr32)
-  Class: Eq_36
   DataType: ptr32
   OrigDataType: ptr32
-T_37: (in 8<32> @ 10001067 : word32)
-  Class: Eq_37
-  DataType: ui32
-  OrigDataType: ui32
-T_38: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_33
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_39: (in 4<32> @ 10001067 : word32)
-  Class: Eq_39
-  DataType: ui32
-  OrigDataType: ui32
-T_40: (in fp - 4<32> @ 00000000 : word32)
-  Class: Eq_34
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_41: (in PyArg_ParseTuple(ptrArg08, "ii:dif", fp - 8<32>, fp - 4<32>) @ 10001067 : int32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: int32
-T_42: (in 0<32> @ 10001072 : word32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
+T_28: (in Mem16[&dwLoc04 + 0<32>:word32] @ 10001042 : word32)
+  Class: Eq_28
+  DataType: word32
   OrigDataType: word32
-T_43: (in eax_17 != null @ 00000000 : bool)
-  Class: Eq_43
-  DataType: bool
-  OrigDataType: bool
-T_44: (in Py_BuildValue @ 10001091 : ptr32)
-  Class: Eq_44
-  DataType: (ptr32 Eq_44)
-  OrigDataType: (ptr32 (fn T_51 (T_47, T_50)))
-T_45: (in signature of Py_BuildValue @ 00000000 : void)
-  Class: Eq_44
-  DataType: (ptr32 Eq_44)
-  OrigDataType: 
-T_46: (in  @ 10001091 : int32)
-  Class: Eq_46
-  DataType: int32
-  OrigDataType: 
-T_47: (in 0x1000214C<32> @ 10001091 : word32)
+T_29: (in &dwLoc08 @ 10001042 : (ptr32 int32))
+  Class: Eq_29
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_30: (in 0<32> @ 10001042 : word32)
+  Class: Eq_30
+  DataType: word32
+  OrigDataType: word32
+T_31: (in &dwLoc08 + 0<32> @ 10001042 : word32)
+  Class: Eq_31
+  DataType: ptr32
+  OrigDataType: ptr32
+T_32: (in Mem16[&dwLoc08 + 0<32>:word32] @ 10001042 : word32)
+  Class: Eq_32
+  DataType: word32
+  OrigDataType: word32
+T_33: (in dwLoc04 + dwLoc08 @ 00000000 : word32)
   Class: Eq_23
-  DataType: (ptr32 char)
-  OrigDataType: (ptr32 char)
-T_48: (in dwLoc08 @ 10001091 : word32)
-  Class: Eq_48
-  DataType: word32
-  OrigDataType: word32
-T_49: (in dwLoc04 @ 10001091 : word32)
-  Class: Eq_49
-  DataType: word32
-  OrigDataType: word32
-T_50: (in dwLoc08 - dwLoc04 @ 00000000 : word32)
-  Class: Eq_46
   DataType: int32
   OrigDataType: int32
-T_51: (in Py_BuildValue("i", dwLoc08 - dwLoc04) @ 10001091 : (ptr32 PyObject))
+T_34: (in Py_BuildValue("i", dwLoc04 + dwLoc08) @ 10001042 : (ptr32 PyObject))
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: (ptr32 PyObject)
-T_52: (in eax_17 @ 100010B7 : (ptr32 Eq_2))
+T_35: (in eax_17 @ 10001067 : (ptr32 Eq_2))
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_53: (in PyArg_ParseTuple @ 100010B7 : ptr32)
-  Class: Eq_53
-  DataType: (ptr32 Eq_53)
-  OrigDataType: (ptr32 (fn T_63 (T_4, T_57, T_60, T_62)))
-T_54: (in signature of PyArg_ParseTuple @ 00000000 : void)
-  Class: Eq_53
-  DataType: (ptr32 Eq_53)
+T_36: (in PyArg_ParseTuple @ 10001067 : ptr32)
+  Class: Eq_36
+  DataType: (ptr32 Eq_36)
+  OrigDataType: (ptr32 (fn T_45 (T_4, T_40, T_42, T_44)))
+T_37: (in signature of PyArg_ParseTuple @ 00000000 : void)
+  Class: Eq_36
+  DataType: (ptr32 Eq_36)
   OrigDataType: 
-T_55: (in  @ 100010B7 : (ptr32 int32))
-  Class: Eq_55
+T_38: (in  @ 10001067 : (ptr32 int32))
+  Class: Eq_38
   DataType: (ptr32 int32)
   OrigDataType: 
-T_56: (in  @ 100010B7 : (ptr32 int32))
-  Class: Eq_56
+T_39: (in  @ 10001067 : (ptr32 int32))
+  Class: Eq_39
   DataType: (ptr32 int32)
   OrigDataType: 
-T_57: (in 0x10002158<32> @ 100010B7 : word32)
+T_40: (in 0x10002150<32> @ 10001067 : word32)
   Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_58: (in fp @ 100010B7 : ptr32)
+T_41: (in dwLoc08 @ 10001067 : int32)
+  Class: Eq_41
+  DataType: int32
+  OrigDataType: int32
+T_42: (in &dwLoc08 @ 10001067 : (ptr32 int32))
+  Class: Eq_38
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_43: (in dwLoc04 @ 10001067 : int32)
+  Class: Eq_43
+  DataType: int32
+  OrigDataType: int32
+T_44: (in &dwLoc04 @ 10001067 : (ptr32 int32))
+  Class: Eq_39
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_45: (in PyArg_ParseTuple(ptrArg08, "ii:dif", &dwLoc08, &dwLoc04) @ 10001067 : int32)
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
+  OrigDataType: int32
+T_46: (in 0<32> @ 10001072 : word32)
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
+  OrigDataType: word32
+T_47: (in eax_17 != null @ 00000000 : bool)
+  Class: Eq_47
+  DataType: bool
+  OrigDataType: bool
+T_48: (in Py_BuildValue @ 10001091 : ptr32)
+  Class: Eq_48
+  DataType: (ptr32 Eq_48)
+  OrigDataType: (ptr32 (fn T_61 (T_51, T_60)))
+T_49: (in signature of Py_BuildValue @ 00000000 : void)
+  Class: Eq_48
+  DataType: (ptr32 Eq_48)
+  OrigDataType: 
+T_50: (in  @ 10001091 : int32)
+  Class: Eq_50
+  DataType: int32
+  OrigDataType: 
+T_51: (in 0x1000214C<32> @ 10001091 : word32)
+  Class: Eq_22
+  DataType: (ptr32 char)
+  OrigDataType: (ptr32 char)
+T_52: (in &dwLoc08 @ 10001091 : (ptr32 int32))
+  Class: Eq_52
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_53: (in 0<32> @ 10001091 : word32)
+  Class: Eq_53
+  DataType: word32
+  OrigDataType: word32
+T_54: (in &dwLoc08 + 0<32> @ 10001091 : word32)
+  Class: Eq_54
+  DataType: ptr32
+  OrigDataType: ptr32
+T_55: (in Mem16[&dwLoc08 + 0<32>:word32] @ 10001091 : word32)
+  Class: Eq_55
+  DataType: word32
+  OrigDataType: word32
+T_56: (in &dwLoc04 @ 10001091 : (ptr32 int32))
+  Class: Eq_56
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_57: (in 0<32> @ 10001091 : word32)
+  Class: Eq_57
+  DataType: word32
+  OrigDataType: word32
+T_58: (in &dwLoc04 + 0<32> @ 10001091 : word32)
   Class: Eq_58
   DataType: ptr32
   OrigDataType: ptr32
-T_59: (in 8<32> @ 100010B7 : word32)
+T_59: (in Mem16[&dwLoc04 + 0<32>:word32] @ 10001091 : word32)
   Class: Eq_59
-  DataType: ui32
-  OrigDataType: ui32
-T_60: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_55
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_61: (in 4<32> @ 100010B7 : word32)
-  Class: Eq_61
-  DataType: ui32
-  OrigDataType: ui32
-T_62: (in fp - 4<32> @ 00000000 : word32)
-  Class: Eq_56
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_63: (in PyArg_ParseTuple(ptrArg08, "ii:div", fp - 8<32>, fp - 4<32>) @ 100010B7 : int32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: int32
-T_64: (in 0<32> @ 100010C2 : word32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: word32
-T_65: (in eax_17 != null @ 00000000 : bool)
-  Class: Eq_65
-  DataType: bool
-  OrigDataType: bool
-T_66: (in Py_BuildValue @ 100010E2 : ptr32)
-  Class: Eq_66
-  DataType: (ptr32 Eq_66)
-  OrigDataType: (ptr32 (fn T_75 (T_69, T_74)))
-T_67: (in signature of Py_BuildValue @ 00000000 : void)
-  Class: Eq_66
-  DataType: (ptr32 Eq_66)
-  OrigDataType: 
-T_68: (in  @ 100010E2 : int32)
-  Class: Eq_68
-  DataType: int32
-  OrigDataType: 
-T_69: (in 0x1000214C<32> @ 100010E2 : word32)
-  Class: Eq_23
-  DataType: (ptr32 char)
-  OrigDataType: (ptr32 char)
-T_70: (in dwLoc08 @ 100010E2 : word32)
-  Class: Eq_70
   DataType: word32
   OrigDataType: word32
-T_71: (in CONVERT(dwLoc08, word32, int64) @ 100010E2 : int64)
-  Class: Eq_71
-  DataType: int64
-  OrigDataType: int64
-T_72: (in dwLoc04 @ 100010E2 : word32)
-  Class: Eq_72
+T_60: (in dwLoc08 - dwLoc04 @ 00000000 : word32)
+  Class: Eq_50
   DataType: int32
   OrigDataType: int32
-T_73: (in (int64) dwLoc08 /32 dwLoc04 @ 00000000 : word32)
-  Class: Eq_73
-  DataType: int32
+T_61: (in Py_BuildValue("i", dwLoc08 - dwLoc04) @ 10001091 : (ptr32 PyObject))
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
+  OrigDataType: (ptr32 PyObject)
+T_62: (in eax_17 @ 100010B7 : (ptr32 Eq_2))
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_74: (in CONVERT(CONVERT(dwLoc08, word32, int64) /32 dwLoc04, word32, int32) @ 100010E2 : int32)
+T_63: (in PyArg_ParseTuple @ 100010B7 : ptr32)
+  Class: Eq_63
+  DataType: (ptr32 Eq_63)
+  OrigDataType: (ptr32 (fn T_72 (T_4, T_67, T_69, T_71)))
+T_64: (in signature of PyArg_ParseTuple @ 00000000 : void)
+  Class: Eq_63
+  DataType: (ptr32 Eq_63)
+  OrigDataType: 
+T_65: (in  @ 100010B7 : (ptr32 int32))
+  Class: Eq_65
+  DataType: (ptr32 int32)
+  OrigDataType: 
+T_66: (in  @ 100010B7 : (ptr32 int32))
+  Class: Eq_66
+  DataType: (ptr32 int32)
+  OrigDataType: 
+T_67: (in 0x10002158<32> @ 100010B7 : word32)
+  Class: Eq_9
+  DataType: (ptr32 char)
+  OrigDataType: (ptr32 char)
+T_68: (in dwLoc08 @ 100010B7 : int32)
   Class: Eq_68
   DataType: int32
   OrigDataType: int32
-T_75: (in Py_BuildValue("i", (int32) ((int64) dwLoc08 /32 dwLoc04)) @ 100010E2 : (ptr32 PyObject))
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: (ptr32 PyObject)
-T_76: (in eax_17 @ 10001107 : (ptr32 Eq_2))
+T_69: (in &dwLoc08 @ 100010B7 : (ptr32 int32))
+  Class: Eq_65
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_70: (in dwLoc04 @ 100010B7 : int32)
+  Class: Eq_70
+  DataType: int32
+  OrigDataType: int32
+T_71: (in &dwLoc04 @ 100010B7 : (ptr32 int32))
+  Class: Eq_66
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_72: (in PyArg_ParseTuple(ptrArg08, "ii:div", &dwLoc08, &dwLoc04) @ 100010B7 : int32)
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_77: (in PyArg_ParseTuple @ 10001107 : ptr32)
+T_73: (in 0<32> @ 100010C2 : word32)
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
+  OrigDataType: word32
+T_74: (in eax_17 != null @ 00000000 : bool)
+  Class: Eq_74
+  DataType: bool
+  OrigDataType: bool
+T_75: (in Py_BuildValue @ 100010E2 : ptr32)
+  Class: Eq_75
+  DataType: (ptr32 Eq_75)
+  OrigDataType: (ptr32 (fn T_90 (T_78, T_89)))
+T_76: (in signature of Py_BuildValue @ 00000000 : void)
+  Class: Eq_75
+  DataType: (ptr32 Eq_75)
+  OrigDataType: 
+T_77: (in  @ 100010E2 : int32)
   Class: Eq_77
-  DataType: (ptr32 Eq_77)
-  OrigDataType: (ptr32 (fn T_87 (T_4, T_81, T_84, T_86)))
-T_78: (in signature of PyArg_ParseTuple @ 00000000 : void)
-  Class: Eq_77
-  DataType: (ptr32 Eq_77)
+  DataType: int32
   OrigDataType: 
-T_79: (in  @ 10001107 : (ptr32 real32))
-  Class: Eq_79
-  DataType: (ptr32 real32)
-  OrigDataType: 
-T_80: (in  @ 10001107 : (ptr32 real32))
-  Class: Eq_80
-  DataType: (ptr32 real32)
-  OrigDataType: 
-T_81: (in 0x10002160<32> @ 10001107 : word32)
-  Class: Eq_9
+T_78: (in 0x1000214C<32> @ 100010E2 : word32)
+  Class: Eq_22
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_82: (in fp @ 10001107 : ptr32)
-  Class: Eq_82
+T_79: (in &dwLoc08 @ 100010E2 : (ptr32 int32))
+  Class: Eq_79
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_80: (in 0<32> @ 100010E2 : word32)
+  Class: Eq_80
+  DataType: word32
+  OrigDataType: word32
+T_81: (in &dwLoc08 + 0<32> @ 100010E2 : word32)
+  Class: Eq_81
   DataType: ptr32
   OrigDataType: ptr32
-T_83: (in 8<32> @ 10001107 : word32)
-  Class: Eq_83
-  DataType: ui32
-  OrigDataType: ui32
-T_84: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_79
-  DataType: (ptr32 real32)
-  OrigDataType: (ptr32 real32)
-T_85: (in 4<32> @ 10001107 : word32)
-  Class: Eq_85
-  DataType: ui32
-  OrigDataType: ui32
-T_86: (in fp - 4<32> @ 00000000 : word32)
-  Class: Eq_80
-  DataType: (ptr32 real32)
-  OrigDataType: (ptr32 real32)
-T_87: (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", fp - 8<32>, fp - 4<32>) @ 10001107 : int32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
-  OrigDataType: int32
-T_88: (in 0<32> @ 10001112 : word32)
-  Class: Eq_2
-  DataType: (ptr32 Eq_2)
+T_82: (in Mem16[&dwLoc08 + 0<32>:word32] @ 100010E2 : word32)
+  Class: Eq_82
+  DataType: word32
   OrigDataType: word32
-T_89: (in eax_17 != null @ 00000000 : bool)
-  Class: Eq_89
-  DataType: bool
-  OrigDataType: bool
-T_90: (in Py_BuildValue @ 10001136 : ptr32)
-  Class: Eq_90
-  DataType: (ptr32 Eq_90)
-  OrigDataType: (ptr32 (fn T_99 (T_93, T_98)))
-T_91: (in signature of Py_BuildValue @ 00000000 : void)
-  Class: Eq_90
-  DataType: (ptr32 Eq_90)
-  OrigDataType: 
-T_92: (in  @ 10001136 : real64)
-  Class: Eq_92
-  DataType: real64
-  OrigDataType: 
-T_93: (in 0x10002168<32> @ 10001136 : word32)
-  Class: Eq_23
-  DataType: (ptr32 char)
-  OrigDataType: (ptr32 char)
-T_94: (in rLoc08 @ 10001136 : real32)
-  Class: Eq_94
-  DataType: real32
-  OrigDataType: real32
-T_95: (in CONVERT(rLoc08, real32, real64) @ 10001136 : real64)
-  Class: Eq_95
-  DataType: real64
-  OrigDataType: real64
-T_96: (in rLoc04 @ 10001136 : real32)
-  Class: Eq_96
-  DataType: real32
-  OrigDataType: real32
-T_97: (in CONVERT(rLoc04, real32, real64) @ 10001136 : real64)
-  Class: Eq_97
-  DataType: real64
-  OrigDataType: real64
-T_98: (in (real64) rLoc08 / (real64) rLoc04 @ 00000000 : real64)
-  Class: Eq_92
-  DataType: real64
-  OrigDataType: real64
-T_99: (in Py_BuildValue("f", (real64) rLoc08 / (real64) rLoc04) @ 10001136 : (ptr32 PyObject))
+T_83: (in CONVERT(Mem16[&dwLoc08 + 0<32>:word32], word32, int64) @ 100010E2 : int64)
+  Class: Eq_83
+  DataType: int64
+  OrigDataType: int64
+T_84: (in &dwLoc04 @ 100010E2 : (ptr32 int32))
+  Class: Eq_84
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 int32 dw0000)))
+T_85: (in 0<32> @ 100010E2 : word32)
+  Class: Eq_85
+  DataType: word32
+  OrigDataType: word32
+T_86: (in &dwLoc04 + 0<32> @ 100010E2 : word32)
+  Class: Eq_86
+  DataType: ptr32
+  OrigDataType: ptr32
+T_87: (in Mem16[&dwLoc04 + 0<32>:word32] @ 100010E2 : word32)
+  Class: Eq_87
+  DataType: int32
+  OrigDataType: int32
+T_88: (in (int64) dwLoc08 /32 dwLoc04 @ 00000000 : word32)
+  Class: Eq_88
+  DataType: int32
+  OrigDataType: int32
+T_89: (in CONVERT(CONVERT(Mem16[&dwLoc08 + 0<32>:word32], word32, int64) /32 Mem16[&dwLoc04 + 0<32>:word32], word32, int32) @ 100010E2 : int32)
+  Class: Eq_77
+  DataType: int32
+  OrigDataType: int32
+T_90: (in Py_BuildValue("i", (int32) ((int64) dwLoc08 /32 dwLoc04)) @ 100010E2 : (ptr32 PyObject))
   Class: Eq_2
   DataType: (ptr32 Eq_2)
   OrigDataType: (ptr32 PyObject)
-T_100: (in eax @ 10001117 : (ptr32 Eq_100))
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
-  OrigDataType: (ptr32 PyObject)
-T_101: (in self @ 10001117 : (ptr32 Eq_101))
-  Class: Eq_101
-  DataType: (ptr32 Eq_101)
-  OrigDataType: (ptr32 PyObject)
-T_102: (in args @ 10001117 : (ptr32 Eq_102))
-  Class: Eq_102
-  DataType: (ptr32 Eq_102)
-  OrigDataType: (ptr32 PyObject)
-T_103: (in eax_10 @ 1000114A : (ptr32 Eq_100))
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+T_91: (in eax_17 @ 10001107 : (ptr32 Eq_2))
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_104: (in PyArg_ParseTuple @ 1000114A : ptr32)
-  Class: Eq_104
-  DataType: (ptr32 Eq_104)
-  OrigDataType: (ptr32 (fn T_108 (T_106, T_107)))
-T_105: (in signature of PyArg_ParseTuple @ 00000000 : void)
-  Class: Eq_104
-  DataType: (ptr32 Eq_104)
+T_92: (in PyArg_ParseTuple @ 10001107 : ptr32)
+  Class: Eq_92
+  DataType: (ptr32 Eq_92)
+  OrigDataType: (ptr32 (fn T_101 (T_4, T_96, T_98, T_100)))
+T_93: (in signature of PyArg_ParseTuple @ 00000000 : void)
+  Class: Eq_92
+  DataType: (ptr32 Eq_92)
   OrigDataType: 
-T_106: (in args @ 1000114A : (ptr32 PyObject))
-  Class: Eq_4
-  DataType: (ptr32 Eq_4)
-  OrigDataType: (ptr32 (union (PyObject u1)))
-T_107: (in 0x1000216C<32> @ 1000114A : word32)
+T_94: (in  @ 10001107 : (ptr32 real32))
+  Class: Eq_94
+  DataType: (ptr32 real32)
+  OrigDataType: 
+T_95: (in  @ 10001107 : (ptr32 real32))
+  Class: Eq_95
+  DataType: (ptr32 real32)
+  OrigDataType: 
+T_96: (in 0x10002160<32> @ 10001107 : word32)
   Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_108: (in PyArg_ParseTuple(args, ":unused") @ 1000114A : int32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+T_97: (in rLoc08 @ 10001107 : real32)
+  Class: Eq_97
+  DataType: real32
+  OrigDataType: real32
+T_98: (in &rLoc08 @ 10001107 : (ptr32 real32))
+  Class: Eq_94
+  DataType: (ptr32 real32)
+  OrigDataType: (ptr32 real32)
+T_99: (in rLoc04 @ 10001107 : real32)
+  Class: Eq_99
+  DataType: real32
+  OrigDataType: real32
+T_100: (in &rLoc04 @ 10001107 : (ptr32 real32))
+  Class: Eq_95
+  DataType: (ptr32 real32)
+  OrigDataType: (ptr32 real32)
+T_101: (in PyArg_ParseTuple(ptrArg08, "ff:fdiv", &rLoc08, &rLoc04) @ 10001107 : int32)
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
   OrigDataType: int32
-T_109: (in 0<32> @ 10001155 : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+T_102: (in 0<32> @ 10001112 : word32)
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
   OrigDataType: word32
-T_110: (in eax_10 != null @ 00000000 : bool)
-  Class: Eq_110
+T_103: (in eax_17 != null @ 00000000 : bool)
+  Class: Eq_103
   DataType: bool
   OrigDataType: bool
-T_111: (in eax_16 @ 10001158 : (ptr32 Eq_111))
+T_104: (in Py_BuildValue @ 10001136 : ptr32)
+  Class: Eq_104
+  DataType: (ptr32 Eq_104)
+  OrigDataType: (ptr32 (fn T_119 (T_107, T_118)))
+T_105: (in signature of Py_BuildValue @ 00000000 : void)
+  Class: Eq_104
+  DataType: (ptr32 Eq_104)
+  OrigDataType: 
+T_106: (in  @ 10001136 : real64)
+  Class: Eq_106
+  DataType: real64
+  OrigDataType: 
+T_107: (in 0x10002168<32> @ 10001136 : word32)
+  Class: Eq_22
+  DataType: (ptr32 char)
+  OrigDataType: (ptr32 char)
+T_108: (in &rLoc08 @ 10001136 : (ptr32 real32))
+  Class: Eq_108
+  DataType: (ptr32 real32)
+  OrigDataType: (ptr32 (struct (0 real32 r0000)))
+T_109: (in 0<32> @ 10001136 : word32)
+  Class: Eq_109
+  DataType: word32
+  OrigDataType: word32
+T_110: (in &rLoc08 + 0<32> @ 10001136 : word32)
+  Class: Eq_110
+  DataType: ptr32
+  OrigDataType: ptr32
+T_111: (in Mem16[&rLoc08 + 0<32>:real32] @ 10001136 : real32)
   Class: Eq_111
-  DataType: (ptr32 Eq_111)
-  OrigDataType: (ptr32 PyObject)
-T_112: (in _Py_NoneStruct @ 10001158 : PyObject)
+  DataType: real32
+  OrigDataType: real32
+T_112: (in CONVERT(Mem16[&rLoc08 + 0<32>:real32], real32, real64) @ 10001136 : real64)
   Class: Eq_112
-  DataType: Eq_112
-  OrigDataType: PyObject
-T_113: (in &_Py_NoneStruct @ 10001158 : word32)
-  Class: Eq_111
-  DataType: (ptr32 Eq_111)
-  OrigDataType: (ptr32 PyObject)
-T_114: (in 0<32> @ 1000115D : word32)
+  DataType: real64
+  OrigDataType: real64
+T_113: (in &rLoc04 @ 10001136 : (ptr32 real32))
+  Class: Eq_113
+  DataType: (ptr32 real32)
+  OrigDataType: (ptr32 (struct (0 real32 r0000)))
+T_114: (in 0<32> @ 10001136 : word32)
   Class: Eq_114
   DataType: word32
   OrigDataType: word32
-T_115: (in eax_16 + 0<32> @ 1000115D : word32)
+T_115: (in &rLoc04 + 0<32> @ 10001136 : word32)
   Class: Eq_115
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_116: (in Mem9[eax_16 + 0<32>:word32] @ 1000115D : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_116: (in Mem16[&rLoc04 + 0<32>:real32] @ 10001136 : real32)
   Class: Eq_116
-  DataType: int32
-  OrigDataType: int32
-T_117: (in 1<32> @ 1000115D : word32)
+  DataType: real32
+  OrigDataType: real32
+T_117: (in CONVERT(Mem16[&rLoc04 + 0<32>:real32], real32, real64) @ 10001136 : real64)
   Class: Eq_117
-  DataType: word32
-  OrigDataType: word32
-T_118: (in eax_16->ob_refcnt + 1<32> @ 00000000 : word32)
-  Class: Eq_118
-  DataType: int32
-  OrigDataType: int32
-T_119: (in 0<32> @ 1000115D : word32)
-  Class: Eq_119
-  DataType: word32
-  OrigDataType: word32
-T_120: (in eax_16 + 0<32> @ 1000115D : word32)
-  Class: Eq_120
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 int32)
-T_121: (in Mem18[eax_16 + 0<32>:word32] @ 1000115D : word32)
-  Class: Eq_118
-  DataType: int32
-  OrigDataType: int32
-T_122: (in _Py_NoneStruct @ 10001165 : PyObject)
-  Class: Eq_112
-  DataType: Eq_112
-  OrigDataType: PyObject
-T_123: (in &_Py_NoneStruct @ 10001165 : word32)
-  Class: Eq_100
-  DataType: (ptr32 Eq_100)
+  DataType: real64
+  OrigDataType: real64
+T_118: (in (real64) rLoc08 / (real64) rLoc04 @ 00000000 : real64)
+  Class: Eq_106
+  DataType: real64
+  OrigDataType: real64
+T_119: (in Py_BuildValue("f", (real64) rLoc08 / (real64) rLoc04) @ 10001136 : (ptr32 PyObject))
+  Class: Eq_2
+  DataType: (ptr32 Eq_2)
   OrigDataType: (ptr32 PyObject)
-T_124: (in Py_InitModule4 @ 10001183 : ptr32)
+T_120: (in eax @ 10001117 : (ptr32 Eq_120))
+  Class: Eq_120
+  DataType: (ptr32 Eq_120)
+  OrigDataType: (ptr32 PyObject)
+T_121: (in self @ 10001117 : (ptr32 Eq_121))
+  Class: Eq_121
+  DataType: (ptr32 Eq_121)
+  OrigDataType: (ptr32 PyObject)
+T_122: (in args @ 10001117 : (ptr32 Eq_122))
+  Class: Eq_122
+  DataType: (ptr32 Eq_122)
+  OrigDataType: (ptr32 PyObject)
+T_123: (in eax_10 @ 1000114A : (ptr32 Eq_120))
+  Class: Eq_120
+  DataType: (ptr32 Eq_120)
+  OrigDataType: int32
+T_124: (in PyArg_ParseTuple @ 1000114A : ptr32)
   Class: Eq_124
   DataType: (ptr32 Eq_124)
-  OrigDataType: (ptr32 (fn T_136 (T_131, T_132, T_133, T_134, T_135)))
-T_125: (in signature of Py_InitModule4 @ 00000000 : void)
+  OrigDataType: (ptr32 (fn T_128 (T_126, T_127)))
+T_125: (in signature of PyArg_ParseTuple @ 00000000 : void)
   Class: Eq_124
   DataType: (ptr32 Eq_124)
   OrigDataType: 
-T_126: (in ptrArg04 @ 10001183 : (ptr32 char))
-  Class: Eq_126
-  DataType: (ptr32 char)
-  OrigDataType: 
-T_127: (in ptrArg08 @ 10001183 : (ptr32 PyMethodDef))
-  Class: Eq_127
-  DataType: (ptr32 (arr PyMethodDef 5))
-  OrigDataType: 
-T_128: (in ptrArg0C @ 10001183 : (ptr32 char))
-  Class: Eq_128
-  DataType: (ptr32 char)
-  OrigDataType: 
-T_129: (in ptrArg10 @ 10001183 : (ptr32 PyObject))
-  Class: Eq_129
-  DataType: (ptr32 Eq_129)
-  OrigDataType: 
-T_130: (in dwArg14 @ 10001183 : int32)
-  Class: Eq_130
-  DataType: int32
-  OrigDataType: 
-T_131: (in 0x10002174<32> @ 10001183 : word32)
-  Class: Eq_126
+T_126: (in args @ 1000114A : (ptr32 PyObject))
+  Class: Eq_4
+  DataType: (ptr32 Eq_4)
+  OrigDataType: (ptr32 (union (PyObject u1)))
+T_127: (in 0x1000216C<32> @ 1000114A : word32)
+  Class: Eq_9
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_132: (in 0x10003010<32> @ 10001183 : word32)
-  Class: Eq_127
+T_128: (in PyArg_ParseTuple(args, ":unused") @ 1000114A : int32)
+  Class: Eq_120
+  DataType: (ptr32 Eq_120)
+  OrigDataType: int32
+T_129: (in 0<32> @ 10001155 : word32)
+  Class: Eq_120
+  DataType: (ptr32 Eq_120)
+  OrigDataType: word32
+T_130: (in eax_10 != null @ 00000000 : bool)
+  Class: Eq_130
+  DataType: bool
+  OrigDataType: bool
+T_131: (in eax_16 @ 10001158 : (ptr32 Eq_131))
+  Class: Eq_131
+  DataType: (ptr32 Eq_131)
+  OrigDataType: (ptr32 PyObject)
+T_132: (in _Py_NoneStruct @ 10001158 : PyObject)
+  Class: Eq_132
+  DataType: Eq_132
+  OrigDataType: PyObject
+T_133: (in &_Py_NoneStruct @ 10001158 : word32)
+  Class: Eq_131
+  DataType: (ptr32 Eq_131)
+  OrigDataType: (ptr32 PyObject)
+T_134: (in 0<32> @ 1000115D : word32)
+  Class: Eq_134
+  DataType: word32
+  OrigDataType: word32
+T_135: (in eax_16 + 0<32> @ 1000115D : word32)
+  Class: Eq_135
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_136: (in Mem9[eax_16 + 0<32>:word32] @ 1000115D : word32)
+  Class: Eq_136
+  DataType: int32
+  OrigDataType: int32
+T_137: (in 1<32> @ 1000115D : word32)
+  Class: Eq_137
+  DataType: word32
+  OrigDataType: word32
+T_138: (in eax_16->ob_refcnt + 1<32> @ 00000000 : word32)
+  Class: Eq_138
+  DataType: int32
+  OrigDataType: int32
+T_139: (in 0<32> @ 1000115D : word32)
+  Class: Eq_139
+  DataType: word32
+  OrigDataType: word32
+T_140: (in eax_16 + 0<32> @ 1000115D : word32)
+  Class: Eq_140
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 int32)
+T_141: (in Mem18[eax_16 + 0<32>:word32] @ 1000115D : word32)
+  Class: Eq_138
+  DataType: int32
+  OrigDataType: int32
+T_142: (in _Py_NoneStruct @ 10001165 : PyObject)
+  Class: Eq_132
+  DataType: Eq_132
+  OrigDataType: PyObject
+T_143: (in &_Py_NoneStruct @ 10001165 : word32)
+  Class: Eq_120
+  DataType: (ptr32 Eq_120)
+  OrigDataType: (ptr32 PyObject)
+T_144: (in Py_InitModule4 @ 10001183 : ptr32)
+  Class: Eq_144
+  DataType: (ptr32 Eq_144)
+  OrigDataType: (ptr32 (fn T_156 (T_151, T_152, T_153, T_154, T_155)))
+T_145: (in signature of Py_InitModule4 @ 00000000 : void)
+  Class: Eq_144
+  DataType: (ptr32 Eq_144)
+  OrigDataType: 
+T_146: (in ptrArg04 @ 10001183 : (ptr32 char))
+  Class: Eq_146
+  DataType: (ptr32 char)
+  OrigDataType: 
+T_147: (in ptrArg08 @ 10001183 : (ptr32 PyMethodDef))
+  Class: Eq_147
+  DataType: (ptr32 (arr PyMethodDef 5))
+  OrigDataType: 
+T_148: (in ptrArg0C @ 10001183 : (ptr32 char))
+  Class: Eq_148
+  DataType: (ptr32 char)
+  OrigDataType: 
+T_149: (in ptrArg10 @ 10001183 : (ptr32 PyObject))
+  Class: Eq_149
+  DataType: (ptr32 Eq_149)
+  OrigDataType: 
+T_150: (in dwArg14 @ 10001183 : int32)
+  Class: Eq_150
+  DataType: int32
+  OrigDataType: 
+T_151: (in 0x10002174<32> @ 10001183 : word32)
+  Class: Eq_146
+  DataType: (ptr32 char)
+  OrigDataType: (ptr32 char)
+T_152: (in 0x10003010<32> @ 10001183 : word32)
+  Class: Eq_147
   DataType: (ptr32 (arr PyMethodDef 5))
   OrigDataType: (ptr32 (arr PyMethodDef 5))
-T_133: (in 0<32> @ 10001183 : word32)
-  Class: Eq_128
+T_153: (in 0<32> @ 10001183 : word32)
+  Class: Eq_148
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_134: (in 0<32> @ 10001183 : word32)
-  Class: Eq_129
-  DataType: (ptr32 Eq_129)
-  OrigDataType: (ptr32 PyObject)
-T_135: (in 0x3EF<32> @ 10001183 : word32)
-  Class: Eq_130
-  DataType: int32
-  OrigDataType: int32
-T_136: (in Py_InitModule4("pySample", methods, null, null, 0x3EF<32>) @ 10001183 : (ptr32 PyObject))
-  Class: Eq_136
-  DataType: (ptr32 Eq_136)
-  OrigDataType: (ptr32 PyObject)
-T_137: (in eax @ 1000118C : word32)
-  Class: Eq_137
-  DataType: word32
-  OrigDataType: word32
-T_138: (in dwArg04 @ 1000118C : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_139: (in dwArg08 @ 1000118C : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_140: (in dwArg0C @ 1000118C : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_141: (in ebxOut @ 1000118C : ptr32)
-  Class: Eq_141
-  DataType: ptr32
-  OrigDataType: ptr32
-T_142: (in esiOut @ 1000118C : ptr32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: ptr32
-T_143: (in ediOut @ 1000118C : ptr32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: ptr32
-T_144: (in eax_14 @ 100011E9 : word32)
-  Class: Eq_137
-  DataType: word32
-  OrigDataType: word32
-T_145: (in ebp_145 @ 100011EE : Eq_145)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_146: (in 0<32> @ 100011EE : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_147: (in 0<32> @ 100011F2 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_148: (in dwArg08 != 0<32> @ 00000000 : bool)
-  Class: Eq_148
-  DataType: bool
-  OrigDataType: bool
-T_149: (in adjust_fdiv @ 10001210 : ptr32)
+T_154: (in 0<32> @ 10001183 : word32)
   Class: Eq_149
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_153 t0000)))
-T_150: (in signature of adjust_fdiv @ 00000000 : void)
+  DataType: (ptr32 Eq_149)
+  OrigDataType: (ptr32 PyObject)
+T_155: (in 0x3EF<32> @ 10001183 : word32)
   Class: Eq_150
-  DataType: Eq_150
-  OrigDataType: 
-T_151: (in 0<32> @ 10001210 : word32)
-  Class: Eq_151
-  DataType: word32
-  OrigDataType: word32
-T_152: (in adjust_fdiv + 0<32> @ 10001210 : word32)
-  Class: Eq_152
-  DataType: ptr32
-  OrigDataType: ptr32
-T_153: (in Mem23[adjust_fdiv + 0<32>:word32] @ 10001210 : word32)
-  Class: Eq_153
-  DataType: word32
-  OrigDataType: word32
-T_154: (in 100033A4 @ 10001210 : ptr32)
-  Class: Eq_154
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_155 t0000)))
-T_155: (in Mem38[0x100033A4<p32>:word32] @ 10001210 : word32)
-  Class: Eq_153
-  DataType: word32
-  OrigDataType: word32
-T_156: (in esp_118 @ 1000120F : (ptr32 ptr32))
+  DataType: int32
+  OrigDataType: int32
+T_156: (in Py_InitModule4("pySample", methods, null, null, 0x3EF<32>) @ 10001183 : (ptr32 PyObject))
   Class: Eq_156
-  DataType: (ptr32 ptr32)
-  OrigDataType: (ptr32 (struct (0 T_309 t0000)))
-T_157: (in fp @ 1000120F : ptr32)
+  DataType: (ptr32 Eq_156)
+  OrigDataType: (ptr32 PyObject)
+T_157: (in eax @ 1000118C : word32)
   Class: Eq_157
-  DataType: ptr32
-  OrigDataType: ptr32
-T_158: (in 16<i32> @ 1000120F : int32)
+  DataType: word32
+  OrigDataType: word32
+T_158: (in dwArg04 @ 1000118C : Eq_158)
   Class: Eq_158
-  DataType: int32
-  OrigDataType: int32
-T_159: (in fp - 16<i32> @ 00000000 : word32)
-  Class: Eq_156
-  DataType: (ptr32 ptr32)
-  OrigDataType: ptr32
-T_160: (in 1<32> @ 10001216 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+  DataType: Eq_158
   OrigDataType: word32
-T_161: (in dwArg08 != 1<32> @ 00000000 : bool)
+T_159: (in dwArg08 @ 1000118C : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_160: (in dwArg0C @ 1000118C : Eq_160)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: word32
+T_161: (in ebxOut @ 1000118C : ptr32)
   Class: Eq_161
-  DataType: bool
-  OrigDataType: bool
-T_162: (in 10003070 @ 100011FA : ptr32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_162: (in esiOut @ 1000118C : ptr32)
   Class: Eq_162
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_163 t0000)))
-T_163: (in Mem8[0x10003070<p32>:word32] @ 100011FA : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_163: (in ediOut @ 1000118C : ptr32)
   Class: Eq_163
-  DataType: int32
-  OrigDataType: int32
-T_164: (in 0<32> @ 100011FA : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: int32
-T_165: (in g_dw10003070 <= 0<32> @ 00000000 : bool)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_164: (in eax_14 @ 100011E9 : word32)
+  Class: Eq_157
+  DataType: word32
+  OrigDataType: word32
+T_165: (in ebp_145 @ 100011EE : Eq_165)
   Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_166: (in 0<32> @ 100011EE : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_167: (in 0<32> @ 100011F2 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_168: (in dwArg08 != 0<32> @ 00000000 : bool)
+  Class: Eq_168
   DataType: bool
   OrigDataType: bool
-T_166: (in 0<32> @ 10001233 : word32)
-  Class: Eq_137
-  DataType: word32
-  OrigDataType: word32
-T_167: (in 10003070 @ 100011FC : ptr32)
-  Class: Eq_167
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_168 t0000)))
-T_168: (in Mem8[0x10003070<p32>:word32] @ 100011FC : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: word32
-T_169: (in 1<32> @ 100011FC : word32)
+T_169: (in adjust_fdiv @ 10001210 : ptr32)
   Class: Eq_169
-  DataType: word32
-  OrigDataType: word32
-T_170: (in g_dw10003070 - 1<32> @ 00000000 : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: word32
-T_171: (in 10003070 @ 100011FC : ptr32)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_173 t0000)))
+T_170: (in signature of adjust_fdiv @ 00000000 : void)
+  Class: Eq_170
+  DataType: Eq_170
+  OrigDataType: 
+T_171: (in 0<32> @ 10001210 : word32)
   Class: Eq_171
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_172 t0000)))
-T_172: (in Mem18[0x10003070<p32>:word32] @ 100011FC : word32)
-  Class: Eq_163
-  DataType: int32
+  DataType: word32
   OrigDataType: word32
-T_173: (in 0<32> @ 100012EA : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_172: (in adjust_fdiv + 0<32> @ 10001210 : word32)
+  Class: Eq_172
+  DataType: ptr32
+  OrigDataType: ptr32
+T_173: (in Mem23[adjust_fdiv + 0<32>:word32] @ 10001210 : word32)
+  Class: Eq_173
+  DataType: word32
   OrigDataType: word32
-T_174: (in dwArg08 != 0<32> @ 00000000 : bool)
+T_174: (in 100033A4 @ 10001210 : ptr32)
   Class: Eq_174
-  DataType: bool
-  OrigDataType: bool
-T_175: (in edi_124 @ 10001222 : Eq_145)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_176: (in fs @ 10001222 : selector)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_175 t0000)))
+T_175: (in Mem38[0x100033A4<p32>:word32] @ 10001210 : word32)
+  Class: Eq_173
+  DataType: word32
+  OrigDataType: word32
+T_176: (in esp_118 @ 1000120F : (ptr32 ptr32))
   Class: Eq_176
-  DataType: (ptr32 Eq_176)
-  OrigDataType: (ptr32 (segment (18 T_178 t0018)))
-T_177: (in 0x18<32> @ 10001222 : word32)
+  DataType: (ptr32 ptr32)
+  OrigDataType: (ptr32 (struct (0 T_329 t0000)))
+T_177: (in fp @ 1000120F : ptr32)
   Class: Eq_177
-  DataType: (memptr (ptr32 Eq_176) (ptr32 Eq_178))
-  OrigDataType: (memptr T_176 (struct (0 T_178 t0000)))
-T_178: (in Mem38[fs:0x18<32>:word32] @ 10001222 : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_178: (in 16<i32> @ 1000120F : int32)
   Class: Eq_178
-  DataType: (ptr32 Eq_178)
-  OrigDataType: (ptr32 (struct (4 T_181 t0004)))
-T_179: (in 4<32> @ 10001222 : word32)
-  Class: Eq_179
-  DataType: word32
+  DataType: int32
+  OrigDataType: int32
+T_179: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_176
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
+T_180: (in 1<32> @ 10001216 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_180: (in Mem38[fs:0x18<32>:word32] + 4<32> @ 10001222 : word32)
-  Class: Eq_180
-  DataType: word32
-  OrigDataType: word32
-T_181: (in Mem38[Mem38[fs:0x18<32>:word32] + 4<32>:word32] @ 10001222 : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_182: (in eax_136 @ 1000124D : Eq_145)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_183: (in InterlockedCompareExchange @ 1000124D : ptr32)
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: (ptr32 (fn T_190 (T_188, T_175, T_189)))
-T_184: (in signature of InterlockedCompareExchange @ 00000000 : void)
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: 
-T_185: (in Destination @ 1000124D : (ptr32 LONG))
-  Class: Eq_185
-  DataType: (ptr32 Eq_185)
-  OrigDataType: 
-T_186: (in Exchange @ 1000124D : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: 
-T_187: (in Comperand @ 1000124D : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: 
-T_188: (in 0x100033AC<p32> @ 1000124D : ptr32)
-  Class: Eq_185
-  DataType: (ptr32 Eq_185)
-  OrigDataType: (ptr32 LONG)
-T_189: (in 0<32> @ 1000124D : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_190: (in InterlockedCompareExchange(&g_t100033AC, edi_124, 0<32>) @ 1000124D : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_191: (in 0<32> @ 10001251 : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_192: (in eax_136 != 0<32> @ 00000000 : bool)
-  Class: Eq_192
+T_181: (in dwArg08 != 1<32> @ 00000000 : bool)
+  Class: Eq_181
   DataType: bool
   OrigDataType: bool
-T_193: (in 1<32> @ 10001380 : word32)
-  Class: Eq_137
+T_182: (in 10003070 @ 100011FA : ptr32)
+  Class: Eq_182
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_183 t0000)))
+T_183: (in Mem8[0x10003070<p32>:word32] @ 100011FA : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: int32
+T_184: (in 0<32> @ 100011FA : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: int32
+T_185: (in g_dw10003070 <= 0<32> @ 00000000 : bool)
+  Class: Eq_185
+  DataType: bool
+  OrigDataType: bool
+T_186: (in 0<32> @ 10001233 : word32)
+  Class: Eq_157
   DataType: word32
   OrigDataType: word32
-T_194: (in InterlockedCompareExchange @ 10001310 : ptr32)
+T_187: (in 10003070 @ 100011FC : ptr32)
+  Class: Eq_187
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_188 t0000)))
+T_188: (in Mem8[0x10003070<p32>:word32] @ 100011FC : word32)
   Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: (ptr32 (fn T_198 (T_195, T_196, T_197)))
-T_195: (in 0x100033AC<p32> @ 10001310 : ptr32)
-  Class: Eq_185
-  DataType: (ptr32 Eq_185)
-  OrigDataType: (ptr32 LONG)
-T_196: (in 1<32> @ 10001310 : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_197: (in 0<32> @ 10001310 : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_198: (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) @ 10001310 : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_199: (in 0<32> @ 10001310 : word32)
-  Class: Eq_145
-  DataType: Eq_145
+  DataType: int32
   OrigDataType: word32
-T_200: (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) != 0<32> @ 00000000 : bool)
+T_189: (in 1<32> @ 100011FC : word32)
+  Class: Eq_189
+  DataType: word32
+  OrigDataType: word32
+T_190: (in g_dw10003070 - 1<32> @ 00000000 : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_191: (in 10003070 @ 100011FC : ptr32)
+  Class: Eq_191
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_192 t0000)))
+T_192: (in Mem18[0x10003070<p32>:word32] @ 100011FC : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_193: (in 0<32> @ 100012EA : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_194: (in dwArg08 != 0<32> @ 00000000 : bool)
+  Class: Eq_194
+  DataType: bool
+  OrigDataType: bool
+T_195: (in edi_124 @ 10001222 : Eq_165)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_196: (in fs @ 10001222 : selector)
+  Class: Eq_196
+  DataType: (ptr32 Eq_196)
+  OrigDataType: (ptr32 (segment (18 T_198 t0018)))
+T_197: (in 0x18<32> @ 10001222 : word32)
+  Class: Eq_197
+  DataType: (memptr (ptr32 Eq_196) (ptr32 Eq_198))
+  OrigDataType: (memptr T_196 (struct (0 T_198 t0000)))
+T_198: (in Mem38[fs:0x18<32>:word32] @ 10001222 : word32)
+  Class: Eq_198
+  DataType: (ptr32 Eq_198)
+  OrigDataType: (ptr32 (struct (4 T_201 t0004)))
+T_199: (in 4<32> @ 10001222 : word32)
+  Class: Eq_199
+  DataType: word32
+  OrigDataType: word32
+T_200: (in Mem38[fs:0x18<32>:word32] + 4<32> @ 10001222 : word32)
   Class: Eq_200
-  DataType: bool
-  OrigDataType: bool
-T_201: (in eax_136 == edi_124 @ 00000000 : bool)
-  Class: Eq_201
-  DataType: bool
-  OrigDataType: bool
-T_202: (in 100033A8 @ 10001262 : ptr32)
-  Class: Eq_202
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_203 t0000)))
-T_203: (in Mem135[0x100033A8<p32>:word32] @ 10001262 : word32)
-  Class: Eq_203
   DataType: word32
   OrigDataType: word32
-T_204: (in 0<32> @ 10001262 : word32)
-  Class: Eq_203
-  DataType: word32
+T_201: (in Mem38[Mem38[fs:0x18<32>:word32] + 4<32>:word32] @ 10001222 : word32)
+  Class: Eq_165
+  DataType: Eq_165
   OrigDataType: word32
-T_205: (in g_dw100033A8 == 0<32> @ 00000000 : bool)
+T_202: (in eax_136 @ 1000124D : Eq_165)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_203: (in InterlockedCompareExchange @ 1000124D : ptr32)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: (ptr32 (fn T_210 (T_208, T_195, T_209)))
+T_204: (in signature of InterlockedCompareExchange @ 00000000 : void)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: 
+T_205: (in Destination @ 1000124D : (ptr32 LONG))
   Class: Eq_205
-  DataType: bool
-  OrigDataType: bool
-T_206: (in Sleep @ 10001302 : ptr32)
-  Class: Eq_206
-  DataType: (ptr32 Eq_206)
-  OrigDataType: (ptr32 (fn T_210 (T_209)))
-T_207: (in signature of Sleep @ 00000000 : void)
-  Class: Eq_206
-  DataType: (ptr32 Eq_206)
+  DataType: (ptr32 Eq_205)
   OrigDataType: 
-T_208: (in dwMilliseconds @ 10001302 : DWORD)
-  Class: Eq_139
-  DataType: Eq_139
+T_206: (in Exchange @ 1000124D : LONG)
+  Class: Eq_165
+  DataType: Eq_165
   OrigDataType: 
-T_209: (in 0x3E8<32> @ 10001302 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_210: (in Sleep(0x3E8<32>) @ 10001302 : void)
-  Class: Eq_210
-  DataType: void
-  OrigDataType: void
-T_211: (in 100033A8 @ 1000131A : ptr32)
-  Class: Eq_211
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_212 t0000)))
-T_212: (in Mem53[0x100033A8<p32>:word32] @ 1000131A : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_213: (in 2<32> @ 1000131A : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_214: (in g_dw100033A8 == 2<32> @ 00000000 : bool)
-  Class: Eq_214
-  DataType: bool
-  OrigDataType: bool
-T_215: (in eax_69 @ 10001332 : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: (ptr32 void)
-T_216: (in _decode_pointer @ 10001332 : ptr32)
-  Class: Eq_216
-  DataType: (ptr32 Eq_216)
-  OrigDataType: (ptr32 (fn T_221 (T_220)))
-T_217: (in signature of _decode_pointer @ 00000000 : void)
-  Class: Eq_216
-  DataType: (ptr32 Eq_216)
+T_207: (in Comperand @ 1000124D : LONG)
+  Class: Eq_165
+  DataType: Eq_165
   OrigDataType: 
-T_218: (in ptrArg04 @ 10001332 : (ptr32 void))
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: 
-T_219: (in 100033B4 @ 10001332 : ptr32)
-  Class: Eq_219
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_220 t0000)))
-T_220: (in Mem53[0x100033B4<p32>:word32] @ 10001332 : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_221: (in _decode_pointer(g_ptr100033B4) @ 10001332 : (ptr32 void))
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: (ptr32 void)
-T_222: (in esp_105 @ 10001338 : ptr32)
-  Class: Eq_222
-  DataType: ptr32
-  OrigDataType: ptr32
-T_223: (in 16<i32> @ 10001338 : int32)
-  Class: Eq_223
-  DataType: int32
-  OrigDataType: int32
-T_224: (in fp - 16<i32> @ 00000000 : word32)
-  Class: Eq_222
-  DataType: ptr32
-  OrigDataType: ptr32
-T_225: (in 0<32> @ 10001339 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_226: (in eax_69 == 0<32> @ 00000000 : bool)
-  Class: Eq_226
-  DataType: bool
-  OrigDataType: bool
-T_227: (in _amsg_exit @ 1000131E : ptr32)
-  Class: Eq_227
-  DataType: (ptr32 Eq_227)
-  OrigDataType: (ptr32 (fn T_231 (T_230)))
-T_228: (in signature of _amsg_exit @ 00000000 : void)
-  Class: Eq_227
-  DataType: (ptr32 Eq_227)
-  OrigDataType: 
-T_229: (in n @ 1000131E : int32)
-  Class: Eq_229
-  DataType: int32
-  OrigDataType: 
-T_230: (in 0x1F<32> @ 1000131E : word32)
-  Class: Eq_229
-  DataType: int32
-  OrigDataType: int32
-T_231: (in _amsg_exit(0x1F<32>) @ 1000131E : void)
-  Class: Eq_231
-  DataType: void
-  OrigDataType: void
-T_232: (in 1<32> @ 10001277 : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_233: (in 100033A8 @ 10001277 : ptr32)
-  Class: Eq_233
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_234 t0000)))
-T_234: (in Mem166[0x100033A8<p32>:word32] @ 10001277 : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_235: (in 16<i32> @ 10001289 : int32)
-  Class: Eq_235
-  DataType: int32
-  OrigDataType: int32
-T_236: (in fp - 16<i32> @ 00000000 : word32)
-  Class: Eq_156
-  DataType: (ptr32 ptr32)
-  OrigDataType: ptr32
-T_237: (in _initterm_e @ 1000128A : ptr32)
-  Class: Eq_237
-  DataType: (ptr32 Eq_237)
-  OrigDataType: (ptr32 (fn T_243 (T_241, T_242)))
-T_238: (in signature of _initterm_e @ 00000000 : void)
-  Class: Eq_237
-  DataType: (ptr32 Eq_237)
-  OrigDataType: 
-T_239: (in fStart @ 1000128A : (ptr32 PVFV))
-  Class: Eq_239
-  DataType: (ptr32 Eq_239)
-  OrigDataType: 
-T_240: (in fEnd @ 1000128A : (ptr32 PVFV))
-  Class: Eq_240
-  DataType: (ptr32 Eq_240)
-  OrigDataType: 
-T_241: (in 0x100020A0<32> @ 1000128A : word32)
-  Class: Eq_239
-  DataType: (ptr32 Eq_239)
-  OrigDataType: (ptr32 PVFV)
-T_242: (in 0x100020A8<32> @ 1000128A : word32)
-  Class: Eq_240
-  DataType: (ptr32 Eq_240)
-  OrigDataType: (ptr32 PVFV)
-T_243: (in _initterm_e(&g_t100020A0, &g_t100020A8) @ 1000128A : int32)
-  Class: Eq_243
-  DataType: int32
-  OrigDataType: int32
-T_244: (in 0<32> @ 1000128A : word32)
-  Class: Eq_243
-  DataType: int32
-  OrigDataType: word32
-T_245: (in _initterm_e(&g_t100020A0, &g_t100020A8) == 0<32> @ 00000000 : bool)
-  Class: Eq_245
-  DataType: bool
-  OrigDataType: bool
-T_246: (in _amsg_exit @ 10001266 : ptr32)
-  Class: Eq_227
-  DataType: (ptr32 Eq_227)
-  OrigDataType: (ptr32 (fn T_248 (T_247)))
-T_247: (in 0x1F<32> @ 10001266 : word32)
-  Class: Eq_229
-  DataType: int32
-  OrigDataType: int32
-T_248: (in _amsg_exit(0x1F<32>) @ 10001266 : void)
-  Class: Eq_231
-  DataType: void
-  OrigDataType: void
-T_249: (in 1<32> @ 10001257 : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_250: (in Sleep @ 10001243 : ptr32)
-  Class: Eq_206
-  DataType: (ptr32 Eq_206)
-  OrigDataType: (ptr32 (fn T_252 (T_251)))
-T_251: (in 0x3E8<32> @ 10001243 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_252: (in Sleep(0x3E8<32>) @ 10001243 : void)
-  Class: Eq_210
-  DataType: void
-  OrigDataType: void
-T_253: (in esp_110 @ 1000136F : (ptr32 Eq_253))
-  Class: Eq_253
-  DataType: (ptr32 Eq_253)
-  OrigDataType: (ptr32 (struct (FFFFFFFC T_260 tFFFFFFFC) (0 T_145 t0000)))
-T_254: (in 4<i32> @ 1000136F : int32)
-  Class: Eq_254
-  DataType: int32
-  OrigDataType: int32
-T_255: (in esp_105 - 4<i32> @ 00000000 : word32)
-  Class: Eq_253
-  DataType: (ptr32 Eq_253)
-  OrigDataType: ptr32
-T_256: (in 0<32> @ 1000136F : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_257: (in 0<32> @ 1000136F : word32)
-  Class: Eq_257
-  DataType: word32
-  OrigDataType: word32
-T_258: (in esp_110 + 0<32> @ 1000136F : word32)
-  Class: Eq_258
-  DataType: ptr32
-  OrigDataType: ptr32
-T_259: (in Mem111[esp_110 + 0<32>:word32] @ 1000136F : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_260: (in 0x100033AC<p32> @ 10001371 : ptr32)
-  Class: Eq_260
-  DataType: (ptr32 Eq_260)
-  OrigDataType: ptr32
-T_261: (in -4<i32> @ 10001371 : int32)
-  Class: Eq_261
-  DataType: int32
-  OrigDataType: int32
-T_262: (in esp_110 + -4<i32> @ 10001371 : word32)
-  Class: Eq_262
-  DataType: ptr32
-  OrigDataType: ptr32
-T_263: (in Mem114[esp_110 + -4<i32>:word32] @ 10001371 : word32)
-  Class: Eq_260
-  DataType: (ptr32 Eq_260)
-  OrigDataType: word32
-T_264: (in 0<32> @ 10001372 : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_265: (in 100033A8 @ 10001372 : ptr32)
-  Class: Eq_265
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_266 t0000)))
-T_266: (in Mem116[0x100033A8<p32>:word32] @ 10001372 : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_267: (in InterlockedExchange @ 10001378 : ptr32)
-  Class: Eq_267
-  DataType: (ptr32 Eq_267)
-  OrigDataType: (ptr32 (fn T_277 (T_273, T_276)))
-T_268: (in signature of InterlockedExchange @ 00000000 : void)
-  Class: Eq_267
-  DataType: (ptr32 Eq_267)
-  OrigDataType: 
-T_269: (in Target @ 10001378 : (ptr32 LONG))
-  Class: Eq_260
-  DataType: (ptr32 Eq_260)
-  OrigDataType: 
-T_270: (in Value @ 10001378 : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: 
-T_271: (in -4<i32> @ 10001378 : int32)
-  Class: Eq_271
-  DataType: int32
-  OrigDataType: int32
-T_272: (in esp_110 + -4<i32> @ 10001378 : word32)
-  Class: Eq_272
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_273: (in Mem116[esp_110 + -4<i32>:(ptr32 LONG)] @ 10001378 : (ptr32 LONG))
-  Class: Eq_260
-  DataType: (ptr32 Eq_260)
+T_208: (in 0x100033AC<p32> @ 1000124D : ptr32)
+  Class: Eq_205
+  DataType: (ptr32 Eq_205)
   OrigDataType: (ptr32 LONG)
-T_274: (in 0<32> @ 10001378 : word32)
-  Class: Eq_274
+T_209: (in 0<32> @ 1000124D : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_210: (in InterlockedCompareExchange(&g_t100033AC, edi_124, 0<32>) @ 1000124D : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_211: (in 0<32> @ 10001251 : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_212: (in eax_136 != 0<32> @ 00000000 : bool)
+  Class: Eq_212
+  DataType: bool
+  OrigDataType: bool
+T_213: (in 1<32> @ 10001380 : word32)
+  Class: Eq_157
   DataType: word32
   OrigDataType: word32
-T_275: (in esp_110 + 0<32> @ 10001378 : word32)
-  Class: Eq_275
+T_214: (in InterlockedCompareExchange @ 10001310 : ptr32)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: (ptr32 (fn T_218 (T_215, T_216, T_217)))
+T_215: (in 0x100033AC<p32> @ 10001310 : ptr32)
+  Class: Eq_205
+  DataType: (ptr32 Eq_205)
+  OrigDataType: (ptr32 LONG)
+T_216: (in 1<32> @ 10001310 : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_217: (in 0<32> @ 10001310 : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_218: (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) @ 10001310 : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_219: (in 0<32> @ 10001310 : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_220: (in InterlockedCompareExchange(&g_t100033AC, 1<32>, 0<32>) != 0<32> @ 00000000 : bool)
+  Class: Eq_220
+  DataType: bool
+  OrigDataType: bool
+T_221: (in eax_136 == edi_124 @ 00000000 : bool)
+  Class: Eq_221
+  DataType: bool
+  OrigDataType: bool
+T_222: (in 100033A8 @ 10001262 : ptr32)
+  Class: Eq_222
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_276: (in Mem116[esp_110 + 0<32>:LONG] @ 10001378 : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_277: (in InterlockedExchange(esp_110->ptrFFFFFFFC, esp_110->t0000) @ 10001378 : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_278: (in 4<32> @ 10001378 : word32)
-  Class: Eq_278
-  DataType: int32
-  OrigDataType: int32
-T_279: (in esp_110 + 4<32> @ 10001378 : word32)
-  Class: Eq_156
-  DataType: (ptr32 ptr32)
-  OrigDataType: ptr32
-T_280: (in esp_81 @ 10001343 : ptr32)
-  Class: Eq_280
+  OrigDataType: (ptr32 (struct (0 T_223 t0000)))
+T_223: (in Mem135[0x100033A8<p32>:word32] @ 10001262 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_224: (in 0<32> @ 10001262 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_225: (in g_dw100033A8 == 0<32> @ 00000000 : bool)
+  Class: Eq_225
+  DataType: bool
+  OrigDataType: bool
+T_226: (in Sleep @ 10001302 : ptr32)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
+  OrigDataType: (ptr32 (fn T_230 (T_229)))
+T_227: (in signature of Sleep @ 00000000 : void)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
+  OrigDataType: 
+T_228: (in dwMilliseconds @ 10001302 : DWORD)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: 
+T_229: (in 0x3E8<32> @ 10001302 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_230: (in Sleep(0x3E8<32>) @ 10001302 : void)
+  Class: Eq_230
+  DataType: void
+  OrigDataType: void
+T_231: (in 100033A8 @ 1000131A : ptr32)
+  Class: Eq_231
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_232 t0000)))
+T_232: (in Mem53[0x100033A8<p32>:word32] @ 1000131A : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_233: (in 2<32> @ 1000131A : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_234: (in g_dw100033A8 == 2<32> @ 00000000 : bool)
+  Class: Eq_234
+  DataType: bool
+  OrigDataType: bool
+T_235: (in eax_69 @ 10001332 : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: (ptr32 void)
+T_236: (in _decode_pointer @ 10001332 : ptr32)
+  Class: Eq_236
+  DataType: (ptr32 Eq_236)
+  OrigDataType: (ptr32 (fn T_241 (T_240)))
+T_237: (in signature of _decode_pointer @ 00000000 : void)
+  Class: Eq_236
+  DataType: (ptr32 Eq_236)
+  OrigDataType: 
+T_238: (in ptrArg04 @ 10001332 : (ptr32 void))
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: 
+T_239: (in 100033B4 @ 10001332 : ptr32)
+  Class: Eq_239
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_240 t0000)))
+T_240: (in Mem53[0x100033B4<p32>:word32] @ 10001332 : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_241: (in _decode_pointer(g_ptr100033B4) @ 10001332 : (ptr32 void))
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: (ptr32 void)
+T_242: (in esp_105 @ 10001338 : ptr32)
+  Class: Eq_242
   DataType: ptr32
   OrigDataType: ptr32
-T_281: (in 16<i32> @ 10001343 : int32)
+T_243: (in 16<i32> @ 10001338 : int32)
+  Class: Eq_243
+  DataType: int32
+  OrigDataType: int32
+T_244: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_242
+  DataType: ptr32
+  OrigDataType: ptr32
+T_245: (in 0<32> @ 10001339 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_246: (in eax_69 == 0<32> @ 00000000 : bool)
+  Class: Eq_246
+  DataType: bool
+  OrigDataType: bool
+T_247: (in _amsg_exit @ 1000131E : ptr32)
+  Class: Eq_247
+  DataType: (ptr32 Eq_247)
+  OrigDataType: (ptr32 (fn T_251 (T_250)))
+T_248: (in signature of _amsg_exit @ 00000000 : void)
+  Class: Eq_247
+  DataType: (ptr32 Eq_247)
+  OrigDataType: 
+T_249: (in n @ 1000131E : int32)
+  Class: Eq_249
+  DataType: int32
+  OrigDataType: 
+T_250: (in 0x1F<32> @ 1000131E : word32)
+  Class: Eq_249
+  DataType: int32
+  OrigDataType: int32
+T_251: (in _amsg_exit(0x1F<32>) @ 1000131E : void)
+  Class: Eq_251
+  DataType: void
+  OrigDataType: void
+T_252: (in 1<32> @ 10001277 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_253: (in 100033A8 @ 10001277 : ptr32)
+  Class: Eq_253
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_254 t0000)))
+T_254: (in Mem166[0x100033A8<p32>:word32] @ 10001277 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_255: (in 16<i32> @ 10001289 : int32)
+  Class: Eq_255
+  DataType: int32
+  OrigDataType: int32
+T_256: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_176
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
+T_257: (in _initterm_e @ 1000128A : ptr32)
+  Class: Eq_257
+  DataType: (ptr32 Eq_257)
+  OrigDataType: (ptr32 (fn T_263 (T_261, T_262)))
+T_258: (in signature of _initterm_e @ 00000000 : void)
+  Class: Eq_257
+  DataType: (ptr32 Eq_257)
+  OrigDataType: 
+T_259: (in fStart @ 1000128A : (ptr32 PVFV))
+  Class: Eq_259
+  DataType: (ptr32 Eq_259)
+  OrigDataType: 
+T_260: (in fEnd @ 1000128A : (ptr32 PVFV))
+  Class: Eq_260
+  DataType: (ptr32 Eq_260)
+  OrigDataType: 
+T_261: (in 0x100020A0<32> @ 1000128A : word32)
+  Class: Eq_259
+  DataType: (ptr32 Eq_259)
+  OrigDataType: (ptr32 PVFV)
+T_262: (in 0x100020A8<32> @ 1000128A : word32)
+  Class: Eq_260
+  DataType: (ptr32 Eq_260)
+  OrigDataType: (ptr32 PVFV)
+T_263: (in _initterm_e(&g_t100020A0, &g_t100020A8) @ 1000128A : int32)
+  Class: Eq_263
+  DataType: int32
+  OrigDataType: int32
+T_264: (in 0<32> @ 1000128A : word32)
+  Class: Eq_263
+  DataType: int32
+  OrigDataType: word32
+T_265: (in _initterm_e(&g_t100020A0, &g_t100020A8) == 0<32> @ 00000000 : bool)
+  Class: Eq_265
+  DataType: bool
+  OrigDataType: bool
+T_266: (in _amsg_exit @ 10001266 : ptr32)
+  Class: Eq_247
+  DataType: (ptr32 Eq_247)
+  OrigDataType: (ptr32 (fn T_268 (T_267)))
+T_267: (in 0x1F<32> @ 10001266 : word32)
+  Class: Eq_249
+  DataType: int32
+  OrigDataType: int32
+T_268: (in _amsg_exit(0x1F<32>) @ 10001266 : void)
+  Class: Eq_251
+  DataType: void
+  OrigDataType: void
+T_269: (in 1<32> @ 10001257 : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_270: (in Sleep @ 10001243 : ptr32)
+  Class: Eq_226
+  DataType: (ptr32 Eq_226)
+  OrigDataType: (ptr32 (fn T_272 (T_271)))
+T_271: (in 0x3E8<32> @ 10001243 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_272: (in Sleep(0x3E8<32>) @ 10001243 : void)
+  Class: Eq_230
+  DataType: void
+  OrigDataType: void
+T_273: (in esp_110 @ 1000136F : (ptr32 Eq_273))
+  Class: Eq_273
+  DataType: (ptr32 Eq_273)
+  OrigDataType: (ptr32 (struct (FFFFFFFC T_280 tFFFFFFFC) (0 T_165 t0000)))
+T_274: (in 4<i32> @ 1000136F : int32)
+  Class: Eq_274
+  DataType: int32
+  OrigDataType: int32
+T_275: (in esp_105 - 4<i32> @ 00000000 : word32)
+  Class: Eq_273
+  DataType: (ptr32 Eq_273)
+  OrigDataType: ptr32
+T_276: (in 0<32> @ 1000136F : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_277: (in 0<32> @ 1000136F : word32)
+  Class: Eq_277
+  DataType: word32
+  OrigDataType: word32
+T_278: (in esp_110 + 0<32> @ 1000136F : word32)
+  Class: Eq_278
+  DataType: ptr32
+  OrigDataType: ptr32
+T_279: (in Mem111[esp_110 + 0<32>:word32] @ 1000136F : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_280: (in 0x100033AC<p32> @ 10001371 : ptr32)
+  Class: Eq_280
+  DataType: (ptr32 Eq_280)
+  OrigDataType: ptr32
+T_281: (in -4<i32> @ 10001371 : int32)
   Class: Eq_281
   DataType: int32
   OrigDataType: int32
-T_282: (in fp - 16<i32> @ 00000000 : word32)
+T_282: (in esp_110 + -4<i32> @ 10001371 : word32)
+  Class: Eq_282
+  DataType: ptr32
+  OrigDataType: ptr32
+T_283: (in Mem114[esp_110 + -4<i32>:word32] @ 10001371 : word32)
   Class: Eq_280
-  DataType: ptr32
-  OrigDataType: ptr32
-T_283: (in edi_82 @ 10001344 : DWORD)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
-T_284: (in _decode_pointer @ 10001344 : ptr32)
-  Class: Eq_216
-  DataType: (ptr32 Eq_216)
-  OrigDataType: (ptr32 (fn T_287 (T_286)))
-T_285: (in 100033B0 @ 10001344 : ptr32)
+  DataType: (ptr32 Eq_280)
+  OrigDataType: word32
+T_284: (in 0<32> @ 10001372 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_285: (in 100033A8 @ 10001372 : ptr32)
   Class: Eq_285
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_286 t0000)))
-T_286: (in Mem67[0x100033B0<p32>:word32] @ 10001344 : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_287: (in _decode_pointer(g_ptr100033B0) @ 10001344 : (ptr32 void))
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: (ptr32 void)
-T_288: (in 4<32> @ 10001350 : word32)
-  Class: Eq_288
-  DataType: ui32
-  OrigDataType: ui32
-T_289: (in edi_82 - 4<32> @ 00000000 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: ptr32
-T_290: (in edi_82 >= eax_69 @ 00000000 : bool)
-  Class: Eq_290
-  DataType: bool
-  OrigDataType: bool
-T_291: (in _initterm @ 1000129D : ptr32)
-  Class: Eq_291
-  DataType: (ptr32 Eq_291)
-  OrigDataType: (ptr32 (fn T_297 (T_295, T_296)))
-T_292: (in signature of _initterm @ 00000000 : void)
-  Class: Eq_291
-  DataType: (ptr32 Eq_291)
-  OrigDataType: 
-T_293: (in fStart @ 1000129D : (ptr32 PVFV))
-  Class: Eq_293
-  DataType: (ptr32 Eq_293)
-  OrigDataType: 
-T_294: (in fEnd @ 1000129D : (ptr32 PVFV))
-  Class: Eq_294
-  DataType: (ptr32 Eq_294)
-  OrigDataType: 
-T_295: (in 0x10002098<32> @ 1000129D : word32)
-  Class: Eq_293
-  DataType: (ptr32 Eq_293)
-  OrigDataType: (ptr32 PVFV)
-T_296: (in 0x1000209C<32> @ 1000129D : word32)
-  Class: Eq_294
-  DataType: (ptr32 Eq_294)
-  OrigDataType: (ptr32 PVFV)
-T_297: (in _initterm(&g_t10002098, &g_t1000209C) @ 1000129D : void)
-  Class: Eq_297
-  DataType: void
-  OrigDataType: void
-T_298: (in 2<32> @ 100012A3 : word32)
-  Class: Eq_203
-  DataType: word32
-  OrigDataType: word32
-T_299: (in 100033A8 @ 100012A3 : ptr32)
-  Class: Eq_299
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_300 t0000)))
-T_300: (in Mem181[0x100033A8<p32>:word32] @ 100012A3 : word32)
-  Class: Eq_203
+  OrigDataType: (ptr32 (struct (0 T_286 t0000)))
+T_286: (in Mem116[0x100033A8<p32>:word32] @ 10001372 : word32)
+  Class: Eq_223
   DataType: word32
   OrigDataType: word32
-T_301: (in 0<32> @ 100012AC : word32)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: word32
-T_302: (in ebp_145 != 0<32> @ 00000000 : bool)
-  Class: Eq_302
-  DataType: bool
-  OrigDataType: bool
-T_303: (in 0<32> @ 1000128C : word32)
-  Class: Eq_137
-  DataType: word32
-  OrigDataType: word32
-T_304: (in esp_261 @ 10001381 : (ptr32 Eq_304))
-  Class: Eq_304
-  DataType: (ptr32 Eq_304)
-  OrigDataType: (ptr32 (struct (0 T_313 t0000) (4 T_317 t0004)))
-T_305: (in 4<i32> @ 10001381 : int32)
-  Class: Eq_305
-  DataType: int32
-  OrigDataType: int32
-T_306: (in esp_118 + 4<i32> @ 10001381 : word32)
-  Class: Eq_304
-  DataType: (ptr32 Eq_304)
-  OrigDataType: ptr32
-T_307: (in 0<32> @ 10001381 : word32)
-  Class: Eq_307
-  DataType: word32
-  OrigDataType: word32
-T_308: (in esp_118 + 0<32> @ 10001381 : word32)
-  Class: Eq_308
-  DataType: ptr32
-  OrigDataType: ptr32
-T_309: (in Mem258[esp_118 + 0<32>:word32] @ 10001381 : word32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: word32
-T_310: (in edi @ 10001381 : word32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: word32
-T_311: (in 0<32> @ 10001382 : word32)
-  Class: Eq_311
-  DataType: word32
-  OrigDataType: word32
-T_312: (in esp_261 + 0<32> @ 10001382 : word32)
-  Class: Eq_312
-  DataType: ptr32
-  OrigDataType: ptr32
-T_313: (in Mem258[esp_261 + 0<32>:word32] @ 10001382 : word32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: word32
-T_314: (in esi @ 10001382 : word32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: word32
-T_315: (in 4<i32> @ 10001383 : int32)
-  Class: Eq_315
-  DataType: int32
-  OrigDataType: int32
-T_316: (in esp_261 + 4<i32> @ 10001383 : word32)
-  Class: Eq_316
-  DataType: ptr32
-  OrigDataType: ptr32
-T_317: (in Mem258[esp_261 + 4<i32>:word32] @ 10001383 : word32)
-  Class: Eq_141
-  DataType: ptr32
-  OrigDataType: word32
-T_318: (in ebx @ 10001383 : word32)
-  Class: Eq_141
-  DataType: ptr32
-  OrigDataType: word32
-T_319: (in eax_89 @ 10001348 : (ptr32 code))
-  Class: Eq_319
-  DataType: (ptr32 code)
-  OrigDataType: (ptr32 code)
-T_320: (in 0<32> @ 10001348 : word32)
-  Class: Eq_320
-  DataType: word32
-  OrigDataType: word32
-T_321: (in edi_82 + 0<32> @ 10001348 : word32)
-  Class: Eq_321
-  DataType: ptr32
-  OrigDataType: ptr32
-T_322: (in Mem78[edi_82 + 0<32>:word32] @ 10001348 : word32)
-  Class: Eq_319
-  DataType: (ptr32 code)
-  OrigDataType: word32
-T_323: (in 0<32> @ 1000134C : word32)
-  Class: Eq_319
-  DataType: (ptr32 code)
-  OrigDataType: word32
-T_324: (in eax_89 == null @ 00000000 : bool)
-  Class: Eq_324
-  DataType: bool
-  OrigDataType: bool
-T_325: (in esp_102 @ 10001357 : (ptr32 Eq_139))
-  Class: Eq_325
-  DataType: (ptr32 Eq_139)
-  OrigDataType: (ptr32 (struct (0 T_215 t0000)))
-T_326: (in 4<i32> @ 10001357 : int32)
-  Class: Eq_326
-  DataType: int32
-  OrigDataType: int32
-T_327: (in esp_81 - 4<i32> @ 00000000 : word32)
-  Class: Eq_325
-  DataType: (ptr32 Eq_139)
-  OrigDataType: ptr32
-T_328: (in 0<32> @ 10001357 : word32)
-  Class: Eq_328
-  DataType: word32
-  OrigDataType: word32
-T_329: (in esp_102 + 0<32> @ 10001357 : word32)
-  Class: Eq_329
-  DataType: ptr32
-  OrigDataType: ptr32
-T_330: (in Mem103[esp_102 + 0<32>:word32] @ 10001357 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_331: (in free @ 10001358 : ptr32)
-  Class: Eq_331
-  DataType: (ptr32 Eq_331)
-  OrigDataType: (ptr32 (fn T_337 (T_336)))
-T_332: (in signature of free @ 00000000 : void)
-  Class: Eq_331
-  DataType: (ptr32 Eq_331)
+T_287: (in InterlockedExchange @ 10001378 : ptr32)
+  Class: Eq_287
+  DataType: (ptr32 Eq_287)
+  OrigDataType: (ptr32 (fn T_297 (T_293, T_296)))
+T_288: (in signature of InterlockedExchange @ 00000000 : void)
+  Class: Eq_287
+  DataType: (ptr32 Eq_287)
   OrigDataType: 
-T_333: (in ptrArg04 @ 10001358 : (ptr32 void))
-  Class: Eq_139
-  DataType: Eq_139
+T_289: (in Target @ 10001378 : (ptr32 LONG))
+  Class: Eq_280
+  DataType: (ptr32 Eq_280)
   OrigDataType: 
-T_334: (in 0<32> @ 10001358 : word32)
-  Class: Eq_334
-  DataType: word32
-  OrigDataType: word32
-T_335: (in esp_102 + 0<32> @ 10001358 : word32)
-  Class: Eq_335
+T_290: (in Value @ 10001378 : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: 
+T_291: (in -4<i32> @ 10001378 : int32)
+  Class: Eq_291
+  DataType: int32
+  OrigDataType: int32
+T_292: (in esp_110 + -4<i32> @ 10001378 : word32)
+  Class: Eq_292
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_336: (in Mem103[esp_102 + 0<32>:(ptr32 void)] @ 10001358 : (ptr32 void))
-  Class: Eq_139
-  DataType: Eq_139
+T_293: (in Mem116[esp_110 + -4<i32>:(ptr32 LONG)] @ 10001378 : (ptr32 LONG))
+  Class: Eq_280
+  DataType: (ptr32 Eq_280)
+  OrigDataType: (ptr32 LONG)
+T_294: (in 0<32> @ 10001378 : word32)
+  Class: Eq_294
+  DataType: word32
+  OrigDataType: word32
+T_295: (in esp_110 + 0<32> @ 10001378 : word32)
+  Class: Eq_295
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_296: (in Mem116[esp_110 + 0<32>:LONG] @ 10001378 : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_297: (in InterlockedExchange(esp_110->ptrFFFFFFFC, esp_110->t0000) @ 10001378 : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_298: (in 4<32> @ 10001378 : word32)
+  Class: Eq_298
+  DataType: int32
+  OrigDataType: int32
+T_299: (in esp_110 + 4<32> @ 10001378 : word32)
+  Class: Eq_176
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
+T_300: (in esp_81 @ 10001343 : ptr32)
+  Class: Eq_300
+  DataType: ptr32
+  OrigDataType: ptr32
+T_301: (in 16<i32> @ 10001343 : int32)
+  Class: Eq_301
+  DataType: int32
+  OrigDataType: int32
+T_302: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_300
+  DataType: ptr32
+  OrigDataType: ptr32
+T_303: (in edi_82 @ 10001344 : DWORD)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
+T_304: (in _decode_pointer @ 10001344 : ptr32)
+  Class: Eq_236
+  DataType: (ptr32 Eq_236)
+  OrigDataType: (ptr32 (fn T_307 (T_306)))
+T_305: (in 100033B0 @ 10001344 : ptr32)
+  Class: Eq_305
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_306 t0000)))
+T_306: (in Mem67[0x100033B0<p32>:word32] @ 10001344 : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
   OrigDataType: (ptr32 void)
-T_337: (in free(*esp_102) @ 10001358 : void)
-  Class: Eq_337
+T_307: (in _decode_pointer(g_ptr100033B0) @ 10001344 : (ptr32 void))
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: (ptr32 void)
+T_308: (in 4<32> @ 10001350 : word32)
+  Class: Eq_308
+  DataType: ui32
+  OrigDataType: ui32
+T_309: (in edi_82 - 4<32> @ 00000000 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: ptr32
+T_310: (in edi_82 >= eax_69 @ 00000000 : bool)
+  Class: Eq_310
+  DataType: bool
+  OrigDataType: bool
+T_311: (in _initterm @ 1000129D : ptr32)
+  Class: Eq_311
+  DataType: (ptr32 Eq_311)
+  OrigDataType: (ptr32 (fn T_317 (T_315, T_316)))
+T_312: (in signature of _initterm @ 00000000 : void)
+  Class: Eq_311
+  DataType: (ptr32 Eq_311)
+  OrigDataType: 
+T_313: (in fStart @ 1000129D : (ptr32 PVFV))
+  Class: Eq_313
+  DataType: (ptr32 Eq_313)
+  OrigDataType: 
+T_314: (in fEnd @ 1000129D : (ptr32 PVFV))
+  Class: Eq_314
+  DataType: (ptr32 Eq_314)
+  OrigDataType: 
+T_315: (in 0x10002098<32> @ 1000129D : word32)
+  Class: Eq_313
+  DataType: (ptr32 Eq_313)
+  OrigDataType: (ptr32 PVFV)
+T_316: (in 0x1000209C<32> @ 1000129D : word32)
+  Class: Eq_314
+  DataType: (ptr32 Eq_314)
+  OrigDataType: (ptr32 PVFV)
+T_317: (in _initterm(&g_t10002098, &g_t1000209C) @ 1000129D : void)
+  Class: Eq_317
   DataType: void
   OrigDataType: void
-T_338: (in eax_106 @ 1000135F : (ptr32 void))
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_339: (in _encoded_null @ 1000135F : ptr32)
-  Class: Eq_339
-  DataType: (ptr32 Eq_339)
-  OrigDataType: (ptr32 (fn T_341 ()))
-T_340: (in signature of _encoded_null @ 00000000 : void)
-  Class: Eq_339
-  DataType: (ptr32 Eq_339)
-  OrigDataType: 
-T_341: (in _encoded_null() @ 1000135F : (ptr32 void))
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_342: (in 100033B0 @ 10001365 : ptr32)
-  Class: Eq_342
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_343 t0000)))
-T_343: (in Mem107[0x100033B0<p32>:word32] @ 10001365 : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
+T_318: (in 2<32> @ 100012A3 : word32)
+  Class: Eq_223
+  DataType: word32
   OrigDataType: word32
-T_344: (in 100033B4 @ 1000136A : ptr32)
+T_319: (in 100033A8 @ 100012A3 : ptr32)
+  Class: Eq_319
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_320 t0000)))
+T_320: (in Mem181[0x100033A8<p32>:word32] @ 100012A3 : word32)
+  Class: Eq_223
+  DataType: word32
+  OrigDataType: word32
+T_321: (in 0<32> @ 100012AC : word32)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: word32
+T_322: (in ebp_145 != 0<32> @ 00000000 : bool)
+  Class: Eq_322
+  DataType: bool
+  OrigDataType: bool
+T_323: (in 0<32> @ 1000128C : word32)
+  Class: Eq_157
+  DataType: word32
+  OrigDataType: word32
+T_324: (in esp_261 @ 10001381 : (ptr32 Eq_324))
+  Class: Eq_324
+  DataType: (ptr32 Eq_324)
+  OrigDataType: (ptr32 (struct (0 T_333 t0000) (4 T_337 t0004)))
+T_325: (in 4<i32> @ 10001381 : int32)
+  Class: Eq_325
+  DataType: int32
+  OrigDataType: int32
+T_326: (in esp_118 + 4<i32> @ 10001381 : word32)
+  Class: Eq_324
+  DataType: (ptr32 Eq_324)
+  OrigDataType: ptr32
+T_327: (in 0<32> @ 10001381 : word32)
+  Class: Eq_327
+  DataType: word32
+  OrigDataType: word32
+T_328: (in esp_118 + 0<32> @ 10001381 : word32)
+  Class: Eq_328
+  DataType: ptr32
+  OrigDataType: ptr32
+T_329: (in Mem258[esp_118 + 0<32>:word32] @ 10001381 : word32)
+  Class: Eq_163
+  DataType: ptr32
+  OrigDataType: word32
+T_330: (in edi @ 10001381 : word32)
+  Class: Eq_163
+  DataType: ptr32
+  OrigDataType: word32
+T_331: (in 0<32> @ 10001382 : word32)
+  Class: Eq_331
+  DataType: word32
+  OrigDataType: word32
+T_332: (in esp_261 + 0<32> @ 10001382 : word32)
+  Class: Eq_332
+  DataType: ptr32
+  OrigDataType: ptr32
+T_333: (in Mem258[esp_261 + 0<32>:word32] @ 10001382 : word32)
+  Class: Eq_162
+  DataType: ptr32
+  OrigDataType: word32
+T_334: (in esi @ 10001382 : word32)
+  Class: Eq_162
+  DataType: ptr32
+  OrigDataType: word32
+T_335: (in 4<i32> @ 10001383 : int32)
+  Class: Eq_335
+  DataType: int32
+  OrigDataType: int32
+T_336: (in esp_261 + 4<i32> @ 10001383 : word32)
+  Class: Eq_336
+  DataType: ptr32
+  OrigDataType: ptr32
+T_337: (in Mem258[esp_261 + 4<i32>:word32] @ 10001383 : word32)
+  Class: Eq_161
+  DataType: ptr32
+  OrigDataType: word32
+T_338: (in ebx @ 10001383 : word32)
+  Class: Eq_161
+  DataType: ptr32
+  OrigDataType: word32
+T_339: (in eax_89 @ 10001348 : (ptr32 code))
+  Class: Eq_339
+  DataType: (ptr32 code)
+  OrigDataType: (ptr32 code)
+T_340: (in 0<32> @ 10001348 : word32)
+  Class: Eq_340
+  DataType: word32
+  OrigDataType: word32
+T_341: (in edi_82 + 0<32> @ 10001348 : word32)
+  Class: Eq_341
+  DataType: ptr32
+  OrigDataType: ptr32
+T_342: (in Mem78[edi_82 + 0<32>:word32] @ 10001348 : word32)
+  Class: Eq_339
+  DataType: (ptr32 code)
+  OrigDataType: word32
+T_343: (in 0<32> @ 1000134C : word32)
+  Class: Eq_339
+  DataType: (ptr32 code)
+  OrigDataType: word32
+T_344: (in eax_89 == null @ 00000000 : bool)
   Class: Eq_344
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_345 t0000)))
-T_345: (in Mem108[0x100033B4<p32>:word32] @ 1000136A : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: word32
-T_346: (in 4<i32> @ 1000135E : int32)
+  DataType: bool
+  OrigDataType: bool
+T_345: (in esp_102 @ 10001357 : (ptr32 Eq_159))
+  Class: Eq_345
+  DataType: (ptr32 Eq_159)
+  OrigDataType: (ptr32 (struct (0 T_235 t0000)))
+T_346: (in 4<i32> @ 10001357 : int32)
   Class: Eq_346
   DataType: int32
   OrigDataType: int32
-T_347: (in esp_102 + 4<i32> @ 1000135E : word32)
-  Class: Eq_222
-  DataType: ptr32
+T_347: (in esp_81 - 4<i32> @ 00000000 : word32)
+  Class: Eq_345
+  DataType: (ptr32 Eq_159)
   OrigDataType: ptr32
-T_348: (in ecx_99 @ 1000134E : word32)
+T_348: (in 0<32> @ 10001357 : word32)
   Class: Eq_348
   DataType: word32
   OrigDataType: word32
-T_349: (in edx_286 @ 1000134E : word32)
+T_349: (in esp_102 + 0<32> @ 10001357 : word32)
   Class: Eq_349
-  DataType: word32
-  OrigDataType: word32
-T_350: (in 16<i32> @ 100012B6 : int32)
-  Class: Eq_350
-  DataType: int32
-  OrigDataType: int32
-T_351: (in fp - 16<i32> @ 00000000 : word32)
-  Class: Eq_156
-  DataType: (ptr32 ptr32)
+  DataType: ptr32
   OrigDataType: ptr32
-T_352: (in 100033B8 @ 100012BD : ptr32)
-  Class: Eq_352
-  DataType: (ptr32 (ptr32 code))
-  OrigDataType: (ptr32 (struct (0 T_353 t0000)))
-T_353: (in Mem196[0x100033B8<p32>:word32] @ 100012BD : word32)
-  Class: Eq_353
-  DataType: (ptr32 code)
+T_350: (in Mem103[esp_102 + 0<32>:word32] @ 10001357 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_354: (in 0<32> @ 100012BD : word32)
-  Class: Eq_353
-  DataType: (ptr32 code)
-  OrigDataType: word32
-T_355: (in g_ptr100033B8 == null @ 00000000 : bool)
-  Class: Eq_355
-  DataType: bool
-  OrigDataType: bool
-T_356: (in InterlockedExchange @ 100012B0 : ptr32)
-  Class: Eq_267
-  DataType: (ptr32 Eq_267)
-  OrigDataType: (ptr32 (fn T_358 (T_357, T_145)))
-T_357: (in 0x100033AC<p32> @ 100012B0 : ptr32)
-  Class: Eq_260
-  DataType: (ptr32 Eq_260)
-  OrigDataType: (ptr32 LONG)
-T_358: (in InterlockedExchange(&g_t100033AC, ebp_145) @ 100012B0 : LONG)
-  Class: Eq_145
-  DataType: Eq_145
-  OrigDataType: LONG
-T_359: (in 10003070 @ 100012DD : ptr32)
-  Class: Eq_359
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_360 t0000)))
-T_360: (in Mem244[0x10003070<p32>:word32] @ 100012DD : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: word32
-T_361: (in 1<32> @ 100012DD : word32)
-  Class: Eq_361
-  DataType: word32
-  OrigDataType: word32
-T_362: (in g_dw10003070 + 1<32> @ 00000000 : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: word32
-T_363: (in 10003070 @ 100012DD : ptr32)
-  Class: Eq_363
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_364 t0000)))
-T_364: (in Mem246[0x10003070<p32>:word32] @ 100012DD : word32)
-  Class: Eq_163
-  DataType: int32
-  OrigDataType: word32
-T_365: (in 16<i32> @ 100012CB : int32)
-  Class: Eq_365
-  DataType: int32
-  OrigDataType: int32
-T_366: (in fp - 16<i32> @ 00000000 : word32)
-  Class: Eq_156
-  DataType: (ptr32 ptr32)
-  OrigDataType: ptr32
-T_367: (in edi_214 @ 100012CC : word32)
-  Class: Eq_367
-  DataType: word32
-  OrigDataType: word32
-T_368: (in fn10001742 @ 100012CC : ptr32)
-  Class: Eq_368
-  DataType: (ptr32 Eq_368)
-  OrigDataType: (ptr32 (fn T_378 (T_374, T_375, T_376, T_377)))
-T_369: (in signature of fn10001742 @ 10001742 : void)
-  Class: Eq_368
-  DataType: (ptr32 Eq_368)
+T_351: (in free @ 10001358 : ptr32)
+  Class: Eq_351
+  DataType: (ptr32 Eq_351)
+  OrigDataType: (ptr32 (fn T_357 (T_356)))
+T_352: (in signature of free @ 00000000 : void)
+  Class: Eq_351
+  DataType: (ptr32 Eq_351)
   OrigDataType: 
-T_370: (in ebx @ 100012CC : (ptr32 Eq_183))
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
+T_353: (in ptrArg04 @ 10001358 : (ptr32 void))
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: 
+T_354: (in 0<32> @ 10001358 : word32)
+  Class: Eq_354
+  DataType: word32
   OrigDataType: word32
-T_371: (in esi @ 100012CC : ptr32)
-  Class: Eq_371
+T_355: (in esp_102 + 0<32> @ 10001358 : word32)
+  Class: Eq_355
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_356: (in Mem103[esp_102 + 0<32>:(ptr32 void)] @ 10001358 : (ptr32 void))
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: (ptr32 void)
+T_357: (in free(*esp_102) @ 10001358 : void)
+  Class: Eq_357
+  DataType: void
+  OrigDataType: void
+T_358: (in eax_106 @ 1000135F : (ptr32 void))
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_359: (in _encoded_null @ 1000135F : ptr32)
+  Class: Eq_359
+  DataType: (ptr32 Eq_359)
+  OrigDataType: (ptr32 (fn T_361 ()))
+T_360: (in signature of _encoded_null @ 00000000 : void)
+  Class: Eq_359
+  DataType: (ptr32 Eq_359)
+  OrigDataType: 
+T_361: (in _encoded_null() @ 1000135F : (ptr32 void))
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_362: (in 100033B0 @ 10001365 : ptr32)
+  Class: Eq_362
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_363 t0000)))
+T_363: (in Mem107[0x100033B0<p32>:word32] @ 10001365 : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: word32
+T_364: (in 100033B4 @ 1000136A : ptr32)
+  Class: Eq_364
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_365 t0000)))
+T_365: (in Mem108[0x100033B4<p32>:word32] @ 1000136A : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: word32
+T_366: (in 4<i32> @ 1000135E : int32)
+  Class: Eq_366
+  DataType: int32
+  OrigDataType: int32
+T_367: (in esp_102 + 4<i32> @ 1000135E : word32)
+  Class: Eq_242
   DataType: ptr32
+  OrigDataType: ptr32
+T_368: (in ecx_99 @ 1000134E : word32)
+  Class: Eq_368
+  DataType: word32
   OrigDataType: word32
-T_372: (in edi @ 100012CC : word32)
+T_369: (in edx_286 @ 1000134E : word32)
+  Class: Eq_369
+  DataType: word32
+  OrigDataType: word32
+T_370: (in 16<i32> @ 100012B6 : int32)
+  Class: Eq_370
+  DataType: int32
+  OrigDataType: int32
+T_371: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_176
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
+T_372: (in 100033B8 @ 100012BD : ptr32)
   Class: Eq_372
-  DataType: word32
-  OrigDataType: word32
-T_373: (in ediOut @ 100012CC : ptr32)
+  DataType: (ptr32 (ptr32 code))
+  OrigDataType: (ptr32 (struct (0 T_373 t0000)))
+T_373: (in Mem196[0x100033B8<p32>:word32] @ 100012BD : word32)
   Class: Eq_373
-  DataType: ptr32
-  OrigDataType: ptr32
-T_374: (in InterlockedCompareExchange @ 100012CC : ptr32)
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: ptr32
-T_375: (in 0x100033AC<p32> @ 100012CC : ptr32)
-  Class: Eq_371
-  DataType: ptr32
-  OrigDataType: ptr32
-T_376: (in 2<32> @ 100012CC : word32)
-  Class: Eq_372
-  DataType: word32
+  DataType: (ptr32 code)
   OrigDataType: word32
-T_377: (in out edi_214 @ 100012CC : ptr32)
+T_374: (in 0<32> @ 100012BD : word32)
   Class: Eq_373
-  DataType: ptr32
-  OrigDataType: ptr32
-T_378: (in fn10001742(InterlockedCompareExchange, 0x100033AC<p32>, 2<32>, out edi_214) @ 100012CC : word32)
-  Class: Eq_378
-  DataType: word32
+  DataType: (ptr32 code)
   OrigDataType: word32
-T_379: (in 0<32> @ 100012CC : word32)
-  Class: Eq_378
-  DataType: word32
-  OrigDataType: word32
-T_380: (in fn10001742(InterlockedCompareExchange, 0x100033AC<p32>, 2<32>, out edi_214) == 0<32> @ 00000000 : bool)
-  Class: Eq_380
+T_375: (in g_ptr100033B8 == null @ 00000000 : bool)
+  Class: Eq_375
   DataType: bool
   OrigDataType: bool
-T_381: (in ecx_240 @ 100012D7 : word32)
+T_376: (in InterlockedExchange @ 100012B0 : ptr32)
+  Class: Eq_287
+  DataType: (ptr32 Eq_287)
+  OrigDataType: (ptr32 (fn T_378 (T_377, T_165)))
+T_377: (in 0x100033AC<p32> @ 100012B0 : ptr32)
+  Class: Eq_280
+  DataType: (ptr32 Eq_280)
+  OrigDataType: (ptr32 LONG)
+T_378: (in InterlockedExchange(&g_t100033AC, ebp_145) @ 100012B0 : LONG)
+  Class: Eq_165
+  DataType: Eq_165
+  OrigDataType: LONG
+T_379: (in 10003070 @ 100012DD : ptr32)
+  Class: Eq_379
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_380 t0000)))
+T_380: (in Mem244[0x10003070<p32>:word32] @ 100012DD : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_381: (in 1<32> @ 100012DD : word32)
   Class: Eq_381
   DataType: word32
   OrigDataType: word32
-T_382: (in edx_242 @ 100012D7 : word32)
-  Class: Eq_382
+T_382: (in g_dw10003070 + 1<32> @ 00000000 : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_383: (in 10003070 @ 100012DD : ptr32)
+  Class: Eq_383
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_384 t0000)))
+T_384: (in Mem246[0x10003070<p32>:word32] @ 100012DD : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_385: (in 16<i32> @ 100012CB : int32)
+  Class: Eq_385
+  DataType: int32
+  OrigDataType: int32
+T_386: (in fp - 16<i32> @ 00000000 : word32)
+  Class: Eq_176
+  DataType: (ptr32 ptr32)
+  OrigDataType: ptr32
+T_387: (in edi_214 @ 100012CC : word32)
+  Class: Eq_387
   DataType: word32
   OrigDataType: word32
-T_383: (in 100033B8 @ 100012D7 : ptr32)
-  Class: Eq_383
+T_388: (in fn10001742 @ 100012CC : ptr32)
+  Class: Eq_388
+  DataType: (ptr32 Eq_388)
+  OrigDataType: (ptr32 (fn T_398 (T_394, T_395, T_396, T_397)))
+T_389: (in signature of fn10001742 @ 10001742 : void)
+  Class: Eq_388
+  DataType: (ptr32 Eq_388)
+  OrigDataType: 
+T_390: (in ebx @ 100012CC : (ptr32 Eq_203))
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: word32
+T_391: (in esi @ 100012CC : ptr32)
+  Class: Eq_391
+  DataType: ptr32
+  OrigDataType: word32
+T_392: (in edi @ 100012CC : word32)
+  Class: Eq_392
+  DataType: word32
+  OrigDataType: word32
+T_393: (in ediOut @ 100012CC : ptr32)
+  Class: Eq_393
+  DataType: ptr32
+  OrigDataType: ptr32
+T_394: (in InterlockedCompareExchange @ 100012CC : ptr32)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: ptr32
+T_395: (in 0x100033AC<p32> @ 100012CC : ptr32)
+  Class: Eq_391
+  DataType: ptr32
+  OrigDataType: ptr32
+T_396: (in 2<32> @ 100012CC : word32)
+  Class: Eq_392
+  DataType: word32
+  OrigDataType: word32
+T_397: (in out edi_214 @ 100012CC : ptr32)
+  Class: Eq_393
+  DataType: ptr32
+  OrigDataType: ptr32
+T_398: (in fn10001742(InterlockedCompareExchange, 0x100033AC<p32>, 2<32>, out edi_214) @ 100012CC : word32)
+  Class: Eq_398
+  DataType: word32
+  OrigDataType: word32
+T_399: (in 0<32> @ 100012CC : word32)
+  Class: Eq_398
+  DataType: word32
+  OrigDataType: word32
+T_400: (in fn10001742(InterlockedCompareExchange, 0x100033AC<p32>, 2<32>, out edi_214) == 0<32> @ 00000000 : bool)
+  Class: Eq_400
+  DataType: bool
+  OrigDataType: bool
+T_401: (in ecx_240 @ 100012D7 : word32)
+  Class: Eq_401
+  DataType: word32
+  OrigDataType: word32
+T_402: (in edx_242 @ 100012D7 : word32)
+  Class: Eq_402
+  DataType: word32
+  OrigDataType: word32
+T_403: (in 100033B8 @ 100012D7 : ptr32)
+  Class: Eq_403
   DataType: (ptr32 (ptr32 code))
-  OrigDataType: (ptr32 (struct (0 T_384 t0000)))
-T_384: (in Mem233[0x100033B8<p32>:word32] @ 100012D7 : word32)
-  Class: Eq_353
+  OrigDataType: (ptr32 (struct (0 T_404 t0000)))
+T_404: (in Mem233[0x100033B8<p32>:word32] @ 100012D7 : word32)
+  Class: Eq_373
   DataType: (ptr32 code)
   OrigDataType: (ptr32 code)
-T_385: (in eax @ 10001385 : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
+T_405: (in eax @ 10001385 : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_386: (in ecx @ 10001385 : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
+T_406: (in ecx @ 10001385 : Eq_160)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_387: (in edx @ 10001385 : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
+T_407: (in edx @ 10001385 : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_388: (in ebx @ 10001385 : (ptr32 Eq_183))
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
+T_408: (in ebx @ 10001385 : (ptr32 Eq_203))
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
   OrigDataType: word32
-T_389: (in esi @ 10001385 : ptr32)
-  Class: Eq_371
-  DataType: ptr32
-  OrigDataType: word32
-T_390: (in edi @ 10001385 : word32)
-  Class: Eq_372
-  DataType: word32
-  OrigDataType: word32
-T_391: (in ebp_13 @ 1000138F : (ptr32 Eq_391))
+T_409: (in esi @ 10001385 : ptr32)
   Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: (ptr32 (struct (FFFFFFE4 T_139 tFFFFFFE4) (FFFFFFFC T_410 tFFFFFFFC) (8 T_405 t0008)))
-T_392: (in fn100017E8 @ 1000138F : ptr32)
-  Class: Eq_392
-  DataType: (ptr32 Eq_392)
-  OrigDataType: (ptr32 (fn T_401 (T_388, T_389, T_390, T_399, T_400)))
-T_393: (in signature of fn100017E8 @ 100017E8 : void)
-  Class: Eq_392
-  DataType: (ptr32 Eq_392)
-  OrigDataType: 
-T_394: (in ebx @ 1000138F : (ptr32 Eq_183))
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: word32
-T_395: (in esi @ 1000138F : ptr32)
-  Class: Eq_371
   DataType: ptr32
   OrigDataType: word32
-T_396: (in edi @ 1000138F : word32)
-  Class: Eq_372
+T_410: (in edi @ 10001385 : word32)
+  Class: Eq_392
   DataType: word32
   OrigDataType: word32
-T_397: (in dwArg00 @ 1000138F : word32)
-  Class: Eq_397
+T_411: (in ebp_13 @ 1000138F : (ptr32 Eq_411))
+  Class: Eq_411
+  DataType: (ptr32 Eq_411)
+  OrigDataType: (ptr32 (struct (FFFFFFE4 T_159 tFFFFFFE4) (FFFFFFFC T_430 tFFFFFFFC) (8 T_425 t0008)))
+T_412: (in fn100017E8 @ 1000138F : ptr32)
+  Class: Eq_412
+  DataType: (ptr32 Eq_412)
+  OrigDataType: (ptr32 (fn T_421 (T_408, T_409, T_410, T_419, T_420)))
+T_413: (in signature of fn100017E8 @ 100017E8 : void)
+  Class: Eq_412
+  DataType: (ptr32 Eq_412)
+  OrigDataType: 
+T_414: (in ebx @ 1000138F : (ptr32 Eq_203))
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: word32
+T_415: (in esi @ 1000138F : ptr32)
+  Class: Eq_391
+  DataType: ptr32
+  OrigDataType: word32
+T_416: (in edi @ 1000138F : word32)
+  Class: Eq_392
   DataType: word32
   OrigDataType: word32
-T_398: (in dwArg08 @ 1000138F : ui32)
-  Class: Eq_398
+T_417: (in dwArg00 @ 1000138F : word32)
+  Class: Eq_417
+  DataType: word32
+  OrigDataType: word32
+T_418: (in dwArg08 @ 1000138F : ui32)
+  Class: Eq_418
   DataType: ui32
   OrigDataType: ui32
-T_399: (in dwLoc0C @ 1000138F : word32)
-  Class: Eq_397
+T_419: (in dwLoc0C @ 1000138F : word32)
+  Class: Eq_417
   DataType: word32
   OrigDataType: word32
-T_400: (in 0x10<32> @ 1000138F : word32)
-  Class: Eq_398
+T_420: (in 0x10<32> @ 1000138F : word32)
+  Class: Eq_418
   DataType: ui32
   OrigDataType: word32
-T_401: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10<32>) @ 1000138F : word32)
-  Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: word32
-T_402: (in ebx_113 @ 10001398 : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_403: (in 8<32> @ 10001398 : word32)
-  Class: Eq_403
-  DataType: word32
-  OrigDataType: word32
-T_404: (in ebp_13 + 8<32> @ 10001398 : word32)
-  Class: Eq_404
-  DataType: word32
-  OrigDataType: word32
-T_405: (in Mem7[ebp_13 + 8<32>:word32] @ 10001398 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_406: (in 1<32> @ 1000139E : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_407: (in -28<i32> @ 1000139E : int32)
-  Class: Eq_407
-  DataType: int32
-  OrigDataType: int32
-T_408: (in ebp_13 + -28<i32> @ 1000139E : word32)
-  Class: Eq_408
-  DataType: ptr32
-  OrigDataType: ptr32
-T_409: (in Mem25[ebp_13 + -28<i32>:word32] @ 1000139E : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_410: (in 0<32> @ 100013A3 : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_411: (in -4<i32> @ 100013A3 : int32)
+T_421: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x10<32>) @ 1000138F : word32)
   Class: Eq_411
-  DataType: int32
-  OrigDataType: int32
-T_412: (in ebp_13 + -4<i32> @ 100013A3 : word32)
-  Class: Eq_412
-  DataType: ptr32
-  OrigDataType: ptr32
-T_413: (in Mem27[ebp_13 + -4<i32>:word32] @ 100013A3 : word32)
-  Class: Eq_410
+  DataType: (ptr32 Eq_411)
+  OrigDataType: word32
+T_422: (in ebx_113 @ 10001398 : Eq_158)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_423: (in 8<32> @ 10001398 : word32)
+  Class: Eq_423
   DataType: word32
   OrigDataType: word32
-T_414: (in 10003008 @ 100013A6 : ptr32)
-  Class: Eq_414
-  DataType: (ptr32 Eq_139)
-  OrigDataType: (ptr32 (struct (0 T_415 t0000)))
-T_415: (in Mem28[0x10003008<p32>:word32] @ 100013A6 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_416: (in 1<32> @ 100013AC : word32)
-  Class: Eq_410
+T_424: (in ebp_13 + 8<32> @ 10001398 : word32)
+  Class: Eq_424
   DataType: word32
   OrigDataType: word32
-T_417: (in -4<i32> @ 100013AC : int32)
-  Class: Eq_417
-  DataType: int32
-  OrigDataType: int32
-T_418: (in ebp_13 + -4<i32> @ 100013AC : word32)
-  Class: Eq_418
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_419: (in Mem29[ebp_13 + -4<i32>:word32] @ 100013AC : word32)
-  Class: Eq_410
-  DataType: word32
+T_425: (in Mem7[ebp_13 + 8<32>:word32] @ 10001398 : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_420: (in esp_100 @ 1000138A : (ptr32 Eq_420))
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
-  OrigDataType: (ptr32 (struct (FFFFFFFC T_459 tFFFFFFFC)))
-T_421: (in fp @ 1000138A : ptr32)
-  Class: Eq_421
-  DataType: ptr32
-  OrigDataType: ptr32
-T_422: (in 8<i32> @ 1000138A : int32)
-  Class: Eq_422
-  DataType: int32
-  OrigDataType: int32
-T_423: (in fp - 8<i32> @ 00000000 : word32)
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
-  OrigDataType: ptr32
-T_424: (in edi_107 @ 10001394 : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
+T_426: (in 1<32> @ 1000139E : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_425: (in esi_110 @ 10001396 : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_426: (in 0<32> @ 100013B1 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_427: (in edx != 0<32> @ 00000000 : bool)
+T_427: (in -28<i32> @ 1000139E : int32)
   Class: Eq_427
-  DataType: bool
-  OrigDataType: bool
-T_428: (in 1<32> @ 100013C5 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+  DataType: int32
+  OrigDataType: int32
+T_428: (in ebp_13 + -28<i32> @ 1000139E : word32)
+  Class: Eq_428
+  DataType: ptr32
+  OrigDataType: ptr32
+T_429: (in Mem25[ebp_13 + -28<i32>:word32] @ 1000139E : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_429: (in edx == 1<32> @ 00000000 : bool)
-  Class: Eq_429
-  DataType: bool
-  OrigDataType: bool
-T_430: (in 10003070 @ 100013B9 : ptr32)
+T_430: (in 0<32> @ 100013A3 : word32)
   Class: Eq_430
-  DataType: (ptr32 int32)
-  OrigDataType: (ptr32 (struct (0 T_431 t0000)))
-T_431: (in Mem29[0x10003070<p32>:word32] @ 100013B9 : word32)
-  Class: Eq_163
-  DataType: int32
+  DataType: word32
   OrigDataType: word32
-T_432: (in 0<32> @ 100013B9 : word32)
-  Class: Eq_163
+T_431: (in -4<i32> @ 100013A3 : int32)
+  Class: Eq_431
   DataType: int32
+  OrigDataType: int32
+T_432: (in ebp_13 + -4<i32> @ 100013A3 : word32)
+  Class: Eq_432
+  DataType: ptr32
+  OrigDataType: ptr32
+T_433: (in Mem27[ebp_13 + -4<i32>:word32] @ 100013A3 : word32)
+  Class: Eq_430
+  DataType: word32
   OrigDataType: word32
-T_433: (in g_dw10003070 != 0<32> @ 00000000 : bool)
-  Class: Eq_433
+T_434: (in 10003008 @ 100013A6 : ptr32)
+  Class: Eq_434
+  DataType: (ptr32 Eq_159)
+  OrigDataType: (ptr32 (struct (0 T_435 t0000)))
+T_435: (in Mem28[0x10003008<p32>:word32] @ 100013A6 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_436: (in 1<32> @ 100013AC : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_437: (in -4<i32> @ 100013AC : int32)
+  Class: Eq_437
+  DataType: int32
+  OrigDataType: int32
+T_438: (in ebp_13 + -4<i32> @ 100013AC : word32)
+  Class: Eq_438
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_439: (in Mem29[ebp_13 + -4<i32>:word32] @ 100013AC : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_440: (in esp_100 @ 1000138A : (ptr32 Eq_440))
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
+  OrigDataType: (ptr32 (struct (FFFFFFFC T_479 tFFFFFFFC)))
+T_441: (in fp @ 1000138A : ptr32)
+  Class: Eq_441
+  DataType: ptr32
+  OrigDataType: ptr32
+T_442: (in 8<i32> @ 1000138A : int32)
+  Class: Eq_442
+  DataType: int32
+  OrigDataType: int32
+T_443: (in fp - 8<i32> @ 00000000 : word32)
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
+  OrigDataType: ptr32
+T_444: (in edi_107 @ 10001394 : Eq_160)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: word32
+T_445: (in esi_110 @ 10001396 : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_446: (in 0<32> @ 100013B1 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_447: (in edx != 0<32> @ 00000000 : bool)
+  Class: Eq_447
   DataType: bool
   OrigDataType: bool
-T_434: (in 0<32> @ 100013BB : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_448: (in 1<32> @ 100013C5 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_435: (in -28<i32> @ 100013BB : int32)
-  Class: Eq_435
+T_449: (in edx == 1<32> @ 00000000 : bool)
+  Class: Eq_449
+  DataType: bool
+  OrigDataType: bool
+T_450: (in 10003070 @ 100013B9 : ptr32)
+  Class: Eq_450
+  DataType: (ptr32 int32)
+  OrigDataType: (ptr32 (struct (0 T_451 t0000)))
+T_451: (in Mem29[0x10003070<p32>:word32] @ 100013B9 : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_452: (in 0<32> @ 100013B9 : word32)
+  Class: Eq_183
+  DataType: int32
+  OrigDataType: word32
+T_453: (in g_dw10003070 != 0<32> @ 00000000 : bool)
+  Class: Eq_453
+  DataType: bool
+  OrigDataType: bool
+T_454: (in 0<32> @ 100013BB : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_455: (in -28<i32> @ 100013BB : int32)
+  Class: Eq_455
   DataType: int32
   OrigDataType: int32
-T_436: (in ebp_13 + -28<i32> @ 100013BB : word32)
-  Class: Eq_436
+T_456: (in ebp_13 + -28<i32> @ 100013BB : word32)
+  Class: Eq_456
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_437: (in Mem248[ebp_13 + -28<i32>:word32] @ 100013BB : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_457: (in Mem248[ebp_13 + -28<i32>:word32] @ 100013BB : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_438: (in 0<32> @ 1000147A : word32)
-  Class: Eq_410
+T_458: (in 0<32> @ 1000147A : word32)
+  Class: Eq_430
   DataType: word32
   OrigDataType: word32
-T_439: (in -4<i32> @ 1000147A : int32)
-  Class: Eq_439
+T_459: (in -4<i32> @ 1000147A : int32)
+  Class: Eq_459
   DataType: int32
   OrigDataType: int32
-T_440: (in ebp_13 + -4<i32> @ 1000147A : word32)
-  Class: Eq_440
+T_460: (in ebp_13 + -4<i32> @ 1000147A : word32)
+  Class: Eq_460
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_441: (in Mem253[ebp_13 + -4<i32>:word32] @ 1000147A : word32)
-  Class: Eq_410
+T_461: (in Mem253[ebp_13 + -4<i32>:word32] @ 1000147A : word32)
+  Class: Eq_430
   DataType: word32
   OrigDataType: word32
-T_442: (in 0xFFFFFFFE<32> @ 1000147E : word32)
-  Class: Eq_410
+T_462: (in 0xFFFFFFFE<32> @ 1000147E : word32)
+  Class: Eq_430
   DataType: word32
   OrigDataType: word32
-T_443: (in -4<i32> @ 1000147E : int32)
-  Class: Eq_443
+T_463: (in -4<i32> @ 1000147E : int32)
+  Class: Eq_463
   DataType: int32
   OrigDataType: int32
-T_444: (in ebp_13 + -4<i32> @ 1000147E : word32)
-  Class: Eq_444
+T_464: (in ebp_13 + -4<i32> @ 1000147E : word32)
+  Class: Eq_464
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_445: (in Mem256[ebp_13 + -4<i32>:word32] @ 1000147E : word32)
-  Class: Eq_410
+T_465: (in Mem256[ebp_13 + -4<i32>:word32] @ 1000147E : word32)
+  Class: Eq_430
   DataType: word32
   OrigDataType: word32
-T_446: (in fn10001493 @ 10001485 : ptr32)
-  Class: Eq_446
-  DataType: (ptr32 Eq_446)
-  OrigDataType: (ptr32 (fn T_448 ()))
-T_447: (in signature of fn10001493 @ 10001493 : void)
-  Class: Eq_446
-  DataType: (ptr32 Eq_446)
+T_466: (in fn10001493 @ 10001485 : ptr32)
+  Class: Eq_466
+  DataType: (ptr32 Eq_466)
+  OrigDataType: (ptr32 (fn T_468 ()))
+T_467: (in signature of fn10001493 @ 10001493 : void)
+  Class: Eq_466
+  DataType: (ptr32 Eq_466)
   OrigDataType: 
-T_448: (in fn10001493() @ 10001485 : void)
-  Class: Eq_448
+T_468: (in fn10001493() @ 10001485 : void)
+  Class: Eq_468
   DataType: void
   OrigDataType: void
-T_449: (in eax_257 @ 1000148A : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
+T_469: (in eax_257 @ 1000148A : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_450: (in -28<i32> @ 1000148A : int32)
-  Class: Eq_450
-  DataType: int32
-  OrigDataType: int32
-T_451: (in ebp_13 + -28<i32> @ 1000148A : word32)
-  Class: Eq_451
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_452: (in Mem256[ebp_13 + -28<i32>:word32] @ 1000148A : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_453: (in fn1000182D @ 1000148D : ptr32)
-  Class: Eq_453
-  DataType: (ptr32 Eq_453)
-  OrigDataType: (ptr32 (fn T_460 (T_391, T_459)))
-T_454: (in signature of fn1000182D @ 1000182D : void)
-  Class: Eq_453
-  DataType: (ptr32 Eq_453)
-  OrigDataType: 
-T_455: (in ebp @ 1000148D : (ptr32 Eq_391))
-  Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: (ptr32 (struct (FFFFFFF0 T_989 tFFFFFFF0) (0 T_995 t0000)))
-T_456: (in dwArg00 @ 1000148D : Eq_456)
-  Class: Eq_456
-  DataType: Eq_456
-  OrigDataType: word32
-T_457: (in -4<i32> @ 1000148D : int32)
-  Class: Eq_457
-  DataType: int32
-  OrigDataType: int32
-T_458: (in esp_100 + -4<i32> @ 1000148D : word32)
-  Class: Eq_458
-  DataType: ptr32
-  OrigDataType: ptr32
-T_459: (in Mem256[esp_100 + -4<i32>:word32] @ 1000148D : word32)
-  Class: Eq_456
-  DataType: Eq_456
-  OrigDataType: word32
-T_460: (in fn1000182D(ebp_13, esp_100->tFFFFFFFC) @ 1000148D : word32)
-  Class: Eq_373
-  DataType: ptr32
-  OrigDataType: word32
-T_461: (in 100020CC @ 100013D3 : ptr32)
-  Class: Eq_461
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_462 t0000)))
-T_462: (in Mem29[0x100020CC<p32>:word32] @ 100013D3 : word32)
-  Class: Eq_462
-  DataType: word32
-  OrigDataType: word32
-T_463: (in 0<32> @ 100013D3 : word32)
-  Class: Eq_462
-  DataType: word32
-  OrigDataType: word32
-T_464: (in g_dw100020CC == 0<32> @ 00000000 : bool)
-  Class: Eq_464
-  DataType: bool
-  OrigDataType: bool
-T_465: (in 2<32> @ 100013CA : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_466: (in edx != 2<32> @ 00000000 : bool)
-  Class: Eq_466
-  DataType: bool
-  OrigDataType: bool
-T_467: (in esp_106 @ 100013FA : (ptr32 Eq_467))
-  Class: Eq_467
-  DataType: (ptr32 Eq_467)
-  OrigDataType: (ptr32 (struct (FFFFFFF8 T_138 tFFFFFFF8) (FFFFFFFC T_139 tFFFFFFFC) (0 T_140 t0000)))
-T_468: (in 4<i32> @ 100013FA : int32)
-  Class: Eq_468
-  DataType: int32
-  OrigDataType: int32
-T_469: (in esp_100 - 4<i32> @ 00000000 : word32)
-  Class: Eq_467
-  DataType: (ptr32 Eq_467)
-  OrigDataType: ptr32
-T_470: (in 0<32> @ 100013FA : word32)
+T_470: (in -28<i32> @ 1000148A : int32)
   Class: Eq_470
-  DataType: word32
-  OrigDataType: word32
-T_471: (in esp_106 + 0<32> @ 100013FA : word32)
+  DataType: int32
+  OrigDataType: int32
+T_471: (in ebp_13 + -28<i32> @ 1000148A : word32)
   Class: Eq_471
-  DataType: ptr32
-  OrigDataType: ptr32
-T_472: (in Mem108[esp_106 + 0<32>:word32] @ 100013FA : word32)
-  Class: Eq_140
-  DataType: Eq_140
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_472: (in Mem256[ebp_13 + -28<i32>:word32] @ 1000148A : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_473: (in -4<i32> @ 100013FB : int32)
+T_473: (in fn1000182D @ 1000148D : ptr32)
   Class: Eq_473
-  DataType: int32
-  OrigDataType: int32
-T_474: (in esp_106 + -4<i32> @ 100013FB : word32)
-  Class: Eq_474
-  DataType: ptr32
-  OrigDataType: ptr32
-T_475: (in Mem111[esp_106 + -4<i32>:word32] @ 100013FB : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_476: (in -8<i32> @ 100013FC : int32)
+  DataType: (ptr32 Eq_473)
+  OrigDataType: (ptr32 (fn T_480 (T_411, T_479)))
+T_474: (in signature of fn1000182D @ 1000182D : void)
+  Class: Eq_473
+  DataType: (ptr32 Eq_473)
+  OrigDataType: 
+T_475: (in ebp @ 1000148D : (ptr32 Eq_411))
+  Class: Eq_411
+  DataType: (ptr32 Eq_411)
+  OrigDataType: (ptr32 (struct (FFFFFFF0 T_1009 tFFFFFFF0) (0 T_1015 t0000)))
+T_476: (in dwArg00 @ 1000148D : Eq_476)
   Class: Eq_476
+  DataType: Eq_476
+  OrigDataType: word32
+T_477: (in -4<i32> @ 1000148D : int32)
+  Class: Eq_477
   DataType: int32
   OrigDataType: int32
-T_477: (in esp_106 + -8<i32> @ 100013FC : word32)
-  Class: Eq_477
+T_478: (in esp_100 + -4<i32> @ 1000148D : word32)
+  Class: Eq_478
   DataType: ptr32
   OrigDataType: ptr32
-T_478: (in Mem114[esp_106 + -8<i32>:word32] @ 100013FC : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_479: (in Mem256[esp_100 + -4<i32>:word32] @ 1000148D : word32)
+  Class: Eq_476
+  DataType: Eq_476
   OrigDataType: word32
-T_479: (in eax_115 @ 100013FD : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
+T_480: (in fn1000182D(ebp_13, esp_100->tFFFFFFFC) @ 1000148D : word32)
+  Class: Eq_393
+  DataType: ptr32
   OrigDataType: word32
-T_480: (in fn100017C6 @ 100013FD : ptr32)
-  Class: Eq_480
-  DataType: (ptr32 Eq_480)
-  OrigDataType: (ptr32 (fn T_490 (T_486, T_489)))
-T_481: (in signature of fn100017C6 @ 100017C6 : void)
-  Class: Eq_480
-  DataType: (ptr32 Eq_480)
-  OrigDataType: 
-T_482: (in dwArg04 @ 100013FD : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: HMODULE
-T_483: (in dwArg08 @ 100013FD : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_484: (in -8<i32> @ 100013FD : int32)
-  Class: Eq_484
-  DataType: int32
-  OrigDataType: int32
-T_485: (in esp_106 + -8<i32> @ 100013FD : word32)
-  Class: Eq_485
+T_481: (in 100020CC @ 100013D3 : ptr32)
+  Class: Eq_481
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_486: (in Mem114[esp_106 + -8<i32>:word32] @ 100013FD : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_487: (in -4<i32> @ 100013FD : int32)
-  Class: Eq_487
-  DataType: int32
-  OrigDataType: int32
-T_488: (in esp_106 + -4<i32> @ 100013FD : word32)
-  Class: Eq_488
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_489: (in Mem114[esp_106 + -4<i32>:word32] @ 100013FD : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_490: (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 100013FD : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_491: (in -28<i32> @ 10001402 : int32)
-  Class: Eq_491
-  DataType: int32
-  OrigDataType: int32
-T_492: (in ebp_13 + -28<i32> @ 10001402 : word32)
-  Class: Eq_492
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_493: (in Mem122[ebp_13 + -28<i32>:word32] @ 10001402 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_494: (in 4<32> @ 100013FD : word32)
-  Class: Eq_494
-  DataType: int32
-  OrigDataType: int32
-T_495: (in esp_106 + 4<32> @ 100013FD : word32)
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
-  OrigDataType: ptr32
-T_496: (in 1<32> @ 10001408 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_497: (in esi_110 != 1<32> @ 00000000 : bool)
-  Class: Eq_497
-  DataType: bool
-  OrigDataType: bool
-T_498: (in -28<i32> @ 100013E1 : int32)
-  Class: Eq_498
-  DataType: int32
-  OrigDataType: int32
-T_499: (in ebp_13 + -28<i32> @ 100013E1 : word32)
-  Class: Eq_499
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_500: (in Mem76[ebp_13 + -28<i32>:word32] @ 100013E1 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_501: (in 0<32> @ 100013E1 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_502: (in ebp_13->tFFFFFFE4 == 0<32> @ 00000000 : bool)
-  Class: Eq_502
-  DataType: bool
-  OrigDataType: bool
-T_503: (in fn00000000 @ 100013DA : ptr32)
-  Class: Eq_503
-  DataType: (ptr32 Eq_503)
-  OrigDataType: (ptr32 (fn T_505 (T_402, T_387)))
-T_504: (in signature of fn00000000 @ 00000000 : void)
-  Class: Eq_504
-  DataType: Eq_504
-  OrigDataType: 
-T_505: (in fn00000000(ebx_113, edx) @ 100013DA : void)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: void
-T_506: (in -28<i32> @ 100013DA : int32)
-  Class: Eq_506
-  DataType: int32
-  OrigDataType: int32
-T_507: (in ebp_13 + -28<i32> @ 100013DA : word32)
-  Class: Eq_507
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_508: (in Mem74[ebp_13 + -28<i32>:word32] @ 100013DA : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_509: (in esp_80 @ 100013E7 : (ptr32 Eq_509))
-  Class: Eq_509
-  DataType: (ptr32 Eq_509)
-  OrigDataType: (ptr32 (struct (FFFFFFF8 T_138 tFFFFFFF8) (FFFFFFFC T_139 tFFFFFFFC) (0 T_140 t0000)))
-T_510: (in 4<i32> @ 100013E7 : int32)
-  Class: Eq_510
-  DataType: int32
-  OrigDataType: int32
-T_511: (in esp_100 - 4<i32> @ 00000000 : word32)
-  Class: Eq_509
-  DataType: (ptr32 Eq_509)
-  OrigDataType: ptr32
-T_512: (in 0<32> @ 100013E7 : word32)
-  Class: Eq_512
+  OrigDataType: (ptr32 (struct (0 T_482 t0000)))
+T_482: (in Mem29[0x100020CC<p32>:word32] @ 100013D3 : word32)
+  Class: Eq_482
   DataType: word32
   OrigDataType: word32
-T_513: (in esp_80 + 0<32> @ 100013E7 : word32)
-  Class: Eq_513
-  DataType: ptr32
-  OrigDataType: ptr32
-T_514: (in Mem82[esp_80 + 0<32>:word32] @ 100013E7 : word32)
-  Class: Eq_140
-  DataType: Eq_140
+T_483: (in 0<32> @ 100013D3 : word32)
+  Class: Eq_482
+  DataType: word32
   OrigDataType: word32
-T_515: (in -4<i32> @ 100013E8 : int32)
-  Class: Eq_515
+T_484: (in g_dw100020CC == 0<32> @ 00000000 : bool)
+  Class: Eq_484
+  DataType: bool
+  OrigDataType: bool
+T_485: (in 2<32> @ 100013CA : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_486: (in edx != 2<32> @ 00000000 : bool)
+  Class: Eq_486
+  DataType: bool
+  OrigDataType: bool
+T_487: (in esp_106 @ 100013FA : (ptr32 Eq_487))
+  Class: Eq_487
+  DataType: (ptr32 Eq_487)
+  OrigDataType: (ptr32 (struct (FFFFFFF8 T_158 tFFFFFFF8) (FFFFFFFC T_159 tFFFFFFFC) (0 T_160 t0000)))
+T_488: (in 4<i32> @ 100013FA : int32)
+  Class: Eq_488
   DataType: int32
   OrigDataType: int32
-T_516: (in esp_80 + -4<i32> @ 100013E8 : word32)
-  Class: Eq_516
+T_489: (in esp_100 - 4<i32> @ 00000000 : word32)
+  Class: Eq_487
+  DataType: (ptr32 Eq_487)
+  OrigDataType: ptr32
+T_490: (in 0<32> @ 100013FA : word32)
+  Class: Eq_490
+  DataType: word32
+  OrigDataType: word32
+T_491: (in esp_106 + 0<32> @ 100013FA : word32)
+  Class: Eq_491
   DataType: ptr32
   OrigDataType: ptr32
-T_517: (in Mem85[esp_80 + -4<i32>:word32] @ 100013E8 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_492: (in Mem108[esp_106 + 0<32>:word32] @ 100013FA : word32)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_518: (in -8<i32> @ 100013E9 : int32)
+T_493: (in -4<i32> @ 100013FB : int32)
+  Class: Eq_493
+  DataType: int32
+  OrigDataType: int32
+T_494: (in esp_106 + -4<i32> @ 100013FB : word32)
+  Class: Eq_494
+  DataType: ptr32
+  OrigDataType: ptr32
+T_495: (in Mem111[esp_106 + -4<i32>:word32] @ 100013FB : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_496: (in -8<i32> @ 100013FC : int32)
+  Class: Eq_496
+  DataType: int32
+  OrigDataType: int32
+T_497: (in esp_106 + -8<i32> @ 100013FC : word32)
+  Class: Eq_497
+  DataType: ptr32
+  OrigDataType: ptr32
+T_498: (in Mem114[esp_106 + -8<i32>:word32] @ 100013FC : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_499: (in eax_115 @ 100013FD : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_500: (in fn100017C6 @ 100013FD : ptr32)
+  Class: Eq_500
+  DataType: (ptr32 Eq_500)
+  OrigDataType: (ptr32 (fn T_510 (T_506, T_509)))
+T_501: (in signature of fn100017C6 @ 100017C6 : void)
+  Class: Eq_500
+  DataType: (ptr32 Eq_500)
+  OrigDataType: 
+T_502: (in dwArg04 @ 100013FD : Eq_158)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: HMODULE
+T_503: (in dwArg08 @ 100013FD : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_504: (in -8<i32> @ 100013FD : int32)
+  Class: Eq_504
+  DataType: int32
+  OrigDataType: int32
+T_505: (in esp_106 + -8<i32> @ 100013FD : word32)
+  Class: Eq_505
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_506: (in Mem114[esp_106 + -8<i32>:word32] @ 100013FD : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_507: (in -4<i32> @ 100013FD : int32)
+  Class: Eq_507
+  DataType: int32
+  OrigDataType: int32
+T_508: (in esp_106 + -4<i32> @ 100013FD : word32)
+  Class: Eq_508
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_509: (in Mem114[esp_106 + -4<i32>:word32] @ 100013FD : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_510: (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 100013FD : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_511: (in -28<i32> @ 10001402 : int32)
+  Class: Eq_511
+  DataType: int32
+  OrigDataType: int32
+T_512: (in ebp_13 + -28<i32> @ 10001402 : word32)
+  Class: Eq_512
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_513: (in Mem122[ebp_13 + -28<i32>:word32] @ 10001402 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_514: (in 4<32> @ 100013FD : word32)
+  Class: Eq_514
+  DataType: int32
+  OrigDataType: int32
+T_515: (in esp_106 + 4<32> @ 100013FD : word32)
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
+  OrigDataType: ptr32
+T_516: (in 1<32> @ 10001408 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_517: (in esi_110 != 1<32> @ 00000000 : bool)
+  Class: Eq_517
+  DataType: bool
+  OrigDataType: bool
+T_518: (in -28<i32> @ 100013E1 : int32)
   Class: Eq_518
   DataType: int32
   OrigDataType: int32
-T_519: (in esp_80 + -8<i32> @ 100013E9 : word32)
+T_519: (in ebp_13 + -28<i32> @ 100013E1 : word32)
   Class: Eq_519
-  DataType: ptr32
-  OrigDataType: ptr32
-T_520: (in Mem88[esp_80 + -8<i32>:word32] @ 100013E9 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_520: (in Mem76[ebp_13 + -28<i32>:word32] @ 100013E1 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_521: (in eax_90 @ 100013EA : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
+T_521: (in 0<32> @ 100013E1 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_522: (in fn100011E9 @ 100013EA : ptr32)
+T_522: (in ebp_13->tFFFFFFE4 == 0<32> @ 00000000 : bool)
   Class: Eq_522
-  DataType: (ptr32 Eq_522)
-  OrigDataType: (ptr32 (fn T_536 (T_526, T_529, T_532, T_533, T_534, T_535)))
-T_523: (in signature of fn100011E9 @ 100011E9 : void)
-  Class: Eq_522
-  DataType: (ptr32 Eq_522)
-  OrigDataType: 
-T_524: (in -8<i32> @ 100013EA : int32)
+  DataType: bool
+  OrigDataType: bool
+T_523: (in fn00000000 @ 100013DA : ptr32)
+  Class: Eq_523
+  DataType: (ptr32 Eq_523)
+  OrigDataType: (ptr32 (fn T_525 (T_422, T_407)))
+T_524: (in signature of fn00000000 @ 00000000 : void)
   Class: Eq_524
+  DataType: Eq_524
+  OrigDataType: 
+T_525: (in fn00000000(ebx_113, edx) @ 100013DA : void)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: void
+T_526: (in -28<i32> @ 100013DA : int32)
+  Class: Eq_526
   DataType: int32
   OrigDataType: int32
-T_525: (in esp_80 + -8<i32> @ 100013EA : word32)
-  Class: Eq_525
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_526: (in Mem88[esp_80 + -8<i32>:word32] @ 100013EA : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_527: (in -4<i32> @ 100013EA : int32)
+T_527: (in ebp_13 + -28<i32> @ 100013DA : word32)
   Class: Eq_527
-  DataType: int32
-  OrigDataType: int32
-T_528: (in esp_80 + -4<i32> @ 100013EA : word32)
-  Class: Eq_528
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_529: (in Mem88[esp_80 + -4<i32>:word32] @ 100013EA : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_528: (in Mem74[ebp_13 + -28<i32>:word32] @ 100013DA : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_530: (in 0<32> @ 100013EA : word32)
+T_529: (in esp_80 @ 100013E7 : (ptr32 Eq_529))
+  Class: Eq_529
+  DataType: (ptr32 Eq_529)
+  OrigDataType: (ptr32 (struct (FFFFFFF8 T_158 tFFFFFFF8) (FFFFFFFC T_159 tFFFFFFFC) (0 T_160 t0000)))
+T_530: (in 4<i32> @ 100013E7 : int32)
   Class: Eq_530
-  DataType: word32
-  OrigDataType: word32
-T_531: (in esp_80 + 0<32> @ 100013EA : word32)
-  Class: Eq_531
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_532: (in Mem88[esp_80 + 0<32>:word32] @ 100013EA : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_533: (in out ebx_113 @ 100013EA : ptr32)
-  Class: Eq_141
-  DataType: ptr32
-  OrigDataType: ptr32
-T_534: (in out esi_110 @ 100013EA : ptr32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: ptr32
-T_535: (in out edi_107 @ 100013EA : ptr32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: ptr32
-T_536: (in fn100011E9(esp_80->tFFFFFFF8, esp_80->tFFFFFFFC, esp_80->t0000, out ebx_113, out esi_110, out edi_107) @ 100013EA : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_537: (in -28<i32> @ 100013EF : int32)
-  Class: Eq_537
   DataType: int32
   OrigDataType: int32
-T_538: (in ebp_13 + -28<i32> @ 100013EF : word32)
+T_531: (in esp_100 - 4<i32> @ 00000000 : word32)
+  Class: Eq_529
+  DataType: (ptr32 Eq_529)
+  OrigDataType: ptr32
+T_532: (in 0<32> @ 100013E7 : word32)
+  Class: Eq_532
+  DataType: word32
+  OrigDataType: word32
+T_533: (in esp_80 + 0<32> @ 100013E7 : word32)
+  Class: Eq_533
+  DataType: ptr32
+  OrigDataType: ptr32
+T_534: (in Mem82[esp_80 + 0<32>:word32] @ 100013E7 : word32)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: word32
+T_535: (in -4<i32> @ 100013E8 : int32)
+  Class: Eq_535
+  DataType: int32
+  OrigDataType: int32
+T_536: (in esp_80 + -4<i32> @ 100013E8 : word32)
+  Class: Eq_536
+  DataType: ptr32
+  OrigDataType: ptr32
+T_537: (in Mem85[esp_80 + -4<i32>:word32] @ 100013E8 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_538: (in -8<i32> @ 100013E9 : int32)
   Class: Eq_538
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_539: (in Mem101[ebp_13 + -28<i32>:word32] @ 100013EF : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_540: (in 4<32> @ 100013EA : word32)
-  Class: Eq_540
   DataType: int32
   OrigDataType: int32
-T_541: (in esp_80 + 4<32> @ 100013EA : word32)
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
+T_539: (in esp_80 + -8<i32> @ 100013E9 : word32)
+  Class: Eq_539
+  DataType: ptr32
   OrigDataType: ptr32
-T_542: (in 0<32> @ 100013F4 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_540: (in Mem88[esp_80 + -8<i32>:word32] @ 100013E9 : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_543: (in eax_90 == 0<32> @ 00000000 : bool)
-  Class: Eq_543
-  DataType: bool
-  OrigDataType: bool
-T_544: (in 0<32> @ 10001430 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_541: (in eax_90 @ 100013EA : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_545: (in esi_110 == 0<32> @ 00000000 : bool)
+T_542: (in fn100011E9 @ 100013EA : ptr32)
+  Class: Eq_542
+  DataType: (ptr32 Eq_542)
+  OrigDataType: (ptr32 (fn T_556 (T_546, T_549, T_552, T_553, T_554, T_555)))
+T_543: (in signature of fn100011E9 @ 100011E9 : void)
+  Class: Eq_542
+  DataType: (ptr32 Eq_542)
+  OrigDataType: 
+T_544: (in -8<i32> @ 100013EA : int32)
+  Class: Eq_544
+  DataType: int32
+  OrigDataType: int32
+T_545: (in esp_80 + -8<i32> @ 100013EA : word32)
   Class: Eq_545
-  DataType: bool
-  OrigDataType: bool
-T_546: (in 0<32> @ 1000140C : word32)
-  Class: Eq_139
-  DataType: Eq_139
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_546: (in Mem88[esp_80 + -8<i32>:word32] @ 100013EA : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_547: (in eax_115 != 0<32> @ 00000000 : bool)
+T_547: (in -4<i32> @ 100013EA : int32)
   Class: Eq_547
+  DataType: int32
+  OrigDataType: int32
+T_548: (in esp_80 + -4<i32> @ 100013EA : word32)
+  Class: Eq_548
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_549: (in Mem88[esp_80 + -4<i32>:word32] @ 100013EA : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_550: (in 0<32> @ 100013EA : word32)
+  Class: Eq_550
+  DataType: word32
+  OrigDataType: word32
+T_551: (in esp_80 + 0<32> @ 100013EA : word32)
+  Class: Eq_551
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_552: (in Mem88[esp_80 + 0<32>:word32] @ 100013EA : word32)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: word32
+T_553: (in out ebx_113 @ 100013EA : ptr32)
+  Class: Eq_161
+  DataType: ptr32
+  OrigDataType: ptr32
+T_554: (in out esi_110 @ 100013EA : ptr32)
+  Class: Eq_162
+  DataType: ptr32
+  OrigDataType: ptr32
+T_555: (in out edi_107 @ 100013EA : ptr32)
+  Class: Eq_163
+  DataType: ptr32
+  OrigDataType: ptr32
+T_556: (in fn100011E9(esp_80->tFFFFFFF8, esp_80->tFFFFFFFC, esp_80->t0000, out ebx_113, out esi_110, out edi_107) @ 100013EA : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_557: (in -28<i32> @ 100013EF : int32)
+  Class: Eq_557
+  DataType: int32
+  OrigDataType: int32
+T_558: (in ebp_13 + -28<i32> @ 100013EF : word32)
+  Class: Eq_558
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_559: (in Mem101[ebp_13 + -28<i32>:word32] @ 100013EF : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_560: (in 4<32> @ 100013EA : word32)
+  Class: Eq_560
+  DataType: int32
+  OrigDataType: int32
+T_561: (in esp_80 + 4<32> @ 100013EA : word32)
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
+  OrigDataType: ptr32
+T_562: (in 0<32> @ 100013F4 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_563: (in eax_90 == 0<32> @ 00000000 : bool)
+  Class: Eq_563
   DataType: bool
   OrigDataType: bool
-T_548: (in 0<32> @ 1000140E : word32)
-  Class: Eq_548
-  DataType: word32
+T_564: (in 0<32> @ 10001430 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_549: (in esp_106 + 0<32> @ 1000140E : word32)
-  Class: Eq_549
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_550: (in Mem129[esp_106 + 0<32>:word32] @ 1000140E : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_551: (in -4<i32> @ 1000140F : int32)
-  Class: Eq_551
-  DataType: int32
-  OrigDataType: int32
-T_552: (in esp_106 + -4<i32> @ 1000140F : word32)
-  Class: Eq_552
-  DataType: ptr32
-  OrigDataType: ptr32
-T_553: (in Mem131[esp_106 + -4<i32>:word32] @ 1000140F : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_554: (in -8<i32> @ 10001410 : int32)
-  Class: Eq_554
-  DataType: int32
-  OrigDataType: int32
-T_555: (in esp_106 + -8<i32> @ 10001410 : word32)
-  Class: Eq_555
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_556: (in Mem133[esp_106 + -8<i32>:word32] @ 10001410 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_557: (in fn100017C6 @ 10001411 : ptr32)
-  Class: Eq_480
-  DataType: (ptr32 Eq_480)
-  OrigDataType: (ptr32 (fn T_564 (T_560, T_563)))
-T_558: (in -8<i32> @ 10001411 : int32)
-  Class: Eq_558
-  DataType: int32
-  OrigDataType: int32
-T_559: (in esp_106 + -8<i32> @ 10001411 : word32)
-  Class: Eq_559
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_560: (in Mem133[esp_106 + -8<i32>:word32] @ 10001411 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_561: (in -4<i32> @ 10001411 : int32)
-  Class: Eq_561
-  DataType: int32
-  OrigDataType: int32
-T_562: (in esp_106 + -4<i32> @ 10001411 : word32)
-  Class: Eq_562
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_563: (in Mem133[esp_106 + -4<i32>:word32] @ 10001411 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_564: (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 10001411 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_565: (in 0<32> @ 10001416 : word32)
+T_565: (in esi_110 == 0<32> @ 00000000 : bool)
   Class: Eq_565
+  DataType: bool
+  OrigDataType: bool
+T_566: (in 0<32> @ 1000140C : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_567: (in eax_115 != 0<32> @ 00000000 : bool)
+  Class: Eq_567
+  DataType: bool
+  OrigDataType: bool
+T_568: (in 0<32> @ 1000140E : word32)
+  Class: Eq_568
   DataType: word32
   OrigDataType: word32
-T_566: (in esp_106 + 0<32> @ 10001416 : word32)
-  Class: Eq_566
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_567: (in Mem141[esp_106 + 0<32>:word32] @ 10001416 : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_568: (in 0<32> @ 10001417 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_569: (in -4<i32> @ 10001417 : int32)
+T_569: (in esp_106 + 0<32> @ 1000140E : word32)
   Class: Eq_569
-  DataType: int32
-  OrigDataType: int32
-T_570: (in esp_106 + -4<i32> @ 10001417 : word32)
-  Class: Eq_570
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_571: (in Mem143[esp_106 + -4<i32>:word32] @ 10001417 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_570: (in Mem129[esp_106 + 0<32>:word32] @ 1000140E : word32)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_572: (in -8<i32> @ 10001419 : int32)
+T_571: (in -4<i32> @ 1000140F : int32)
+  Class: Eq_571
+  DataType: int32
+  OrigDataType: int32
+T_572: (in esp_106 + -4<i32> @ 1000140F : word32)
   Class: Eq_572
+  DataType: ptr32
+  OrigDataType: ptr32
+T_573: (in Mem131[esp_106 + -4<i32>:word32] @ 1000140F : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_574: (in -8<i32> @ 10001410 : int32)
+  Class: Eq_574
   DataType: int32
   OrigDataType: int32
-T_573: (in esp_106 + -8<i32> @ 10001419 : word32)
-  Class: Eq_573
+T_575: (in esp_106 + -8<i32> @ 10001410 : word32)
+  Class: Eq_575
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_574: (in Mem145[esp_106 + -8<i32>:word32] @ 10001419 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_576: (in Mem133[esp_106 + -8<i32>:word32] @ 10001410 : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_575: (in fn100011E9 @ 1000141A : ptr32)
-  Class: Eq_522
-  DataType: (ptr32 Eq_522)
-  OrigDataType: (ptr32 (fn T_588 (T_578, T_581, T_584, T_585, T_586, T_587)))
-T_576: (in -8<i32> @ 1000141A : int32)
-  Class: Eq_576
+T_577: (in fn100017C6 @ 10001411 : ptr32)
+  Class: Eq_500
+  DataType: (ptr32 Eq_500)
+  OrigDataType: (ptr32 (fn T_584 (T_580, T_583)))
+T_578: (in -8<i32> @ 10001411 : int32)
+  Class: Eq_578
   DataType: int32
   OrigDataType: int32
-T_577: (in esp_106 + -8<i32> @ 1000141A : word32)
-  Class: Eq_577
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_578: (in Mem145[esp_106 + -8<i32>:word32] @ 1000141A : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_579: (in -4<i32> @ 1000141A : int32)
+T_579: (in esp_106 + -8<i32> @ 10001411 : word32)
   Class: Eq_579
-  DataType: int32
-  OrigDataType: int32
-T_580: (in esp_106 + -4<i32> @ 1000141A : word32)
-  Class: Eq_580
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_581: (in Mem145[esp_106 + -4<i32>:word32] @ 1000141A : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_580: (in Mem133[esp_106 + -8<i32>:word32] @ 10001411 : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_582: (in 0<32> @ 1000141A : word32)
+T_581: (in -4<i32> @ 10001411 : int32)
+  Class: Eq_581
+  DataType: int32
+  OrigDataType: int32
+T_582: (in esp_106 + -4<i32> @ 10001411 : word32)
   Class: Eq_582
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_583: (in Mem133[esp_106 + -4<i32>:word32] @ 10001411 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_584: (in fn100017C6(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC) @ 10001411 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_585: (in 0<32> @ 10001416 : word32)
+  Class: Eq_585
   DataType: word32
   OrigDataType: word32
-T_583: (in esp_106 + 0<32> @ 1000141A : word32)
-  Class: Eq_583
+T_586: (in esp_106 + 0<32> @ 10001416 : word32)
+  Class: Eq_586
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_584: (in Mem145[esp_106 + 0<32>:word32] @ 1000141A : word32)
-  Class: Eq_140
-  DataType: Eq_140
+T_587: (in Mem141[esp_106 + 0<32>:word32] @ 10001416 : word32)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_585: (in out ebx_113 @ 1000141A : ptr32)
-  Class: Eq_141
-  DataType: ptr32
-  OrigDataType: ptr32
-T_586: (in out esi_110 @ 1000141A : ptr32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: ptr32
-T_587: (in out edi_107 @ 1000141A : ptr32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: ptr32
-T_588: (in fn100011E9(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC, esp_106->t0000, out ebx_113, out esi_110, out edi_107) @ 1000141A : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_588: (in 0<32> @ 10001417 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_589: (in 4<32> @ 1000141A : word32)
+T_589: (in -4<i32> @ 10001417 : int32)
   Class: Eq_589
   DataType: int32
   OrigDataType: int32
-T_590: (in esp_106 + 4<32> @ 1000141A : word32)
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
-  OrigDataType: ptr32
-T_591: (in 100020CC @ 10001426 : ptr32)
-  Class: Eq_591
+T_590: (in esp_106 + -4<i32> @ 10001417 : word32)
+  Class: Eq_590
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_592 t0000)))
-T_592: (in Mem145[0x100020CC<p32>:word32] @ 10001426 : word32)
-  Class: Eq_462
-  DataType: word32
+  OrigDataType: (ptr32 word32)
+T_591: (in Mem143[esp_106 + -4<i32>:word32] @ 10001417 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_593: (in 0<32> @ 10001426 : word32)
-  Class: Eq_462
-  DataType: word32
-  OrigDataType: word32
-T_594: (in g_dw100020CC == 0<32> @ 00000000 : bool)
-  Class: Eq_594
-  DataType: bool
-  OrigDataType: bool
-T_595: (in fn00000000 @ 1000142C : ptr32)
-  Class: Eq_595
-  DataType: (ptr32 Eq_595)
-  OrigDataType: (ptr32 (fn T_598 (T_402, T_597, T_424)))
-T_596: (in signature of fn00000000 @ 00000000 : void)
-  Class: Eq_596
-  DataType: Eq_596
-  OrigDataType: 
-T_597: (in 0<32> @ 1000142C : word32)
-  Class: Eq_597
-  DataType: word32
-  OrigDataType: word32
-T_598: (in fn00000000(ebx_113, 0<32>, edi_107) @ 1000142C : void)
-  Class: Eq_598
-  DataType: void
-  OrigDataType: void
-T_599: (in esp_184 @ 10001437 : (ptr32 Eq_599))
-  Class: Eq_599
-  DataType: (ptr32 Eq_599)
-  OrigDataType: (ptr32 (struct (FFFFFFF8 T_138 tFFFFFFF8) (FFFFFFFC T_139 tFFFFFFFC) (0 T_140 t0000)))
-T_600: (in 4<i32> @ 10001437 : int32)
-  Class: Eq_600
+T_592: (in -8<i32> @ 10001419 : int32)
+  Class: Eq_592
   DataType: int32
   OrigDataType: int32
-T_601: (in esp_100 - 4<i32> @ 00000000 : word32)
+T_593: (in esp_106 + -8<i32> @ 10001419 : word32)
+  Class: Eq_593
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_594: (in Mem145[esp_106 + -8<i32>:word32] @ 10001419 : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_595: (in fn100011E9 @ 1000141A : ptr32)
+  Class: Eq_542
+  DataType: (ptr32 Eq_542)
+  OrigDataType: (ptr32 (fn T_608 (T_598, T_601, T_604, T_605, T_606, T_607)))
+T_596: (in -8<i32> @ 1000141A : int32)
+  Class: Eq_596
+  DataType: int32
+  OrigDataType: int32
+T_597: (in esp_106 + -8<i32> @ 1000141A : word32)
+  Class: Eq_597
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_598: (in Mem145[esp_106 + -8<i32>:word32] @ 1000141A : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_599: (in -4<i32> @ 1000141A : int32)
   Class: Eq_599
-  DataType: (ptr32 Eq_599)
-  OrigDataType: ptr32
-T_602: (in 0<32> @ 10001437 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_600: (in esp_106 + -4<i32> @ 1000141A : word32)
+  Class: Eq_600
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_601: (in Mem145[esp_106 + -4<i32>:word32] @ 1000141A : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_602: (in 0<32> @ 1000141A : word32)
   Class: Eq_602
   DataType: word32
   OrigDataType: word32
-T_603: (in esp_184 + 0<32> @ 10001437 : word32)
+T_603: (in esp_106 + 0<32> @ 1000141A : word32)
   Class: Eq_603
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_604: (in Mem145[esp_106 + 0<32>:word32] @ 1000141A : word32)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: word32
+T_605: (in out ebx_113 @ 1000141A : ptr32)
+  Class: Eq_161
   DataType: ptr32
   OrigDataType: ptr32
-T_604: (in Mem187[esp_184 + 0<32>:word32] @ 10001437 : word32)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: word32
-T_605: (in -4<i32> @ 10001438 : int32)
-  Class: Eq_605
-  DataType: int32
-  OrigDataType: int32
-T_606: (in esp_184 + -4<i32> @ 10001438 : word32)
-  Class: Eq_606
+T_606: (in out esi_110 @ 1000141A : ptr32)
+  Class: Eq_162
   DataType: ptr32
   OrigDataType: ptr32
-T_607: (in Mem190[esp_184 + -4<i32>:word32] @ 10001438 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_607: (in out edi_107 @ 1000141A : ptr32)
+  Class: Eq_163
+  DataType: ptr32
+  OrigDataType: ptr32
+T_608: (in fn100011E9(esp_106->tFFFFFFF8, esp_106->tFFFFFFFC, esp_106->t0000, out ebx_113, out esi_110, out edi_107) @ 1000141A : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_608: (in -8<i32> @ 10001439 : int32)
-  Class: Eq_608
-  DataType: int32
-  OrigDataType: int32
-T_609: (in esp_184 + -8<i32> @ 10001439 : word32)
+T_609: (in 4<32> @ 1000141A : word32)
   Class: Eq_609
-  DataType: ptr32
+  DataType: int32
+  OrigDataType: int32
+T_610: (in esp_106 + 4<32> @ 1000141A : word32)
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
   OrigDataType: ptr32
-T_610: (in Mem194[esp_184 + -8<i32>:word32] @ 10001439 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_611: (in ebx_198 @ 1000143A : word32)
+T_611: (in 100020CC @ 10001426 : ptr32)
   Class: Eq_611
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_612 t0000)))
+T_612: (in Mem145[0x100020CC<p32>:word32] @ 10001426 : word32)
+  Class: Eq_482
   DataType: word32
   OrigDataType: word32
-T_612: (in esi_200 @ 1000143A : word32)
-  Class: Eq_612
+T_613: (in 0<32> @ 10001426 : word32)
+  Class: Eq_482
   DataType: word32
   OrigDataType: word32
-T_613: (in edi_201 @ 1000143A : word32)
-  Class: Eq_613
-  DataType: word32
-  OrigDataType: word32
-T_614: (in eax_197 @ 1000143A : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: ui32
-T_615: (in fn100011E9 @ 1000143A : ptr32)
-  Class: Eq_522
-  DataType: (ptr32 Eq_522)
-  OrigDataType: (ptr32 (fn T_628 (T_618, T_621, T_624, T_625, T_626, T_627)))
-T_616: (in -8<i32> @ 1000143A : int32)
+T_614: (in g_dw100020CC == 0<32> @ 00000000 : bool)
+  Class: Eq_614
+  DataType: bool
+  OrigDataType: bool
+T_615: (in fn00000000 @ 1000142C : ptr32)
+  Class: Eq_615
+  DataType: (ptr32 Eq_615)
+  OrigDataType: (ptr32 (fn T_618 (T_422, T_617, T_444)))
+T_616: (in signature of fn00000000 @ 00000000 : void)
   Class: Eq_616
-  DataType: int32
-  OrigDataType: int32
-T_617: (in esp_184 + -8<i32> @ 1000143A : word32)
+  DataType: Eq_616
+  OrigDataType: 
+T_617: (in 0<32> @ 1000142C : word32)
   Class: Eq_617
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_618: (in Mem194[esp_184 + -8<i32>:word32] @ 1000143A : word32)
-  Class: Eq_138
-  DataType: Eq_138
+  DataType: word32
   OrigDataType: word32
-T_619: (in -4<i32> @ 1000143A : int32)
+T_618: (in fn00000000(ebx_113, 0<32>, edi_107) @ 1000142C : void)
+  Class: Eq_618
+  DataType: void
+  OrigDataType: void
+T_619: (in esp_184 @ 10001437 : (ptr32 Eq_619))
   Class: Eq_619
+  DataType: (ptr32 Eq_619)
+  OrigDataType: (ptr32 (struct (FFFFFFF8 T_158 tFFFFFFF8) (FFFFFFFC T_159 tFFFFFFFC) (0 T_160 t0000)))
+T_620: (in 4<i32> @ 10001437 : int32)
+  Class: Eq_620
   DataType: int32
   OrigDataType: int32
-T_620: (in esp_184 + -4<i32> @ 1000143A : word32)
-  Class: Eq_620
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_621: (in Mem194[esp_184 + -4<i32>:word32] @ 1000143A : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_622: (in 0<32> @ 1000143A : word32)
+T_621: (in esp_100 - 4<i32> @ 00000000 : word32)
+  Class: Eq_619
+  DataType: (ptr32 Eq_619)
+  OrigDataType: ptr32
+T_622: (in 0<32> @ 10001437 : word32)
   Class: Eq_622
   DataType: word32
   OrigDataType: word32
-T_623: (in esp_184 + 0<32> @ 1000143A : word32)
+T_623: (in esp_184 + 0<32> @ 10001437 : word32)
   Class: Eq_623
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_624: (in Mem194[esp_184 + 0<32>:word32] @ 1000143A : word32)
-  Class: Eq_140
-  DataType: Eq_140
+  DataType: ptr32
+  OrigDataType: ptr32
+T_624: (in Mem187[esp_184 + 0<32>:word32] @ 10001437 : word32)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_625: (in out ebx_198 @ 1000143A : ptr32)
-  Class: Eq_141
+T_625: (in -4<i32> @ 10001438 : int32)
+  Class: Eq_625
+  DataType: int32
+  OrigDataType: int32
+T_626: (in esp_184 + -4<i32> @ 10001438 : word32)
+  Class: Eq_626
   DataType: ptr32
   OrigDataType: ptr32
-T_626: (in out esi_200 @ 1000143A : ptr32)
-  Class: Eq_142
-  DataType: ptr32
-  OrigDataType: ptr32
-T_627: (in out edi_201 @ 1000143A : ptr32)
-  Class: Eq_143
-  DataType: ptr32
-  OrigDataType: ptr32
-T_628: (in fn100011E9(esp_184->tFFFFFFF8, esp_184->tFFFFFFFC, esp_184->t0000, out ebx_198, out esi_200, out edi_201) @ 1000143A : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_627: (in Mem190[esp_184 + -4<i32>:word32] @ 10001438 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_629: (in 4<32> @ 1000143A : word32)
+T_628: (in -8<i32> @ 10001439 : int32)
+  Class: Eq_628
+  DataType: int32
+  OrigDataType: int32
+T_629: (in esp_184 + -8<i32> @ 10001439 : word32)
   Class: Eq_629
-  DataType: int32
-  OrigDataType: int32
-T_630: (in esp_184 + 4<32> @ 1000143A : word32)
-  Class: Eq_420
-  DataType: (ptr32 Eq_420)
+  DataType: ptr32
   OrigDataType: ptr32
-T_631: (in 0<32> @ 10001441 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_630: (in Mem194[esp_184 + -8<i32>:word32] @ 10001439 : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_632: (in eax_197 != 0<32> @ 00000000 : bool)
+T_631: (in ebx_198 @ 1000143A : word32)
+  Class: Eq_631
+  DataType: word32
+  OrigDataType: word32
+T_632: (in esi_200 @ 1000143A : word32)
   Class: Eq_632
-  DataType: bool
-  OrigDataType: bool
-T_633: (in 3<32> @ 10001435 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+  DataType: word32
   OrigDataType: word32
-T_634: (in esi_110 != 3<32> @ 00000000 : bool)
-  Class: Eq_634
-  DataType: bool
-  OrigDataType: bool
-T_635: (in -28<i32> @ 1000144A : int32)
-  Class: Eq_635
-  DataType: int32
-  OrigDataType: int32
-T_636: (in ebp_13 + -28<i32> @ 1000144A : word32)
+T_633: (in edi_201 @ 1000143A : word32)
+  Class: Eq_633
+  DataType: word32
+  OrigDataType: word32
+T_634: (in eax_197 @ 1000143A : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: ui32
+T_635: (in fn100011E9 @ 1000143A : ptr32)
+  Class: Eq_542
+  DataType: (ptr32 Eq_542)
+  OrigDataType: (ptr32 (fn T_648 (T_638, T_641, T_644, T_645, T_646, T_647)))
+T_636: (in -8<i32> @ 1000143A : int32)
   Class: Eq_636
+  DataType: int32
+  OrigDataType: int32
+T_637: (in esp_184 + -8<i32> @ 1000143A : word32)
+  Class: Eq_637
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_637: (in Mem218[ebp_13 + -28<i32>:word32] @ 1000144A : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_638: (in Mem194[esp_184 + -8<i32>:word32] @ 1000143A : word32)
+  Class: Eq_158
+  DataType: Eq_158
   OrigDataType: word32
-T_638: (in 0<32> @ 1000144A : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_639: (in ebp_13->tFFFFFFE4 == 0<32> @ 00000000 : bool)
+T_639: (in -4<i32> @ 1000143A : int32)
   Class: Eq_639
-  DataType: bool
-  OrigDataType: bool
-T_640: (in -28<i32> @ 10001443 : int32)
+  DataType: int32
+  OrigDataType: int32
+T_640: (in esp_184 + -4<i32> @ 1000143A : word32)
   Class: Eq_640
-  DataType: int32
-  OrigDataType: int32
-T_641: (in ebp_13 + -28<i32> @ 10001443 : word32)
-  Class: Eq_641
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_642: (in Mem194[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: ui32
-T_643: (in ebp_13->tFFFFFFE4 & eax_197 @ 00000000 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: ui32
-T_644: (in -28<i32> @ 10001443 : int32)
-  Class: Eq_644
-  DataType: int32
-  OrigDataType: int32
-T_645: (in ebp_13 + -28<i32> @ 10001443 : word32)
-  Class: Eq_645
+T_641: (in Mem194[esp_184 + -4<i32>:word32] @ 1000143A : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_642: (in 0<32> @ 1000143A : word32)
+  Class: Eq_642
+  DataType: word32
+  OrigDataType: word32
+T_643: (in esp_184 + 0<32> @ 1000143A : word32)
+  Class: Eq_643
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_646: (in Mem214[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_644: (in Mem194[esp_184 + 0<32>:word32] @ 1000143A : word32)
+  Class: Eq_160
+  DataType: Eq_160
   OrigDataType: word32
-T_647: (in 100020CC @ 10001453 : ptr32)
-  Class: Eq_647
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_648 t0000)))
-T_648: (in Mem218[0x100020CC<p32>:word32] @ 10001453 : word32)
-  Class: Eq_462
-  DataType: word32
+T_645: (in out ebx_198 @ 1000143A : ptr32)
+  Class: Eq_161
+  DataType: ptr32
+  OrigDataType: ptr32
+T_646: (in out esi_200 @ 1000143A : ptr32)
+  Class: Eq_162
+  DataType: ptr32
+  OrigDataType: ptr32
+T_647: (in out edi_201 @ 1000143A : ptr32)
+  Class: Eq_163
+  DataType: ptr32
+  OrigDataType: ptr32
+T_648: (in fn100011E9(esp_184->tFFFFFFF8, esp_184->tFFFFFFFC, esp_184->t0000, out ebx_198, out esi_200, out edi_201) @ 1000143A : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_649: (in 0<32> @ 10001453 : word32)
-  Class: Eq_462
-  DataType: word32
+T_649: (in 4<32> @ 1000143A : word32)
+  Class: Eq_649
+  DataType: int32
+  OrigDataType: int32
+T_650: (in esp_184 + 4<32> @ 1000143A : word32)
+  Class: Eq_440
+  DataType: (ptr32 Eq_440)
+  OrigDataType: ptr32
+T_651: (in 0<32> @ 10001441 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_650: (in g_dw100020CC == 0<32> @ 00000000 : bool)
-  Class: Eq_650
-  DataType: bool
-  OrigDataType: bool
-T_651: (in fn00000000 @ 1000145A : ptr32)
-  Class: Eq_651
-  DataType: (ptr32 Eq_651)
-  OrigDataType: (ptr32 (fn T_653 (T_611, T_612, T_613)))
-T_652: (in signature of fn00000000 @ 00000000 : void)
+T_652: (in eax_197 != 0<32> @ 00000000 : bool)
   Class: Eq_652
-  DataType: Eq_652
-  OrigDataType: 
-T_653: (in fn00000000(ebx_198, esi_200, edi_201) @ 1000145A : void)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: void
-T_654: (in -28<i32> @ 1000145A : int32)
+  DataType: bool
+  OrigDataType: bool
+T_653: (in 3<32> @ 10001435 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_654: (in esi_110 != 3<32> @ 00000000 : bool)
   Class: Eq_654
-  DataType: int32
-  OrigDataType: int32
-T_655: (in ebp_13 + -28<i32> @ 1000145A : word32)
+  DataType: bool
+  OrigDataType: bool
+T_655: (in -28<i32> @ 1000144A : int32)
   Class: Eq_655
+  DataType: int32
+  OrigDataType: int32
+T_656: (in ebp_13 + -28<i32> @ 1000144A : word32)
+  Class: Eq_656
   DataType: (ptr32 word32)
   OrigDataType: (ptr32 word32)
-T_656: (in Mem247[ebp_13 + -28<i32>:word32] @ 1000145A : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_657: (in Mem218[ebp_13 + -28<i32>:word32] @ 1000144A : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_657: (in 0xFFFFFFFF<32> @ 10001493 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_658: (in 0<32> @ 1000144A : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_658: (in 10003008 @ 10001493 : ptr32)
-  Class: Eq_658
-  DataType: (ptr32 Eq_139)
-  OrigDataType: (ptr32 (struct (0 T_659 t0000)))
-T_659: (in Mem4[0x10003008<p32>:word32] @ 10001493 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_660: (in eax @ 1000149D : Eq_660)
+T_659: (in ebp_13->tFFFFFFE4 == 0<32> @ 00000000 : bool)
+  Class: Eq_659
+  DataType: bool
+  OrigDataType: bool
+T_660: (in -28<i32> @ 10001443 : int32)
   Class: Eq_660
-  DataType: Eq_660
-  OrigDataType: BOOL
-T_661: (in hModule @ 1000149D : Eq_661)
+  DataType: int32
+  OrigDataType: int32
+T_661: (in ebp_13 + -28<i32> @ 10001443 : word32)
   Class: Eq_661
-  DataType: Eq_661
-  OrigDataType: HANDLE
-T_662: (in dwReason @ 1000149D : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_663: (in lpReserved @ 1000149D : Eq_140)
-  Class: Eq_140
-  DataType: Eq_140
-  OrigDataType: LPVOID
-T_664: (in 1<32> @ 100014A3 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_665: (in dwReason != 1<32> @ 00000000 : bool)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_662: (in Mem194[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: ui32
+T_663: (in ebp_13->tFFFFFFE4 & eax_197 @ 00000000 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: ui32
+T_664: (in -28<i32> @ 10001443 : int32)
+  Class: Eq_664
+  DataType: int32
+  OrigDataType: int32
+T_665: (in ebp_13 + -28<i32> @ 10001443 : word32)
   Class: Eq_665
-  DataType: bool
-  OrigDataType: bool
-T_666: (in fn10001388 @ 100014BC : ptr32)
-  Class: Eq_666
-  DataType: (ptr32 Eq_666)
-  OrigDataType: (ptr32 (fn T_671 (T_663, T_662, T_668, T_669, T_670)))
-T_667: (in signature of fn10001388 @ 10001388 : void)
-  Class: Eq_666
-  DataType: (ptr32 Eq_666)
-  OrigDataType: 
-T_668: (in ebx @ 100014BC : word32)
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_666: (in Mem214[ebp_13 + -28<i32>:word32] @ 10001443 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_669: (in esi @ 100014BC : word32)
-  Class: Eq_371
-  DataType: ptr32
-  OrigDataType: word32
-T_670: (in edi @ 100014BC : word32)
-  Class: Eq_372
+T_667: (in 100020CC @ 10001453 : ptr32)
+  Class: Eq_667
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_668 t0000)))
+T_668: (in Mem218[0x100020CC<p32>:word32] @ 10001453 : word32)
+  Class: Eq_482
   DataType: word32
   OrigDataType: word32
-T_671: (in fn10001388(lpReserved, dwReason, ebx, esi, edi) @ 100014BC : word32)
-  Class: Eq_660
-  DataType: Eq_660
+T_669: (in 0<32> @ 10001453 : word32)
+  Class: Eq_482
+  DataType: word32
   OrigDataType: word32
-T_672: (in fn10001864 @ 100014A5 : ptr32)
+T_670: (in g_dw100020CC == 0<32> @ 00000000 : bool)
+  Class: Eq_670
+  DataType: bool
+  OrigDataType: bool
+T_671: (in fn00000000 @ 1000145A : ptr32)
+  Class: Eq_671
+  DataType: (ptr32 Eq_671)
+  OrigDataType: (ptr32 (fn T_673 (T_631, T_632, T_633)))
+T_672: (in signature of fn00000000 @ 00000000 : void)
   Class: Eq_672
-  DataType: (ptr32 Eq_672)
-  OrigDataType: (ptr32 (fn T_674 ()))
-T_673: (in signature of fn10001864 @ 10001864 : void)
-  Class: Eq_672
-  DataType: (ptr32 Eq_672)
+  DataType: Eq_672
   OrigDataType: 
-T_674: (in fn10001864() @ 100014A5 : void)
+T_673: (in fn00000000(ebx_198, esi_200, edi_201) @ 1000145A : void)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: void
+T_674: (in -28<i32> @ 1000145A : int32)
   Class: Eq_674
-  DataType: void
-  OrigDataType: void
-T_675: (in eax @ 100014A5 : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_676: (in ebx @ 100014A5 : (ptr32 Eq_183))
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: word32
-T_677: (in esi @ 100014A5 : ptr32)
-  Class: Eq_371
-  DataType: ptr32
-  OrigDataType: word32
-T_678: (in edi @ 100014A5 : word32)
-  Class: Eq_372
-  DataType: word32
-  OrigDataType: word32
-T_679: (in eax_111 @ 100015CF : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: (union (_onexit_t u1))
-T_680: (in esp_80 @ 100015CF : (ptr32 Eq_680))
-  Class: Eq_680
-  DataType: (ptr32 Eq_680)
-  OrigDataType: (ptr32 (struct (FFFFFFFC T_798 tFFFFFFFC)))
-T_681: (in ebp_13 @ 100015D6 : (ptr32 Eq_391))
-  Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: (ptr32 (struct (FFFFFFDC T_675 tFFFFFFDC) (FFFFFFE0 T_727 tFFFFFFE0) (FFFFFFE4 T_686 tFFFFFFE4) (FFFFFFFC T_705 tFFFFFFFC) (8 T_675 t0008)))
-T_682: (in fn100017E8 @ 100015D6 : ptr32)
-  Class: Eq_392
-  DataType: (ptr32 Eq_392)
-  OrigDataType: (ptr32 (fn T_685 (T_676, T_677, T_678, T_683, T_684)))
-T_683: (in dwLoc0C @ 100015D6 : word32)
-  Class: Eq_397
-  DataType: word32
-  OrigDataType: word32
-T_684: (in 0x14<32> @ 100015D6 : word32)
-  Class: Eq_398
-  DataType: ui32
-  OrigDataType: word32
-T_685: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x14<32>) @ 100015D6 : word32)
-  Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: word32
-T_686: (in eax_22 @ 100015E7 : Eq_139)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: (ptr32 void)
-T_687: (in _decode_pointer @ 100015E7 : ptr32)
-  Class: Eq_216
-  DataType: (ptr32 Eq_216)
-  OrigDataType: (ptr32 (fn T_690 (T_689)))
-T_688: (in 100033B4 @ 100015E7 : ptr32)
-  Class: Eq_688
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_689 t0000)))
-T_689: (in Mem7[0x100033B4<p32>:word32] @ 100015E7 : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_690: (in _decode_pointer(g_ptr100033B4) @ 100015E7 : (ptr32 void))
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: (ptr32 void)
-T_691: (in -28<i32> @ 100015EA : int32)
-  Class: Eq_691
   DataType: int32
   OrigDataType: int32
-T_692: (in ebp_13 + -28<i32> @ 100015EA : word32)
-  Class: Eq_692
-  DataType: word32
+T_675: (in ebp_13 + -28<i32> @ 1000145A : word32)
+  Class: Eq_675
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_676: (in Mem247[ebp_13 + -28<i32>:word32] @ 1000145A : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_693: (in Mem25[ebp_13 + -28<i32>:word32] @ 100015EA : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_677: (in 0xFFFFFFFF<32> @ 10001493 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_694: (in 0xFFFFFFFF<32> @ 100015F0 : word32)
-  Class: Eq_139
-  DataType: Eq_139
+T_678: (in 10003008 @ 10001493 : ptr32)
+  Class: Eq_678
+  DataType: (ptr32 Eq_159)
+  OrigDataType: (ptr32 (struct (0 T_679 t0000)))
+T_679: (in Mem4[0x10003008<p32>:word32] @ 10001493 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_695: (in eax_22 != 0xFFFFFFFF<32> @ 00000000 : bool)
-  Class: Eq_695
+T_680: (in eax @ 1000149D : Eq_680)
+  Class: Eq_680
+  DataType: Eq_680
+  OrigDataType: BOOL
+T_681: (in hModule @ 1000149D : Eq_681)
+  Class: Eq_681
+  DataType: Eq_681
+  OrigDataType: HANDLE
+T_682: (in dwReason @ 1000149D : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_683: (in lpReserved @ 1000149D : Eq_160)
+  Class: Eq_160
+  DataType: Eq_160
+  OrigDataType: LPVOID
+T_684: (in 1<32> @ 100014A3 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_685: (in dwReason != 1<32> @ 00000000 : bool)
+  Class: Eq_685
   DataType: bool
   OrigDataType: bool
-T_696: (in lock @ 10001600 : ptr32)
-  Class: Eq_696
-  DataType: (ptr32 Eq_696)
-  OrigDataType: (ptr32 (fn T_699 (T_698)))
-T_697: (in signature of lock @ 00000000 : void)
-  Class: Eq_697
-  DataType: Eq_697
+T_686: (in fn10001388 @ 100014BC : ptr32)
+  Class: Eq_686
+  DataType: (ptr32 Eq_686)
+  OrigDataType: (ptr32 (fn T_691 (T_683, T_682, T_688, T_689, T_690)))
+T_687: (in signature of fn10001388 @ 10001388 : void)
+  Class: Eq_686
+  DataType: (ptr32 Eq_686)
   OrigDataType: 
-T_698: (in 8<32> @ 10001600 : word32)
-  Class: Eq_698
+T_688: (in ebx @ 100014BC : word32)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: word32
+T_689: (in esi @ 100014BC : word32)
+  Class: Eq_391
+  DataType: ptr32
+  OrigDataType: word32
+T_690: (in edi @ 100014BC : word32)
+  Class: Eq_392
   DataType: word32
   OrigDataType: word32
-T_699: (in lock(8<32>) @ 10001600 : void)
-  Class: Eq_699
+T_691: (in fn10001388(lpReserved, dwReason, ebx, esi, edi) @ 100014BC : word32)
+  Class: Eq_680
+  DataType: Eq_680
+  OrigDataType: word32
+T_692: (in fn10001864 @ 100014A5 : ptr32)
+  Class: Eq_692
+  DataType: (ptr32 Eq_692)
+  OrigDataType: (ptr32 (fn T_694 ()))
+T_693: (in signature of fn10001864 @ 10001864 : void)
+  Class: Eq_692
+  DataType: (ptr32 Eq_692)
+  OrigDataType: 
+T_694: (in fn10001864() @ 100014A5 : void)
+  Class: Eq_694
   DataType: void
   OrigDataType: void
-T_700: (in ecx_35 @ 10001605 : (ptr32 void))
-  Class: Eq_218
+T_695: (in eax @ 100014A5 : Eq_158)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_696: (in ebx @ 100014A5 : (ptr32 Eq_203))
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
+  OrigDataType: word32
+T_697: (in esi @ 100014A5 : ptr32)
+  Class: Eq_391
+  DataType: ptr32
+  OrigDataType: word32
+T_698: (in edi @ 100014A5 : word32)
+  Class: Eq_392
+  DataType: word32
+  OrigDataType: word32
+T_699: (in eax_111 @ 100015CF : Eq_158)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: (union (_onexit_t u1))
+T_700: (in esp_80 @ 100015CF : (ptr32 Eq_700))
+  Class: Eq_700
+  DataType: (ptr32 Eq_700)
+  OrigDataType: (ptr32 (struct (FFFFFFFC T_818 tFFFFFFFC)))
+T_701: (in ebp_13 @ 100015D6 : (ptr32 Eq_411))
+  Class: Eq_411
+  DataType: (ptr32 Eq_411)
+  OrigDataType: (ptr32 (struct (FFFFFFDC T_695 tFFFFFFDC) (FFFFFFE0 T_747 tFFFFFFE0) (FFFFFFE4 T_706 tFFFFFFE4) (FFFFFFFC T_725 tFFFFFFFC) (8 T_695 t0008)))
+T_702: (in fn100017E8 @ 100015D6 : ptr32)
+  Class: Eq_412
+  DataType: (ptr32 Eq_412)
+  OrigDataType: (ptr32 (fn T_705 (T_696, T_697, T_698, T_703, T_704)))
+T_703: (in dwLoc0C @ 100015D6 : word32)
+  Class: Eq_417
+  DataType: word32
+  OrigDataType: word32
+T_704: (in 0x14<32> @ 100015D6 : word32)
+  Class: Eq_418
+  DataType: ui32
+  OrigDataType: word32
+T_705: (in fn100017E8(ebx, esi, edi, dwLoc0C, 0x14<32>) @ 100015D6 : word32)
+  Class: Eq_411
+  DataType: (ptr32 Eq_411)
+  OrigDataType: word32
+T_706: (in eax_22 @ 100015E7 : Eq_159)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: (ptr32 void)
+T_707: (in _decode_pointer @ 100015E7 : ptr32)
+  Class: Eq_236
+  DataType: (ptr32 Eq_236)
+  OrigDataType: (ptr32 (fn T_710 (T_709)))
+T_708: (in 100033B4 @ 100015E7 : ptr32)
+  Class: Eq_708
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_709 t0000)))
+T_709: (in Mem7[0x100033B4<p32>:word32] @ 100015E7 : word32)
+  Class: Eq_238
   DataType: (ptr32 void)
-  OrigDataType: word32
-T_701: (in esp_30 @ 10001605 : word32)
-  Class: Eq_701
-  DataType: (ptr32 Eq_701)
-  OrigDataType: (ptr32 (struct (FFFFFFF0 T_742 tFFFFFFF0) (FFFFFFF4 T_745 tFFFFFFF4) (FFFFFFF8 T_748 tFFFFFFF8) (FFFFFFFC T_726 tFFFFFFFC) (0 T_218 t0000)))
-T_702: (in 0<32> @ 10001605 : word32)
-  Class: Eq_702
-  DataType: word32
-  OrigDataType: word32
-T_703: (in esp_30 + 0<32> @ 10001605 : word32)
-  Class: Eq_703
-  DataType: word32
-  OrigDataType: word32
-T_704: (in Mem29[esp_30 + 0<32>:word32] @ 10001605 : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: word32
-T_705: (in 0<32> @ 10001606 : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_706: (in -4<i32> @ 10001606 : int32)
-  Class: Eq_706
+  OrigDataType: (ptr32 void)
+T_710: (in _decode_pointer(g_ptr100033B4) @ 100015E7 : (ptr32 void))
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: (ptr32 void)
+T_711: (in -28<i32> @ 100015EA : int32)
+  Class: Eq_711
   DataType: int32
   OrigDataType: int32
-T_707: (in ebp_13 + -4<i32> @ 10001606 : word32)
-  Class: Eq_707
-  DataType: ptr32
-  OrigDataType: ptr32
-T_708: (in Mem38[ebp_13 + -4<i32>:word32] @ 10001606 : word32)
-  Class: Eq_410
+T_712: (in ebp_13 + -28<i32> @ 100015EA : word32)
+  Class: Eq_712
   DataType: word32
   OrigDataType: word32
-T_709: (in v14_41 @ 1000160A : (ptr32 void))
-  Class: Eq_218
-  DataType: (ptr32 void)
+T_713: (in Mem25[ebp_13 + -28<i32>:word32] @ 100015EA : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_710: (in 100033B4 @ 1000160A : ptr32)
-  Class: Eq_710
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_711 t0000)))
-T_711: (in Mem38[0x100033B4<p32>:word32] @ 1000160A : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
+T_714: (in 0xFFFFFFFF<32> @ 100015F0 : word32)
+  Class: Eq_159
+  DataType: Eq_159
   OrigDataType: word32
-T_712: (in _decode_pointer @ 10001612 : ptr32)
-  Class: Eq_216
-  DataType: (ptr32 Eq_216)
-  OrigDataType: (ptr32 (fn T_716 (T_715)))
-T_713: (in 0<32> @ 10001612 : word32)
-  Class: Eq_713
-  DataType: word32
-  OrigDataType: word32
-T_714: (in esp_30 + 0<32> @ 10001612 : word32)
-  Class: Eq_714
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_715: (in Mem43[esp_30 + 0<32>:(ptr32 void)] @ 10001612 : (ptr32 void))
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_716: (in _decode_pointer(esp_30->ptr0000) @ 10001612 : (ptr32 void))
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: (ptr32 void)
-T_717: (in -28<i32> @ 10001612 : int32)
+T_715: (in eax_22 != 0xFFFFFFFF<32> @ 00000000 : bool)
+  Class: Eq_715
+  DataType: bool
+  OrigDataType: bool
+T_716: (in lock @ 10001600 : ptr32)
+  Class: Eq_716
+  DataType: (ptr32 Eq_716)
+  OrigDataType: (ptr32 (fn T_719 (T_718)))
+T_717: (in signature of lock @ 00000000 : void)
   Class: Eq_717
-  DataType: int32
-  OrigDataType: int32
-T_718: (in ebp_13 + -28<i32> @ 10001612 : word32)
+  DataType: Eq_717
+  OrigDataType: 
+T_718: (in 8<32> @ 10001600 : word32)
   Class: Eq_718
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_719: (in Mem45[ebp_13 + -28<i32>:word32] @ 10001612 : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_720: (in v15_46 @ 10001615 : (ptr32 void))
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: word32
-T_721: (in 100033B0 @ 10001615 : ptr32)
-  Class: Eq_721
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_722 t0000)))
-T_722: (in Mem45[0x100033B0<p32>:word32] @ 10001615 : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: word32
-T_723: (in _decode_pointer @ 1000161D : ptr32)
-  Class: Eq_216
-  DataType: (ptr32 Eq_216)
-  OrigDataType: (ptr32 (fn T_727 (T_726)))
-T_724: (in -4<i32> @ 1000161D : int32)
-  Class: Eq_724
-  DataType: int32
-  OrigDataType: int32
-T_725: (in esp_30 + -4<i32> @ 1000161D : word32)
-  Class: Eq_725
-  DataType: ptr32
-  OrigDataType: ptr32
-T_726: (in Mem48[esp_30 + -4<i32>:(ptr32 void)] @ 1000161D : (ptr32 void))
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: (ptr32 void)
-T_727: (in _decode_pointer(esp_30->ptrFFFFFFFC) @ 1000161D : (ptr32 void))
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: (ptr32 void)
-T_728: (in -32<i32> @ 1000161D : int32)
-  Class: Eq_728
-  DataType: int32
-  OrigDataType: int32
-T_729: (in ebp_13 + -32<i32> @ 1000161D : word32)
-  Class: Eq_729
-  DataType: ptr32
-  OrigDataType: ptr32
-T_730: (in Mem50[ebp_13 + -32<i32>:word32] @ 1000161D : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_731: (in v16_57 @ 10001628 : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_732: (in 8<32> @ 10001628 : word32)
-  Class: Eq_732
   DataType: word32
   OrigDataType: word32
-T_733: (in ebp_13 + 8<32> @ 10001628 : word32)
-  Class: Eq_733
-  DataType: ptr32
-  OrigDataType: ptr32
-T_734: (in Mem56[ebp_13 + 8<32>:word32] @ 10001628 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_719: (in lock(8<32>) @ 10001600 : void)
+  Class: Eq_719
+  DataType: void
+  OrigDataType: void
+T_720: (in ecx_35 @ 10001605 : (ptr32 void))
+  Class: Eq_238
+  DataType: (ptr32 void)
   OrigDataType: word32
-T_735: (in __dllonexit @ 10001630 : ptr32)
-  Class: Eq_735
-  DataType: (ptr32 Eq_735)
-  OrigDataType: (ptr32 (fn T_749 (T_742, T_745, T_748)))
-T_736: (in signature of __dllonexit @ 00000000 : void)
-  Class: Eq_735
-  DataType: (ptr32 Eq_735)
-  OrigDataType: 
-T_737: (in func @ 10001630 : _onexit_t)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: 
-T_738: (in pbegin @ 10001630 : (ptr32 (ptr32 PVFV)))
-  Class: Eq_738
-  DataType: (ptr32 (ptr32 Eq_738))
-  OrigDataType: 
-T_739: (in pend @ 10001630 : (ptr32 (ptr32 PVFV)))
-  Class: Eq_739
-  DataType: (ptr32 (ptr32 Eq_739))
-  OrigDataType: 
-T_740: (in -16<i32> @ 10001630 : int32)
-  Class: Eq_740
-  DataType: int32
-  OrigDataType: int32
-T_741: (in esp_30 + -16<i32> @ 10001630 : word32)
-  Class: Eq_741
-  DataType: ptr32
-  OrigDataType: ptr32
-T_742: (in Mem59[esp_30 + -16<i32>:_onexit_t] @ 10001630 : _onexit_t)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: _onexit_t
-T_743: (in -12<i32> @ 10001630 : int32)
-  Class: Eq_743
-  DataType: int32
-  OrigDataType: int32
-T_744: (in esp_30 + -12<i32> @ 10001630 : word32)
-  Class: Eq_744
-  DataType: ptr32
-  OrigDataType: ptr32
-T_745: (in Mem59[esp_30 + -12<i32>:(ptr32 (ptr32 PVFV))] @ 10001630 : (ptr32 (ptr32 PVFV)))
-  Class: Eq_738
-  DataType: (ptr32 (ptr32 Eq_738))
-  OrigDataType: (ptr32 (ptr32 PVFV))
-T_746: (in -8<i32> @ 10001630 : int32)
-  Class: Eq_746
-  DataType: int32
-  OrigDataType: int32
-T_747: (in esp_30 + -8<i32> @ 10001630 : word32)
-  Class: Eq_747
-  DataType: ptr32
-  OrigDataType: ptr32
-T_748: (in Mem59[esp_30 + -8<i32>:(ptr32 (ptr32 PVFV))] @ 10001630 : (ptr32 (ptr32 PVFV)))
-  Class: Eq_739
-  DataType: (ptr32 (ptr32 Eq_739))
-  OrigDataType: (ptr32 (ptr32 PVFV))
-T_749: (in __dllonexit(esp_30->tFFFFFFF0, esp_30->ptrFFFFFFF4, esp_30->ptrFFFFFFF8) @ 10001630 : _onexit_t)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: _onexit_t
-T_750: (in -36<i32> @ 10001630 : int32)
-  Class: Eq_750
-  DataType: int32
-  OrigDataType: int32
-T_751: (in ebp_13 + -36<i32> @ 10001630 : word32)
-  Class: Eq_751
-  DataType: ptr32
-  OrigDataType: ptr32
-T_752: (in Mem61[ebp_13 + -36<i32>:word32] @ 10001630 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_721: (in esp_30 @ 10001605 : word32)
+  Class: Eq_721
+  DataType: (ptr32 Eq_721)
+  OrigDataType: (ptr32 (struct (FFFFFFF0 T_762 tFFFFFFF0) (FFFFFFF4 T_765 tFFFFFFF4) (FFFFFFF8 T_768 tFFFFFFF8) (FFFFFFFC T_746 tFFFFFFFC) (0 T_238 t0000)))
+T_722: (in 0<32> @ 10001605 : word32)
+  Class: Eq_722
+  DataType: word32
   OrigDataType: word32
-T_753: (in encode_pointer @ 1000163E : ptr32)
-  Class: Eq_753
-  DataType: (ptr32 Eq_753)
-  OrigDataType: (ptr32 (fn T_762 (T_700, T_757, T_731, T_759, T_761, T_720, T_709)))
-T_754: (in signature of encode_pointer @ 00000000 : void)
-  Class: Eq_754
-  DataType: Eq_754
-  OrigDataType: 
-T_755: (in -28<i32> @ 1000163E : int32)
-  Class: Eq_755
+T_723: (in esp_30 + 0<32> @ 10001605 : word32)
+  Class: Eq_723
+  DataType: word32
+  OrigDataType: word32
+T_724: (in Mem29[esp_30 + 0<32>:word32] @ 10001605 : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: word32
+T_725: (in 0<32> @ 10001606 : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_726: (in -4<i32> @ 10001606 : int32)
+  Class: Eq_726
   DataType: int32
   OrigDataType: int32
-T_756: (in ebp_13 + -28<i32> @ 1000163E : word32)
-  Class: Eq_756
+T_727: (in ebp_13 + -4<i32> @ 10001606 : word32)
+  Class: Eq_727
+  DataType: ptr32
+  OrigDataType: ptr32
+T_728: (in Mem38[ebp_13 + -4<i32>:word32] @ 10001606 : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_729: (in v14_41 @ 1000160A : (ptr32 void))
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: word32
+T_730: (in 100033B4 @ 1000160A : ptr32)
+  Class: Eq_730
   DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (ptr32 void))
-T_757: (in Mem61[ebp_13 + -28<i32>:word32] @ 1000163E : word32)
-  Class: Eq_139
-  DataType: Eq_139
+  OrigDataType: (ptr32 (struct (0 T_731 t0000)))
+T_731: (in Mem38[0x100033B4<p32>:word32] @ 1000160A : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: word32
+T_732: (in _decode_pointer @ 10001612 : ptr32)
+  Class: Eq_236
+  DataType: (ptr32 Eq_236)
+  OrigDataType: (ptr32 (fn T_736 (T_735)))
+T_733: (in 0<32> @ 10001612 : word32)
+  Class: Eq_733
+  DataType: word32
+  OrigDataType: word32
+T_734: (in esp_30 + 0<32> @ 10001612 : word32)
+  Class: Eq_734
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_735: (in Mem43[esp_30 + 0<32>:(ptr32 void)] @ 10001612 : (ptr32 void))
+  Class: Eq_238
+  DataType: (ptr32 void)
   OrigDataType: (ptr32 void)
-T_758: (in 0x1C<32> @ 1000163E : word32)
-  Class: Eq_758
-  DataType: ui32
-  OrigDataType: ui32
-T_759: (in ebp_13 - 0x1C<32> @ 00000000 : word32)
-  Class: Eq_759
+T_736: (in _decode_pointer(esp_30->ptr0000) @ 10001612 : (ptr32 void))
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: (ptr32 void)
+T_737: (in -28<i32> @ 10001612 : int32)
+  Class: Eq_737
+  DataType: int32
+  OrigDataType: int32
+T_738: (in ebp_13 + -28<i32> @ 10001612 : word32)
+  Class: Eq_738
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_739: (in Mem45[ebp_13 + -28<i32>:word32] @ 10001612 : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_740: (in v15_46 @ 10001615 : (ptr32 void))
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: word32
+T_741: (in 100033B0 @ 10001615 : ptr32)
+  Class: Eq_741
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_742 t0000)))
+T_742: (in Mem45[0x100033B0<p32>:word32] @ 10001615 : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: word32
+T_743: (in _decode_pointer @ 1000161D : ptr32)
+  Class: Eq_236
+  DataType: (ptr32 Eq_236)
+  OrigDataType: (ptr32 (fn T_747 (T_746)))
+T_744: (in -4<i32> @ 1000161D : int32)
+  Class: Eq_744
+  DataType: int32
+  OrigDataType: int32
+T_745: (in esp_30 + -4<i32> @ 1000161D : word32)
+  Class: Eq_745
   DataType: ptr32
   OrigDataType: ptr32
-T_760: (in 0x20<32> @ 1000163E : word32)
+T_746: (in Mem48[esp_30 + -4<i32>:(ptr32 void)] @ 1000161D : (ptr32 void))
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: (ptr32 void)
+T_747: (in _decode_pointer(esp_30->ptrFFFFFFFC) @ 1000161D : (ptr32 void))
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: (ptr32 void)
+T_748: (in -32<i32> @ 1000161D : int32)
+  Class: Eq_748
+  DataType: int32
+  OrigDataType: int32
+T_749: (in ebp_13 + -32<i32> @ 1000161D : word32)
+  Class: Eq_749
+  DataType: ptr32
+  OrigDataType: ptr32
+T_750: (in Mem50[ebp_13 + -32<i32>:word32] @ 1000161D : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_751: (in v16_57 @ 10001628 : Eq_158)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_752: (in 8<32> @ 10001628 : word32)
+  Class: Eq_752
+  DataType: word32
+  OrigDataType: word32
+T_753: (in ebp_13 + 8<32> @ 10001628 : word32)
+  Class: Eq_753
+  DataType: ptr32
+  OrigDataType: ptr32
+T_754: (in Mem56[ebp_13 + 8<32>:word32] @ 10001628 : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_755: (in __dllonexit @ 10001630 : ptr32)
+  Class: Eq_755
+  DataType: (ptr32 Eq_755)
+  OrigDataType: (ptr32 (fn T_769 (T_762, T_765, T_768)))
+T_756: (in signature of __dllonexit @ 00000000 : void)
+  Class: Eq_755
+  DataType: (ptr32 Eq_755)
+  OrigDataType: 
+T_757: (in func @ 10001630 : _onexit_t)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: 
+T_758: (in pbegin @ 10001630 : (ptr32 (ptr32 PVFV)))
+  Class: Eq_758
+  DataType: (ptr32 (ptr32 Eq_758))
+  OrigDataType: 
+T_759: (in pend @ 10001630 : (ptr32 (ptr32 PVFV)))
+  Class: Eq_759
+  DataType: (ptr32 (ptr32 Eq_759))
+  OrigDataType: 
+T_760: (in -16<i32> @ 10001630 : int32)
   Class: Eq_760
-  DataType: ui32
-  OrigDataType: ui32
-T_761: (in ebp_13 - 0x20<32> @ 00000000 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_761: (in esp_30 + -16<i32> @ 10001630 : word32)
   Class: Eq_761
   DataType: ptr32
   OrigDataType: ptr32
-T_762: (in encode_pointer(ecx_35, ebp_13->tFFFFFFE4, v16_57, ebp_13 - 0x1C<32>, ebp_13 - 0x20<32>, v15_46, v14_41) @ 1000163E : void)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: void
-T_763: (in 100033B4 @ 1000163E : ptr32)
+T_762: (in Mem59[esp_30 + -16<i32>:_onexit_t] @ 10001630 : _onexit_t)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: _onexit_t
+T_763: (in -12<i32> @ 10001630 : int32)
   Class: Eq_763
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_764 t0000)))
-T_764: (in Mem71[0x100033B4<p32>:word32] @ 1000163E : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: word32
-T_765: (in encode_pointer @ 1000164B : ptr32)
-  Class: Eq_765
-  DataType: (ptr32 Eq_765)
-  OrigDataType: (ptr32 (fn T_769 (T_768)))
-T_766: (in -32<i32> @ 1000164B : int32)
+  DataType: int32
+  OrigDataType: int32
+T_764: (in esp_30 + -12<i32> @ 10001630 : word32)
+  Class: Eq_764
+  DataType: ptr32
+  OrigDataType: ptr32
+T_765: (in Mem59[esp_30 + -12<i32>:(ptr32 (ptr32 PVFV))] @ 10001630 : (ptr32 (ptr32 PVFV)))
+  Class: Eq_758
+  DataType: (ptr32 (ptr32 Eq_758))
+  OrigDataType: (ptr32 (ptr32 PVFV))
+T_766: (in -8<i32> @ 10001630 : int32)
   Class: Eq_766
   DataType: int32
   OrigDataType: int32
-T_767: (in ebp_13 + -32<i32> @ 1000164B : word32)
+T_767: (in esp_30 + -8<i32> @ 10001630 : word32)
   Class: Eq_767
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_768: (in Mem71[ebp_13 + -32<i32>:word32] @ 1000164B : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_769: (in encode_pointer(ebp_13->tFFFFFFE0) @ 1000164B : void)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: void
-T_770: (in 100033B0 @ 1000164B : ptr32)
-  Class: Eq_770
-  DataType: (ptr32 (ptr32 void))
-  OrigDataType: (ptr32 (struct (0 T_771 t0000)))
-T_771: (in Mem82[0x100033B0<p32>:word32] @ 1000164B : word32)
-  Class: Eq_218
-  DataType: (ptr32 void)
-  OrigDataType: word32
-T_772: (in 0xFFFFFFFE<32> @ 10001650 : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_773: (in -4<i32> @ 10001650 : int32)
-  Class: Eq_773
-  DataType: int32
-  OrigDataType: int32
-T_774: (in ebp_13 + -4<i32> @ 10001650 : word32)
-  Class: Eq_774
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_775: (in Mem83[ebp_13 + -4<i32>:word32] @ 10001650 : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_776: (in fn10001665 @ 10001657 : ptr32)
-  Class: Eq_776
-  DataType: (ptr32 Eq_776)
-  OrigDataType: (ptr32 (fn T_778 ()))
-T_777: (in signature of fn10001665 @ 10001665 : void)
-  Class: Eq_776
-  DataType: (ptr32 Eq_776)
-  OrigDataType: 
-T_778: (in fn10001665() @ 10001657 : void)
-  Class: Eq_778
-  DataType: void
-  OrigDataType: void
-T_779: (in esp_75 @ 10001648 : word32)
-  Class: Eq_779
-  DataType: word32
-  OrigDataType: word32
-T_780: (in 0x1C<32> @ 10001648 : word32)
-  Class: Eq_780
-  DataType: word32
-  OrigDataType: word32
-T_781: (in esp_75 + 0x1C<32> @ 00000000 : word32)
-  Class: Eq_680
-  DataType: (ptr32 Eq_680)
-  OrigDataType: word32
-T_782: (in -36<i32> @ 1000165C : int32)
-  Class: Eq_782
-  DataType: int32
-  OrigDataType: int32
-T_783: (in ebp_13 + -36<i32> @ 1000165C : word32)
-  Class: Eq_783
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_784: (in Mem83[ebp_13 + -36<i32>:word32] @ 1000165C : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: word32
-T_785: (in _onexit @ 100015F5 : ptr32)
-  Class: Eq_785
-  DataType: (ptr32 Eq_785)
-  OrigDataType: (ptr32 (fn T_791 (T_790)))
-T_786: (in signature of _onexit @ 00000000 : void)
-  Class: Eq_785
-  DataType: (ptr32 Eq_785)
-  OrigDataType: 
-T_787: (in _Func @ 100015F5 : _onexit_t)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: 
-T_788: (in 8<32> @ 100015F5 : word32)
-  Class: Eq_788
-  DataType: word32
-  OrigDataType: word32
-T_789: (in ebp_13 + 8<32> @ 100015F5 : word32)
-  Class: Eq_789
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_790: (in Mem25[ebp_13 + 8<32>:word32] @ 100015F5 : word32)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: _onexit_t
-T_791: (in _onexit(ebp_13->t0008) @ 100015F5 : _onexit_t)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: _onexit_t
-T_792: (in fp @ 100015FB : ptr32)
-  Class: Eq_792
   DataType: ptr32
   OrigDataType: ptr32
-T_793: (in 8<i32> @ 100015FB : int32)
+T_768: (in Mem59[esp_30 + -8<i32>:(ptr32 (ptr32 PVFV))] @ 10001630 : (ptr32 (ptr32 PVFV)))
+  Class: Eq_759
+  DataType: (ptr32 (ptr32 Eq_759))
+  OrigDataType: (ptr32 (ptr32 PVFV))
+T_769: (in __dllonexit(esp_30->tFFFFFFF0, esp_30->ptrFFFFFFF4, esp_30->ptrFFFFFFF8) @ 10001630 : _onexit_t)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: _onexit_t
+T_770: (in -36<i32> @ 10001630 : int32)
+  Class: Eq_770
+  DataType: int32
+  OrigDataType: int32
+T_771: (in ebp_13 + -36<i32> @ 10001630 : word32)
+  Class: Eq_771
+  DataType: ptr32
+  OrigDataType: ptr32
+T_772: (in Mem61[ebp_13 + -36<i32>:word32] @ 10001630 : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_773: (in encode_pointer @ 1000163E : ptr32)
+  Class: Eq_773
+  DataType: (ptr32 Eq_773)
+  OrigDataType: (ptr32 (fn T_782 (T_720, T_777, T_751, T_779, T_781, T_740, T_729)))
+T_774: (in signature of encode_pointer @ 00000000 : void)
+  Class: Eq_774
+  DataType: Eq_774
+  OrigDataType: 
+T_775: (in -28<i32> @ 1000163E : int32)
+  Class: Eq_775
+  DataType: int32
+  OrigDataType: int32
+T_776: (in ebp_13 + -28<i32> @ 1000163E : word32)
+  Class: Eq_776
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (ptr32 void))
+T_777: (in Mem61[ebp_13 + -28<i32>:word32] @ 1000163E : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: (ptr32 void)
+T_778: (in 0x1C<32> @ 1000163E : word32)
+  Class: Eq_778
+  DataType: ui32
+  OrigDataType: ui32
+T_779: (in ebp_13 - 0x1C<32> @ 00000000 : word32)
+  Class: Eq_779
+  DataType: ptr32
+  OrigDataType: ptr32
+T_780: (in 0x20<32> @ 1000163E : word32)
+  Class: Eq_780
+  DataType: ui32
+  OrigDataType: ui32
+T_781: (in ebp_13 - 0x20<32> @ 00000000 : word32)
+  Class: Eq_781
+  DataType: ptr32
+  OrigDataType: ptr32
+T_782: (in encode_pointer(ecx_35, ebp_13->tFFFFFFE4, v16_57, ebp_13 - 0x1C<32>, ebp_13 - 0x20<32>, v15_46, v14_41) @ 1000163E : void)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: void
+T_783: (in 100033B4 @ 1000163E : ptr32)
+  Class: Eq_783
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_784 t0000)))
+T_784: (in Mem71[0x100033B4<p32>:word32] @ 1000163E : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: word32
+T_785: (in encode_pointer @ 1000164B : ptr32)
+  Class: Eq_785
+  DataType: (ptr32 Eq_785)
+  OrigDataType: (ptr32 (fn T_789 (T_788)))
+T_786: (in -32<i32> @ 1000164B : int32)
+  Class: Eq_786
+  DataType: int32
+  OrigDataType: int32
+T_787: (in ebp_13 + -32<i32> @ 1000164B : word32)
+  Class: Eq_787
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_788: (in Mem71[ebp_13 + -32<i32>:word32] @ 1000164B : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_789: (in encode_pointer(ebp_13->tFFFFFFE0) @ 1000164B : void)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: void
+T_790: (in 100033B0 @ 1000164B : ptr32)
+  Class: Eq_790
+  DataType: (ptr32 (ptr32 void))
+  OrigDataType: (ptr32 (struct (0 T_791 t0000)))
+T_791: (in Mem82[0x100033B0<p32>:word32] @ 1000164B : word32)
+  Class: Eq_238
+  DataType: (ptr32 void)
+  OrigDataType: word32
+T_792: (in 0xFFFFFFFE<32> @ 10001650 : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_793: (in -4<i32> @ 10001650 : int32)
   Class: Eq_793
   DataType: int32
   OrigDataType: int32
-T_794: (in fp - 8<i32> @ 00000000 : word32)
-  Class: Eq_680
-  DataType: (ptr32 Eq_680)
-  OrigDataType: ptr32
-T_795: (in fn1000182D @ 1000165F : ptr32)
-  Class: Eq_453
-  DataType: (ptr32 Eq_453)
-  OrigDataType: (ptr32 (fn T_799 (T_681, T_798)))
-T_796: (in -4<i32> @ 1000165F : int32)
-  Class: Eq_796
-  DataType: int32
-  OrigDataType: int32
-T_797: (in esp_80 + -4<i32> @ 1000165F : word32)
-  Class: Eq_797
-  DataType: ptr32
-  OrigDataType: ptr32
-T_798: (in Mem95[esp_80 + -4<i32>:word32] @ 1000165F : word32)
-  Class: Eq_456
-  DataType: Eq_456
-  OrigDataType: word32
-T_799: (in fn1000182D(ebp_13, esp_80->tFFFFFFFC) @ 1000165F : word32)
-  Class: Eq_373
-  DataType: ptr32
-  OrigDataType: word32
-T_800: (in unlock @ 10001667 : ptr32)
-  Class: Eq_800
-  DataType: (ptr32 Eq_800)
-  OrigDataType: (ptr32 (fn T_802 ()))
-T_801: (in signature of unlock @ 00000000 : void)
-  Class: Eq_801
-  DataType: Eq_801
-  OrigDataType: 
-T_802: (in unlock() @ 10001667 : void)
-  Class: Eq_802
-  DataType: void
-  OrigDataType: void
-T_803: (in ebx @ 1000166D : (ptr32 Eq_183))
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: word32
-T_804: (in esi @ 1000166D : ptr32)
-  Class: Eq_371
-  DataType: ptr32
-  OrigDataType: word32
-T_805: (in edi @ 1000166D : word32)
-  Class: Eq_372
+T_794: (in ebp_13 + -4<i32> @ 10001650 : word32)
+  Class: Eq_794
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_795: (in Mem83[ebp_13 + -4<i32>:word32] @ 10001650 : word32)
+  Class: Eq_430
   DataType: word32
   OrigDataType: word32
-T_806: (in fn100015CF @ 10001672 : ptr32)
-  Class: Eq_806
-  DataType: (ptr32 Eq_806)
-  OrigDataType: (ptr32 (fn T_808 (T_803, T_804, T_805)))
-T_807: (in signature of fn100015CF @ 100015CF : void)
-  Class: Eq_806
-  DataType: (ptr32 Eq_806)
+T_796: (in fn10001665 @ 10001657 : ptr32)
+  Class: Eq_796
+  DataType: (ptr32 Eq_796)
+  OrigDataType: (ptr32 (fn T_798 ()))
+T_797: (in signature of fn10001665 @ 10001665 : void)
+  Class: Eq_796
+  DataType: (ptr32 Eq_796)
   OrigDataType: 
-T_808: (in fn100015CF(ebx, esi, edi) @ 10001672 : word32)
+T_798: (in fn10001665() @ 10001657 : void)
+  Class: Eq_798
+  DataType: void
+  OrigDataType: void
+T_799: (in esp_75 @ 10001648 : word32)
+  Class: Eq_799
+  DataType: word32
+  OrigDataType: word32
+T_800: (in 0x1C<32> @ 10001648 : word32)
+  Class: Eq_800
+  DataType: word32
+  OrigDataType: word32
+T_801: (in esp_75 + 0x1C<32> @ 00000000 : word32)
+  Class: Eq_700
+  DataType: (ptr32 Eq_700)
+  OrigDataType: word32
+T_802: (in -36<i32> @ 1000165C : int32)
+  Class: Eq_802
+  DataType: int32
+  OrigDataType: int32
+T_803: (in ebp_13 + -36<i32> @ 1000165C : word32)
+  Class: Eq_803
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_804: (in Mem83[ebp_13 + -36<i32>:word32] @ 1000165C : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_805: (in _onexit @ 100015F5 : ptr32)
+  Class: Eq_805
+  DataType: (ptr32 Eq_805)
+  OrigDataType: (ptr32 (fn T_811 (T_810)))
+T_806: (in signature of _onexit @ 00000000 : void)
+  Class: Eq_805
+  DataType: (ptr32 Eq_805)
+  OrigDataType: 
+T_807: (in _Func @ 100015F5 : _onexit_t)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: 
+T_808: (in 8<32> @ 100015F5 : word32)
   Class: Eq_808
   DataType: word32
   OrigDataType: word32
-T_809: (in esi_13 @ 1000168E : (ptr32 word32))
+T_809: (in ebp_13 + 8<32> @ 100015F5 : word32)
   Class: Eq_809
   DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
-T_810: (in 0x100021D8<p32> @ 1000168E : ptr32)
-  Class: Eq_809
-  DataType: (ptr32 word32)
-  OrigDataType: ptr32
-T_811: (in true @ 10001690 : bool)
-  Class: Eq_811
-  DataType: bool
-  OrigDataType: bool
-T_812: (in 0<32> @ 10001696 : word32)
+  OrigDataType: (ptr32 word32)
+T_810: (in Mem25[ebp_13 + 8<32>:word32] @ 100015F5 : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: _onexit_t
+T_811: (in _onexit(ebp_13->t0008) @ 100015F5 : _onexit_t)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: _onexit_t
+T_812: (in fp @ 100015FB : ptr32)
   Class: Eq_812
-  DataType: word32
-  OrigDataType: word32
-T_813: (in esi_13 + 0<32> @ 10001696 : word32)
-  Class: Eq_813
   DataType: ptr32
   OrigDataType: ptr32
-T_814: (in Mem9[esi_13 + 0<32>:word32] @ 10001696 : word32)
-  Class: Eq_814
-  DataType: word32
-  OrigDataType: word32
-T_815: (in 0<32> @ 10001696 : word32)
-  Class: Eq_814
-  DataType: word32
-  OrigDataType: word32
-T_816: (in *esi_13 == 0<32> @ 00000000 : bool)
-  Class: Eq_816
-  DataType: bool
-  OrigDataType: bool
-T_817: (in 4<32> @ 1000169A : word32)
-  Class: Eq_817
+T_813: (in 8<i32> @ 100015FB : int32)
+  Class: Eq_813
   DataType: int32
   OrigDataType: int32
-T_818: (in esi_13 + 4<32> @ 1000169A : word32)
-  Class: Eq_809
-  DataType: (ptr32 word32)
+T_814: (in fp - 8<i32> @ 00000000 : word32)
+  Class: Eq_700
+  DataType: (ptr32 Eq_700)
   OrigDataType: ptr32
-T_819: (in 0x100021D8<p32> @ 1000169F : ptr32)
-  Class: Eq_809
-  DataType: (ptr32 word32)
+T_815: (in fn1000182D @ 1000165F : ptr32)
+  Class: Eq_473
+  DataType: (ptr32 Eq_473)
+  OrigDataType: (ptr32 (fn T_819 (T_701, T_818)))
+T_816: (in -4<i32> @ 1000165F : int32)
+  Class: Eq_816
+  DataType: int32
+  OrigDataType: int32
+T_817: (in esp_80 + -4<i32> @ 1000165F : word32)
+  Class: Eq_817
+  DataType: ptr32
   OrigDataType: ptr32
-T_820: (in esi_13 < g_a100021D8 @ 00000000 : bool)
+T_818: (in Mem95[esp_80 + -4<i32>:word32] @ 1000165F : word32)
+  Class: Eq_476
+  DataType: Eq_476
+  OrigDataType: word32
+T_819: (in fn1000182D(ebp_13, esp_80->tFFFFFFFC) @ 1000165F : word32)
+  Class: Eq_393
+  DataType: ptr32
+  OrigDataType: word32
+T_820: (in unlock @ 10001667 : ptr32)
   Class: Eq_820
-  DataType: bool
-  OrigDataType: bool
-T_821: (in fn00000000 @ 10001698 : ptr32)
+  DataType: (ptr32 Eq_820)
+  OrigDataType: (ptr32 (fn T_822 ()))
+T_821: (in signature of unlock @ 00000000 : void)
   Class: Eq_821
-  DataType: (ptr32 Eq_821)
-  OrigDataType: (ptr32 (fn T_823 ()))
-T_822: (in signature of fn00000000 @ 00000000 : void)
-  Class: Eq_822
-  DataType: Eq_822
+  DataType: Eq_821
   OrigDataType: 
-T_823: (in fn00000000() @ 10001698 : void)
-  Class: Eq_823
+T_822: (in unlock() @ 10001667 : void)
+  Class: Eq_822
   DataType: void
   OrigDataType: void
-T_824: (in eax @ 10001698 : uint32)
-  Class: Eq_824
-  DataType: uint32
+T_823: (in ebx @ 1000166D : (ptr32 Eq_203))
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
   OrigDataType: word32
-T_825: (in dwArg04 @ 10001698 : (ptr32 Eq_825))
-  Class: Eq_825
-  DataType: (ptr32 Eq_825)
-  OrigDataType: (ptr32 (struct (0 T_828 t0000) (3C T_834 t003C)))
-T_826: (in 0<32> @ 100016D9 : word32)
+T_824: (in esi @ 1000166D : ptr32)
+  Class: Eq_391
+  DataType: ptr32
+  OrigDataType: word32
+T_825: (in edi @ 1000166D : word32)
+  Class: Eq_392
+  DataType: word32
+  OrigDataType: word32
+T_826: (in fn100015CF @ 10001672 : ptr32)
   Class: Eq_826
+  DataType: (ptr32 Eq_826)
+  OrigDataType: (ptr32 (fn T_828 (T_823, T_824, T_825)))
+T_827: (in signature of fn100015CF @ 100015CF : void)
+  Class: Eq_826
+  DataType: (ptr32 Eq_826)
+  OrigDataType: 
+T_828: (in fn100015CF(ebx, esi, edi) @ 10001672 : word32)
+  Class: Eq_828
   DataType: word32
   OrigDataType: word32
-T_827: (in dwArg04 + 0<32> @ 100016D9 : word32)
-  Class: Eq_827
-  DataType: word32
-  OrigDataType: word32
-T_828: (in Mem0[dwArg04 + 0<32>:word16] @ 100016D9 : word16)
-  Class: Eq_828
-  DataType: word16
-  OrigDataType: word16
-T_829: (in 0x5A4D<16> @ 100016D9 : word16)
-  Class: Eq_828
-  DataType: word16
-  OrigDataType: word16
-T_830: (in dwArg04->w0000 == 0x5A4D<16> @ 00000000 : bool)
-  Class: Eq_830
+T_829: (in esi_13 @ 1000168E : (ptr32 word32))
+  Class: Eq_829
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct 0004 (0 word32 dw0000)))
+T_830: (in 0x100021D8<p32> @ 1000168E : ptr32)
+  Class: Eq_829
+  DataType: (ptr32 word32)
+  OrigDataType: ptr32
+T_831: (in true @ 10001690 : bool)
+  Class: Eq_831
   DataType: bool
   OrigDataType: bool
-T_831: (in eax_9 @ 100016E1 : (ptr32 Eq_831))
-  Class: Eq_831
-  DataType: (ptr32 Eq_831)
-  OrigDataType: (ptr32 (struct (0 T_838 t0000) (18 T_844 t0018)))
-T_832: (in 0x3C<32> @ 100016E1 : word32)
+T_832: (in 0<32> @ 10001696 : word32)
   Class: Eq_832
   DataType: word32
   OrigDataType: word32
-T_833: (in dwArg04 + 0x3C<32> @ 100016E1 : word32)
+T_833: (in esi_13 + 0<32> @ 10001696 : word32)
   Class: Eq_833
   DataType: ptr32
   OrigDataType: ptr32
-T_834: (in Mem0[dwArg04 + 0x3C<32>:word32] @ 100016E1 : word32)
+T_834: (in Mem9[esi_13 + 0<32>:word32] @ 10001696 : word32)
   Class: Eq_834
   DataType: word32
   OrigDataType: word32
-T_835: (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 100016E1 : word32)
-  Class: Eq_831
-  DataType: (ptr32 Eq_831)
+T_835: (in 0<32> @ 10001696 : word32)
+  Class: Eq_834
+  DataType: word32
   OrigDataType: word32
-T_836: (in 0<32> @ 100016E9 : word32)
+T_836: (in *esi_13 == 0<32> @ 00000000 : bool)
   Class: Eq_836
-  DataType: word32
-  OrigDataType: word32
-T_837: (in eax_9 + 0<32> @ 100016E9 : word32)
+  DataType: bool
+  OrigDataType: bool
+T_837: (in 4<32> @ 1000169A : word32)
   Class: Eq_837
-  DataType: word32
-  OrigDataType: word32
-T_838: (in Mem0[eax_9 + 0<32>:word32] @ 100016E9 : word32)
-  Class: Eq_838
-  DataType: word32
-  OrigDataType: word32
-T_839: (in 0x4550<32> @ 100016E9 : word32)
-  Class: Eq_838
-  DataType: word32
-  OrigDataType: word32
-T_840: (in eax_9->dw0000 != 0x4550<32> @ 00000000 : bool)
+  DataType: int32
+  OrigDataType: int32
+T_838: (in esi_13 + 4<32> @ 1000169A : word32)
+  Class: Eq_829
+  DataType: (ptr32 word32)
+  OrigDataType: ptr32
+T_839: (in 0x100021D8<p32> @ 1000169F : ptr32)
+  Class: Eq_829
+  DataType: (ptr32 word32)
+  OrigDataType: ptr32
+T_840: (in esi_13 < g_a100021D8 @ 00000000 : bool)
   Class: Eq_840
   DataType: bool
   OrigDataType: bool
-T_841: (in 0<32> @ 100016DD : word32)
-  Class: Eq_824
+T_841: (in fn00000000 @ 10001698 : ptr32)
+  Class: Eq_841
+  DataType: (ptr32 Eq_841)
+  OrigDataType: (ptr32 (fn T_843 ()))
+T_842: (in signature of fn00000000 @ 00000000 : void)
+  Class: Eq_842
+  DataType: Eq_842
+  OrigDataType: 
+T_843: (in fn00000000() @ 10001698 : void)
+  Class: Eq_843
+  DataType: void
+  OrigDataType: void
+T_844: (in eax @ 10001698 : uint32)
+  Class: Eq_844
   DataType: uint32
   OrigDataType: word32
-T_842: (in 0x18<32> @ 100016F8 : word32)
-  Class: Eq_842
+T_845: (in dwArg04 @ 10001698 : (ptr32 Eq_845))
+  Class: Eq_845
+  DataType: (ptr32 Eq_845)
+  OrigDataType: (ptr32 (struct (0 T_848 t0000) (3C T_854 t003C)))
+T_846: (in 0<32> @ 100016D9 : word32)
+  Class: Eq_846
   DataType: word32
   OrigDataType: word32
-T_843: (in eax_9 + 0x18<32> @ 100016F8 : word32)
-  Class: Eq_843
-  DataType: ptr32
-  OrigDataType: ptr32
-T_844: (in Mem0[eax_9 + 0x18<32>:word16] @ 100016F8 : word16)
-  Class: Eq_844
+T_847: (in dwArg04 + 0<32> @ 100016D9 : word32)
+  Class: Eq_847
+  DataType: word32
+  OrigDataType: word32
+T_848: (in Mem0[dwArg04 + 0<32>:word16] @ 100016D9 : word16)
+  Class: Eq_848
   DataType: word16
   OrigDataType: word16
-T_845: (in 0x10B<16> @ 100016F8 : word16)
-  Class: Eq_844
+T_849: (in 0x5A4D<16> @ 100016D9 : word16)
+  Class: Eq_848
   DataType: word16
   OrigDataType: word16
-T_846: (in eax_9->w0018 == 0x10B<16> @ 00000000 : bool)
-  Class: Eq_846
+T_850: (in dwArg04->w0000 == 0x5A4D<16> @ 00000000 : bool)
+  Class: Eq_850
   DataType: bool
   OrigDataType: bool
-T_847: (in CONVERT(Mem0[eax_9 + 0x18<32>:word16] == 0x10B<16>, bool, int8) @ 100016F8 : int8)
-  Class: Eq_847
-  DataType: int8
-  OrigDataType: int8
-T_848: (in CONVERT(CONVERT(Mem0[eax_9 + 0x18<32>:word16] == 0x10B<16>, bool, int8), int8, uint32) @ 100016F8 : uint32)
-  Class: Eq_824
-  DataType: uint32
-  OrigDataType: uint32
-T_849: (in eax @ 100016F8 : (ptr32 Eq_849))
-  Class: Eq_849
-  DataType: (ptr32 Eq_849)
-  OrigDataType: word32
-T_850: (in dwArg04 @ 100016F8 : (ptr32 Eq_850))
-  Class: Eq_850
-  DataType: (ptr32 Eq_850)
-  OrigDataType: (ptr32 (struct (3C T_855 t003C)))
-T_851: (in dwArg08 @ 100016F8 : uint32)
+T_851: (in eax_9 @ 100016E1 : (ptr32 Eq_851))
   Class: Eq_851
-  DataType: uint32
-  OrigDataType: up32
-T_852: (in ecx_7 @ 10001707 : (ptr32 Eq_852))
+  DataType: (ptr32 Eq_851)
+  OrigDataType: (ptr32 (struct (0 T_858 t0000) (18 T_864 t0018)))
+T_852: (in 0x3C<32> @ 100016E1 : word32)
   Class: Eq_852
-  DataType: (ptr32 Eq_852)
-  OrigDataType: (ptr32 (struct (6 T_860 t0006) (14 T_867 t0014)))
-T_853: (in 0x3C<32> @ 10001707 : word32)
-  Class: Eq_853
   DataType: word32
   OrigDataType: word32
-T_854: (in dwArg04 + 0x3C<32> @ 10001707 : word32)
+T_853: (in dwArg04 + 0x3C<32> @ 100016E1 : word32)
+  Class: Eq_853
+  DataType: ptr32
+  OrigDataType: ptr32
+T_854: (in Mem0[dwArg04 + 0x3C<32>:word32] @ 100016E1 : word32)
   Class: Eq_854
   DataType: word32
   OrigDataType: word32
-T_855: (in Mem0[dwArg04 + 0x3C<32>:word32] @ 10001707 : word32)
-  Class: Eq_855
+T_855: (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 100016E1 : word32)
+  Class: Eq_851
+  DataType: (ptr32 Eq_851)
+  OrigDataType: word32
+T_856: (in 0<32> @ 100016E9 : word32)
+  Class: Eq_856
   DataType: word32
   OrigDataType: word32
-T_856: (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 10001707 : word32)
-  Class: Eq_852
-  DataType: (ptr32 Eq_852)
-  OrigDataType: word32
-T_857: (in esi_15 @ 1000170F : up32)
+T_857: (in eax_9 + 0<32> @ 100016E9 : word32)
   Class: Eq_857
-  DataType: up32
-  OrigDataType: up32
-T_858: (in 6<32> @ 1000170F : word32)
+  DataType: word32
+  OrigDataType: word32
+T_858: (in Mem0[eax_9 + 0<32>:word32] @ 100016E9 : word32)
   Class: Eq_858
   DataType: word32
   OrigDataType: word32
-T_859: (in ecx_7 + 6<32> @ 1000170F : word32)
-  Class: Eq_859
+T_859: (in 0x4550<32> @ 100016E9 : word32)
+  Class: Eq_858
   DataType: word32
   OrigDataType: word32
-T_860: (in Mem14[ecx_7 + 6<32>:word16] @ 1000170F : word16)
+T_860: (in eax_9->dw0000 != 0x4550<32> @ 00000000 : bool)
   Class: Eq_860
-  DataType: word16
-  OrigDataType: word16
-T_861: (in CONVERT(Mem14[ecx_7 + 6<32>:word16], word16, word32) @ 1000170F : word32)
-  Class: Eq_857
-  DataType: up32
-  OrigDataType: word32
-T_862: (in edx_16 @ 10001713 : up32)
-  Class: Eq_857
-  DataType: up32
-  OrigDataType: up32
-T_863: (in 0<32> @ 10001713 : word32)
-  Class: Eq_857
-  DataType: up32
-  OrigDataType: word32
-T_864: (in eax_22 @ 10001718 : (ptr32 Eq_849))
-  Class: Eq_849
-  DataType: (ptr32 Eq_849)
-  OrigDataType: (ptr32 (struct 0028 (8 up32 dw0008) (C word32 dw000C)))
-T_865: (in 0x14<32> @ 10001718 : word32)
-  Class: Eq_865
-  DataType: word32
-  OrigDataType: word32
-T_866: (in ecx_7 + 0x14<32> @ 10001718 : word32)
-  Class: Eq_866
-  DataType: ptr32
-  OrigDataType: ptr32
-T_867: (in Mem0[ecx_7 + 0x14<32>:word16] @ 10001718 : word16)
-  Class: Eq_867
-  DataType: word16
-  OrigDataType: word16
-T_868: (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) @ 10001718 : word32)
-  Class: Eq_868
-  DataType: word32
-  OrigDataType: word32
-T_869: (in 0x18<32> @ 10001718 : word32)
-  Class: Eq_869
-  DataType: word32
-  OrigDataType: word32
-T_870: (in (word32) ecx_7->w0014 + 0x18<32> @ 00000000 : word32)
-  Class: Eq_870
-  DataType: word32
-  OrigDataType: word32
-T_871: (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) + 0x18<32> + ecx_7 @ 10001718 : word32)
-  Class: Eq_849
-  DataType: (ptr32 Eq_849)
-  OrigDataType: word32
-T_872: (in 0<32> @ 1000171C : word32)
-  Class: Eq_857
-  DataType: up32
-  OrigDataType: up32
-T_873: (in esi_15 <= 0<32> @ 00000000 : bool)
-  Class: Eq_873
   DataType: bool
   OrigDataType: bool
-T_874: (in 0<32> @ 1000173C : word32)
-  Class: Eq_849
-  DataType: (ptr32 Eq_849)
+T_861: (in 0<32> @ 100016DD : word32)
+  Class: Eq_844
+  DataType: uint32
   OrigDataType: word32
-T_875: (in 1<32> @ 10001732 : word32)
+T_862: (in 0x18<32> @ 100016F8 : word32)
+  Class: Eq_862
+  DataType: word32
+  OrigDataType: word32
+T_863: (in eax_9 + 0x18<32> @ 100016F8 : word32)
+  Class: Eq_863
+  DataType: ptr32
+  OrigDataType: ptr32
+T_864: (in Mem0[eax_9 + 0x18<32>:word16] @ 100016F8 : word16)
+  Class: Eq_864
+  DataType: word16
+  OrigDataType: word16
+T_865: (in 0x10B<16> @ 100016F8 : word16)
+  Class: Eq_864
+  DataType: word16
+  OrigDataType: word16
+T_866: (in eax_9->w0018 == 0x10B<16> @ 00000000 : bool)
+  Class: Eq_866
+  DataType: bool
+  OrigDataType: bool
+T_867: (in CONVERT(Mem0[eax_9 + 0x18<32>:word16] == 0x10B<16>, bool, int8) @ 100016F8 : int8)
+  Class: Eq_867
+  DataType: int8
+  OrigDataType: int8
+T_868: (in CONVERT(CONVERT(Mem0[eax_9 + 0x18<32>:word16] == 0x10B<16>, bool, int8), int8, uint32) @ 100016F8 : uint32)
+  Class: Eq_844
+  DataType: uint32
+  OrigDataType: uint32
+T_869: (in eax @ 100016F8 : (ptr32 Eq_869))
+  Class: Eq_869
+  DataType: (ptr32 Eq_869)
+  OrigDataType: word32
+T_870: (in dwArg04 @ 100016F8 : (ptr32 Eq_870))
+  Class: Eq_870
+  DataType: (ptr32 Eq_870)
+  OrigDataType: (ptr32 (struct (3C T_875 t003C)))
+T_871: (in dwArg08 @ 100016F8 : uint32)
+  Class: Eq_871
+  DataType: uint32
+  OrigDataType: up32
+T_872: (in ecx_7 @ 10001707 : (ptr32 Eq_872))
+  Class: Eq_872
+  DataType: (ptr32 Eq_872)
+  OrigDataType: (ptr32 (struct (6 T_880 t0006) (14 T_887 t0014)))
+T_873: (in 0x3C<32> @ 10001707 : word32)
+  Class: Eq_873
+  DataType: word32
+  OrigDataType: word32
+T_874: (in dwArg04 + 0x3C<32> @ 10001707 : word32)
+  Class: Eq_874
+  DataType: word32
+  OrigDataType: word32
+T_875: (in Mem0[dwArg04 + 0x3C<32>:word32] @ 10001707 : word32)
   Class: Eq_875
   DataType: word32
   OrigDataType: word32
-T_876: (in edx_16 + 1<32> @ 00000000 : word32)
-  Class: Eq_857
-  DataType: up32
+T_876: (in Mem0[dwArg04 + 0x3C<32>:word32] + dwArg04 @ 10001707 : word32)
+  Class: Eq_872
+  DataType: (ptr32 Eq_872)
   OrigDataType: word32
-T_877: (in 0x28<32> @ 10001735 : word32)
+T_877: (in esi_15 @ 1000170F : up32)
   Class: Eq_877
-  DataType: word32
-  OrigDataType: word32
-T_878: (in eax_22 + 0x28<32> @ 10001735 : word32)
-  Class: Eq_849
-  DataType: (ptr32 Eq_849)
-  OrigDataType: word32
-T_879: (in edx_16 < esi_15 @ 00000000 : bool)
-  Class: Eq_879
-  DataType: bool
-  OrigDataType: bool
-T_880: (in 8<32> @ 10001730 : word32)
-  Class: Eq_880
-  DataType: word32
-  OrigDataType: word32
-T_881: (in eax_22 + 8<32> @ 10001730 : word32)
-  Class: Eq_881
-  DataType: word32
-  OrigDataType: word32
-T_882: (in Mem21[eax_22 + 8<32>:word32] @ 10001730 : word32)
-  Class: Eq_882
   DataType: up32
   OrigDataType: up32
-T_883: (in ecx_28 @ 10001730 : uint32)
-  Class: Eq_851
-  DataType: uint32
+T_878: (in 6<32> @ 1000170F : word32)
+  Class: Eq_878
+  DataType: word32
+  OrigDataType: word32
+T_879: (in ecx_7 + 6<32> @ 1000170F : word32)
+  Class: Eq_879
+  DataType: word32
+  OrigDataType: word32
+T_880: (in Mem14[ecx_7 + 6<32>:word16] @ 1000170F : word16)
+  Class: Eq_880
+  DataType: word16
+  OrigDataType: word16
+T_881: (in CONVERT(Mem14[ecx_7 + 6<32>:word16], word16, word32) @ 1000170F : word32)
+  Class: Eq_877
+  DataType: up32
+  OrigDataType: word32
+T_882: (in edx_16 @ 10001713 : up32)
+  Class: Eq_877
+  DataType: up32
   OrigDataType: up32
-T_884: (in eax_22->dw0008 + ecx_28 @ 00000000 : word32)
-  Class: Eq_851
-  DataType: uint32
-  OrigDataType: up32
-T_885: (in dwArg08 < eax_22->dw0008 + ecx_28 @ 00000000 : bool)
+T_883: (in 0<32> @ 10001713 : word32)
+  Class: Eq_877
+  DataType: up32
+  OrigDataType: word32
+T_884: (in eax_22 @ 10001718 : (ptr32 Eq_869))
+  Class: Eq_869
+  DataType: (ptr32 Eq_869)
+  OrigDataType: (ptr32 (struct 0028 (8 up32 dw0008) (C word32 dw000C)))
+T_885: (in 0x14<32> @ 10001718 : word32)
   Class: Eq_885
-  DataType: bool
-  OrigDataType: bool
-T_886: (in 0xC<32> @ 10001722 : word32)
+  DataType: word32
+  OrigDataType: word32
+T_886: (in ecx_7 + 0x14<32> @ 10001718 : word32)
   Class: Eq_886
-  DataType: word32
-  OrigDataType: word32
-T_887: (in eax_22 + 0xC<32> @ 10001722 : word32)
+  DataType: ptr32
+  OrigDataType: ptr32
+T_887: (in Mem0[ecx_7 + 0x14<32>:word16] @ 10001718 : word16)
   Class: Eq_887
-  DataType: ptr32
-  OrigDataType: ptr32
-T_888: (in Mem21[eax_22 + 0xC<32>:word32] @ 10001722 : word32)
-  Class: Eq_851
-  DataType: uint32
+  DataType: word16
+  OrigDataType: word16
+T_888: (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) @ 10001718 : word32)
+  Class: Eq_888
+  DataType: word32
   OrigDataType: word32
-T_889: (in dwArg08 < ecx_28 @ 00000000 : bool)
+T_889: (in 0x18<32> @ 10001718 : word32)
   Class: Eq_889
+  DataType: word32
+  OrigDataType: word32
+T_890: (in (word32) ecx_7->w0014 + 0x18<32> @ 00000000 : word32)
+  Class: Eq_890
+  DataType: word32
+  OrigDataType: word32
+T_891: (in CONVERT(Mem0[ecx_7 + 0x14<32>:word16], word16, word32) + 0x18<32> + ecx_7 @ 10001718 : word32)
+  Class: Eq_869
+  DataType: (ptr32 Eq_869)
+  OrigDataType: word32
+T_892: (in 0<32> @ 1000171C : word32)
+  Class: Eq_877
+  DataType: up32
+  OrigDataType: up32
+T_893: (in esi_15 <= 0<32> @ 00000000 : bool)
+  Class: Eq_893
   DataType: bool
   OrigDataType: bool
-T_890: (in eax @ 10001727 : ui32)
-  Class: Eq_890
-  DataType: ui32
+T_894: (in 0<32> @ 1000173C : word32)
+  Class: Eq_869
+  DataType: (ptr32 Eq_869)
   OrigDataType: word32
-T_891: (in eax_59 @ 10001742 : ui32)
-  Class: Eq_890
-  DataType: ui32
-  OrigDataType: ui32
-T_892: (in ebp_13 @ 10001749 : (ptr32 Eq_391))
-  Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: (ptr32 (struct (FFFFFFFC T_897 tFFFFFFFC) (8 T_917 t0008)))
-T_893: (in fn100017E8 @ 10001749 : ptr32)
-  Class: Eq_392
-  DataType: (ptr32 Eq_392)
-  OrigDataType: (ptr32 (fn T_896 (T_370, T_371, T_372, T_894, T_895)))
-T_894: (in dwLoc0C @ 10001749 : word32)
-  Class: Eq_397
+T_895: (in 1<32> @ 10001732 : word32)
+  Class: Eq_895
   DataType: word32
   OrigDataType: word32
-T_895: (in 8<32> @ 10001749 : word32)
-  Class: Eq_398
-  DataType: ui32
+T_896: (in edx_16 + 1<32> @ 00000000 : word32)
+  Class: Eq_877
+  DataType: up32
   OrigDataType: word32
-T_896: (in fn100017E8(ebx, esi, edi, dwLoc0C, 8<32>) @ 10001749 : word32)
-  Class: Eq_391
-  DataType: (ptr32 Eq_391)
-  OrigDataType: word32
-T_897: (in 0<32> @ 1000174E : word32)
-  Class: Eq_410
+T_897: (in 0x28<32> @ 10001735 : word32)
+  Class: Eq_897
   DataType: word32
   OrigDataType: word32
-T_898: (in -4<i32> @ 1000174E : int32)
-  Class: Eq_898
-  DataType: int32
-  OrigDataType: int32
-T_899: (in ebp_13 + -4<i32> @ 1000174E : word32)
+T_898: (in eax_22 + 0x28<32> @ 10001735 : word32)
+  Class: Eq_869
+  DataType: (ptr32 Eq_869)
+  OrigDataType: word32
+T_899: (in edx_16 < esi_15 @ 00000000 : bool)
   Class: Eq_899
-  DataType: word32
-  OrigDataType: word32
-T_900: (in Mem19[ebp_13 + -4<i32>:word32] @ 1000174E : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_901: (in dwLoc0C_84 @ 10001757 : Eq_456)
-  Class: Eq_456
-  DataType: Eq_456
-  OrigDataType: (union (ui32 u0) (ptr32 u1))
-T_902: (in 0x10000000<p32> @ 10001757 : ptr32)
-  Class: Eq_456
-  DataType: ptr32
-  OrigDataType: ptr32
-T_903: (in fn100016D0 @ 10001760 : ptr32)
-  Class: Eq_903
-  DataType: (ptr32 Eq_903)
-  OrigDataType: (ptr32 (fn T_906 (T_905)))
-T_904: (in signature of fn100016D0 @ 100016D0 : void)
-  Class: Eq_903
-  DataType: (ptr32 Eq_903)
-  OrigDataType: 
-T_905: (in 0x10000000<p32> @ 10001760 : ptr32)
-  Class: Eq_825
-  DataType: (ptr32 Eq_825)
-  OrigDataType: ptr32
-T_906: (in fn100016D0(&g_t10000000) @ 10001760 : word32)
-  Class: Eq_906
-  DataType: word32
-  OrigDataType: word32
-T_907: (in 0<32> @ 10001760 : word32)
-  Class: Eq_906
-  DataType: word32
-  OrigDataType: word32
-T_908: (in fn100016D0(&g_t10000000) == 0<32> @ 00000000 : bool)
-  Class: Eq_908
   DataType: bool
   OrigDataType: bool
-T_909: (in 0xFFFFFFFE<32> @ 1000179F : word32)
-  Class: Eq_410
+T_900: (in 8<32> @ 10001730 : word32)
+  Class: Eq_900
   DataType: word32
   OrigDataType: word32
-T_910: (in -4<i32> @ 1000179F : int32)
+T_901: (in eax_22 + 8<32> @ 10001730 : word32)
+  Class: Eq_901
+  DataType: word32
+  OrigDataType: word32
+T_902: (in Mem21[eax_22 + 8<32>:word32] @ 10001730 : word32)
+  Class: Eq_902
+  DataType: up32
+  OrigDataType: up32
+T_903: (in ecx_28 @ 10001730 : uint32)
+  Class: Eq_871
+  DataType: uint32
+  OrigDataType: up32
+T_904: (in eax_22->dw0008 + ecx_28 @ 00000000 : word32)
+  Class: Eq_871
+  DataType: uint32
+  OrigDataType: up32
+T_905: (in dwArg08 < eax_22->dw0008 + ecx_28 @ 00000000 : bool)
+  Class: Eq_905
+  DataType: bool
+  OrigDataType: bool
+T_906: (in 0xC<32> @ 10001722 : word32)
+  Class: Eq_906
+  DataType: word32
+  OrigDataType: word32
+T_907: (in eax_22 + 0xC<32> @ 10001722 : word32)
+  Class: Eq_907
+  DataType: ptr32
+  OrigDataType: ptr32
+T_908: (in Mem21[eax_22 + 0xC<32>:word32] @ 10001722 : word32)
+  Class: Eq_871
+  DataType: uint32
+  OrigDataType: word32
+T_909: (in dwArg08 < ecx_28 @ 00000000 : bool)
+  Class: Eq_909
+  DataType: bool
+  OrigDataType: bool
+T_910: (in eax @ 10001727 : ui32)
   Class: Eq_910
-  DataType: int32
-  OrigDataType: int32
-T_911: (in ebp_13 + -4<i32> @ 1000179F : word32)
-  Class: Eq_911
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_912: (in Mem58[ebp_13 + -4<i32>:word32] @ 1000179F : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_913: (in 0<32> @ 100017A6 : word32)
-  Class: Eq_890
   DataType: ui32
   OrigDataType: word32
-T_914: (in eax_36 @ 10001762 : Eq_138)
-  Class: Eq_138
-  DataType: Eq_138
+T_911: (in eax_59 @ 10001742 : ui32)
+  Class: Eq_910
+  DataType: ui32
   OrigDataType: ui32
-T_915: (in 8<32> @ 10001762 : word32)
-  Class: Eq_915
+T_912: (in ebp_13 @ 10001749 : (ptr32 Eq_411))
+  Class: Eq_411
+  DataType: (ptr32 Eq_411)
+  OrigDataType: (ptr32 (struct (FFFFFFFC T_917 tFFFFFFFC) (8 T_937 t0008)))
+T_913: (in fn100017E8 @ 10001749 : ptr32)
+  Class: Eq_412
+  DataType: (ptr32 Eq_412)
+  OrigDataType: (ptr32 (fn T_916 (T_390, T_391, T_392, T_914, T_915)))
+T_914: (in dwLoc0C @ 10001749 : word32)
+  Class: Eq_417
   DataType: word32
   OrigDataType: word32
-T_916: (in ebp_13 + 8<32> @ 10001762 : word32)
-  Class: Eq_916
+T_915: (in 8<32> @ 10001749 : word32)
+  Class: Eq_418
+  DataType: ui32
+  OrigDataType: word32
+T_916: (in fn100017E8(ebx, esi, edi, dwLoc0C, 8<32>) @ 10001749 : word32)
+  Class: Eq_411
+  DataType: (ptr32 Eq_411)
+  OrigDataType: word32
+T_917: (in 0<32> @ 1000174E : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_918: (in -4<i32> @ 1000174E : int32)
+  Class: Eq_918
+  DataType: int32
+  OrigDataType: int32
+T_919: (in ebp_13 + -4<i32> @ 1000174E : word32)
+  Class: Eq_919
+  DataType: word32
+  OrigDataType: word32
+T_920: (in Mem19[ebp_13 + -4<i32>:word32] @ 1000174E : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_921: (in dwLoc0C_84 @ 10001757 : Eq_476)
+  Class: Eq_476
+  DataType: Eq_476
+  OrigDataType: (union (ui32 u0) (ptr32 u1))
+T_922: (in 0x10000000<p32> @ 10001757 : ptr32)
+  Class: Eq_476
   DataType: ptr32
   OrigDataType: ptr32
-T_917: (in Mem24[ebp_13 + 8<32>:word32] @ 10001762 : word32)
-  Class: Eq_138
-  DataType: Eq_138
+T_923: (in fn100016D0 @ 10001760 : ptr32)
+  Class: Eq_923
+  DataType: (ptr32 Eq_923)
+  OrigDataType: (ptr32 (fn T_926 (T_925)))
+T_924: (in signature of fn100016D0 @ 100016D0 : void)
+  Class: Eq_923
+  DataType: (ptr32 Eq_923)
+  OrigDataType: 
+T_925: (in 0x10000000<p32> @ 10001760 : ptr32)
+  Class: Eq_845
+  DataType: (ptr32 Eq_845)
+  OrigDataType: ptr32
+T_926: (in fn100016D0(&g_t10000000) @ 10001760 : word32)
+  Class: Eq_926
+  DataType: word32
   OrigDataType: word32
-T_918: (in 0x10000000<p32> @ 10001767 : ptr32)
-  Class: Eq_918
+T_927: (in 0<32> @ 10001760 : word32)
+  Class: Eq_926
+  DataType: word32
+  OrigDataType: word32
+T_928: (in fn100016D0(&g_t10000000) == 0<32> @ 00000000 : bool)
+  Class: Eq_928
+  DataType: bool
+  OrigDataType: bool
+T_929: (in 0xFFFFFFFE<32> @ 1000179F : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_930: (in -4<i32> @ 1000179F : int32)
+  Class: Eq_930
+  DataType: int32
+  OrigDataType: int32
+T_931: (in ebp_13 + -4<i32> @ 1000179F : word32)
+  Class: Eq_931
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_932: (in Mem58[ebp_13 + -4<i32>:word32] @ 1000179F : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_933: (in 0<32> @ 100017A6 : word32)
+  Class: Eq_910
+  DataType: ui32
+  OrigDataType: word32
+T_934: (in eax_36 @ 10001762 : Eq_158)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: ui32
+T_935: (in 8<32> @ 10001762 : word32)
+  Class: Eq_935
+  DataType: word32
+  OrigDataType: word32
+T_936: (in ebp_13 + 8<32> @ 10001762 : word32)
+  Class: Eq_936
+  DataType: ptr32
+  OrigDataType: ptr32
+T_937: (in Mem24[ebp_13 + 8<32>:word32] @ 10001762 : word32)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: word32
+T_938: (in 0x10000000<p32> @ 10001767 : ptr32)
+  Class: Eq_938
   DataType: ui32
   OrigDataType: (union (ui32 u0) (ptr32 u1))
-T_919: (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
-  Class: Eq_456
-  DataType: Eq_456
+T_939: (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
+  Class: Eq_476
+  DataType: Eq_476
   OrigDataType: ui32
-T_920: (in eax_43 @ 10001769 : (ptr32 Eq_920))
-  Class: Eq_920
-  DataType: (ptr32 Eq_920)
-  OrigDataType: (ptr32 (struct (24 T_930 t0024)))
-T_921: (in fn10001700 @ 10001769 : ptr32)
-  Class: Eq_921
-  DataType: (ptr32 Eq_921)
-  OrigDataType: (ptr32 (fn T_925 (T_923, T_924)))
-T_922: (in signature of fn10001700 @ 10001700 : void)
-  Class: Eq_921
-  DataType: (ptr32 Eq_921)
+T_940: (in eax_43 @ 10001769 : (ptr32 Eq_940))
+  Class: Eq_940
+  DataType: (ptr32 Eq_940)
+  OrigDataType: (ptr32 (struct (24 T_950 t0024)))
+T_941: (in fn10001700 @ 10001769 : ptr32)
+  Class: Eq_941
+  DataType: (ptr32 Eq_941)
+  OrigDataType: (ptr32 (fn T_945 (T_943, T_944)))
+T_942: (in signature of fn10001700 @ 10001700 : void)
+  Class: Eq_941
+  DataType: (ptr32 Eq_941)
   OrigDataType: 
-T_923: (in 0x10000000<p32> @ 10001769 : ptr32)
-  Class: Eq_850
-  DataType: (ptr32 Eq_850)
+T_943: (in 0x10000000<p32> @ 10001769 : ptr32)
+  Class: Eq_870
+  DataType: (ptr32 Eq_870)
   OrigDataType: ptr32
-T_924: (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
-  Class: Eq_851
+T_944: (in eax_36 - 0x10000000<p32> @ 00000000 : word32)
+  Class: Eq_871
   DataType: uint32
   OrigDataType: ui32
-T_925: (in fn10001700(&g_t10000000, eax_36 - 0x10000000<p32>) @ 10001769 : word32)
-  Class: Eq_920
-  DataType: (ptr32 Eq_920)
+T_945: (in fn10001700(&g_t10000000, eax_36 - 0x10000000<p32>) @ 10001769 : word32)
+  Class: Eq_940
+  DataType: (ptr32 Eq_940)
   OrigDataType: word32
-T_926: (in 0<32> @ 10001772 : word32)
-  Class: Eq_920
-  DataType: (ptr32 Eq_920)
+T_946: (in 0<32> @ 10001772 : word32)
+  Class: Eq_940
+  DataType: (ptr32 Eq_940)
   OrigDataType: word32
-T_927: (in eax_43 == null @ 00000000 : bool)
-  Class: Eq_927
+T_947: (in eax_43 == null @ 00000000 : bool)
+  Class: Eq_947
   DataType: bool
   OrigDataType: bool
-T_928: (in 0x24<32> @ 1000177C : word32)
-  Class: Eq_928
+T_948: (in 0x24<32> @ 1000177C : word32)
+  Class: Eq_948
   DataType: word32
   OrigDataType: word32
-T_929: (in eax_43 + 0x24<32> @ 1000177C : word32)
-  Class: Eq_929
-  DataType: word32
-  OrigDataType: word32
-T_930: (in Mem42[eax_43 + 0x24<32>:word32] @ 1000177C : word32)
-  Class: Eq_930
-  DataType: uint32
-  OrigDataType: uint32
-T_931: (in 0x1F<32> @ 1000177C : word32)
-  Class: Eq_931
-  DataType: word32
-  OrigDataType: word32
-T_932: (in eax_43->dw0024 >> 0x1F<32> @ 00000000 : word32)
-  Class: Eq_932
-  DataType: uint32
-  OrigDataType: uint32
-T_933: (in ~(eax_43->dw0024 >> 0x1F<32>) @ 1000177C : word32)
-  Class: Eq_933
-  DataType: uint32
-  OrigDataType: uint32
-T_934: (in 1<32> @ 1000177C : word32)
-  Class: Eq_934
-  DataType: ui32
-  OrigDataType: ui32
-T_935: (in ~(eax_43->dw0024 >> 0x1F<32>) & 1<32> @ 00000000 : word32)
-  Class: Eq_890
-  DataType: ui32
-  OrigDataType: ui32
-T_936: (in 0xFFFFFFFE<32> @ 1000177F : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_937: (in -4<i32> @ 1000177F : int32)
-  Class: Eq_937
-  DataType: int32
-  OrigDataType: int32
-T_938: (in ebp_13 + -4<i32> @ 1000177F : word32)
-  Class: Eq_938
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 word32)
-T_939: (in Mem68[ebp_13 + -4<i32>:word32] @ 1000177F : word32)
-  Class: Eq_410
-  DataType: word32
-  OrigDataType: word32
-T_940: (in fn1000182D @ 100017AD : ptr32)
-  Class: Eq_453
-  DataType: (ptr32 Eq_453)
-  OrigDataType: (ptr32 (fn T_941 (T_892, T_901)))
-T_941: (in fn1000182D(ebp_13, dwLoc0C_84) @ 100017AD : word32)
-  Class: Eq_373
-  DataType: ptr32
-  OrigDataType: word32
-T_942: (in eax @ 100017AD : word32)
-  Class: Eq_942
-  DataType: word32
-  OrigDataType: word32
-T_943: (in 1<32> @ 100017CB : word32)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: word32
-T_944: (in dwArg08 != 1<32> @ 00000000 : bool)
-  Class: Eq_944
-  DataType: bool
-  OrigDataType: bool
-T_945: (in 1<32> @ 100017E3 : word32)
-  Class: Eq_942
-  DataType: word32
-  OrigDataType: word32
-T_946: (in 100020CC @ 100017D4 : ptr32)
-  Class: Eq_946
-  DataType: (ptr32 word32)
-  OrigDataType: (ptr32 (struct (0 T_947 t0000)))
-T_947: (in Mem0[0x100020CC<p32>:word32] @ 100017D4 : word32)
-  Class: Eq_462
-  DataType: word32
-  OrigDataType: word32
-T_948: (in 0<32> @ 100017D4 : word32)
-  Class: Eq_462
-  DataType: word32
-  OrigDataType: word32
-T_949: (in g_dw100020CC != 0<32> @ 00000000 : bool)
+T_949: (in eax_43 + 0x24<32> @ 1000177C : word32)
   Class: Eq_949
-  DataType: bool
-  OrigDataType: bool
-T_950: (in DisableThreadLibraryCalls @ 100017DA : ptr32)
-  Class: Eq_950
-  DataType: (ptr32 Eq_950)
-  OrigDataType: (ptr32 (fn T_953 (T_482)))
-T_951: (in signature of DisableThreadLibraryCalls @ 00000000 : void)
-  Class: Eq_950
-  DataType: (ptr32 Eq_950)
-  OrigDataType: 
-T_952: (in hLibModule @ 100017DA : HMODULE)
-  Class: Eq_138
-  DataType: Eq_138
-  OrigDataType: 
-T_953: (in DisableThreadLibraryCalls(dwArg04) @ 100017DA : BOOL)
-  Class: Eq_660
-  DataType: Eq_660
-  OrigDataType: BOOL
-T_954: (in ebp @ 100017DA : ptr32)
-  Class: Eq_954
-  DataType: ptr32
+  DataType: word32
   OrigDataType: word32
-T_955: (in esp_14 @ 10001800 : (ptr32 Eq_955))
-  Class: Eq_955
-  DataType: (ptr32 Eq_955)
-  OrigDataType: (ptr32 (struct (FFFFFFEC T_979 tFFFFFFEC) (FFFFFFF0 T_976 tFFFFFFF0) (FFFFFFF4 T_968 tFFFFFFF4) (FFFFFFF8 T_965 tFFFFFFF8) (FFFFFFFC T_962 tFFFFFFFC)))
-T_956: (in fp @ 10001800 : ptr32)
-  Class: Eq_956
-  DataType: ptr32
-  OrigDataType: ptr32
-T_957: (in 8<i32> @ 10001800 : int32)
+T_950: (in Mem42[eax_43 + 0x24<32>:word32] @ 1000177C : word32)
+  Class: Eq_950
+  DataType: uint32
+  OrigDataType: uint32
+T_951: (in 0x1F<32> @ 1000177C : word32)
+  Class: Eq_951
+  DataType: word32
+  OrigDataType: word32
+T_952: (in eax_43->dw0024 >> 0x1F<32> @ 00000000 : word32)
+  Class: Eq_952
+  DataType: uint32
+  OrigDataType: uint32
+T_953: (in ~(eax_43->dw0024 >> 0x1F<32>) @ 1000177C : word32)
+  Class: Eq_953
+  DataType: uint32
+  OrigDataType: uint32
+T_954: (in 1<32> @ 1000177C : word32)
+  Class: Eq_954
+  DataType: ui32
+  OrigDataType: ui32
+T_955: (in ~(eax_43->dw0024 >> 0x1F<32>) & 1<32> @ 00000000 : word32)
+  Class: Eq_910
+  DataType: ui32
+  OrigDataType: ui32
+T_956: (in 0xFFFFFFFE<32> @ 1000177F : word32)
+  Class: Eq_430
+  DataType: word32
+  OrigDataType: word32
+T_957: (in -4<i32> @ 1000177F : int32)
   Class: Eq_957
   DataType: int32
   OrigDataType: int32
-T_958: (in fp - 8<i32> @ 00000000 : word32)
+T_958: (in ebp_13 + -4<i32> @ 1000177F : word32)
   Class: Eq_958
-  DataType: ptr32
-  OrigDataType: ptr32
-T_959: (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
-  Class: Eq_955
-  DataType: (ptr32 Eq_955)
-  OrigDataType: ptr32
-T_960: (in -4<i32> @ 10001802 : int32)
-  Class: Eq_960
-  DataType: int32
-  OrigDataType: int32
-T_961: (in esp_14 + -4<i32> @ 10001802 : word32)
-  Class: Eq_961
-  DataType: ptr32
-  OrigDataType: ptr32
-T_962: (in Mem17[esp_14 + -4<i32>:word32] @ 10001802 : word32)
-  Class: Eq_183
-  DataType: (ptr32 Eq_183)
-  OrigDataType: word32
-T_963: (in -8<i32> @ 10001803 : int32)
-  Class: Eq_963
-  DataType: int32
-  OrigDataType: int32
-T_964: (in esp_14 + -8<i32> @ 10001803 : word32)
-  Class: Eq_964
-  DataType: ptr32
-  OrigDataType: ptr32
-T_965: (in Mem20[esp_14 + -8<i32>:word32] @ 10001803 : word32)
-  Class: Eq_371
-  DataType: ptr32
-  OrigDataType: word32
-T_966: (in -12<i32> @ 10001804 : int32)
-  Class: Eq_966
-  DataType: int32
-  OrigDataType: int32
-T_967: (in esp_14 + -12<i32> @ 10001804 : word32)
-  Class: Eq_967
-  DataType: ptr32
-  OrigDataType: ptr32
-T_968: (in Mem23[esp_14 + -12<i32>:word32] @ 10001804 : word32)
-  Class: Eq_372
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 word32)
+T_959: (in Mem68[ebp_13 + -4<i32>:word32] @ 1000177F : word32)
+  Class: Eq_430
   DataType: word32
   OrigDataType: word32
-T_969: (in 10003000 @ 1000180F : ptr32)
+T_960: (in fn1000182D @ 100017AD : ptr32)
+  Class: Eq_473
+  DataType: (ptr32 Eq_473)
+  OrigDataType: (ptr32 (fn T_961 (T_912, T_921)))
+T_961: (in fn1000182D(ebp_13, dwLoc0C_84) @ 100017AD : word32)
+  Class: Eq_393
+  DataType: ptr32
+  OrigDataType: word32
+T_962: (in eax @ 100017AD : word32)
+  Class: Eq_962
+  DataType: word32
+  OrigDataType: word32
+T_963: (in 1<32> @ 100017CB : word32)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: word32
+T_964: (in dwArg08 != 1<32> @ 00000000 : bool)
+  Class: Eq_964
+  DataType: bool
+  OrigDataType: bool
+T_965: (in 1<32> @ 100017E3 : word32)
+  Class: Eq_962
+  DataType: word32
+  OrigDataType: word32
+T_966: (in 100020CC @ 100017D4 : ptr32)
+  Class: Eq_966
+  DataType: (ptr32 word32)
+  OrigDataType: (ptr32 (struct (0 T_967 t0000)))
+T_967: (in Mem0[0x100020CC<p32>:word32] @ 100017D4 : word32)
+  Class: Eq_482
+  DataType: word32
+  OrigDataType: word32
+T_968: (in 0<32> @ 100017D4 : word32)
+  Class: Eq_482
+  DataType: word32
+  OrigDataType: word32
+T_969: (in g_dw100020CC != 0<32> @ 00000000 : bool)
   Class: Eq_969
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_970 t0000)))
-T_970: (in Mem23[0x10003000<p32>:word32] @ 1000180F : word32)
+  DataType: bool
+  OrigDataType: bool
+T_970: (in DisableThreadLibraryCalls @ 100017DA : ptr32)
   Class: Eq_970
-  DataType: ui32
-  OrigDataType: word32
-T_971: (in 8<32> @ 1000180F : word32)
-  Class: Eq_971
-  DataType: int32
-  OrigDataType: int32
-T_972: (in fp + 8<32> @ 00000000 : word32)
-  Class: Eq_972
-  DataType: ptr32
-  OrigDataType: ptr32
-T_973: (in g_dw10003000 ^ fp + 8<32> @ 00000000 : word32)
-  Class: Eq_973
-  DataType: ui32
-  OrigDataType: ui32
-T_974: (in -16<i32> @ 1000180F : int32)
+  DataType: (ptr32 Eq_970)
+  OrigDataType: (ptr32 (fn T_973 (T_502)))
+T_971: (in signature of DisableThreadLibraryCalls @ 00000000 : void)
+  Class: Eq_970
+  DataType: (ptr32 Eq_970)
+  OrigDataType: 
+T_972: (in hLibModule @ 100017DA : HMODULE)
+  Class: Eq_158
+  DataType: Eq_158
+  OrigDataType: 
+T_973: (in DisableThreadLibraryCalls(dwArg04) @ 100017DA : BOOL)
+  Class: Eq_680
+  DataType: Eq_680
+  OrigDataType: BOOL
+T_974: (in ebp @ 100017DA : ptr32)
   Class: Eq_974
-  DataType: int32
-  OrigDataType: int32
-T_975: (in esp_14 + -16<i32> @ 1000180F : word32)
+  DataType: ptr32
+  OrigDataType: word32
+T_975: (in esp_14 @ 10001800 : (ptr32 Eq_975))
   Class: Eq_975
+  DataType: (ptr32 Eq_975)
+  OrigDataType: (ptr32 (struct (FFFFFFEC T_999 tFFFFFFEC) (FFFFFFF0 T_996 tFFFFFFF0) (FFFFFFF4 T_988 tFFFFFFF4) (FFFFFFF8 T_985 tFFFFFFF8) (FFFFFFFC T_982 tFFFFFFFC)))
+T_976: (in fp @ 10001800 : ptr32)
+  Class: Eq_976
   DataType: ptr32
   OrigDataType: ptr32
-T_976: (in Mem32[esp_14 + -16<i32>:word32] @ 1000180F : word32)
-  Class: Eq_973
-  DataType: ui32
-  OrigDataType: word32
-T_977: (in -20<i32> @ 10001813 : int32)
+T_977: (in 8<i32> @ 10001800 : int32)
   Class: Eq_977
   DataType: int32
   OrigDataType: int32
-T_978: (in esp_14 + -20<i32> @ 10001813 : word32)
+T_978: (in fp - 8<i32> @ 00000000 : word32)
   Class: Eq_978
   DataType: ptr32
   OrigDataType: ptr32
-T_979: (in Mem36[esp_14 + -20<i32>:word32] @ 10001813 : word32)
-  Class: Eq_397
-  DataType: word32
-  OrigDataType: word32
-T_980: (in 8<32> @ 10001826 : word32)
+T_979: (in fp - 8<i32> - dwArg08 @ 00000000 : word32)
+  Class: Eq_975
+  DataType: (ptr32 Eq_975)
+  OrigDataType: ptr32
+T_980: (in -4<i32> @ 10001802 : int32)
   Class: Eq_980
-  DataType: ui32
-  OrigDataType: ui32
-T_981: (in fp - 8<32> @ 00000000 : word32)
-  Class: Eq_981
-  DataType: ptr32
-  OrigDataType: ptr32
-T_982: (in fs @ 10001826 : selector)
-  Class: Eq_982
-  DataType: (ptr32 Eq_982)
-  OrigDataType: (ptr32 (segment (0 T_984 t0000)))
-T_983: (in 0<32> @ 10001826 : word32)
-  Class: Eq_983
-  DataType: (memptr (ptr32 Eq_982) ptr32)
-  OrigDataType: (memptr T_982 (struct (0 T_984 t0000)))
-T_984: (in Mem41[fs:0<32>:word32] @ 10001826 : word32)
-  Class: Eq_981
-  DataType: ptr32
-  OrigDataType: word32
-T_985: (in fp + 8<32> @ 00000000 : word32)
-  Class: Eq_954
-  DataType: ptr32
-  OrigDataType: ptr32
-T_986: (in edi @ 1000182C : word32)
-  Class: Eq_986
-  DataType: word32
-  OrigDataType: word32
-T_987: (in -16<i32> @ 10001830 : int32)
-  Class: Eq_987
   DataType: int32
   OrigDataType: int32
-T_988: (in ebp + -16<i32> @ 10001830 : word32)
-  Class: Eq_988
-  DataType: word32
-  OrigDataType: word32
-T_989: (in Mem0[ebp + -16<i32>:word32] @ 10001830 : word32)
-  Class: Eq_989
-  DataType: word32
-  OrigDataType: word32
-T_990: (in fs @ 10001830 : selector)
-  Class: Eq_990
-  DataType: (ptr32 Eq_990)
-  OrigDataType: (ptr32 (segment (0 T_992 t0000)))
-T_991: (in 0x00000000<p32> @ 10001830 : ptr32)
-  Class: Eq_991
-  DataType: Eq_991
-  OrigDataType: (union (ptr32 u0) ((memptr T_990 (struct (0 word32 dw0000))) u1))
-T_992: (in Mem8[fs:0x00000000<p32>:word32] @ 10001830 : word32)
-  Class: Eq_989
-  DataType: word32
-  OrigDataType: word32
-T_993: (in 0<32> @ 1000183F : word32)
-  Class: Eq_993
-  DataType: word32
-  OrigDataType: word32
-T_994: (in ebp + 0<32> @ 1000183F : word32)
-  Class: Eq_994
+T_981: (in esp_14 + -4<i32> @ 10001802 : word32)
+  Class: Eq_981
   DataType: ptr32
   OrigDataType: ptr32
-T_995: (in Mem22[ebp + 0<32>:word32] @ 1000183F : word32)
-  Class: Eq_456
-  DataType: Eq_456
+T_982: (in Mem17[esp_14 + -4<i32>:word32] @ 10001802 : word32)
+  Class: Eq_203
+  DataType: (ptr32 Eq_203)
   OrigDataType: word32
-T_996: (in dwArg08 @ 10001840 : word32)
+T_983: (in -8<i32> @ 10001803 : int32)
+  Class: Eq_983
+  DataType: int32
+  OrigDataType: int32
+T_984: (in esp_14 + -8<i32> @ 10001803 : word32)
+  Class: Eq_984
+  DataType: ptr32
+  OrigDataType: ptr32
+T_985: (in Mem20[esp_14 + -8<i32>:word32] @ 10001803 : word32)
+  Class: Eq_391
+  DataType: ptr32
+  OrigDataType: word32
+T_986: (in -12<i32> @ 10001804 : int32)
   Class: Eq_986
+  DataType: int32
+  OrigDataType: int32
+T_987: (in esp_14 + -12<i32> @ 10001804 : word32)
+  Class: Eq_987
+  DataType: ptr32
+  OrigDataType: ptr32
+T_988: (in Mem23[esp_14 + -12<i32>:word32] @ 10001804 : word32)
+  Class: Eq_392
   DataType: word32
   OrigDataType: word32
-T_997: (in eax_9 @ 1000186A : ui32)
-  Class: Eq_970
+T_989: (in 10003000 @ 1000180F : ptr32)
+  Class: Eq_989
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_990 t0000)))
+T_990: (in Mem23[0x10003000<p32>:word32] @ 1000180F : word32)
+  Class: Eq_990
+  DataType: ui32
+  OrigDataType: word32
+T_991: (in 8<32> @ 1000180F : word32)
+  Class: Eq_991
+  DataType: int32
+  OrigDataType: int32
+T_992: (in fp + 8<32> @ 00000000 : word32)
+  Class: Eq_992
+  DataType: ptr32
+  OrigDataType: ptr32
+T_993: (in g_dw10003000 ^ fp + 8<32> @ 00000000 : word32)
+  Class: Eq_993
   DataType: ui32
   OrigDataType: ui32
-T_998: (in 10003000 @ 1000186A : ptr32)
+T_994: (in -16<i32> @ 1000180F : int32)
+  Class: Eq_994
+  DataType: int32
+  OrigDataType: int32
+T_995: (in esp_14 + -16<i32> @ 1000180F : word32)
+  Class: Eq_995
+  DataType: ptr32
+  OrigDataType: ptr32
+T_996: (in Mem32[esp_14 + -16<i32>:word32] @ 1000180F : word32)
+  Class: Eq_993
+  DataType: ui32
+  OrigDataType: word32
+T_997: (in -20<i32> @ 10001813 : int32)
+  Class: Eq_997
+  DataType: int32
+  OrigDataType: int32
+T_998: (in esp_14 + -20<i32> @ 10001813 : word32)
   Class: Eq_998
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_999 t0000)))
-T_999: (in Mem6[0x10003000<p32>:word32] @ 1000186A : word32)
-  Class: Eq_970
-  DataType: ui32
+  DataType: ptr32
+  OrigDataType: ptr32
+T_999: (in Mem36[esp_14 + -20<i32>:word32] @ 10001813 : word32)
+  Class: Eq_417
+  DataType: word32
   OrigDataType: word32
-T_1000: (in 0xBB40E64E<32> @ 10001885 : word32)
-  Class: Eq_970
+T_1000: (in 8<32> @ 10001826 : word32)
+  Class: Eq_1000
   DataType: ui32
-  OrigDataType: word32
-T_1001: (in eax_9 == 0xBB40E64E<32> @ 00000000 : bool)
+  OrigDataType: ui32
+T_1001: (in fp - 8<32> @ 00000000 : word32)
   Class: Eq_1001
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1002: (in fs @ 10001826 : selector)
+  Class: Eq_1002
+  DataType: (ptr32 Eq_1002)
+  OrigDataType: (ptr32 (segment (0 T_1004 t0000)))
+T_1003: (in 0<32> @ 10001826 : word32)
+  Class: Eq_1003
+  DataType: (memptr (ptr32 Eq_1002) ptr32)
+  OrigDataType: (memptr T_1002 (struct (0 T_1004 t0000)))
+T_1004: (in Mem41[fs:0<32>:word32] @ 10001826 : word32)
+  Class: Eq_1001
+  DataType: ptr32
+  OrigDataType: word32
+T_1005: (in fp + 8<32> @ 00000000 : word32)
+  Class: Eq_974
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1006: (in edi @ 1000182C : word32)
+  Class: Eq_1006
+  DataType: word32
+  OrigDataType: word32
+T_1007: (in -16<i32> @ 10001830 : int32)
+  Class: Eq_1007
+  DataType: int32
+  OrigDataType: int32
+T_1008: (in ebp + -16<i32> @ 10001830 : word32)
+  Class: Eq_1008
+  DataType: word32
+  OrigDataType: word32
+T_1009: (in Mem0[ebp + -16<i32>:word32] @ 10001830 : word32)
+  Class: Eq_1009
+  DataType: word32
+  OrigDataType: word32
+T_1010: (in fs @ 10001830 : selector)
+  Class: Eq_1010
+  DataType: (ptr32 Eq_1010)
+  OrigDataType: (ptr32 (segment (0 T_1012 t0000)))
+T_1011: (in 0x00000000<p32> @ 10001830 : ptr32)
+  Class: Eq_1011
+  DataType: Eq_1011
+  OrigDataType: (union (ptr32 u0) ((memptr T_1010 (struct (0 word32 dw0000))) u1))
+T_1012: (in Mem8[fs:0x00000000<p32>:word32] @ 10001830 : word32)
+  Class: Eq_1009
+  DataType: word32
+  OrigDataType: word32
+T_1013: (in 0<32> @ 1000183F : word32)
+  Class: Eq_1013
+  DataType: word32
+  OrigDataType: word32
+T_1014: (in ebp + 0<32> @ 1000183F : word32)
+  Class: Eq_1014
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1015: (in Mem22[ebp + 0<32>:word32] @ 1000183F : word32)
+  Class: Eq_476
+  DataType: Eq_476
+  OrigDataType: word32
+T_1016: (in dwArg08 @ 10001840 : word32)
+  Class: Eq_1006
+  DataType: word32
+  OrigDataType: word32
+T_1017: (in eax_9 @ 1000186A : ui32)
+  Class: Eq_990
+  DataType: ui32
+  OrigDataType: ui32
+T_1018: (in 10003000 @ 1000186A : ptr32)
+  Class: Eq_1018
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1019 t0000)))
+T_1019: (in Mem6[0x10003000<p32>:word32] @ 1000186A : word32)
+  Class: Eq_990
+  DataType: ui32
+  OrigDataType: word32
+T_1020: (in 0xBB40E64E<32> @ 10001885 : word32)
+  Class: Eq_990
+  DataType: ui32
+  OrigDataType: word32
+T_1021: (in eax_9 == 0xBB40E64E<32> @ 00000000 : bool)
+  Class: Eq_1021
   DataType: bool
   OrigDataType: bool
-T_1002: (in GetSystemTimeAsFileTime @ 10001899 : ptr32)
-  Class: Eq_1002
-  DataType: (ptr32 Eq_1002)
-  OrigDataType: (ptr32 (fn T_1008 (T_1007)))
-T_1003: (in signature of GetSystemTimeAsFileTime @ 00000000 : void)
-  Class: Eq_1002
-  DataType: (ptr32 Eq_1002)
+T_1022: (in GetSystemTimeAsFileTime @ 10001899 : ptr32)
+  Class: Eq_1022
+  DataType: (ptr32 Eq_1022)
+  OrigDataType: (ptr32 (fn T_1028 (T_1027)))
+T_1023: (in signature of GetSystemTimeAsFileTime @ 00000000 : void)
+  Class: Eq_1022
+  DataType: (ptr32 Eq_1022)
   OrigDataType: 
-T_1004: (in lpSystemTimeAsFileTime @ 10001899 : LPFILETIME)
-  Class: Eq_1004
-  DataType: Eq_1004
+T_1024: (in lpSystemTimeAsFileTime @ 10001899 : LPFILETIME)
+  Class: Eq_1024
+  DataType: Eq_1024
   OrigDataType: 
-T_1005: (in fp @ 10001899 : ptr32)
-  Class: Eq_1005
+T_1025: (in fp @ 10001899 : ptr32)
+  Class: Eq_1025
   DataType: ptr32
   OrigDataType: ptr32
-T_1006: (in 0xC<32> @ 10001899 : word32)
-  Class: Eq_1006
+T_1026: (in 0xC<32> @ 10001899 : word32)
+  Class: Eq_1026
   DataType: ui32
   OrigDataType: ui32
-T_1007: (in fp - 0xC<32> @ 00000000 : word32)
-  Class: Eq_1004
-  DataType: Eq_1004
+T_1027: (in fp - 0xC<32> @ 00000000 : word32)
+  Class: Eq_1024
+  DataType: Eq_1024
   OrigDataType: LPFILETIME
-T_1008: (in GetSystemTimeAsFileTime(fp - 0xC<32>) @ 10001899 : void)
-  Class: Eq_1008
+T_1028: (in GetSystemTimeAsFileTime(fp - 0xC<32>) @ 10001899 : void)
+  Class: Eq_1028
   DataType: void
   OrigDataType: void
-T_1009: (in esi_46 @ 100018BB : ui32)
-  Class: Eq_1009
-  DataType: ui32
-  OrigDataType: ui32
-T_1010: (in GetCurrentProcessId @ 100018BB : ptr32)
-  Class: Eq_1010
-  DataType: (ptr32 Eq_1010)
-  OrigDataType: (ptr32 (fn T_1012 ()))
-T_1011: (in signature of GetCurrentProcessId @ 00000000 : void)
-  Class: Eq_1010
-  DataType: (ptr32 Eq_1010)
-  OrigDataType: 
-T_1012: (in GetCurrentProcessId() @ 100018BB : DWORD)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_1013: (in GetCurrentThreadId @ 100018BB : ptr32)
-  Class: Eq_1013
-  DataType: (ptr32 Eq_1013)
-  OrigDataType: (ptr32 (fn T_1015 ()))
-T_1014: (in signature of GetCurrentThreadId @ 00000000 : void)
-  Class: Eq_1013
-  DataType: (ptr32 Eq_1013)
-  OrigDataType: 
-T_1015: (in GetCurrentThreadId() @ 100018BB : DWORD)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_1016: (in GetCurrentProcessId() ^ GetCurrentThreadId() @ 00000000 : word32)
-  Class: Eq_1016
-  DataType: ui32
-  OrigDataType: ui32
-T_1017: (in GetTickCount @ 100018BB : ptr32)
-  Class: Eq_1017
-  DataType: (ptr32 Eq_1017)
-  OrigDataType: (ptr32 (fn T_1019 ()))
-T_1018: (in signature of GetTickCount @ 00000000 : void)
-  Class: Eq_1017
-  DataType: (ptr32 Eq_1017)
-  OrigDataType: 
-T_1019: (in GetTickCount() @ 100018BB : DWORD)
-  Class: Eq_139
-  DataType: Eq_139
-  OrigDataType: DWORD
-T_1020: (in GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount() @ 00000000 : word32)
-  Class: Eq_1009
-  DataType: ui32
-  OrigDataType: ui32
-T_1021: (in QueryPerformanceCounter @ 100018C1 : ptr32)
-  Class: Eq_1021
-  DataType: (ptr32 Eq_1021)
-  OrigDataType: (ptr32 (fn T_1026 (T_1025)))
-T_1022: (in signature of QueryPerformanceCounter @ 00000000 : void)
-  Class: Eq_1021
-  DataType: (ptr32 Eq_1021)
-  OrigDataType: 
-T_1023: (in lpPerformanceCount @ 100018C1 : (ptr32 LARGE_INTEGER))
-  Class: Eq_1023
-  DataType: (ptr32 Eq_1023)
-  OrigDataType: 
-T_1024: (in 0x14<32> @ 100018C1 : word32)
-  Class: Eq_1024
-  DataType: ui32
-  OrigDataType: ui32
-T_1025: (in fp - 0x14<32> @ 00000000 : word32)
-  Class: Eq_1023
-  DataType: (ptr32 Eq_1023)
-  OrigDataType: (ptr32 LARGE_INTEGER)
-T_1026: (in QueryPerformanceCounter(fp - 0x14<32>) @ 100018C1 : BOOL)
-  Class: Eq_660
-  DataType: Eq_660
-  OrigDataType: BOOL
-T_1027: (in esi_54 @ 100018CD : ui32)
-  Class: Eq_970
-  DataType: ui32
-  OrigDataType: ui32
-T_1028: (in dwLoc10 @ 100018CD : word32)
-  Class: Eq_1028
-  DataType: word32
-  OrigDataType: word32
-T_1029: (in dwLoc14 @ 100018CD : word32)
+T_1029: (in esi_46 @ 100018BB : ui32)
   Class: Eq_1029
-  DataType: word32
-  OrigDataType: word32
-T_1030: (in dwLoc10 ^ dwLoc14 @ 00000000 : word32)
+  DataType: ui32
+  OrigDataType: ui32
+T_1030: (in GetCurrentProcessId @ 100018BB : ptr32)
   Class: Eq_1030
-  DataType: ui32
-  OrigDataType: ui32
-T_1031: (in esi_46 ^ (dwLoc10 ^ dwLoc14) @ 00000000 : word32)
-  Class: Eq_970
-  DataType: ui32
-  OrigDataType: ui32
-T_1032: (in 0xBB40E64E<32> @ 100018D1 : word32)
-  Class: Eq_970
-  DataType: ui32
-  OrigDataType: word32
-T_1033: (in esi_54 != 0xBB40E64E<32> @ 00000000 : bool)
+  DataType: (ptr32 Eq_1030)
+  OrigDataType: (ptr32 (fn T_1032 ()))
+T_1031: (in signature of GetCurrentProcessId @ 00000000 : void)
+  Class: Eq_1030
+  DataType: (ptr32 Eq_1030)
+  OrigDataType: 
+T_1032: (in GetCurrentProcessId() @ 100018BB : DWORD)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_1033: (in GetCurrentThreadId @ 100018BB : ptr32)
   Class: Eq_1033
-  DataType: bool
-  OrigDataType: bool
-T_1034: (in 0xFFFF0000<32> @ 10001889 : word32)
-  Class: Eq_1034
+  DataType: (ptr32 Eq_1033)
+  OrigDataType: (ptr32 (fn T_1035 ()))
+T_1034: (in signature of GetCurrentThreadId @ 00000000 : void)
+  Class: Eq_1033
+  DataType: (ptr32 Eq_1033)
+  OrigDataType: 
+T_1035: (in GetCurrentThreadId() @ 100018BB : DWORD)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_1036: (in GetCurrentProcessId() ^ GetCurrentThreadId() @ 00000000 : word32)
+  Class: Eq_1036
   DataType: ui32
   OrigDataType: ui32
-T_1035: (in eax_9 & 0xFFFF0000<32> @ 00000000 : word32)
-  Class: Eq_1035
-  DataType: ui32
-  OrigDataType: ui32
-T_1036: (in 0<32> @ 10001889 : word32)
-  Class: Eq_1035
-  DataType: ui32
-  OrigDataType: word32
-T_1037: (in (eax_9 & 0xFFFF0000<32>) == 0<32> @ 00000000 : bool)
+T_1037: (in GetTickCount @ 100018BB : ptr32)
   Class: Eq_1037
-  DataType: bool
-  OrigDataType: bool
-T_1038: (in ~eax_9 @ 1000188D : word32)
-  Class: Eq_1038
+  DataType: (ptr32 Eq_1037)
+  OrigDataType: (ptr32 (fn T_1039 ()))
+T_1038: (in signature of GetTickCount @ 00000000 : void)
+  Class: Eq_1037
+  DataType: (ptr32 Eq_1037)
+  OrigDataType: 
+T_1039: (in GetTickCount() @ 100018BB : DWORD)
+  Class: Eq_159
+  DataType: Eq_159
+  OrigDataType: DWORD
+T_1040: (in GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount() @ 00000000 : word32)
+  Class: Eq_1029
   DataType: ui32
   OrigDataType: ui32
-T_1039: (in 10003004 @ 1000188D : ptr32)
-  Class: Eq_1039
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1040 t0000)))
-T_1040: (in Mem76[0x10003004<p32>:word32] @ 1000188D : word32)
-  Class: Eq_1038
-  DataType: ui32
-  OrigDataType: word32
-T_1041: (in 0xFFFF0000<32> @ 100018DC : word32)
+T_1041: (in QueryPerformanceCounter @ 100018C1 : ptr32)
   Class: Eq_1041
-  DataType: ui32
-  OrigDataType: ui32
-T_1042: (in esi_54 & 0xFFFF0000<32> @ 00000000 : word32)
-  Class: Eq_1042
-  DataType: ui32
-  OrigDataType: ui32
-T_1043: (in 0<32> @ 100018DC : word32)
-  Class: Eq_1042
-  DataType: ui32
-  OrigDataType: word32
-T_1044: (in (esi_54 & 0xFFFF0000<32>) != 0<32> @ 00000000 : bool)
+  DataType: (ptr32 Eq_1041)
+  OrigDataType: (ptr32 (fn T_1046 (T_1045)))
+T_1042: (in signature of QueryPerformanceCounter @ 00000000 : void)
+  Class: Eq_1041
+  DataType: (ptr32 Eq_1041)
+  OrigDataType: 
+T_1043: (in lpPerformanceCount @ 100018C1 : (ptr32 LARGE_INTEGER))
+  Class: Eq_1043
+  DataType: (ptr32 Eq_1043)
+  OrigDataType: 
+T_1044: (in tLoc14 @ 100018C1 : LARGE_INTEGER)
   Class: Eq_1044
-  DataType: bool
-  OrigDataType: bool
-T_1045: (in 0xBB40E64F<32> @ 100018D3 : word32)
-  Class: Eq_970
-  DataType: ui32
-  OrigDataType: word32
-T_1046: (in 10003000 @ 100018E5 : ptr32)
-  Class: Eq_1046
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1047 t0000)))
-T_1047: (in Mem69[0x10003000<p32>:word32] @ 100018E5 : word32)
-  Class: Eq_970
-  DataType: ui32
-  OrigDataType: word32
-T_1048: (in ~esi_54 @ 100018ED : word32)
-  Class: Eq_1038
+  DataType: Eq_1044
+  OrigDataType: LARGE_INTEGER
+T_1045: (in &tLoc14 @ 100018C1 : (ptr32 LARGE_INTEGER))
+  Class: Eq_1043
+  DataType: (ptr32 Eq_1043)
+  OrigDataType: (ptr32 LARGE_INTEGER)
+T_1046: (in QueryPerformanceCounter(&tLoc14) @ 100018C1 : BOOL)
+  Class: Eq_680
+  DataType: Eq_680
+  OrigDataType: BOOL
+T_1047: (in esi_54 @ 100018CD : ui32)
+  Class: Eq_990
   DataType: ui32
   OrigDataType: ui32
-T_1049: (in 10003004 @ 100018ED : ptr32)
+T_1048: (in &tLoc14 @ 100018CD : (ptr32 LARGE_INTEGER))
+  Class: Eq_1048
+  DataType: (ptr32 Eq_1048)
+  OrigDataType: (ptr32 (struct (0 LARGE_INTEGER t0000) (4 T_1051 t0004)))
+T_1049: (in 4<i32> @ 100018CD : int32)
   Class: Eq_1049
-  DataType: (ptr32 ui32)
-  OrigDataType: (ptr32 (struct (0 T_1050 t0000)))
-T_1050: (in Mem71[0x10003004<p32>:word32] @ 100018ED : word32)
-  Class: Eq_1038
-  DataType: ui32
-  OrigDataType: word32
-T_1051: (in 0x10<32> @ 100018E3 : word32)
+  DataType: int32
+  OrigDataType: int32
+T_1050: (in &tLoc14 + 4<i32> @ 100018CD : word32)
+  Class: Eq_1050
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1051: (in Mem49[&tLoc14 + 4<i32>:word32] @ 100018CD : word32)
   Class: Eq_1051
   DataType: word32
   OrigDataType: word32
-T_1052: (in esi_54 << 0x10<32> @ 00000000 : word32)
+T_1052: (in &tLoc14 @ 100018CD : (ptr32 LARGE_INTEGER))
   Class: Eq_1052
-  DataType: ui32
-  OrigDataType: ui32
-T_1053: (in esi_54 | esi_54 << 0x10<32> @ 00000000 : word32)
-  Class: Eq_970
-  DataType: ui32
-  OrigDataType: ui32
-T_1054:
-  Class: Eq_1054
+  DataType: (ptr32 Eq_1052)
+  OrigDataType: (ptr32 (struct (0 LARGE_INTEGER t0000)))
+T_1053: (in 0<32> @ 100018CD : word32)
+  Class: Eq_1053
   DataType: word32
   OrigDataType: word32
-T_1055:
+T_1054: (in &tLoc14 + 0<32> @ 100018CD : word32)
+  Class: Eq_1054
+  DataType: ptr32
+  OrigDataType: ptr32
+T_1055: (in Mem49[&tLoc14 + 0<32>:word32] @ 100018CD : word32)
   Class: Eq_1055
   DataType: word32
   OrigDataType: word32
-T_1056:
+T_1056: (in tLoc14.dw0004 ^ tLoc14 @ 00000000 : word32)
   Class: Eq_1056
-  DataType: word32
+  DataType: ui32
+  OrigDataType: ui32
+T_1057: (in esi_46 ^ (tLoc14.dw0004 ^ tLoc14) @ 00000000 : word32)
+  Class: Eq_990
+  DataType: ui32
+  OrigDataType: ui32
+T_1058: (in 0xBB40E64E<32> @ 100018D1 : word32)
+  Class: Eq_990
+  DataType: ui32
   OrigDataType: word32
-T_1057:
-  Class: Eq_1057
-  DataType: word32
-  OrigDataType: word32
-T_1058:
-  Class: Eq_1058
-  DataType: word32
-  OrigDataType: word32
-T_1059:
+T_1059: (in esi_54 != 0xBB40E64E<32> @ 00000000 : bool)
   Class: Eq_1059
-  DataType: word32
-  OrigDataType: word32
-T_1060:
+  DataType: bool
+  OrigDataType: bool
+T_1060: (in 0xFFFF0000<32> @ 10001889 : word32)
   Class: Eq_1060
-  DataType: word32
-  OrigDataType: word32
-T_1061:
+  DataType: ui32
+  OrigDataType: ui32
+T_1061: (in eax_9 & 0xFFFF0000<32> @ 00000000 : word32)
   Class: Eq_1061
-  DataType: word32
+  DataType: ui32
+  OrigDataType: ui32
+T_1062: (in 0<32> @ 10001889 : word32)
+  Class: Eq_1061
+  DataType: ui32
   OrigDataType: word32
-T_1062:
-  Class: Eq_1062
-  DataType: word32
-  OrigDataType: word32
-T_1063:
+T_1063: (in (eax_9 & 0xFFFF0000<32>) == 0<32> @ 00000000 : bool)
   Class: Eq_1063
-  DataType: word32
-  OrigDataType: word32
-T_1064:
+  DataType: bool
+  OrigDataType: bool
+T_1064: (in ~eax_9 @ 1000188D : word32)
   Class: Eq_1064
-  DataType: word32
-  OrigDataType: word32
-T_1065:
+  DataType: ui32
+  OrigDataType: ui32
+T_1065: (in 10003004 @ 1000188D : ptr32)
   Class: Eq_1065
-  DataType: word32
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1066 t0000)))
+T_1066: (in Mem76[0x10003004<p32>:word32] @ 1000188D : word32)
+  Class: Eq_1064
+  DataType: ui32
   OrigDataType: word32
-T_1066:
-  Class: Eq_1066
-  DataType: word32
-  OrigDataType: word32
-T_1067:
+T_1067: (in 0xFFFF0000<32> @ 100018DC : word32)
   Class: Eq_1067
-  DataType: word32
-  OrigDataType: word32
-T_1068:
+  DataType: ui32
+  OrigDataType: ui32
+T_1068: (in esi_54 & 0xFFFF0000<32> @ 00000000 : word32)
   Class: Eq_1068
-  DataType: word32
+  DataType: ui32
+  OrigDataType: ui32
+T_1069: (in 0<32> @ 100018DC : word32)
+  Class: Eq_1068
+  DataType: ui32
   OrigDataType: word32
-T_1069:
-  Class: Eq_1069
-  DataType: word32
-  OrigDataType: word32
-T_1070:
+T_1070: (in (esi_54 & 0xFFFF0000<32>) != 0<32> @ 00000000 : bool)
   Class: Eq_1070
-  DataType: word32
+  DataType: bool
+  OrigDataType: bool
+T_1071: (in 0xBB40E64F<32> @ 100018D3 : word32)
+  Class: Eq_990
+  DataType: ui32
   OrigDataType: word32
-T_1071:
-  Class: Eq_1071
-  DataType: word32
-  OrigDataType: word32
-T_1072:
+T_1072: (in 10003000 @ 100018E5 : ptr32)
   Class: Eq_1072
-  DataType: word32
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1073 t0000)))
+T_1073: (in Mem69[0x10003000<p32>:word32] @ 100018E5 : word32)
+  Class: Eq_990
+  DataType: ui32
   OrigDataType: word32
-T_1073:
-  Class: Eq_1073
-  DataType: word32
-  OrigDataType: word32
-T_1074:
-  Class: Eq_1074
-  DataType: word32
-  OrigDataType: word32
-T_1075:
+T_1074: (in ~esi_54 @ 100018ED : word32)
+  Class: Eq_1064
+  DataType: ui32
+  OrigDataType: ui32
+T_1075: (in 10003004 @ 100018ED : ptr32)
   Class: Eq_1075
-  DataType: word32
+  DataType: (ptr32 ui32)
+  OrigDataType: (ptr32 (struct (0 T_1076 t0000)))
+T_1076: (in Mem71[0x10003004<p32>:word32] @ 100018ED : word32)
+  Class: Eq_1064
+  DataType: ui32
   OrigDataType: word32
-T_1076:
-  Class: Eq_1076
-  DataType: word32
-  OrigDataType: word32
-T_1077:
+T_1077: (in 0x10<32> @ 100018E3 : word32)
   Class: Eq_1077
   DataType: word32
   OrigDataType: word32
-T_1078:
+T_1078: (in esi_54 << 0x10<32> @ 00000000 : word32)
   Class: Eq_1078
-  DataType: word32
-  OrigDataType: word32
-T_1079:
-  Class: Eq_1079
-  DataType: word32
-  OrigDataType: word32
+  DataType: ui32
+  OrigDataType: ui32
+T_1079: (in esi_54 | esi_54 << 0x10<32> @ 00000000 : word32)
+  Class: Eq_990
+  DataType: ui32
+  OrigDataType: ui32
 T_1080:
   Class: Eq_1080
   DataType: word32
@@ -4954,18 +4960,122 @@ T_1088:
 T_1089:
   Class: Eq_1089
   DataType: word32
-  OrigDataType: (struct 0004 (0 T_814 t0000))
+  OrigDataType: word32
 T_1090:
   Class: Eq_1090
-  DataType: (arr word32 1)
-  OrigDataType: (arr T_1089 1)
+  DataType: word32
+  OrigDataType: word32
 T_1091:
   Class: Eq_1091
-  DataType: Eq_1091
+  DataType: word32
+  OrigDataType: word32
+T_1092:
+  Class: Eq_1092
+  DataType: word32
+  OrigDataType: word32
+T_1093:
+  Class: Eq_1093
+  DataType: word32
+  OrigDataType: word32
+T_1094:
+  Class: Eq_1094
+  DataType: word32
+  OrigDataType: word32
+T_1095:
+  Class: Eq_1095
+  DataType: word32
+  OrigDataType: word32
+T_1096:
+  Class: Eq_1096
+  DataType: word32
+  OrigDataType: word32
+T_1097:
+  Class: Eq_1097
+  DataType: word32
+  OrigDataType: word32
+T_1098:
+  Class: Eq_1098
+  DataType: word32
+  OrigDataType: word32
+T_1099:
+  Class: Eq_1099
+  DataType: word32
+  OrigDataType: word32
+T_1100:
+  Class: Eq_1100
+  DataType: word32
+  OrigDataType: word32
+T_1101:
+  Class: Eq_1101
+  DataType: word32
+  OrigDataType: word32
+T_1102:
+  Class: Eq_1102
+  DataType: word32
+  OrigDataType: word32
+T_1103:
+  Class: Eq_1103
+  DataType: word32
+  OrigDataType: word32
+T_1104:
+  Class: Eq_1104
+  DataType: word32
+  OrigDataType: word32
+T_1105:
+  Class: Eq_1105
+  DataType: word32
+  OrigDataType: word32
+T_1106:
+  Class: Eq_1106
+  DataType: word32
+  OrigDataType: word32
+T_1107:
+  Class: Eq_1107
+  DataType: word32
+  OrigDataType: word32
+T_1108:
+  Class: Eq_1108
+  DataType: word32
+  OrigDataType: word32
+T_1109:
+  Class: Eq_1109
+  DataType: word32
+  OrigDataType: word32
+T_1110:
+  Class: Eq_1110
+  DataType: word32
+  OrigDataType: word32
+T_1111:
+  Class: Eq_1111
+  DataType: word32
+  OrigDataType: word32
+T_1112:
+  Class: Eq_1112
+  DataType: word32
+  OrigDataType: word32
+T_1113:
+  Class: Eq_1113
+  DataType: word32
+  OrigDataType: word32
+T_1114:
+  Class: Eq_1114
+  DataType: word32
+  OrigDataType: word32
+T_1115:
+  Class: Eq_1115
+  DataType: word32
+  OrigDataType: (struct 0004 (0 T_834 t0000))
+T_1116:
+  Class: Eq_1116
+  DataType: (arr word32 1)
+  OrigDataType: (arr T_1115 1)
+T_1117:
+  Class: Eq_1117
+  DataType: Eq_1117
   OrigDataType: 
 */
 typedef struct Globals {
-	Eq_825 t10000000;	// 10000000
+	Eq_845 t10000000;	// 10000000
 	<anonymous> * __imp__GetSystemTimeAsFileTime;	// 10002000
 	<anonymous> * __imp__GetCurrentProcessId;	// 10002004
 	<anonymous> * __imp__GetCurrentThreadId;	// 10002008
@@ -5001,10 +5111,10 @@ typedef struct Globals {
 	<anonymous> * __imp__PyArg_ParseTuple;	// 10002088
 	<anonymous> * __imp___Py_NoneStruct;	// 1000208C
 	<anonymous> * __imp__Py_BuildValue;	// 10002090
-	Eq_293 t10002098;	// 10002098
-	Eq_294 t1000209C;	// 1000209C
-	Eq_239 t100020A0;	// 100020A0
-	Eq_240 t100020A8;	// 100020A8
+	Eq_313 t10002098;	// 10002098
+	Eq_314 t1000209C;	// 1000209C
+	Eq_259 t100020A0;	// 100020A0
+	Eq_260 t100020A8;	// 100020A8
 	word32 dw100020CC;	// 100020CC
 	char str100020E0[];	// 100020E0
 	char str100020F4[];	// 100020F4
@@ -5060,12 +5170,12 @@ typedef struct Globals {
 	word32 dw1000232C;	// 1000232C
 	ui32 dw10003000;	// 10003000
 	ui32 dw10003004;	// 10003004
-	Eq_1091 t10003008;	// 10003008
+	Eq_1117 t10003008;	// 10003008
 	PyMethodDef methods[5];	// 10003010
 	int32 dw10003070;	// 10003070
 	word32 dw100033A4;	// 100033A4
 	word32 dw100033A8;	// 100033A8
-	Eq_185 t100033AC;	// 100033AC
+	Eq_205 t100033AC;	// 100033AC
 	void * ptr100033B0;	// 100033B0
 	void * ptr100033B4;	// 100033B4
 	<anonymous> * ptr100033B8;	// 100033B8
@@ -5079,269 +5189,278 @@ typedef PyObject Eq_4;
 
 typedef PyObject * (Eq_6)(PyObject *, char *, int32 *, int32 *);
 
-typedef PyObject * (Eq_21)(char *, int32);
+typedef PyObject * (Eq_20)(char *, int32);
 
-typedef PyObject * (Eq_31)(PyObject *, char *, int32 *, int32 *);
+typedef PyObject * (Eq_36)(PyObject *, char *, int32 *, int32 *);
 
-typedef PyObject * (Eq_44)(char *, int32);
+typedef PyObject * (Eq_48)(char *, int32);
 
-typedef PyObject * (Eq_53)(PyObject *, char *, int32 *, int32 *);
+typedef PyObject * (Eq_63)(PyObject *, char *, int32 *, int32 *);
 
-typedef PyObject * (Eq_66)(char *, int32);
+typedef PyObject * (Eq_75)(char *, int32);
 
-typedef PyObject * (Eq_77)(PyObject *, char *, real32 *, real32 *);
+typedef PyObject * (Eq_92)(PyObject *, char *, real32 *, real32 *);
 
-typedef PyObject * (Eq_90)(char *, real64);
+typedef PyObject * (Eq_104)(char *, real64);
 
-typedef PyObject Eq_100;
+typedef PyObject Eq_120;
 
-typedef PyObject Eq_101;
+typedef PyObject Eq_121;
 
-typedef PyObject Eq_102;
+typedef PyObject Eq_122;
 
-typedef PyObject * (Eq_104)(PyObject *, char *);
+typedef PyObject * (Eq_124)(PyObject *, char *);
 
-typedef PyObject Eq_111;
+typedef PyObject Eq_131;
 
-typedef PyObject Eq_112;
+typedef PyObject Eq_132;
 
-typedef PyObject * (Eq_124)(char *, PyMethodDef *[5], char *, PyObject *, int32);
+typedef PyObject * (Eq_144)(char *, PyMethodDef *[5], char *, PyObject *, int32);
 
-typedef PyMethodDef Eq_127;
+typedef PyMethodDef Eq_147;
 
-typedef PyObject Eq_129;
+typedef PyObject Eq_149;
 
-typedef PyObject Eq_136;
+typedef PyObject Eq_156;
 
-typedef union Eq_138 {
+typedef union Eq_158 {
 	_onexit_t u0;
 	HMODULE u1;
-} Eq_138;
+} Eq_158;
 
-typedef DWORD Eq_139;
+typedef DWORD Eq_159;
 
-typedef LPVOID Eq_140;
+typedef LPVOID Eq_160;
 
-typedef LONG Eq_145;
+typedef LONG Eq_165;
 
-typedef struct Eq_176 {
-	struct Eq_178 * ptr0018;	// 18
-} Eq_176;
+typedef struct Eq_196 {
+	struct Eq_198 * ptr0018;	// 18
+} Eq_196;
 
-typedef struct Eq_178 {
-	Eq_145 t0004;	// 4
-} Eq_178;
+typedef struct Eq_198 {
+	Eq_165 t0004;	// 4
+} Eq_198;
 
-typedef LONG (Eq_183)(LONG *, LONG, LONG);
+typedef LONG (Eq_203)(LONG *, LONG, LONG);
 
-typedef LONG Eq_185;
+typedef LONG Eq_205;
 
-typedef void (Eq_206)(DWORD);
+typedef void (Eq_226)(DWORD);
 
-typedef DWORD (Eq_216)(void);
+typedef DWORD (Eq_236)(void);
 
-typedef void (Eq_227)(int32);
+typedef void (Eq_247)(int32);
 
-typedef int32 (Eq_237)(PVFV *, PVFV *);
+typedef int32 (Eq_257)(PVFV *, PVFV *);
 
-typedef PVFV Eq_239;
+typedef PVFV Eq_259;
 
-typedef PVFV Eq_240;
+typedef PVFV Eq_260;
 
-typedef struct Eq_253 {
+typedef struct Eq_273 {
 	LONG * ptrFFFFFFFC;	// FFFFFFFC
-	Eq_145 t0000;	// 0
-} Eq_253;
+	Eq_165 t0000;	// 0
+} Eq_273;
 
-typedef LONG Eq_260;
+typedef LONG Eq_280;
 
-typedef LONG (Eq_267)(LONG *, LONG);
+typedef LONG (Eq_287)(LONG *, LONG);
 
-typedef void (Eq_291)(PVFV *, PVFV *);
+typedef void (Eq_311)(PVFV *, PVFV *);
 
-typedef PVFV Eq_293;
+typedef PVFV Eq_313;
 
-typedef PVFV Eq_294;
+typedef PVFV Eq_314;
 
-typedef struct Eq_304 {
+typedef struct Eq_324 {
 	ptr32 ptr0000;	// 0
 	ptr32 ptr0004;	// 4
-} Eq_304;
+} Eq_324;
 
-typedef void (Eq_331)(DWORD);
+typedef void (Eq_351)(DWORD);
 
-typedef void (Eq_339)();
+typedef void (Eq_359)();
 
-typedef word32 (Eq_368)( *, ptr32, word32, ptr32);
+typedef word32 (Eq_388)( *, ptr32, word32, ptr32);
 
-typedef struct Eq_391 {
-	Eq_138 tFFFFFFDC;	// FFFFFFDC
-	Eq_139 tFFFFFFE0;	// FFFFFFE0
-	Eq_139 tFFFFFFE4;	// FFFFFFE4
+typedef struct Eq_411 {
+	Eq_158 tFFFFFFDC;	// FFFFFFDC
+	Eq_159 tFFFFFFE0;	// FFFFFFE0
+	Eq_159 tFFFFFFE4;	// FFFFFFE4
 	word32 dwFFFFFFF0;	// FFFFFFF0
 	word32 dwFFFFFFFC;	// FFFFFFFC
-	Eq_456 t0000;	// 0
-	Eq_138 t0008;	// 8
-} Eq_391;
+	Eq_476 t0000;	// 0
+	Eq_158 t0008;	// 8
+} Eq_411;
 
-typedef Eq_391 * (Eq_392)( *, ptr32, word32, word32, ui32);
+typedef Eq_411 * (Eq_412)( *, ptr32, word32, word32, ui32);
 
-typedef struct Eq_420 {
-	Eq_456 tFFFFFFFC;	// FFFFFFFC
-} Eq_420;
+typedef struct Eq_440 {
+	Eq_476 tFFFFFFFC;	// FFFFFFFC
+} Eq_440;
 
-typedef void (Eq_446)();
+typedef void (Eq_466)();
 
-typedef ptr32 (Eq_453)(Eq_391 *, Eq_456);
+typedef ptr32 (Eq_473)(Eq_411 *, Eq_476);
 
-typedef union Eq_456 {
+typedef union Eq_476 {
 	ui32 u0;
 	ptr32 u1;
-} Eq_456;
+} Eq_476;
 
-typedef struct Eq_467 {
-	Eq_138 tFFFFFFF8;	// FFFFFFF8
-	Eq_139 tFFFFFFFC;	// FFFFFFFC
-	Eq_140 t0000;	// 0
-} Eq_467;
+typedef struct Eq_487 {
+	Eq_158 tFFFFFFF8;	// FFFFFFF8
+	Eq_159 tFFFFFFFC;	// FFFFFFFC
+	Eq_160 t0000;	// 0
+} Eq_487;
 
-typedef DWORD (Eq_480)(Eq_138, DWORD);
+typedef DWORD (Eq_500)(Eq_158, DWORD);
 
-typedef DWORD (Eq_503)(Eq_138, DWORD);
+typedef DWORD (Eq_523)(Eq_158, DWORD);
 
-typedef struct Eq_509 {
-	Eq_138 tFFFFFFF8;	// FFFFFFF8
-	Eq_139 tFFFFFFFC;	// FFFFFFFC
-	Eq_140 t0000;	// 0
-} Eq_509;
+typedef struct Eq_529 {
+	Eq_158 tFFFFFFF8;	// FFFFFFF8
+	Eq_159 tFFFFFFFC;	// FFFFFFFC
+	Eq_160 t0000;	// 0
+} Eq_529;
 
-typedef DWORD (Eq_522)(Eq_138, DWORD, LPVOID, ptr32, ptr32, ptr32);
+typedef DWORD (Eq_542)(Eq_158, DWORD, LPVOID, ptr32, ptr32, ptr32);
 
-typedef void (Eq_595)(Eq_138, word32, LPVOID);
+typedef void (Eq_615)(Eq_158, word32, LPVOID);
 
-typedef struct Eq_599 {
-	Eq_138 tFFFFFFF8;	// FFFFFFF8
-	Eq_139 tFFFFFFFC;	// FFFFFFFC
-	Eq_140 t0000;	// 0
-} Eq_599;
+typedef struct Eq_619 {
+	Eq_158 tFFFFFFF8;	// FFFFFFF8
+	Eq_159 tFFFFFFFC;	// FFFFFFFC
+	Eq_160 t0000;	// 0
+} Eq_619;
 
-typedef DWORD (Eq_651)(word32, word32, word32);
+typedef DWORD (Eq_671)(word32, word32, word32);
 
-typedef BOOL Eq_660;
+typedef BOOL Eq_680;
 
-typedef HANDLE Eq_661;
+typedef HANDLE Eq_681;
 
-typedef BOOL (Eq_666)(LPVOID, DWORD,  *, ptr32, word32);
+typedef BOOL (Eq_686)(LPVOID, DWORD,  *, ptr32, word32);
 
-typedef void (Eq_672)();
+typedef void (Eq_692)();
 
-typedef struct Eq_680 {
-	Eq_456 tFFFFFFFC;	// FFFFFFFC
-} Eq_680;
+typedef struct Eq_700 {
+	Eq_476 tFFFFFFFC;	// FFFFFFFC
+} Eq_700;
 
-typedef void (Eq_696)(word32);
+typedef void (Eq_716)(word32);
 
-typedef struct Eq_701 {
-	Eq_138 tFFFFFFF0;	// FFFFFFF0
+typedef struct Eq_721 {
+	Eq_158 tFFFFFFF0;	// FFFFFFF0
 	PVFV ** ptrFFFFFFF4;	// FFFFFFF4
 	PVFV ** ptrFFFFFFF8;	// FFFFFFF8
 	void * ptrFFFFFFFC;	// FFFFFFFC
 	void * ptr0000;	// 0
-} Eq_701;
+} Eq_721;
 
-typedef Eq_138 (Eq_735)(Eq_138, PVFV * *, PVFV * *);
+typedef Eq_158 (Eq_755)(Eq_158, PVFV * *, PVFV * *);
 
-typedef PVFV Eq_738;
+typedef PVFV Eq_758;
 
-typedef PVFV Eq_739;
+typedef PVFV Eq_759;
 
-typedef void (Eq_753)(void, DWORD, Eq_138, ptr32, ptr32, void, void);
+typedef void (Eq_773)(void, DWORD, Eq_158, ptr32, ptr32, void, void);
 
-typedef void (Eq_765)(DWORD);
+typedef void (Eq_785)(DWORD);
 
-typedef void (Eq_776)();
+typedef void (Eq_796)();
 
-typedef Eq_138 (Eq_785)(Eq_138);
+typedef Eq_158 (Eq_805)(Eq_158);
 
-typedef void (Eq_800)();
+typedef void (Eq_820)();
 
-typedef word32 (Eq_806)( *, ptr32, word32);
+typedef word32 (Eq_826)( *, ptr32, word32);
 
-typedef void (Eq_821)();
+typedef void (Eq_841)();
 
-typedef struct Eq_825 {
+typedef struct Eq_845 {
 	word16 w0000;	// 0
 	word32 dw003C;	// 3C
-} Eq_825;
+} Eq_845;
 
-typedef struct Eq_831 {
+typedef struct Eq_851 {
 	word32 dw0000;	// 0
 	word16 w0018;	// 18
-} Eq_831;
+} Eq_851;
 
-typedef struct Eq_849 {	// size: 40 28
+typedef struct Eq_869 {	// size: 40 28
 	up32 dw0008;	// 8
 	word32 dw000C;	// C
-} Eq_849;
+} Eq_869;
 
-typedef struct Eq_850 {
+typedef struct Eq_870 {
 	word32 dw003C;	// 3C
-} Eq_850;
+} Eq_870;
 
-typedef struct Eq_852 {
+typedef struct Eq_872 {
 	word16 w0006;	// 6
 	word16 w0014;	// 14
-} Eq_852;
+} Eq_872;
 
-typedef word32 (Eq_903)(Eq_825 *);
+typedef word32 (Eq_923)(Eq_845 *);
 
-typedef union Eq_918 {
+typedef union Eq_938 {
 	ui32 u0;
 	ptr32 u1;
-} Eq_918;
+} Eq_938;
 
-typedef struct Eq_920 {
+typedef struct Eq_940 {
 	uint32 dw0024;	// 24
-} Eq_920;
+} Eq_940;
 
-typedef Eq_920 * (Eq_921)(Eq_850 *, uint32);
+typedef Eq_940 * (Eq_941)(Eq_870 *, uint32);
 
-typedef BOOL (Eq_950)(Eq_138);
+typedef BOOL (Eq_970)(Eq_158);
 
-typedef struct Eq_955 {
+typedef struct Eq_975 {
 	word32 dwFFFFFFEC;	// FFFFFFEC
 	ui32 dwFFFFFFF0;	// FFFFFFF0
 	word32 dwFFFFFFF4;	// FFFFFFF4
 	ptr32 ptrFFFFFFF8;	// FFFFFFF8
-	Eq_145 (* ptrFFFFFFFC)(LONG *, Eq_145, Eq_145);	// FFFFFFFC
-} Eq_955;
+	Eq_165 (* ptrFFFFFFFC)(LONG *, Eq_165, Eq_165);	// FFFFFFFC
+} Eq_975;
 
-typedef struct Eq_982 {
+typedef struct Eq_1002 {
 	ptr32 ptr0000;	// 0
-} Eq_982;
+} Eq_1002;
 
-typedef struct Eq_990 {
+typedef struct Eq_1010 {
 	word32 dw0000;	// 0
-} Eq_990;
+} Eq_1010;
 
-typedef union Eq_991 {
+typedef union Eq_1011 {
 	ptr32 u0;
-	word32 Eq_990::* u1;
-} Eq_991;
+	word32 Eq_1010::* u1;
+} Eq_1011;
 
-typedef void (Eq_1002)(LPFILETIME);
+typedef void (Eq_1022)(LPFILETIME);
 
-typedef LPFILETIME Eq_1004;
+typedef LPFILETIME Eq_1024;
 
-typedef DWORD (Eq_1010)();
+typedef DWORD (Eq_1030)();
 
-typedef DWORD (Eq_1013)();
+typedef DWORD (Eq_1033)();
 
-typedef DWORD (Eq_1017)();
+typedef DWORD (Eq_1037)();
 
-typedef BOOL (Eq_1021)(LARGE_INTEGER *);
+typedef BOOL (Eq_1041)(LARGE_INTEGER *);
 
-typedef LARGE_INTEGER Eq_1023;
+typedef LARGE_INTEGER Eq_1043;
 
-typedef DWORD Eq_1091;
+typedef LARGE_INTEGER Eq_1044;
+
+typedef struct Eq_1048 {
+	LARGE_INTEGER t0000;	// 0
+	word32 dw0004;	// 4
+} Eq_1048;
+
+typedef LARGE_INTEGER Eq_1052;
+
+typedef DWORD Eq_1117;
 

--- a/subjects/PE/x86/pySample/shingledPySample.reko/pySample_text.c
+++ b/subjects/PE/x86/pySample/shingledPySample.reko/pySample_text.c
@@ -7,7 +7,7 @@
 // 10001000: Register (ptr32 Eq_n) fn10001000(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * fn10001000(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:sum", fp - 0x04, fp - 0x08);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:sum", &dwLoc04, &dwLoc08);
 	if (eax_n != null)
 		return Py_BuildValue("i", dwLoc04 + dwLoc08);
 	return eax_n;
@@ -16,7 +16,7 @@ PyObject * fn10001000(PyObject * ptrArg04, PyObject * ptrArg08)
 // 10001050: Register (ptr32 Eq_n) fn10001050(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * fn10001050(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:dif", fp - 0x08, fp - 0x04);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:dif", &dwLoc08, &dwLoc04);
 	if (eax_n != null)
 		return Py_BuildValue("i", dwLoc08 - dwLoc04);
 	return eax_n;
@@ -25,7 +25,7 @@ PyObject * fn10001050(PyObject * ptrArg04, PyObject * ptrArg08)
 // 100010A0: Register (ptr32 Eq_n) fn100010A0(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * fn100010A0(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:div", fp - 0x08, fp - 0x04);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:div", &dwLoc08, &dwLoc04);
 	if (eax_n != null)
 		return Py_BuildValue("i", (int32) ((int64) dwLoc08 /32 dwLoc04));
 	return eax_n;
@@ -34,7 +34,7 @@ PyObject * fn100010A0(PyObject * ptrArg04, PyObject * ptrArg08)
 // 100010F0: Register (ptr32 Eq_n) fn100010F0(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * fn100010F0(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ff:fdiv", fp - 0x08, fp - 0x04);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ff:fdiv", &rLoc08, &rLoc04);
 	if (eax_n != null)
 		return Py_BuildValue("f", (real64) rLoc08 / (real64) rLoc04);
 	return eax_n;
@@ -440,8 +440,8 @@ void fn10001864()
 	{
 		GetSystemTimeAsFileTime(fp - 0x0C);
 		ui32 esi_n = GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount();
-		QueryPerformanceCounter(fp - 0x14);
-		ui32 esi_n = esi_n ^ (dwLoc10 ^ dwLoc14);
+		QueryPerformanceCounter(&tLoc14);
+		ui32 esi_n = esi_n ^ (tLoc14.dw0004 ^ tLoc14);
 		if (esi_n == 0xBB40E64E)
 			esi_n = ~0x44BF19B0;
 		else if ((esi_n & 0xFFFF0000) == 0x00)

--- a/subjects/PE/x86/pySample/shingledPySample.reko/pySample_text.dis
+++ b/subjects/PE/x86/pySample/shingledPySample.reko/pySample_text.dis
@@ -7,10 +7,10 @@ PyObject * fn10001000(PyObject * ptrArg04, PyObject * ptrArg08)
 // Preserved:
 fn10001000_entry:
 l10001000:
-	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002144<32>, fp - 4<32>, fp - 8<32>)
+	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002144<32>, &dwLoc04, &dwLoc08)
 	branch eax_17 != 0<32> l10001027
 l10001027:
-	return Py_BuildValue(0x1000214C<32>, dwLoc04 + dwLoc08)
+	return Py_BuildValue(0x1000214C<32>, Mem16[&dwLoc04:word32] + Mem16[&dwLoc08:word32])
 l10001023:
 	return eax_17
 fn10001000_exit:
@@ -25,10 +25,10 @@ PyObject * fn10001050(PyObject * ptrArg04, PyObject * ptrArg08)
 // Preserved:
 fn10001050_entry:
 l10001050:
-	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002150<32>, fp - 8<32>, fp - 4<32>)
+	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002150<32>, &dwLoc08, &dwLoc04)
 	branch eax_17 != 0<32> l10001078
 l10001078:
-	return Py_BuildValue(0x1000214C<32>, dwLoc08 - dwLoc04)
+	return Py_BuildValue(0x1000214C<32>, Mem16[&dwLoc08:word32] - Mem16[&dwLoc04:word32])
 l10001074:
 	return eax_17
 fn10001050_exit:
@@ -43,10 +43,10 @@ PyObject * fn100010A0(PyObject * ptrArg04, PyObject * ptrArg08)
 // Preserved:
 fn100010A0_entry:
 l100010A0:
-	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002158<32>, fp - 8<32>, fp - 4<32>)
+	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002158<32>, &dwLoc08, &dwLoc04)
 	branch eax_17 != 0<32> l100010C8
 l100010C8:
-	return Py_BuildValue(0x1000214C<32>, CONVERT(CONVERT(dwLoc08, word32, int64) /32 dwLoc04, word32, int32))
+	return Py_BuildValue(0x1000214C<32>, CONVERT(CONVERT(Mem16[&dwLoc08:word32], word32, int64) /32 Mem16[&dwLoc04:word32], word32, int32))
 l100010C4:
 	return eax_17
 fn100010A0_exit:
@@ -61,10 +61,10 @@ PyObject * fn100010F0(PyObject * ptrArg04, PyObject * ptrArg08)
 // Preserved:
 fn100010F0_entry:
 l100010F0:
-	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002160<32>, fp - 8<32>, fp - 4<32>)
+	word32 eax_17 = PyArg_ParseTuple(ptrArg08, 0x10002160<32>, &rLoc08, &rLoc04)
 	branch eax_17 != 0<32> l10001118
 l10001118:
-	return Py_BuildValue(0x10002168<32>, CONVERT(rLoc08, real32, real64) / CONVERT(rLoc04, real32, real64))
+	return Py_BuildValue(0x10002168<32>, CONVERT(Mem16[&rLoc08:real32], real32, real64) / CONVERT(Mem16[&rLoc04:real32], real32, real64))
 l10001114:
 	return eax_17
 fn100010F0_exit:
@@ -610,8 +610,8 @@ l10001887:
 l10001894:
 	GetSystemTimeAsFileTime(fp - 0xC<32>)
 	word32 esi_46 = GetCurrentProcessId() ^ GetCurrentThreadId() ^ GetTickCount()
-	QueryPerformanceCounter(fp - 0x14<32>)
-	word32 esi_54 = esi_46 ^ (dwLoc10 ^ dwLoc14)
+	QueryPerformanceCounter(&tLoc14)
+	word32 esi_54 = esi_46 ^ (Mem49[&tLoc14 + 4<i32>:word32] ^ Mem49[&tLoc14:word32])
 	branch esi_54 != 0xBB40E64E<32> l100018DA
 l100018DA:
 	branch (esi_54 & 0xFFFF0000<32>) != 0<32> l100018E5

--- a/subjects/scripting/pyFuncNames.reko/dif.c
+++ b/subjects/scripting/pyFuncNames.reko/dif.c
@@ -7,7 +7,7 @@
 // 10001050: Register (ptr32 Eq_n) dif_wrapper(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * dif_wrapper(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:dif", fp - 0x08, fp - 0x04);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:dif", &dwLoc08, &dwLoc04);
 	if (eax_n != null)
 		return Py_BuildValue("i", dwLoc08 - dwLoc04);
 	return eax_n;

--- a/subjects/scripting/pyFuncNames.reko/div.c
+++ b/subjects/scripting/pyFuncNames.reko/div.c
@@ -7,7 +7,7 @@
 // 100010A0: Register (ptr32 Eq_n) div_wrapper(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * div_wrapper(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:div", fp - 0x08, fp - 0x04);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:div", &dwLoc08, &dwLoc04);
 	if (eax_n != null)
 		return Py_BuildValue("i", (int32) ((int64) dwLoc08 /32 dwLoc04));
 	return eax_n;

--- a/subjects/scripting/pyFuncNames.reko/fdiv.c
+++ b/subjects/scripting/pyFuncNames.reko/fdiv.c
@@ -7,7 +7,7 @@
 // 100010F0: Register (ptr32 Eq_n) fdiv_wrapper(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * fdiv_wrapper(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ff:fdiv", fp - 0x08, fp - 0x04);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ff:fdiv", &rLoc08, &rLoc04);
 	if (eax_n != null)
 		return Py_BuildValue("f", (real64) rLoc08 / (real64) rLoc04);
 	return eax_n;

--- a/subjects/scripting/pyFuncNames.reko/sum.c
+++ b/subjects/scripting/pyFuncNames.reko/sum.c
@@ -7,7 +7,7 @@
 // 10001000: Register (ptr32 Eq_n) sum_wrapper(Stack (ptr32 Eq_n) ptrArg04, Stack (ptr32 Eq_n) ptrArg08)
 PyObject * sum_wrapper(PyObject * ptrArg04, PyObject * ptrArg08)
 {
-	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:sum", fp - 0x04, fp - 0x08);
+	PyObject * eax_n = PyArg_ParseTuple(ptrArg08, "ii:sum", &dwLoc04, &dwLoc08);
 	if (eax_n != null)
 		return Py_BuildValue("i", dwLoc04 + dwLoc08);
 	return eax_n;


### PR DESCRIPTION
There are two phases. `EscapedFrameIntervalsFinder` finds intervals in the
`[[-12, -4], (struct ""str"" 0008 (0 int32 dw0000) (4 real32 r0004))]`
form.  Then `ComplexStackVariableTransformer` rewrites expressions like
`fp - <offset>` if offset is inside of one of  the intervals collected by
`EscapedFrameIntervalsFinder`.
Current implementation works only if user or environment procedure
signature is defined.