### PR TITLE
Use ArrayExpressionMatcher for scaling array index down

### DIFF
--- a/src/UnitTests/Decompiler/Typing/ComplexExpressionBuilderTests.cs
+++ b/src/UnitTests/Decompiler/Typing/ComplexExpressionBuilderTests.cs
@@ -465,6 +465,25 @@ namespace Reko.UnitTests.Decompiler.Typing
         }
 
         [Test]
+        public void CEB_ArrayOfStructs_Shl()
+        {
+            var array = new ArrayType(new StructureType(8)
+            {
+                Fields =
+                {
+                    new StructureField(0, PrimitiveType.Word32),
+                    new StructureField(4, PrimitiveType.Real32),
+                }
+            }, 0);
+            var a = new Identifier("a", Ptr32(array), null);
+            var i = new Identifier("i", PrimitiveType.Int32, null);
+            CreateTv(a, array, array);
+            var ceb = CreateBuilder(null, a, m.Shl(i, 3));
+            var e = ceb.BuildComplex(PrimitiveType.Word32);
+            Assert.AreEqual("a[i].dw0000", e.ToString());
+        }
+
+        [Test]
         public void CEB_ArrayOfPtrsToStruct()
         {
             var array = new ArrayType(ptrPoint, 0);

--- a/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_text.c
+++ b/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_text.c
@@ -2438,7 +2438,7 @@ ui32 * (* g_ptr9B38)[] = &g_aA554; // 00009B38
 // 00009B3C: void SysCtlPeripheralReset(Register uint32 r0)
 void SysCtlPeripheralReset(uint32 r0)
 {
-	ui32 * r2_n = (ui32 *) (g_ptr9B78 + ((r0 >> 28) << 0x02) / 4)[4];
+	ui32 * r2_n = (ui32 *) (g_ptr9B78 + (r0 >> 28))[4];
 	*r2_n = r0 & 0x0FFFFFFF | *r2_n;
 	up32 dwLoc0C_n = 0x00;
 	if (false)
@@ -2457,7 +2457,7 @@ Eq_n (* g_ptr9B78)[] = &g_aA554; // 00009B78
 //      OSRAMInit
 void SysCtlPeripheralEnable(uint32 r0)
 {
-	ui32 * r3_n = (ui32 *) (g_ptr9B94 + ((r0 >> 28) << 0x02) / 4)[7];
+	ui32 * r3_n = (ui32 *) (g_ptr9B94 + (r0 >> 28))[7];
 	*r3_n = r0 & 0x0FFFFFFF | *r3_n;
 }
 
@@ -2465,7 +2465,7 @@ Eq_n (* g_ptr9B94)[] = &g_aA554; // 00009B94
 // 00009B98: void SysCtlPeripheralDisable(Register uint32 r0)
 void SysCtlPeripheralDisable(uint32 r0)
 {
-	ui32 * r2_n = (ui32 *) (g_ptr9BB0 + ((r0 >> 28) << 0x02) / 4)[7];
+	ui32 * r2_n = (ui32 *) (g_ptr9BB0 + (r0 >> 28))[7];
 	*r2_n &= ~(r0 & 0x0FFFFFFF);
 }
 
@@ -2473,7 +2473,7 @@ Eq_n (* g_ptr9BB0)[] = &g_aA554; // 00009BB0
 // 00009BB4: void SysCtlPeripheralSleepEnable(Register uint32 r0)
 void SysCtlPeripheralSleepEnable(uint32 r0)
 {
-	ui32 * r3_n = (ui32 *) (g_ptr9BCC + ((r0 >> 28) << 0x02) / 4)[0x0A];
+	ui32 * r3_n = (ui32 *) (g_ptr9BCC + (r0 >> 28))[0x0A];
 	*r3_n = r0 & 0x0FFFFFFF | *r3_n;
 }
 
@@ -2481,7 +2481,7 @@ Eq_n (* g_ptr9BCC)[] = &g_aA554; // 00009BCC
 // 00009BD0: void SysCtlPeripheralSleepDisable(Register uint32 r0)
 void SysCtlPeripheralSleepDisable(uint32 r0)
 {
-	ui32 * r2_n = (ui32 *) (g_ptr9BE8 + ((r0 >> 28) << 0x02) / 4)[0x0A];
+	ui32 * r2_n = (ui32 *) (g_ptr9BE8 + (r0 >> 28))[0x0A];
 	*r2_n &= ~(r0 & 0x0FFFFFFF);
 }
 
@@ -2489,7 +2489,7 @@ Eq_n (* g_ptr9BE8)[] = &g_aA554; // 00009BE8
 // 00009BEC: void SysCtlPeripheralDeepSleepEnable(Register uint32 r0)
 void SysCtlPeripheralDeepSleepEnable(uint32 r0)
 {
-	ui32 * r3_n = (ui32 *) (g_ptr9C04 + ((r0 >> 28) << 0x02) / 4)[0x0D];
+	ui32 * r3_n = (ui32 *) (g_ptr9C04 + (r0 >> 28))[0x0D];
 	*r3_n = r0 & 0x0FFFFFFF | *r3_n;
 }
 
@@ -2497,7 +2497,7 @@ Eq_n (* g_ptr9C04)[] = &g_aA554; // 00009C04
 // 00009C08: void SysCtlPeripheralDeepSleepDisable(Register uint32 r0)
 void SysCtlPeripheralDeepSleepDisable(uint32 r0)
 {
-	ui32 * r2_n = (ui32 *) (g_ptr9C20 + ((r0 >> 28) << 0x02) / 4)[0x0D];
+	ui32 * r2_n = (ui32 *) (g_ptr9C20 + (r0 >> 28))[0x0D];
 	*r2_n &= ~(r0 & 0x0FFFFFFF);
 }
 
@@ -2696,7 +2696,7 @@ uint32 SysCtlClockGet()
 			r0_n = 0x00;
 			return r0_n;
 		}
-		r0_n = (uint32) (g_ptr9E58 + ((uint32) SLICE(r3_n, ui4, 6) << 0x02) / 4)[0x0C];
+		r0_n = (uint32) (g_ptr9E58 + (uint32) SLICE(r3_n, ui4, 6))[0x0C];
 		break;
 	}
 	if (r3_n << 20 >= 0x00)

--- a/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_text_memcpy.c
+++ b/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_text_memcpy.c
@@ -39,7 +39,7 @@ l0000A63C:
 		}
 		struct Eq_n * r4_n = r1;
 		struct Eq_n * r3_n = r0;
-		struct Eq_n * r5_n = r0 + ((r2 - 0x10 >> 4) + 0x01 << 4) / 16;
+		struct Eq_n * r5_n = r0 + ((r2 - 0x10 >> 4) + 0x01);
 		do
 		{
 			r3_n->a0000[0] = r4_n->a0000[0];

--- a/subjects/Elf/AVR32/ls.reko/ls_seg00001000_0000.c
+++ b/subjects/Elf/AVR32/ls.reko/ls_seg00001000_0000.c
@@ -854,7 +854,7 @@ Eq_n (* fn000030D8)[](Eq_n r4, Eq_n r5, Eq_n r7, ui32 r12, Eq_n lr, ptr32 & r9Ou
 	struct Eq_n * r6_n = 0x30DC - g_dw311E;
 	Eq_n (* r8_n)[] = r6_n->ptrFFFFFFC8;
 	struct Eq_n * r10_n = r8_n[r12].ptr0000;
-	byte * r12_n = (byte *) *((char *) &(r8_n + (r12 << 0x03) / 8)->ptr0000 + 4);
+	byte * r12_n = (byte *) *((char *) &(r8_n + r12)->ptr0000 + 4);
 	ptr32 r9;
 	if (r10_n != null)
 	{

--- a/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize.h
+++ b/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize.h
@@ -23701,7 +23701,7 @@ T_5072: (in o0_24 + (Mem0[0x27F4C<32>:word32] << 2<32>) @ 00014E48 : word32)
   Class: Eq_5066
   DataType: (ptr32 (arr Eq_194))
   OrigDataType: up32
-T_5073: (in o0_24 >= &(o0_24 + (n_base_source_files << 2<32>) / 4<i32>)->u0 @ 00014E48 : bool)
+T_5073: (in o0_24 >= &(o0_24 + n_base_source_files)->u0 @ 00014E48 : bool)
   Class: Eq_5073
   DataType: bool
   OrigDataType: bool
@@ -32053,7 +32053,7 @@ T_7155: (in Mem1270[(o2_1268 + 1<32> << 2<32>) + i1_156 + -4<i32>:word32] @ 0001
   Class: Eq_7143
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_7156: (in fprintf(&g_t2B640, "%s: option `%s' requires an argument\n", i1_156[0<i32>], (i1_156 + ((char *) o2_1268 + 1<i32> << 2<32>) / 4<i32>)[-1<i32>]) @ 00016358 : int32)
+T_7156: (in fprintf(&g_t2B640, "%s: option `%s' requires an argument\n", i1_156[0<i32>], (i1_156 + ((char *) o2_1268 + 1<i32>))[-1<i32>]) @ 00016358 : int32)
   Class: Eq_7156
   DataType: int32
   OrigDataType: int32
@@ -34818,7 +34818,7 @@ T_7844: (in Mem874[(o2_1011 << 2<32>) + i1_156 + -4<i32>:word32] @ 00016818 : wo
   Class: Eq_7833
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_7845: (in fprintf(&g_t2B640, "%s: option `%s' requires an argument\n", i1_156[0<i32>], (i1_156 + (o2_1011 << 2<32>) / 4<i32>)[-1<i32>]) @ 00016818 : int32)
+T_7845: (in fprintf(&g_t2B640, "%s: option `%s' requires an argument\n", i1_156[0<i32>], (i1_156 + o2_1011)[-1<i32>]) @ 00016818 : int32)
   Class: Eq_7845
   DataType: int32
   OrigDataType: int32

--- a/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize_text.c
+++ b/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize_text.c
@@ -2703,7 +2703,7 @@ void do_processing()
 {
 	union Eq_n * l1_n;
 	Eq_n o0_n[] = g_ptr28160;
-	if (o0_n < &(o0_n + (n_base_source_files << 0x02) / 4)->u0)
+	if (o0_n < &(o0_n + n_base_source_files)->u0)
 	{
 		Eq_n o0_n;
 		o0_n.u0 = o0_n[0].u0;
@@ -3753,7 +3753,7 @@ l000161B8:
 										}
 										else if (opterr != 0x00)
 										{
-											struct Eq_n * o3_n = (i1_n + ((char *) o2_n + 1 << 0x02) / 4)[-1];
+											struct Eq_n * o3_n = (i1_n + ((char *) o2_n + 1))[-1];
 											struct Eq_n * o0_n;
 											if ((int32) o3_n->b0001 == 0x2D)
 											{
@@ -3798,7 +3798,7 @@ l00016398:
 										goto l00016398;
 									}
 									if (opterr != 0x00)
-										fprintf(&g_t2B640, "%s: option `%s' requires an argument\n", i1_n[0], (i1_n + ((char *) o2_n + 1 << 0x02) / 4)[-1]);
+										fprintf(&g_t2B640, "%s: option `%s' requires an argument\n", i1_n[0], (i1_n + ((char *) o2_n + 1))[-1]);
 									uint32 o0_n = (uint32) strlen(g_ptr2B2C0);
 									Eq_n o2_n;
 									o2_n.u0 = l3_n->t000C.u0;
@@ -3957,7 +3957,7 @@ l000166CC:
 													if (o2_n >= i6_n->ptr0044)
 													{
 														if (opterr != 0x00)
-															fprintf(&g_t2B640, "%s: option `%s' requires an argument\n", i1_n[0], (i1_n + (o2_n << 0x02) / 4)[-1]);
+															fprintf(&g_t2B640, "%s: option `%s' requires an argument\n", i1_n[0], (i1_n + o2_n)[-1]);
 														g_ptr2B2C0 += (uint32) strlen(g_ptr2B2C0);
 														o0_n = (int32) *i2_n;
 														goto l00016388;

--- a/subjects/Elf/nanoMips/ping/ping.reko/ping_text_0000.c
+++ b/subjects/Elf/nanoMips/ping/ping.reko/ping_text_0000.c
@@ -2545,7 +2545,7 @@ Eq_n pinger(Eq_n r0, Eq_n r4, ptr32 & r12Out)
 				r9_n.u3 = preload.u3;
 				Eq_n r5_n;
 				r5_n.u3 = interval.u3;
-				int32 r8_n = r8_n + (r4_n - r8_n) *s 0x007D;
+				int32 r8_n = r8_n + (r4_n - r8_n) * 0x007D;
 				if (r5_n == 0x00 && (r8_n < 0x0A && in_flight(out r7_n) >= r9_n))
 				{
 					r12Out = r12;
@@ -6076,7 +6076,7 @@ void __init_libc(Eq_n r0, word32 r4[], struct Eq_n * r5)
 		r4_n = r4_n + 0x01;
 		r4_n = r4_n;
 	} while (r4[r4_n] != 0x00);
-	struct Eq_n * r4_n = (struct Eq_n *) (r4 + (r4_n << 0x02) / 4);
+	struct Eq_n * r4_n = (struct Eq_n *) (r4 + r4_n);
 	uint32 r7_n;
 	Eq_n fp;
 	while (true)
@@ -6085,7 +6085,7 @@ void __init_libc(Eq_n r0, word32 r4[], struct Eq_n * r5)
 		if (r7_n == 0x00)
 			break;
 		if (r7_n < 0x26)
-			(&(&(fp - 0x10 + (r7_n << 0x02) / 4)->dwFFFFFF68 + 38)[-38].dwFFFFFF68)[38] = r4_n->dw0004;
+			(&(&(fp - 0x10 + r7_n)->dwFFFFFF68 + 38)[-38].dwFFFFFF68)[38] = r4_n->dw0004;
 		++r4_n;
 	}
 	__hwcap = r7_n;
@@ -8753,7 +8753,7 @@ struct Eq_n * netlink_msg_to_ifaddr(Eq_n r0, struct Eq_n * r4, struct Eq_n * r5,
 		Eq_n r6_n;
 		r6_n.u3 = r5[5];
 		struct Eq_n * r18_n;
-		for (r18_n = (struct Eq_n *) (r4 + ((r6_n & 0x3F) << 0x02) / 4)[2]; r18_n != null; r18_n = r18_n->ptr001C)
+		for (r18_n = (struct Eq_n *) (r4 + (r6_n & 0x3F))[2]; r18_n != null; r18_n = r18_n->ptr001C)
 		{
 			r7_n.u3 = r18_n->t008C.u3;
 			if (r6_n == r7_n)
@@ -8858,7 +8858,7 @@ l00406288:
 			free(r0, r4_n, r11, out r3_n, out r4_n, out r6_n, out r7_n, out r8_n, out r9_n, out r11);
 			goto l004060A8;
 		}
-		*((char *) &(r4 + ((*((word32) r4_n + 0x008C) & 0x3F) << 0x02) / 4)->t0001 + 1) = (struct Eq_n *) r4_n;
+		*((char *) &(r4 + (*((word32) r4_n + 0x008C) & 0x3F))->t0001 + 1) = (struct Eq_n *) r4_n;
 	}
 	else
 	{
@@ -9831,7 +9831,7 @@ l00406A46:
 	if ((word32) r16_n.u11->a0000[0].u0 == 0x3A && r4_n == ~0x00)
 	{
 		&r6.u1->b0000 = (word32) r16_n.u11[1];
-		(&(&(fp - 0x20 + ((r17_n & 0x07) << 0x01) / 2)->wFFFFFFF0 + 8)[-8].wFFFFFFF0)[8] = 0;
+		(&(&(fp - 0x20 + (r17_n & 0x07))->wFFFFFFF0 + 8)[-8].wFFFFFFF0)[8] = 0;
 		r7_n.u11->a0000 = r16_n.u11 + 1;
 		if (r6 != 0x00)
 		{
@@ -9867,7 +9867,7 @@ l00406A6E:
 			}
 			r5_n = (r5_n << 0x04) + r6_n;
 		}
-		(&(&(fp - 0x20 + ((r17_n & 0x07) << 0x01) / 2)->wFFFFFFF0 + 8)[-8].wFFFFFFF0)[8] = (int16) r5_n;
+		(&(&(fp - 0x20 + (r17_n & 0x07))->wFFFFFFF0 + 8)[-8].wFFFFFFF0)[8] = (int16) r5_n;
 		&r6.u1->b0000 = (word32) r16_n.u11[r7_n];
 		if (r6 != 0x00)
 		{
@@ -10200,7 +10200,7 @@ l00406D90:
 		r16_n.u0 = 0x00;
 	word32 r4_n;
 	r2_n = res_mkquery(0x00, r6, 0x01, 0x1C, r16_n *s 0x0118 + (fp - 1616), 0x0118, out r4_n, out r8_n, out r11_n, out r12_n);
-	(fp + ~0x101F + (r16_n << 0x02) / 4)[621] = (Eq_n) r4_n;
+	(fp + ~0x101F + r16_n)[621] = (Eq_n) r4_n;
 	r16_n.u3 = (byte) r16_n.u0 + 1;
 	if (r4_n == ~0x00)
 		goto l00406D8C;
@@ -10990,7 +10990,7 @@ Eq_n __lookup_serv(Eq_n r2, Eq_n r3, struct Eq_n * r4, Eq_n r5, word32 r6, byte 
 			}
 			else
 				r16_n.u0 = 0x00;
-			struct Eq_n * r18_n = (struct Eq_n *) (r4 + (r16_n << 0x02) / 4);
+			struct Eq_n * r18_n = (struct Eq_n *) (r4 + r16_n);
 			r18_n->b0003 = 0x01;
 			r18_n->w0000 = (word16) r4_n;
 			r18_n->b0002 = 0x11;
@@ -11081,7 +11081,7 @@ l00407424:
 							{
 								if (r19_n == 0x06)
 									break;
-								struct Eq_n * r7_n = (struct Eq_n *) (r4 + (r16_n << 0x02) / 4);
+								struct Eq_n * r7_n = (struct Eq_n *) (r4 + r16_n);
 								r7_n->b0003 = 0x01;
 								r7_n->w0000 = (word16) r4_n;
 								r7_n->b0002 = 0x11;
@@ -11090,7 +11090,7 @@ l00407424:
 							word32 r6_n;
 							if (strncmp(r4_n, 0x00411F40, 0x04, out r6_n) == 0x00 && r19_n != 0x11)
 							{
-								struct Eq_n * r7_n = (struct Eq_n *) (r4 + (r16_n << 0x02) / 4);
+								struct Eq_n * r7_n = (struct Eq_n *) (r4 + r16_n);
 								r7_n->b0003 = 0x02;
 								r7_n->w0000 = (word16) r4_n;
 								r7_n->b0002 = 0x06;
@@ -11587,7 +11587,7 @@ l004079EE:
 					while (r20_n != r8_n)
 					{
 						Eq_n r6_n = r19_n;
-						if (memcmp(&tLoc84 + r8_n *s 7, &tLocA0, r19_n, out r7_n, out r8_n, out r9_n) == 0x00)
+						if (memcmp(&tLoc84 + r8_n * 7, &tLocA0, r19_n, out r7_n, out r8_n, out r9_n) == 0x00)
 						{
 							r7_n = r9;
 							while (r7_n < r9_n)
@@ -15983,7 +15983,7 @@ Eq_n cycle(Eq_n r4, struct Eq_n * r5, int32 r6, union Eq_n & r4Out, ptr32 & r7Ou
 	ptr32 r7;
 	if (r6 >= 0x02)
 	{
-		union Eq_n * r22_n = (union Eq_n *) (r5 + (r6 << 0x02) / 4);
+		union Eq_n * r22_n = (union Eq_n *) (r5 + r6);
 		ptr32 fp;
 		r22_n->u3 = (byte *) (fp - 288);
 		for (; r18_n != 0x00; r18_n -= r7_n)
@@ -16238,7 +16238,7 @@ l00409EEC:
 		else
 		{
 			Eq_n r30_n = (word32) r16_n.u0 - 1;
-			if (((char *) &(fp - 0x30 + (r30_n << 0x02) / 4)->tFFFFFF40 + 0x00C0)[-0x00C0] >= r19_n)
+			if (((char *) &(fp - 0x30 + r30_n)->tFFFFFF40 + 0x00C0)[-0x00C0] >= r19_n)
 			{
 				word32 r4_n;
 				word32 r7_n;
@@ -16298,7 +16298,7 @@ l00409EDE:
 			word32 r8_n;
 			word32 r11_n;
 			word32 r12_n;
-			trinkle(r18_n - (r17_n.u3 + (&((&((fp - 0x30) + (r19_n << 0x02) / 4)->dwFFFFFF40 + 48))[-48].dwFFFFFF40)[48]), r17_n, &tLocF8, (word32) r16_n - 1, 0x01, &dwLocF0, out r4_n, out r7_n, out r8_n, out r11_n, out r12_n);
+			trinkle(r18_n - (r17_n.u3 + (&((&((fp - 0x30) + r19_n)->dwFFFFFF40 + 48))[-48].dwFFFFFF40)[48]), r17_n, &tLocF8, (word32) r16_n - 1, 0x01, &dwLocF0, out r4_n, out r7_n, out r8_n, out r11_n, out r12_n);
 			ui32 r7_n = fn00409F48(&tLocF8, 0x01);
 			Eq_n r17_n;
 			r17_n.u3 = tLocF8.t0000.u3;
@@ -16853,7 +16853,7 @@ l0040A154:
 			r16_n.u3 = &r6.u12->dwFFFFFFEC;
 			r24_n = (struct Eq_n *) (r13.u11 + 2);
 			r5_n = (struct Eq_n *) (r5.u11 + 2);
-			struct Eq_n * r25_n = r24_n + ((r16_n >> 0x04) + 0x01 << 0x04) / 16;
+			struct Eq_n * r25_n = r24_n + ((r16_n >> 0x04) + 0x01);
 			r2 = r5_n;
 			struct Eq_n * r8_n = r24_n;
 			do
@@ -16921,7 +16921,7 @@ l0040A312:
 		r24_n.u3 = &r6.u12->dwFFFFFFEC;
 		struct Eq_n * r16_n = (struct Eq_n *) (r13.u11 + 3);
 		struct Eq_n * r5_n = (struct Eq_n *) (r5.u11 + 3);
-		struct Eq_n * r15_n = r16_n + ((r24_n >> 0x04) + 0x01 << 0x04) / 16;
+		struct Eq_n * r15_n = r16_n + ((r24_n >> 0x04) + 0x01);
 		r2 = r5_n;
 		struct Eq_n * r8_n = r16_n;
 		do
@@ -17675,7 +17675,7 @@ byte * strspn(byte * r4, struct Eq_n * r5)
 	if ((word32) r5[1] != 0x00)
 	{
 		ptr32 fp;
-		(&(&(fp - 0x10 + ((r7_n >> 0x05) << 0x02) / 4)->dwFFFFFFE0 + 8)[-8].dwFFFFFFE0)[8] = 0x01 << r7_n;
+		(&(&(fp - 0x10 + (r7_n >> 0x05))->dwFFFFFFE0 + 8)[-8].dwFFFFFFE0)[8] = 0x01 << r7_n;
 		ui32 r7_n;
 		do
 		{
@@ -17690,7 +17690,7 @@ byte * strspn(byte * r4, struct Eq_n * r5)
 		} while (r7_n != 0x00);
 		if (r9_n == 0x00)
 			return null;
-		r4_n = 0x01 << r9_n & (&((&((fp - 0x10) + ((r9_n >> 0x05) << 0x02) / 4)->dwFFFFFFE0 + 8))[-8].dwFFFFFFE0)[8];
+		r4_n = 0x01 << r9_n & (&((&((fp - 0x10) + (r9_n >> 0x05))->dwFFFFFFE0 + 8))[-8].dwFFFFFFE0)[8];
 		if (r4_n == null)
 			return r4_n;
 		uint32 r5_n;
@@ -17700,7 +17700,7 @@ byte * strspn(byte * r4, struct Eq_n * r5)
 			++r6_n;
 			r5_n = (word32) *r6_n;
 			r7_n = 0x01 << r5_n;
-		} while (r5_n != 0x00 && (r7_n & (&((&((fp - 0x10) + ((r5_n >> 0x05) << 0x02) / 4)->dwFFFFFFE0 + 8))[-8].dwFFFFFFE0)[8]) != 0x00);
+		} while (r5_n != 0x00 && (r7_n & (&((&((fp - 0x10) + (r5_n >> 0x05))->dwFFFFFFE0 + 8))[-8].dwFFFFFFE0)[8]) != 0x00);
 	}
 	else
 	{
@@ -17740,7 +17740,7 @@ Eq_n twoway_strstr(Eq_n r4, Eq_n r5)
 				struct Eq_n * r5_n = fp + ~0x102F + ((r6_n >> 0x05) << 0x02);
 				r6_n = CONVERT(Mem53[r5 + r20_n:byte], byte, word32);
 				ui32 r7_n = 0x01 << r6_n | r5_n->dw0BE0;
-				(fp + ~0x102F + (r6_n << 0x02) / 4)[0x0300] = (Eq_n) r20_n;
+				(fp + ~0x102F + r6_n)[0x0300] = (Eq_n) r20_n;
 				r5_n->dw0BE0 = r7_n;
 				if (r6_n == 0x00)
 				{
@@ -17862,7 +17862,7 @@ l0040AB24:
 			Mem216 = Mem333;
 			Eq_n r4_n = r16_n + r20_n;
 			uint32 r6_n = (word32) r4_n.u11->bFFFFFFFF;
-			if ((0x01 << r6_n & ((fp + ~0x102F) + ((r6_n >> 0x05) << 0x02) / 4)[760]) == 0x00)
+			if ((0x01 << r6_n & ((fp + ~0x102F) + (r6_n >> 0x05))[760]) == 0x00)
 			{
 				r16_n = r4_n;
 				r21_n.u0 = 0x00;
@@ -19168,7 +19168,7 @@ l0040B4C4:
 				}
 				else
 				{
-					(fp + ~0x102F + (r30_n << 0x02) / 4)[896] = (Eq_n) r7_n;
+					(fp + ~0x102F + r30_n)[896] = (Eq_n) r7_n;
 					r20_n = 0x01;
 					dwLoc0260_n.u0 = 0x01;
 				}
@@ -19497,7 +19497,7 @@ l0040B7D6:
 									if (r30_n == r17_n)
 									{
 										struct Eq_n * r7_n = fp + ~0x102F + ((r7_n + ~0x00 & 0x7F) << 0x02);
-										r7_n->dw0E00 |= (fp + ~0x102F + (r7_n << 0x02) / 4)[896];
+										r7_n->dw0E00 |= (fp + ~0x102F + r7_n)[896];
 										r30_n = r7_n;
 									}
 									r7_n = fp + ~0x102F + (r17_n << 0x02);
@@ -19535,7 +19535,7 @@ l0040B7D6:
 				}
 				if (r20_n == 0x12)
 				{
-					r7_n = (struct Eq_n *) (fp + ~0x102F + (r17_n << 0x02) / 4)[896];
+					r7_n = (struct Eq_n *) (fp + ~0x102F + r17_n)[896];
 					if (r7_n <= (struct Eq_n *) 9007198)
 						goto l0040B72E;
 				}
@@ -19547,13 +19547,13 @@ l0040B898:
 					struct Eq_n * r6_n;
 					do
 					{
-						up32 r7_n = (up32) (fp + ~0x102F + (r6_n << 0x02) / 4)[896];
+						up32 r7_n = (up32) (fp + ~0x102F + r6_n)[896];
 						if (r7_n <= 9007198)
 							break;
 						if (r7_n == 9007199)
 						{
 							struct Eq_n * r7_n = r18_n & 0x7F;
-							if (r30_n == r7_n || ((fp + ~0x102F) + (r7_n << 0x02) / 4)[896] <= 0x0F2F09FF)
+							if (r30_n == r7_n || ((fp + ~0x102F) + r7_n)[896] <= 0x0F2F09FF)
 								break;
 						}
 l0040B8DA:
@@ -19607,7 +19607,7 @@ l0040B8DA:
 							r6_n = r6_n & 0x7F;
 							goto l0040B898;
 						}
-						(fp + ~0x102F + (r30_n << 0x02) / 4)[896] = (Eq_n) r19_n;
+						(fp + ~0x102F + r30_n)[896] = (Eq_n) r19_n;
 						r6_n = r17_n & 0x7F;
 						r30_n = r6_n & 0x7F;
 					} while ((r6_n & 0x7F) != r6_n);
@@ -19617,7 +19617,7 @@ l0040B8DA:
 					if (r30_n == r6_n)
 					{
 						struct Eq_n * r8_n = r30_n + 0x01;
-						(fp + ~0x102F + ((r8_n & 0x7F) << 0x02) / 4)[895] = (Eq_n) 0x00;
+						(fp + ~0x102F + (r8_n & 0x7F))[895] = (Eq_n) 0x00;
 						r30_n = r8_n & 0x7F;
 					}
 					Eq_n r5_n;
@@ -19630,12 +19630,12 @@ l0040B8DA:
 					word32 r12_n;
 					word32 r13_n;
 					word32 r14_n;
-					__adddf3(__floatunsidf((fp + ~0x102F + (r6_n << 0x02) / 4)[896], out r5_n), r5_n, 0x00, 0x00, out r4_n, out r5_n, out r6_n, out r7_n, out r8_n, out r11_n, out r12_n, out r13_n, out r14_n);
+					__adddf3(__floatunsidf((fp + ~0x102F + r6_n)[896], out r5_n), r5_n, 0x00, 0x00, out r4_n, out r5_n, out r6_n, out r7_n, out r8_n, out r11_n, out r12_n, out r13_n, out r14_n);
 					struct Eq_n * r18_n = r18_n & 0x7F;
 					if (r18_n == r30_n)
 					{
 						struct Eq_n * r8_n = r30_n + 0x01;
-						(fp + ~0x102F + ((r8_n & 0x7F) << 0x02) / 4)[895] = (Eq_n) 0x00;
+						(fp + ~0x102F + (r8_n & 0x7F))[895] = (Eq_n) 0x00;
 						r30_n = r8_n & 0x7F;
 					}
 					word32 r3_n;
@@ -19660,7 +19660,7 @@ l0040B8DA:
 					word32 r12_n;
 					word32 r13_n;
 					word32 r14_n;
-					__adddf3(__floatunsidf((fp + ~0x102F + (r18_n << 0x02) / 4)[896], out r5_n), r5_n, r4_n, r5_n, out r4_n, out r5_n, out r6_n, out r7_n, out r8_n, out r11_n, out r12_n, out r13_n, out r14_n);
+					__adddf3(__floatunsidf((fp + ~0x102F + r18_n)[896], out r5_n), r5_n, r4_n, r5_n, out r4_n, out r5_n, out r6_n, out r7_n, out r8_n, out r11_n, out r12_n, out r13_n, out r14_n);
 					word32 r3_n;
 					Eq_n r4_n;
 					Eq_n r5_n;
@@ -19786,7 +19786,7 @@ l0040BAAA:
 								}
 							}
 							int32 r6_n = 499999999;
-							up32 r7_n = (up32) (fp + ~0x102F + (r7_n << 0x02) / 4)[896];
+							up32 r7_n = (up32) (fp + ~0x102F + r7_n)[896];
 							Eq_n r6_n;
 							Eq_n r7_n;
 							if (r7_n <= 499999999)

--- a/subjects/Elf/x86-64/ls/ls.reko/ls_text.c
+++ b/subjects/Elf/x86-64/ls/ls.reko/ls_text.c
@@ -4789,7 +4789,7 @@ ui64 fn000000000040AC80(Eq_n rsi, struct Eq_n * rdi)
 	rdi->ptr0030();
 	Eq_n rax_n;
 	if (rax_n < (rdi->t0010).u3)
-		return rdi->ptr0000 + (rax_n << 0x04) /64 16;
+		return rdi->ptr0000 + rax_n;
 	abort();
 }
 

--- a/subjects/Hunk-m68k/MATRIXMU.reko/MATRIXMU_code.c
+++ b/subjects/Hunk-m68k/MATRIXMU.reko/MATRIXMU_code.c
@@ -325,7 +325,7 @@ int32 fn00001390(Eq_n dwArg04[], ptr32 dwArg08, ptr32 dwArg0C)
 			{
 				uint32 d1_n = __swap(20) *32 (word16) d2_n;
 				union Eq_n * a1_n = dwArg08 + ((word16) d2_n *32 20 + SEQ(SLICE(__swap(SEQ(SLICE(d1_n, word16, 16), (word16) d1_n + (word16) __swap(d2_n) * 0x14)), word16, 16), 0x00)) + (d3_n << 0x02);
-				Eq_n d0_n = (dwArg04 + (d4_n << 0x04) / 16)->a0000[d2_n];
+				Eq_n d0_n = (dwArg04 + d4_n)->a0000[d2_n];
 				Eq_n d1_n;
 				d1_n.u0 = a1_n->u0;
 				uint32 d5_n = __swap(d0_n) *32 (word16) d1_n;

--- a/subjects/PDP-11/spcinv.reko/spcinv.h
+++ b/subjects/PDP-11/spcinv.reko/spcinv.h
@@ -723,7 +723,7 @@ Eq_1414: (fn void (Eq_66, (ptr16 Eq_1120)))
 	T_1414 (in fn093C @ 0824 : ptr16)
 	T_1415 (in signature of fn093C @ 093C : void)
 Eq_1474: (struct "Eq_1474" 0002 (0 byte b0000))
-	T_1474 (in r0.u1 + (r3_15 << 1<i16>) /16 2<i32> - 0x16<16> + 0xE40<16> @ 0950 : word16)
+	T_1474 (in r0.u1 + r3_15 - 0x16<16> + 0xE40<16> @ 0950 : word16)
 	T_1475 (in r3_22 @ 0950 : (ptr16 Eq_1474))
 	T_1488 (in r3_22 + 2<16> @ 095C : word16)
 Eq_1603: (fn Eq_66 (Eq_66, (ptr16 byte), ptr16))
@@ -6709,7 +6709,7 @@ T_1471: (in 0x16<16> @ 0950 : word16)
   Class: Eq_1471
   DataType: ui16
   OrigDataType: ui16
-T_1472: (in r0.u1 + (r3_15 << 1<i16>) /16 2<i32> - 0x16<16> @ 0950 : word16)
+T_1472: (in r0.u1 + r3_15 - 0x16<16> @ 0950 : word16)
   Class: Eq_1472
   DataType: ui16
   OrigDataType: ui16
@@ -6717,7 +6717,7 @@ T_1473: (in 0xE40<16> @ 0950 : word16)
   Class: Eq_1473
   DataType: word16
   OrigDataType: word16
-T_1474: (in r0.u1 + (r3_15 << 1<i16>) /16 2<i32> - 0x16<16> + 0xE40<16> @ 0950 : word16)
+T_1474: (in r0.u1 + r3_15 - 0x16<16> + 0xE40<16> @ 0950 : word16)
   Class: Eq_1474
   DataType: (ptr16 Eq_1474)
   OrigDataType: ui16

--- a/subjects/PDP-11/spcinv.reko/spcinv_text.c
+++ b/subjects/PDP-11/spcinv.reko/spcinv_text.c
@@ -467,7 +467,7 @@ byte * g_ptr066A = &g_b1116; // 066A
 //      fn06D6
 bool fn067C(Eq_n r0, Eq_n r3, byte * r4, union Eq_n & r0Out, byte & r4Out, struct Eq_n & r5Out)
 {
-	struct Eq_n * r1_n = (struct Eq_n *) (r0.u1 + (r3 - 0x01 << 1) /16 2);
+	struct Eq_n * r1_n = (struct Eq_n *) (r0.u1 + (r3 - 0x01));
 	byte v12_n = r1_n->b0E2A;
 	bool Z_n = SLICE(cond(v12_n), bool, 2);
 	struct Eq_n * r5;
@@ -776,7 +776,7 @@ void fn093C(Eq_n r0, struct Eq_n * r1)
 	cui16 r3_n = r3_n - 0x01;
 	if (g_w0F20 >= 0x00)
 		r3_n = r3_n - 0x02;
-	struct Eq_n * r3_n = r0.u1 + (r3_n << 1) /16 2 - 22 + 0x0E40;
+	struct Eq_n * r3_n = r0.u1 + r3_n - 22 + 0x0E40;
 	word16 wLoc04_n = 0x07;
 	word16 v19_n;
 	do

--- a/subjects/PE/PPC/hello_ppc.reko/hello_ppc_text.c
+++ b/subjects/PE/PPC/hello_ppc.reko/hello_ppc_text.c
@@ -93,7 +93,7 @@ union Eq_n * fn004002F8(union Eq_n * r2, Eq_n r3, ptr32 r25, ptr32 r26, Eq_n r27
 			Eq_n r30_n[] = (Eq_n (*)[]) (&r2->u1)[5];
 			Eq_n r11_n;
 			&r11_n.u1->b0000 = r30_n[r10_n].t0000.u1;
-			struct Eq_n * r30_n = (struct Eq_n *) &(r30_n + (r10_n << 0x02) / 4)->t0000.u0;
+			struct Eq_n * r30_n = (struct Eq_n *) &(r30_n + r10_n)->t0000.u0;
 			if (r11_n == 0x00)
 			{
 				Eq_n r3_n;
@@ -1175,12 +1175,12 @@ union Eq_n * fn00401CE8(union Eq_n * r2, Eq_n r3, struct Eq_n * r4, struct Eq_n 
 		if ((r3_n & 0x03) != 0x00)
 		{
 			r11_n[r3].dw0000 = r3_n + 0x07 & ~0x07;
-			r8_n = (struct Eq_n *) &(r11_n + (r3 << 0x04) / 16)->dw0000;
+			r8_n = (struct Eq_n *) &(r11_n + r3)->dw0000;
 		}
 		else
 		{
 			r11_n[r3].dw0000 = r3_n;
-			r8_n = (struct Eq_n *) &(r11_n + (r3 << 0x04) / 16)->dw0000;
+			r8_n = (struct Eq_n *) &(r11_n + r3)->dw0000;
 		}
 		r8_n->dw000C = r3_n;
 		r8_n->ptr0008 = r31_n;
@@ -1215,7 +1215,7 @@ union Eq_n * fn00401DD8(union Eq_n * r2, Eq_n r3, struct Eq_n * r4, struct Eq_n 
 	v4->ptr000C = r31;
 	Eq_n (*** r29_n)[] = (Eq_n (***)[]) (&r2->u0)[0x008C];
 	Eq_n r5_n[] = (Eq_n (*)[]) **r29_n;
-	struct Eq_n * r11_n = (struct Eq_n *) &(r5_n + (r3 << 0x04) / 16)->dw0000;
+	struct Eq_n * r11_n = (struct Eq_n *) &(r5_n + r3)->dw0000;
 	word32 r8_n = r11_n->dw0004;
 	struct Eq_n * r9_n = r11_n->ptr0008;
 	int32 r30_n = (char *) &r4->dw0004 + 3 & ~0x07;
@@ -1228,7 +1228,7 @@ union Eq_n * fn00401DD8(union Eq_n * r2, Eq_n r3, struct Eq_n * r4, struct Eq_n 
 		r28 = &(r9_n + (r30_n - r10_n) / 16)->dw0000 + 2 & ~0x07;
 		union Eq_n * dwLoc3C;
 		r2 = dwLoc3C;
-		r11_n = (struct Eq_n *) &(r10_n + (r3 << 0x04) / 16)->dw0000;
+		r11_n = (struct Eq_n *) &(r10_n + r3)->dw0000;
 		if ((word32) **(&dwLoc3C->u0)[0x0098] != 0x00)
 		{
 			r3Out = ~0x00;
@@ -1280,7 +1280,7 @@ union Eq_n * fn00401ED4(union Eq_n * r2, ui32 r3, ui32 r30, word32 r31)
 	}
 	Eq_n r11_n[] = (Eq_n (*)[]) *r11_n;
 	r11_n[r3].dw0000 = 0x00;
-	struct Eq_n * r31_n = (struct Eq_n *) &(r11_n + (r3 << 0x04) / 16)->dw0000;
+	struct Eq_n * r31_n = (struct Eq_n *) &(r11_n + r3)->dw0000;
 	r31_n->dw0004 = 0x00;
 	r31_n->dw0008 = 0x00;
 	return r2;

--- a/subjects/PE/m68k/hello_m68k_CRTHEAP.c
+++ b/subjects/PE/m68k/hello_m68k_CRTHEAP.c
@@ -413,7 +413,7 @@ l000029B4:
 	}
 	a5->tFFFFFADC.u1 = (struct Eq_n *) a0;
 l00002974:
-	a0.u1->a0000 = a5->tFFFFFADC.u1->a0000[0].u1 + (a5->dwFFFFFAE0 << 0x04) / 4;
+	a0.u1->a0000 = a5->tFFFFFADC.u1->a0000[0].u1 + a5->dwFFFFFAE0 * 4;
 	int32 d0_n = 7;
 	word16 v30_n;
 	do
@@ -465,7 +465,7 @@ int32 fn000029C8(Eq_n a0, struct Eq_n * a5, int32 dwArg04, up32 dwArg08, struct 
 			a1_n.u1[dwArg04 * 4] = (struct Eq_n) SEQ(SLICE((word128) a0 + 3, word16, 16), (word16) a0 + 0x03 & ~0x03);
 		else
 			a1_n.u1[dwArg04 * 4] = (struct Eq_n) a0;
-		struct Eq_n * a1_n = (struct Eq_n *) (a1_n.u1 + (dwArg04 << 0x04) / 4);
+		struct Eq_n * a1_n = (struct Eq_n *) (a1_n.u1 + dwArg04 * 4);
 		a1_n->t000C.u1 = (struct Eq_n *) a0;
 		a1_n->dw0008 = d4_n;
 		a1_n->dw0004 = 0;
@@ -497,7 +497,7 @@ l00002A4C:
 int32 fn00002A54(struct Eq_n * a5, int32 dwArg04, up32 dwArg08, union Eq_n & d3Out, union Eq_n & d4Out, union Eq_n & d5Out, ptr32 & a2Out, struct Eq_n & a5Out, word32 & a6Out)
 {
 	ptr32 fp;
-	struct Eq_n * a2_n = (struct Eq_n *) (a5->tFFFFFADC.u1->a0000[0].u1 + (dwArg04 << 0x04) / 4);
+	struct Eq_n * a2_n = (struct Eq_n *) (a5->tFFFFFADC.u1->a0000[0].u1 + dwArg04 * 4);
 	uipr32 d4_n = a2_n->dw0008;
 	word32 d1_n = a2_n->dw0004;
 	up32 d0_n = d4_n - d1_n;
@@ -508,7 +508,7 @@ int32 fn00002A54(struct Eq_n * a5, int32 dwArg04, up32 dwArg08, union Eq_n & d3O
 		__syscall<word16>(0xA020);
 		word32 d4_n = d4_n - d0_n + d3_n;
 		uipr32 d4_n = SEQ(SLICE(d4_n + 0x04, word16, 16), (word16) d4_n + 0x04 & ~0x03);
-		a2_n = (struct Eq_n *) (a5->tFFFFFADC.u1->a0000[0].u1 + (dwArg04 << 0x04) / 4);
+		a2_n = (struct Eq_n *) (a5->tFFFFFADC.u1->a0000[0].u1 + dwArg04 * 4);
 		if (a5->tFFFFFAF0.u1->a0000[0].u0 != 0x00)
 		{
 			Eq_n d3;

--- a/subjects/Raw/CR16/CompactRISC.reko/CompactRISC.h
+++ b/subjects/Raw/CR16/CompactRISC.reko/CompactRISC.h
@@ -41291,7 +41291,7 @@ T_9191: (in Mem1384[r11_r10_1053 + (r3_r2_1268 << 2<8>) + 2<32>:word16] @ 0000AA
   Class: Eq_9191
   DataType: word16
   OrigDataType: word16
-T_9192: (in (r11_r10_1053 + (r3_r2_1268 << 2<8>) / 4<i32>)[0<i32>].w0002 + r7_1336 @ 0000AA82 : word16)
+T_9192: (in (r11_r10_1053 + r3_r2_1268)[0<i32>].w0002 + r7_1336 @ 0000AA82 : word16)
   Class: Eq_9192
   DataType: word16
   OrigDataType: word16

--- a/subjects/Raw/CR16/CompactRISC.reko/CompactRISC_code.c
+++ b/subjects/Raw/CR16/CompactRISC.reko/CompactRISC_code.c
@@ -3969,7 +3969,7 @@ l0000A4A4:
 					int32 r3_r2_n = (int32) (wArg2A_n + 0x01);
 					r0_n = wArg2A_n + 0x01;
 					++wArg2A_n;
-					r5_r4_n = r13_n + (r3_r2_n << 0x02) / 4;
+					r5_r4_n = r13_n + r3_r2_n;
 					r3_r2_n = SEQ(SLICE(r3_r2_n << 0x02, word16, 16), (word16) r3_r2_n << 0x02);
 				}
 				++r11_n;
@@ -4000,7 +4000,7 @@ l0000ADDC:
 			else
 			{
 				++r5_n;
-				r7_r6_n = r13_n + ((int32) r5_n << 0x02) / 4;
+				r7_r6_n = r13_n + (int32) r5_n;
 				r0_n = r5_n;
 			}
 			++r11_n;
@@ -4083,7 +4083,7 @@ l0000A504:
 		int32 r1_r0_n = (int32) (r0_n + ~0x00);
 		ci16 wArg06_n = r0_n;
 		struct Eq_n * dwArg0A_n = r3_r2_n;
-		struct Eq_n * dwLoc0E_n = (struct Eq_n *) (r13_n + (r1_r0_n << 0x02) / 4);
+		struct Eq_n * dwLoc0E_n = (struct Eq_n *) (r13_n + r1_r0_n);
 		struct Eq_n * dwLoc1E_n = (struct Eq_n *) (r3_r2.u1 + r1_r0_n / 9244);
 		struct Eq_n * dwArg1A_n = (struct Eq_n *) (r3_r2.u1 + (r1_r0_n * 0x02) / 9244);
 		struct Eq_n * dwArg22_n = (struct Eq_n *) (r3_r2.u1 + (r1_r0_n * 0x02 + -2) / 9244);
@@ -4148,8 +4148,8 @@ l0000A6E6:
 		dwArg22_n[1434] = (struct Eq_n) r2_n;
 		int32 r1_r0_n = (int32) wArg12_n;
 		int32 r3_r2_n = (int32) r2_n;
-		struct Eq_n * r7_r6_n = (struct Eq_n *) (r13_n + (r1_r0_n << 0x02) / 4);
-		struct Eq_n * r5_r4_n = (struct Eq_n *) (r13_n + (r3_r2_n << 0x02) / 4);
+		struct Eq_n * r7_r6_n = (struct Eq_n *) (r13_n + r1_r0_n);
+		struct Eq_n * r5_r4_n = (struct Eq_n *) (r13_n + r3_r2_n);
 		dwLoc0E_n->w0000 = r7_r6_n->w0000 + r5_r4_n->w0000;
 		wLoc02_n = SLICE(dwLoc04_n, word16, 16);
 		ci16 wLoc26_n = wArg06_n + ~0x01;
@@ -4263,8 +4263,8 @@ l0000A77A:
 				{
 					ci16 r0_n = r11_r10_n->w1668;
 					int32 r3_r2_n = (int32) r0_n;
-					struct Eq_n * r5_r4_n = (struct Eq_n *) (r2_r1_n + (r3_r2_n << 0x02) / 4);
-					ci16 r2_n = (r2_r1_n + ((word32) r5_r4_n->w0002 << 0x02) / 4)->t0002.w0000;
+					struct Eq_n * r5_r4_n = (struct Eq_n *) (r2_r1_n + r3_r2_n);
+					ci16 r2_n = (r2_r1_n + (word32) r5_r4_n->w0002)->t0002.w0000;
 					word16 r10_n = (word16) r11_r10_n;
 					ci16 r2_n = r2_n + 0x01;
 					if (r7_n >= r2_n + 0x01)
@@ -4286,7 +4286,7 @@ l0000A77A:
 						word32 r3_r2_n = (word32) r2_n;
 						word32 r9_r8_n = (word32) r5_r4_n->w0000;
 						r3_r2.u1->dw23F8 = fn0000D358((word16) r3_r2_n, SLICE(r3_r2_n, word16, 16), (word16) r9_r8_n, SLICE(r9_r8_n, word16, 16)) + (r3_r2.u1)->dw23F8;
-						word32 r3_r2_n = (word32) ((r11_r10_n + (r3_r2_n << 0x02) / 4)[0].w0002 + r7_n);
+						word32 r3_r2_n = (word32) ((r11_r10_n + r3_r2_n)[0].w0002 + r7_n);
 						r3_r2.u1->dw2400 = fn0000D358((word16) r3_r2_n, SLICE(r3_r2_n, word16, 16), (word16) r9_r8_n, SLICE(r9_r8_n, word16, 16)) + (r3_r2.u1)->dw2400;
 					}
 					wLoc26_n = wLoc26_n + 0x01;
@@ -4302,8 +4302,8 @@ l0000A77A:
 				do
 				{
 					ci16 r5_n = r9_r8_n->w1668;
-					struct Eq_n * r1_r0_n = (struct Eq_n *) (r2_r1_n + ((int32) r5_n << 0x02) / 4);
-					ci16 r4_n = (r2_r1_n + ((word32) r1_r0_n->w0002 << 0x02) / 4)->t0002.w0000;
+					struct Eq_n * r1_r0_n = (struct Eq_n *) (r2_r1_n + (int32) r5_n);
+					ci16 r4_n = (r2_r1_n + (word32) r1_r0_n->w0002)->t0002.w0000;
 					word16 r8_n = (word16) r9_r8_n;
 					ci16 r4_n = r4_n + 0x01;
 					if (r7_n >= r4_n + 0x01)
@@ -4468,7 +4468,7 @@ l0000ACB8:
 						struct Eq_n * r11_r10_n;
 						if (r3_n <= r0_n)
 						{
-							struct Eq_n * r9_r8_n = (struct Eq_n *) (r2_r1_n + ((int32) r0_n << 0x02) / 4);
+							struct Eq_n * r9_r8_n = (struct Eq_n *) (r2_r1_n + (int32) r0_n);
 							word16 r0_n = r9_r8_n->w0002;
 							if (r0_n != wLoc16_n)
 							{
@@ -4493,7 +4493,7 @@ l0000ACB8:
 l0000ACD6:
 		if (wArg2A_n != ~0x00)
 		{
-			Eq_n r5_r4_n = r13_n + ((int32) wArg2A_n + 1 << 0x02) / 4;
+			Eq_n r5_r4_n = r13_n + ((int32) wArg2A_n + 1);
 			struct Eq_n * r7_r6_n;
 			do
 			{
@@ -5730,7 +5730,7 @@ l0000C0B6:
 	else
 		dwArg06_n = r13;
 	Eq_n r4_r3_n;
-	&r4_r3_n.u2->b0000 = r12_n.u2 + (((word32) dwArg06_n - 16 >> 0x04) + 1 << 0x04) / 16;
+	&r4_r3_n.u2->b0000 = r12_n.u2 + (((word32) dwArg06_n - 16 >> 0x04) + 1);
 	do
 	{
 		ui32 r9_r8_n = (word32) dwLoc52_n.u1 + (word32) (r12_n.u2)->b0000;

--- a/subjects/VMS-vax/unzip.h
+++ b/subjects/VMS-vax/unzip.h
@@ -88110,7 +88110,7 @@ T_20566: (in fp_237 + -1356<i32> + (Mem568[Mem568[sp_236 + 8<i32>:word32] + 0<32
   Class: Eq_20469
   DataType: (ptr32 (arr Eq_20591))
   OrigDataType: ptr32
-T_20567: (in r8_295 < fp_237->aFFFFFAB4 + (*((word32) (sp_236)[2<i32>].dwFFFFFFFC + 4<i32>) << 2<i8>) / 4<i32> @ 00018ACE : bool)
+T_20567: (in r8_295 < fp_237->aFFFFFAB4 + *((word32) (sp_236)[2<i32>].dwFFFFFFFC + 4<i32>) @ 00018ACE : bool)
   Class: Eq_20567
   DataType: bool
   OrigDataType: bool

--- a/subjects/VMS-vax/unzip_code_0001.c
+++ b/subjects/VMS-vax/unzip_code_0001.c
@@ -4106,7 +4106,7 @@ int32 fn0001878E(struct Eq_n * ap, union Eq_n * fp, union Eq_n & r3Out, ptr32 & 
 								if (sp_n[0x0D] > sp_n[8])
 								{
 									sp_n[0x0D] = (struct Eq_n) (sp_n[0x0D] - ((word32) (sp_n)[4].dwFFFFFFFC + 5));
-									up32 * r3_n = fp_n->aFFFFFFB8 + (r9_n << 2) / 4;
+									up32 * r3_n = fp_n->aFFFFFFB8 + r9_n;
 									r10_n = (struct Eq_n *) ((char *) r10_n + 1);
 									if ((char *) r10_n + 1 < sp_n[11])
 									{
@@ -4177,7 +4177,7 @@ int32 fn0001878E(struct Eq_n * ap, union Eq_n * fp, union Eq_n & r3Out, ptr32 & 
 							} while (r9_n > (word32) ((word32) (sp_n)[9].dwFFFFFFFC + (sp_n[0x0C] * 4 + 4))->dwFFFFFFFC + (r6_n + 4));
 						}
 						fp_n->bFFFFFA6B = (int8) (r9_n - r6_n);
-						if (r8_n >= fp_n->aFFFFFAB4 + (*((word32) (sp_n)[2].dwFFFFFFFC + 4) << 2) / 4)
+						if (r8_n >= fp_n->aFFFFFAB4 + *((word32) (sp_n)[2].dwFFFFFFFC + 4))
 							fp_n->bFFFFFA6A = 99;
 						else
 						{


### PR DESCRIPTION
- Create test for `ComplexExpressionBuilder` with array access using SHL
Expected: "a[i].dw0000"
But was:  "a[(i << 3<8>) / 8<i32>].dw0000"
- Use ArrayExpressionMatcher for scaling array index down
`(i << 3<8>) / 8<i32>` -> `i`