### PR TITLE
Include C common escape characters when finding strings

### DIFF
--- a/src/Decompiler/Scanning/StringFinder.cs
+++ b/src/Decompiler/Scanning/StringFinder.cs
@@ -78,9 +78,10 @@ namespace Reko.Scanning
 
         //$TODO: This assumes only ASCII values are valid.
         // How to deal with Swedish? Cyrillic? Chinese?
+        // Added common escaped characters for C strings.
         public static bool IsValid(char ch)
         {
-            return (' ' <= ch && ch < 0x7F);
+            return ((' ' <= ch && ch < 0x7F) || (0x07 <= ch && ch <= 0x0d));
         }
     }
 

--- a/src/Decompiler/Scanning/StringFinder.cs
+++ b/src/Decompiler/Scanning/StringFinder.cs
@@ -81,7 +81,9 @@ namespace Reko.Scanning
         // Added common escaped characters for C strings.
         public static bool IsValid(char ch)
         {
-            return ((' ' <= ch && ch < 0x7F) || (0x07 <= ch && ch <= 0x0d));
+            
+            return ((ch >= ' ' && ch <= '~') || ( ch >= '\a' && ch <= '\r'));
+
         }
     }
 

--- a/src/Decompiler/Scanning/StringFinder.cs
+++ b/src/Decompiler/Scanning/StringFinder.cs
@@ -81,9 +81,7 @@ namespace Reko.Scanning
         // Added common escaped characters for C strings.
         public static bool IsValid(char ch)
         {
-            
             return ((ch >= ' ' && ch <= '~') || ( ch >= '\a' && ch <= '\r'));
-
         }
     }
 

--- a/src/UnitTests/Decompiler/Scanning/StringFinderTests.cs
+++ b/src/UnitTests/Decompiler/Scanning/StringFinderTests.cs
@@ -90,6 +90,24 @@ namespace Reko.UnitTests.Decompiler.Scanning
         }
 
         [Test]
+        public void StrFind_ValidCharacterRangeMatch()
+        {
+            Given_Image(0x06, 0, 0x07, 0, 0x0D, 0, 0x0E, 0, 0x1F, 00, 0x20, 0, 0x7E, 0, 0x7F, 0);
+
+            var sf = new StringFinder(program);
+            var hits = sf.FindStrings(new StringFinderCriteria(
+                StringType: StringType.NullTerminated(PrimitiveType.Char),
+                Encoding: Encoding.ASCII,
+                MinimumLength: 1,
+                CreateReader: (m, a, b) => new LeImageReader(m, a, b))).ToArray();
+            Assert.AreEqual(4, hits.Length);
+            Assert.AreEqual(Address.Ptr32(0x00400002), hits[0].Address);
+            Assert.AreEqual(Address.Ptr32(0x00400004), hits[1].Address);
+            Assert.AreEqual(Address.Ptr32(0x0040000A), hits[2].Address);
+            Assert.AreEqual(Address.Ptr32(0x0040000C), hits[3].Address);
+        }
+
+        [Test]
         public void StrFind_TwoMatch()
         {
             Given_Image(0x42, 0, 0x12, 0x43, 0x00);


### PR DESCRIPTION
When finding strings from the dialog, wasn't including strings with common C escape characters.
common C escape characters are now considered valid.
Eg. 0x07 - 0x0d
/a 0x07, /b 0x08, /t 0x09, /n 0x0a, /v 0x0b, /f 0x0c, /r 0x0d