### PR TITLE
AEON: Make bg.beqi operand signed

### DIFF
--- a/src/Arch/OpenRISC/Aeon/AeonDisassembler.cs
+++ b/src/Arch/OpenRISC/Aeon/AeonDisassembler.cs
@@ -390,7 +390,7 @@ namespace Reko.Arch.OpenRISC.Aeon
             var decoder110100 = Mask(0, 3, "  opc=110100",
                 Instr(Mnemonic.bg_blesi__, InstrClass.ConditionalTransfer, R21, simm16_5, disp3_13),  // guess
                 Instr(Mnemonic.bg_bltsi__, InstrClass.ConditionalTransfer, R21, simm16_5, disp3_13),  // guess
-                Instr(Mnemonic.bg_beqi__, InstrClass.ConditionalTransfer, R21, uimm16_5, disp3_13),   // guess
+                Instr(Mnemonic.bg_beqi__, InstrClass.ConditionalTransfer, R21, simm16_5, disp3_13),   // guess
                 Instr(Mnemonic.bg_b011i__, InstrClass.ConditionalTransfer, R21, uimm16_5, disp3_13),  // guess
                 Instr(Mnemonic.bg_b__bitseti__, InstrClass.ConditionalTransfer, R21, uimm16_5, disp3_13),  // guess
                 Instr(Mnemonic.bg_bgtui__, InstrClass.ConditionalTransfer, R21, uimm16_5, disp3_13),  // guess

--- a/src/UnitTests/Arch/OpenRISC/AeonRewriterTests.cs
+++ b/src/UnitTests/Arch/OpenRISC/AeonRewriterTests.cs
@@ -175,10 +175,19 @@ namespace Reko.UnitTests.Arch.OpenRISC
         [Test]
         public void AeonRw_bg_beqi__()
         {
-            Given_HexString("D0B700CA");
-            AssertCode(     // bg.beqi?	r3,0x17,00100019
+            Given_HexString("D0A700CA");
+            AssertCode(     // bg.beqi?	r5,0x7,00100019
                 "0|T--|00100000(4): 1 instructions",
-                "1|T--|if (r5 == 0x17<32>) branch 00100019");
+                "1|T--|if (r5 == 7<i32>) branch 00100019");
+        }
+
+        [Test]
+        public void AeonRw_bg_beqi___negative()
+        {
+            Given_HexString("D29F24BA");
+            AssertCode(     // bg.beqi?	r20,-0x1,00100497
+                "0|T--|00100000(4): 1 instructions",
+                "1|T--|if (r20 == -1<i32>) branch 00100497");
         }
 
         [Test]


### PR DESCRIPTION
`bg.beqi` appears to have a 5-bit signed immediate operand, analogous to `bn.beqi`'s 3-bit operand.