### PR TITLE
Fix calculation of alignment of unions and regenerate windows32.xml and wsock32.xml

### DIFF
--- a/src/Core/Hll/C/TypeSizer.cs
+++ b/src/Core/Hll/C/TypeSizer.cs
@@ -169,7 +169,7 @@ namespace Reko.Core.Hll.C
             {
                 var (fieldSize, fieldAlignment) = field.Type!.Accept(this);
                 size = Math.Max(size, fieldSize);
-                alignment = Math.Max(size, fieldAlignment);
+                alignment = Math.Max(alignment, fieldAlignment);
             }
             union.ByteSize = size;
             return (size, alignment);

--- a/src/Environments/Windows/wsock32.xml
+++ b/src/Environments/Windows/wsock32.xml
@@ -64,7 +64,7 @@
         </ptr>
       </field>
     </struct>
-    <struct name="netent" size="14">
+    <struct name="netent" size="16">
       <field offset="0" name="n_name">
         <ptr>
           <prim domain="Character" size="1" />
@@ -80,11 +80,11 @@
       <field offset="8" name="n_addrtype">
         <prim domain="SignedInt" size="2" />
       </field>
-      <field offset="10" name="n_net">
+      <field offset="12" name="n_net">
         <type>u_long</type>
       </field>
     </struct>
-    <struct name="servent" size="14">
+    <struct name="servent" size="16">
       <field offset="0" name="s_name">
         <ptr>
           <prim domain="Character" size="1" />
@@ -100,7 +100,7 @@
       <field offset="8" name="s_port">
         <prim domain="SignedInt" size="2" />
       </field>
-      <field offset="10" name="s_proto">
+      <field offset="12" name="s_proto">
         <ptr>
           <prim domain="Character" size="1" />
         </ptr>
@@ -189,7 +189,7 @@
         </arr>
       </field>
     </struct>
-    <struct name="WSAData" size="398">
+    <struct name="WSAData" size="400">
       <field offset="0" name="wVersion">
         <type>WORD</type>
       </field>
@@ -212,7 +212,7 @@
       <field offset="392" name="iMaxUdpDg">
         <prim domain="UnsignedInt" size="2" />
       </field>
-      <field offset="394" name="lpVendorInfo">
+      <field offset="396" name="lpVendorInfo">
         <ptr>
           <prim domain="Character" size="1" />
         </ptr>

--- a/src/tools/c2xml/UnitTests/XmlConverterTests.cs
+++ b/src/tools/c2xml/UnitTests/XmlConverterTests.cs
@@ -1095,6 +1095,61 @@ namespace Reko.Tools.C2Xml.UnitTests
     int i;
 };", sExp, "");
         }
+
+        [Test]
+        public void C2x_union_alignment()
+        {
+            var sExp =
+@"<?xml version=""1.0"" encoding=""utf-16""?>
+<library xmlns=""http://schemata.jklnet.org/Decompiler"">
+  <Types>
+    <struct name=""s1"" size=""8"">
+      <field offset=""0"" name=""c"">
+        <prim domain=""Character"" size=""1"" />
+      </field>
+      <field offset=""4"" name=""i"">
+        <prim domain=""SignedInt"" size=""4"" />
+      </field>
+    </struct>
+    <struct name=""s2"" size=""4"">
+      <field offset=""0"" name=""i"">
+        <prim domain=""SignedInt"" size=""4"" />
+      </field>
+    </struct>
+    <union name=""u"" size=""8"">
+      <alt name=""alt1"">
+        <struct name=""s1"" />
+      </alt>
+      <alt name=""alt2"">
+        <struct name=""s2"" />
+      </alt>
+    </union>
+    <struct name=""test"" size=""12"">
+      <field offset=""0"" name=""c"">
+        <prim domain=""Character"" size=""1"" />
+      </field>
+      <field offset=""4"" name=""u"">
+        <union name=""u"" />
+      </field>
+    </struct>
+  </Types>
+</library>";
+            RunTest(
+@"struct test {
+    char c;
+    union u {
+        struct s1
+        {
+            char c;
+            int i;
+        } alt1;
+        struct s2
+        {
+            int i;
+        } alt2;
+    } u;
+};", sExp, "");
+        }
     }
 }
 


### PR DESCRIPTION
```
struct test {
    char c;
    union u {
        struct s1
        {
            char c;
            int i;
        } alt1;
        struct s2
        {
            int i;
        } alt2;
    } u;
```

Expected: struct "test" size 12 / union "u" offset 4
But was: struct "test" size 16 / union "u" offset 8