### PR TITLE
Avoid exceptions during transformation of non-primitive type constants

### DIFF
--- a/src/Core/Operators/BinaryOperator.cs
+++ b/src/Core/Operators/BinaryOperator.cs
@@ -39,11 +39,8 @@ namespace Reko.Core.Operators
 
         protected Constant BuildConstant(DataType t1, DataType t2, long val)
 		{
-            //$REVIEW what to do when these resolutions fail?
-			PrimitiveType p1 = t1.ResolveAs<PrimitiveType>()!;
-			PrimitiveType p2 = t2.ResolveAs<PrimitiveType>()!;
-			int bitSize = Math.Max(p1.BitSize, p2.BitSize);
-			return Constant.Create(PrimitiveType.Create(p1.Domain|p2.Domain, bitSize), val);
+			int bitSize = Math.Max(t1.BitSize, t2.BitSize);
+			return Constant.Create(PrimitiveType.Create(t1.Domain|t2.Domain, bitSize), val);
 		}
 
         protected Constant BuildConstant(DataType t1, DataType t2, ulong val)

--- a/src/Core/Operators/IAddOperator.cs
+++ b/src/Core/Operators/IAddOperator.cs
@@ -49,10 +49,10 @@ namespace Reko.Core.Operators
             }
             else
             {
-                var p1 = (PrimitiveType) c1.DataType;
-                var p2 = (PrimitiveType) c1.DataType;
-                if ((p1.Domain & p2.Domain) == 0 && 
-                    (p1.Domain | p2.Domain) != Domain.Integer)
+                var dt1 = c1.DataType;
+                var dt2 = c2.DataType;
+                if ((dt1.Domain & dt2.Domain) == 0 &&
+                    (dt1.Domain | dt2.Domain) != Domain.Integer)
                     throw new ArgumentException(string.Format("Can't add types of disjoint domains {0} and {1}", c1.DataType, c2.DataType));
             }
             if (c2.DataType.BitSize <= 64 && c2.DataType.BitSize <= 64)


### PR DESCRIPTION
There are still exceptions on my binaries if there is non-primitive type constants. The fix is removing conversion to `PrimitiveType` in some places. There is `Domain` property in all children of `DataType` now, so such conversion is not required more.