### PR TITLE
CDirectiveLexer: #undef support, etc.

### DIFF
--- a/src/Core/Hll/C/CDirectiveLexer.cs
+++ b/src/Core/Hll/C/CDirectiveLexer.cs
@@ -185,6 +185,10 @@ namespace Reko.Core.Hll.C
                             token = ReadDefine();
                             state = State.StartLine;
                             break;
+                        case Directive.Undef:
+                            token = ReadUndef();
+                            state = State.StartLine;
+                            break;
                         case Directive.Ifdef:
                             var ifdefVar = (string) Expect(CTokenType.Id)!;
                             startIgnoring = !IsDefined(ifdefVar);
@@ -253,6 +257,14 @@ namespace Reko.Core.Hll.C
                 }
                 tokens.Add(token);
             }
+        }
+
+        public CToken ReadUndef()
+        {
+            var macroName = (string) Expect(CTokenType.Id)!;
+            this.macros.Remove(macroName);
+
+            return ReadToken();
         }
 
         public virtual CToken ReadPragma(string pragma)

--- a/src/Core/Hll/C/CDirectiveLexer.cs
+++ b/src/Core/Hll/C/CDirectiveLexer.cs
@@ -74,6 +74,7 @@ namespace Reko.Core.Hll.C
             StartLine,
             InsideLine,
             Hash,
+            IgnoreToEndOfLine,
         }
 
         private enum Directive
@@ -187,30 +188,30 @@ namespace Reko.Core.Hll.C
                             break;
                         case Directive.Undef:
                             token = ReadUndef();
-                            state = State.StartLine;
+                            state = State.IgnoreToEndOfLine;
                             break;
                         case Directive.Ifdef:
                             var ifdefVar = (string) Expect(CTokenType.Id)!;
                             startIgnoring = !IsDefined(ifdefVar);
                             ifdefs.Push((startIgnoring, ignoreTokens));
                             ignoreTokens |= startIgnoring;
-                            token = ReadToken();    //$TODO: read to end of line
-                            state = State.StartLine;
+                            token = ReadToken();
+                            state = State.IgnoreToEndOfLine;
                             break;
                         case Directive.Ifndef:
                             ifdefVar = (string) Expect(CTokenType.Id)!;
                             startIgnoring = IsDefined(ifdefVar);
                             ifdefs.Push((startIgnoring, ignoreTokens));
                             ignoreTokens |= startIgnoring;
-                            token = ReadToken();    //$TODO: read to end of line
-                            state = State.StartLine;
+                            token = ReadToken();
+                            state = State.IgnoreToEndOfLine;
                             break;
                         case Directive.Endif:
                             if (ifdefs.Count == 0)
                                 throw new FormatException($"Unbalanced #if/#endif");
                             (_, ignoreTokens) = ifdefs.Pop();
-                            token = ReadToken();    //$TODO: read to end of line
-                            state = State.StartLine;
+                            token = ReadToken();
+                            state = State.IgnoreToEndOfLine;
                             break;
                         }
                         break;
@@ -220,12 +221,19 @@ namespace Reko.Core.Hll.C
                         state = State.StartLine;
                         (startIgnoring, ignoreTokens) = ifdefs.Peek();
                         ignoreTokens |= !startIgnoring;
-                        token = ReadToken();    //$TODO: read to end of line
-                        state = State.StartLine;
+                        token = ReadToken();
+                        state = State.IgnoreToEndOfLine;
                         break;
                     default:
                         throw new FormatException($"Unexpected token {token.Type} on line {lexer.LineNumber}.");
                     }
+                    break;
+                case State.IgnoreToEndOfLine:
+                    if (token.Type == CTokenType.EOF)
+                        return token;
+                    if (token.Type == CTokenType.NewLine)
+                        state = State.StartLine;
+                    token = ReadToken();
                     break;
                 }
             }
@@ -244,7 +252,7 @@ namespace Reko.Core.Hll.C
 
         public CToken ReadDefine()
         {
-            var macroName = (string)Expect(CTokenType.Id)!;
+            var macroName = (string) Expect(CTokenType.Id)!;
             //$TODO: arguments #define(A,B) A##B
             var tokens = new List<CToken>();
             for (; ; )

--- a/src/Core/Hll/C/CDirectiveLexer.cs
+++ b/src/Core/Hll/C/CDirectiveLexer.cs
@@ -85,7 +85,6 @@ namespace Reko.Core.Hll.C
             Ifndef,
             Line,
             Pragma,
-            __Pragma,
             Undef,
         }
 

--- a/src/UnitTests/Core/Hll/C/CDirectiveLexerTests.cs
+++ b/src/UnitTests/Core/Hll/C/CDirectiveLexerTests.cs
@@ -185,6 +185,48 @@ namespace Reko.UnitTests.Core.Hll.C
         }
 
         [Test]
+        public void CDirectiveLexer_undef()
+        {
+            Lex(
+                "#define omg lol\r\n" +
+                "omg wtf\r\n" +
+                "#undef omg\r\n" +
+                "omg hi");
+            Assert.AreEqual("lol", lexer.Read().Value);
+            Assert.AreEqual("wtf", lexer.Read().Value);
+            Assert.AreEqual("omg", lexer.Read().Value);
+            Assert.AreEqual("hi", lexer.Read().Value);
+            Assert.AreEqual(CTokenType.EOF, lexer.Read().Type);
+        }
+
+        [Test]
+        public void CDirectiveLexer_undef_nonexistent()
+        {
+            Lex(
+                "/* does not exist */\r\n" +
+                "#undef macro\r\nmacro");
+            Assert.AreEqual("macro", lexer.Read().Value);
+            Assert.AreEqual(CTokenType.EOF, lexer.Read().Type);
+        }
+
+        [Test]
+        public void CDirectiveLexer_undef_comments()
+        {
+            Lex(
+                "#define xxx yyy\r\n" +
+                "aaa xxx bbb\r\n" +
+                "#/*xd*/undef/* asdf */xxx// comment;?\r\n" +
+                "ccc xxx ddd");
+            Assert.AreEqual("aaa", lexer.Read().Value);
+            Assert.AreEqual("yyy", lexer.Read().Value);
+            Assert.AreEqual("bbb", lexer.Read().Value);
+            Assert.AreEqual("ccc", lexer.Read().Value);
+            Assert.AreEqual("xxx", lexer.Read().Value);
+            Assert.AreEqual("ddd", lexer.Read().Value);
+            Assert.AreEqual(CTokenType.EOF, lexer.Read().Type);
+        }
+
+        [Test]
         public void CDirectiveLexer_multiline()
         {
             Lex(

--- a/src/UnitTests/Core/Hll/C/CDirectiveLexerTests.cs
+++ b/src/UnitTests/Core/Hll/C/CDirectiveLexerTests.cs
@@ -227,6 +227,20 @@ namespace Reko.UnitTests.Core.Hll.C
         }
 
         [Test]
+        public void CDirectiveLexer_undef_multiple_tokens()
+        {
+            Lex(
+                "#define token1 something\r\n" +
+                "#define token2 something_else\r\n" +
+                "// should probably warn\r\n" +
+                "#undef token1 token2\r\n" +
+                "token1 token2");
+            Assert.AreEqual("token1", lexer.Read().Value);
+            Assert.AreEqual("something_else", lexer.Read().Value);
+            Assert.AreEqual(CTokenType.EOF, lexer.Read().Type);
+        }
+
+        [Test]
         public void CDirectiveLexer_multiline()
         {
             Lex(
@@ -333,6 +347,30 @@ done
             Assert.AreEqual("b", lexer.Read().Value);
             Assert.AreEqual("bnotc", lexer.Read().Value);
             Assert.AreEqual("postb", lexer.Read().Value);
+            Assert.AreEqual("done", lexer.Read().Value);
+            Assert.AreEqual(CTokenType.EOF, lexer.Read().Type);
+        }
+
+        [Test]
+        public void CDirectiveLexer_various_extra_tokens()
+        {
+            LexMsvc(@"
+#define X 0
+#undef Y
+#ifdef Y qwer
+bad
+#else 1.23
+good
+# ifndef X
+bad2
+# else hi qqq
+good2
+# endif
+#endif -1111
+done
+");
+            Assert.AreEqual("good", lexer.Read().Value);
+            Assert.AreEqual("good2", lexer.Read().Value);
             Assert.AreEqual("done", lexer.Read().Value);
             Assert.AreEqual(CTokenType.EOF, lexer.Read().Type);
         }


### PR DESCRIPTION
This PR includes a few changes to `CDirectiveLexer`:
* Add support for `#undef`. Includes unit tests.
* Add `State.IgnoreToEndOfLine`, and use it to ignore extra tokens for various directives. Includes unit tests.
* Other minor cleanup: remove unused `Directive.__Pragma`; formatting.