### PR TITLE
Find string - Common C escape characters are now considered Valid, Add Procedure name to Dump Flow

### DIFF
--- a/src/Decompiler/Analysis/ProcedureFlow.cs
+++ b/src/Decompiler/Analysis/ProcedureFlow.cs
@@ -110,7 +110,8 @@ namespace Reko.Analysis
 
 		public override void Emit(IProcessorArchitecture arch, TextWriter writer)
 		{
-			EmitRegisterValues("// MayUse: ", BitsUsed, writer);
+            writer.WriteLine("// Procedure: " + Procedure.Name);
+            EmitRegisterValues("// MayUse: ", BitsUsed, writer);
 			writer.WriteLine();
             EmitStorageDataTypes("// DataTypes: ", LiveInDataTypes, writer);
 			EmitRegisters(arch, "// LiveOut:", grfLiveOut, BitsLiveOut.Keys, writer);

--- a/src/Decompiler/Scanning/StringFinder.cs
+++ b/src/Decompiler/Scanning/StringFinder.cs
@@ -78,9 +78,10 @@ namespace Reko.Scanning
 
         //$TODO: This assumes only ASCII values are valid.
         // How to deal with Swedish? Cyrillic? Chinese?
+        // Added common escaped characters for C strings.
         public static bool IsValid(char ch)
         {
-            return (' ' <= ch && ch < 0x7F);
+            return ((' ' <= ch && ch < 0x7F) || ( 0x07 <= ch && ch <= 0x0d));
         }
     }
 


### PR DESCRIPTION
When finding strings from the dialog, wasn't including strings with common C escape characters.
common C escape characters are now considered valid.
Eg. 0x07 - 0x0d
/a, /b, /t, /n, /v, /f, /r.
Add Procedure name to output, with Dump of Flow.