### PR TITLE
AEON: Add bt.swst

### DIFF
--- a/src/Arch/OpenRISC/Aeon/AeonRewriter.cs
+++ b/src/Arch/OpenRISC/Aeon/AeonRewriter.cs
@@ -176,6 +176,7 @@ namespace Reko.Arch.OpenRISC.Aeon
                 case Mnemonic.bn_srli__: RewriteShifti(m.Shr); break;
                 case Mnemonic.bn_sub: RewriteAddSub(m.ISub); break;
                 case Mnemonic.bn_subb__: RewriteAddSub(Subb); break;
+                case Mnemonic.bt_swst____:
                 case Mnemonic.bn_sw:
                 case Mnemonic.bg_sw:
                 case Mnemonic.bg_sw__: RewriteStore(PrimitiveType.Word32); break;

--- a/src/Arch/OpenRISC/Aeon/Mnemonic.cs
+++ b/src/Arch/OpenRISC/Aeon/Mnemonic.cs
@@ -130,7 +130,7 @@ namespace Reko.Arch.OpenRISC.Aeon
         bn_srli__,
         bn_sub,
         bn_subb__,
-        bt_sw__,
+        bt_swst____,
         bn_sw,
         bg_sw,
         bg_sw__,

--- a/src/Arch/OpenRISC/Aeon/MovhiSequenceFuser.cs
+++ b/src/Arch/OpenRISC/Aeon/MovhiSequenceFuser.cs
@@ -80,6 +80,7 @@ namespace Reko.Arch.OpenRISC.Aeon
             case Mnemonic.bg_sb__:
             case Mnemonic.bn_sh__:
             case Mnemonic.bg_sh__:
+            case Mnemonic.bt_swst____:
             case Mnemonic.bn_sw:
             case Mnemonic.bg_sw:
             case Mnemonic.bg_sw__:

--- a/src/UnitTests/Arch/OpenRISC/AeonDisassemblerTests.cs
+++ b/src/UnitTests/Arch/OpenRISC/AeonDisassemblerTests.cs
@@ -746,6 +746,12 @@ namespace Reko.UnitTests.Arch.OpenRISC
         }
 
         [Test]
+        public void AeonDis_bt_swst____()
+        {
+            AssertCode("bt.swst??\t0x1C(r1),r15", "81 EE");
+        }
+
+        [Test]
         public void AeonDis_bg_syncwritebuffer()
         {
             // confirmed with source

--- a/src/UnitTests/Arch/OpenRISC/AeonRewriterTests.cs
+++ b/src/UnitTests/Arch/OpenRISC/AeonRewriterTests.cs
@@ -1133,6 +1133,15 @@ namespace Reko.UnitTests.Arch.OpenRISC
         }
 
         [Test]
+        public void AeonRw_bt_swst____()
+        {
+            Given_HexString("80FE");
+            AssertCode(     // bt.swst??	0x3C(r1),r7
+                "0|L--|00100000(2): 1 instructions",
+                "1|L--|Mem0[r1 + 60<i32>:word32] = r7");
+        }
+
+        [Test]
         public void AeonRw_bg_syncwritebuffer()
         {
             Given_HexString("F4000005");


### PR DESCRIPTION
This instruction stores the value of a register (other than r0) at a given 5-bit offset (left shifted by 2 bits) from the stack pointer (r1). The mnemonic is made up.

Also added `MuStack`, which provides a mutator for memory access with an unsigned offset (optionally shifted) from r1.