### PR TITLE
CallRewriter: copy StackDelta/FpuStackDelta when signature making

### DIFF
--- a/src/Decompiler/Analysis/CallRewriter.cs
+++ b/src/Decompiler/Analysis/CallRewriter.cs
@@ -104,6 +104,15 @@ namespace Reko.Analysis
             ProcessInputStorages(ssa, flow, sb);
             ProcessOutputStorages(ssa, flow, sb);
             var sig = sb.BuildSignature();
+            if (ssa.Procedure.Signature.StackDelta != 0)
+            {
+                sig.StackDelta = ssa.Procedure.Signature.StackDelta;
+            }
+            var fpuStackDelta = flow.GetFpuStackDelta(ssa.Procedure.Architecture);
+            if (fpuStackDelta != 0)
+            {
+                sig.FpuStackDelta = -fpuStackDelta;
+            }
             return sig;
         }
 

--- a/src/tests/Analysis/DfaAsciiHex.exp
+++ b/src/tests/Analysis/DfaAsciiHex.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register byte al, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  al:[0..7] ds:[0..15]
 // LiveOut:
 // Trashed: SCZO al Top
@@ -22,7 +22,7 @@ l0C00_0009:
 fn0C00_0000_exit:
 
 // FlagGroup bool fn0C00_000A(Register byte al, Register out ptr16 alOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  al:[0..7]
 // LiveOut: C al
 // Trashed: SCZO al Top

--- a/src/tests/Analysis/DfaChainTest.exp
+++ b/src/tests/Analysis/DfaChainTest.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: SCZO ax dx Top
@@ -16,7 +16,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // Register word16 fn0C00_000B(Register word16 dx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  dx:[0..15]
 // LiveOut: ax
 // Trashed: SCZO ax dx Top
@@ -32,7 +32,7 @@ l0C00_000B:
 fn0C00_000B_exit:
 
 // Register word16 fn0C00_000F(Register word16 dx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  dx:[0..15]
 // LiveOut: ax
 // Trashed: SCZO ax dx Top

--- a/src/tests/Analysis/DfaFactorial.exp
+++ b/src/tests/Analysis/DfaFactorial.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: SCZO ax cx dx Top
@@ -16,7 +16,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // Register word16 fn0C00_000F(Stack word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  Stack +0002:[0..15]
 // LiveOut: ax
 // Trashed: SCZO ax dx Top

--- a/src/tests/Analysis/DfaFactorialReg.exp
+++ b/src/tests/Analysis/DfaFactorialReg.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: SCZO ax cx dx Top
@@ -16,7 +16,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // Register word16 fn0C00_000B(Register word16 cx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  cx:[0..15]
 // LiveOut: ax
 // Trashed: SCZO ax cx dx Top

--- a/src/tests/Analysis/DfaFibonacci.exp
+++ b/src/tests/Analysis/DfaFibonacci.exp
@@ -1,5 +1,5 @@
 // Register word32 fn10000000(Stack word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  Stack +0004:[0..31]
 // LiveOut: eax
 // Trashed: SCZO eax Top

--- a/src/tests/Analysis/DfaFpuOps.exp
+++ b/src/tests/Analysis/DfaFpuOps.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: SCZO bx Top
@@ -17,7 +17,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // void fn0C00_0010(Register selector ds, Stack word16 wArg02, Stack word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15] Stack +0002:[0..15] Stack +0004:[0..15]
 // LiveOut:
 // Trashed: bx FPU -1 FPU -2 Top
@@ -38,7 +38,7 @@ l0C00_0010:
 fn0C00_0010_exit:
 
 // void fn0C00_0037(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: FPU -1 Top

--- a/src/tests/Analysis/DfaFpuStackReturn.exp
+++ b/src/tests/Analysis/DfaFpuStackReturn.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: bx FPU -1 Top
@@ -16,7 +16,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // FpuStack real64 fn0C00_000C(Sequence segptr32 ds_bx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 1; fpuMaxParam: -1
 // MayUse:  Sequence ds:bx:[0..31]
 // LiveOut: FPU -1
 // Trashed: FPU -1 FPU -2 Top

--- a/src/tests/Analysis/DfaFstsw.exp
+++ b/src/tests/Analysis/DfaFstsw.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register word16 bx, Register word16 si, Register selector ds, FpuStack real64 rArg0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: -1; fpuMaxParam: -1
 // MayUse:  bx:[0..15] ds:[0..15] FPU +0:[0..63] si:[0..15]
 // LiveOut:
 // Trashed: SCZOP ax FPUF Top

--- a/src/tests/Analysis/DfaGlobalHandle.exp
+++ b/src/tests/Analysis/DfaGlobalHandle.exp
@@ -1,5 +1,5 @@
 // void fn10000000(Stack word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
 // Trashed: eax

--- a/src/tests/Analysis/DfaJumpIntoProc3.exp
+++ b/src/tests/Analysis/DfaJumpIntoProc3.exp
@@ -1,5 +1,5 @@
 // void fn10000000()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse: 
 // LiveOut:
 // Trashed: eax ebx ecx Top
@@ -17,7 +17,7 @@ l10000000:
 fn10000000_exit:
 
 // void fn10000013(Stack word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
 // Trashed: eax Top
@@ -36,7 +36,7 @@ l10000013_thunk_fn10000020:
 fn10000013_exit:
 
 // void fn10000018(Register word32 ebx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ebx:[0..31]
 // LiveOut:
 // Trashed: eax ecx Top
@@ -53,7 +53,7 @@ l10000018:
 fn10000018_exit:
 
 // void fn10000020(Stack word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
 // Trashed: eax Top

--- a/src/tests/Analysis/DfaMoveChain.exp
+++ b/src/tests/Analysis/DfaMoveChain.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: ax bx cx Top

--- a/src/tests/Analysis/DfaMutualTest.exp
+++ b/src/tests/Analysis/DfaMutualTest.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register word16 dx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  dx:[0..15]
 // LiveOut:
 // Trashed: SCZO ax dx Top
@@ -17,7 +17,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // Register word16 fn0C00_0004(Register word16 dx, Register out ptr16 dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  dx:[0..15]
 // LiveOut: ax dx
 // Trashed: SCZO ax dx Top
@@ -45,7 +45,7 @@ l0C00_0010:
 fn0C00_0004_exit:
 
 // Register word16 fn0C00_0013(Register word16 dx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  dx:[0..15]
 // LiveOut: dx
 // Trashed: SCZO ax dx Top

--- a/src/tests/Analysis/DfaNegsNots.exp
+++ b/src/tests/Analysis/DfaNegsNots.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register word32 eax, Register word16 bx, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  bx:[0..15] ds:[0..15] eax:[0..31]
 // LiveOut:
 // Trashed: SCZO bx eax ecx Top

--- a/src/tests/Analysis/DfaPreservedAlias.exp
+++ b/src/tests/Analysis/DfaPreservedAlias.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: ax Top
@@ -18,7 +18,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // void fn0C00_000C(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: Top

--- a/src/tests/Analysis/DfaReadFile.exp
+++ b/src/tests/Analysis/DfaReadFile.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse: 
 // LiveOut:
 // Trashed: SCZO bx cx ds dx Top
@@ -38,7 +38,7 @@ l0C00_001F:
 fn0C00_001F_exit:
 
 // Register word16 fn0C00_0023(Sequence word32 ds_dx, Register word16 cx, Register word16 bx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  bx:[0..15] cx:[0..15] Sequence ds:dx:[0..31]
 // LiveOut: ax
 // Trashed: C ax Top

--- a/src/tests/Analysis/DfaRecurseWithPushes.exp
+++ b/src/tests/Analysis/DfaRecurseWithPushes.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register word16 si, Register word16 di, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  di:[0..15] ds:[0..15] si:[0..15]
 // LiveOut:
 // Trashed: SCZO ax di esi Top
@@ -16,7 +16,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // void fn0C00_0004(Register word16 si, Register word16 di, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  di:[0..15] ds:[0..15] si:[0..15]
 // LiveOut:
 // Trashed: SCZO ax di esi Top
@@ -40,7 +40,7 @@ l0C00_001C:
 fn0C00_0004_exit:
 
 // void fn0C00_001D(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: esi Top

--- a/src/tests/Analysis/DfaReg00001.exp
+++ b/src/tests/Analysis/DfaReg00001.exp
@@ -1,5 +1,5 @@
 // void fn00400000(Stack word32 dwArg00, Stack word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  Stack +0000:[0..31] Stack +0004:[0..31]
 // LiveOut:
 // Trashed: SCZOP eax ecx edx
@@ -16,7 +16,7 @@ l00400000:
 fn00400000_exit:
 
 // Register word32 fn0040000C(Stack word32 dwArg04, Stack word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  Stack +0004:[0..31] Stack +0008:[0..31]
 // LiveOut: eax
 // Trashed: SCZOP eax ecx edx

--- a/src/tests/Analysis/DfaReg00005.exp
+++ b/src/tests/Analysis/DfaReg00005.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: SCZO al Top
@@ -21,7 +21,7 @@ l0C00_000B:
 fn0C00_0000_exit:
 
 // FlagGroup bool fn0C00_000C(Register byte al, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  al:[0..7] ds:[0..15]
 // LiveOut: C
 // Trashed: SCZO Top

--- a/src/tests/Analysis/DfaReg00009.exp
+++ b/src/tests/Analysis/DfaReg00009.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: SCZO ax bx cx di dx es gs Top

--- a/src/tests/Analysis/DfaReg00010.exp
+++ b/src/tests/Analysis/DfaReg00010.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register word16 bp, Register word16 si, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  bp:[0..15] ds:[0..15] si:[0..15]
 // LiveOut:
 // Trashed: SCZO ax bp bx cx dx si Top
@@ -16,7 +16,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // void fn0C00_0004(Register word16 bp, Register word16 si, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  bp:[0..15] ds:[0..15] si:[0..15]
 // LiveOut:
 // Trashed: SCZO ax bp bx cx dx si Top

--- a/src/tests/Analysis/DfaReg00011.exp
+++ b/src/tests/Analysis/DfaReg00011.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse: 
 // LiveOut:
 // Trashed: SCZO ax bx es Top
@@ -16,7 +16,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // void fn0C00_0004()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse: 
 // LiveOut:
 // Trashed: SCZO ax bx es Top

--- a/src/tests/Analysis/DfaReg00015.exp
+++ b/src/tests/Analysis/DfaReg00015.exp
@@ -35,7 +35,7 @@ l0C00_001E:
 fn0C00_0000_exit:
 
 // void fn0C00_0037(Register word16 ax, Register word16 dx, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ax:[0..15] ds:[0..15] dx:[0..15]
 // LiveOut:
 // Trashed: Top

--- a/src/tests/Analysis/DfaReg00282.exp
+++ b/src/tests/Analysis/DfaReg00282.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register word16 ax)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ax:[0..15]
 // LiveOut:
 // Trashed: SCZO ax bx Top

--- a/src/tests/Analysis/DfaRegPairReturn.exp
+++ b/src/tests/Analysis/DfaRegPairReturn.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  cs:[0..15]
 // LiveOut:
 // Trashed: SCZO ax ds dx Top
@@ -20,7 +20,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // Sequence ui32 fn0C00_001B(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut: dx:ax
 // Trashed: ax dx Top

--- a/src/tests/Analysis/DfaRemoveSpaces.exp
+++ b/src/tests/Analysis/DfaRemoveSpaces.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  cs:[0..15] ds:[0..15]
 // LiveOut:
 // Trashed: SCZO ax cx di es si sp Top
@@ -18,7 +18,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // void fn0C00_0015(Stack segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  Stack +0002:[0..31]
 // LiveOut:
 // Trashed: SCZO di es si Top
@@ -53,7 +53,7 @@ l0C00_002C:
 fn0C00_0015_exit:
 
 // Register word16 fn0C00_002F(Stack segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  Stack +0002:[0..31]
 // LiveOut: ax
 // Trashed: SCZO ax cx si Top

--- a/src/tests/Analysis/DfaStackPointerMessing.exp
+++ b/src/tests/Analysis/DfaStackPointerMessing.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register word16 bx, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  bx:[0..15] ds:[0..15] ss:[0..15]
 // LiveOut:
 // Trashed: ax ss Top
@@ -16,7 +16,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // Register word16 fn0C00_0008(Register word16 bx, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  bx:[0..15] ds:[0..15] ss:[0..15]
 // LiveOut: ax
 // Trashed: ax sp ss Top

--- a/src/tests/Analysis/DfaStringInstructions.exp
+++ b/src/tests/Analysis/DfaStringInstructions.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register word32 eax, Register word16 si, Register selector es, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15] eax:[0..31] es:[0..15] si:[0..15]
 // LiveOut:
 // Trashed: SCZO cx di eax si Top
@@ -21,7 +21,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // void fn0C00_0026(Register selector es, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15] es:[0..15]
 // LiveOut:
 // Trashed: SCZO al cx di Top

--- a/src/tests/Analysis/DfaSuccessiveDecs.exp
+++ b/src/tests/Analysis/DfaSuccessiveDecs.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ds:[0..15]
 // LiveOut:
 // Trashed: SCZO ax Top
@@ -16,7 +16,7 @@ l0C00_0000:
 fn0C00_0000_exit:
 
 // Register word16 fn0C00_000C(Register word16 ax)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  ax:[0..15]
 // LiveOut: ax
 // Trashed: SCZO ax Top

--- a/src/tests/Analysis/DfaWhileBigHead.exp
+++ b/src/tests/Analysis/DfaWhileBigHead.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Sequence segptr32 ds_si)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  Sequence ds:si:[0..31]
 // LiveOut:
 // Trashed: SCZO ax Top

--- a/src/tests/Analysis/DfaWhileGoto.exp
+++ b/src/tests/Analysis/DfaWhileGoto.exp
@@ -1,5 +1,5 @@
 // void fn0C00_0000(Register word16 si, Register word16 di, Register selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 // MayUse:  di:[0..15] ds:[0..15] si:[0..15]
 // LiveOut:
 // Trashed: SCZO ax bx si Top

--- a/subjects/Archives/ArTar/hello.reko/hello_O1_fini.dis
+++ b/subjects/Archives/ArTar/hello.reko/hello_O1_fini.dis
@@ -1,5 +1,5 @@
 void _fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Archives/ArTar/hello.reko/hello_O1_init.dis
+++ b/subjects/Archives/ArTar/hello.reko/hello_O1_init.dis
@@ -1,5 +1,5 @@
 void _init()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __libc_csu_init

--- a/subjects/Archives/ArTar/hello.reko/hello_O1_text.dis
+++ b/subjects/Archives/ArTar/hello.reko/hello_O1_text.dis
@@ -17,7 +17,7 @@ l0000000000001080:
 
 
 void deregister_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __do_global_dtors_aux
@@ -39,7 +39,7 @@ deregister_tm_clones_exit:
 
 
 void register_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      frame_dummy
@@ -62,7 +62,7 @@ register_tm_clones_exit:
 
 
 void __do_global_dtors_aux()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -85,7 +85,7 @@ __do_global_dtors_aux_exit:
 
 
 void frame_dummy()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __libc_csu_init
@@ -102,7 +102,7 @@ frame_dummy_exit:
 
 
 word128 Q_rsqrt(word128 xmm0, word32 dwArg00)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -118,7 +118,7 @@ Q_rsqrt_exit:
 
 
 word128 lib_rsqrt(word128 xmm0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -138,7 +138,7 @@ lib_rsqrt_exit:
 
 
 void main(word64 rsi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rsi:[0..63]
 // LiveOut:
@@ -161,7 +161,7 @@ main_exit:
 
 
 void __libc_csu_init(word64 rdx, word64 rsi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..31] rdx:[0..63] rsi:[0..63]
 // LiveOut:
@@ -187,7 +187,7 @@ __libc_csu_init_exit:
 
 
 void __libc_csu_fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Archives/TarRaw/hello.reko/hello_normal.dis
+++ b/subjects/Archives/TarRaw/hello.reko/hello_normal.dis
@@ -1,5 +1,5 @@
 void hello()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -13,7 +13,7 @@ hello_exit:
 
 
 void puts(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      hello
@@ -36,7 +36,7 @@ l0109:
 
 
 void putchar(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      puts

--- a/subjects/CPM-80/CB80_code.dis
+++ b/subjects/CPM-80/CB80_code.dis
@@ -21,7 +21,7 @@ fn0387_exit:
 
 
 void fn0390(byte b, byte c, byte e, byte bArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0990
@@ -49,7 +49,7 @@ l03A9:
 
 
 bool fn03BB(byte c, ptr16 & aOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn03CB
@@ -68,7 +68,7 @@ fn03BB_exit:
 
 
 word16 fn03CB(byte c)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0990
@@ -88,7 +88,7 @@ fn03CB_exit:
 
 
 byte fn03E6(byte c)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0990
@@ -109,7 +109,7 @@ fn03E6_exit:
 
 
 void fn0400()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -124,7 +124,7 @@ fn0400_exit:
 
 
 void fn040D(byte b, byte c, byte e, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0BE4
@@ -157,7 +157,7 @@ l0457:
 
 
 byte fn045B()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn100A
@@ -183,7 +183,7 @@ fn045B_exit:
 
 
 byte fn0473(byte c)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0483
@@ -201,7 +201,7 @@ fn0473_exit:
 
 
 word16 fn0483(byte b, byte c, byte d, byte e, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0534
@@ -256,7 +256,7 @@ l0520:
 
 
 byte fn0524(byte c)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn056B
@@ -273,7 +273,7 @@ fn0524_exit:
 
 
 word16 fn0534(byte c)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn056B
@@ -301,7 +301,7 @@ fn0534_exit:
 
 
 bool fn056B(word16 bc, ptr16 & bcOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn05CE
@@ -361,7 +361,7 @@ fn056B_exit:
 
 
 byte fn05CE(word16 bc)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn061B
@@ -393,7 +393,7 @@ l05DD:
 
 
 bool fn05EF(word16 bc, ptr16 & bOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn061B
@@ -427,7 +427,7 @@ fn05EF_exit:
 
 
 bool fn061B(byte b, byte c, byte d, byte e)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn082F
@@ -451,7 +451,7 @@ fn061B_exit:
 
 
 void fn063E(byte b, byte c, byte d, byte e)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn06CE
@@ -505,7 +505,7 @@ l0678:
 
 
 byte fn06CE(byte b, byte c)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn075C
@@ -529,7 +529,7 @@ fn06CE_exit:
 
 
 void fn0722(byte c, byte b)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  b:[0..7] c:[0..7]
 // LiveOut:
@@ -551,7 +551,7 @@ fn0722_exit:
 
 
 void fn0745(word16 bc)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn07B3
@@ -575,7 +575,7 @@ l0753:
 
 
 void fn075C(byte b, byte c, byte d, byte e)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0BE4
@@ -618,7 +618,7 @@ fn075C_exit:
 
 
 void fn07B3(byte b)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0814
@@ -667,7 +667,7 @@ l07C9:
 
 
 void fn0814(byte b)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0BE4
@@ -691,7 +691,7 @@ fn0814_exit:
 
 
 byte fn082F(byte f, byte b, byte c, byte e, word16 wArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0BE4
@@ -790,7 +790,7 @@ fn082F_exit:
 
 
 void fn08EC()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn082F
@@ -811,7 +811,7 @@ fn08EC_exit:
 
 
 void fn08FD()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn082F
@@ -831,7 +831,7 @@ fn08FD_exit:
 
 
 void fn0920()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn082F
@@ -870,7 +870,7 @@ fn0920_exit:
 
 
 bool fn0990(byte f, byte b, byte c, byte d, byte e, ptr16 & afOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn082F
@@ -1019,7 +1019,7 @@ fn0990_exit:
 
 
 word16 fn0B74()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0990
@@ -1035,7 +1035,7 @@ fn0B74_exit:
 
 
 void fn0B91()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0990
@@ -1052,7 +1052,7 @@ fn0B91_exit:
 
 
 void fn0BE4(byte f)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn100A
@@ -1112,7 +1112,7 @@ fn0BE4_exit:
 
 
 byte fn0C93()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0E63
@@ -1127,7 +1127,7 @@ fn0C93_exit:
 
 
 bool fn0D64(ptr16 & aOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0D84
@@ -1144,7 +1144,7 @@ fn0D64_exit:
 
 
 void fn0D6F()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1159,7 +1159,7 @@ fn0D6F_exit:
 
 
 void fn0D84()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1179,7 +1179,7 @@ fn0D84_exit:
 
 
 void fn0DB9()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1192,7 +1192,7 @@ fn0DB9_exit:
 
 
 void fn0DCB()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1207,7 +1207,7 @@ fn0DCB_exit:
 
 
 void fn0E63(byte c)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  c:[0..7]
 // LiveOut:
@@ -1238,7 +1238,7 @@ fn0E63_exit:
 
 
 bool fn0EAB(ptr16 & aOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0E63
@@ -1270,7 +1270,7 @@ fn0EAB_exit:
 
 
 void fn0FB8()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1432,7 +1432,7 @@ l1002:
 
 
 void fn1229()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn100A
@@ -1465,7 +1465,7 @@ l124E:
 
 
 void fn1262()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn100A
@@ -1489,7 +1489,7 @@ l1275:
 
 
 word16 fn1279()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn100A
@@ -1527,7 +1527,7 @@ l12A1:
 
 
 word16 fn12D8()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn100A
@@ -1555,7 +1555,7 @@ fn12D8_exit:
 
 
 void fn1315()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1568,7 +1568,7 @@ fn1315_exit:
 
 
 byte fn1326(byte c, word16 hl, ptr16 & lOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0483
@@ -1592,7 +1592,7 @@ fn1326_exit:
 
 
 bool fn1335(word16 de, word16 hl)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0534
@@ -1607,7 +1607,7 @@ fn1335_exit:
 
 
 void fn133C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1620,7 +1620,7 @@ fn133C_exit:
 
 
 word16 fn1346(word16 bc, word16 de)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0BE4
@@ -1639,7 +1639,7 @@ fn1346_exit:
 
 
 bool fn1348(word16 de, word16 hl, ptr16 & deOut, ptr16 & hlOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn063E
@@ -1658,7 +1658,7 @@ fn1348_exit:
 
 
 byte fn1353(byte a, word16 de, ptr16 & lOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn075C
@@ -1678,7 +1678,7 @@ fn1353_exit:
 
 
 byte fn1356(word16 de, word16 hl)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1353

--- a/subjects/Elf/Msp430/a.reko/a_text.dis
+++ b/subjects/Elf/Msp430/a.reko/a_text.dis
@@ -151,7 +151,7 @@ l5AD8:
 
 
 word20 msp430_compute_modulator_bits(ui40 r13_r12, ui40 r15_r14)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      init_uart_isr
@@ -198,7 +198,7 @@ msp430_compute_modulator_bits_exit:
 
 
 word20 init_uart_isr(word40 r14_r13, word20 sr, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00004000
@@ -245,7 +245,7 @@ init_uart_isr_exit:
 
 
 void getchar(word20 sr)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  sr:[0..19]
 // LiveOut:
@@ -263,7 +263,7 @@ getchar_exit:
 
 
 void uart_putchar_isr_mode(word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00004000
@@ -279,7 +279,7 @@ uart_putchar_isr_mode_exit:
 
 
 word20 putchar(word20 sr, word20 r15, ptr16 & r11Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      task_1
@@ -317,7 +317,7 @@ putchar_exit:
 
 
 word20 x_getchar(word20 sr, word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      getchar
@@ -338,7 +338,7 @@ x_getchar_exit:
 
 
 word20 x_putchar(word20 sr, word20 r14, word20 r15, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      putchar
@@ -379,7 +379,7 @@ x_putchar_exit:
 
 
 void vRxISR(word20 sr)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  sr:[0..19]
 // LiveOut:
@@ -403,7 +403,7 @@ vRxISR_exit:
 
 
 void vTxISR(word20 sr)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  sr:[0..19]
 // LiveOut:
@@ -425,7 +425,7 @@ vTxISR_exit:
 
 
 word20 xTaskCreate(word20 sr, word20 r12, word20 r13, word20 r14, word20 r15, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00004000
@@ -505,7 +505,7 @@ xTaskCreate_exit:
 
 
 void vTaskDelete(word20 sr, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r15:[0..19] sr:[0..19]
 // LiveOut:
@@ -549,7 +549,7 @@ vTaskDelete_exit:
 
 
 word20 vTaskDelayUntil(word20 sr, word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      task_1
@@ -608,7 +608,7 @@ vTaskDelayUntil_exit:
 
 
 void vTaskDelay(word20 sr, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r15:[0..19] sr:[0..19]
 // LiveOut:
@@ -649,7 +649,7 @@ vTaskDelay_exit:
 
 
 void vTaskStartScheduler(word20 sr)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00004000
@@ -674,7 +674,7 @@ vTaskStartScheduler_exit:
 
 
 void vTaskEndScheduler()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -689,7 +689,7 @@ vTaskEndScheduler_exit:
 
 
 word20 vTaskSuspendAll(word20 sr)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vTaskDelayUntil
@@ -720,7 +720,7 @@ vTaskSuspendAll_exit:
 
 
 word20 xTaskResumeAll(word20 sr, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vTaskDelayUntil
@@ -802,7 +802,7 @@ l000047D4:
 
 
 word20 xTaskGetTickCount(word20 sr, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      task_idle
@@ -833,7 +833,7 @@ xTaskGetTickCount_exit:
 
 
 void uxTaskGetNumberOfTasks()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -855,7 +855,7 @@ uxTaskGetNumberOfTasks_exit:
 
 
 void vTaskIncrementTick()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xTaskResumeAll
@@ -909,7 +909,7 @@ l000048AC:
 
 
 void vTaskPlaceOnEventList(word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xQueueSend
@@ -940,7 +940,7 @@ vTaskPlaceOnEventList_exit:
 
 
 word20 xTaskRemoveFromEventList(word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xQueueSendFromISR
@@ -1011,7 +1011,7 @@ l49B6:
 
 
 void prvInitialiseTCBVariables(word20 r12, word20 r13, word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xTaskCreate
@@ -1040,7 +1040,7 @@ prvInitialiseTCBVariables_exit:
 
 
 void prvInitialiseTaskLists()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xTaskCreate
@@ -1067,7 +1067,7 @@ prvInitialiseTaskLists_exit:
 
 
 word20 prvCheckTasksWaitingTermination(word20 sr)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      prvIdleTask
@@ -1116,7 +1116,7 @@ prvCheckTasksWaitingTermination_exit:
 
 
 word20 prvAllocateTCBAndStack(word20 sr, word20 r15, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xTaskCreate
@@ -1147,7 +1147,7 @@ prvAllocateTCBAndStack_exit:
 
 
 void prvDeleteTCB()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      prvCheckTasksWaitingTermination
@@ -1164,7 +1164,7 @@ prvDeleteTCB_exit:
 
 
 void vTaskSwitchContext()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vPortYield
@@ -1195,7 +1195,7 @@ vTaskSwitchContext_exit:
 
 
 void vListInitialise(word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      prvInitialiseTaskLists
@@ -1218,7 +1218,7 @@ vListInitialise_exit:
 
 
 void vListInitialiseItem(word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      prvInitialiseTCBVariables
@@ -1235,7 +1235,7 @@ vListInitialiseItem_exit:
 
 
 void vListInsertEnd(word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xTaskCreate
@@ -1262,7 +1262,7 @@ vListInsertEnd_exit:
 
 
 void vListInsert(word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vTaskDelayUntil
@@ -1306,7 +1306,7 @@ vListInsert_exit:
 
 
 void vListRemove(word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vTaskDelete
@@ -1339,7 +1339,7 @@ vListRemove_exit:
 
 
 word20 xQueueCreate(word20 sr, word20 r15, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      init_uart_isr
@@ -1364,7 +1364,7 @@ xQueueCreate_exit:
 
 
 word20 xQueueSend(word20 sr, word20 r13, word20 r14, word20 r15, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      x_putchar
@@ -1476,7 +1476,7 @@ xQueueSend_exit:
 
 
 word20 xQueueSendFromISR(word20 sr, word20 r13, word20 r14, word20 r15, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vRxISR
@@ -1518,7 +1518,7 @@ xQueueSendFromISR_exit:
 
 
 word20 xQueueReceive(word20 sr, word20 r13, word20 r14, word20 r15, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      x_getchar
@@ -1633,7 +1633,7 @@ xQueueReceive_exit:
 
 
 word20 xQueueReceiveFromISR(word20 sr, word20 r13, word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vTxISR
@@ -1678,7 +1678,7 @@ xQueueReceiveFromISR_exit:
 
 
 void uxQueueMessagesWaiting()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1700,7 +1700,7 @@ uxQueueMessagesWaiting_exit:
 
 
 void vQueueDelete()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1715,7 +1715,7 @@ vQueueDelete_exit:
 
 
 word20 prvUnlockQueue(word20 sr, word20 r15, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xQueueSend
@@ -1775,7 +1775,7 @@ prvUnlockQueue_exit:
 
 
 word20 prvIsQueueEmpty(word20 sr, word20 r15, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xQueueReceive
@@ -1806,7 +1806,7 @@ prvIsQueueEmpty_exit:
 
 
 word20 prvIsQueueFull(word20 sr, word20 r15, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xQueueSend
@@ -1837,7 +1837,7 @@ prvIsQueueFull_exit:
 
 
 word20 pvPortMalloc(word20 sr, word20 r15, ptr16 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      prvAllocateTCBAndStack
@@ -1872,7 +1872,7 @@ pvPortMalloc_exit:
 
 
 void vPortFree()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      prvAllocateTCBAndStack
@@ -1889,7 +1889,7 @@ vPortFree_exit:
 
 
 void vPortInitialiseBlocks()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1903,7 +1903,7 @@ vPortInitialiseBlocks_exit:
 
 
 word20 pxPortInitialiseStack(word20 r13, word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xTaskCreate
@@ -1933,7 +1933,7 @@ pxPortInitialiseStack_exit:
 
 
 void xPortStartScheduler()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vTaskStartScheduler
@@ -1950,7 +1950,7 @@ xPortStartScheduler_exit:
 
 
 void vPortEndScheduler()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vTaskEndScheduler
@@ -1965,7 +1965,7 @@ vPortEndScheduler_exit:
 
 
 word20 vPortYield(word20 sr, ptr16 & r8Out, ptr16 & r9Out, ptr16 & r10Out, ptr16 & r11Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vRxISR
@@ -2000,7 +2000,7 @@ vPortYield_exit:
 
 
 void prvSetupTimerInterrupt()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xPortStartScheduler
@@ -2022,7 +2022,7 @@ prvSetupTimerInterrupt_exit:
 
 
 void prvTickISR()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -2040,7 +2040,7 @@ prvTickISR_exit:
 
 
 void printf(word20 r8)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00004000
@@ -2058,7 +2058,7 @@ printf_exit:
 
 
 word20 PRINT(word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vuprintf
@@ -2094,7 +2094,7 @@ PRINT_exit:
 
 
 word20 __write_pad(word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vuprintf
@@ -2131,7 +2131,7 @@ __write_pad_exit:
 
 
 void vuprintf(word20 r8, word20 r13, word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      printf
@@ -2559,7 +2559,7 @@ vuprintf_exit:
 
 
 word20 memchr(word20 r13, word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vuprintf
@@ -2589,7 +2589,7 @@ memchr_exit:
 
 
 void strncpy(word20 r13, word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      prvInitialiseTCBVariables
@@ -2625,7 +2625,7 @@ strncpy_exit:
 
 
 word20 memcpy(word20 sr, word20 r13, word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      xQueueSend
@@ -2738,7 +2738,7 @@ memcpy_exit:
 
 
 word20 memset(word20 sr, word20 r13, word20 r14, word20 r15)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      prvAllocateTCBAndStack
@@ -2798,7 +2798,7 @@ memset_exit:
 
 
 ui40 fn00005ADC(word20 r10, word20 r11, word20 r12, word20 r13)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      msp430_compute_modulator_bits
@@ -2821,7 +2821,7 @@ fn00005ADC_exit:
 
 
 word20 fn00005B04(ui40 r11_r10, ui40 r13_r12)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      msp430_compute_modulator_bits
@@ -2865,7 +2865,7 @@ fn00005B04_exit:
 
 
 bool fn00005B4E(ui40 r11_r10, word20 r8, word20 r12, word20 r13, ptr16 & r13_r12Out, ptr16 & r15_r14Out, ptr16 & r8Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      vuprintf

--- a/subjects/Elf/x86-64/ais3_crackme/ais3_crackme.reko/ais3_crackme_fini.dis
+++ b/subjects/Elf/x86-64/ais3_crackme/ais3_crackme.reko/ais3_crackme_fini.dis
@@ -1,5 +1,5 @@
 void _fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Elf/x86-64/ais3_crackme/ais3_crackme.reko/ais3_crackme_init.dis
+++ b/subjects/Elf/x86-64/ais3_crackme/ais3_crackme.reko/ais3_crackme_init.dis
@@ -1,5 +1,5 @@
 void _init()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __libc_csu_init

--- a/subjects/Elf/x86-64/ais3_crackme/ais3_crackme.reko/ais3_crackme_text.dis
+++ b/subjects/Elf/x86-64/ais3_crackme/ais3_crackme.reko/ais3_crackme_text.dis
@@ -17,7 +17,7 @@ l0000000000400410:
 
 
 void call_gmon_start()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _init
@@ -36,7 +36,7 @@ call_gmon_start_exit:
 
 
 void deregister_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __do_global_dtors_aux
@@ -59,7 +59,7 @@ deregister_tm_clones_exit:
 
 
 void register_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      frame_dummy
@@ -82,7 +82,7 @@ register_tm_clones_exit:
 
 
 void __do_global_dtors_aux()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -100,7 +100,7 @@ __do_global_dtors_aux_exit:
 
 
 void frame_dummy()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -124,7 +124,7 @@ frame_dummy_exit:
 
 
 word32 verify(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -153,7 +153,7 @@ verify_exit:
 
 
 void main(word64 rsi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  edi:[0..31] rsi:[0..63]
 // LiveOut:
@@ -177,7 +177,7 @@ main_exit:
 
 
 void __libc_csu_init(word64 rdx, word64 rsi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..31] rdx:[0..63] rsi:[0..63]
 // LiveOut:
@@ -203,7 +203,7 @@ __libc_csu_init_exit:
 
 
 void __libc_csu_fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Elf/x86-64/ls/ls.reko/ls_fini.dis
+++ b/subjects/Elf/x86-64/ls/ls.reko/ls_fini.dis
@@ -1,5 +1,5 @@
 void _fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Elf/x86-64/ls/ls.reko/ls_init.dis
+++ b/subjects/Elf/x86-64/ls/ls.reko/ls_init.dis
@@ -1,5 +1,5 @@
 void _init()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Elf/x86-64/ls/ls.reko/ls_text.dis
+++ b/subjects/Elf/x86-64/ls/ls.reko/ls_text.dis
@@ -1114,7 +1114,7 @@ l0000000000404890:
 
 
 void fn00000000004048C0()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1135,7 +1135,7 @@ fn00000000004048C0_exit:
 
 
 byte fn00000000004049E0(word64 rcx, byte dl, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -1322,7 +1322,7 @@ fn00000000004049E0_exit:
 
 
 word64 fn0000000000404CD0(word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -1355,7 +1355,7 @@ fn0000000000404CD0_exit:
 
 
 void fn0000000000404D20(word32 edx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -1391,7 +1391,7 @@ fn0000000000404D20_exit:
 
 
 void fn0000000000404D90(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000404DD0
@@ -1415,7 +1415,7 @@ fn0000000000404D90_exit:
 
 
 void fn0000000000404DD0()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -1450,7 +1450,7 @@ fn0000000000404DD0_exit:
 
 
 void fn0000000000404E80()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -1530,7 +1530,7 @@ fn0000000000404E80_exit:
 
 
 void fn0000000000405090(byte sil, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -1608,7 +1608,7 @@ l0000000000405100:
 
 
 void fn0000000000405200(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004079F0
@@ -1661,7 +1661,7 @@ fn0000000000405200_exit:
 
 
 word64 fn00000000004052D0(word64 rcx, word64 rdx, word64 rsi, word64 rdi, word64 r12, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -1825,7 +1825,7 @@ fn00000000004052D0_exit:
 
 
 void fn0000000000405630(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -1876,7 +1876,7 @@ fn0000000000405630_exit:
 
 
 void fn0000000000405700(word32 edx, word32 esi, word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004057B0
@@ -1924,7 +1924,7 @@ fn0000000000405700_exit:
 
 
 void fn00000000004057B0(byte dl, word32 esi, word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000406B70
@@ -1952,7 +1952,7 @@ fn00000000004057B0_exit:
 
 
 void fn0000000000405810(word64 rdx, word64 rsi, word32 edi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -1979,7 +1979,7 @@ fn0000000000405810_exit:
 
 
 word32 fn0000000000405C20(word32 ecx, word32 edx, word32 esi, byte dil)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000405D00
@@ -2046,7 +2046,7 @@ fn0000000000405C20_exit:
 
 
 byte fn0000000000405D00(word64 rcx, word32 edx, word64 rsi, byte dil)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000406B70
@@ -2080,7 +2080,7 @@ fn0000000000405D00_exit:
 
 
 word64 fn0000000000405D50(word64 rdi, word64 r12, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000405ED0
@@ -2143,7 +2143,7 @@ fn0000000000405D50_exit:
 
 
 word64 fn0000000000405ED0(word32 edi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004079F0
@@ -2296,7 +2296,7 @@ fn0000000000405ED0_exit:
 
 
 word32 fn00000000004061B0(word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000405ED0
@@ -2414,7 +2414,7 @@ fn0000000000406440_exit:
 
 
 void fn0000000000406490()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -2457,7 +2457,7 @@ l00000000004064D9:
 
 
 word64 fn0000000000406540(word64 rax, word64 rcx, word64 rdx, byte sil, word64 rdi, selector fs, ptr64 & rcxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000406B70
@@ -2689,7 +2689,7 @@ fn0000000000406540_exit:
 
 
 word64 fn0000000000406A30()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000407870
@@ -2720,7 +2720,7 @@ fn0000000000406A30_exit:
 
 
 word64 fn0000000000406A80(word32 ecx, word64 rdx, word64 rsi, word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000406B70
@@ -2755,7 +2755,7 @@ fn0000000000406A80_exit:
 
 
 void fn0000000000406B70(word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004079F0
@@ -3108,7 +3108,7 @@ l0000000000406DF5:
 
 
 void fn0000000000407870(word64 rsi, word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004079F0
@@ -3177,7 +3177,7 @@ fn0000000000407870_exit:
 
 
 void fn00000000004079F0(word64 r12, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -3372,7 +3372,7 @@ fn00000000004079F0_exit:
 
 
 word64 fn0000000000407EA0(word64 rcx, word32 edx, word32 esi, word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -3999,7 +3999,7 @@ l000000000040978D:
 
 
 word32 fn0000000000409CC0(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000407EA0
@@ -4035,7 +4035,7 @@ fn0000000000409CC0_exit:
 
 
 word64 fn0000000000409D20(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000407EA0
@@ -4091,7 +4091,7 @@ fn0000000000409D20_exit:
 
 
 word64 fn0000000000409E50(word64 rcx, word64 rdx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -4184,7 +4184,7 @@ fn0000000000409F80_exit:
 
 
 word64 fn000000000040A000(word64 rdx, word64 rsi, word64 rdi, selector fs, ptr64 & rdxOut, ptr64 & rsiOut, ptr64 & rdiOut, ptr64 & r8Out, ptr64 & r9Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040A120
@@ -4254,7 +4254,7 @@ fn000000000040A000_exit:
 
 
 word64 fn000000000040A120(word64 rcx, word64 rdx, word64 rsi, word64 rdi, word64 r8, word64 r9, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -4285,7 +4285,7 @@ fn000000000040A120_exit:
 
 
 word64 fn000000000040A2B0(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000407EA0
@@ -4320,7 +4320,7 @@ fn000000000040A2B0_exit:
 
 
 word64 fn000000000040A390(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000405090
@@ -4373,7 +4373,7 @@ fn000000000040A390_exit:
 
 
 word64 fn000000000040A400(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040A630
@@ -4399,7 +4399,7 @@ fn000000000040A400_exit:
 
 
 void fn000000000040A600(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000406B70
@@ -4481,7 +4481,7 @@ fn000000000040A600_exit:
 
 
 word64 fn000000000040A610(word64 rdx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000405090
@@ -4501,7 +4501,7 @@ fn000000000040A610_exit:
 
 
 word64 fn000000000040A630(word64 rdx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040A610
@@ -4551,7 +4551,7 @@ fn000000000040A630_exit:
 
 
 void fn000000000040A730(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..63]
 // LiveOut:
@@ -4607,7 +4607,7 @@ fn000000000040A730_exit:
 
 
 void fn000000000040AB30(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000406B70
@@ -4630,7 +4630,7 @@ fn000000000040AB30_exit:
 
 
 byte fn000000000040AB70(word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -4657,7 +4657,7 @@ fn000000000040AB70_exit:
 
 
 word64 fn000000000040ABC0(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040B400
@@ -4707,7 +4707,7 @@ fn000000000040ABC0_exit:
 
 
 word64 fn000000000040AC80(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040ACB0
@@ -4731,7 +4731,7 @@ fn000000000040AC80_exit:
 
 
 word64 fn000000000040ACB0(word32 ecx, word64 rdx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040B8F0
@@ -4818,7 +4818,7 @@ fn000000000040ACB0_exit:
 
 
 byte fn000000000040ADB0(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040B400
@@ -4858,7 +4858,7 @@ fn000000000040ADB0_exit:
 
 
 word32 fn000000000040AE40(word32 edx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040B710
@@ -4941,7 +4941,7 @@ fn000000000040AE40_exit:
 
 
 word64 fn000000000040AFB0(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -4956,7 +4956,7 @@ fn000000000040AFB0_exit:
 
 
 word64 fn000000000040B400(word64 rcx, word64 rdx, word64 rsi, word64 rdi, word64 r8)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -5114,7 +5114,7 @@ fn000000000040B640_exit:
 
 
 word32 fn000000000040B710(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040B8F0
@@ -5196,7 +5196,7 @@ fn000000000040B710_exit:
 
 
 word32 fn000000000040B8F0(word64 rdx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040BB50
@@ -5321,7 +5321,7 @@ fn000000000040B8F0_exit:
 
 
 word64 fn000000000040BB50(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -5348,7 +5348,7 @@ fn000000000040BB50_exit:
 
 
 word64 fn000000000040BB90(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -5453,7 +5453,7 @@ fn000000000040BB90_exit:
 
 
 word64 fn000000000040BD70(word64 rcx, word32 edx, word64 rsi, word64 rdi, word64 r8, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -5935,7 +5935,7 @@ fn000000000040BD70_exit:
 
 
 word32 fn000000000040C810(word64 rdx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -6022,7 +6022,7 @@ fn000000000040C810_exit:
 
 
 word64 fn000000000040C9B0(word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004057B0
@@ -6071,7 +6071,7 @@ fn000000000040C9B0_exit:
 
 
 word64 fn000000000040CB40(word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000406B70
@@ -6120,7 +6120,7 @@ fn000000000040CB40_exit:
 
 
 word64 fn000000000040CCD0(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000406B70
@@ -6156,7 +6156,7 @@ fn000000000040CCD0_exit:
 
 
 word64 fn000000000040CD70(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000405D50
@@ -6183,7 +6183,7 @@ fn000000000040CD70_exit:
 
 
 word64 fn000000000040CDC0(word64 rcx, word64 rdx, word64 rsi, word64 rdi, word32 r8d, word32 r9d)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -6396,7 +6396,7 @@ fn000000000040CDC0_exit:
 
 
 word32 fn000000000040D240(word32 edx, word64 rsi, word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004052D0
@@ -6521,7 +6521,7 @@ fn000000000040D240_exit:
 
 
 word32 fn000000000040D420(word32 esi, word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000405700
@@ -6542,7 +6542,7 @@ fn000000000040D420_exit:
 
 
 word64 fn000000000040D450(word64 rcx, word64 rdx, word64 rbx, word64 rsi, word64 rdi, ptr64 & rdxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040D450
@@ -6661,7 +6661,7 @@ fn000000000040D450_exit:
 
 
 void fn000000000040D690(word64 rdx, word64 rbx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000404E80
@@ -6680,7 +6680,7 @@ fn000000000040D690_exit:
 
 
 void fn000000000040D6A0(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -6717,7 +6717,7 @@ fn000000000040D6A0_exit:
 
 
 void fn000000000040D740(word32 esi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040E970
@@ -6760,7 +6760,7 @@ l000000000040D754_1:
 
 
 word64 fn000000000040D7B0(word32 esi, word64 rdi, selector fs, ptr64 & ecxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040D8A0
@@ -6828,7 +6828,7 @@ fn000000000040D7B0_exit:
 
 
 word64 fn000000000040D8A0(word64 rcx, word64 rdx, word64 rsi, word64 rdi, word32 r8d, word32 r9d, selector fs, word64 qwArg08, word64 qwArg10, word64 qwArg18)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040D8A0
@@ -7498,7 +7498,7 @@ fn000000000040E450_exit:
 
 
 word64 fn000000000040E600(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -7522,7 +7522,7 @@ fn000000000040E600_exit:
 
 
 word32 fn000000000040E630(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -7542,7 +7542,7 @@ fn000000000040E630_exit:
 
 
 void fn000000000040E640(word32 esi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -7563,7 +7563,7 @@ fn000000000040E640_exit:
 
 
 void fn000000000040E650(word32 edx, word32 esi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -7588,7 +7588,7 @@ fn000000000040E650_exit:
 
 
 void fn000000000040E6B0(word64 rdx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..63] rdx:[0..63] rsi:[0..63]
 // LiveOut:
@@ -7614,7 +7614,7 @@ fn000000000040E6B0_exit:
 
 
 word64 fn000000000040E6F0(word64 rcx, word64 rdx, word64 rsi, word64 rdi, word64 r8, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004052D0
@@ -7638,7 +7638,7 @@ fn000000000040E6F0_exit:
 
 
 void fn000000000040E930(word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -7657,7 +7657,7 @@ fn000000000040E930_exit:
 
 
 void fn000000000040E970(word64 rdx, word32 esi, word32 edi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000409F80
@@ -7677,7 +7677,7 @@ fn000000000040E970_exit:
 
 
 void fn000000000040EAB0(word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -7749,7 +7749,7 @@ fn000000000040EC10_exit:
 
 
 void fn000000000040EC30(word64 rdx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040ECD0
@@ -7773,7 +7773,7 @@ fn000000000040EC30_exit:
 
 
 void fn000000000040EC80(word64 rdx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040ECD0
@@ -7797,7 +7797,7 @@ fn000000000040EC80_exit:
 
 
 word64 fn000000000040ECD0(word64 rcx, word64 rdx, word64 rsi, byte dil, word64 r8, word32 r9d, selector fs, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040ECD0
@@ -9097,7 +9097,7 @@ l000000000040EDC0:
 
 
 word64 fn0000000000410600(word64 rcx, word64 rdx, word64 rsi, word64 rdi, word32 r8d, word32 r9d, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000406A80
@@ -9112,7 +9112,7 @@ fn0000000000410600_exit:
 
 
 void fn0000000000410630(word64 rcx, word64 rdx, word64 rsi, word64 rdi, word64 r9)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000410AC0
@@ -9148,7 +9148,7 @@ fn0000000000410630_exit:
 
 
 void fn0000000000410AC0(word64 rcx, word64 rdx, word64 rsi, word64 rdi, word64 r8)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000410B30
@@ -9186,7 +9186,7 @@ fn0000000000410AC0_exit:
 
 
 void fn0000000000410B30(byte al, word64 rcx, word64 rdx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -9211,7 +9211,7 @@ fn0000000000410B30_exit:
 
 
 word64 fn0000000000410C40(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -9242,7 +9242,7 @@ fn0000000000410C40_exit:
 
 
 word64 fn0000000000410C90(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000405ED0
@@ -9332,7 +9332,7 @@ l0000000000410E50:
 
 
 word32 fn0000000000410E90(word64 rcx, word32 edx, word64 rsi, word64 rdi, word64 r8)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004028C0
@@ -9647,7 +9647,7 @@ l000000000041132F:
 
 
 word32 fn0000000000411360(word64 rcx, word32 edx, word64 rsi, word64 rdi, word64 r8)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040C810
@@ -9959,7 +9959,7 @@ fn00000000004117B0_exit:
 
 
 word32 fn0000000000411820(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000407EA0
@@ -9993,7 +9993,7 @@ fn0000000000411840_exit:
 
 
 void fn0000000000411880(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..63]
 // LiveOut:
@@ -10023,7 +10023,7 @@ fn0000000000411880_exit:
 
 
 word32 fn0000000000411900(selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000000040D7B0
@@ -10234,7 +10234,7 @@ l0000000000411C14:
 
 
 word32 fn0000000000411D30(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000411880
@@ -10295,7 +10295,7 @@ fn0000000000411DB0_exit:
 
 
 void fn0000000000411DF0(word32 edx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000000411DB0

--- a/subjects/Elf/x86-64/pngpixel/pngpixel.reko/pngpixel_fini.dis
+++ b/subjects/Elf/x86-64/pngpixel/pngpixel.reko/pngpixel_fini.dis
@@ -1,5 +1,5 @@
 void _fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Elf/x86-64/pngpixel/pngpixel.reko/pngpixel_init.dis
+++ b/subjects/Elf/x86-64/pngpixel/pngpixel.reko/pngpixel_init.dis
@@ -1,5 +1,5 @@
 void _init()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __libc_csu_init

--- a/subjects/Elf/x86-64/pngpixel/pngpixel.reko/pngpixel_text.dis
+++ b/subjects/Elf/x86-64/pngpixel/pngpixel.reko/pngpixel_text.dis
@@ -17,7 +17,7 @@ l0000000000400CD0:
 
 
 void deregister_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __do_global_dtors_aux
@@ -40,7 +40,7 @@ deregister_tm_clones_exit:
 
 
 void register_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      frame_dummy
@@ -63,7 +63,7 @@ register_tm_clones_exit:
 
 
 void __do_global_dtors_aux()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -81,7 +81,7 @@ __do_global_dtors_aux_exit:
 
 
 void frame_dummy()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -105,7 +105,7 @@ frame_dummy_exit:
 
 
 word32 component(word32 ecx, word32 edx, word32 esi, word64 rdi, word32 r8d)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      print_pixel
@@ -142,7 +142,7 @@ l0000000000400EC1:
 
 
 void print_pixel(word32 ecx, word64 rdx, word64 rsi, word64 rdi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -208,7 +208,7 @@ l00000000004012E9:
 
 
 void main(word64 rsi, word32 edi, selector fs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  edi:[0..31] fs:[0..15] rsi:[0..63]
 // LiveOut:
@@ -349,7 +349,7 @@ l0000000000401772:
 
 
 void __libc_csu_init(word64 rdx, word64 rsi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..31] rdx:[0..63] rsi:[0..63]
 // LiveOut:
@@ -375,7 +375,7 @@ __libc_csu_init_exit:
 
 
 void __libc_csu_fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Elf/x86-64/retpoline/retpoline.reko/retpoline_fini.dis
+++ b/subjects/Elf/x86-64/retpoline/retpoline.reko/retpoline_fini.dis
@@ -1,5 +1,5 @@
 void _fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Elf/x86-64/retpoline/retpoline.reko/retpoline_init.dis
+++ b/subjects/Elf/x86-64/retpoline/retpoline.reko/retpoline_init.dis
@@ -1,5 +1,5 @@
 void _init()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __libc_csu_init

--- a/subjects/Elf/x86-64/retpoline/retpoline.reko/retpoline_text.dis
+++ b/subjects/Elf/x86-64/retpoline/retpoline.reko/retpoline_text.dis
@@ -17,7 +17,7 @@ l0000000000400480:
 
 
 void deregister_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __do_global_dtors_aux
@@ -40,7 +40,7 @@ deregister_tm_clones_exit:
 
 
 void register_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      frame_dummy
@@ -63,7 +63,7 @@ register_tm_clones_exit:
 
 
 void __do_global_dtors_aux()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -82,7 +82,7 @@ __do_global_dtors_aux_exit:
 
 
 void frame_dummy()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -97,7 +97,7 @@ frame_dummy_exit:
 
 
 void my1(word32 esi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      branches
@@ -113,7 +113,7 @@ my1_exit:
 
 
 void my2(byte sil, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..63] sil:[0..7]
 // LiveOut:
@@ -127,7 +127,7 @@ my2_exit:
 
 
 void branches(word32 esi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  esi:[0..31] rdi:[0..31]
 // LiveOut:
@@ -159,7 +159,7 @@ branches_exit:
 
 
 void main()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -191,7 +191,7 @@ l00000000004006F5:
 
 
 void fn0000000000400700()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __llvm_retpoline_r11
@@ -206,7 +206,7 @@ fn0000000000400700_exit:
 
 
 void __libc_csu_init(word64 rdx, word64 rsi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..31] rdx:[0..63] rsi:[0..63]
 // LiveOut:
@@ -232,7 +232,7 @@ __libc_csu_init_exit:
 
 
 void __libc_csu_fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Elf/x86-64/retpoline/retpoline_stripped.reko/retpoline_stripped_init.dis
+++ b/subjects/Elf/x86-64/retpoline/retpoline_stripped.reko/retpoline_stripped_init.dis
@@ -1,5 +1,5 @@
 void fn0000000000400428()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Elf/x86-64/retpoline/retpoline_stripped.reko/retpoline_stripped_text.dis
+++ b/subjects/Elf/x86-64/retpoline/retpoline_stripped.reko/retpoline_stripped_text.dis
@@ -17,7 +17,7 @@ l0000000000400480:
 
 
 void fn00000000004004B0()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -38,7 +38,7 @@ fn00000000004004B0_exit:
 
 
 void fn0000000000400560(word32 esi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  edi:[0..31] esi:[0..31]
 // LiveOut:
@@ -68,7 +68,7 @@ l00000000004006F5:
 
 
 void fn0000000000400700()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000000004006F0

--- a/subjects/Elf/x86-64/simd_double/simd_double.reko/simd_double_fini.dis
+++ b/subjects/Elf/x86-64/simd_double/simd_double.reko/simd_double_fini.dis
@@ -1,5 +1,5 @@
 void _fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Elf/x86-64/simd_double/simd_double.reko/simd_double_init.dis
+++ b/subjects/Elf/x86-64/simd_double/simd_double.reko/simd_double_init.dis
@@ -1,5 +1,5 @@
 void _init()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __libc_csu_init

--- a/subjects/Elf/x86-64/simd_double/simd_double.reko/simd_double_text.dis
+++ b/subjects/Elf/x86-64/simd_double/simd_double.reko/simd_double_text.dis
@@ -17,7 +17,7 @@ l0000000000000620:
 
 
 void deregister_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __do_global_dtors_aux
@@ -39,7 +39,7 @@ deregister_tm_clones_exit:
 
 
 void register_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      frame_dummy
@@ -62,7 +62,7 @@ register_tm_clones_exit:
 
 
 void __do_global_dtors_aux()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -85,7 +85,7 @@ __do_global_dtors_aux_exit:
 
 
 void frame_dummy()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -100,7 +100,7 @@ frame_dummy_exit:
 
 
 word64 _mm_malloc(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -135,7 +135,7 @@ _mm_malloc_exit:
 
 
 void _mm_free(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -151,7 +151,7 @@ _mm_free_exit:
 
 
 void vec_add(word64 rcx, word64 rdx, word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -176,7 +176,7 @@ vec_add_exit:
 
 
 void main()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -243,7 +243,7 @@ main_exit:
 
 
 void __libc_csu_init(word64 rdx, word64 rsi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..31] rdx:[0..63] rsi:[0..63]
 // LiveOut:
@@ -269,7 +269,7 @@ __libc_csu_init_exit:
 
 
 void __libc_csu_fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN_code.dis
+++ b/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN_code.dis
@@ -1,5 +1,5 @@
 void fn00001000(word32 d0, word32 a0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a0:[0..31] d0:[0..31]
 // LiveOut:
@@ -207,7 +207,7 @@ l00001112:
 
 
 word32 fn00001214(word32 a3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -223,7 +223,7 @@ fn00001214_exit:
 
 
 void fn0000126C(word32 a2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -256,7 +256,7 @@ fn00001278_exit:
 
 
 word32 fn0000127C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -285,7 +285,7 @@ fn0000127C_exit:
 
 
 word32 fn000012D0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000131C
@@ -316,7 +316,7 @@ fn000012D0_exit:
 
 
 word32 fn0000131C(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -346,7 +346,7 @@ fn0000131C_exit:
 
 
 void fn00001354(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -372,7 +372,7 @@ fn00001354_exit:
 
 
 void fn00001390()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001394
@@ -387,7 +387,7 @@ fn00001390_exit:
 
 
 void fn00001394()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000013AC
@@ -412,7 +412,7 @@ fn00001394_exit:
 
 
 void fn000013AC()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000013C4
@@ -437,7 +437,7 @@ fn000013AC_exit:
 
 
 void fn000013C4()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000013D8
@@ -461,7 +461,7 @@ fn000013C4_exit:
 
 
 word32 fn000013D8()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -485,7 +485,7 @@ fn000013D8_exit:
 
 
 void fn00001474(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000013D8
@@ -502,7 +502,7 @@ fn00001474_exit:
 
 
 void fn00001490(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001474
@@ -1058,7 +1058,7 @@ l00001816:
 
 
 word32 fn00001E10(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001490
@@ -1094,7 +1094,7 @@ fn00001E10_exit:
 
 
 word32 fn00001E6C(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E10
@@ -1173,7 +1173,7 @@ fn00001E6C_exit:
 
 
 word32 fn00001F80(word32 dwArg04, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E6C
@@ -1230,7 +1230,7 @@ fn00001F80_exit:
 
 
 word32 fn0000202C(word32 dwArg04, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E6C
@@ -1273,7 +1273,7 @@ fn0000202C_exit:
 
 
 void fn00002098(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1292,7 +1292,7 @@ fn00002098_exit:
 
 
 void fn00002160(word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002098
@@ -1338,7 +1338,7 @@ fn00002160_exit:
 
 
 word32 fn000021FC(word32 dwArg04, word32 dwArg08, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000202C
@@ -1424,7 +1424,7 @@ fn000021FC_exit:
 
 
 word32 fn00002320(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000202C
@@ -1463,7 +1463,7 @@ fn00002320_exit:
 
 
 void fn00002390(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1494,7 +1494,7 @@ fn00002390_exit:
 
 
 word32 fn00002400()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E6C
@@ -1516,7 +1516,7 @@ fn00002400_exit:
 
 
 word64 fn00002430(word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001490
@@ -1610,7 +1610,7 @@ fn00002430_exit:
 
 
 word32 fn00002534(word32 d0, word32 d1, word32 d2, ptr32 & d1Out, ptr32 & d2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002430
@@ -1733,7 +1733,7 @@ fn00002534_exit:
 
 
 word32 fn000026C0(word32 d2, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C04
@@ -1765,7 +1765,7 @@ fn000026C0_exit:
 
 
 word32 fn000026F2(word32 d0, word32 d1, word32 d2, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002534
@@ -1839,7 +1839,7 @@ fn000026F2_exit:
 
 
 word32 fn00002778(word64 qwArg04, word64 qwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001490
@@ -1934,7 +1934,7 @@ fn00002778_exit:
 
 
 void fn00002B74(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1965,7 +1965,7 @@ fn00002B74_exit:
 
 
 word32 fn00002BB8(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000013D8
@@ -1981,7 +1981,7 @@ fn00002BB8_exit:
 
 
 word32 fn00002BD4(byte bArg07, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C04
@@ -2007,7 +2007,7 @@ fn00002BD4_exit:
 
 
 word32 fn00002C04(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002BB8
@@ -3018,7 +3018,7 @@ fn00002C04_exit:
 
 
 word32 fn00003C28(word32 d4, word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C04
@@ -3048,7 +3048,7 @@ fn00003C28_exit:
 
 
 word32 fn00003CA8(word32 dwArg04, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C04
@@ -3124,7 +3124,7 @@ fn00003CA8_exit:
 
 
 word32 fn00003DA4()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00003CA8
@@ -3153,7 +3153,7 @@ fn00003DA4_exit:
 
 
 word32 fn00003DE0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000013D8

--- a/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG_code.dis
+++ b/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG_code.dis
@@ -1,5 +1,5 @@
 void fn00001000(word32 d0, word32 a0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a0:[0..31] d0:[0..31]
 // LiveOut:
@@ -207,7 +207,7 @@ l00001112:
 
 
 word32 fn00001214(word32 a3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -223,7 +223,7 @@ fn00001214_exit:
 
 
 void fn0000126C(word32 a2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -256,7 +256,7 @@ fn00001278_exit:
 
 
 word32 fn0000127C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -285,7 +285,7 @@ fn0000127C_exit:
 
 
 word32 fn000012D0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000131C
@@ -316,7 +316,7 @@ fn000012D0_exit:
 
 
 word32 fn0000131C(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -346,7 +346,7 @@ fn0000131C_exit:
 
 
 void fn00001354(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -374,7 +374,7 @@ fn00001354_exit:
 
 
 word32 fn00001390(word32 d0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -432,7 +432,7 @@ fn00001390_exit:
 
 
 void fn000014AC(word32 d2, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -468,7 +468,7 @@ fn000014AC_exit:
 
 
 word32 fn000014EC(word32 d2, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C3C
@@ -500,7 +500,7 @@ fn000014EC_exit:
 
 
 word32 fn0000151E(word32 d0, word32 d1, word32 d2, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000014AC
@@ -575,7 +575,7 @@ fn0000151E_exit:
 
 
 word32 fn000015A4(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -591,7 +591,7 @@ fn000015A4_exit:
 
 
 word32 fn000015C0(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000015A4
@@ -1156,7 +1156,7 @@ l00001946:
 
 
 word32 fn00001F40(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000015C0
@@ -1192,7 +1192,7 @@ fn00001F40_exit:
 
 
 word32 fn00001F9C(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001F40
@@ -1270,7 +1270,7 @@ fn00001F9C_exit:
 
 
 word32 fn000020B0(word32 dwArg04, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001F9C
@@ -1327,7 +1327,7 @@ fn000020B0_exit:
 
 
 word32 fn0000215C(word32 dwArg04, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001F9C
@@ -1370,7 +1370,7 @@ fn0000215C_exit:
 
 
 void fn000021C8(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1389,7 +1389,7 @@ fn000021C8_exit:
 
 
 void fn00002290(word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000021C8
@@ -1435,7 +1435,7 @@ fn00002290_exit:
 
 
 word32 fn0000232C(word32 dwArg04, word32 dwArg08, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000215C
@@ -1521,7 +1521,7 @@ fn0000232C_exit:
 
 
 word32 fn00002450(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000215C
@@ -1560,7 +1560,7 @@ fn00002450_exit:
 
 
 void fn000024C0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1591,7 +1591,7 @@ fn000024C0_exit:
 
 
 word32 fn00002530()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001F9C
@@ -1613,7 +1613,7 @@ fn00002530_exit:
 
 
 word64 fn00002560(word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000015C0
@@ -1707,7 +1707,7 @@ fn00002560_exit:
 
 
 word32 fn00002664(word32 d0, word32 d1, word32 d2, ptr32 & d1Out, ptr32 & d2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002560
@@ -1830,7 +1830,7 @@ fn00002664_exit:
 
 
 word32 fn000027B0(word64 qwArg04, word64 qwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000015C0
@@ -1925,7 +1925,7 @@ fn000027B0_exit:
 
 
 void fn00002BAC(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1956,7 +1956,7 @@ fn00002BAC_exit:
 
 
 word32 fn00002BF0(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -1972,7 +1972,7 @@ fn00002BF0_exit:
 
 
 word32 fn00002C0C(byte bArg07, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C3C
@@ -1998,7 +1998,7 @@ fn00002C0C_exit:
 
 
 word32 fn00002C3C(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002BF0
@@ -3009,7 +3009,7 @@ fn00002C3C_exit:
 
 
 word32 fn00003C60(word32 d4, word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C3C
@@ -3039,7 +3039,7 @@ fn00003C60_exit:
 
 
 word32 fn00003CE0(word32 dwArg04, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C3C
@@ -3115,7 +3115,7 @@ fn00003CE0_exit:
 
 
 word32 fn00003DDC()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00003CE0

--- a/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL_code.dis
+++ b/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL_code.dis
@@ -1,5 +1,5 @@
 void fn00001000(word32 d0, word32 a0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a0:[0..31] d0:[0..31]
 // LiveOut:
@@ -207,7 +207,7 @@ l00001112:
 
 
 word32 fn00001214(word32 a3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -223,7 +223,7 @@ fn00001214_exit:
 
 
 void fn0000126C(word32 a2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -256,7 +256,7 @@ fn00001278_exit:
 
 
 word32 fn0000127C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -285,7 +285,7 @@ fn0000127C_exit:
 
 
 word32 fn000012D0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000131C
@@ -316,7 +316,7 @@ fn000012D0_exit:
 
 
 word32 fn0000131C(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -346,7 +346,7 @@ fn0000131C_exit:
 
 
 void fn00001354(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -372,7 +372,7 @@ fn00001354_exit:
 
 
 word32 fn00001390()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -453,7 +453,7 @@ fn00001390_exit:
 
 
 word32 fn000016FC(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -469,7 +469,7 @@ fn000016FC_exit:
 
 
 word32 fn00001718(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000016FC
@@ -1034,7 +1034,7 @@ l00001A9E:
 
 
 word32 fn00002098(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001718
@@ -1070,7 +1070,7 @@ fn00002098_exit:
 
 
 word32 fn000020F4(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002098
@@ -1149,7 +1149,7 @@ fn000020F4_exit:
 
 
 word32 fn00002208(word32 dwArg04, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000020F4
@@ -1206,7 +1206,7 @@ fn00002208_exit:
 
 
 word32 fn000022B4(word32 dwArg04, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000020F4
@@ -1249,7 +1249,7 @@ fn000022B4_exit:
 
 
 void fn00002320(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1268,7 +1268,7 @@ fn00002320_exit:
 
 
 void fn000023E8(word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002320
@@ -1314,7 +1314,7 @@ fn000023E8_exit:
 
 
 word32 fn00002484(word32 dwArg04, word32 dwArg08, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000022B4
@@ -1400,7 +1400,7 @@ fn00002484_exit:
 
 
 word32 fn000025A8(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000022B4
@@ -1439,7 +1439,7 @@ fn000025A8_exit:
 
 
 void fn00002618(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1470,7 +1470,7 @@ fn00002618_exit:
 
 
 word32 fn00002688()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000020F4
@@ -1492,7 +1492,7 @@ fn00002688_exit:
 
 
 word64 fn000026B8(word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001718
@@ -1586,7 +1586,7 @@ fn000026B8_exit:
 
 
 word32 fn000027BC(word32 d0, word32 d1, word32 d2, ptr32 & d1Out, ptr32 & d2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000026B8
@@ -1709,7 +1709,7 @@ fn000027BC_exit:
 
 
 word32 fn00002948(word32 d2, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002E8C
@@ -1741,7 +1741,7 @@ fn00002948_exit:
 
 
 word32 fn0000297A(word32 d0, word32 d1, word32 d2, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000027BC
@@ -1815,7 +1815,7 @@ fn0000297A_exit:
 
 
 word32 fn00002A00(word64 qwArg04, word64 qwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001718
@@ -1910,7 +1910,7 @@ fn00002A00_exit:
 
 
 void fn00002DFC(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1941,7 +1941,7 @@ fn00002DFC_exit:
 
 
 word32 fn00002E40(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -1957,7 +1957,7 @@ fn00002E40_exit:
 
 
 word32 fn00002E5C(byte bArg07, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002E8C
@@ -1983,7 +1983,7 @@ fn00002E5C_exit:
 
 
 word32 fn00002E8C(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002E40
@@ -2994,7 +2994,7 @@ fn00002E8C_exit:
 
 
 word32 fn00003EB0(word32 d4, word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002E8C
@@ -3024,7 +3024,7 @@ fn00003EB0_exit:
 
 
 word32 fn00003F30(word32 dwArg04, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002E8C
@@ -3100,7 +3100,7 @@ fn00003F30_exit:
 
 
 word32 fn0000402C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00003F30
@@ -3129,7 +3129,7 @@ fn0000402C_exit:
 
 
 word32 fn00004068(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390

--- a/subjects/Hunk-m68k/BYTEOPS.reko/BYTEOPS_code.dis
+++ b/subjects/Hunk-m68k/BYTEOPS.reko/BYTEOPS_code.dis
@@ -1,5 +1,5 @@
 void fn00001000(word32 d0, word32 a0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a0:[0..31] d0:[0..31]
 // LiveOut:
@@ -209,7 +209,7 @@ l00001112:
 
 
 word32 fn00001214(word32 a3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -225,7 +225,7 @@ fn00001214_exit:
 
 
 void fn0000126C(word32 a2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -258,7 +258,7 @@ fn00001278_exit:
 
 
 word32 fn0000127C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -287,7 +287,7 @@ fn0000127C_exit:
 
 
 word32 fn000012D0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000131C
@@ -318,7 +318,7 @@ fn000012D0_exit:
 
 
 word32 fn0000131C(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -348,7 +348,7 @@ fn0000131C_exit:
 
 
 void fn00001354(word32 d2, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -374,7 +374,7 @@ fn00001354_exit:
 
 
 word32 fn00001390(word32 d2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -398,7 +398,7 @@ fn00001390_exit:
 
 
 word32 fn0000143C(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -414,7 +414,7 @@ fn0000143C_exit:
 
 
 word32 fn00001458(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000143C
@@ -979,7 +979,7 @@ l000017DE:
 
 
 word32 fn00001DD8(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001458
@@ -1015,7 +1015,7 @@ fn00001DD8_exit:
 
 
 word32 fn00001E34(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001DD8
@@ -1093,7 +1093,7 @@ fn00001E34_exit:
 
 
 word32 fn00001F48(word32 dwArg04, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E34
@@ -1149,7 +1149,7 @@ fn00001F48_exit:
 
 
 word32 fn00001FF4(word32 dwArg04, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E34
@@ -1191,7 +1191,7 @@ fn00001FF4_exit:
 
 
 void fn00002060(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1210,7 +1210,7 @@ fn00002060_exit:
 
 
 void fn00002128(word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002060
@@ -1256,7 +1256,7 @@ fn00002128_exit:
 
 
 word32 fn000021C4(word32 dwArg04, word32 dwArg08, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001FF4
@@ -1342,7 +1342,7 @@ fn000021C4_exit:
 
 
 word32 fn000022E8(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001FF4
@@ -1381,7 +1381,7 @@ fn000022E8_exit:
 
 
 void fn00002358(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1412,7 +1412,7 @@ fn00002358_exit:
 
 
 word32 fn000023C8()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E34
@@ -1433,7 +1433,7 @@ fn000023C8_exit:
 
 
 word64 fn000023F8(word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001458
@@ -1527,7 +1527,7 @@ fn000023F8_exit:
 
 
 word32 fn000024FC(word32 d0, word32 d1, word32 d2, ptr32 & d1Out, ptr32 & d2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000023F8
@@ -1650,7 +1650,7 @@ fn000024FC_exit:
 
 
 word32 fn00002648(word64 qwArg04, word64 qwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001458
@@ -1745,7 +1745,7 @@ fn00002648_exit:
 
 
 void fn00002A44(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1776,7 +1776,7 @@ fn00002A44_exit:
 
 
 void fn00002A88(word32 d2, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -1812,7 +1812,7 @@ fn00002A88_exit:
 
 
 word32 fn00002AC8(word32 d2, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -1844,7 +1844,7 @@ fn00002AC8_exit:
 
 
 word32 fn00002AFA(word32 d0, word32 d1, word32 d2, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000024FC

--- a/subjects/Hunk-m68k/FIBO.reko/FIBO_code.dis
+++ b/subjects/Hunk-m68k/FIBO.reko/FIBO_code.dis
@@ -1,5 +1,5 @@
 void fn00001000(word32 d0, word32 a0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a0:[0..31] d0:[0..31]
 // LiveOut:
@@ -209,7 +209,7 @@ l00001112:
 
 
 word32 fn00001214(word32 a3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -225,7 +225,7 @@ fn00001214_exit:
 
 
 void fn0000126C(word32 a2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -261,7 +261,7 @@ fn00001278_exit:
 
 
 word32 fn0000127C(word32 d2, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -291,7 +291,7 @@ fn0000127C_exit:
 
 
 word32 fn000012D0(word32 dwArg04, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000131C
@@ -325,7 +325,7 @@ fn000012D0_exit:
 
 
 word32 fn0000131C(word32 dwArg04, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -358,7 +358,7 @@ fn0000131C_exit:
 
 
 void fn00001354(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -385,7 +385,7 @@ fn00001354_exit:
 
 
 word32 fn00001390()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -415,7 +415,7 @@ fn00001390_exit:
 
 
 word32 fn0000145C(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -438,7 +438,7 @@ fn0000145C_exit:
 
 
 void fn00001498(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -455,7 +455,7 @@ fn00001498_exit:
 
 
 void fn000014B4(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001498
@@ -1011,7 +1011,7 @@ l0000183A:
 
 
 word32 fn00001E34(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000014B4
@@ -1047,7 +1047,7 @@ fn00001E34_exit:
 
 
 word32 fn00001E90(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E34
@@ -1126,7 +1126,7 @@ fn00001E90_exit:
 
 
 word32 fn00001FA4(word32 dwArg04, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E90
@@ -1183,7 +1183,7 @@ fn00001FA4_exit:
 
 
 word32 fn00002050(word32 dwArg04, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E90
@@ -1226,7 +1226,7 @@ fn00002050_exit:
 
 
 void fn000020BC(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1245,7 +1245,7 @@ fn000020BC_exit:
 
 
 void fn00002184(word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000020BC
@@ -1291,7 +1291,7 @@ fn00002184_exit:
 
 
 word32 fn00002220(word32 dwArg04, word32 dwArg08, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002050
@@ -1377,7 +1377,7 @@ fn00002220_exit:
 
 
 word32 fn00002344(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002050
@@ -1416,7 +1416,7 @@ fn00002344_exit:
 
 
 void fn000023B4(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1447,7 +1447,7 @@ fn000023B4_exit:
 
 
 word32 fn00002424()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E90
@@ -1469,7 +1469,7 @@ fn00002424_exit:
 
 
 word64 fn00002454(word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000014B4
@@ -1563,7 +1563,7 @@ fn00002454_exit:
 
 
 word32 fn00002558(word32 d0, word32 d1, word32 d2, ptr32 & d1Out, ptr32 & d2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002454
@@ -1686,7 +1686,7 @@ fn00002558_exit:
 
 
 word32 fn000026E4(word32 d2, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C28
@@ -1718,7 +1718,7 @@ fn000026E4_exit:
 
 
 word32 fn00002716(word32 d0, word32 d1, word32 d2, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002558
@@ -1792,7 +1792,7 @@ fn00002716_exit:
 
 
 word32 fn0000279C(word64 qwArg04, word64 qwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000014B4
@@ -1887,7 +1887,7 @@ fn0000279C_exit:
 
 
 void fn00002B98(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1918,7 +1918,7 @@ fn00002B98_exit:
 
 
 void fn00002BDC(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -1935,7 +1935,7 @@ fn00002BDC_exit:
 
 
 word32 fn00002BF8(byte bArg07, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C28
@@ -1961,7 +1961,7 @@ fn00002BF8_exit:
 
 
 void fn00002C28(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002BDC
@@ -2969,7 +2969,7 @@ fn00002C28_exit:
 
 
 word32 fn00003C4C(word32 d4, word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C28
@@ -2999,7 +2999,7 @@ fn00003C4C_exit:
 
 
 word32 fn00003CCC(word32 dwArg04, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002C28
@@ -3075,7 +3075,7 @@ fn00003CCC_exit:
 
 
 word32 fn00003DC8()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00003CCC
@@ -3104,7 +3104,7 @@ fn00003DC8_exit:
 
 
 word32 fn00003E04(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390

--- a/subjects/Hunk-m68k/MATRIXMU.reko/MATRIXMU_code.dis
+++ b/subjects/Hunk-m68k/MATRIXMU.reko/MATRIXMU_code.dis
@@ -1,5 +1,5 @@
 void fn00001000(word32 d0, word32 a0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a0:[0..31] d0:[0..31]
 // LiveOut:
@@ -207,7 +207,7 @@ l00001112:
 
 
 word32 fn00001214(word32 a3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -223,7 +223,7 @@ fn00001214_exit:
 
 
 void fn0000126C(word32 a2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -257,7 +257,7 @@ fn00001278_exit:
 
 
 void fn0000127C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -286,7 +286,7 @@ fn0000127C_exit:
 
 
 void fn000012D0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000131C
@@ -318,7 +318,7 @@ fn000012D0_exit:
 
 
 void fn0000131C(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -346,7 +346,7 @@ fn0000131C_exit:
 
 
 void fn00001354(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -372,7 +372,7 @@ fn00001354_exit:
 
 
 word32 fn00001390(word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001468
@@ -415,7 +415,7 @@ fn00001390_exit:
 
 
 word32 fn00001468()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354

--- a/subjects/Hunk-m68k/MAX.reko/MAX_code.dis
+++ b/subjects/Hunk-m68k/MAX.reko/MAX_code.dis
@@ -1,5 +1,5 @@
 void fn00001000(word32 d0, word32 a0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a0:[0..31] d0:[0..31]
 // LiveOut:
@@ -207,7 +207,7 @@ l00001112:
 
 
 word32 fn00001214(word32 a3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -223,7 +223,7 @@ fn00001214_exit:
 
 
 void fn0000126C(word32 a2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -256,7 +256,7 @@ fn00001278_exit:
 
 
 word32 fn0000127C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -285,7 +285,7 @@ fn0000127C_exit:
 
 
 word32 fn000012D0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000131C
@@ -316,7 +316,7 @@ fn000012D0_exit:
 
 
 word32 fn0000131C(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -346,7 +346,7 @@ fn0000131C_exit:
 
 
 void fn00001354(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -374,7 +374,7 @@ fn00001354_exit:
 
 
 word32 fn00001390(word32 d0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -397,7 +397,7 @@ fn00001390_exit:
 
 
 word32 fn00001408(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -418,7 +418,7 @@ fn00001408_exit:
 
 
 void fn0000141C(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -435,7 +435,7 @@ fn0000141C_exit:
 
 
 word32 fn00001438(byte bArg07, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001468
@@ -461,7 +461,7 @@ fn00001438_exit:
 
 
 void fn00001468(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000141C
@@ -1469,7 +1469,7 @@ fn00001468_exit:
 
 
 word32 fn0000248C(word32 d4, word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001468
@@ -1499,7 +1499,7 @@ fn0000248C_exit:
 
 
 word32 fn0000254C(word32 d2, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001468
@@ -1531,7 +1531,7 @@ fn0000254C_exit:
 
 
 word32 fn0000257E(word32 d0, word32 d1, word32 d2, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000254C
@@ -1605,7 +1605,7 @@ fn0000257E_exit:
 
 
 word32 fn00002604(word32 dwArg04, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001468
@@ -1681,7 +1681,7 @@ fn00002604_exit:
 
 
 word32 fn00002718(word32 dwArg04, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002604
@@ -1724,7 +1724,7 @@ fn00002718_exit:
 
 
 void fn00002784(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1743,7 +1743,7 @@ fn00002784_exit:
 
 
 void fn0000284C(word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002784
@@ -1789,7 +1789,7 @@ fn0000284C_exit:
 
 
 word32 fn000028E8(word32 dwArg04, word32 dwArg08, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002718
@@ -1875,7 +1875,7 @@ fn000028E8_exit:
 
 
 word32 fn00002A0C(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002718
@@ -1914,7 +1914,7 @@ fn00002A0C_exit:
 
 
 void fn00002A7C(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1945,7 +1945,7 @@ fn00002A7C_exit:
 
 
 word32 fn00002AEC()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002604
@@ -1974,7 +1974,7 @@ fn00002AEC_exit:
 
 
 word32 fn00002B28(word32 dwArg04, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002AEC
@@ -2031,7 +2031,7 @@ fn00002B28_exit:
 
 
 word32 fn00002BBC()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002604
@@ -2053,7 +2053,7 @@ fn00002BBC_exit:
 
 
 void fn00002ED4(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -2084,7 +2084,7 @@ fn00002ED4_exit:
 
 
 word32 fn00002F18(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -2100,7 +2100,7 @@ fn00002F18_exit:
 
 
 word32 fn00002F34(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002F18
@@ -2665,7 +2665,7 @@ l000032BA:
 
 
 word32 fn000038B4(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002F34
@@ -2701,7 +2701,7 @@ fn000038B4_exit:
 
 
 word32 fn00003910(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000038B4
@@ -2779,7 +2779,7 @@ fn00003910_exit:
 
 
 word64 fn00003A24(word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002F34
@@ -2873,7 +2873,7 @@ fn00003A24_exit:
 
 
 word32 fn00003B28(word32 d0, word32 d1, word32 d2, ptr32 & d1Out, ptr32 & d2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00003A24
@@ -2996,7 +2996,7 @@ fn00003B28_exit:
 
 
 word32 fn00003C74(word64 qwArg04, word64 qwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002F34

--- a/subjects/Hunk-m68k/STRLEN.reko/STRLEN_code.dis
+++ b/subjects/Hunk-m68k/STRLEN.reko/STRLEN_code.dis
@@ -1,5 +1,5 @@
 void fn00001000(word32 d0, word32 a0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a0:[0..31] d0:[0..31]
 // LiveOut:
@@ -207,7 +207,7 @@ l00001112:
 
 
 word32 fn00001214(word32 a3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -223,7 +223,7 @@ fn00001214_exit:
 
 
 void fn0000126C(word32 a2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -257,7 +257,7 @@ fn00001278_exit:
 
 
 void fn0000127C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -286,7 +286,7 @@ fn0000127C_exit:
 
 
 void fn000012D0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000131C
@@ -318,7 +318,7 @@ fn000012D0_exit:
 
 
 void fn0000131C(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -346,7 +346,7 @@ fn0000131C_exit:
 
 
 void fn00001354(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -372,7 +372,7 @@ fn00001354_exit:
 
 
 word32 fn00001390()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -387,7 +387,7 @@ fn00001390_exit:
 
 
 word32 fn000013AC(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390

--- a/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG_code.dis
+++ b/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG_code.dis
@@ -1,5 +1,5 @@
 void fn00001000(word32 d0, word32 a0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a0:[0..31] d0:[0..31]
 // LiveOut:
@@ -207,7 +207,7 @@ l00001112:
 
 
 word32 fn00001214(word32 a3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -223,7 +223,7 @@ fn00001214_exit:
 
 
 void fn0000126C(word32 a2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -256,7 +256,7 @@ fn00001278_exit:
 
 
 word32 fn0000127C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -285,7 +285,7 @@ fn0000127C_exit:
 
 
 word32 fn000012D0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000131C
@@ -316,7 +316,7 @@ fn000012D0_exit:
 
 
 word32 fn0000131C(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -346,7 +346,7 @@ fn0000131C_exit:
 
 
 void fn00001354(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001000
@@ -374,7 +374,7 @@ fn00001354_exit:
 
 
 word32 fn00001390(word32 d0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001354
@@ -389,7 +389,7 @@ fn00001390_exit:
 
 
 word32 fn000013FC(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -405,7 +405,7 @@ fn000013FC_exit:
 
 
 word32 fn00001418(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000013FC
@@ -970,7 +970,7 @@ l0000179E:
 
 
 word32 fn00001D98(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001418
@@ -1006,7 +1006,7 @@ fn00001D98_exit:
 
 
 word32 fn00001DF4(word32 dwArg04, word32 dwArg08, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001D98
@@ -1084,7 +1084,7 @@ fn00001DF4_exit:
 
 
 word32 fn00001F08(word32 dwArg04, ptr32 & a0Out, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001DF4
@@ -1141,7 +1141,7 @@ fn00001F08_exit:
 
 
 word32 fn00001FB4(word32 dwArg04, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001DF4
@@ -1184,7 +1184,7 @@ fn00001FB4_exit:
 
 
 void fn00002020(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1203,7 +1203,7 @@ fn00002020_exit:
 
 
 void fn000020E8(word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002020
@@ -1249,7 +1249,7 @@ fn000020E8_exit:
 
 
 word32 fn00002184(word32 dwArg04, word32 dwArg08, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001FB4
@@ -1335,7 +1335,7 @@ fn00002184_exit:
 
 
 word32 fn000022A8(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001FB4
@@ -1374,7 +1374,7 @@ fn000022A8_exit:
 
 
 void fn00002318(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1405,7 +1405,7 @@ fn00002318_exit:
 
 
 word32 fn00002388()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001DF4
@@ -1427,7 +1427,7 @@ fn00002388_exit:
 
 
 word64 fn000023B8(word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001418
@@ -1521,7 +1521,7 @@ fn000023B8_exit:
 
 
 word32 fn000024BC(word32 d0, word32 d1, word32 d2, ptr32 & d1Out, ptr32 & d2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000023B8
@@ -1644,7 +1644,7 @@ fn000024BC_exit:
 
 
 word32 fn00002648(word32 d2, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002B8C
@@ -1676,7 +1676,7 @@ fn00002648_exit:
 
 
 word32 fn0000267A(word32 d0, word32 d1, word32 d2, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000024BC
@@ -1750,7 +1750,7 @@ fn0000267A_exit:
 
 
 word32 fn00002700(word64 qwArg04, word64 qwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001418
@@ -1845,7 +1845,7 @@ fn00002700_exit:
 
 
 void fn00002AFC(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -1876,7 +1876,7 @@ fn00002AFC_exit:
 
 
 word32 fn00002B40(word32 d0, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001390
@@ -1892,7 +1892,7 @@ fn00002B40_exit:
 
 
 word32 fn00002B5C(byte bArg07, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002B8C
@@ -1918,7 +1918,7 @@ fn00002B5C_exit:
 
 
 word32 fn00002B8C(word32 d0, word32 dwArg04, word32 dwArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002B40
@@ -2929,7 +2929,7 @@ fn00002B8C_exit:
 
 
 word32 fn00003BB0(word32 d4, word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10, ptr32 & d1Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002B8C
@@ -2959,7 +2959,7 @@ fn00003BB0_exit:
 
 
 word32 fn00003C30(word32 dwArg04, ptr32 & a5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002B8C
@@ -3035,7 +3035,7 @@ fn00003C30_exit:
 
 
 word32 fn00003D2C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00003C30

--- a/subjects/MZ-x86/BENCHFN_0800.dis
+++ b/subjects/MZ-x86/BENCHFN_0800.dis
@@ -36,7 +36,7 @@ l0800_014F:
 
 
 void fn0800_0162(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  cs:[0..15] ds:[0..15]
 // LiveOut:
@@ -55,7 +55,7 @@ fn0800_0162_exit:
 
 
 void __restorezero(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __exit
@@ -74,7 +74,7 @@ __restorezero_exit:
 
 
 void fn0800_01DA(char * ds_dx, word16 cx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __exit
@@ -92,7 +92,7 @@ fn0800_01DA_exit:
 
 
 void _abort()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __setargv
@@ -112,7 +112,7 @@ _abort_exit:
 
 
 void fn0800_01E9(word16 cx, word16 dx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __setenvp
@@ -129,7 +129,7 @@ l0800_01E9:
 
 
 void _f3()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_01E9
@@ -145,7 +145,7 @@ _f3_exit:
 
 
 void _f2()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      f1_name_overridden
@@ -170,7 +170,7 @@ _f2_exit:
 
 
 void f1_name_overridden()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _f0
@@ -195,7 +195,7 @@ f1_name_overridden_exit:
 
 
 void _f0()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _main
@@ -219,7 +219,7 @@ _f0_exit:
 
 
 void _main(word16 cx, word16 dx, word16 bx, selector es, selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  bx:[0..15] cx:[0..15] ds:[0..15] dx:[0..15] es:[0..15] ss:[0..15]
 // LiveOut:
@@ -258,7 +258,7 @@ _main_exit:
 
 
 word16 __IOERROR(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __read
@@ -294,7 +294,7 @@ __IOERROR_exit:
 
 
 void _exit(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ds:[0..15] ss:[0..15] Stack +0002:[0..15]
 // LiveOut:
@@ -433,7 +433,7 @@ l0800_03BB:
 
 
 byte fn0800_03BF(segptr32 ds_si, segptr32 es_di, word16 ax, word16 cx, ptr16 & axOut, ptr16 & cxOut, ptr16 & siOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __setargv
@@ -478,7 +478,7 @@ fn0800_03BF_exit:
 
 
 void __setenvp(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ds:[0..15]
 // LiveOut:
@@ -520,7 +520,7 @@ __setenvp_exit:
 
 
 void ___pull_free_block(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _malloc
@@ -547,7 +547,7 @@ ___pull_free_block_exit:
 
 
 word16 fn0800_04BF(selector ds, word16 wArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _malloc
@@ -573,7 +573,7 @@ fn0800_04BF_exit:
 
 
 word16 fn0800_04F9(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _malloc
@@ -599,7 +599,7 @@ fn0800_04F9_exit:
 
 
 word16 fn0800_0536(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _malloc
@@ -625,7 +625,7 @@ fn0800_0536_exit:
 
 
 word16 _malloc(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __setenvp
@@ -671,7 +671,7 @@ _malloc_exit:
 
 
 void ___brk(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _brk
@@ -693,7 +693,7 @@ ___brk_exit:
 
 
 word16 ___sbrk(selector ds, word32 dwArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_04F9
@@ -725,7 +725,7 @@ ___sbrk_exit:
 
 
 void _brk(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_1606
@@ -742,7 +742,7 @@ _brk_exit:
 
 
 word16 fn0800_065B(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _fseek
@@ -777,7 +777,7 @@ fn0800_065B_exit:
 
 
 void _fseek(selector ds, word16 wArg02, ui32 dwArg04, word16 wArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _setvbuf
@@ -813,7 +813,7 @@ _fseek_exit:
 
 
 void fn0800_075B(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0782
@@ -841,7 +841,7 @@ fn0800_075B_exit:
 
 
 word16 fn0800_0782(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _fgetc
@@ -880,7 +880,7 @@ fn0800_0782_exit:
 
 
 void _fgetc(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ds:[0..15] Stack +0002:[0..15]
 // LiveOut:
@@ -953,7 +953,7 @@ _fgetc_exit:
 
 
 word16 _isatty(word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _fgetc
@@ -970,7 +970,7 @@ _isatty_exit:
 
 
 void _setvbuf(selector ds, word16 wArg02, word16 wArg04, word16 wArg06, word16 wArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _fgetc
@@ -1038,7 +1038,7 @@ _setvbuf_exit:
 
 
 word16 _read(selector ds, word16 wArg02, word16 wArg04, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0782
@@ -1102,7 +1102,7 @@ _read_exit:
 
 
 word16 __read(selector ds, word16 wArg02, word16 wArg04, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _fgetc
@@ -1124,7 +1124,7 @@ __read_exit:
 
 
 word16 _write(selector ds, word16 wArg02, word16 wArg04, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _fflush
@@ -1198,7 +1198,7 @@ _write_exit:
 
 
 word16 __write(selector ds, word16 wArg02, word16 wArg04, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _write
@@ -1228,7 +1228,7 @@ __write_exit:
 
 
 word16 _lseek(selector ds, word16 wArg02, word32 dwArg04, byte bArg08, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _fseek
@@ -1258,7 +1258,7 @@ _lseek_exit:
 
 
 void __LONGTOA(selector ds, byte bArg02, byte bArg04, word16 wArg06, word16 wArg08, word32 dwArg0A)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 14; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __VPRINTER
@@ -1332,7 +1332,7 @@ l0800_0C9B:
 
 
 word16 _eof(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _fgetc
@@ -1385,7 +1385,7 @@ _eof_exit:
 
 
 word16 _fflush(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _fseek
@@ -1433,7 +1433,7 @@ _fflush_exit:
 
 
 word16 _printf(word16 cx, word16 dx, word16 bx, selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _main
@@ -1451,7 +1451,7 @@ _printf_exit:
 
 
 void __fputc(selector ds, byte bArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ds:[0..15] Stack +0002:[0..7] Stack +0004:[0..15]
 // LiveOut:
@@ -1467,7 +1467,7 @@ __fputc_exit:
 
 
 void _fputc(selector ds, byte bArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __fputc
@@ -1549,7 +1549,7 @@ __REALCVT_exit:
 
 
 word16 fn0800_1048(segptr32 es_di, selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __VPRINTER
@@ -1572,7 +1572,7 @@ fn0800_1048_exit:
 
 
 word16 __VPRINTER(word16 cx, word16 dx, word16 bx, selector ds, word16 wArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 10; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _printf
@@ -2056,7 +2056,7 @@ l0800_10EE:
 
 
 word16 fn0800_108C(word16 di, selector es)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __VPRINTER
@@ -2080,7 +2080,7 @@ fn0800_108C_exit:
 
 
 word16 fn0800_1099(segptr32 ds_di, segptr32 ss_bp, byte al, word16 cx, word16 dx, word16 bx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __VPRINTER
@@ -2103,7 +2103,7 @@ fn0800_1099_exit:
 
 
 word16 fn0800_10A1(segptr32 ss_bp, word16 cx, word16 dx, word16 bx, word16 di)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __VPRINTER
@@ -2132,7 +2132,7 @@ fn0800_10A1_exit:
 
 
 void fn0800_1596(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_165F
@@ -2159,7 +2159,7 @@ fn0800_1596_exit:
 
 
 void fn0800_15CF(selector ds, word16 wArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_165F
@@ -2182,7 +2182,7 @@ fn0800_15CF_exit:
 
 
 void fn0800_1606(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _free
@@ -2219,7 +2219,7 @@ fn0800_1606_exit:
 
 
 void fn0800_165F(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _free
@@ -2252,7 +2252,7 @@ fn0800_165F_exit:
 
 
 void _free(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _setvbuf
@@ -2276,7 +2276,7 @@ _free_exit:
 
 
 word16 _scanf(word16 di, selector es, selector ds, word16 wArg02, ptr16 & bxOut, ptr16 & bpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _main
@@ -2299,7 +2299,7 @@ _scanf_exit:
 
 
 word16 __scanner(word16 di, selector es, selector ds, word16 wArg02, word16 wArg04, word16 wArg06, word16 wArg08, ptr16 & bxOut, ptr16 & bpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _scanf
@@ -2750,7 +2750,7 @@ __scanner_exit:
 
 
 ptr32 fn0800_1708(segptr32 ss_bp, selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __scanner
@@ -3054,7 +3054,7 @@ __scanpop_exit:
 
 
 bool fn0800_1B9E(byte cl, byte bl)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __scantol
@@ -3092,7 +3092,7 @@ fn0800_1B9E_exit:
 
 
 word16 __scantol(selector ds, word16 wArg02, word16 wArg04, word16 wArg06, word16 wArg08, word16 wArg0A, word16 wArg0C, word16 wArg0E, ptr16 & dxOut, ptr16 & bxOut, ptr16 & diOut, ptr16 & esOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __scanner
@@ -3331,7 +3331,7 @@ __scantol_exit:
 
 
 void _tell(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ds:[0..15] Stack +0002:[0..15]
 // LiveOut:

--- a/subjects/MachO/amd64/MachO-OSX-x64-ls.reko/MachO-OSX-x64-ls_TEXT_text.dis
+++ b/subjects/MachO/amd64/MachO-OSX-x64-ls.reko/MachO-OSX-x64-ls_TEXT_text.dis
@@ -23,7 +23,7 @@ l00000001000017A3:
 
 
 word64 fn0000000100001B4A(word64 rsi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001000023B0
@@ -389,7 +389,7 @@ l0000000100002332:
 
 
 void fn00000001000023B0(word32 edx, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001000026A0
@@ -910,7 +910,7 @@ l00000001000026D5:
 
 
 word32 fn0000000100003201(word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001000035A9
@@ -965,7 +965,7 @@ fn0000000100003201_exit:
 
 
 void fn000000010000328E(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001000026A0
@@ -1047,7 +1047,7 @@ fn000000010000328E_exit:
 
 
 void fn00000001000033F4(word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001000034AC
@@ -1085,7 +1085,7 @@ fn00000001000033F4_exit:
 
 
 word32 fn00000001000034AC(word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001000035A9
@@ -1156,7 +1156,7 @@ fn00000001000034AC_exit:
 
 
 word32 fn000000010000356F(word64 rdi, ptr64 & rbxOut, ptr64 & rbpOut, ptr64 & r12dOut, ptr64 & r14Out, ptr64 & r15Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001000035A9
@@ -1265,7 +1265,7 @@ fn000000010000356F_exit:
 
 
 void fn00000001000035A9(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..63]
 // LiveOut:
@@ -1312,7 +1312,7 @@ fn00000001000035A9_exit:
 
 
 void fn0000000100003786()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000100003AA8
@@ -1334,7 +1334,7 @@ fn0000000100003786_exit:
 
 
 void fn0000000100003AA8(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000100003AA8
@@ -1769,7 +1769,7 @@ fn0000000100003AA8_exit:
 
 
 word32 fn0000000100004715(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000000010000356F
@@ -1834,7 +1834,7 @@ l000000010000481E:
 
 
 void fn000000010000488B()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001000026A0
@@ -2008,7 +2008,7 @@ fn0000000100004ABB_exit:
 
 
 word64 fn0000000100004AFA(word32 esi, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000100001B4A

--- a/subjects/MachO/amd64/const.reko/const_TEXT_text.dis
+++ b/subjects/MachO/amd64/const.reko/const_TEXT_text.dis
@@ -1,5 +1,5 @@
 void f(word32 eax)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  eax:[0..31]
 // LiveOut:

--- a/subjects/PDP-11/lunar.reko/lunar_image.dis
+++ b/subjects/PDP-11/lunar.reko/lunar_image.dis
@@ -1,5 +1,5 @@
 void fn0128()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0B06
@@ -73,7 +73,7 @@ l02B4:
 
 
 word16 fn02C8(word16 r4, ptr16 & r3Out, ptr16 & r4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0242
@@ -98,7 +98,7 @@ fn02C8_exit:
 
 
 void fn0300(word16 r4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn053A
@@ -209,7 +209,7 @@ l0440_thunk_fn0242:
 
 
 void fn0444()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn053A
@@ -253,7 +253,7 @@ l0456:
 
 
 void fn0488()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn053A
@@ -334,7 +334,7 @@ fn0488_exit:
 
 
 void fn053A()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0128
@@ -372,7 +372,7 @@ l056A:
 
 
 void fn0790()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn053A
@@ -388,7 +388,7 @@ fn0790_exit:
 
 
 void fn0856(word16 r4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn053A
@@ -553,7 +553,7 @@ fn0856_exit:
 
 
 void fn0A0A()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn053A
@@ -623,7 +623,7 @@ fn0A0A_exit:
 
 
 void fn0A94(word16 r3, word16 r4, word16 r5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0A0A
@@ -687,7 +687,7 @@ fn0AF6_exit:
 
 
 void fn0B06(word16 r3, word16 r4, word16 r5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0856
@@ -759,7 +759,7 @@ l0B44:
 
 
 void fn0C36(word16 r2, word16 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0B06
@@ -804,7 +804,7 @@ l0C72:
 
 
 void fn0C76()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0C36
@@ -830,7 +830,7 @@ fn0C76_exit:
 
 
 void fn0C90(word16 wArg02, byte bArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0856
@@ -857,7 +857,7 @@ fn0C90_exit:
 
 
 void fn0CCA(word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0856
@@ -925,7 +925,7 @@ fn0D3C_exit:
 
 
 void fn0D66()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -938,7 +938,7 @@ fn0D66_exit:
 
 
 word16 fn0D78(word16 r4, word16 r5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0CEC
@@ -1002,7 +1002,7 @@ fn0D78_exit:
 
 
 word16 fn0E06(word16 r0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn053A
@@ -1036,7 +1036,7 @@ fn0E06_exit:
 
 
 word16 fn0E32()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn053A
@@ -1078,7 +1078,7 @@ fn0E32_exit:
 
 
 word16 fn0E98(word16 r5, ptr16 & r5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0E32
@@ -1200,7 +1200,7 @@ l0FA8:
 
 
 word16 fn100C(word16 r4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn053A
@@ -1217,7 +1217,7 @@ fn100C_exit:
 
 
 void fn103C(word16 r0, word16 r3, word16 r5, word16 wArg00)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r0:[0..15] r3:[0..15] r5:[0..15] Stack +0000:[0..15]
 // LiveOut:
@@ -1251,7 +1251,7 @@ l1090:
 
 
 bool fn114A(word16 r0, word16 r1, ptr16 & r2_r3Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0300
@@ -1453,7 +1453,7 @@ fn114A_exit:
 
 
 word16 fn123A(word16 r0, word16 r1, ptr16 & r2Out, ptr16 & r3Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn053A
@@ -1493,7 +1493,7 @@ fn123A_exit:
 
 
 word16 fn125E(word16 r0, word16 r1, ptr16 & r2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn02C8
@@ -1514,7 +1514,7 @@ fn125E_exit:
 
 
 word16 fn126C(word16 r0, word16 r2, word16 r3, ptr16 & r3Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0300
@@ -1836,7 +1836,7 @@ l011E:
 
 
 void fn1578()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn053A
@@ -1882,7 +1882,7 @@ l15B8:
 
 
 word16 fn15F2(word16 r0, word16 r1)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1674
@@ -1927,7 +1927,7 @@ fn15F2_exit:
 
 
 word16 fn1658(word16 r1, word16 r3, word16 wArg02, ptr16 & r3Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn15F2
@@ -1951,7 +1951,7 @@ fn1658_exit:
 
 
 void fn1674(word16 r0, word16 r1)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1578
@@ -2016,7 +2016,7 @@ l3548:
 
 
 void fn355A()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn34E0

--- a/subjects/PDP-11/space_text.dis
+++ b/subjects/PDP-11/space_text.dis
@@ -1,5 +1,5 @@
 void fn0468(word16 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0472
@@ -86,7 +86,7 @@ l04E8:
 
 
 void fn04FA(word16 r0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0472
@@ -172,7 +172,7 @@ l0548:
 
 
 void fn054C(word16 r0, word16 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r0:[0..15] r3:[0..15]
 // LiveOut:
@@ -350,7 +350,7 @@ fn0670_exit:
 
 
 void fn0754(word16 wArg00, word16 wArg02, word16 wArg04, word16 wArg06, word16 wArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0000:[0..15] Stack +0002:[0..15] Stack +0004:[0..15] Stack +0006:[0..15] Stack +0008:[0..15]
 // LiveOut:
@@ -722,7 +722,7 @@ fn0B60_exit:
 
 
 void fn0C4A(word16 r0, word16 r1, word16 wArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r0:[0..15] r1:[0..15] Stack +0002:[0..15] Stack +0004:[0..15]
 // LiveOut:
@@ -755,7 +755,7 @@ fn0C4A_exit:
 
 
 void fn0CF4(word16 r5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r5:[0..15]
 // LiveOut:
@@ -791,7 +791,7 @@ fn0CF4_exit:
 
 
 word16 fn0D3E(word16 r0, word16 r2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0CF4
@@ -912,7 +912,7 @@ fn0EA8_exit:
 
 
 void fn0EF8(word16 r4, word16 r5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn243A
@@ -996,7 +996,7 @@ fn0EF8_exit:
 
 
 void fn0F48(word16 r5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r5:[0..15]
 // LiveOut:
@@ -1143,7 +1143,7 @@ fn0FB2_exit:
 
 
 void fn11A6(word16 r0, word16 r5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0818
@@ -1196,7 +1196,7 @@ l11DC:
 
 
 void fn12AC(word16 r2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r2:[0..15]
 // LiveOut:
@@ -1218,7 +1218,7 @@ fn12AC_exit:
 
 
 void fn12CA(word16 r2, word16 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r2:[0..15] r3:[0..15]
 // LiveOut:
@@ -1284,7 +1284,7 @@ fn12CA_exit:
 
 
 word16 fn1366(word16 r0, word16 r3, word16 r4, ptr16 & r2Out, ptr16 & r3Out, ptr16 & r4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn12CA
@@ -1316,7 +1316,7 @@ fn1366_exit:
 
 
 word16 fn1370(word16 r0, word16 r3, word16 r4, ptr16 & r2Out, ptr16 & r3Out, ptr16 & r4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn12CA
@@ -1353,7 +1353,7 @@ fn1370_exit:
 
 
 void fn13FE()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn14A8
@@ -1385,7 +1385,7 @@ fn13FE_exit:
 
 
 word16 fn1420(word16 r2, word16 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn12AC
@@ -1435,7 +1435,7 @@ fn1420_exit:
 
 
 void fn145E(word16 r2, word16 wArg00, word16 wArg02, ptr16 ptrArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r2:[0..7] Stack +0000:[0..15] Stack +0002:[0..15] Stack +0004:[0..15]
 // LiveOut:
@@ -1473,7 +1473,7 @@ fn145E_exit:
 
 
 void fn14A8(word16 r2, word16 r5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r2:[0..15] r5:[0..15]
 // LiveOut:
@@ -1606,7 +1606,7 @@ l14F6:
 
 
 void fn15CC(word16 r5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0CF4
@@ -1639,7 +1639,7 @@ fn15CC_exit:
 
 
 void fn16DA(word16 r0, word16 r2, word16 r3, word16 r4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r0:[0..15] r2:[0..15] r3:[0..15] r4:[0..15]
 // LiveOut:
@@ -1676,7 +1676,7 @@ fn16DA_exit:
 
 
 void fn171E(word16 r0, word16 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r0:[0..15] r3:[0..15]
 // LiveOut:
@@ -1694,7 +1694,7 @@ fn171E_exit:
 
 
 void fn172C(word16 r0, word16 r2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn171E
@@ -1809,7 +1809,7 @@ fn18BE_exit:
 
 
 void fn18F6(word16 r4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1900
@@ -1827,7 +1827,7 @@ fn18F6_exit:
 
 
 void fn18FE()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn18F6
@@ -1843,7 +1843,7 @@ fn18FE_exit:
 
 
 word16 fn1900(word16 r3, word16 r4, ptr16 & r3Out, ptr16 & r4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1836
@@ -1954,7 +1954,7 @@ fn1932_exit:
 
 
 void fn194E(word16 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r3:[0..15]
 // LiveOut:
@@ -1986,7 +1986,7 @@ fn1966_exit:
 
 
 void fn196A(word16 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1966
@@ -2005,7 +2005,7 @@ fn196A_exit:
 
 
 void fn197A(word16 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r3:[0..15]
 // LiveOut:
@@ -2037,7 +2037,7 @@ fn197A_exit:
 
 
 void fn1CFA()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1DAE
@@ -2052,7 +2052,7 @@ fn1CFA_exit:
 
 
 void fn1CFC()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -2065,7 +2065,7 @@ fn1CFC_exit:
 
 
 word16 fn1D30(word16 r0, word16 r3, ptr16 & r4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn14A8
@@ -2413,7 +2413,7 @@ fn4030_exit:
 
 
 void fn4072(word16 r5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r5:[0..15]
 // LiveOut:
@@ -2428,7 +2428,7 @@ fn4072_exit:
 
 
 void fn4078()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn4072
@@ -2579,7 +2579,7 @@ fn45C8_exit:
 
 
 void fn45F6(word16 r0, word16 r2, word16 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn145E
@@ -2708,7 +2708,7 @@ l4608:
 
 
 word16 fn474C(word16 r1, word16 r2, word16 r3, word16 r4, ptr16 & r4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn45F6
@@ -2789,7 +2789,7 @@ l47C6:
 
 
 void fn5A90()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/PDP-11/spcinv.reko/spcinv_text.dis
+++ b/subjects/PDP-11/spcinv.reko/spcinv_text.dis
@@ -200,7 +200,7 @@ fn0470_exit:
 
 
 word16 fn0486(word16 r0, word16 r4, ptr16 & r4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0200
@@ -221,7 +221,7 @@ fn0486_exit:
 
 
 word16 fn04A0(word16 r4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0200
@@ -358,7 +358,7 @@ fn04A0_exit:
 
 
 bool fn05D4(word16 r0, word16 r3, word16 r4, ptr16 & r0Out, ptr16 & r3Out, ptr16 & r4Out, ptr16 & r5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn04A0
@@ -410,7 +410,7 @@ fn05D4_exit:
 
 
 bool fn064A(word16 r0, word16 r1, word16 r3, word16 r4, ptr16 & r0Out, ptr16 & r4Out, ptr16 & r5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn04A0
@@ -457,7 +457,7 @@ fn064A_exit:
 
 
 bool fn067C(word16 r0, word16 r3, word16 r4, ptr16 & r0Out, ptr16 & r4Out, ptr16 & r5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn04A0
@@ -491,7 +491,7 @@ fn067C_exit:
 
 
 void fn06A2()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -520,7 +520,7 @@ fn06A2_exit:
 
 
 word16 fn06D6(word16 r4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0200
@@ -608,7 +608,7 @@ fn06D6_exit:
 
 
 word16 fn07A6(word16 r4, ptr16 & r4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0200
@@ -794,7 +794,7 @@ fn07A6_exit:
 
 
 void fn093C(word16 r0, word16 r1)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn07A6
@@ -824,7 +824,7 @@ fn093C_exit:
 
 
 void fn096A(word16 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn07A6
@@ -851,7 +851,7 @@ fn096A_exit:
 
 
 word16 fn0998(word16 r0, word16 r4, ptr16 & r4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0200
@@ -1004,7 +1004,7 @@ fn0A7C_exit:
 
 
 word16 fn0A94()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn05D4
@@ -1099,7 +1099,7 @@ fn0AE8_exit:
 
 
 word16 fn0AF6(word16 r4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0200
@@ -1143,7 +1143,7 @@ fn0B1A_exit:
 
 
 void fn0B60(word16 r0, word16 r3, word16 r4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r0:[0..15] r3:[0..15] r4:[0..15]
 // LiveOut:
@@ -1199,7 +1199,7 @@ l0B92:
 
 
 void fn0BD6()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0200
@@ -1306,7 +1306,7 @@ fn0C20_exit:
 
 
 void fn0D98(word16 r0, word16 r4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r0:[0..15] r4:[0..15]
 // LiveOut:

--- a/subjects/PE/m68k/hello_m68k_CRTDOS.dis
+++ b/subjects/PE/m68k/hello_m68k_CRTDOS.dis
@@ -1,5 +1,5 @@
 void fn00003340(word32 a5, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31] Stack +0006:[0..15]
 // LiveOut:

--- a/subjects/PE/m68k/hello_m68k_CRTHEAP.dis
+++ b/subjects/PE/m68k/hello_m68k_CRTHEAP.dis
@@ -1,5 +1,5 @@
 void fn000024B0(word32 a5, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31] Stack +0004:[0..31]
 // LiveOut:
@@ -13,7 +13,7 @@ fn000024B0_exit:
 
 
 word32 fn000024C4(word32 a5, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000024B0
@@ -52,7 +52,7 @@ fn000024C4_exit:
 
 
 word32 fn00002510(word32 a5, word32 dwArg04, ptr32 & d3Out, ptr32 & d4Out, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000024C4
@@ -122,7 +122,7 @@ fn00002510_exit:
 
 
 word32 fn000025B4(word32 a5, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002510
@@ -154,7 +154,7 @@ fn000025B4_exit:
 
 
 void fn00002610(word32 a5, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31] Stack +0004:[0..31]
 // LiveOut:
@@ -168,7 +168,7 @@ fn00002610_exit:
 
 
 word32 fn00002644(word32 a5, word32 dwArg04, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000024C4
@@ -202,7 +202,7 @@ fn00002644_exit:
 
 
 word32 fn0000273C(word32 a0, word32 a5, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000025B4
@@ -230,7 +230,7 @@ fn0000273C_exit:
 
 
 word32 fn0000275C(word32 a0, word32 a5, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000273C
@@ -264,7 +264,7 @@ fn0000275C_exit:
 
 
 word32 fn000027A0(word32 a5, word32 a6, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002510
@@ -288,7 +288,7 @@ fn000027A0_exit:
 
 
 word32 fn000027B0(word32 a5, word32 dwArg04, ptr32 & a0Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002510
@@ -361,7 +361,7 @@ l000027FE:
 
 
 word32 fn000028A0(word32 a0, word32 a2, word32 a5, word32 dwArg04, ptr32 & d3Out, ptr32 & d4Out, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002510
@@ -487,7 +487,7 @@ fn000028A0_exit:
 
 
 word32 fn000029C8(word32 a0, word32 a5, word32 dwArg04, word32 dwArg08, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000028A0
@@ -541,7 +541,7 @@ fn000029C8_exit:
 
 
 word32 fn00002A54(word32 a5, word32 dwArg04, word32 dwArg08, ptr32 & d3Out, ptr32 & d4Out, ptr32 & d5Out, ptr32 & a2Out, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000028A0
@@ -608,7 +608,7 @@ fn00002A54_exit:
 
 
 void fn00002AE0(word32 a5, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000029C8
@@ -631,7 +631,7 @@ fn00002AE0_exit:
 
 
 void fn00002B18(word32 a5, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31] Stack +0004:[0..31]
 // LiveOut:
@@ -668,7 +668,7 @@ fn00002B18_exit:
 
 
 word32 fn00002BB4(word32 a5, word32 dwArg04, word32 dwArg08, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002A54
@@ -771,7 +771,7 @@ fn00002BB4_exit:
 
 
 void fn00002E18(word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002BB4
@@ -819,7 +819,7 @@ fn00002E18_exit:
 
 
 word32 fn00002EA8(word32 a5, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002BB4

--- a/subjects/PE/m68k/hello_m68k_CRTLOAD.dis
+++ b/subjects/PE/m68k/hello_m68k_CRTLOAD.dis
@@ -1,5 +1,5 @@
 void fn00001498()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -40,7 +40,7 @@ l000014E2:
 
 
 void fn000014E8(word32 a3, word32 a5, word16 wArg00, word32 dwArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a3:[0..15] a5:[0..31] Stack +0000:[0..15] Stack +0002:[0..31]
 // LiveOut:

--- a/subjects/PE/m68k/hello_m68k_CRTSTART.dis
+++ b/subjects/PE/m68k/hello_m68k_CRTSTART.dis
@@ -1,5 +1,5 @@
 void fn000021F0(word32 a5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31]
 // LiveOut:
@@ -35,7 +35,7 @@ fn000021F0_exit:
 
 
 void fn00002264(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -66,7 +66,7 @@ fn00002264_exit:
 
 
 void fn00002294(word32 a5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31]
 // LiveOut:
@@ -80,7 +80,7 @@ fn00002294_exit:
 
 
 void fn000022C4(word32 a2, word32 a5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a2:[0..31] a5:[0..31]
 // LiveOut:
@@ -126,7 +126,7 @@ fn000022C4_exit:
 
 
 word32 fn00002354(word32 a5, word32 dwArg08, byte bArg0F)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002294
@@ -173,7 +173,7 @@ fn00002354_exit:
 
 
 word32 fn000023B4(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000022C4
@@ -210,7 +210,7 @@ fn000023B4_exit:
 
 
 void fn000023F8(word32 a5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31]
 // LiveOut:
@@ -233,7 +233,7 @@ fn000023F8_exit:
 
 
 word32 fn00002418(word32 a5, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000023F8
@@ -264,7 +264,7 @@ fn00002418_exit:
 
 
 word32 fn0000243C(word32 a5, word32 dwArg04, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000023F8

--- a/subjects/PE/m68k/hello_m68k_CRTSTDIO.dis
+++ b/subjects/PE/m68k/hello_m68k_CRTSTDIO.dis
@@ -1,5 +1,5 @@
 void fn000015E8(word32 d3, word32 a2, word32 a5, word32 a6, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a2:[0..31] a5:[0..31] a6:[0..31] d3:[0..31] Stack +0004:[0..31]
 // LiveOut:
@@ -54,7 +54,7 @@ fn000015E8_exit:
 
 
 void fn00001680(word32 a5, word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31] Stack +0004:[0..31] Stack +0008:[0..31]
 // LiveOut:
@@ -92,7 +92,7 @@ fn00001680_exit:
 
 
 void fn000016D0(word32 d6, word32 a5, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31] d6:[8..31] Stack +0008:[0..31]
 // LiveOut:
@@ -145,7 +145,7 @@ fn000016D0_exit:
 
 
 word32 fn00001C40(word32 a5, byte bArg04, word32 dwArg08, ptr32 & d4Out, ptr32 & d5Out, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001C84
@@ -198,7 +198,7 @@ fn00001C40_exit:
 
 
 void fn00001C84(word32 a5, word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31] Stack +0004:[0..31] Stack +0008:[0..31] Stack +000C:[0..31] Stack +0010:[0..31]
 // LiveOut:
@@ -229,7 +229,7 @@ fn00001C84_exit:
 
 
 void fn00001CC4(word32 a5, word32 dwArg04, word32 dwArg08, word32 dwArg0C, word32 dwArg10)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31] Stack +0004:[0..31] Stack +0008:[0..31] Stack +000C:[0..31] Stack +0010:[0..31]
 // LiveOut:
@@ -260,7 +260,7 @@ fn00001CC4_exit:
 
 
 void fn00001D0C(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -274,7 +274,7 @@ fn00001D0C_exit:
 
 
 word32 fn00001D24(word32 a5, word32 dwArg04, ptr32 & d3Out, ptr32 & d4Out, ptr32 & d5Out, ptr32 & d6Out, ptr32 & d7Out, ptr32 & a2Out, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E04
@@ -362,7 +362,7 @@ fn00001D24_exit:
 
 
 word32 fn00001D80(word32 a5, word32 dwArg04, ptr32 & d3Out, ptr32 & d4Out, ptr32 & a2Out, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001680
@@ -423,7 +423,7 @@ fn00001D80_exit:
 
 
 void fn00001DF4(word32 a5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31]
 // LiveOut:
@@ -441,7 +441,7 @@ fn00001DF4_exit:
 
 
 word32 fn00001E04(word32 a5, word32 dwArg04, ptr32 & d3Out, ptr32 & d4Out, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001D24
@@ -516,7 +516,7 @@ fn00001E04_exit:
 
 
 word32 fn00001E94(word32 a5, word32 dwArg08, ptr32 & d3Out, ptr32 & d4Out, ptr32 & d5Out, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001C40
@@ -674,7 +674,7 @@ fn00001E94_exit:
 
 
 void fn00001FD8(word32 a5)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a5:[0..31]
 // LiveOut:
@@ -706,7 +706,7 @@ fn00001FD8_exit:
 
 
 word32 fn00002014(word32 a2, word32 a5, word32 a6, word32 dwArg04, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001E94
@@ -747,7 +747,7 @@ fn00002014_exit:
 
 
 word32 fn00002068(word32 d3, word32 a5, word32 dwArg04, ptr32 & d3Out, ptr32 & d4Out, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00001FD8
@@ -841,7 +841,7 @@ fn00002068_exit:
 
 
 word32 fn000020F0(word32 a5, word32 dwArg04, ptr32 & a5Out, ptr32 & a6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00002068

--- a/subjects/PE/x86-64/array/reko_array.reko/reko_array_text.dis
+++ b/subjects/PE/x86-64/array/reko_array.reko/reko_array_text.dis
@@ -1,5 +1,5 @@
 void reko_array_byref(word64 rcx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      reko_array_01
@@ -21,7 +21,7 @@ reko_array_byref_exit:
 
 
 void reko_array_01()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -35,7 +35,7 @@ reko_array_01_exit:
 
 
 void reko_array_local()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/PE/x86-64/varargs_test/varargs_test.reko/varargs_test_text.dis
+++ b/subjects/PE/x86-64/varargs_test/varargs_test.reko/varargs_test_text.dis
@@ -1,5 +1,5 @@
 word32 fn0000000140001000()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -19,7 +19,7 @@ fn0000000140001000_exit:
 
 
 word64 fn00000001400010C0()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400010D0
@@ -35,7 +35,7 @@ fn00000001400010C0_exit:
 
 
 void fn00000001400010D0(word64 rcx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000140001000
@@ -52,7 +52,7 @@ fn00000001400010D0_exit:
 
 
 word64 fn0000000140001130()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000140001140
@@ -68,7 +68,7 @@ fn0000000140001130_exit:
 
 
 void fn0000000140001140(word64 rcx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000140001000
@@ -85,7 +85,7 @@ fn0000000140001140_exit:
 
 
 word32 fn00000001400011B0(word64 rcx, word64 qwArg00)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000140001000
@@ -112,7 +112,7 @@ fn00000001400011B0_exit:
 
 
 void fn00000001400011D4(word64 rbx, ULONGLONG tArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rbx:[0..63] Stack +0008:[0..63]
 // LiveOut:
@@ -161,7 +161,7 @@ fn00000001400011D4_exit:
 
 
 void fn0000000140001290()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011D4
@@ -193,7 +193,7 @@ fn00000001400012A0_exit:
 
 
 word32 fn00000001400012BC(word64 rax)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -327,7 +327,7 @@ fn0000000140001448_exit:
 
 
 word32 fn000000014000147C(word64 rcx, word64 qwArg00)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011B0
@@ -358,7 +358,7 @@ l0000000140001493:
 
 
 void fn0000000140001550(word64 rcx, ULONGLONG tArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011B0
@@ -386,7 +386,7 @@ fn0000000140001550_exit:
 
 
 void fn00000001400015C4(selector gs)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -413,7 +413,7 @@ fn00000001400015C4_exit:
 
 
 void fn0000000140001600(word32 ecx, word32 edx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -443,7 +443,7 @@ fn0000000140001600_exit:
 
 
 byte fn000000014000164C(word32 ecx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011D4
@@ -494,7 +494,7 @@ fn000000014000164C_exit:
 
 
 word64 fn0000000140001718(word64 rcx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -554,7 +554,7 @@ l0000000140001787:
 
 
 void fn00000001400017B4(byte cl)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -575,7 +575,7 @@ fn00000001400017B4_exit:
 
 
 void fn00000001400017D8(byte dl)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -597,7 +597,7 @@ fn00000001400017D8_exit:
 
 
 word64 fn0000000140001804(word64 rcx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000140001854
@@ -625,7 +625,7 @@ fn0000000140001804_exit:
 
 
 void fn0000000140001854(word64 rcx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011D4
@@ -641,7 +641,7 @@ fn0000000140001854_exit:
 
 
 word64 fn000000014000186C(LARGE_INTEGER tArg18)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -675,7 +675,7 @@ fn000000014000186C_exit:
 
 
 word32 fn0000000140001918()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011D4
@@ -690,7 +690,7 @@ fn0000000140001918_exit:
 
 
 word32 fn0000000140001920()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011D4
@@ -721,7 +721,7 @@ fn0000000140001928_exit:
 
 
 byte fn0000000140001938()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011D4
@@ -738,7 +738,7 @@ fn0000000140001938_exit:
 
 
 void fn000000014000193C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000140001290
@@ -757,7 +757,7 @@ fn000000014000193C_exit:
 
 
 word32 fn0000000140001958()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011D4
@@ -772,7 +772,7 @@ fn0000000140001958_exit:
 
 
 void fn0000000140001964()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -787,7 +787,7 @@ fn0000000140001964_exit:
 
 
 void fn000000014000196C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -802,7 +802,7 @@ fn000000014000196C_exit:
 
 
 word64 fn0000000140001974(word32 ecx, word64 qwArg00, ULONGLONG tArg10, ptr64 & rcxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011D4
@@ -855,7 +855,7 @@ l0000000140001999:
 
 
 word32 fn0000000140001ABC()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011D4
@@ -871,7 +871,7 @@ fn0000000140001ABC_exit:
 
 
 void fn0000000140001AC0()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -916,7 +916,7 @@ fn0000000140001B14_exit:
 
 
 void fn0000000140001B24(word64 rcx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rcx:[0..63]
 // LiveOut:
@@ -946,7 +946,7 @@ fn0000000140001B24_exit:
 
 
 void fn0000000140001B5C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011D4
@@ -973,7 +973,7 @@ fn0000000140001B5C_exit:
 
 
 void fn0000000140001BA8()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1016,7 +1016,7 @@ fn0000000140001BF4_exit:
 
 
 void fn0000000140001BFC(word32 edx, word32 ebx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000140001600
@@ -1101,7 +1101,7 @@ fn0000000140001BFC_exit:
 
 
 word32 fn0000000140001DC4()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400015C4
@@ -1118,7 +1118,7 @@ fn0000000140001DC4_exit:
 
 
 void fn0000000140001DD0()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00000001400011D4
@@ -1133,7 +1133,7 @@ fn0000000140001DD0_exit:
 
 
 void fn0000000140001E7C(word64 rdx, word64 r9)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r9:[0..63] rdx:[0..63]
 // LiveOut:
@@ -1148,7 +1148,7 @@ fn0000000140001E7C_exit:
 
 
 void fn0000000140001E9C(word64 rcx, word64 rdx, word64 r8, word64 qwArg00)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000000140001E7C
@@ -1194,7 +1194,7 @@ fn0000000140001F10_exit:
 
 
 void fn0000000140001F12(word64 rcx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rcx:[0..63]
 // LiveOut:
@@ -1208,7 +1208,7 @@ fn0000000140001F12_exit:
 
 
 void fn0000000140001F30()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/PE/x86/ExeDll/Executable.reko/Executable_text.dis
+++ b/subjects/PE/x86/ExeDll/Executable.reko/Executable_text.dis
@@ -1,5 +1,5 @@
 word32 fn00401000()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -19,7 +19,7 @@ fn00401000_exit:
 
 
 word32 fn00401050()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00401060
@@ -35,7 +35,7 @@ fn00401050_exit:
 
 
 void fn00401060(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00401000
@@ -181,7 +181,7 @@ Win32CrtStartup_exit:
 
 
 void fn004012D8(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -197,7 +197,7 @@ fn004012D8_exit:
 
 
 word32 fn004013FB(word32 dwArg04, word32 dwArg08, ptr32 & edxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00401544
@@ -231,7 +231,7 @@ fn004013FB_exit:
 
 
 byte fn0040143F()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -263,7 +263,7 @@ fn0040143F_exit:
 
 
 byte fn00401474(word32 edx, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -291,7 +291,7 @@ fn00401474_exit:
 
 
 void fn004014AD(word32 ebx, word32 edi, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ebx:[0..31] edi:[0..31] fs:[0..15] Stack +0004:[0..31]
 // LiveOut:
@@ -336,7 +336,7 @@ fn004014AD_exit:
 
 
 byte fn00401544(word32 ebx, word32 esi, word32 edi, ptr32 & edxOut, ptr32 & ebxOut, ptr32 & ebpOut, ptr32 & esiOut, ptr32 & ediOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -389,7 +389,7 @@ fn00401544_exit:
 
 
 void fn004015CE(byte bArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -410,7 +410,7 @@ fn004015CE_exit:
 
 
 void fn004015EB(byte bArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -432,7 +432,7 @@ fn004015EB_exit:
 
 
 word32 fn00401613(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0040164E
@@ -455,7 +455,7 @@ fn00401613_exit:
 
 
 void fn0040164E(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -469,7 +469,7 @@ fn0040164E_exit:
 
 
 void fn00401663()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -511,7 +511,7 @@ fn00401663_exit:
 
 
 void fn004016FF()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -524,7 +524,7 @@ fn004016FF_exit:
 
 
 void fn00401703()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -537,7 +537,7 @@ fn00401703_exit:
 
 
 void fn00401709()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -550,7 +550,7 @@ fn00401709_exit:
 
 
 void fn0040170C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -564,7 +564,7 @@ fn0040170C_exit:
 
 
 void fn00401718()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -585,7 +585,7 @@ fn00401718_exit:
 
 
 word32 fn00401739()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00401718
@@ -601,7 +601,7 @@ fn00401739_exit:
 
 
 void fn0040173F()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -622,7 +622,7 @@ fn0040173F_exit:
 
 
 void fn0040175C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -635,7 +635,7 @@ fn0040175C_exit:
 
 
 word32 fn00401768()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -650,7 +650,7 @@ fn00401768_exit:
 
 
 word32 fn0040176E()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -665,7 +665,7 @@ fn0040176E_exit:
 
 
 void fn00401774(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -702,7 +702,7 @@ l0040178A:
 
 
 byte fn0040188F()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -731,7 +731,7 @@ fn0040188F_exit:
 
 
 void fn004018D3()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -745,7 +745,7 @@ fn004018D3_exit:
 
 
 void fn00401920()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -789,7 +789,7 @@ fn00401976_exit:
 
 
 word32 fn00401980(word32 ebx, word32 esi, word32 edi, word32 dwArg00, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -814,7 +814,7 @@ fn00401980_exit:
 
 
 word32 fn004019C6(word32 ebp, word32 dwArg00, ptr32 & ebpOut, ptr32 & esiOut, ptr32 & ediOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -840,7 +840,7 @@ fn004019C6_exit:
 
 
 void fn004019FE(word32 edx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00401474
@@ -913,7 +913,7 @@ fn004019FE_exit:
 
 
 word32 fn00401B98()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0040143F
@@ -930,7 +930,7 @@ fn00401B98_exit:
 
 
 void fn00401BA4()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -943,7 +943,7 @@ fn00401BA4_exit:
 
 
 byte fn00401C48()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00401474

--- a/subjects/PE/x86/LocalStackVariables/LocalStackVariables.reko/LocalStackVariables_text.dis
+++ b/subjects/PE/x86/LocalStackVariables/LocalStackVariables.reko/LocalStackVariables_text.dis
@@ -44,7 +44,7 @@ main_exit:
 
 
 word32 GetMin(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main

--- a/subjects/PE/x86/RussianText/RussianText.reko/RussianText_text.dis
+++ b/subjects/PE/x86/RussianText/RussianText.reko/RussianText_text.dis
@@ -1,5 +1,5 @@
 void _GetExceptDLLinfo(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  fs:[0..15] Stack +0004:[0..31]
 // LiveOut:
@@ -14,7 +14,7 @@ __GetExceptDLLinfo_exit:
 
 
 void fn00401084()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -27,7 +27,7 @@ fn00401084_exit:
 
 
 void fn0040110B()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -48,7 +48,7 @@ fn0040110B_exit:
 
 
 word32 fn00401158()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _GetExceptDLLinfo
@@ -79,7 +79,7 @@ main_exit:
 
 
 void fn0040117C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -92,7 +92,7 @@ fn0040117C_exit:
 
 
 void fn00401180()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -105,7 +105,7 @@ fn00401180_exit:
 
 
 void fn004011B0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  fs:[0..15] Stack +0004:[0..31]
 // LiveOut:
@@ -129,7 +129,7 @@ fn004011B0_exit:
 
 
 void fn004011FC(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      _GetExceptDLLinfo

--- a/subjects/PE/x86/SmallBinaries/strcpyChain.reko/strcpyChain_code.dis
+++ b/subjects/PE/x86/SmallBinaries/strcpyChain.reko/strcpyChain_code.dis
@@ -1,5 +1,5 @@
 void fn12340000()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/PE/x86/SmallBinaries/strcpyEcxChain.reko/strcpyEcxChain_code.dis
+++ b/subjects/PE/x86/SmallBinaries/strcpyEcxChain.reko/strcpyEcxChain_code.dis
@@ -1,5 +1,5 @@
 void fn12340000(word32 ecx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ecx:[0..31]
 // LiveOut:

--- a/subjects/PE/x86/VCExeSample/VCExeSample.reko/VCExeSample_text.dis
+++ b/subjects/PE/x86/VCExeSample/VCExeSample.reko/VCExeSample_text.dis
@@ -30,7 +30,7 @@ test1_exit:
 
 
 void test2(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -62,7 +62,7 @@ indirect_call_test3_exit:
 
 
 void test4()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -76,7 +76,7 @@ test4_exit:
 
 
 void test5()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -106,7 +106,7 @@ test6_exit:
 
 
 void test7(real64 rArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 1; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..63]
 // LiveOut:
@@ -124,7 +124,7 @@ test7_exit:
 
 
 void nested_if_blocks_test8(real64 rArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      loop_test11
@@ -147,7 +147,7 @@ nested_if_blocks_test8_exit:
 
 
 void loop_test9(real32 rArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      loop_test11
@@ -170,7 +170,7 @@ l0040123F:
 
 
 void const_div_test10(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..31]
 // LiveOut:
@@ -192,7 +192,7 @@ const_div_test10_exit:
 
 
 void loop_test11(real64 rArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0004:[0..63]
 // LiveOut:
@@ -222,7 +222,7 @@ l0040131E:
 
 
 void nested_structs_test12(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      nested_structs_test13
@@ -255,7 +255,7 @@ nested_structs_test13_exit:
 
 
 void gbl_nested_structs_test14()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/PE/x86/import-ordinals/main_text.dis
+++ b/subjects/PE/x86/import-ordinals/main_text.dis
@@ -1,5 +1,5 @@
 word32 fn00401000()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00401010
@@ -14,7 +14,7 @@ fn00401000_exit:
 
 
 void fn00401010(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00401040
@@ -37,7 +37,7 @@ fn00401010_exit:
 
 
 word32 fn00401040(word32 ecx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -184,7 +184,7 @@ Win32CrtStartup_exit:
 
 
 word32 fn004013F6(word32 dwArg04, word32 dwArg08, ptr32 & edxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0040153F
@@ -218,7 +218,7 @@ fn004013F6_exit:
 
 
 byte fn0040143A()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -250,7 +250,7 @@ fn0040143A_exit:
 
 
 byte fn0040146F(word32 edx, word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -278,7 +278,7 @@ fn0040146F_exit:
 
 
 byte fn0040153F(word32 ebx, word32 esi, word32 edi, ptr32 & edxOut, ptr32 & ebxOut, ptr32 & ebpOut, ptr32 & esiOut, ptr32 & ediOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -330,7 +330,7 @@ fn0040153F_exit:
 
 
 void fn004015C9(byte bArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -351,7 +351,7 @@ fn004015C9_exit:
 
 
 void fn004015E6(byte bArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -373,7 +373,7 @@ fn004015E6_exit:
 
 
 void fn0040165E()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -415,7 +415,7 @@ fn0040165E_exit:
 
 
 word32 fn00401761()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -430,7 +430,7 @@ fn00401761_exit:
 
 
 word32 fn00401767()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -445,7 +445,7 @@ fn00401767_exit:
 
 
 void fn0040176D(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -480,7 +480,7 @@ l00401783:
 
 
 byte fn0040188B()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -526,7 +526,7 @@ fn00401972_exit:
 
 
 word32 fn00401980(word32 ebx, word32 esi, word32 edi, word32 dwArg00, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -551,7 +551,7 @@ fn00401980_exit:
 
 
 word32 fn004019C6(word32 ebp, word32 dwArg00, ptr32 & ebpOut, ptr32 & esiOut, ptr32 & ediOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      Win32CrtStartup
@@ -577,7 +577,7 @@ fn004019C6_exit:
 
 
 void fn004019FE(word32 edx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0040146F
@@ -650,7 +650,7 @@ fn004019FE_exit:
 
 
 word32 fn00401B98()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0040143A
@@ -666,7 +666,7 @@ fn00401B98_exit:
 
 
 byte fn00401C46()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0040146F

--- a/subjects/PE/x86/pySample/pySample_text.dis
+++ b/subjects/PE/x86/pySample/pySample_text.dis
@@ -79,7 +79,7 @@ fn100010F0_exit:
 
 
 void initpySample()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -93,7 +93,7 @@ initpySample_exit:
 
 
 word32 fn100011E9(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & ebxOut, ptr32 & esiOut, ptr32 & ediOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 16; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001388
@@ -225,7 +225,7 @@ l10001264:
 
 
 word32 fn10001388(word32 ecx, word32 edx, word32 ebx, word32 esi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      DllMain
@@ -328,7 +328,7 @@ fn10001388_exit:
 
 
 void fn10001493()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001388
@@ -364,7 +364,7 @@ DllMain_exit:
 
 
 word32 fn100016D0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001742
@@ -386,7 +386,7 @@ fn100016D0_exit:
 
 
 word32 fn10001700(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001742
@@ -419,7 +419,7 @@ fn10001700_exit:
 
 
 word32 fn10001742(word32 ebx, word32 esi, word32 edi, ptr32 & ediOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn100011E9
@@ -453,7 +453,7 @@ fn10001742_exit:
 
 
 word32 fn100017C6(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 16; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001388
@@ -474,7 +474,7 @@ fn100017C6_exit:
 
 
 word32 fn100017E8(word32 ebx, word32 esi, word32 edi, word32 dwArg00, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001388
@@ -499,7 +499,7 @@ fn100017E8_exit:
 
 
 word32 fn1000182D(word32 ebp, word32 dwArg00)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001388
@@ -519,7 +519,7 @@ fn1000182D_exit:
 
 
 void fn10001864()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      DllMain

--- a/subjects/PE/x86/pySample/shingledPySample.reko/pySample_text.dis
+++ b/subjects/PE/x86/pySample/shingledPySample.reko/pySample_text.dis
@@ -79,7 +79,7 @@ fn100010F0_exit:
 
 
 void initpySample()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -93,7 +93,7 @@ initpySample_exit:
 
 
 word32 fn100011E9(word32 dwArg04, word32 dwArg08, word32 dwArg0C, ptr32 & ebxOut, ptr32 & esiOut, ptr32 & ediOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 16; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001388
@@ -225,7 +225,7 @@ l10001264:
 
 
 word32 fn10001388(word32 ecx, word32 edx, word32 ebx, word32 esi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      DllMain
@@ -328,7 +328,7 @@ fn10001388_exit:
 
 
 void fn10001493()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001388
@@ -364,7 +364,7 @@ DllMain_exit:
 
 
 word32 fn100015CF(word32 ebx, word32 esi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1000166E
@@ -408,7 +408,7 @@ fn100015CF_exit:
 
 
 void fn10001665()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn100015CF
@@ -424,7 +424,7 @@ fn10001665_exit:
 
 
 void fn1000166E(word32 ebx, word32 esi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ebx:[0..31] edi:[0..31] esi:[0..31] fs:[0..15]
 // LiveOut:
@@ -438,7 +438,7 @@ fn1000166E_exit:
 
 
 void fn10001680()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -461,7 +461,7 @@ fn10001680_exit:
 
 
 word32 fn100016D0(word32 dwArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001742
@@ -483,7 +483,7 @@ fn100016D0_exit:
 
 
 word32 fn10001700(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001742
@@ -516,7 +516,7 @@ fn10001700_exit:
 
 
 word32 fn10001742(word32 ebx, word32 esi, word32 edi, ptr32 & ediOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn100011E9
@@ -550,7 +550,7 @@ fn10001742_exit:
 
 
 word32 fn100017C6(word32 dwArg04, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 16; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001388
@@ -571,7 +571,7 @@ fn100017C6_exit:
 
 
 word32 fn100017E8(word32 ebx, word32 esi, word32 edi, word32 dwArg00, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001388
@@ -597,7 +597,7 @@ fn100017E8_exit:
 
 
 word32 fn1000182D(word32 ebp, word32 dwArg00)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn10001388
@@ -618,7 +618,7 @@ fn1000182D_exit:
 
 
 void fn10001864()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      DllMain

--- a/subjects/Raw/1750A/fft.reko/fft_normal.dis
+++ b/subjects/Raw/1750A/fft.reko/fft_normal.dis
@@ -1,5 +1,5 @@
 word16 reverse(word16 gp0, ptr16 & gp14Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0100
@@ -28,7 +28,7 @@ reverse_exit:
 
 
 word16 init_fft(ptr16 & gp4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -58,7 +58,7 @@ init_fft_exit:
 
 
 word16 compute_output()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -87,7 +87,7 @@ compute_output_exit:
 
 
 void fft(word16 gp3, word16 gp4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -140,7 +140,7 @@ fft_exit:
 
 
 void main()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -177,7 +177,7 @@ main_exit:
 
 
 word16 frex(word16 gp1, word16 gp3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      sqrt
@@ -207,7 +207,7 @@ frex_exit:
 
 
 real48 sqrt(word32 gp0_gp1, word16 gp2, ptr16 & gp14Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      compute_output
@@ -247,7 +247,7 @@ sqrt_exit:
 
 
 word32 auxasin(real48 gp0_gp1_gp2, ptr16 & gp2Out, ptr16 & gp14Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      asin
@@ -268,7 +268,7 @@ auxasin_exit:
 
 
 void asin(word32 gp0_gp1, word16 gp2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  gp2:[0..15] Sequence gp0:gp1:[0..31]
 // LiveOut:
@@ -311,7 +311,7 @@ asin_exit:
 
 
 void rsin()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -324,7 +324,7 @@ rsin_exit:
 
 
 void rcos()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -337,7 +337,7 @@ rcos_exit:
 
 
 word16 sincos(word16 gp1, word16 gp4, ptr16 & gp1Out, ptr16 & gp2Out, ptr16 & gp3Out, ptr16 & gp4Out, ptr16 & gp14Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      sin
@@ -385,7 +385,7 @@ sincos_exit:
 
 
 word48 sin(word32 gp0_gp1, word16 gp2, ptr16 & gp3Out, ptr16 & gp4Out, ptr16 & gp14Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fft
@@ -430,7 +430,7 @@ sin_exit:
 
 
 word48 cos(word32 gp0_gp1, word16 gp2, ptr16 & gp14Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fft
@@ -468,7 +468,7 @@ cos_exit:
 
 
 word16 cvia(word16 gp0, word16 gp1)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      pr_dec_word
@@ -517,7 +517,7 @@ cvia_exit:
 
 
 word16 cvla(word32 gp12_gp13, word16 gp0, word16 gp1, word16 gp2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      pr_long_word
@@ -580,7 +580,7 @@ cvla_exit:
 
 
 word16 cvfa(word32 gp1_gp2, word16 gp0, ptr16 & gp14Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      pr_fp_num
@@ -598,7 +598,7 @@ cvfa_exit:
 
 
 word16 cvea(word32 gp1_gp2, word16 gp0, word16 gp3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      pr_efp_num
@@ -616,7 +616,7 @@ cvea_exit:
 
 
 word16 fn043E(real48 gp12_gp13_gp14, word16 gp0, word16 gp1, word16 gp11)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      cvfa
@@ -716,7 +716,7 @@ l0460:
 
 
 void putchar(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      puts
@@ -733,7 +733,7 @@ putchar_exit:
 
 
 void puts(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      pr_dec_word
@@ -764,7 +764,7 @@ l04BA:
 
 
 void pr_nibble(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      pr_hex_byte
@@ -787,7 +787,7 @@ pr_nibble_exit:
 
 
 word16 pr_hex_byte(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      pr_hex_word
@@ -804,7 +804,7 @@ pr_hex_byte_exit:
 
 
 void pr_hex_word(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  gp0:[0..15]
 // LiveOut:
@@ -818,7 +818,7 @@ pr_hex_word_exit:
 
 
 void pr_dec_word(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  gp0:[0..15]
 // LiveOut:
@@ -832,7 +832,7 @@ pr_dec_word_exit:
 
 
 void pr_long_word(word32 gp0_gp1, word32 gp12_gp13)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Sequence gp0:gp1:[0..31] Sequence gp12:gp13:[0..31]
 // LiveOut:
@@ -848,7 +848,7 @@ pr_long_word_exit:
 
 
 word16 pr_fp_num(word32 gp0_gp1)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -865,7 +865,7 @@ pr_fp_num_exit:
 
 
 void pr_efp_num(word32 gp0_gp1, word16 gp2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  gp2:[0..15] Sequence gp0:gp1:[0..31]
 // LiveOut:

--- a/subjects/Raw/1750A/hello.reko/hello_normal.dis
+++ b/subjects/Raw/1750A/hello.reko/hello_normal.dis
@@ -1,5 +1,5 @@
 void hello()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -13,7 +13,7 @@ hello_exit:
 
 
 void puts(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      hello
@@ -36,7 +36,7 @@ l0109:
 
 
 void putchar(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      puts

--- a/subjects/Raw/1750A/trigtst.reko/trigtst_seg000000.dis
+++ b/subjects/Raw/1750A/trigtst.reko/trigtst_seg000000.dis
@@ -16,7 +16,7 @@ l00000110:
 
 
 void fn0111()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0100
@@ -111,7 +111,7 @@ fn0111_exit:
 
 
 word32 fn01E6(word32 gp0_gp1, word16 gp2, ptr16 & gp2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0111
@@ -157,7 +157,7 @@ fn01E6_exit:
 
 
 word16 fn02BF(word16 gp1, word16 gp4, ptr16 & gp1Out, ptr16 & gp2Out, ptr16 & gp14Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn032A
@@ -199,7 +199,7 @@ fn02BF_exit:
 
 
 word32 fn032A(word32 gp0_gp1, word16 gp2, ptr16 & gp2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0111
@@ -240,7 +240,7 @@ fn032A_exit:
 
 
 word32 fn034E(word32 gp0_gp1, word16 gp2, ptr16 & gp2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0111
@@ -276,7 +276,7 @@ fn034E_exit:
 
 
 word16 fn03E0(word32 gp1_gp2, word16 gp0, word16 gp3, ptr16 & gp14Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn04AE
@@ -294,7 +294,7 @@ fn03E0_exit:
 
 
 word16 fn03EC(real48 gp12_gp13_gp14, word16 gp0, word16 gp1, word16 gp11)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn03E0
@@ -393,7 +393,7 @@ l0000040E:
 
 
 void fn045A(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0111
@@ -411,7 +411,7 @@ fn045A_exit:
 
 
 void fn045D(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn04AE
@@ -439,7 +439,7 @@ l00000468:
 
 
 word16 fn04AE(word32 gp0_gp1, word16 gp2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0111
@@ -456,7 +456,7 @@ fn04AE_exit:
 
 
 void fn04B9(word16 gp0)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0111

--- a/subjects/Raw/C166/st10F168/Rmm68jx.reko/Rmm68jx_code.dis
+++ b/subjects/Raw/C166/st10F168/Rmm68jx.reko/Rmm68jx_code.dis
@@ -1,5 +1,5 @@
 void fn0000(word16 SP)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  SP:[0..15]
 // LiveOut:
@@ -18,7 +18,7 @@ fn0000_exit:
 
 
 void fn0034()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -76,7 +76,7 @@ l0086:
 
 
 word16 fn0110(word16 S0TIC)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0034
@@ -97,7 +97,7 @@ fn0110_exit:
 
 
 word16 fn011C(word16 S0RIC)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0034
@@ -114,7 +114,7 @@ fn011C_exit:
 
 
 void fn0128(word16 r1, word16 S0TIC)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0034

--- a/subjects/Raw/H8/Tar/tar.reko/tar_seg8000.dis
+++ b/subjects/Raw/H8/Tar/tar.reko/tar_seg8000.dis
@@ -1,5 +1,5 @@
 void fn8000(word16 er0_16_16, word16 er1_16_16, word16 er2_16_16, word16 er3_16_16, word16 r4, word16 er4_16_16, word16 er5_16_16, word16 r6)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  er0_16_16:[0..15] er1_16_16:[0..15] er2_16_16:[0..15] er3_16_16:[0..15] er4_16_16:[0..15] er5_16_16:[0..15] r4:[0..15] r6:[0..15]
 // LiveOut:
@@ -13,7 +13,7 @@ fn8000_exit:
 
 
 word32 fn00008032(word16 er1_16_16, word16 er2_16_16, word16 er3_16_16, word16 r4, word16 r5, word16 r6, ptr32 & er1Out, ptr32 & er2Out, ptr32 & er3Out, ptr32 & er4Out, ptr32 & er5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008866
@@ -425,7 +425,7 @@ l000081AE:
 
 
 word32 fn00008584(word16 er0_16_16, word16 er1_16_16, word16 er2_16_16, word16 er3_16_16, word16 r4, word16 r5, word16 r6, ptr32 & er1Out, ptr32 & er2Out, ptr32 & er3Out, ptr32 & er4Out, ptr32 & er5Out, ptr32 & er6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008866
@@ -609,7 +609,7 @@ l0000863A:
 
 
 word32 fn00008866(word32 er0, word16 r1, word16 er1_16_16, word16 r2, word16 er2_16_16, word16 er3_16_16, word16 r4, word16 er4_16_16, word16 r5, word16 er5_16_16, word16 r6, ptr32 & er1Out, ptr32 & er2Out, ptr32 & er3Out, ptr32 & er4Out, ptr32 & er5Out, ptr32 & r6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008866
@@ -832,7 +832,7 @@ l00008AD8:
 
 
 word32 fn00008AEA(word16 er0_16_16, word16 er4_16_16, word16 r6, ptr32 & er2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009478
@@ -862,7 +862,7 @@ fn00008AEA_exit:
 
 
 word32 fn00008BB0(word16 r0, word16 er0_16_16, word16 r1, word32 er4, word16 r6, ptr32 & er4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008F4E
@@ -1055,7 +1055,7 @@ fn00008BB0_exit:
 
 
 word32 fn00008F4E(word16 er0_16_16, word32 er4, word16 r6, ptr32 & er4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009478
@@ -1211,7 +1211,7 @@ fn00008F4E_exit:
 
 
 word32 fn00009370(word16 er0_16_16, word16 er2_16_16, word16 er3_16_16, word16 r4, word16 er4_16_16, word16 r5, word16 r6, ptr32 & er1Out, ptr32 & er2Out, ptr32 & er3Out, ptr32 & er4Out, ptr32 & r5Out, ptr32 & r6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009478
@@ -1304,7 +1304,7 @@ l00009462:
 
 
 word32 fn00009478(word16 er0_16_16, word16 er1_16_16, word16 er2_16_16, word16 er3_16_16, word16 r4, word16 er4_16_16, word16 er5_16_16, word16 r6, ptr32 & er1Out, ptr32 & er2Out, ptr32 & er3Out, ptr32 & er4Out, ptr32 & er5Out, ptr32 & r6Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009AF8
@@ -1690,7 +1690,7 @@ l00009818:
 
 
 void fn00009AF8(word16 er0_16_16, word16 er1_16_16, word16 er2_16_16, word16 er3_16_16, word16 r4, word16 er4_16_16, word16 er5_16_16, word16 r6)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn8000
@@ -1728,7 +1728,7 @@ fn00009AF8_exit:
 
 
 void fn00009B54(word16 r0, word16 r1)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009478
@@ -1745,7 +1745,7 @@ fn00009B54_exit:
 
 
 byte fn00009B66()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008866
@@ -1764,7 +1764,7 @@ fn00009B66_exit:
 
 
 word32 fn00009B90(word32 er0, word16 r6)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008866
@@ -1790,7 +1790,7 @@ fn00009B90_exit:
 
 
 word32 fn00009B9A(word32 er0, word16 r1, word16 r6)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008F4E
@@ -1813,7 +1813,7 @@ fn00009B9A_exit:
 
 
 word32 fn00009BA6(word32 er0, word16 r1, word16 r2, word16 r6)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008866
@@ -1841,7 +1841,7 @@ fn00009BA6_exit:
 
 
 word32 fn00009BB6(word32 er0, word16 r1, word16 r2, word16 r6, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008866
@@ -1866,7 +1866,7 @@ fn00009BB6_exit:
 
 
 word32 fn00009BEC(word16 r0, word16 er0_16_16)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008F4E
@@ -1881,7 +1881,7 @@ fn00009BEC_exit:
 
 
 word32 fn00009BF4(word16 r0, word16 er0_16_16, word16 r1)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008F4E
@@ -1898,7 +1898,7 @@ fn00009BF4_exit:
 
 
 word32 fn00009BFC(word16 r0, word16 er0_16_16)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009478
@@ -1913,7 +1913,7 @@ fn00009BFC_exit:
 
 
 word32 fn00009C18(word32 er0, word32 er4, word16 r6, ptr32 & er2Out, ptr32 & er4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008AEA
@@ -1953,7 +1953,7 @@ fn00009C18_exit:
 
 
 word32 fn00009C34(word16 r0, word16 er0_16_16, byte r1l, byte r2l)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009478
@@ -1971,7 +1971,7 @@ fn00009C34_exit:
 
 
 word32 fn00009C6E(word16 r0, word16 er0_16_16, word32 er4, word16 r6, ptr32 & er4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008BB0
@@ -1993,7 +1993,7 @@ fn00009C6E_exit:
 
 
 word32 fn00009C92(word16 r0, word16 er0_16_16, word32 er4, word16 r6, ptr32 & er4Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008BB0
@@ -2015,7 +2015,7 @@ fn00009C92_exit:
 
 
 word32 fn00009CBC(word16 er0_16_16, word16 r4, word16 er4_16_16, word16 er5_16_16, word16 r6, ptr32 & er2Out, ptr32 & er4Out, ptr32 & er5Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009478
@@ -2073,7 +2073,7 @@ fn00009CBC_exit:
 
 
 word32 fn00009D34(word16 er0_16_16, word16 r6, ptr32 & er2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009C18
@@ -2104,7 +2104,7 @@ fn00009D34_exit:
 
 
 word32 fn00009D6A(word16 er0_16_16, word16 r6, ptr32 & er2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009478
@@ -2123,7 +2123,7 @@ fn00009D6A_exit:
 
 
 word32 fn00009DC0(word16 er0_16_16, word16 r6, ptr32 & er2Out)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009D6A
@@ -2150,7 +2150,7 @@ fn00009DC0_exit:
 
 
 word32 fn00009DDC(word16 er0_16_16, word16 r6)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009478
@@ -2166,7 +2166,7 @@ fn00009DDC_exit:
 
 
 word32 fn00009DF2(word16 er0_16_16, word16 r6)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009478
@@ -2181,7 +2181,7 @@ fn00009DF2_exit:
 
 
 word16 fn00009E08(byte r0h, byte r1h, byte r1l)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008866
@@ -2199,7 +2199,7 @@ fn00009E08_exit:
 
 
 word16 fn00009E18(ptr32 & r1Out, ptr32 & r2lOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009B66

--- a/subjects/Raw/Padauk/adctest_pfs173.reko/adctest_pfs173_CODE_02.dis
+++ b/subjects/Raw/Padauk/adctest_pfs173.reko/adctest_pfs173_CODE_02.dis
@@ -35,7 +35,7 @@ l0015:
 
 
 byte fn0038()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0112
@@ -64,7 +64,7 @@ l003B:
 
 
 void fn004F()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000
@@ -166,7 +166,7 @@ l007A:
 
 
 void fn00CE()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0068
@@ -242,7 +242,7 @@ l00DC:
 
 
 void fn0112()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0068
@@ -281,7 +281,7 @@ fn0112_exit:
 
 
 byte fn0146(byte f)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0068
@@ -306,7 +306,7 @@ fn0146_exit:
 
 
 void fn015A()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0178
@@ -329,7 +329,7 @@ fn015A_exit:
 
 
 void fn0178()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0189
@@ -358,7 +358,7 @@ fn0178_exit:
 
 
 void fn0189()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn01C7
@@ -382,7 +382,7 @@ fn0189_exit:
 
 
 void fn0195()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn01C7
@@ -440,7 +440,7 @@ l01AA:
 
 
 byte fn01C7(byte f)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0146
@@ -1150,7 +1150,7 @@ fn01C7_exit:
 
 
 byte fn056C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn01C7
@@ -1180,7 +1180,7 @@ fn056C_exit:
 
 
 byte fn0588()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn01C7
@@ -1209,7 +1209,7 @@ fn0588_exit:
 
 
 byte fn059D(byte a)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0112
@@ -1236,7 +1236,7 @@ fn059D_exit:
 
 
 byte fn05A9()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn056C
@@ -1270,7 +1270,7 @@ fn05A9_exit:
 
 
 byte fn05C0(byte a)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn01C7
@@ -1296,7 +1296,7 @@ fn05C0_exit:
 
 
 byte fn05CF()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn05C0

--- a/subjects/TLCS/90/TLCS-90.reko/TLCS-90_code.dis
+++ b/subjects/TLCS/90/TLCS-90.reko/TLCS-90_code.dis
@@ -1,5 +1,5 @@
 void fn0000(byte a)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a:[0..7]
 // LiveOut:
@@ -157,7 +157,7 @@ l03AA:
 
 
 byte fn03B2(word32 h_l_b_c, byte a, word16 de, word16 ix, word16 wArg24, ptr32 & ixOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn039D
@@ -315,7 +315,7 @@ l05E8:
 
 
 void fn0607(byte a, word16 de, word16 ix, word16 wArg20)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn04EE
@@ -334,7 +334,7 @@ fn0607_exit:
 
 
 void fn060E(byte a, byte c, word16 de, word16 ix, word16 wArg20)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0607
@@ -442,7 +442,7 @@ l0805:
 
 
 void fn0822()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0805
@@ -459,7 +459,7 @@ fn0822_exit:
 
 
 void fn0823()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0805
@@ -475,7 +475,7 @@ fn0823_exit:
 
 
 void fn0914(word16 bc, word16 de, word16 hl, word16 ix, word16 wArg00, word16 wArg02, word16 wArg28)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  bc:[0..15] de:[0..15] hl:[0..15] ix:[0..15] Stack +0000:[0..15] Stack +0002:[0..15] Stack +0028:[0..15]
 // LiveOut:
@@ -756,7 +756,7 @@ l0C35:
 
 
 void fn0C39(byte a, byte b, word16 de, byte l, byte h, word16 ix, word16 wArg20)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn164F
@@ -789,7 +789,7 @@ fn0C39_exit:
 
 
 void fn0C80(byte a, word16 de, byte l, byte h, word16 ix, word16 wArg20)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0C39
@@ -827,7 +827,7 @@ fn0C80_exit:
 
 
 void fn0CB7(byte c, byte b, word16 de, byte h, byte l, word16 ix, word16 wArg20)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0C80
@@ -914,7 +914,7 @@ fn0CB7_exit:
 
 
 void fn0DFC(byte c, byte b, word16 de, byte l, byte h, word16 ix, word16 wArg20)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0CB7
@@ -959,7 +959,7 @@ fn0DFC_exit:
 
 
 void fn0E3B(byte b, byte c, word16 de)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1BF9
@@ -983,7 +983,7 @@ fn0E3B_exit:
 
 
 void fn0F96()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1C89
@@ -998,7 +998,7 @@ fn0F96_exit:
 
 
 void fn0F9A()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1011,7 +1011,7 @@ fn0F9A_exit:
 
 
 void fn152A(byte b, word16 hl)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn22A6
@@ -1139,7 +1139,7 @@ fn1BF9_exit:
 
 
 void fn1C89(byte a, byte c)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a:[0..7] c:[0..7]
 // LiveOut:
@@ -1160,7 +1160,7 @@ fn1C89_exit:
 
 
 void fn22A6(word16 bc, word16 ix, word16 wArg05, word16 wArg10)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  bc:[0..15] ix:[0..15] Stack +0005:[0..15] Stack +0010:[0..15]
 // LiveOut:

--- a/subjects/TLCS/900/ngp_iq/NGP_IQ.reko/NGP_IQ_text.dis
+++ b/subjects/TLCS/900/ngp_iq/NGP_IQ.reko/NGP_IQ_text.dis
@@ -161,7 +161,7 @@ l00200361:
 
 
 void fn002004F2(byte w)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00200089
@@ -182,7 +182,7 @@ fn002004F2_exit:
 
 
 bool fn0020050A(word16 hl)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00200532
@@ -200,7 +200,7 @@ fn0020050A_exit:
 
 
 bool fn00200532(word32 xhl)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00200089
@@ -219,7 +219,7 @@ fn00200532_exit:
 
 
 word32 fn00200557(byte c, byte b, word32 xhl)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00200089
@@ -255,7 +255,7 @@ fn00200557_exit:
 
 
 void fn002005B8()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00200089
@@ -286,7 +286,7 @@ fn002005B8_exit:
 
 
 void fn002005F5(byte w, byte a, word16 xwa_16_16, word32 xix, word16 sr)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a:[0..7] sr:[0..15] w:[0..7] xix:[0..31] xwa_16_16:[0..15]
 // LiveOut:
@@ -304,7 +304,7 @@ fn002005F5_exit:
 
 
 void fn0020060C()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00200089

--- a/subjects/VMS-vax/unzip_code_0000.dis
+++ b/subjects/VMS-vax/unzip_code_0000.dis
@@ -1,5 +1,5 @@
 void fn0000802E(word32 r4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r4:[0..31]
 // LiveOut:
@@ -204,7 +204,7 @@ l00008081:
 
 
 void fn00008322(word32 r0, word32 r2, word32 r5, word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000802E
@@ -931,7 +931,7 @@ fn00008322_exit:
 
 
 word32 fn00008CCE(word32 r0, word32 r2, word32 r3, word32 r4, word32 ap)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000098D6
@@ -1264,7 +1264,7 @@ l00008EC2:
 
 
 void fn00009746(word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  fp:[0..31]
 // LiveOut:
@@ -1315,7 +1315,7 @@ l00009746:
 
 
 void fn000098B6()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -1335,7 +1335,7 @@ l000098B6:
 
 
 word32 fn000098D6(word32 r0, word32 r2, word32 r3, word32 r4, word32 ap)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008322
@@ -1573,7 +1573,7 @@ l00009A52:
 
 
 word32 fn00009B0A(word32 r8, word32 r10, word32 r11, word32 ap, word32 fp, ptr32 & r3Out, ptr32 & r5Out, ptr32 & r6Out, ptr32 & r8Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000F816
@@ -1646,7 +1646,7 @@ l00009BAE:
 
 
 word32 fn00009C8A(word32 r3, word32 r6, word32 r7, word32 fp, ptr32 & r3Out, ptr32 & r5Out, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009B0A
@@ -1717,7 +1717,7 @@ fn00009C8A_exit:
 
 
 void fn0000A07A(word32 r6, word32 r7, word32 r8, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  fp:[0..31] r6:[0..31] r7:[0..31] r8:[0..31]
 // LiveOut:
@@ -1856,7 +1856,7 @@ l0000A17D:
 
 
 void fn0000A5B2(word32 r2, word32 r5, word32 r6, word32 r7, word32 r8)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r2:[8..31] r5:[0..31] r6:[0..31] r7:[0..31] r8:[0..31]
 // LiveOut:
@@ -2037,7 +2037,7 @@ fn0000A8D6_exit:
 
 
 word32 fn0000AA6A(word32 r8, word32 r10, word32 r11, word32 ap, word32 fp, ptr32 & r3Out, ptr32 & r6Out, ptr32 & r7Out, ptr32 & r8Out, ptr32 & r10Out, ptr32 & r11Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00009B0A
@@ -2332,7 +2332,7 @@ fn0000AA6A_exit:
 
 
 word32 fn0000AEF2(word32 ap, ptr32 & r3Out, ptr32 & r6Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000AA6A
@@ -2418,7 +2418,7 @@ fn0000AEF2_exit:
 
 
 word32 fn0000B072(word32 r6, word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0001530A
@@ -2455,7 +2455,7 @@ fn0000B072_exit:
 
 
 void fn0000B192(word32 r2, word32 ap, word32 pc)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31] pc:[0..31] r2:[0..31]
 // LiveOut:
@@ -2531,7 +2531,7 @@ fn0000B192_exit:
 
 
 void fn0000B86E(word32 r2, word32 pc)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  pc:[0..31] r2:[0..31]
 // LiveOut:
@@ -2605,7 +2605,7 @@ fn0000B86E_exit:
 
 
 void fn0000B8F6(word32 r2, word32 r3, word32 ap, word32 pc)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31] pc:[0..31] r2:[0..31] r3:[0..31]
 // LiveOut:
@@ -2702,7 +2702,7 @@ fn0000B8F6_exit:
 
 
 void fn0000B9BA(word32 ap)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31]
 // LiveOut:
@@ -2731,7 +2731,7 @@ fn0000B9BA_exit:
 
 
 void fn0000BBB2(word32 ap)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31]
 // LiveOut:
@@ -2787,7 +2787,7 @@ l0000BDC2:
 
 
 word32 fn0000C022(word32 r3, word32 ap, word32 fp, ptr32 & r3Out, ptr32 & r4Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000B192
@@ -2958,7 +2958,7 @@ fn0000C1FE_exit:
 
 
 word32 fn0000C6FA(word32 r6, word32 r7, word32 r8, word32 ap, word32 fp, ptr32 & r2Out, ptr32 & r3Out, ptr32 & r4Out, ptr32 & r7Out, ptr32 & r8Out, ptr32 & r9Out, ptr32 & r10Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000802E
@@ -3483,7 +3483,7 @@ fn0000C6FA_exit:
 
 
 word32 fn0000CE52(word32 r3, word32 ap, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000D0D6
@@ -3538,7 +3538,7 @@ fn0000CE52_exit:
 
 
 void fn0000CEBE(word32 r2, word32 fp, word32 pc)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  fp:[0..31] pc:[0..31] r2:[0..31]
 // LiveOut:
@@ -3596,7 +3596,7 @@ l0000CEE8:
 
 
 word32 fn0000CF42(word32 r2, word32 fp, ptr32 & apOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00008322
@@ -3650,7 +3650,7 @@ fn0000CF42_exit:
 
 
 word32 fn0000CFBA(word32 r6, word32 ap, word32 fp, ptr32 & r2Out, ptr32 & r3Out, ptr32 & r6Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000AA6A
@@ -3699,7 +3699,7 @@ fn0000CFBA_exit:
 
 
 void fn0000D0D6(word32 ap)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000802E
@@ -3915,7 +3915,7 @@ fn0000D0D6_exit:
 
 
 word32 fn0000D39E(word32 r6, word32 fp, ptr32 & r3Out, ptr32 & r6Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000CFBA
@@ -3967,7 +3967,7 @@ l0000D3CF:
 
 
 void fn0000D406(word32 ap)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000108D2
@@ -3991,7 +3991,7 @@ fn0000D406_exit:
 
 
 void fn0000D422(word32 r2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r2:[0..31]
 // LiveOut:
@@ -4016,7 +4016,7 @@ fn0000D422_exit:
 
 
 void fn0000D4A2(word32 r2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00010E6A
@@ -4058,7 +4058,7 @@ fn0000D4A2_exit:
 
 
 void fn0000D50E(word32 ap)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31]
 // LiveOut:
@@ -4086,7 +4086,7 @@ fn0000D50E_exit:
 
 
 word32 fn0000D566(word32 ap, word32 fp, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000F816
@@ -4116,7 +4116,7 @@ fn0000D566_exit:
 
 
 word32 fn0000D5BE(word32 r0, word32 r4, word32 ap, word32 fp, ptr32 & r2Out, ptr32 & r3Out, ptr32 & r4Out, ptr32 & r5Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000E3DA
@@ -4245,7 +4245,7 @@ fn0000D5BE_exit:
 
 
 word32 fn0000D69A(word32 r4, word32 fp, word32 pc, ptr32 & r2Out, ptr32 & r3Out, ptr32 & r4Out, ptr32 & r6Out, ptr32 & apOut, ptr32 & fpOut, ptr32 & pcOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00015256
@@ -4386,7 +4386,7 @@ fn0000D69A_exit:
 
 
 word32 fn0000DC76(word32 ap, word32 fp, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00010E6A
@@ -4429,7 +4429,7 @@ fn0000DC76_exit:
 
 
 word32 fn0000E25A(word32 ap, word32 fp, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00010676
@@ -4449,7 +4449,7 @@ fn0000E25A_exit:
 
 
 word32 fn0000E276(word32 ap, word32 fp, ptr32 & r2Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000105F2
@@ -4474,7 +4474,7 @@ fn0000E276_exit:
 
 
 void fn0000E2A6(word32 r7, word32 ap)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000121EA
@@ -4506,7 +4506,7 @@ fn0000E2A6_exit:
 
 
 word32 fn0000E2EA(word32 ap, word32 fp, ptr32 & r6Out, ptr32 & r7Out, ptr32 & r8Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000802E
@@ -4658,7 +4658,7 @@ fn0000E2EA_exit:
 
 
 void fn0000E3DA(word32 r0, word32 r1, word32 r2, word32 r4, word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31] fp:[0..31] r0:[0..31] r1:[0..31] r2:[0..31] r4:[0..31]
 // LiveOut:
@@ -5516,7 +5516,7 @@ l0000F4E2:
 
 
 void fn0000F816(word32 r3, word32 r5, word32 r6, word32 r8, word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31] fp:[0..31] r3:[0..31] r5:[0..31] r6:[0..31] r8:[0..31]
 // LiveOut:
@@ -5583,7 +5583,7 @@ fn0000F816_exit:
 
 
 void fn000100C2(word32 r2, word32 r7, word32 r11, word32 ap)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31] r11:[0..31] r2:[0..31] r7:[0..31]
 // LiveOut:
@@ -5999,7 +5999,7 @@ fn000100C2_exit:
 
 
 word32 fn000105F2(word32 r7, word32 ap, word32 fp, ptr32 & r2Out, ptr32 & r7Out, ptr32 & r8Out, ptr32 & r9Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000100C2
@@ -6169,7 +6169,7 @@ fn00010676_exit:
 
 
 word32 fn0001084A(word32 r2, word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000186B2
@@ -6199,7 +6199,7 @@ fn0001084A_exit:
 
 
 word32 fn00010892(word32 ap, word32 fp, ptr32 & r2Out, ptr32 & r3Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000E3DA
@@ -6244,7 +6244,7 @@ fn00010892_exit:
 
 
 word32 fn000108D2()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000802E
@@ -6335,7 +6335,7 @@ fn000108D2_exit:
 
 
 void fn00010E6A(word32 r2, word32 r3, word32 r6, word32 r7, word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000108D2

--- a/subjects/VMS-vax/unzip_code_0001.dis
+++ b/subjects/VMS-vax/unzip_code_0001.dis
@@ -1,5 +1,5 @@
 void fn000117AA(word32 r2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00010E6A
@@ -146,7 +146,7 @@ l00011898:
 
 
 word32 fn00011C0A(word32 r0, word32 r1, word32 r4, word32 ap, word32 fp, ptr32 & r2Out, ptr32 & r3Out, ptr32 & r4Out, ptr32 & r5Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000E3DA
@@ -244,7 +244,7 @@ fn00011C0A_exit:
 
 
 word32 fn00011CDA(word32 r0, word32 r4, word32 ap, word32 fp, ptr32 & r2Out, ptr32 & r3Out, ptr32 & r4Out, ptr32 & r5Out, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00011C0A
@@ -479,7 +479,7 @@ l00011F06:
 
 
 void fn000121EA(word32 r2, word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31] fp:[0..31] r2:[0..31]
 // LiveOut:
@@ -565,7 +565,7 @@ l0001251B:
 
 
 void fn000125CA(word32 r2, word32 pc)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  pc:[0..31] r2:[0..31]
 // LiveOut:
@@ -590,7 +590,7 @@ l000125CA:
 
 
 void fn00012616(word32 r8)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  r8:[0..31]
 // LiveOut:
@@ -720,7 +720,7 @@ fn00012616_exit:
 
 
 void fn00012702(word32 r0, word32 r2, word32 ap)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000802E
@@ -809,7 +809,7 @@ fn00012702_exit:
 
 
 void fn00012A2A(word32 r2, word32 r4, word32 r5, word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00010E6A
@@ -1313,7 +1313,7 @@ fn00012A2A_exit:
 
 
 void fn00012D86(word32 r0, word32 r1, word32 r3, word32 r4, word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31] fp:[0..31] r0:[0..31] r1:[0..31] r3:[0..31] r4:[8..31]
 // LiveOut:
@@ -1764,7 +1764,7 @@ fn00012D86_exit:
 
 
 void fn0001325E(word32 r4, word32 r5, word32 r6, word32 r8, word32 r9, word32 r10, word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31] fp:[0..31] r10:[16..31] r4:[8..31] r5:[0..31] r6:[0..31] r8:[0..31] r9:[16..31]
 // LiveOut:
@@ -4239,7 +4239,7 @@ fn00014812_exit:
 
 
 word32 fn00015106(word32 r3, word32 r4, word32 r6, word32 r7, word32 r8, word32 r9, word32 r10, word32 r11, word32 ap, word32 fp, ptr32 & r5Out, ptr32 & r6Out, ptr32 & r8Out, ptr32 & r9Out, ptr32 & r10Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0001325E
@@ -4601,7 +4601,7 @@ l00016765:
 
 
 void fn000167AA(word32 r2, word32 r4, word32 fp, word32 pc)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  fp:[0..31] pc:[0..31] r2:[0..31] r4:[0..31]
 // LiveOut:
@@ -4632,7 +4632,7 @@ l000169AC:
 
 
 void fn000173CA(word32 r0, word32 r1, word32 r3, word32 r4, word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31] fp:[0..31] r0:[0..31] r1:[0..31] r3:[0..31] r4:[0..31]
 // LiveOut:
@@ -4996,7 +4996,7 @@ fn000173CA_exit:
 
 
 word32 fn00017662(word32 ap, word32 fp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00012D86
@@ -5031,7 +5031,7 @@ fn00017662_exit:
 
 
 word32 fn00017772(word32 ap, word32 fp, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0001325E
@@ -5084,7 +5084,7 @@ fn00017772_exit:
 
 
 word32 fn000177CA(word32 r6, word32 ap, word32 fp, word32 pc, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00017DEE
@@ -5136,7 +5136,7 @@ fn000177CA_exit:
 
 
 void fn00017DEE(word32 r3, word32 r6, word32 ap, word32 fp, word32 pc)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31] fp:[0..31] pc:[0..31] r3:[0..31] r6:[0..31]
 // LiveOut:
@@ -5244,7 +5244,7 @@ fn00017DEE_exit:
 
 
 word32 fn000185AE(word32 r4, word32 ap, word32 fp, word32 pc, ptr32 & r2Out, ptr32 & r3Out, ptr32 & r4Out, ptr32 & r6Out, ptr32 & apOut, ptr32 & fpOut, ptr32 & pcOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000186B2
@@ -5294,7 +5294,7 @@ fn000185AE_exit:
 
 
 void fn000186B2(word32 r2, word32 r4, word32 ap, word32 fp, word32 pc)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ap:[0..31] fp:[0..31] pc:[0..31] r2:[0..31] r4:[0..31]
 // LiveOut:
@@ -5336,7 +5336,7 @@ fn000186B2_exit:
 
 
 void fn0001872A(word32 r0, word32 r3)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000108D2
@@ -5390,7 +5390,7 @@ fn0001872A_exit:
 
 
 word32 fn0001878E(word32 ap, word32 fp, ptr32 & r3Out, ptr32 & r5Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000167AA
@@ -5703,7 +5703,7 @@ fn0001878E_exit:
 
 
 void fn00018BF6(word32 ap)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000167AA
@@ -5735,7 +5735,7 @@ fn00018BF6_exit:
 
 
 word32 fn00018C3A(word32 r3, word32 r5, word32 r6, word32 ap, word32 fp, ptr32 & r3Out, ptr32 & r5Out, ptr32 & r6Out, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn00018C3A
@@ -6146,7 +6146,7 @@ fn00018C3A_exit:
 
 
 word32 fn00018F22(word32 ap, word32 fp, ptr32 & apOut, ptr32 & fpOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn000108D2

--- a/subjects/i8051/reko-825/ledwith8051.reko/ledwith8051.dis
+++ b/subjects/i8051/reko-825/ledwith8051.reko/ledwith8051.dis
@@ -22,7 +22,7 @@ l0020:
 
 
 void fn0003()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0000

--- a/subjects/i8051/rtl8188efw_code.dis
+++ b/subjects/i8051/rtl8188efw_code.dis
@@ -1,5 +1,5 @@
 void fn0000(selector __data)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  __data:[0..15]
 // LiveOut:

--- a/subjects/regressions/angr-148/test.reko/test_fini.dis
+++ b/subjects/regressions/angr-148/test.reko/test_fini.dis
@@ -1,5 +1,5 @@
 void _fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/regressions/angr-148/test.reko/test_init.dis
+++ b/subjects/regressions/angr-148/test.reko/test_init.dis
@@ -1,5 +1,5 @@
 void _init()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __libc_csu_init

--- a/subjects/regressions/angr-148/test.reko/test_text.dis
+++ b/subjects/regressions/angr-148/test.reko/test_text.dis
@@ -17,7 +17,7 @@ l0000000000400440:
 
 
 void deregister_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __do_global_dtors_aux
@@ -40,7 +40,7 @@ deregister_tm_clones_exit:
 
 
 void register_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      frame_dummy
@@ -63,7 +63,7 @@ register_tm_clones_exit:
 
 
 void __do_global_dtors_aux()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -81,7 +81,7 @@ __do_global_dtors_aux_exit:
 
 
 void frame_dummy()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -105,7 +105,7 @@ frame_dummy_exit:
 
 
 word32 f()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -120,7 +120,7 @@ f_exit:
 
 
 void main()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -134,7 +134,7 @@ main_exit:
 
 
 void __libc_csu_init(word64 rdx, word64 rsi, word32 edi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..31] rdx:[0..63] rsi:[0..63]
 // LiveOut:
@@ -160,7 +160,7 @@ __libc_csu_init_exit:
 
 
 void __libc_csu_fini()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/regressions/reko-121/m68k_jump_code_0000.dis
+++ b/subjects/regressions/reko-121/m68k_jump_code_0000.dis
@@ -1,5 +1,5 @@
 void fn0000C02A(word32 a0, word32 a1)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  a0:[0..31] a1:[0..31]
 // LiveOut:

--- a/subjects/regressions/reko-351/a.reko/a_text.dis
+++ b/subjects/regressions/reko-351/a.reko/a_text.dis
@@ -1,5 +1,5 @@
 void deregister_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      __do_global_dtors_aux
@@ -20,7 +20,7 @@ deregister_tm_clones_exit:
 
 
 void register_tm_clones()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      frame_dummy
@@ -47,7 +47,7 @@ register_tm_clones_exit:
 
 
 void __do_global_dtors_aux()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -86,7 +86,7 @@ __do_global_dtors_aux_exit:
 
 
 void call___do_global_dtors_aux()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -99,7 +99,7 @@ call___do_global_dtors_aux_exit:
 
 
 void frame_dummy()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -127,7 +127,7 @@ frame_dummy_exit:
 
 
 void call_frame_dummy()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -226,7 +226,7 @@ l800003E0:
 
 
 void main()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -270,7 +270,7 @@ l80000530:
 
 
 void __do_global_ctors_aux()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -297,7 +297,7 @@ __do_global_ctors_aux_exit:
 
 
 void call___do_global_ctors_aux()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:

--- a/subjects/regressions/reko-367/code_code.dis
+++ b/subjects/regressions/reko-367/code_code.dis
@@ -1,5 +1,5 @@
 void fn80000000()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -13,7 +13,7 @@ fn80000000_exit:
 
 
 real96 fn80000132(real96 rArg04, real96 rArg10)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn800001F2
@@ -39,7 +39,7 @@ l8000015A:
 
 
 real96 fn8000018E(real96 rArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn800001F2
@@ -65,7 +65,7 @@ l800001B8:
 
 
 real96 fn800001F2(real96 rArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn8000036C
@@ -94,7 +94,7 @@ l80000224:
 
 
 real96 fn800002AE(real96 rArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn8000036C
@@ -122,7 +122,7 @@ l800002E2:
 
 
 void fn8000036C(real96 rArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn800003CC
@@ -139,7 +139,7 @@ fn8000036C_exit:
 
 
 void fn800003CC()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn80000000

--- a/subjects/regressions/reko-90/PP.reko/PP_0800.dis
+++ b/subjects/regressions/reko-90/PP.reko/PP_0800.dis
@@ -1,5 +1,5 @@
 void fn0800_0150()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8B0D
@@ -15,7 +15,7 @@ fn0800_0150_exit:
 
 
 void fn0800_0163()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8B0D
@@ -46,7 +46,7 @@ l0800_0164:
 
 
 void fn0800_0176(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  cs:[0..15] ds:[0..15]
 // LiveOut:
@@ -65,7 +65,7 @@ fn0800_0176_exit:
 
 
 byte fn0800_01B9(selector ds, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8B0D
@@ -86,7 +86,7 @@ fn0800_01B9_exit:
 
 
 void fn0800_01E6(word16 si, word16 di, selector es)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0150
@@ -140,7 +140,7 @@ l0800_0218:
 
 
 void fn0800_023D(char * ds_dx, word16 cx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  cx:[0..15] Sequence ds:dx:[0..31]
 // LiveOut:
@@ -155,7 +155,7 @@ fn0800_023D_exit:
 
 
 void main(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ds:[0..15] ss:[0..15]
 // LiveOut:
@@ -293,7 +293,7 @@ main_exit:
 
 
 void fn0800_0402(word16 cx, word16 dx, word16 bx, selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -426,7 +426,7 @@ fn0800_0402_exit:
 
 
 word16 fn0800_0541(word16 di, selector ds, ptr16 & bpOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -769,7 +769,7 @@ fn0800_0541_exit:
 
 
 word16 fn0800_09A3(selector ds, ptr16 & bpOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0541
@@ -894,7 +894,7 @@ fn0800_09A3_exit:
 
 
 word16 fn0800_0ABC(selector ds, word32 dwArg04, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -940,7 +940,7 @@ fn0800_0ABC_exit:
 
 
 word16 fn0800_0B79(word32 dwArg02, ui32 dwArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -1021,7 +1021,7 @@ fn0800_0B79_exit:
 
 
 word16 fn0800_0C08(word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_831D
@@ -1046,7 +1046,7 @@ fn0800_0C08_exit:
 
 
 word16 fn0800_0C29(selector ds, word32 dwArg02, byte bArg06, ptr16 & clOut, ptr16 & dxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0402
@@ -1080,7 +1080,7 @@ fn0800_0C29_exit:
 
 
 word16 fn0800_0C6C(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0402
@@ -1106,7 +1106,7 @@ fn0800_0C6C_exit:
 
 
 word16 fn0800_0C93(selector ds, word32 dwArg02, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -1174,7 +1174,7 @@ fn0800_0C93_exit:
 
 
 byte fn0800_0D24(selector ds, word16 wArg02, segptr32 ptrArg04, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut, ptr16 & siOut, ptr16 & diOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0402
@@ -1235,7 +1235,7 @@ fn0800_0D24_exit:
 
 
 word16 fn0800_0DA9(selector ds, word32 dwArg02, word32 dwArg06, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0D24
@@ -1260,7 +1260,7 @@ fn0800_0DA9_exit:
 
 
 word16 fn0800_0DCE(word16 cx, word16 dx, word16 bx, selector ds, ptr16 & diOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0402
@@ -1282,7 +1282,7 @@ fn0800_0DCE_exit:
 
 
 word16 fn0800_0DE8(word16 cx, word16 dx, selector ds, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -1556,7 +1556,7 @@ l0800_0E86:
 
 
 word16 fn0800_112D(word16 cx, word16 dx, selector ds, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -1707,7 +1707,7 @@ l0800_119C:
 
 
 word16 fn0800_12E2(word16 cx, word16 dx, selector ds, ptr16 & bpOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -2271,7 +2271,7 @@ fn0800_12E2_exit:
 
 
 word16 fn0800_18D9(word16 cx, word16 dx, selector ds, ptr16 & bpOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -2392,7 +2392,7 @@ l0800_19AD:
 
 
 word16 fn0800_19EE(word16 cx, word16 dx, selector ds, ptr16 & bpOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -2778,7 +2778,7 @@ l0800_1CA8:
 
 
 word16 fn0800_1CF6(selector ds, word16 wArg02, ptr16 & dxOut, ptr16 & bpOut, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -2910,7 +2910,7 @@ fn0800_1CF6_exit:
 
 
 word16 fn0800_1E5E(selector ds, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -2963,7 +2963,7 @@ fn0800_1E5E_exit:
 
 
 word16 fn0800_1F5C(selector ds, segptr32 ptrArg02, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -3093,7 +3093,7 @@ fn0800_1F5C_exit:
 
 
 byte fn0800_2085(selector ds, segptr32 ptrArg02, segptr32 ptrArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -3257,7 +3257,7 @@ fn0800_2085_exit:
 
 
 void fn0800_2201(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_18D9
@@ -3322,7 +3322,7 @@ fn0800_2201_exit:
 
 
 void fn0800_22FE(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_18D9
@@ -3388,7 +3388,7 @@ fn0800_22FE_exit:
 
 
 byte fn0800_23EC(selector ds, segptr32 ptrArg02, ptr16 & bpOut, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -3533,7 +3533,7 @@ fn0800_23EC_exit:
 
 
 selector fn0800_24FE(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_19EE
@@ -3705,7 +3705,7 @@ fn0800_24FE_exit:
 
 
 byte fn0800_2688(selector ds, ui32 dwArg02, word16 wArg06, word16 wArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_1F5C
@@ -3802,7 +3802,7 @@ l0800_2779:
 
 
 word16 fn0800_283D(selector ds, segptr32 ptrArg02, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -3910,7 +3910,7 @@ fn0800_283D_exit:
 
 
 int32 fn0800_2931(segptr32 ptrArg02, segptr32 ptrArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -4005,7 +4005,7 @@ fn0800_2931_exit:
 
 
 word16 fn0800_29C5(word16 cx, word16 dx, word16 si, selector ds, segptr32 ptrArg02, segptr32 ptrArg06, segptr32 ptrArg0A, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_18D9
@@ -4268,7 +4268,7 @@ fn0800_29C5_exit:
 
 
 word16 fn0800_2C9A(selector ds, ptr16 & dxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -4308,7 +4308,7 @@ fn0800_2C9A_exit:
 
 
 word16 fn0800_2CCF(selector ds, segptr32 ptrArg02, word16 wArg06, word16 wArg08, ptr16 & clOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -4344,7 +4344,7 @@ fn0800_2CCF_exit:
 
 
 word16 fn0800_2D0A(selector ds, ptr16 & dxOut, ptr16 & bpOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_5374
@@ -4429,7 +4429,7 @@ fn0800_2D0A_exit:
 
 
 void fn0800_2DBF(selector ds, word16 wArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -4452,7 +4452,7 @@ fn0800_2DBF_exit:
 
 
 word16 fn0800_2DE2(word16 cx, word16 dx, word16 si, selector ds, segptr32 ptrArg02, ptr16 & cxOut, ptr16 & dxOut, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -4825,7 +4825,7 @@ fn0800_2DE2_exit:
 
 
 word16 fn0800_31B4(selector ds, word32 dwArg02, ptr16 & cxOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_2DE2
@@ -4904,7 +4904,7 @@ fn0800_31B4_exit:
 
 
 word16 fn0800_32CD(selector ds, word32 dwArg02, word16 wArg06, selector psegArg08, word16 wArg0A, ptr16 & cxOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_31B4
@@ -4961,7 +4961,7 @@ fn0800_32CD_exit:
 
 
 word16 fn0800_335C(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_2DE2
@@ -5015,7 +5015,7 @@ fn0800_335C_exit:
 
 
 word16 fn0800_33CD(selector ds, segptr32 ptrArg02, word16 wArg06, word32 dwArg08, ptr16 & cxOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_2DE2
@@ -5089,7 +5089,7 @@ fn0800_33CD_exit:
 
 
 word16 fn0800_3479(selector ds, segptr32 ptrArg02, word16 wArg06, ptr16 & cxOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_2DE2
@@ -5156,7 +5156,7 @@ fn0800_3479_exit:
 
 
 word16 fn0800_3509(word16 wArg02, selector psegArg04, word32 dwArg06, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0C93
@@ -5219,7 +5219,7 @@ fn0800_3509_exit:
 
 
 byte fn0800_35A3(word16 wArg02, selector psegArg04, word32 dwArg06, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0ABC
@@ -5280,7 +5280,7 @@ fn0800_35A3_exit:
 
 
 word16 fn0800_363D(selector ds, segptr32 ptrArg02, word32 dwArg06, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_388C
@@ -5308,7 +5308,7 @@ fn0800_363D_exit:
 
 
 word16 fn0800_3678(selector ds, segptr32 ptrArg02, ptr16 & dxOut, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -5417,7 +5417,7 @@ fn0800_3678_exit:
 
 
 word16 fn0800_3764(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -5464,7 +5464,7 @@ fn0800_3764_exit:
 
 
 word16 fn0800_37BE(word16 cx, word16 dx, selector ds, word32 dwArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -5483,7 +5483,7 @@ fn0800_37BE_exit:
 
 
 word16 fn0800_37DF(selector ds, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -5553,7 +5553,7 @@ fn0800_37DF_exit:
 
 
 word16 fn0800_388C(word16 dx, selector ds, ptr16 & cxOut, ptr16 & dxOut, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -5619,7 +5619,7 @@ fn0800_388C_exit:
 
 
 word16 fn0800_395B(segptr32 ptrArg02, segptr32 ptrArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_388C
@@ -5640,7 +5640,7 @@ fn0800_395B_exit:
 
 
 word16 fn0800_3992(selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -5801,7 +5801,7 @@ fn0800_3992_exit:
 
 
 word16 fn0800_3B0A(selector ds, word16 wArg0A, word16 wArg0C, ptr16 & dxOut, ptr16 & bpOut, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -5903,7 +5903,7 @@ fn0800_3B0A_exit:
 
 
 word16 fn0800_3BC3(word16 cx, word16 dx, selector ds, word32 dwArg02, ui32 dwArg06, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_1E5E
@@ -5969,7 +5969,7 @@ fn0800_3BC3_exit:
 
 
 byte fn0800_3C99(selector ds, word32 dwArg02, word16 wArg06, word16 wArg08, ptr16 & bpOut, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_1E5E
@@ -6083,7 +6083,7 @@ fn0800_3C99_exit:
 
 
 word16 fn0800_3DCF(selector ds, segptr32 ptrArg02, ptr16 & chOut, ptr16 & dxOut, ptr16 & diOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_3E27
@@ -6134,7 +6134,7 @@ fn0800_3DCF_exit:
 
 
 word16 fn0800_3E27(selector ds, word32 dwArg02, ptr16 & cxOut, ptr16 & dxOut, ptr16 & diOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -6173,7 +6173,7 @@ fn0800_3E27_exit:
 
 
 ui32 fn0800_3E5D(selector ds, word32 dwArg02, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_1CF6
@@ -6208,7 +6208,7 @@ fn0800_3E5D_exit:
 
 
 word16 fn0800_3E9A(selector ds, segptr32 ptrArg02, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_51A9
@@ -6254,7 +6254,7 @@ fn0800_3E9A_exit:
 
 
 word16 fn0800_3F0A(selector ds, word32 dwArg02, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -6284,7 +6284,7 @@ fn0800_3F0A_exit:
 
 
 ui32 fn0800_3F58(selector ds, word32 dwArg02, ptr16 & diOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -6321,7 +6321,7 @@ fn0800_3F58_exit:
 
 
 word16 fn0800_3FAD(selector ds, word32 dwArg02, ptr16 & diOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_46FE
@@ -6350,7 +6350,7 @@ fn0800_3FAD_exit:
 
 
 byte fn0800_401E(selector ds, byte bArg02, word32 dwArg04, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_409C
@@ -6389,7 +6389,7 @@ fn0800_401E_exit:
 
 
 byte fn0800_4047(selector ds, byte bArg02, segptr32 ptrArg04, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut, ptr16 & diOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_401E
@@ -6446,7 +6446,7 @@ fn0800_4047_exit:
 
 
 word16 fn0800_409C(selector ds, word16 wArg02, word16 wArg04, word32 dwArg06, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -6484,7 +6484,7 @@ fn0800_409C_exit:
 
 
 word16 fn0800_40BF(selector ds, byte bArg02, word32 dwArg04, ptr16 & diOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_46FE
@@ -6518,7 +6518,7 @@ fn0800_40BF_exit:
 
 
 byte fn0800_4110(selector ds, word32 dwArg02, word16 wArg06, word16 wArg08, word32 dwArg0A, ptr16 & siOut, ptr16 & diOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_1CF6
@@ -6555,7 +6555,7 @@ fn0800_4110_exit:
 
 
 byte fn0800_4152(selector ds, word32 dwArg02, word16 wArg06, word16 wArg08, word32 dwArg0A, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -6596,7 +6596,7 @@ fn0800_4152_exit:
 
 
 void fn0800_4194(selector ds, word32 dwArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -6628,7 +6628,7 @@ fn0800_4194_exit:
 
 
 word16 fn0800_4234(selector ds, word32 dwArg02, word32 dwArg06, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -6662,7 +6662,7 @@ fn0800_4234_exit:
 
 
 word32 fn0800_4271(selector ds, word16 wArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_3DCF
@@ -6717,7 +6717,7 @@ fn0800_4271_exit:
 
 
 word16 fn0800_4311(selector ds, word32 dwArg02, ptr16 & dxOut, ptr16 & bpOut, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_09A3
@@ -6760,7 +6760,7 @@ fn0800_4311_exit:
 
 
 word16 fn0800_4346(selector ds, word16 wArg04, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_09A3
@@ -6790,7 +6790,7 @@ fn0800_4346_exit:
 
 
 word16 fn0800_4357(segptr32 ptrArg02, segptr32 ptrArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_29C5
@@ -6855,7 +6855,7 @@ fn0800_4357_exit:
 
 
 void fn0800_43D4(word16 wArg02, selector psegArg04, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_5A24
@@ -6885,7 +6885,7 @@ fn0800_43D4_exit:
 
 
 void fn0800_441C(selector ds, segptr32 ptrArg02, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7A02
@@ -6970,7 +6970,7 @@ fn0800_441C_exit:
 
 
 void fn0800_4550(word16 wArg02, selector psegArg04, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_441C
@@ -7031,7 +7031,7 @@ fn0800_4550_exit:
 
 
 word16 fn0800_45E2(word16 wArg02, word16 wArg04, word16 wArg06, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_4550
@@ -7064,7 +7064,7 @@ fn0800_45E2_exit:
 
 
 word16 fn0800_463B(selector ds, word16 wArg02, selector psegArg04, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_441C
@@ -7128,7 +7128,7 @@ fn0800_463B_exit:
 
 
 word16 fn0800_46FE(selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_112D
@@ -7521,7 +7521,7 @@ fn0800_46FE_exit:
 
 
 word16 fn0800_4B97(word16 ax, word16 dx, selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_112D
@@ -7550,7 +7550,7 @@ fn0800_4B97_exit:
 
 
 word16 fn0800_4BB1(word16 ax, word16 dx, selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_112D
@@ -7619,7 +7619,7 @@ fn0800_4BB1_exit:
 
 
 word16 fn0800_4C55(selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_112D
@@ -7773,7 +7773,7 @@ fn0800_4C55_exit:
 
 
 void fn0800_4F2C(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ds:[0..15] ss:[0..15]
 // LiveOut:
@@ -7982,7 +7982,7 @@ fn0800_4F2C_exit:
 
 
 word16 fn0800_518F(word16 ax, word16 dx, selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_112D
@@ -8011,7 +8011,7 @@ fn0800_518F_exit:
 
 
 word16 fn0800_51A9(selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_112D
@@ -8203,7 +8203,7 @@ l0800_52FF:
 
 
 word16 fn0800_5374(selector ds, ptr16 & dxOut, ptr16 & bpOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_112D
@@ -8414,7 +8414,7 @@ fn0800_5374_exit:
 
 
 word16 fn0800_55E8(selector ds, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_5374
@@ -8550,7 +8550,7 @@ l0800_5719:
 
 
 word16 fn0800_579B(selector ds, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_5374
@@ -8665,7 +8665,7 @@ l0800_5863:
 
 
 void fn0800_593F(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_579B
@@ -8685,7 +8685,7 @@ fn0800_593F_exit:
 
 
 selector fn0800_5975(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_579B
@@ -8719,7 +8719,7 @@ fn0800_5975_exit:
 
 
 void fn0800_5A0F(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_579B
@@ -8735,7 +8735,7 @@ fn0800_5A0F_exit:
 
 
 selector fn0800_5A24(selector ds, word16 wArg02, word16 wArg04, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_55E8
@@ -8771,7 +8771,7 @@ fn0800_5A24_exit:
 
 
 word16 fn0800_5A8D(selector ds, word16 wArg02, selector psegArg04, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_55E8
@@ -8815,7 +8815,7 @@ fn0800_5A8D_exit:
 
 
 word16 fn0800_5B15(selector ds, ptr16 & siOut, ptr16 & diOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_55E8
@@ -8894,7 +8894,7 @@ fn0800_5B15_exit:
 
 
 word16 fn0800_5C1A(selector ds, word16 wArg02, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_5374
@@ -8923,7 +8923,7 @@ fn0800_5C1A_exit:
 
 
 word16 fn0800_5C39(selector ds, word16 wArg02, ptr16 & siOut, ptr16 & diOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_55E8
@@ -8981,7 +8981,7 @@ l0800_5CB0:
 
 
 word16 fn0800_5CD9(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_579B
@@ -9024,7 +9024,7 @@ fn0800_5CD9_exit:
 
 
 selector fn0800_5D2F(selector ds, byte bArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_55E8
@@ -9056,7 +9056,7 @@ fn0800_5D2F_exit:
 
 
 word16 fn0800_5DCE(word16 ax, word16 dx, selector ds, word32 dwArg02, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_4B97
@@ -9110,7 +9110,7 @@ fn0800_5DCE_exit:
 
 
 word16 fn0800_5E64(selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -9747,7 +9747,7 @@ l0800_5EB1_1:
 
 
 word16 fn0800_669C(selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -9857,7 +9857,7 @@ fn0800_669C_exit:
 
 
 word16 fn0800_67BF(selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -10059,7 +10059,7 @@ fn0800_67BF_exit:
 
 
 word16 fn0800_6AD4(selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -10201,7 +10201,7 @@ fn0800_6AD4_exit:
 
 
 void fn0800_6EE6(word16 cx, word16 dx, word16 bx, selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  bx:[0..15] cx:[0..15] ds:[0..15] dx:[0..15] ss:[0..15]
 // LiveOut:
@@ -10217,7 +10217,7 @@ fn0800_6EE6_exit:
 
 
 void fn0800_6EFF(word16 cx, word16 dx, word16 bx, selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  bx:[0..15] cx:[0..15] ds:[0..15] dx:[0..15] ss:[0..15] Stack +0002:[0..15]
 // LiveOut:
@@ -10239,7 +10239,7 @@ fn0800_6EFF_exit:
 
 
 void fn0800_6F20(selector ds, word16 wArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ds:[0..15] ss:[0..15] Stack +0002:[0..15] Stack +0004:[0..15]
 // LiveOut:
@@ -10604,7 +10604,7 @@ fn0800_6F20_exit:
 
 
 word16 fn0800_73AC(selector ds, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -10631,7 +10631,7 @@ fn0800_73AC_exit:
 
 
 word16 fn0800_741D(selector ds, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -10814,7 +10814,7 @@ l0800_758D:
 
 
 word16 fn0800_75EA(selector ds, word16 wArg02, word16 wArg04, word32 dwArg06, ptr16 & bpOut, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -11175,7 +11175,7 @@ fn0800_75EA_exit:
 
 
 byte fn0800_7A02(selector ds, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_75EA
@@ -11314,7 +11314,7 @@ l0800_7BB2:
 
 
 byte fn0800_7C78(selector ds, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_75EA
@@ -11439,7 +11439,7 @@ l0800_7CD6:
 
 
 void fn0800_7EAF(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7C78
@@ -11525,7 +11525,7 @@ l0800_7EFA:
 
 
 selector fn0800_7FDC(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7A02
@@ -11739,7 +11739,7 @@ l0800_8293:
 
 
 selector fn0800_831D(selector ds, word16 wArg02, segptr32 ptrArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7FDC
@@ -11769,7 +11769,7 @@ fn0800_831D_exit:
 
 
 byte fn0800_8359(selector ds, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7A02
@@ -11795,7 +11795,7 @@ fn0800_8359_exit:
 
 
 void fn0800_83A1(selector ds, segptr32 ptrArg02, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7A02
@@ -11832,7 +11832,7 @@ fn0800_83A1_exit:
 
 
 void fn0800_8407(selector ds, word16 wArg02, segptr32 ptrArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7A02
@@ -11862,7 +11862,7 @@ fn0800_8407_exit:
 
 
 void fn0800_8465(selector ds, word16 wArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_75EA
@@ -11883,7 +11883,7 @@ fn0800_8465_exit:
 
 
 void fn0800_8489(selector ds, word16 wArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7A02
@@ -11953,7 +11953,7 @@ l0800_84B2:
 
 
 void fn0800_854B(selector ds, word16 wArg02, word16 wArg04)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7C78
@@ -12020,7 +12020,7 @@ l0800_85E7:
 
 
 word16 fn0800_8600(selector ds, byte bArg02, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7C78
@@ -12048,7 +12048,7 @@ fn0800_8600_exit:
 
 
 byte fn0800_8624(selector ds, byte bArg02, ptr16 & diOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_75EA
@@ -12087,7 +12087,7 @@ fn0800_8624_exit:
 
 
 void fn0800_867A(word16 wArg04, selector psegArg06, word16 wArg08, selector psegArg0A)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_09A3
@@ -12321,7 +12321,7 @@ l0800_8728:
 
 
 word16 fn0800_87EF(segptr32 ds_si)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_867A
@@ -12339,7 +12339,7 @@ fn0800_87EF_exit:
 
 
 word16 fn0800_87F4(segptr32 ds_si)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_87EF
@@ -12355,7 +12355,7 @@ fn0800_87F4_exit:
 
 
 void fn0800_87F8(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_75EA
@@ -12418,7 +12418,7 @@ l0800_8804_1:
 
 
 void fn0800_8832(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7FDC
@@ -12459,7 +12459,7 @@ fn0800_8832_exit:
 
 
 void fn0800_889A(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8832
@@ -12561,7 +12561,7 @@ fn0800_889A_exit:
 
 
 void fn0800_89A8(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_7FDC
@@ -12655,7 +12655,7 @@ l0800_8AA5:
 
 
 void fn0800_8ACF(selector ds, segptr32 ptrArg02, segptr32 ptrArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ds:[0..15] Stack +0002:[0..31] Stack +0006:[0..31]
 // LiveOut:
@@ -12676,7 +12676,7 @@ fn0800_8ACF_exit:
 
 
 byte fn0800_8B0D(selector ds, word16 wArg02, word16 wArg04, word16 wArg06, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8B5A
@@ -12734,7 +12734,7 @@ l0800_8B4E:
 
 
 byte fn0800_8B5A(selector ds, word16 wArg02, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0D24
@@ -12753,7 +12753,7 @@ fn0800_8B5A_exit:
 
 
 void fn0800_8B69(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ds:[0..15] ss:[0..15] Stack +0002:[0..15]
 // LiveOut:
@@ -12768,7 +12768,7 @@ fn0800_8B69_exit:
 
 
 void fn0800_8B95(segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9764
@@ -12788,7 +12788,7 @@ fn0800_8B95_exit:
 
 
 void fn0800_8BA8(segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9764
@@ -12832,7 +12832,7 @@ fn0800_8BBB_exit:
 
 
 word32 fn0800_8BC2(word32 dwArg02, word32 dwArg06, ptr16 & cxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 12; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0B79
@@ -12979,7 +12979,7 @@ fn0800_8BD8_exit:
 
 
 ui32 fn0800_8C69(word16 ax, byte cl, word16 dx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_46FE
@@ -13005,7 +13005,7 @@ fn0800_8C69_exit:
 
 
 word16 fn0800_8C8A(word16 ax, byte cl, word16 dx, ptr16 & clOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -13034,7 +13034,7 @@ fn0800_8C8A_exit:
 
 
 ui32 fn0800_8CAA(word16 ax, byte cl, word16 dx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -13061,7 +13061,7 @@ fn0800_8CAA_exit:
 
 
 word16 fn0800_8CCB(ui32 cx_bx, word16 ax, word16 dx, ptr16 & chOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A215
@@ -13108,7 +13108,7 @@ fn0800_8CCB_exit:
 
 
 word16 fn0800_8D2B(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8D64
@@ -13160,7 +13160,7 @@ fn0800_8D2B_exit:
 
 
 void fn0800_8D64(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8ACF
@@ -13176,7 +13176,7 @@ fn0800_8D64_exit:
 
 
 word16 fn0800_8D76(word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A96D
@@ -13193,7 +13193,7 @@ fn0800_8D76_exit:
 
 
 void fn0800_8D87(byte bArg02, byte bArg04, word16 wArg06, segptr32 ptrArg08, word32 dwArg0C)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 16; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8E09
@@ -13269,7 +13269,7 @@ l0800_8DCF:
 
 
 void fn0800_8E09(word32 dwArg02, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8E6A
@@ -13285,7 +13285,7 @@ fn0800_8E09_exit:
 
 
 word16 fn0800_8E29(selector ds, word16 wArg02, word32 dwArg04, byte bArg08, ptr16 & cxOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_97B6
@@ -13319,7 +13319,7 @@ fn0800_8E29_exit:
 
 
 word16 fn0800_8E52(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_3678
@@ -13342,7 +13342,7 @@ fn0800_8E52_exit:
 
 
 word32 fn0800_8E6A(selector ds, word16 wArg02, word16 wArg04, word16 wArg06, word32 dwArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 12; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A614
@@ -13371,7 +13371,7 @@ fn0800_8E6A_exit:
 
 
 word32 fn0800_8F18(word16 ax, word16 cx, word16 dx, word16 bx, ptr16 & chOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0B79
@@ -13402,7 +13402,7 @@ fn0800_8F18_exit:
 
 
 byte fn0800_8F2F(word16 ax, word16 cx, word16 dx, word16 bx, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A1D6
@@ -13429,7 +13429,7 @@ fn0800_8F2F_exit:
 
 
 word16 fn0800_8F50(selector ds, word16 wArg02, segptr32 ptrArg04, word16 wArg08, ptr16 & chOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_AAB3
@@ -13462,7 +13462,7 @@ fn0800_8F50_exit:
 
 
 word16 fn0800_8F7F(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DA9
@@ -13492,7 +13492,7 @@ fn0800_8F7F_exit:
 
 
 word16 fn0800_8F97(word16 di, selector ds, word16 wArg02, word16 wArg04, word16 wArg06, word16 wArg08, word16 wArg0A, selector psegArg0C, ptr16 & diOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_BF18
@@ -13985,7 +13985,7 @@ fn0800_8F97_exit:
 
 
 ptr32 fn0800_8FAB(segptr32 ss_bp, selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8F97
@@ -14249,7 +14249,7 @@ l0800_9436:
 
 
 bool fn0800_9485(byte cl, byte bl, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_94B0
@@ -14290,7 +14290,7 @@ fn0800_9485_exit:
 
 
 word16 fn0800_94B0(selector ds, word16 wArg02, word16 wArg04, word16 wArg06, word16 wArg08, word16 wArg0A, word16 wArg0C, segptr32 ptrArg0E, segptr32 ptrArg12, ptr16 & dxOut, ptr16 & diOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8F97
@@ -14534,7 +14534,7 @@ fn0800_94B0_exit:
 
 
 void fn0800_9652(segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0002:[0..31]
 // LiveOut:
@@ -14549,7 +14549,7 @@ fn0800_9652_exit:
 
 
 void fn0800_9667(segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0002:[0..31]
 // LiveOut:
@@ -14565,7 +14565,7 @@ fn0800_9667_exit:
 
 
 word16 fn0800_9764(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -14592,7 +14592,7 @@ fn0800_9764_exit:
 
 
 int32 fn0800_97B6(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_AD2F
@@ -14609,7 +14609,7 @@ fn0800_97B6_exit:
 
 
 byte fn0800_97CC(selector ds, word16 wArg02, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0C29
@@ -14638,7 +14638,7 @@ fn0800_97CC_exit:
 
 
 word16 fn0800_97F8(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A614
@@ -14660,7 +14660,7 @@ fn0800_97F8_exit:
 
 
 word16 fn0800_9810(segptr32 es_di, byte dh, byte dl)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9828
@@ -14678,7 +14678,7 @@ fn0800_9810_exit:
 
 
 word16 fn0800_9817(segptr32 es_di, byte al)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9810
@@ -14698,7 +14698,7 @@ fn0800_9817_exit:
 
 
 word16 fn0800_9820(segptr32 es_di, byte al)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9817
@@ -14715,7 +14715,7 @@ fn0800_9820_exit:
 
 
 word16 fn0800_9828(word16 cx, word16 dx, word16 bx, selector ds, word16 wArg02, segptr32 ptrArg04, ptr16 & siOut, ptr16 & diOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 14; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_B2EF
@@ -15204,7 +15204,7 @@ l0800_98AE:
 
 
 word16 fn0800_9842(word16 di, selector es)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9828
@@ -15228,7 +15228,7 @@ fn0800_9842_exit:
 
 
 word16 fn0800_984F(segptr32 ss_bp, byte al, word16 cx, word16 dx, word16 bx, word16 di)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9828
@@ -15251,7 +15251,7 @@ fn0800_984F_exit:
 
 
 word16 fn0800_9858(segptr32 ss_bp, word16 cx, word16 dx, word16 bx, word16 di)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9828
@@ -15280,7 +15280,7 @@ fn0800_9858_exit:
 
 
 word32 fn0800_9CE6(word32 dwArg02, word32 dwArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8E6A
@@ -15300,7 +15300,7 @@ fn0800_9CE6_exit:
 
 
 word16 fn0800_9D41(word16 dx, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9E75
@@ -15347,7 +15347,7 @@ fn0800_9D41_exit:
 
 
 word16 fn0800_9DA4(word16 dx, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9E75
@@ -15394,7 +15394,7 @@ fn0800_9DA4_exit:
 
 
 word16 fn0800_9E15(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9D41
@@ -15421,7 +15421,7 @@ fn0800_9E15_exit:
 
 
 word16 fn0800_9E3E(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9DA4
@@ -15452,7 +15452,7 @@ fn0800_9E3E_exit:
 
 
 word16 fn0800_9E75(selector ds, word16 wArg04, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_4346
@@ -15489,7 +15489,7 @@ fn0800_9E75_exit:
 
 
 word16 fn0800_9E9E(word16 ax, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9F89
@@ -15522,7 +15522,7 @@ fn0800_9E9E_exit:
 
 
 word16 fn0800_9F02(word16 ax, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9F89
@@ -15558,7 +15558,7 @@ fn0800_9F02_exit:
 
 
 word16 fn0800_9F5C(word16 ax, word16 dx, selector ds, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9F89
@@ -15606,7 +15606,7 @@ fn0800_9F7F_exit:
 
 
 word16 fn0800_9F89(selector ds, word32 dwArg02, ptr16 & dxOut, ptr16 & bpOut, ptr16 & siOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_4311
@@ -15737,7 +15737,7 @@ fn0800_9F9F_exit:
 
 
 void fn0800_A006(word16 bx, selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  bx:[0..15] ds:[0..15] ss:[0..15]
 // LiveOut:
@@ -15784,7 +15784,7 @@ fn0800_A006_exit:
 
 
 void fn0800_A080(word16 ax, word16 cx, word16 bx, selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ax:[0..15] bx:[0..15] cx:[0..15] ds:[0..15]
 // LiveOut:
@@ -15822,7 +15822,7 @@ fn0800_A080_exit:
 
 
 word16 fn0800_A162(selector ds, word16 wArg02, word16 wArg04, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 6; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A1D6
@@ -15875,7 +15875,7 @@ fn0800_A162_exit:
 
 
 word16 fn0800_A1D6(selector ds, word16 wArg02, word16 wArg04, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9D41
@@ -15913,7 +15913,7 @@ fn0800_A1D6_exit:
 
 
 word16 fn0800_A215(selector ds, ui32 dwArg02, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9E9E
@@ -15976,7 +15976,7 @@ fn0800_A215_exit:
 
 
 word16 fn0800_A2A3(selector ds, word16 wArg04, ptr16 & cxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_B140
@@ -16076,7 +16076,7 @@ fn0800_A2D8_exit:
 
 
 void fn0800_A36D(segptr32 ds_si, segptr32 es_di, word16 ax, word16 cx)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ax:[0..15] cx:[0..15] Sequence ds:si:[0..31] Sequence es:di:[0..31]
 // LiveOut:
@@ -16107,7 +16107,7 @@ fn0800_A36D_exit:
 
 
 word16 fn0800_A401(byte al, selector ds, selector psegArg02, word16 wArg04, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A162
@@ -16133,7 +16133,7 @@ fn0800_A401_exit:
 
 
 word16 fn0800_A471(selector ds, segptr32 ptrArg02, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_C379
@@ -16212,7 +16212,7 @@ fn0800_A471_exit:
 
 
 void fn0800_A4F6(selector ds, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_37DF
@@ -16239,7 +16239,7 @@ fn0800_A4F6_exit:
 
 
 word16 fn0800_A53C(selector ds, byte bArg06, ptr16 & cxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A4F6
@@ -16269,7 +16269,7 @@ fn0800_A53C_exit:
 
 
 word16 fn0800_A559(byte al, selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A614
@@ -16291,7 +16291,7 @@ fn0800_A559_exit:
 
 
 void fn0800_A57F(byte al, selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A559
@@ -16314,7 +16314,7 @@ fn0800_A57F_exit:
 
 
 word16 fn0800_A59D(selector ds, word16 wArg02, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_AED6
@@ -16376,7 +16376,7 @@ fn0800_A59D_exit:
 
 
 word16 fn0800_A614(selector ds, segptr32 ptrArg02, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DA9
@@ -16445,7 +16445,7 @@ fn0800_A614_exit:
 
 
 word16 fn0800_A6B7(selector ds, segptr32 ptrArg02, ptr16 & dxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A614
@@ -16517,7 +16517,7 @@ fn0800_A6B7_exit:
 
 
 word16 fn0800_A77D(selector ds, word32 dwArg02, word16 wArg06, segptr32 ptrArg08, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_2DE2
@@ -16587,7 +16587,7 @@ fn0800_A77D_exit:
 
 
 word16 fn0800_A817(byte al, selector ds, segptr32 ptrArg02, segptr32 ptrArg06, word16 wArg0A, ptr16 & cxOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_33CD
@@ -16620,7 +16620,7 @@ fn0800_A817_exit:
 
 
 word16 fn0800_A84A(byte al, selector ds, segptr32 ptrArg02, ptr16 & cxOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_3479
@@ -16652,7 +16652,7 @@ fn0800_A84A_exit:
 
 
 word16 fn0800_A877(selector ds, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A6B7
@@ -16685,7 +16685,7 @@ fn0800_A877_exit:
 
 
 word16 fn0800_A8B7(selector ds, segptr32 ptrArg02, segptr32 ptrArg06, segptr32 ptrArg0A, ptr16 & clOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 14; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A96D
@@ -16764,7 +16764,7 @@ fn0800_A8B7_exit:
 
 
 word16 fn0800_A96D(selector ds, word16 wArg02, word32 dwArg04, word32 dwArg08, segptr32 ptrArg0C, ptr16 & cxOut, ptr16 & dxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 16; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_AA7E
@@ -16831,7 +16831,7 @@ fn0800_A96D_exit:
 
 
 word32 fn0800_AA34(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_AA7E
@@ -16867,7 +16867,7 @@ fn0800_AA34_exit:
 
 
 word32 fn0800_AA7E(selector ds, word32 dwArg02, word32 dwArg06, ptr16 & cxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -16900,7 +16900,7 @@ fn0800_AA7E_exit:
 
 
 word16 fn0800_AAB3(word16 dx, selector ds, segptr32 ptrArg02, word16 wArg06, segptr32 ptrArg08, ptr16 & chOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 12; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_ABA3
@@ -16992,7 +16992,7 @@ fn0800_AAB3_exit:
 
 
 word16 fn0800_ABA3(selector ds, word32 dwArg02, word16 wArg06, word16 wArg08, word32 dwArg0A, ptr16 & chOut, ptr16 & siOut, ptr16 & diOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_4110
@@ -17061,7 +17061,7 @@ fn0800_ABA3_exit:
 
 
 word16 fn0800_AC31(segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 6; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_ACB3
@@ -17121,7 +17121,7 @@ fn0800_AC31_exit:
 
 
 int32 fn0800_ACB3(selector ds, segptr32 ptrArg02, ui32 dwArg06, word16 wArg0A, ptr16 & cxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -17196,7 +17196,7 @@ fn0800_ACB3_exit:
 
 
 int32 fn0800_AD2F(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_12E2
@@ -17246,7 +17246,7 @@ fn0800_AD2F_exit:
 
 
 word16 fn0800_AD85(selector ds, word32 dwArg02, word16 wArg06, word16 wArg08, word32 dwArg0A, ptr16 & siOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_4152
@@ -17312,7 +17312,7 @@ fn0800_AD85_exit:
 
 
 void fn0800_AE10(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_AE4C
@@ -17344,7 +17344,7 @@ fn0800_AE10_exit:
 
 
 word16 fn0800_AE4C(selector ds, segptr32 ptrArg02, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 6; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_AED6
@@ -17387,7 +17387,7 @@ fn0800_AE4C_exit:
 
 
 word16 fn0800_AEC2(selector ds, segptr32 ptrArg02, ptr16 & chOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_3DCF
@@ -17410,7 +17410,7 @@ fn0800_AEC2_exit:
 
 
 word16 fn0800_AED6(selector ds, segptr32 ptrArg02, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_AEC2
@@ -17474,7 +17474,7 @@ fn0800_AED6_exit:
 
 
 word32 fn0800_AFCB(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_C379
@@ -17539,7 +17539,7 @@ fn0800_AFCB_exit:
 
 
 void fn0800_B03B(segptr32 ptrArg02, segptr32 ptrArg06, word16 wArg0A)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9CE6
@@ -17565,7 +17565,7 @@ fn0800_B03B_exit:
 
 
 void fn0800_B05F(segptr32 ptrArg02, word16 wArg06, byte bArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_B083
@@ -17606,7 +17606,7 @@ l0800_B07B_1:
 
 
 void fn0800_B083(word32 dwArg02, byte bArg06, word16 wArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_C379
@@ -17622,7 +17622,7 @@ fn0800_B083_exit:
 
 
 void fn0800_B0A1(segptr32 ptrArg02, segptr32 ptrArg06, word16 wArg0A)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_B0F3
@@ -17680,7 +17680,7 @@ fn0800_B0A1_exit:
 
 
 void fn0800_B0F3(word32 dwArg02, word32 dwArg06, word16 wArg0A)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_09A3
@@ -17701,7 +17701,7 @@ fn0800_B0F3_exit:
 
 
 word16 fn0800_B113(selector ds, word16 wArg02, segptr32 ptrArg04, ptr16 & cxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_B140
@@ -17723,7 +17723,7 @@ fn0800_B113_exit:
 
 
 word16 fn0800_B12E(selector ds, word16 wArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_B140
@@ -17740,7 +17740,7 @@ fn0800_B12E_exit:
 
 
 byte fn0800_B140(selector ds, word32 dwArg02, word16 wArg06, word16 wArg08, ptr16 & cxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A96D
@@ -17856,7 +17856,7 @@ fn0800_B140_exit:
 
 
 word16 fn0800_B2A0(selector ds, segptr32 ptrArg02, word16 wArg06, ptr16 & cxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_B140
@@ -17892,7 +17892,7 @@ fn0800_B2A0_exit:
 
 
 word16 fn0800_B2EF(word16 cx, word16 dx, word16 bx, selector ds, word32 dwArg02, ptr16 & siOut, ptr16 & diOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      main
@@ -17927,7 +17927,7 @@ fn0800_B2EF_exit:
 
 
 word16 fn0800_B30A(selector ds, byte bArg02, segptr32 ptrArg04, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_4047
@@ -17951,7 +17951,7 @@ fn0800_B30A_exit:
 
 
 word16 fn0800_B324(selector ds, byte bArg02, segptr32 ptrArg04, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_B30A
@@ -18064,7 +18064,7 @@ fn0800_B324_exit:
 
 
 word16 fn0800_B4BE(selector ds, segptr32 ptrArg02, word16 wArg06, segptr32 ptrArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 12; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_AD85
@@ -18193,7 +18193,7 @@ fn0800_B4BE_exit:
 
 
 void fn0800_B6A8(selector ds, segptr32 ptrArg02, segptr32 ptrArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 10; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_B6D6
@@ -18231,7 +18231,7 @@ fn0800_B6A8_exit:
 
 
 void fn0800_B6D6(selector ds, word16 wArg02, word16 wArg04, word16 wArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_B6D6
@@ -18515,7 +18515,7 @@ fn0800_B6D6_exit:
 
 
 void fn0800_B95E(selector ds, word16 wArg02, word16 wArg04, word16 wArg06, word16 wArg08, word16 wArg0A)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_5E64
@@ -18536,7 +18536,7 @@ fn0800_B95E_exit:
 
 
 word16 fn0800_B97F(selector ds, word16 wArg02, segptr32 ptrArg04, word16 wArg08, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_AE4C
@@ -18612,7 +18612,7 @@ fn0800_B97F_exit:
 
 
 word16 fn0800_BA4A(selector ds, segptr32 ptrArg02, segptr32 ptrArg06, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_37DF
@@ -18638,7 +18638,7 @@ fn0800_BA4A_exit:
 
 
 void fn0800_BA67(selector ds, segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0DE8
@@ -18660,7 +18660,7 @@ fn0800_BA67_exit:
 
 
 word16 fn0800_BA89(selector ds, segptr32 ptrArg02, word16 wArg06, word16 wArg08, word16 wArg0A, word16 wArg0C, ptr16 & cxOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A96D
@@ -18758,7 +18758,7 @@ fn0800_BA89_exit:
 
 
 void fn0800_BB98(word16 wArg02, word32 dwArg04, segptr32 ptrArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 12; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0002:[0..15] Stack +0004:[0..31] Stack +0008:[0..31]
 // LiveOut:
@@ -18781,7 +18781,7 @@ fn0800_BB98_exit:
 
 
 void fn0800_BBE9(segptr32 ptrArg02)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 6; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  Stack +0002:[0..31]
 // LiveOut:
@@ -18897,7 +18897,7 @@ l0800_BD02:
 
 
 word16 fn0800_BE3B(word32 dwArg02, word32 dwArg06, word32 dwArg0A, word32 dwArg0E, word32 dwArg12)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_3509
@@ -18913,7 +18913,7 @@ fn0800_BE3B_exit:
 
 
 word16 fn0800_BEA2(word16 cx, word16 dx, selector ds, segptr32 ptrArg02, word32 dwArg06, ptr16 & diOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0541
@@ -18936,7 +18936,7 @@ fn0800_BEA2_exit:
 
 
 word16 fn0800_BF18(word16 di, selector ds, word16 wArg06, word16 wArg08, ptr16 & diOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0541
@@ -18956,7 +18956,7 @@ fn0800_BF18_exit:
 
 
 void fn0800_BF5F(segptr32 ptrArg02, segptr32 ptrArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_8E6A
@@ -19011,7 +19011,7 @@ fn0800_BF5F_exit:
 
 
 void fn0800_BF9E(segptr32 ptrArg02, segptr32 ptrArg06)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0402
@@ -19041,7 +19041,7 @@ fn0800_BF9E_exit:
 
 
 word16 fn0800_BFC7(segptr32 ptrArg02, ptr16 & cxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_0402
@@ -19083,7 +19083,7 @@ fn0800_BFC7_exit:
 
 
 word16 fn0800_BFE6(segptr32 ptrArg02, segptr32 ptrArg06, word16 wArg0A)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_29C5
@@ -19118,7 +19118,7 @@ fn0800_BFE6_exit:
 
 
 void fn0800_C01E(segptr32 ptrArg02, segptr32 ptrArg06, word16 wArg0A)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_BB98
@@ -19158,7 +19158,7 @@ l0800_C042_2:
 
 
 word16 fn0800_C04F(selector ds, segptr32 ptrArg02, segptr32 ptrArg06, ptr16 & cxOut, ptr16 & dxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_9764
@@ -19218,7 +19218,7 @@ fn0800_C04F_exit:
 
 
 void fn0800_C177(selector ds, ui32 dwArg02, segptr32 ptrArg06, segptr32 ptrArg0A)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ds:[0..15] ss:[0..15] Stack +0002:[0..31] Stack +0006:[0..31] Stack +000A:[0..31]
 // LiveOut:
@@ -19384,7 +19384,7 @@ fn0800_C177_exit:
 
 
 void fn0800_C379(selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_C04F
@@ -19461,7 +19461,7 @@ fn0800_C379_exit:
 
 
 word16 fn0800_C553(selector ds, word16 wArg02, word16 wArg04, word16 wArg06, byte bArg08)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 10; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_C04F
@@ -19543,7 +19543,7 @@ fn0800_C553_exit:
 
 
 word16 fn0800_C632(selector ds, word16 wArg02, word32 dwArg04, word16 wArg08, ptr16 & dxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_A6B7
@@ -19659,7 +19659,7 @@ fn0800_C632_exit:
 
 
 word16 fn0800_C779(selector ds, word16 wArg02, segptr32 ptrArg04, word16 wArg08, ptr16 & cxOut, ptr16 & dxOut, ptr16 & bxOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn0800_B324

--- a/subjects/regressions/reko-90/PP.reko/PP_1483.dis
+++ b/subjects/regressions/reko-90/PP.reko/PP_1483.dis
@@ -1,5 +1,5 @@
 void fn1483_0ADB()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse: 
 // LiveOut:
@@ -12,7 +12,7 @@ fn1483_0ADB_exit:
 
 
 void fn1483_0ADC(segptr32 ds_di, segptr32 ss_bp, word16 ax, word16 cx, word16 dx, byte bl, byte bh, word16 si, selector es, selector fs, word16 wArg00, word16 wArg04, word16 wArg0A, selector psegArg01A2)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  ax:[0..15] bh:[0..7] bl:[0..7] cs:[0..15] cx:[0..15] dx:[0..15] es:[0..15] fs:[0..15] Sequence ds:di:[0..31] Sequence ss:bp:[0..31] si:[0..15] Stack +0000:[0..15] Stack +0004:[0..15] Stack +000A:[0..15] Stack +01A2:[0..15]
 // LiveOut:
@@ -27,7 +27,7 @@ fn1483_0ADC_exit:
 
 
 word16 fn1483_0C11(segptr32 ds_si, segptr32 es_di, byte al, word16 cx, word16 bx, word16 bp)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1483_0C55
@@ -91,7 +91,7 @@ l1483_0C24:
 
 
 word32 fn1483_0C55()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1483_0C11
@@ -117,7 +117,7 @@ fn1483_0C55_exit:
 
 
 word16 fn1483_0C91(segptr32 ds_bx, segptr32 ss_bp, byte al, word16 cx, word16 si, word16 di, selector psegArg00, ptr16 & diOut, ptr16 & esOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1483_0C11
@@ -237,7 +237,7 @@ fn1483_0CED_exit:
 
 
 word16 fn1483_0CFA(segptr32 ds_di, segptr32 ss_bp, byte al, byte ah, word16 cx, word16 dx, byte bl, byte bh, word16 si, selector fs, selector psegArg00, word16 wArg04, word16 wArg0E, ptr16 & esOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1483_0D3F
@@ -260,7 +260,7 @@ fn1483_0CFA_exit:
 
 
 word16 fn1483_0CFC(segptr32 ds_di, segptr32 ss_bp, byte al, byte ah, word16 cx, word16 dx, byte bl, byte bh, word16 si, selector fs, selector psegArg00, word16 wArg04, word16 wArg0E, ptr16 & esOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1483_0CED
@@ -319,7 +319,7 @@ fn1483_0D06_exit:
 
 
 segptr32 fn1483_0D3F(segptr32 ds_di, segptr32 ss_bp, word16 ax, word16 cx, word16 dx, byte bl, byte bh, word16 si, selector es, selector fs, word16 wArg02, word16 wArg06, word16 wArg0C, selector psegArg01A4)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: -9582; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1483_0ADC
@@ -541,7 +541,7 @@ fn1483_0D3F_exit:
 
 
 void fn1483_1777(byte al, byte bl, byte bh, word16 si, selector ds)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 2; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  al:[0..7] bh:[0..7] bl:[0..7] ds:[0..15] si:[0..15]
 // LiveOut:
@@ -633,7 +633,7 @@ fn1483_1BB8_exit:
 
 
 word16 fn1483_1BB9(word16 ax, word16 cx, word16 dx, word16 bx, word16 bp, word16 si, word16 di, selector es, selector ds, ptr16 & cxOut, ptr16 & dhOut, ptr16 & bxOut, ptr16 & bpOut, ptr16 & siOut, ptr16 & diOut, ptr16 & esOut, ptr16 & dsOut)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 4; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      fn1483_1B91

--- a/subjects/regressions/snowman-82/flags.reko/flags_TEXT_text.dis
+++ b/subjects/regressions/snowman-82/flags.reko/flags_TEXT_text.dis
@@ -1,5 +1,5 @@
 void foo(byte sil, word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..63] sil:[0..7]
 // LiveOut:
@@ -17,7 +17,7 @@ foo_exit:
 
 
 void bar()
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // Called from:
 //      foo

--- a/subjects/regressions/snowman-83/flags3.reko/flags3_TEXT_text.dis
+++ b/subjects/regressions/snowman-83/flags3.reko/flags3_TEXT_text.dis
@@ -1,5 +1,5 @@
 void foo(word64 rdi)
-// stackDelta: 0; fpuStackDelta: 0; fpuMaxParam: -1
+// stackDelta: 8; fpuStackDelta: 0; fpuMaxParam: -1
 
 // MayUse:  rdi:[0..63]
 // LiveOut:


### PR DESCRIPTION
Do not lose stack delta after building of signature by `CallRewriter`. It's not affect output source code (only *.dis files) though. Anyway it would be nice to have consistent procedure signature data.