### PR TITLE
AEON: Improve instruction decoding

### DIFF
--- a/src/UnitTests/Arch/OpenRISC/AeonDisassemblerTests.cs
+++ b/src/UnitTests/Arch/OpenRISC/AeonDisassemblerTests.cs
@@ -67,8 +67,8 @@ namespace Reko.UnitTests.Arch.OpenRISC
         [Test]
         public void AeonDis_bt_trap()
         {
-            // XXX: actually "bt.trap 1"
-            AssertCode("bt.trap", "8002");
+            // confirmed with source
+            AssertCode("bt.trap\t0x1", "80 02");
         }
 
         [Test]
@@ -372,13 +372,13 @@ namespace Reko.UnitTests.Arch.OpenRISC
         public void AeonDis_bt_nop()
         {
             // confirmed with source
-            AssertCode("bt.nop", "8001");
+            AssertCode("bt.nop\t0x0", "80 01");
         }
 
         [Test]
         public void AeonDis_bn_nop()
         {
-            AssertCode("bn.nop", "000000");
+            AssertCode("bn.nop", "00 00 00");
         }
 
         [Test]

--- a/src/UnitTests/Arch/OpenRISC/AeonRewriterTests.cs
+++ b/src/UnitTests/Arch/OpenRISC/AeonRewriterTests.cs
@@ -207,7 +207,7 @@ namespace Reko.UnitTests.Arch.OpenRISC
             Given_HexString("8002");
             AssertCode(     // bt.trap
                 "0|L--|00100000(2): 1 instructions",
-                "1|L--|bt_trap()");
+                "1|L--|__trap(1<32>)");
         }
 
         [Test]


### PR DESCRIPTION
Corrected decoding of `bt.nop` and `bt.trap`. improved display of potential operands for certain Nyi opcodes.