### PR TITLE
Standardize minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required ( VERSION 3.10 FATAL_ERROR )
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/cmake")
 find_package(Dotnet 2.0 REQUIRED)
 

--- a/cmake/msbuild2cmake.cmake
+++ b/cmake/msbuild2cmake.cmake
@@ -18,7 +18,7 @@
 # `TARGET`, which is the name of the target (defined in CMakeLists.txt) to build
 #
 
-cmake_minimum_required ( VERSION 3.10 FATAL_ERROR )
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 function(check_msys output)
 	execute_process(

--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(reko-native)
 

--- a/src/Native/reko.cmake
+++ b/src/Native/reko.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required ( VERSION 3.10 FATAL_ERROR )
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 list(INSERT CMAKE_MODULE_PATH 0 "${REKO_SRC}/../cmake")
 
 include(msbuild2cmake)

--- a/src/reko.cmake
+++ b/src/reko.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required ( VERSION 3.10 FATAL_ERROR )
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 list(INSERT CMAKE_MODULE_PATH 0 "${REKO_SRC}/../cmake")
 
 include(msbuild2cmake)


### PR DESCRIPTION
One CMake file had a minimum version of 3.0, while (most of) the rest had 3.10. I was getting a warning that versions prior to 3.5 would be deprecated, so I changed that one to 3.10. I also made the formatting of the `cmake_minimum_required()` lines consistent with each other and their surroundings.