### PR TITLE
Fix: RISC-V CSRR instruction definition

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Sven Almgren (blindmatrix)
 David Connolly
 throwaway96
 Johan Mattsson
+Gregor Alujevič

--- a/src/Arch/RiscV/InstructionSet.cs
+++ b/src/Arch/RiscV/InstructionSet.cs
@@ -443,9 +443,9 @@ namespace Reko.Arch.RiscV
                         (0b0011000_00010, Instr(Mnemonic.mret, InstrClass.Transfer | InstrClass.Return)),
                         (0b0001000_00101, Instr(Mnemonic.wfi, InstrClass.Linear))),
 
-                    Instr(Mnemonic.csrrw, d, Csr20, r2),
-                    Instr(Mnemonic.csrrs, d, Csr20, r2),
-                    Instr(Mnemonic.csrrc, d, Csr20, r2),
+                    Instr(Mnemonic.csrrw, d, Csr20, r1),
+                    Instr(Mnemonic.csrrs, d, Csr20, r1),
+                    Instr(Mnemonic.csrrc, d, Csr20, r1),
                     invalid,
                     Instr(Mnemonic.csrrwi, d, Csr20, Imm(15, 5)),
                     Instr(Mnemonic.csrrsi, d, Csr20, Imm(15, 5)),

--- a/src/UnitTests/Arch/RiscV/RiscVDisassemblerTests.cs
+++ b/src/UnitTests/Arch/RiscV/RiscVDisassemblerTests.cs
@@ -233,9 +233,39 @@ namespace Reko.UnitTests.Arch.RiscV
         }
 
         [Test]
+        public void RiscV_dasm_csrrw()
+        {
+            AssertCode("csrrw\tt5,mtvec,a1", "739F5530");
+        }
+
+        [Test]
+        public void RiscV_dasm_csrrs()
+        {
+            AssertCode("csrrs\tt5,mtvec,a1", "73AF5530");
+        }
+
+        [Test]
         public void RiscV_dasm_csrrc()
         {
-            AssertCode("csrrc\tzero,mstatus,zero", "73B00230");
+            AssertCode("csrrc\tt5,mtvec,a1", "73BF5530");
+        }
+
+        [Test]
+        public void RiscV_dasm_csrrwi()
+        {
+            AssertCode("csrrwi\tt5,mtvec,0000000B", "73 df 55 30");
+        }
+
+        [Test]
+        public void RiscV_dasm_csrrsi()
+        {
+            AssertCode("csrrsi\tt5,mtvec,0000000B", "73 ef 55 30");
+        }
+
+        [Test]
+        public void RiscV_dasm_csrrci()
+        {
+            AssertCode("csrrci\tt5,mtvec,0000000B", "73 ff 55 30");
         }
 
         [Test]

--- a/src/UnitTests/Arch/RiscV/RiscVRewriterTests.cs
+++ b/src/UnitTests/Arch/RiscV/RiscVRewriterTests.cs
@@ -1048,9 +1048,9 @@ namespace Reko.UnitTests.Arch.RiscV
         public void RiscV_rw_csrrc()
         {
             Given_HexString("73B00230");
-            AssertCode(     // csrrc	zero,mstatus,zero
+            AssertCode(     // csrrc	zero,mstatus,t0
                 "0|L--|0000000000010000(4): 1 instructions",
-                "1|L--|__csrrc<word64>(mstatus, 0<64>)");
+                "1|L--|__csrrc<word64>(mstatus, t0)");
         }
 
         [Test]
@@ -1066,9 +1066,9 @@ namespace Reko.UnitTests.Arch.RiscV
         public void RiscV_rw_csrrs()
         {
             Given_HexString("73292000");
-            AssertCode(     // csrrs	s2,frm,sp
+            AssertCode(     // csrrs	s2,frm,zero
                 "0|L--|0000000000010000(4): 1 instructions",
-                "1|L--|s2 = __csrrs<word64>(frm, sp)");
+                "1|L--|s2 = __csrrs<word64>(frm, 0<64>)");
         }
 
         [Test]
@@ -1084,9 +1084,9 @@ namespace Reko.UnitTests.Arch.RiscV
         public void RiscV_rw_csrrw()
         {
             Given_HexString("73900930");
-            AssertCode(     // csrrw	zero,mstatus,zero
+            AssertCode(     // csrrw	zero,mstatus,x19
                 "0|L--|0000000000010000(4): 1 instructions",
-                "1|L--|__csrrw<word64>(mstatus, 0<64>)");
+                "1|L--|__csrrw<word64>(mstatus, s3)");
         }
 
         [Test]


### PR DESCRIPTION
CSRR instructions use the rs1 source regiter.