### PR TITLE
AEON: make bn.beqi immediate signed

### DIFF
--- a/src/Arch/OpenRISC/Aeon/AeonDisassembler.cs
+++ b/src/Arch/OpenRISC/Aeon/AeonDisassembler.cs
@@ -557,7 +557,7 @@ namespace Reko.Arch.OpenRISC.Aeon
             
             var decode001000 = Mask(0, 2, "  8",
                 // branch if reg == imm
-                Instr(Mnemonic.bn_beqi__, InstrClass.ConditionalTransfer, R13, uimm10_3, disp2_8),   // guess
+                Instr(Mnemonic.bn_beqi__, InstrClass.ConditionalTransfer, R13, simm10_3, disp2_8),   // guess
                 Instr(Mnemonic.bn_bf, InstrClass.ConditionalTransfer, disp2_16),                     // chenxing(mod), source
                 Instr(Mnemonic.bn_bnei__, InstrClass.ConditionalTransfer, R13, uimm10_3, disp2_8),
                 Instr(Mnemonic.bn_bnf__, InstrClass.ConditionalTransfer, disp2_16));

--- a/src/UnitTests/Arch/OpenRISC/AeonRewriterTests.cs
+++ b/src/UnitTests/Arch/OpenRISC/AeonRewriterTests.cs
@@ -160,7 +160,16 @@ namespace Reko.UnitTests.Arch.OpenRISC
             Given_HexString("2061E0");
             AssertCode(     // bn.beqi?	r3,0x0,00100078
                 "0|T--|00100000(3): 1 instructions",
-                "1|T--|if (r3 == 0<32>) branch 00100078");
+                "1|T--|if (r3 == 0<i32>) branch 00100078");
+        }
+
+        [Test]
+        public void AeonRw_bn_beqi___negative()
+        {
+            Given_HexString("207C68");
+            AssertCode(     // bn.beqi?	r3,-0x1,0010001A
+                "0|T--|00100000(3): 1 instructions",
+                "1|T--|if (r3 == -1<i32>) branch 0010001A");
         }
 
         [Test]


### PR DESCRIPTION
I've found significant evidence that `bn.beqi`'s 3-bit immediate is signed. There are many cases in which it makes a lot more sense to compare with -1 than with 7.