### PR TITLE
Do not reset enclosing pointer when creating array access

### DIFF
--- a/src/Decompiler/Typing/ComplexExpressionBuilder.cs
+++ b/src/Decompiler/Typing/ComplexExpressionBuilder.cs
@@ -374,7 +374,6 @@ namespace Reko.Typing
             arrayIndex = CreateOffsetExpression(offset, arrayIndex);
             if (dereferenced)
             {
-                enclosingPtr = null;
                 dereferenceGenerated = true;
                 return new ArrayAccess(dtPointee, e, arrayIndex);
             }

--- a/src/UnitTests/Decompiler/Typing/ComplexExpressionBuilderTests.cs
+++ b/src/UnitTests/Decompiler/Typing/ComplexExpressionBuilderTests.cs
@@ -427,5 +427,15 @@ namespace Reko.UnitTests.Decompiler.Typing
             var ceb = CreateBuilder(null, a, m.SMul(i, 8));
             Assert.AreEqual("a[i].dw0000", ceb.BuildComplex(true).ToString());
         }
+
+        [Test]
+        public void CEB_ArrayOfPtrsToStruct()
+        {
+            var array = new ArrayType(ptrPoint, 0);
+            var a = new Identifier("a", Ptr32(array), null);
+            CreateTv(a, Ptr32(array), Ptr32(array));
+            var ceb = CreateBuilder(null, a, null, 8);
+            Assert.AreEqual("a[2<i32>]", ceb.BuildComplex(true).ToString());
+        }
     }
 }

--- a/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize.h
+++ b/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize.h
@@ -6778,7 +6778,7 @@ T_901: (in 0<32> @ 00011D14 : word32)
   Class: Eq_797
   DataType: (struct "Eq_797" 000C (0 (ptr32 Eq_8368) ptr0000))
   OrigDataType: word32
-T_902: (in (&(&(&(&(&i0_120.ptr0000->a0000[0<i32>].ptr0000.a0000)[0<i32>].ptr0000.a0000)[0<i32>].ptr0000.a0000)[0<i32>].ptr0000.a0000)[0<i32>].ptr0000.a0000)[0<i32>].ptr0000 != 0<32> @ 00011D14 : bool)
+T_902: (in i0_120.ptr0000->a0000[0<i32>].ptr0000 != 0<32> @ 00011D14 : bool)
   Class: Eq_902
   DataType: bool
   OrigDataType: bool

--- a/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize_text.c
+++ b/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize_text.c
@@ -647,7 +647,7 @@ struct Eq_n * visit_each_hash_node(struct Eq_n * o0)
 //      lookup
 Eq_n add_symbol(Eq_n o0, Eq_n o1, ptr32 & i1Out, ptr32 & i6Out)
 {
-	(&(&(&(&(&o0.ptr0000->a0000[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000 = (struct Eq_n *) 0x00;
+	o0.ptr0000->a0000[0].ptr0000 = (struct Eq_n *) 0x00;
 	Eq_n i0_n;
 	ptr32 i1_n;
 	ptr32 i6_n;
@@ -692,12 +692,12 @@ Eq_n lookup(Eq_n o0, Eq_n o1, struct Eq_n & l1Out, union Eq_n & i1Out)
 			goto l00011D34;
 		if (o0.ptr0000[o3_n * 0x0C / 8] != 0x00)
 		{
-			i0_n = (Eq_n) (&(&(&(&(&i0_n.ptr0000->a0000[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000;
+			i0_n = (Eq_n) i0_n.ptr0000->a0000[0].ptr0000;
 			while (strcmp(i0_n.ptr0000->t0004, o1) != 0x00)
 			{
-				if ((&(&(&(&(&i0_n.ptr0000->a0000[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000 == 0x00)
+				if (i0_n.ptr0000->a0000[0].ptr0000 == 0x00)
 					goto l00011D1C;
-				i0_n = (Eq_n) (&(&(&(&(&i0_n.ptr0000->a0000[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000.a0000)[0].ptr0000;
+				i0_n = (Eq_n) i0_n.ptr0000->a0000[0].ptr0000;
 			}
 l00011D34:
 			l1Out = o0;

--- a/subjects/Raw/MicroBlaze/MicroBlaze.reko/MicroBlaze.c
+++ b/subjects/Raw/MicroBlaze/MicroBlaze.reko/MicroBlaze.c
@@ -6985,7 +6985,7 @@ l000124AC:
 		ui32 r23_n = (word32) r19_n->b1ABD8;
 		ui32 r8_n = (r23_n + 0x0101) * 0x02;
 		int32 r24_n = (word32) r6[r8_n * 0x02 / 0x0404];
-		int32 r22_n = (word32) *((word32) &(r6 + (r8_n * 0x02) / 0x0404)->a0000[0] + 2);
+		int32 r22_n = (word32) *((char *) &(r6 + (r8_n * 0x02) / 0x0404)->a0000[0] + 2);
 		ui32 r18_n = r9_n & 0x1F;
 		if (r18_n != 0x00)
 		{
@@ -7250,7 +7250,7 @@ l000124AC:
 		word32 r19_n = CONVERT(Mem30[r8_n + r4_n:byte], byte, word32);
 		int32 r4_n;
 		int32 r21_n = (word32) r6[r19_n * 0x04 / 0x0404];
-		int32 r19_n = (word32) *((word32) &(r6 + (r19_n * 0x04) / 0x0404)->a0000[0] + 2);
+		int32 r19_n = (word32) *((char *) &(r6 + (r19_n * 0x04) / 0x0404)->a0000[0] + 2);
 		ui32 r18_n = r9_n & 0x1F;
 		if (r18_n != 0x00)
 		{
@@ -14383,7 +14383,7 @@ void fn0002225C(struct Eq_n * r5, int32 r6, int32 r7, word32 (** r8)[], word32 r
 	struct Eq_n * r28_n = r5;
 	if (0x03 - r7 < 0x00)
 	{
-		struct Eq_n * r3_n = r5->a0000[0].dw0000;
+		struct Eq_n * r3_n = r5->a0000[0];
 		r3_n->dw0014 = 0x32;
 		int32 r4_n = r3_n->dw0000;
 		r3_n->dw0018 = r7;
@@ -14416,7 +14416,7 @@ l000222EC:
 			goto l000225E8;
 		}
 	}
-	Eq_n r3_n = r28_n->a0000[0].dw0000;
+	Eq_n r3_n = r28_n->a0000[0];
 	*((word32) r3_n + 20) = 0x32;
 	int32 r4_n = *r3_n;
 	*((word32) r3_n + 24) = r7;
@@ -14442,7 +14442,7 @@ l000222F8:
 		if (r19_n < 0x00)
 		{
 l00022320:
-			Eq_n r3_n = r28_n->a0000[0].dw0000;
+			Eq_n r3_n = r28_n->a0000[0];
 			int32 r4_n = *r3_n;
 			*((word32) r3_n + 20) = 0x08;
 			(0x0002232C + r4_n)();
@@ -14499,7 +14499,7 @@ l00022320:
 				if (r19_n - r3_n >= 0x00)
 				{
 l00022400:
-					Eq_n r3_n = r28_n->a0000[0].dw0000;
+					Eq_n r3_n = r28_n->a0000[0];
 					int32 r4_n = *r3_n;
 					*((word32) r3_n + 20) = 0x08;
 					(140300 + r4_n)();
@@ -14575,7 +14575,7 @@ l00022400:
 	}
 	r30_n = r23_n + r19_n;
 l00022508:
-	Eq_n r3_n = r28_n->a0000[0].dw0000;
+	Eq_n r3_n = r28_n->a0000[0];
 	int32 r4_n = *r3_n;
 	*((word32) r3_n + 20) = 0x08;
 	(0x00022514 + r4_n)();
@@ -16872,7 +16872,7 @@ void fn000291C4(struct Eq_n * r5, int32 r6, int32 r7, struct Eq_n ** r8, word32 
 	struct Eq_n * r24_n = r5;
 	if (0x03 - r7 < 0x00)
 	{
-		struct Eq_n * r3_n = r5->a0000[0].dw0000;
+		struct Eq_n * r3_n = r5->a0000[0];
 		r3_n->dw0014 = 0x32;
 		int32 r4_n = r3_n->dw0000;
 		r3_n->dw0018 = r7;
@@ -16925,7 +16925,7 @@ l00029260:
 				if (r25_n < 0x00)
 				{
 l00029290:
-					Eq_n r3_n = r24_n->a0000[0].dw0000;
+					Eq_n r3_n = r24_n->a0000[0];
 					int32 r4_n = *r3_n;
 					*((word32) r3_n + 20) = 0x08;
 					word32 r11_n;
@@ -16986,7 +16986,7 @@ l00029290:
 						if (r26 - r3_n >= 0x00)
 						{
 l00029368:
-							Eq_n r3_n = r24_n->a0000[0].dw0000;
+							Eq_n r3_n = r24_n->a0000[0];
 							int32 r4_n = *r3_n;
 							*((word32) r3_n + 20) = 0x08;
 							word32 r11_n;
@@ -17157,7 +17157,7 @@ l000293FC:
 					if (0x0F - (int32) (*r19_n) < 0x00)
 					{
 						ptr32 r19_n = r19_n + 1;
-						Eq_n r3_n = r24_n->a0000[0].dw0000;
+						Eq_n r3_n = r24_n->a0000[0];
 						int32 r4_n = *r3_n;
 						*((word32) r3_n + 20) = 0x08;
 						word32 r11_n;
@@ -17170,7 +17170,7 @@ l000293FC:
 			return;
 		}
 	}
-	Eq_n r3_n = r24_n->a0000[0].dw0000;
+	Eq_n r3_n = r24_n->a0000[0];
 	*((word32) r3_n + 20) = 0x32;
 	int32 r4_n = *r3_n;
 	*((word32) r3_n + 24) = r7;

--- a/subjects/VMS-vax/unzip_code_0001.c
+++ b/subjects/VMS-vax/unzip_code_0001.c
@@ -4538,7 +4538,7 @@ int32 fn0001878E(struct Eq_n * ap, union Eq_n * fp, union Eq_n & r3Out, ptr32 & 
 {
 	word32 r3_n;
 	if (ap[1] > 0x0100)
-		r3_n = *((byte) &ap->ptr0004[0x00AA].b0000 + 4);
+		r3_n = (word32) (&ap->ptr0004[0x00AA].b0000)[4];
 	else
 		r3_n = 0x10;
 	struct Eq_n * sp_n;

--- a/subjects/regressions/reko-90/PP.reko/PP_0800.c
+++ b/subjects/regressions/reko-90/PP.reko/PP_0800.c
@@ -395,11 +395,11 @@ Eq_n fn0800-0541(Eq_n di, Eq_n ds, ptr16 & bpOut, union Eq_n & dsOut)
 	if (ax_n != *((word32) ds + 9882))
 	{
 		Eq_n ptrLoc06_n;
-		if (SEQ(ds, *((word32) ds + 9884))[ax_n].b0000 + 0x00 == 0x2D)
+		if (SEQ(ds, *((word32) ds + 9884))[ax_n]->b0000 == 0x2D)
 			ptrLoc06_n = ptrLoc06;
 		else
 		{
-			if (SEQ(ds, *((word32) ds + 9884))[*((word32) ds + 0x00002A27)].b0000 + 0x00 != 0x2F)
+			if (SEQ(ds, *((word32) ds + 9884))[*((word32) ds + 0x00002A27)]->b0000 != 0x2F)
 			{
 				bpOut = bp;
 				dsOut = ds;
@@ -407,11 +407,11 @@ Eq_n fn0800-0541(Eq_n di, Eq_n ds, ptr16 & bpOut, union Eq_n & dsOut)
 			}
 			ptrLoc06_n = ptrLoc06;
 		}
-		while (SEQ(ds, *((word32) ds + 9884))[*((word32) ds + 0x00002A27)].b0000 + 0x00 == 0x2D || (SEQ(ds, *((word32) ds + 9884)))[*((word32) ds + 0x00002A27)].b0000 + 0x00 == 0x2F)
+		while (SEQ(ds, *((word32) ds + 9884))[*((word32) ds + 0x00002A27)]->b0000 == 0x2D || (SEQ(ds, *((word32) ds + 9884)))[*((word32) ds + 0x00002A27)]->b0000 == 0x2F)
 		{
 			byte cl_n;
 			word16 bx_n;
-			Eq_n ax_n = fn0800-0C29(ds, SEQ(ds, 0x0838), SEQ(ds, *((word32) ds + 9884))[*((word32) ds + 0x00002A27)].b0000 + 1, out cl_n, out dx, out bx_n);
+			Eq_n ax_n = fn0800-0C29(ds, SEQ(ds, 0x0838), SEQ(ds, *((word32) ds + 9884))[*((word32) ds + 0x00002A27)]->t0001, out cl_n, out dx, out bx_n);
 			Eq_n si_n = ax_n;
 			if (ax_n >= 11)
 			{


### PR DESCRIPTION
- Create unit test to reproduce incorrect build of access of array elem…ent of pointer type

Expected: `a[2<i32>]`
But was: `a[2<i32>].dw0000`

- Do not reset enclosing pointer when creating array access