### PR TITLE
Do not scale array index down if it can't be divided by element size

### DIFF
--- a/src/UnitTests/Decompiler/Typing/ComplexExpressionBuilderTests.cs
+++ b/src/UnitTests/Decompiler/Typing/ComplexExpressionBuilderTests.cs
@@ -544,5 +544,18 @@ namespace Reko.UnitTests.Decompiler.Typing
             var e = ceb.BuildComplex(PrimitiveType.Int32);
             Assert.AreEqual("a.point->dw0004", e.ToString());
         }
+
+        [Test]
+        public void CEB_PointerToStruct_ArrayField()
+        {
+            StructureType str = Struct(
+                Fld(0, new ArrayType(PrimitiveType.Real64, 4)));
+            var id = new Identifier("id", PrimitiveType.Ptr32, null);
+            var index = new Identifier("index", PrimitiveType.Ptr32, null);
+            CreateTv(id, Ptr32(str), PrimitiveType.Ptr32);
+            var ceb = CreateBuilder(null, id, m.IMul(index, 8));
+            var e = ceb.BuildComplex(PrimitiveType.Real64);
+            Assert.AreEqual("id->a0000[index]", e.ToString());
+        }
     }
 }

--- a/src/tests/Typing/TerAddNonConstantToPointer.exp
+++ b/src/tests/Typing/TerAddNonConstantToPointer.exp
@@ -19,7 +19,7 @@ proc1_entry:
 l1:
 	p->w0000 = 4<16>
 	p->w0004 = 4<16>
-	p = p + i /16 6<i32>
+	p = (struct Eq_3 *) ((char *) &p->w0000 + i)
 proc1_exit:
 
 // Equivalence classes ////////////

--- a/subjects/CPM-80/CB80.h
+++ b/subjects/CPM-80/CB80.h
@@ -8199,7 +8199,7 @@ T_1841: (in 0x2F<8> @ 0B90 : byte)
   Class: Eq_1840
   DataType: cu8
   OrigDataType: cu8
-T_1842: (in g_t1692.u1[(uint16) g_b1697 /16 3<i32>] < 0x2F<8> @ 0B90 : bool)
+T_1842: (in (&g_t1692.u1->a0000[0<i32>].u0)[(uint16) g_b1697] < 0x2F<8> @ 0B90 : bool)
   Class: Eq_1842
   DataType: bool
   OrigDataType: bool
@@ -8207,11 +8207,11 @@ T_1843: (in CONVERT(Mem0[Mem0[0x1692<16>:word16] + CONVERT(Mem0[0x1697<16>:byte]
   Class: Eq_1843
   DataType: byte
   OrigDataType: byte
-T_1844: (in 0<8> - (byte) ((g_t1692.u1)[(uint16) g_b1697 /16 3<i32>] < 0x2F<8>) @ 0B90 : byte)
+T_1844: (in 0<8> - (byte) ((&(((g_t1692.u1)->a0000))[0<i32>].u0)[(uint16) g_b1697] < 0x2F<8>) @ 0B90 : byte)
   Class: Eq_1844
   DataType: byte
   OrigDataType: byte
-T_1845: (in 0<8> - (byte) (g_t1696.u0 < 1<8>) & 0<8> - (byte) ((g_t1692.u1)[(uint16) g_b1697 /16 3<i32>] < 0x2F<8>) @ 0B90 : byte)
+T_1845: (in 0<8> - (byte) (g_t1696.u0 < 1<8>) & 0<8> - (byte) ((&(((g_t1692.u1)->a0000))[0<i32>].u0)[(uint16) g_b1697] < 0x2F<8>) @ 0B90 : byte)
   Class: Eq_1845
   DataType: byte
   OrigDataType: byte

--- a/subjects/CPM-80/CB80_code.c
+++ b/subjects/CPM-80/CB80_code.c
@@ -737,7 +737,7 @@ Eq_n fn0990(byte f, byte b, Eq_n c, byte d, Eq_n e, union Eq_n & afOut)
 		f = (byte) af_n;
 		if ((SLICE(af_n, byte, 8) & sp_n->b0003) >> 0x01 >= 0x00)
 			break;
-		sp_n->tFFFFFFFE.u1 = (byte *) (g_t1692.u1 + (uint16) g_b1697 /16 3);
+		sp_n->tFFFFFFFE.u1 = (byte *) (&g_t1692.u1->a0000->u0 + (uint16) g_b1697);
 		byte a_n = *sp_n->tFFFFFFFE.u1;
 		Mem429[Mem415[5771:word16] + (CONVERT(Mem415[0x1697:byte], byte, uint16) + 0x01):byte] = a_n;
 		Eq_n C_n = (bool) cond(a_n - 0x2A);
@@ -748,7 +748,7 @@ Eq_n fn0990(byte f, byte b, Eq_n c, byte d, Eq_n e, union Eq_n & afOut)
 		}
 		fn0B91();
 	}
-	cu8 * hl_n = (cu8 *) (g_t1692.u1 + (uint16) g_b1697 /16 3);
+	cu8 * hl_n = (cu8 *) (&g_t1692.u1->a0000->u0 + (uint16) g_b1697);
 	sp_n->tFFFFFFFE.u1 = (byte *) SEQ(SLICE(0x01 - (uint16) g_t1696.u0, byte, 8), f);
 	byte b_n;
 	if ((0x00 - (byte) (*hl_n < 0x2F) & sp_n->b0003) >> 0x01 < 0x00)
@@ -761,7 +761,7 @@ Eq_n fn0990(byte f, byte b, Eq_n c, byte d, Eq_n e, union Eq_n & afOut)
 			return C_n;
 		}
 		sp_n->tFFFFFFFE.u1 = g_t1696.u1;
-		sp_n->ptrFFFFFFFC = (byte *) (g_t1692.u1 + (uint16) g_b1697 /16 3);
+		sp_n->ptrFFFFFFFC = (byte *) (&g_t1692.u1->a0000->u0 + (uint16) g_b1697);
 		byte * de_n = (char *) g_t168B.u1 + 9;
 		byte * bc_n = sp_n->ptrFFFFFFFC;
 		byte l_n = sp_n->b0002;
@@ -776,7 +776,7 @@ Eq_n fn0990(byte f, byte b, Eq_n c, byte d, Eq_n e, union Eq_n & afOut)
 	}
 	else
 	{
-		cu8 * hl_n = (cu8 *) (g_t1692.u1 + (uint16) g_b1697 /16 3);
+		cu8 * hl_n = (cu8 *) (&g_t1692.u1->a0000->u0 + (uint16) g_b1697);
 		sp_n->tFFFFFFFE.u1 = (byte *) SEQ(0x00 - (byte) (g_t1696.u0 < 0x01), f);
 		bcu8 a_n = 0x00 - (byte) (*hl_n < 0x2F) | sp_n->b0003;
 		Eq_n C_n = cond(a_n >> 0x01);
@@ -840,7 +840,7 @@ Eq_n fn0990(byte f, byte b, Eq_n c, byte d, Eq_n e, union Eq_n & afOut)
 word16 fn0B74()
 {
 	byte f;
-	return SEQ(0x00 - (byte) (g_t1696.u0 < 0x01) & 0x00 - (byte) ((g_t1692.u1)[(uint16) g_b1697 /16 3] < 0x2F), f);
+	return SEQ(0x00 - (byte) (g_t1696.u0 < 0x01) & 0x00 - (byte) ((&(((g_t1692.u1)->a0000))[0].u0)[(uint16) g_b1697] < 0x2F), f);
 }
 
 // 0B91: void fn0B91()

--- a/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo.h
+++ b/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo.h
@@ -12166,7 +12166,7 @@ T_2302: (in 2<32> @ 00000E26 : word32)
   Class: Eq_2301
   DataType: up32
   OrigDataType: up32
-T_2303: (in *((char *) &(r4_21 + ((r4_21->ptr0004)->dw004C * 0x14<32>) / 156<i32>)->ptr0004 + 4<i32>) < 2<32> @ 00000E26 : bool)
+T_2303: (in (r4_21->a0000 + (r4_21->ptr0004)->dw004C)[0<i32>].dw0008 < 2<32> @ 00000E26 : bool)
   Class: Eq_2303
   DataType: bool
   OrigDataType: bool
@@ -15120,7 +15120,7 @@ T_3038: (in 0<32> @ 00001210 : word32)
   Class: Eq_3037
   DataType: word32
   OrigDataType: word32
-T_3039: (in *((char *) &(r4_20 + (r2_54 * 0x14<32>) / 128<i32>)->ptr0004 + 4<i32>) != 0<32> @ 00001210 : bool)
+T_3039: (in (r4_20->a0000 + r2_54)[0<i32>].dw0008 != 0<32> @ 00001210 : bool)
   Class: Eq_3039
   DataType: bool
   OrigDataType: bool
@@ -15356,7 +15356,7 @@ T_3097: (in 0<32> @ 00001286 : word32)
   Class: Eq_3096
   DataType: word32
   OrigDataType: word32
-T_3098: (in (r2_40 + (r1_41 * 0x14<32>) / 128<i32>)->a0000[0<i32>].dw0008 != 0<32> @ 00001286 : bool)
+T_3098: (in (r2_40->a0000 + r1_41)[0<i32>].dw0008 != 0<32> @ 00001286 : bool)
   Class: Eq_3098
   DataType: bool
   OrigDataType: bool
@@ -20371,7 +20371,7 @@ T_4340: (in 0xFFFFFFFC<32> @ 0000801C : word32)
   Class: Eq_4340
   DataType: ui32
   OrigDataType: ui32
-T_4341: (in r0_7 + ~r3_18 / 4<i32> & 0xFFFFFFFC<32> @ 0000801C : word32)
+T_4341: (in (char *) r0_7 + ~r3_18 & 0xFFFFFFFC<32> @ 0000801C : word32)
   Class: Eq_4341
   DataType: ui32
   OrigDataType: ui32
@@ -20379,7 +20379,7 @@ T_4342: (in 4<32> @ 0000801C : word32)
   Class: Eq_4342
   DataType: word32
   OrigDataType: word32
-T_4343: (in (r0_7 + ~r3_18 / 4<i32> & 0xFFFFFFFC<32>) + 4<32> @ 0000801C : word32)
+T_4343: (in ((char *) r0_7 + ~r3_18 & 0xFFFFFFFC<32>) + 4<32> @ 0000801C : word32)
   Class: Eq_4343
   DataType: ui32
   OrigDataType: ui32
@@ -28963,7 +28963,7 @@ T_6482: (in 0<32> @ 00009024 : word32)
   Class: Eq_6481
   DataType: word32
   OrigDataType: word32
-T_6483: (in (&(r5_17 + (r1_194 * 0x14<32>) / 128<i32>)->a0000[0<i32>].u0)[1<i32>] != 0<32> @ 00009024 : bool)
+T_6483: (in *((word160) &(r5_17->a0000 + r1_194)[0<i32>] + 4<i32>) != 0<32> @ 00009024 : bool)
   Class: Eq_6483
   DataType: bool
   OrigDataType: bool
@@ -29579,7 +29579,7 @@ T_6636: (in 0<32> @ 00009034 : word32)
   Class: Eq_6635
   DataType: word32
   OrigDataType: word32
-T_6637: (in (&(r5_17 + (r3_199 + (r1_194 - 1<32>) << 2<u32>) / 128<i32>)->a0000[0<i32>].u0)[1<i32>] != 0<32> @ 00009034 : bool)
+T_6637: (in ((char *) r5_17->a0000 + (r3_199 + (r1_194 - 1<32>) << 2<u32>))[4<i32>] != 0<32> @ 00009034 : bool)
   Class: Eq_6637
   DataType: bool
   OrigDataType: bool
@@ -29671,7 +29671,7 @@ T_6659: (in 0<32> @ 00009044 : word32)
   Class: Eq_6635
   DataType: word32
   OrigDataType: word32
-T_6660: (in (&(r5_17 + (r3_199 + (r1_194 - 2<32>) << 2<u32>) / 128<i32>)->a0000[0<i32>].u0)[1<i32>] != 0<32> @ 00009044 : bool)
+T_6660: (in ((char *) r5_17->a0000 + (r3_199 + (r1_194 - 2<32>) << 2<u32>))[4<i32>] != 0<32> @ 00009044 : bool)
   Class: Eq_6660
   DataType: bool
   OrigDataType: bool

--- a/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_privileged_functions.c
+++ b/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_privileged_functions.c
@@ -638,9 +638,9 @@ void xQueueGenericReset(struct Eq_n * r0, word32 r1, word32 cpsr)
 	ui32 r2_n = r0->dw003C * r3_n;
 	struct Eq_n * r0_n = r0->ptr0000;
 	r0->dw0038 = 0x00;
-	r0->dw0004 = r0_n + r2_n / 0x0066;
+	r0->dw0004 = (char *) &r0_n->ptr0000 + r2_n;
 	r0->ptr0044 = (struct Eq_n *) &g_tFFFFFFFF;
-	r0->dw000C = r0_n + (r2_n - r3_n) / 0x0066;
+	r0->dw000C = (char *) &r0_n->ptr0000 + (r2_n - r3_n);
 	r0->ptr0008 = r0_n;
 	r0->b0045 = ~0x00;
 	if (r1 != 0x00)
@@ -701,7 +701,7 @@ void xQueueCreateMutex(word32 cpsr)
 //      xTaskCreateRestricted
 void prvInitialiseNewTask(ui32 r0, word32 r1, ui32 r2, word32 r3, int32 dwArg00, struct Eq_n ** dwArg04, struct Eq_n * dwArg08, struct Eq_n * dwArg0C)
 {
-	ui32 r5_n = dwArg08->ptr0050 + (r2 + 0x3FFFFFFF << 0x02) / 0x0066;
+	ui32 r5_n = (char *) &dwArg08->ptr0050->ptr0000 + (r2 + 0x3FFFFFFF << 0x02);
 	byte * r3_n = r1 - 0x01 + 1;
 	byte * r0_n = (char *) &dwArg08->ptr0050 + 4;
 	uint32 r2_n = dwArg00 & 0x7FFFFFFF;
@@ -1235,7 +1235,7 @@ l00000DB2:
 			}
 			r4_n->dw0084 = ~0x00;
 l00000E14:
-			if (*((char *) &(r4_n + ((r4_n->ptr0004)->dw004C * 0x14) / 0x009C)->ptr0004 + 4) >= 0x02)
+			if ((r4_n->a0000 + (r4_n->ptr0004)->dw004C)[0].dw0008 >= 0x02)
 				r6_n = 0x01;
 l00000E28:
 			if (r4_n->dw0090 != 0x00)
@@ -1465,7 +1465,7 @@ void vTaskSwitchContext()
 	else
 	{
 		r2_n->dw0090 = r3_n;
-		struct Eq_n * r0_n = (struct Eq_n *) (r2_n + ((0x1F - (uint32) ((byte) __count_leading_zeros<word32>(r2_n->dw007C))) * 0x14) / 0x0094);
+		struct Eq_n * r0_n = (struct Eq_n *) ((char *) r2_n + (0x1F - (uint32) ((byte) __count_leading_zeros<word32>(r2_n->dw007C))) * 0x14);
 		struct Eq_n * r1_n = r0_n->ptr000C->ptr0004;
 		r0_n->ptr000C = r1_n;
 		struct Eq_n * r1_n = r1_n;
@@ -1574,7 +1574,7 @@ void vTaskPriorityInherit(struct Eq_n * r0)
 		if (uxListRemove(&r0->dw000C + 6) == 0x00)
 		{
 			uint32 r2_n = r0->dw004C;
-			if (*((char *) &(r4_n + (r2_n * 0x14) / 0x0080)->ptr0004 + 4) == 0x00)
+			if ((r4_n->a0000 + r2_n)[0].dw0008 == 0x00)
 				r4_n->dw007C &= ~(0x01 << r2_n);
 		}
 		uint32 r2_n = r4_n->ptr0004->dw004C;
@@ -1608,7 +1608,7 @@ struct Eq_n * xTaskPriorityDisinherit(struct Eq_n * r0)
 	{
 		uint32 r1_n = r0->dw004C;
 		r2_n = g_ptr12CC;
-		if ((r2_n + (r1_n * 0x14) / 0x0080)->a0000[0].dw0008 == 0x00)
+		if ((r2_n->a0000 + r1_n)[0].dw0008 == 0x00)
 			r2_n->dw007C &= ~(0x01 << r1_n);
 	}
 	else

--- a/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_text.c
+++ b/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_text.c
@@ -51,7 +51,7 @@ void ResetISR(word32 cpsr)
 	word32 * r0_n = g_ptr8030;
 	if (r3_n < r0_n)
 	{
-		word32 * r2_n = r3_n + ((r0_n + ~r3_n / 4 & ~0x03) + 0x04) / 4;
+		word32 * r2_n = (word32 *) ((char *) r3_n + (((char *) r0_n + ~r3_n & ~0x03) + 0x04));
 		do
 		{
 			*r3_n = 0x00;
@@ -1394,7 +1394,7 @@ word32 vCoRoutineSchedule(struct Eq_n * r0, word32 r4, word32 r5, word32 r6, wor
 		__msr(cpsr, 0x00);
 		uxListRemove((char *) r4_n + 4);
 		uint32 r3_n = r4_n->dw002C;
-		r0 = (struct Eq_n *) (&r5_n->a0000->u0 + 1 + (r3_n * 0x14) / 0x0080);
+		r0 = (struct Eq_n *) ((&r5_n->a0000->u0 + 1)->a0000 + r3_n);
 		if (r3_n > r5_n->dw0070)
 			r5_n->dw0070 = r3_n;
 		vListInsertEnd(r0, (char *) r4_n + 4);
@@ -1456,13 +1456,13 @@ l00008F94:
 	r5_n->dw0078 = r3_n;
 	ui32 r3_n = r1_n << 2;
 	uint32 r2_n;
-	if ((&(r5_n + (r1_n * 0x14) / 0x0080)->a0000[0].u0)[1] == 0x00)
+	if (*((word160) &(r5_n->a0000 + r1_n)[0] + 4) == 0x00)
 	{
 		if (r1_n == 0x00)
 			return cpsr;
 		r3_n = r1_n - 0x01 << 2;
 		r2_n = r1_n - 0x01;
-		if ((&(r5_n + (r3_n + (r1_n - 0x01) << 0x02) / 0x0080)->a0000[0].u0)[1] == 0x00)
+		if (((char *) r5_n->a0000 + (r3_n + (r1_n - 0x01) << 0x02))[4] == 0x00)
 		{
 			if (r1_n == 0x01)
 			{
@@ -1472,7 +1472,7 @@ l00009046:
 			}
 			r3_n = r1_n - 0x02 << 2;
 			r2_n = r1_n - 0x02;
-			if ((&(r5_n + (r3_n + (r1_n - 0x02) << 0x02) / 0x0080)->a0000[0].u0)[1] == 0x00)
+			if (((char *) r5_n->a0000 + (r3_n + (r1_n - 0x02) << 0x02))[4] == 0x00)
 				goto l00009046;
 		}
 		r5_n->dw0070 = r2_n;
@@ -1480,7 +1480,7 @@ l00009046:
 	else
 		r2_n = r1_n;
 	ui32 r3_n = r3_n + r2_n;
-	struct Eq_n * r1_n = (struct Eq_n *) (r5_n + (r3_n << 2) / 0x0080);
+	struct Eq_n * r1_n = (struct Eq_n *) ((char *) r5_n->a0000 + (r3_n << 2));
 	struct Eq_n * r2_n = r1_n->ptr0008->ptr0004;
 	struct Eq_n * r3_n = (r3_n << 2) + g_dw908C;
 	r1_n->ptr0008 = r2_n;
@@ -2246,7 +2246,7 @@ void OSRAMInit(word32 r0)
 			break;
 		r4_n = (word32) r3_n->b01EC;
 		r0_n = (word32) r3_n->b01ED;
-		r6_n = (word32) (r3_n + r4_n / 494)->b01EC;
+		r6_n = (word32) ((char *) r3_n + r4_n)[492];
 	}
 	OSRAMClear();
 }
@@ -2275,7 +2275,7 @@ void OSRAMDisplayOn()
 			break;
 		r4_n = (word32) r3_n->b01EC;
 		r0_n = (word32) r3_n->b01ED;
-		r6_n = (word32) (r3_n + r4_n / 494)->b01EC;
+		r6_n = (word32) ((char *) r3_n + r4_n)[492];
 	}
 }
 

--- a/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_text_memcpy.c
+++ b/subjects/Elf/ARM/angr-685/RTOSDemo.reko/RTOSDemo_text_memcpy.c
@@ -50,8 +50,8 @@ l0000A63C:
 			++r4_n;
 		} while (r5_n != r3_n);
 		ui32 r6_n = r2 - 0x10 & ~0x0F;
-		r5_n = r0 + (r6_n + 0x10) / 16;
-		r1 += (r6_n + 0x10) / 16;
+		r5_n = (struct Eq_n *) ((char *) r0->a0000 + (r6_n + 0x10));
+		r1 = (struct Eq_n *) ((char *) r1->a0000 + (r6_n + 0x10));
 		if ((r2 & 0x0F) > 0x03)
 		{
 			uint32 r6_n = (r2 & 0x0F) - 0x04;
@@ -59,7 +59,7 @@ l0000A63C:
 			uint32 r4_n = (r6_n >> 2) + 0x01;
 			do
 			{
-				r5_n[r3_n / 16] = r1[r3_n / 16];
+				*((char *) &r5_n->a0000[0] + r3_n) = *((char *) &r1->a0000[0] + r3_n);
 				r3_n += 0x04;
 			} while (r3_n != r4_n << 2);
 			struct Eq_n * r3_n = (r6_n & ~0x03) + 0x04;

--- a/subjects/Elf/AVR32/ls.reko/ls_seg00001000_0000.c
+++ b/subjects/Elf/AVR32/ls.reko/ls_seg00001000_0000.c
@@ -1182,7 +1182,7 @@ word64 fn00003334(Eq_n r4, word32 r8, Eq_n r9, word32 r10, Eq_n r11, Eq_n lr, Eq
 	struct Eq_n * r10_n = r6_n->ptr0008;
 	Eq_n r8_n;
 	r8_n.u4 = r10_n->t000C.u4;
-	word32 r4_n = r10_n->ptr0014 + (r8_n * 0x7C) / 0x0C;
+	word32 r4_n = &r10_n->ptr0014->b0000 + r8_n * 0x7C;
 	r6_n->ptr002C();
 	Eq_n r4_n;
 	Eq_n r3_r2_n;
@@ -1809,7 +1809,7 @@ Eq_n fn00003A44(Eq_n r0, Eq_n r2, Eq_n r5, Eq_n r11, Eq_n r12, Eq_n lr, union Eq
 						r8_n = 0x01;
 					if ((byte) r8_n == (byte) r9_n)
 						r8_n = 0x02;
-					word32 r12_n = (word32) r12_n[r8_n / 2];
+					word32 r12_n = (word32) (&r12_n->b0000)[r8_n];
 					if (r12_n != 0x00 && (byte) r12_n != 0x2F)
 						goto l00003B18;
 					goto l00003AE8;
@@ -3400,7 +3400,7 @@ l000050E4:
 				{
 					int32 r9_n = sp_n->dw001C;
 					Eq_n r5_n;
-					r5_n.u4 = r7_n + r9_n / 352;
+					r5_n.u4 = (char *) r7_n + r9_n;
 					lr = fn00002D38(r4_n, r5_n, (bool) r4_n.u0 + r9_n, lr);
 					sp_n->dw001C = (word32) r5_n;
 				}
@@ -9467,14 +9467,14 @@ Eq_n fn00009C40(Eq_n r0, Eq_n r1, Eq_n r2, <anonymous> * r9, word32 * r10, uint3
 		}
 		goto l00009D62;
 	}
-	Eq_n r0_n = fn00009C40(r11 >> 1, r1, r2, r9, r10, r11 - (r11 >> 1), r12 + ((r11 >> 1) << 0x02) / 8, lr, out r1_n, out r2_n, out r3_n, out r4_n, out r5_n, out r6_n, out r10, out lr);
+	Eq_n r0_n = fn00009C40(r11 >> 1, r1, r2, r9, r10, r11 - (r11 >> 1), &r12->dw0000 + (r11 >> 1), lr, out r1_n, out r2_n, out r3_n, out r4_n, out r5_n, out r6_n, out r10, out lr);
 	struct Eq_n * sp_n = fp - 0x3C;
 	if (r0_n == 0x01)
 	{
 		*r10 = r3_n[0];
 		goto l00009D02;
 	}
-	Eq_n r0_n = fn00009C40(fn00009C40(r0_n, r1_n, r2_n, r9, r10, r0_n - (r11 >> 2), r3_n + __align(r11, 4) / 4, lr, out r1_n, out r2_n, out r3_n, out r4_n, out r5_n, out r6_n, out r10_n, out lr_n), r1_n, r2_n, r9, r10, r4_n, r3_n, lr_n, out r1_n, out r2_n, out r3_n, out r4_n, out r5_n, out r6_n, out r10_n, out lr_n);
+	Eq_n r0_n = fn00009C40(fn00009C40(r0_n, r1_n, r2_n, r9, r10, r0_n - (r11 >> 2), (char *) r3_n + __align(r11, 4), lr, out r1_n, out r2_n, out r3_n, out r4_n, out r5_n, out r6_n, out r10_n, out lr_n), r1_n, r2_n, r9, r10, r4_n, r3_n, lr_n, out r1_n, out r2_n, out r3_n, out r4_n, out r5_n, out r6_n, out r10_n, out lr_n);
 	struct Eq_n * sp_n = fp - 0x3C;
 	word32 r1_n = *r5_n;
 	word32 r2_n = r3_n[0];
@@ -9582,7 +9582,7 @@ ui32 g_dw9D64 = 0xD832D703; // 00009D64
 	word32 r6_n;
 	<anonymous> * r10_n;
 	ptr32 lr_n;
-	fn00009C40(r0, r1, r2, r10, r12 + (r11 << 0x02) / 8, r11, r12, lr, out r1_n, out r2_n, out r3_n, out r4_n, out r5_n, out r6_n, out r10_n, out lr_n);
+	fn00009C40(r0, r1, r2, r10, &r12->dw0000 + r11, r11, r12, lr, out r1_n, out r2_n, out r3_n, out r4_n, out r5_n, out r6_n, out r10_n, out lr_n);
 	lrOut = lr_n;
 	return r10_n;
 }

--- a/subjects/Elf/MIPS/redir/redir.reko/redir.h
+++ b/subjects/Elf/MIPS/redir/redir.reko/redir.h
@@ -20793,7 +20793,7 @@ T_4600: (in 32<i32> @ 00405A04 : int32)
   Class: Eq_4599
   DataType: int32
   OrigDataType: int32
-T_4601: (in (word32) (g_ptr10000A40 + (dwLoc014C_568 * 0x98<32> + 8<i32>) / 1686<i32>)->a0004[0<i32>].ptr0000 == 32<i32> @ 00405A04 : bool)
+T_4601: (in (word32) ((char *) g_ptr10000A40 + (dwLoc014C_568 * 0x98<32> + 8<i32>))[4<i32>] == 32<i32> @ 00405A04 : bool)
   Class: Eq_4601
   DataType: bool
   OrigDataType: bool
@@ -21165,7 +21165,7 @@ T_4691: (in CONVERT(Mem116[Mem116[r28_125 + -32288<i32>:word32] + (dwLoc24_383 *
   Class: Eq_4679
   DataType: word32
   OrigDataType: word32
-T_4692: (in (word32) bLoc1C_368 == (word32) (*((char *) (r28_125->ptrFFFF81E0 + (dwLoc24_383 * 0x98<32> + 8<i32>) / 8<i32>) + 4<i32>)) @ 00405F38 : bool)
+T_4692: (in (word32) bLoc1C_368 == (word32) ((char *) r28_125->ptrFFFF81E0 + (dwLoc24_383 * 0x98<32> + 8<i32>))[4<i32>] @ 00405F38 : bool)
   Class: Eq_4692
   DataType: bool
   OrigDataType: bool
@@ -21349,11 +21349,11 @@ T_4737: (in CONVERT(Mem116[Mem116[0x10000A40<32>:word32] + (dwLoc24_383 * 0x98<3
   Class: Eq_4737
   DataType: word32
   OrigDataType: word32
-T_4738: (in toupper((word32) (g_ptr10000A40 + (dwLoc24_383 * 0x98<32> + 8<i32>) / 1686<i32>)->a0004[0<i32>].ptr0000) @ 00405FF4 : word32)
+T_4738: (in toupper((word32) ((char *) g_ptr10000A40 + (dwLoc24_383 * 0x98<32> + 8<i32>))[4<i32>]) @ 00405FF4 : word32)
   Class: Eq_4724
   DataType: word32
   OrigDataType: word32
-T_4739: (in r2_206 == toupper((word32) (((g_ptr10000A40 + (dwLoc24_383 * 0x98<32> + 8<i32>) / 1686<i32>)->a0004))[0<i32>].ptr0000) @ 00405FF4 : bool)
+T_4739: (in r2_206 == toupper((word32) ((char *) g_ptr10000A40 + (dwLoc24_383 * 0x98<32> + 8<i32>))[4<i32>]) @ 00405FF4 : bool)
   Class: Eq_4739
   DataType: bool
   OrigDataType: bool
@@ -21457,7 +21457,7 @@ T_4764: (in 32<i32> @ 00405EE4 : int32)
   Class: Eq_4763
   DataType: int32
   OrigDataType: int32
-T_4765: (in (word32) *((char *) (r28_125->ptrFFFF81E0 + (dwLoc24_383 * 0x98<32> + 8<i32>) / 8<i32>) + 4<i32>) == 32<i32> @ 00405EE4 : bool)
+T_4765: (in (word32) ((char *) r28_125->ptrFFFF81E0 + (dwLoc24_383 * 0x98<32> + 8<i32>))[4<i32>] == 32<i32> @ 00405EE4 : bool)
   Class: Eq_4765
   DataType: bool
   OrigDataType: bool
@@ -21978,7 +21978,7 @@ T_4894: (in Mem48[r2_94 + 0<32>:word32] @ 004065AC : word32)
   Class: Eq_4880
   DataType: (ptr32 char)
   OrigDataType: (ptr32 char)
-T_4895: (in printf("-%c %s ", (g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>) / 1686<i32>)->a0004[0<i32>].ptr0000, *r2_94) @ 004065AC : int32)
+T_4895: (in printf("-%c %s ", ((char *) g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>))[4<i32>], *r2_94) @ 004065AC : int32)
   Class: Eq_4895
   DataType: int32
   OrigDataType: int32
@@ -22050,7 +22050,7 @@ T_4912: (in 2<32> @ 00406414 : ui32)
   Class: Eq_4912
   DataType: ui32
   OrigDataType: ui32
-T_4913: (in (word32) (g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>) / 1686<i32>)->a0004[0<i32>].ptr0000 * 2<32> @ 00406414 : word32)
+T_4913: (in (word32) ((char *) g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>))[4<i32>] * 2<32> @ 00406414 : word32)
   Class: Eq_4913
   DataType: ui32
   OrigDataType: ui32
@@ -22066,7 +22066,7 @@ T_4916: (in 1<32> @ 00406414 : word32)
   Class: Eq_4916
   DataType: ui32
   OrigDataType: ui32
-T_4917: (in (word32) *((char *) *g_ptr10000A6C + (word32) (((g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>) / 1686<i32>)->a0004))[0<i32>].ptr0000 * 2<32>) & 1<32> @ 00406414 : word32)
+T_4917: (in (word32) *((char *) *g_ptr10000A6C + (word32) ((char *) g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>))[4<i32>] * 2<32>) & 1<32> @ 00406414 : word32)
   Class: Eq_4917
   DataType: ui32
   OrigDataType: ui32
@@ -22074,7 +22074,7 @@ T_4918: (in 0xFFFF<32> @ 00406414 : word32)
   Class: Eq_4918
   DataType: ui32
   OrigDataType: ui32
-T_4919: (in (word32) *((char *) *g_ptr10000A6C + (word32) (((g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>) / 1686<i32>)->a0004))[0<i32>].ptr0000 * 2<32>) & 1<32> & 0xFFFF<32> @ 00406414 : word32)
+T_4919: (in (word32) *((char *) *g_ptr10000A6C + (word32) ((char *) g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>))[4<i32>] * 2<32>) & 1<32> & 0xFFFF<32> @ 00406414 : word32)
   Class: Eq_4919
   DataType: ui32
   OrigDataType: ui32
@@ -22082,7 +22082,7 @@ T_4920: (in 0<32> @ 00406414 : word32)
   Class: Eq_4919
   DataType: ui32
   OrigDataType: word32
-T_4921: (in ((word32) *((char *) *g_ptr10000A6C + (word32) (((g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>) / 1686<i32>)->a0004))[0<i32>].ptr0000 * 2<32>) & 1<32> & 0xFFFF<32>) == 0<32> @ 00406414 : bool)
+T_4921: (in ((word32) *((char *) *g_ptr10000A6C + (word32) ((char *) g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>))[4<i32>] * 2<32>) & 1<32> & 0xFFFF<32>) == 0<32> @ 00406414 : bool)
   Class: Eq_4921
   DataType: bool
   OrigDataType: bool
@@ -22138,7 +22138,7 @@ T_4934: (in CONVERT(Mem48[Mem48[0x10000A40<32>:word32] + (dwLoc18_226 * 0x98<32>
   Class: Eq_4934
   DataType: word32
   OrigDataType: word32
-T_4935: (in toupper((word32) (g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>) / 1686<i32>)->a0004[0<i32>].ptr0000) @ 004064C4 : word32)
+T_4935: (in toupper((word32) ((char *) g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>))[4<i32>]) @ 004064C4 : word32)
   Class: Eq_4935
   DataType: word32
   OrigDataType: word32
@@ -22198,7 +22198,7 @@ T_4949: (in CONVERT(Mem48[Mem48[0x10000A40<32>:word32] + (dwLoc18_226 * 0x98<32>
   Class: Eq_4949
   DataType: word32
   OrigDataType: word32
-T_4950: (in tolower((word32) (g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>) / 1686<i32>)->a0004[0<i32>].ptr0000) @ 0040646C : word32)
+T_4950: (in tolower((word32) ((char *) g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>))[4<i32>]) @ 0040646C : word32)
   Class: Eq_4935
   DataType: word32
   OrigDataType: word32
@@ -22330,7 +22330,7 @@ T_4982: (in 32<i32> @ 00406364 : int32)
   Class: Eq_4981
   DataType: int32
   OrigDataType: int32
-T_4983: (in (word32) (g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>) / 1686<i32>)->a0004[0<i32>].ptr0000 != 32<i32> @ 00406364 : bool)
+T_4983: (in (word32) ((char *) g_ptr10000A40 + (dwLoc18_226 * 0x98<32> + 8<i32>))[4<i32>] != 32<i32> @ 00406364 : bool)
   Class: Eq_4983
   DataType: bool
   OrigDataType: bool

--- a/subjects/Elf/MIPS/redir/redir.reko/redir_text.c
+++ b/subjects/Elf/MIPS/redir/redir.reko/redir_text.c
@@ -1995,7 +1995,7 @@ void properties_load(char * r4, char * r5, word32 ra)
 					*r2_n = 0x00;
 					int32 dwLoc2C_n = 0x00;
 					ui32 dwLoc014C_n = 0x00;
-					while ((word32) (g_ptr10000A40 + (dwLoc014C_n * 0x98 + 8) / 0x0696)->a0004[0].ptr0000 != 32 && dwLoc2C_n == 0x00)
+					while ((word32) ((char *) g_ptr10000A40 + (dwLoc014C_n * 0x98 + 8))[4] != 32 && dwLoc2C_n == 0x00)
 					{
 						if (strcasecmp(r2_n, g_ptr10000A40->a0004[dwLoc014C_n].ptr0000) == 0x00)
 						{
@@ -2070,9 +2070,9 @@ char * properties_parse_command_line[](int32 r4, char * r5[], word32 r16, word32
 			}
 			int32 dwLoc20_n = 0x00;
 			ui32 dwLoc24_n = 0x00;
-			while ((word32) *((char *) (r28_n->ptrFFFF81E0 + (dwLoc24_n * 0x98 + 8) / 8) + 4) != 32 && dwLoc20_n == 0x00)
+			while ((word32) ((char *) r28_n->ptrFFFF81E0 + (dwLoc24_n * 0x98 + 8))[4] != 32 && dwLoc20_n == 0x00)
 			{
-				if ((word32) bLoc1C_n != (word32) (*((char *) (r28_n->ptrFFFF81E0 + (dwLoc24_n * 0x98 + 8) / 8) + 4)))
+				if ((word32) bLoc1C_n != (word32) ((char *) r28_n->ptrFFFF81E0 + (dwLoc24_n * 0x98 + 8))[4])
 				{
 					if (r28_n->ptrFFFF81E0->a0008[dwLoc24_n].t0000.u0 != 2)
 						goto l004061C8;
@@ -2082,7 +2082,7 @@ char * properties_parse_command_line[](int32 r4, char * r5[], word32 r16, word32
 					char * (* r5_n)[];
 					r5_n = r5_n;
 					word32 r2_n;
-					if (r2_n == toupper((word32) (((g_ptr10000A40 + (dwLoc24_n * 0x98 + 8) / 0x0696)->a0004))[0].ptr0000))
+					if (r2_n == toupper((word32) ((char *) g_ptr10000A40 + (dwLoc24_n * 0x98 + 8))[4]))
 						goto l00406004;
 					r5_n = r5_n;
 				}
@@ -2144,22 +2144,22 @@ struct Eq_n * properties_print_usage(Eq_n r4)
 	else
 		printf("Usage: redir -h ");
 	ui32 dwLoc18_n = 0x00;
-	while ((word32) (g_ptr10000A40 + (dwLoc18_n * 0x98 + 8) / 0x0696)->a0004[0].ptr0000 != 32)
+	while ((word32) ((char *) g_ptr10000A40 + (dwLoc18_n * 0x98 + 8))[4] != 32)
 	{
 		if (g_ptr10000A40->a0004[dwLoc18_n].t0004.u0 == 2)
 		{
 			word32 dwLoc14_n;
-			if (((word32) *((char *) *g_ptr10000A6C + (word32) (((g_ptr10000A40 + (dwLoc18_n * 0x98 + 8) / 0x0696)->a0004))[0].ptr0000 * 0x02) & 0x01 & 0xFFFF) != 0x00)
-				dwLoc14_n = tolower((word32) (g_ptr10000A40 + (dwLoc18_n * 0x98 + 8) / 0x0696)->a0004[0].ptr0000);
+			if (((word32) *((char *) *g_ptr10000A6C + (word32) ((char *) g_ptr10000A40 + (dwLoc18_n * 0x98 + 8))[4] * 0x02) & 0x01 & 0xFFFF) != 0x00)
+				dwLoc14_n = tolower((word32) ((char *) g_ptr10000A40 + (dwLoc18_n * 0x98 + 8))[4]);
 			else
-				dwLoc14_n = toupper((word32) (g_ptr10000A40 + (dwLoc18_n * 0x98 + 8) / 0x0696)->a0004[0].ptr0000);
-			struct Eq_n * r1_n = (struct Eq_n *) (g_ptr10000A40 + (dwLoc18_n * 0x98 + 8) / 0x0696);
+				dwLoc14_n = toupper((word32) ((char *) g_ptr10000A40 + (dwLoc18_n * 0x98 + 8))[4]);
+			struct Eq_n * r1_n = (struct Eq_n *) ((char *) g_ptr10000A40 + (dwLoc18_n * 0x98 + 8));
 			printf("-%c|%c ", r1_n->t0004.u1, (char) dwLoc14_n);
 		}
 		else
 		{
 			char ** r2_n = (char **) (g_ptr10000A40->a0004 + dwLoc18_n).ptr0000;
-			printf("-%c %s ", (g_ptr10000A40 + (dwLoc18_n * 0x98 + 8) / 0x0696)->a0004[0].ptr0000, *r2_n);
+			printf("-%c %s ", ((char *) g_ptr10000A40 + (dwLoc18_n * 0x98 + 8))[4], *r2_n);
 		}
 		++dwLoc18_n;
 	}

--- a/subjects/Elf/Sparc/from_boomerang/subject.reko/subject_fini.c
+++ b/subjects/Elf/Sparc/from_boomerang/subject.reko/subject_fini.c
@@ -16,7 +16,7 @@ void _fini(word32 o0, word32 o1, word32 o2, word32 o3, word32 o4, word32 o5, str
 //      _fini
 void fn00010CC8(struct Eq_n * o7, word32 i0, word32 i1, word32 i2, word32 i3, word32 i4, word32 i5, ptr32 i6, struct Eq_n * i7)
 {
-	<anonymous> * l0_n = (<anonymous> *) *((char *) (o7 + o7->dw0008 / 0x0C) - 4);
+	<anonymous> * l0_n = (<anonymous> *) ((char *) o7 + o7->dw0008)[-4];
 	if (l0_n == null)
 		return;
 	l0_n();

--- a/subjects/Elf/Sparc/from_boomerang/subject.reko/subject_init.c
+++ b/subjects/Elf/Sparc/from_boomerang/subject.reko/subject_init.c
@@ -18,7 +18,7 @@ void _init(word32 o0, word32 o1, word32 o2, word32 o3, word32 o4, word32 o5, str
 //      _init
 void fn00010C90(struct Eq_n * o7, word32 i0, word32 i1, word32 i2, word32 i3, word32 i4, word32 i5, ptr32 i6, struct Eq_n * i7)
 {
-	<anonymous> * l0_n = (<anonymous> *) *((char *) (o7 + o7->dw0008 / 0x0C) - 8);
+	<anonymous> * l0_n = (<anonymous> *) ((char *) o7 + o7->dw0008)[-8];
 	if (l0_n == null)
 		return;
 	l0_n();

--- a/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize.h
+++ b/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize.h
@@ -6920,7 +6920,7 @@ T_916: (in 0<32> @ 00011CE8 : word32)
   Class: Eq_915
   DataType: word32
   OrigDataType: word32
-T_917: (in o0.ptr0000[o3_41 * 0xC<32> / 8<i32>] == 0<32> @ 00011CE8 : bool)
+T_917: (in o0.ptr0000->a0000[o3_41].ptr0000 == 0<32> @ 00011CE8 : bool)
   Class: Eq_917
   DataType: bool
   OrigDataType: bool

--- a/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize_text.c
+++ b/subjects/Elf/Sparc/rtems/sparc-rtems-unprotoize.reko/sparc-rtems-unprotoize_text.c
@@ -10,7 +10,7 @@ void _start(void (* g1)(), word32 o3, word32 o4, word32 o5, word32 o7, Eq_n tArg
 	if (g1 == null)
 	{
 		atexit(&g_t16EE4);
-		_environ = &tArg44 + ((_init(o3, o4, o5, o7) << 0x02) + 0x04) / 4;
+		_environ = (char *) &tArg44 + ((_init(o3, o4, o5, o7) << 0x02) + 0x04);
 		exit(main(&tArg44));
 	}
 	else
@@ -684,7 +684,7 @@ Eq_n lookup(Eq_n o0, Eq_n o1, struct Eq_n & l1Out, union Eq_n & i1Out)
 		o3_n += o1_n;
 	}
 	ui32 o3_n = o3_n & 0x01FF;
-	Eq_n i0_n = (Eq_n) (o0.ptr0000 + (o3_n * 0x0C) / 8);
+	Eq_n i0_n = (Eq_n) &(o0.ptr0000->a0000 + o3_n)->ptr0000;
 	char * o0_n = i0_n.ptr0000->ptr0004;
 	Eq_n o0_n;
 	if (o0_n == null)
@@ -693,7 +693,7 @@ Eq_n lookup(Eq_n o0, Eq_n o1, struct Eq_n & l1Out, union Eq_n & i1Out)
 	{
 		if (strcmp(o0_n, o1) == 0x00)
 			goto l00011D34;
-		if (o0.ptr0000[o3_n * 0x0C / 8] != 0x00)
+		if (o0.ptr0000->a0000[o3_n].ptr0000 != 0x00)
 		{
 			i0_n = (Eq_n) i0_n.ptr0000->a0000[0].ptr0000;
 			while (strcmp(i0_n.ptr0000->ptr0004, o1) != 0x00)
@@ -1603,7 +1603,7 @@ Eq_n munge_compile_params(Eq_n o0, ptr32 & i6Out)
 	o3_n = l0_n + 0x02;
 l00012D00:
 	aux_info_file_name_index = o3_n;
-	sp_n->a0060[g2_n / 4] = 0x00017220;
+	*((word32) &sp_n->a0060[0] + g2_n) = (word32[]) 0x00017220;
 	ui32 l0_n = o3_n + 0x01;
 	input_file_name_index = l0_n + 0x03;
 	sp_n->a0060[o3_n] = 0x00;
@@ -2954,7 +2954,7 @@ void _obstack_begin(struct Eq_n * o0, word32 o1, word32 o2, <anonymous> * o3, wo
 		word32 o1_n = &i1_n->dw0004 + 1;
 		i0_n->dw000C = o1_n;
 		i0_n->dw0008 = o1_n;
-		word32 o0_n = i1_n + o0_n / 8;
+		word32 o0_n = (char *) &i1_n->dw0000 + o0_n;
 		i1_n->dw0000 = o0_n;
 		i0_n->dw0010 = o0_n;
 		i1_n->dw0004 = 0x00;
@@ -3007,7 +3007,7 @@ void _obstack_begin_n(struct Eq_n * o0, word32 o1, word32 o2, <anonymous> * o3, 
 		word32 o1_n = &i1_n->dw0004 + 1;
 		i0_n->dw000C = o1_n;
 		i0_n->dw0008 = o1_n;
-		word32 o0_n = i1_n + o0_n / 8;
+		word32 o0_n = (char *) &i1_n->dw0000 + o0_n;
 		i1_n->dw0000 = o0_n;
 		i0_n->dw0010 = o0_n;
 		i1_n->dw0004 = 0x00;
@@ -3057,7 +3057,7 @@ void _obstack_newchunk(struct Eq_n * o0, word32 o1, word32 o3, word32 o4, word32
 		i0_n->ptr0004 = l0_n;
 	struct Eq_n * l1_n;
 	l0_n->ptr0004 = l1_n;
-	ptr32 o1_n = l0_n + i1_n / 8;
+	ptr32 o1_n = (char *) &l0_n->ptr0000 + i1_n;
 	i0_n->ptr0010 = o1_n;
 	l0_n->ptr0000 = o1_n;
 	Eq_n l2_n;
@@ -3074,7 +3074,7 @@ void _obstack_newchunk(struct Eq_n * o0, word32 o1, word32 o3, word32 o4, word32
 		if (o0_n >= 0x01)
 		{
 			g2_n = (struct Eq_n *) ((char *) &l1_n->ptr0004 + 4);
-			word32 * o4_n = (word32 *) (l0_n + (((word32) o0_n - 1 << 0x02) + 0x08) / 8);
+			word32 * o4_n = (word32 *) ((char *) &l0_n->ptr0000 + (((word32) o0_n - 1 << 0x02) + 0x08));
 			while (true)
 			{
 				o2_n = (struct Eq_n *) i0_n->ptr0008[o3_n * 0x04];
@@ -3453,7 +3453,7 @@ l00015D40:
 	{
 		g2_n = optind;
 l00015D44:
-		g_ptr2B2F0 += (g2_n - g_ptr2B300) / 4;
+		g_ptr2B2F0 = (ptr32 *) ((char *) g_ptr2B2F0 + (g2_n - g_ptr2B300));
 		g_ptr2B300 = g2_n;
 		i2Out = i2_n;
 		i4Out = i4_n;
@@ -3502,15 +3502,15 @@ l00015D30:
 		ptr32 * g4_n;
 		if (g3_n > 0x00)
 		{
-			g4_n = i4_n + g3_n / 4;
+			g4_n = (ptr32 *) ((char *) i4_n + g3_n);
 			int32 i3_n = g3_n;
 			int32 i1_n = i4_n << 0x02;
 			int32 g3_n = g1_n << 0x02;
 			while (true)
 			{
-				i2_n = o0[i1_n / 4];
-				o0[i1_n / 4] = o0[g3_n / 4];
-				o0[g3_n / 4] = i2_n;
+				i2_n = (int8 *) *((char *) &o0[0] + i1_n);
+				*((char *) &o0[0] + i1_n) = *((char *) &o0[0] + g3_n);
+				*((char *) &o0[0] + g3_n) = (word32 (*)[]) i2_n;
 				i3_n += ~0x00;
 				g3_n += 0x04;
 				if (i3_n == 0x00)
@@ -3520,7 +3520,7 @@ l00015D30:
 			i1_n = i1_n + 0x04;
 		}
 		else
-			g4_n = i4_n + g3_n / 4;
+			g4_n = (ptr32 *) ((char *) i4_n + g3_n);
 		i4_n = g4_n;
 	}
 	v28_n = i5_n <= g1_n;

--- a/subjects/Elf/nanoMips/ping/ping.reko/ping_text_0000.c
+++ b/subjects/Elf/nanoMips/ping/ping.reko/ping_text_0000.c
@@ -1969,7 +1969,7 @@ void ping4_parse_reply(Eq_n r0, Eq_n r4, struct Eq_n * r5, Eq_n r6, Eq_n r7, Eq_
 					Eq_n r4_n = __ins<word32,word32>(r4_n.u3 + 3, 0x00, 0x00, 0x01);
 					r7_n = r7_n + r4_n;
 					r7_n = r7_n;
-					if (r4_n.u12 + 3 < (r5_n + r19_n / 0x0D) - r7_n)
+					if (r4_n.u12 + 3 < (&(r5_n->t0000).u0 + r19_n) - r7_n)
 						continue;
 				}
 l00401A26:
@@ -2001,7 +2001,7 @@ l00401A26:
 				ui32 r17_n = (r16_n[4] & 0x0F) + 0x04;
 				if (r20_n < r17_n << 0x02)
 					return;
-				struct Eq_n * r17_n = (struct Eq_n *) (r16_n + ((r17_n << 0x02) + ~0x07) / 2);
+				struct Eq_n * r17_n = (struct Eq_n *) (&r16_n->b0000 + ((r17_n << 0x02) + ~0x07));
 				if ((word32) r17_n->b0000 != 0x08 || (g_t43148C.u3 != r16_n[0x0C] || is_ours(r4, (word32) r17_n->w0004) == 0x00))
 					return;
 				if (((word32) r16_n->b0000 + ~0x03 & 0xFF) < 0x02)
@@ -2916,7 +2916,7 @@ struct Eq_n * gather_statistics(struct Eq_n * r4, word32 r5, Eq_n r6, Eq_n r7, E
 	++nreceived;
 	Eq_n r17_n = r10;
 	Eq_n r20_n;
-	r20_n.u3 = r4 + r5 / 2;
+	r20_n.u3 = &r4->b0000 + r5;
 	if (r9 == 0x00)
 	{
 		Eq_n r7_n;
@@ -6564,10 +6564,10 @@ l00404B86:
 				r20_n = 0x03F0;
 			}
 			Eq_n r16_n;
-			r16_n.u0 = g_a432550 + r16_n / 4;
+			r16_n.u0 = (char *) g_a432550 + r16_n;
 			if (g_dw45443C == 0x00)
 			{
-				if ((g_a432550 + r20_n / 4)[4] != 0x00)
+				if (((char *) g_a432550 + r20_n)[16] != 0x00)
 					goto l00404C8E;
 				r7_n = r18_n;
 				goto l00404BB8;
@@ -6588,11 +6588,11 @@ l00404B86:
 				r2 = __wait(r16_n, &r16_n.u1->dw0004, 0x01, 0x01, out r4_n, out r5_n, out r8, out r9_n);
 			}
 			r7_n.u3 = r4->t0004.u3;
-			if ((g_a432550 + r20_n / 4)[4] == 0x00)
+			if (((char *) g_a432550 + r20_n)[16] == 0x00)
 			{
 l00404BB8:
-				struct Eq_n * r20_n = (struct Eq_n *) (g_a432550 + r20_n / 4);
-				ui32 r6_n = g_a432550 + ((r22_n << 0x04) + 0x08) / 4;
+				struct Eq_n * r20_n = (struct Eq_n *) ((char *) g_a432550 + r20_n);
+				ui32 r6_n = (char *) g_a432550 + ((r22_n << 0x04) + 0x08);
 				r20_n->dw0010 = r6_n;
 				r20_n->dw0014 = r6_n;
 			}
@@ -6760,10 +6760,10 @@ l00404D5A:
 				r20_n = 0x03F0;
 			}
 			Eq_n r16_n;
-			r16_n.u0 = g_a432550 + r16_n / 4;
+			r16_n.u0 = (char *) g_a432550 + r16_n;
 			if (g_dw45443C == 0x00)
 			{
-				if ((g_a432550 + r20_n / 4)[4] != 0x00)
+				if (((char *) g_a432550 + r20_n)[16] != 0x00)
 					goto l00404E62;
 				r7_n = r18_n;
 				goto l00404D8C;
@@ -6782,11 +6782,11 @@ l00404D5A:
 				r2 = __wait(r16_n, &r16_n.u1->dw0004, 0x01, 0x01, out r4_n, out r5, out r8, out r9);
 			}
 			r7_n.u3 = *r4.u5;
-			if ((g_a432550 + r20_n / 4)[4] == 0x00)
+			if (((char *) g_a432550 + r20_n)[16] == 0x00)
 			{
 l00404D8C:
-				struct Eq_n * r20_n = (struct Eq_n *) (g_a432550 + r20_n / 4);
-				ui32 r6_n = g_a432550 + ((r22_n << 0x04) + 0x08) / 4;
+				struct Eq_n * r20_n = (struct Eq_n *) ((char *) g_a432550 + r20_n);
+				ui32 r6_n = (char *) g_a432550 + ((r22_n << 0x04) + 0x08);
 				r20_n->dw0010 = r6_n;
 				r20_n->dw0014 = r6_n;
 			}
@@ -7048,7 +7048,7 @@ l00404FBA:
 					r2 = __wait(r23_n, &r23_n.u1->dw0004, 0x01, 0x01, out r4_n, out r5_n, out r8_n, out r9_n);
 				}
 			}
-			if ((g_a432550 + r20_n / 4)[4] == 0x00)
+			if (((char *) g_a432550 + r20_n)[16] == 0x00)
 				r17_n = dwLoc34_n;
 			if (g_dw454433 != 0x00)
 			{
@@ -7134,7 +7134,7 @@ l00404FBA:
 						}
 					}
 				}
-				ptr32 r6_n = (ptr32) (g_a432550 + r20_n / 4)[5];
+				ptr32 r6_n = (ptr32) ((char *) g_a432550 + r20_n)[20];
 				struct Eq_n * r9_n = (struct Eq_n *) (g_a432550 + (r7_n.u3 + 1) * 4);
 				r9_n->t0001.u3 = (byte *) dwLoc34_n;
 				if (*((byte) dwLoc34_n.u0 + 0x0C) != 0x00)
@@ -7355,7 +7355,7 @@ l004052C2:
 			r19_n = (word32) ((r7_n & -r7_n) *s 124511785 >> 0x1B)->b412CC0;
 		int32 r17_n = r19_n << 0x04;
 		Eq_n r30_n;
-		r30_n.u0 = g_a432550 + (r17_n + 0x08) / 4;
+		r30_n.u0 = (char *) g_a432550 + (r17_n + 0x08);
 		if (g_dw454433 != 0x00)
 		{
 			while (true)
@@ -7373,8 +7373,8 @@ l004052C2:
 				r2 = __wait(r30_n, &r30_n.u1->dw0004, 0x01, 0x01, out r4_n, out r5_n, out r8, out r9_n);
 			}
 		}
-		struct Eq_n * r7_n = (struct Eq_n *) (g_a432550 + (r17_n + 0x08) / 4);
-		r9_n = (g_a432550 + r17_n / 4)[4];
+		struct Eq_n * r7_n = (struct Eq_n *) ((char *) g_a432550 + (r17_n + 0x08));
+		r9_n = (struct Eq_n *) ((char *) g_a432550 + r17_n)[16];
 		if (r9_n != null && r7_n != r9_n)
 		{
 			Eq_n r17_n;
@@ -7487,10 +7487,10 @@ l0040558C:
 			r7_n.u3 = r9_n->t0001.u3;
 			goto l0040558C;
 		}
-		if (g_a432550[(r17_n + 0x08) / 4] == 0x00)
+		if (*((char *) g_a432550 + (r17_n + 0x08)) == 0x00)
 			goto l004052C2;
 		__sync(0x00);
-		g_a432550[(r17_n + 0x08) / 4] = 0x00;
+		*((char *) g_a432550 + (r17_n + 0x08)) = 0x00;
 		__sync(0x00);
 		if (r30_n.u1->dw0004 == 0x00)
 			goto l004052C2;
@@ -7683,7 +7683,7 @@ l004057CE:
 	}
 	else
 	{
-		struct Eq_n * r5_n = r4_n + __align(r4.u11 + 3, 4) / 4;
+		struct Eq_n * r5_n = (struct Eq_n *) ((char *) &r4_n->dw0000 + __align(r4.u11 + 3, 4));
 		struct Eq_n * r7_n = r4_n;
 		do
 		{
@@ -11314,7 +11314,7 @@ l004076D2:
 			int32 r7_n = r6_n;
 			while (true)
 			{
-				word32 r5_n = (word32) (&tLoc0148)[r7_n / 4];
+				word32 r5_n = (word32) *((char *) &tLoc0148 + r7_n);
 				if (r5_n == 0x00 || r5_n == 0x2E)
 					break;
 				++r7_n;
@@ -15467,7 +15467,7 @@ l00408EC2:
 						else
 						{
 							Eq_n r7_n;
-							r7_n.u3 = (fp - 0x0228 - r21).u1 + (word32) (r6_n < 0x01) / 2;
+							r7_n.u3 = &(fp - 0x0228 - r21).u1->b0000 + (word32) (r6_n < 0x01);
 							r19_n = fp - 0x0228;
 							if ((word32) (r18_n < r7_n) != 0x00)
 								r18_n = r7_n;
@@ -16147,7 +16147,7 @@ l00409DD0:
 		{
 			word32 r4_n = -r5;
 			Eq_n r19_n;
-			r19_n.u3 = r17_n.u3 + (r4_n - (r10 + r30_n / 4)[-2]);
+			r19_n.u3 = r17_n.u3 + (r4_n - ((char *) r10 + r30_n)[-8]);
 			word32 r7_n;
 			word32 r7_n;
 			if (addrcmp(r17_n.u3 + r4_n, r16_n, out r7_n) >= 0x00 || addrcmp(r19_n, r16_n, out r7_n) >= 0x00)
@@ -16877,9 +16877,9 @@ l0040A154:
 			r13_n = __ins<word32,word32>(r16_n, 0x00, 0x00, 0x01);
 l0040A312:
 			int32 r13_n = r13_n.u12 + 4;
-			r5.u3 = r5_n + r13_n / 16;
+			r5.u3 = &r5_n->b0000 + r13_n;
 			r6 = r6_n - __align(&(r6.u12)->dwFFFFFFEC, 16);
-			r13.u3 = r24_n + r13_n / 16;
+			r13.u3 = &r24_n->t0000.u0 + r13_n;
 			goto l0040A322;
 		}
 		if (r8 == 0x03)
@@ -17302,7 +17302,7 @@ Eq_n memset(Eq_n r4, Eq_n r5, Eq_n r6, union Eq_n & r6Out, union Eq_n & r7Out, u
 					struct Eq_n * r9_n = -r4;
 					Eq_n r6_n = __ins<word32,word32>(r6 - (r9_n & 0x03), 0x00, 0x00, 0x01);
 					r5 = ((r5 & 0xFF) << 0x08) + (r5 & 0xFF);
-					r4.u5[(r9_n & 0x03) / 4] = r5 * 0x00010001;
+					((char *) r4.u5 + (r9_n & 0x03))->u3 = r5 * 0x00010001;
 					r7.u0 = r4.u3 + (r9_n & 0x03);
 					r10 = r7 + r6_n;
 					r10->tFFFFFFFC.u1 = (ui32) (r5 * 0x00010001);
@@ -18653,14 +18653,14 @@ struct Eq_n * __copy_tls(struct Eq_n * r4)
 {
 	word32 r16_n = r4 + (Mem15[0x00454448<p32>:word32] + (~Mem15[0x00454450<p32>:word32] << 0x02));
 	struct Eq_n * r19_n;
-	struct Eq_n * r17_n = r4 + (g_dw45444C + ~0x00 & ~0xAF - r4) / 0x00B0;
+	struct Eq_n * r17_n = (struct Eq_n *) ((char *) r4 + (g_dw45444C + ~0x00 & ~0xAF - r4));
 	word32 * r20_n = r16_n + 0x04;
 	for (r19_n = g_ptr454444; r19_n != null; r19_n = r19_n->ptr0000)
 	{
 		Eq_n r6_n;
 		r6_n.u3 = r19_n->t0008.u3;
 		Eq_n r4_n;
-		r4_n.u3 = r17_n + (r19_n->dw0014 + 0xB0) / 0x00B0;
+		r4_n.u3 = (char *) r17_n + (r19_n->dw0014 + 0xB0);
 		*r20_n = (word32) r4_n;
 		word32 r3_n;
 		word32 r5_n;
@@ -18696,7 +18696,7 @@ void __init_tls(Eq_n r0, struct Eq_n * r4)
 			if ((r8_n ^ 0x07) == 0x00)
 				r6_n = r7_n;
 		}
-		r7_n += r4->dw0010 / 32;
+		r7_n = (struct Eq_n *) ((char *) &r7_n->dw0000 + r4->dw0010);
 	}
 	if (r6_n != null)
 	{
@@ -21327,7 +21327,7 @@ l0040C6CC:
 					if (r7_n < r19_n)
 					{
 						dwLoc4C_n.u11->a0000 = r7_n.u11 + 1;
-						r20_n.u3 = (word32) (&g_t41326D)[(word32) *r7_n.u3 / 4272750];
+						r20_n.u3 = (word32) (&g_t41326D.t0000.u0)[(word32) *r7_n.u3];
 					}
 					else
 					{
@@ -21367,7 +21367,7 @@ l0040C6CC:
 					if (r21_n < r19_n)
 					{
 						r4.u11[4] = (struct Eq_n) (r21_n.u11 + 1);
-						r20_n.u3 = (word32) (&g_t41326D)[(word32) *r21_n.u3 / 4272750];
+						r20_n.u3 = (word32) (&g_t41326D.t0000.u0)[(word32) *r21_n.u3];
 					}
 					else
 					{
@@ -21397,7 +21397,7 @@ l0040C9B0:
 				if (r7_n < r19_n)
 				{
 					dwLoc4C_n.u11->a0000 = r7_n.u11 + 1;
-					r20_n.u3 = (word32) (&g_t41326D)[(word32) *r7_n.u3 / 4272750];
+					r20_n.u3 = (word32) (&g_t41326D.t0000.u0)[(word32) *r7_n.u3];
 				}
 				else
 				{
@@ -21450,7 +21450,7 @@ l0040C9B0:
 				if (r21_n < r19_n)
 				{
 					dwLoc4C_n.u11->a0000 = r21_n.u11 + 1;
-					r20_n.u3 = (word32) (&g_t41326D)[(word32) *r21_n.u3 / 4272750];
+					r20_n.u3 = (word32) (&g_t41326D.t0000.u0)[(word32) *r21_n.u3];
 				}
 				else
 				{
@@ -21552,7 +21552,7 @@ l0040C92E:
 						r21_n.u3 = r16_n.u16->t0001.u1;
 l0040C916:
 					}
-					if ((word32) (&g_t41326D)[(word32) *r21_n.u3 / 4272750] >= r30_n)
+					if ((word32) (&g_t41326D.t0000.u0)[(word32) *r21_n.u3] >= r30_n)
 						goto l0040C92E;
 					r21_n.u3 = r16_n.u16->t0001.u1;
 					goto l0040C916;
@@ -21899,7 +21899,7 @@ l0040CC78:
 		if (r11_n != null)
 		{
 			word32 r9_n = (word32) r11_n->w002C;
-			struct Eq_n * r6_n = (struct Eq_n *) (r11_n + r11_n->dw001C / 46);
+			struct Eq_n * r6_n = (struct Eq_n *) ((char *) r11_n + r11_n->dw001C);
 			if (r9_n != 0x00)
 			{
 				int32 r10_n = (word32) r11_n->w002A;
@@ -21912,16 +21912,16 @@ l0040CC78:
 					if (r8_n != 0x01)
 					{
 						if (r8_n == 0x02)
-							r7_n = (uint32 *) (r11_n + r6_n->dw0004 / 46);
+							r7_n = (uint32 *) ((char *) r11_n + r6_n->dw0004);
 						++r16_n;
-						r6_n += r10_n / 0x0C;
+						r6_n = (struct Eq_n *) ((char *) &r6_n->dw0000 + r10_n);
 						if (r16_n != r9_n)
 							continue;
 						break;
 					}
 					++r16_n;
-					r6_n += r10_n / 0x0C;
-					r17_n = r11_n + r6_n->dw0004 / 46 - r6_n->dw0008;
+					r6_n = (struct Eq_n *) ((char *) &r6_n->dw0000 + r10_n);
+					r17_n = (char *) r11_n + r6_n->dw0004 - r6_n->dw0008;
 				} while (r16_n != r9_n);
 				if (r7_n != null && r17_n != ~0x00)
 				{
@@ -21978,18 +21978,18 @@ l0040CC78:
 									uint32 r6_n = (word32) r18_n->b000C;
 									if (!__bit<word32,word32>(0x27 >> (r6_n & 0x0F), 0x00) && (!__bit<word32,word32>(0x0406 >> (r6_n >> 0x04), 0x00) && (word32) r18_n->w000E != 0x00))
 									{
-										if (strcmp(r5, r21_n + (r18_n->a0000)[0] / 16) == 0x00)
+										if (strcmp(r5, (char *) r21_n->a0000 + (r18_n->a0000)[0]) == 0x00)
 										{
 											if (r30_n == null)
 												return r17_n + r18_n->dw0004;
 											struct Eq_n * r7_n = r22_n;
-											Eq_n r5_n = __ext<word32,word32>((word32) r30_n[r16_n * 0x02 / 16], 0x00, 0x0F);
+											Eq_n r5_n = __ext<word32,word32>((word32) *((char *) &r30_n->a0000[0] + r16_n * 0x02), 0x00, 0x0F);
 											while (!__bit<word32,word32>((word32) r7_n->w0002, 0x00) || r5_n != __ext<word32,word32>((word32) r7_n->dw0004, 0x00, 0x0F))
 											{
 												int32 r6_n = (int32) r7_n[1];
 												if (r6_n == 0x00)
 													goto l0040CD9E;
-												r7_n += r6_n / 16;
+												r7_n = (struct Eq_n *) ((char *) r7_n->a0000 + r6_n);
 											}
 											if (strcmp(r4, Mem23[r7_n + Mem23[r7_n + 0x0C:word32]:word32] + r21_n) == 0x00)
 												return r17_n + r18_n->dw0004;
@@ -22834,7 +22834,7 @@ Eq_n __towrite(Eq_n r4, ptr32 & r6Out, union Eq_n & r7Out)
 	else
 	{
 		ptr32 r6_n = (ptr32) r4.u11[48];
-		Eq_n r7_n = (r4.u11[44].a0000 + r6_n / 4).u3.u3;
+		Eq_n r7_n = r4.u11[44].a0000.u3.u3 + r6_n;
 		r6Out = r6_n;
 		r7Out = r7_n;
 		return 0x00;
@@ -23298,7 +23298,7 @@ l0040D84C:
 					Eq_n r22_n = r4.u11[4] - (r4.u11)[8];
 					Eq_n r8_n = Mem466[r4 + 0x78:word32] + r22_n;
 					r7_n = r5_n;
-					if ((r8_n | ((((r4.u11))[0x007C].a0000 + (r22_n >> 0x1F) / 4).u3).u3 + (word32) (r8_n < r22_n)) == 0x00)
+					if ((r8_n | (((((r4.u11))[0x007C].a0000).u3).u3 + (r22_n >> 0x1F)) + (word32) (r8_n < r22_n)) == 0x00)
 						goto l0040D974;
 					if (dwLoc0184_n != (Eq_n (*)[]) 0x30 || r18_n == 0x00)
 						store_int(r18_n, r21_n, r4_n, r5_n);
@@ -23406,7 +23406,7 @@ l0040DAF8:
 					r2_n = __floatscan(r0, r2_n, r4, r21_n, 0x00, r12_n, out r3_n, out r4_n, out r5_n, out r6_n, out r7_n, out r11_n, out r12_n);
 					Eq_n r7_n = r4.u11[4] - (r4.u11)[8];
 					Eq_n r6_n = r7_n + Mem466[r4 + 0x78:word32];
-					r7_n = (r4.u11[0x007C].a0000 + (r7_n >> 0x1F) / 4).u3.u3 + (word32) (r6_n < r7_n) | r6_n;
+					r7_n = r4.u11[0x007C].a0000.u3.u3 + (r7_n >> 0x1F) + (word32) (r6_n < r7_n) | r6_n;
 					if (r7_n == 0x00)
 						goto l0040D974;
 					if (r18_n != 0x00)
@@ -24178,7 +24178,7 @@ struct Eq_n * readdir64(struct Eq_n * r4)
 			return r17_n;
 		}
 	}
-	r17_n = &r4->dw0014 + 3 + r4->dw0010 / 24;
+	r17_n = (struct Eq_n *) ((char *) (&r4->dw0014 + 3) + r4->dw0010);
 	word32 r7_n = r17_n->dw000C;
 	r4->dw0008 = r17_n->dw0008;
 	r4->dw000C = r7_n;

--- a/subjects/Elf/superH/netbsd-ls/ls.reko/ls.h
+++ b/subjects/Elf/superH/netbsd-ls/ls.reko/ls.h
@@ -1082,7 +1082,7 @@ T_16: (in Mem18[0x00401E94<p32>:word32] + 0x00401E94<p32> @ 00401DCC : word32)
 T_17: (in r12_23 @ 00401DCC : Eq_16)
   Class: Eq_16
   DataType: Eq_16
-  OrigDataType: (ptr32 word32)
+  OrigDataType: (ptr32 char)
 T_18: (in 0<32> @ 00401DD2 : word32)
   Class: Eq_9
   DataType: (ptr32 Eq_9)
@@ -3602,7 +3602,7 @@ T_646: (in Mem5[0x00402408<p32>:word32] + 0x00402408<p32> @ 00402384 : word32)
 T_647: (in r12_11 @ 00402384 : Eq_646)
   Class: Eq_646
   DataType: Eq_646
-  OrigDataType: (ptr32 word32)
+  OrigDataType: (ptr32 char)
 T_648: (in 0x48<32> @ 0040238E : word32)
   Class: Eq_648
   DataType: word32
@@ -4396,7 +4396,7 @@ T_832: (in 0<32> @ 004025AE : word32)
   Class: Eq_738
   DataType: word32
   OrigDataType: word32
-T_833: (in *g_ptr402608[r12_612 / 4<i32>] == 0<32> @ 004025AE : bool)
+T_833: (in (*((char *) &g_ptr402608[0<i32>] + r12_612))[0<i32>] == 0<32> @ 004025AE : bool)
   Class: Eq_833
   DataType: bool
   OrigDataType: bool
@@ -9184,7 +9184,7 @@ T_2029: (in 0<32> @ 00403076 : word32)
   Class: Eq_2028
   DataType: word32
   OrigDataType: word32
-T_2030: (in *r12_218[g_dw40322C / 4<i32>] == 0<32> @ 00403076 : bool)
+T_2030: (in (*((char *) &r12_218[0<i32>] + g_dw40322C))[0<i32>] == 0<32> @ 00403076 : bool)
   Class: Eq_2030
   DataType: bool
   OrigDataType: bool
@@ -9220,7 +9220,7 @@ T_2038: (in 0<32> @ 00402D3A : word32)
   Class: Eq_2037
   DataType: word32
   OrigDataType: word32
-T_2039: (in *r12_218[g_dw402E80 / 4<i32>] != 0<32> @ 00402D3A : bool)
+T_2039: (in (*((char *) &r12_218[0<i32>] + g_dw402E80))[0<i32>] != 0<32> @ 00402D3A : bool)
   Class: Eq_2039
   DataType: bool
   OrigDataType: bool
@@ -9280,7 +9280,7 @@ T_2053: (in 0<32> @ 00402D44 : word32)
   Class: Eq_2052
   DataType: word32
   OrigDataType: word32
-T_2054: (in *r12_218[g_dw402E78 / 4<i32>] != 0<32> @ 00402D44 : bool)
+T_2054: (in (*((char *) &r12_218[0<i32>] + g_dw402E78))[0<i32>] != 0<32> @ 00402D44 : bool)
   Class: Eq_2054
   DataType: bool
   OrigDataType: bool
@@ -9376,7 +9376,7 @@ T_2077: (in 0<32> @ 0040308C : word32)
   Class: Eq_2076
   DataType: word32
   OrigDataType: word32
-T_2078: (in *r12_218[g_dw403224 / 4<i32>] == 0<32> @ 0040308C : bool)
+T_2078: (in (*((char *) &r12_218[0<i32>] + g_dw403224))[0<i32>] == 0<32> @ 0040308C : bool)
   Class: Eq_2078
   DataType: bool
   OrigDataType: bool
@@ -9436,7 +9436,7 @@ T_2092: (in 0<32> @ 004030C8 : word32)
   Class: Eq_2091
   DataType: word32
   OrigDataType: word32
-T_2093: (in *r0_497[g_dw40321C / 4<i32>] == 0<32> @ 004030C8 : bool)
+T_2093: (in (*((char *) &r0_497[0<i32>] + g_dw40321C))[0<i32>] == 0<32> @ 004030C8 : bool)
   Class: Eq_2093
   DataType: bool
   OrigDataType: bool
@@ -9480,7 +9480,7 @@ T_2103: (in 0<32> @ 00402D10 : word32)
   Class: Eq_2102
   DataType: word32
   OrigDataType: word32
-T_2104: (in *r12_218[g_dw402E74 / 4<i32>] != 0<32> @ 00402D10 : bool)
+T_2104: (in (*((char *) &r12_218[0<i32>] + g_dw402E74))[0<i32>] != 0<32> @ 00402D10 : bool)
   Class: Eq_2104
   DataType: bool
   OrigDataType: bool
@@ -9512,7 +9512,7 @@ T_2111: (in 0<32> @ 00402D1A : word32)
   Class: Eq_2110
   DataType: word32
   OrigDataType: word32
-T_2112: (in *r12_218[g_dw402E78 / 4<i32>] != 0<32> @ 00402D1A : bool)
+T_2112: (in (*((char *) &r12_218[0<i32>] + g_dw402E78))[0<i32>] != 0<32> @ 00402D1A : bool)
   Class: Eq_2112
   DataType: bool
   OrigDataType: bool
@@ -9548,7 +9548,7 @@ T_2120: (in 0<32> @ 00402D24 : word32)
   Class: Eq_2119
   DataType: word32
   OrigDataType: word32
-T_2121: (in *r12_218[g_dw402E7C / 4<i32>] != 0<32> @ 00402D24 : bool)
+T_2121: (in (*((char *) &r12_218[0<i32>] + g_dw402E7C))[0<i32>] != 0<32> @ 00402D24 : bool)
   Class: Eq_2121
   DataType: bool
   OrigDataType: bool
@@ -9564,7 +9564,7 @@ T_2124: (in 0<32> @ 00402D2C : word32)
   Class: Eq_1961
   DataType: (ptr32 word32)
   OrigDataType: word32
-T_2125: (in r12_218[r2_317 / 4<i32>] != null @ 00402D2C : bool)
+T_2125: (in *((char *) &r12_218[0<i32>] + r2_317) != null @ 00402D2C : bool)
   Class: Eq_2125
   DataType: bool
   OrigDataType: bool
@@ -9668,7 +9668,7 @@ T_2150: (in 0<32> @ 00403152 : word32)
   Class: Eq_2149
   DataType: word32
   OrigDataType: word32
-T_2151: (in *r12_218[g_dw4031D8 / 4<i32>] != 0<32> @ 00403152 : bool)
+T_2151: (in (*((char *) &r12_218[0<i32>] + g_dw4031D8))[0<i32>] != 0<32> @ 00403152 : bool)
   Class: Eq_2151
   DataType: bool
   OrigDataType: bool
@@ -9756,7 +9756,7 @@ T_2172: (in 0<32> @ 004030E6 : word32)
   Class: Eq_2171
   DataType: word32
   OrigDataType: word32
-T_2173: (in *r12_218[g_dw4031C4 / 4<i32>] != 0<32> @ 004030E6 : bool)
+T_2173: (in (*((char *) &r12_218[0<i32>] + g_dw4031C4))[0<i32>] != 0<32> @ 004030E6 : bool)
   Class: Eq_2173
   DataType: bool
   OrigDataType: bool
@@ -9820,7 +9820,7 @@ T_2188: (in 0<32> @ 004030F4 : word32)
   Class: Eq_2187
   DataType: word32
   OrigDataType: word32
-T_2189: (in *r12_218[g_dw4031CC / 4<i32>] != 0<32> @ 004030F4 : bool)
+T_2189: (in (*((char *) &r12_218[0<i32>] + g_dw4031CC))[0<i32>] != 0<32> @ 004030F4 : bool)
   Class: Eq_2189
   DataType: bool
   OrigDataType: bool
@@ -9856,7 +9856,7 @@ T_2197: (in 0<32> @ 004030FE : word32)
   Class: Eq_2196
   DataType: word32
   OrigDataType: word32
-T_2198: (in *r12_218[r14_311 / 4<i32>] != 0<32> @ 004030FE : bool)
+T_2198: (in (*((char *) &r12_218[0<i32>] + r14_311))[0<i32>] != 0<32> @ 004030FE : bool)
   Class: Eq_2198
   DataType: bool
   OrigDataType: bool
@@ -9900,7 +9900,7 @@ T_2208: (in 0<32> @ 0040310A : word32)
   Class: Eq_2207
   DataType: word32
   OrigDataType: word32
-T_2209: (in *r12_218[g_dw4031C0 / 4<i32>] != 0<32> @ 0040310A : bool)
+T_2209: (in (*((char *) &r12_218[0<i32>] + g_dw4031C0))[0<i32>] != 0<32> @ 0040310A : bool)
   Class: Eq_2209
   DataType: bool
   OrigDataType: bool
@@ -10020,7 +10020,7 @@ T_2238: (in 0<32> @ 00403160 : word32)
   Class: Eq_2237
   DataType: word32
   OrigDataType: word32
-T_2239: (in *r12_218[g_dw4031D4 / 4<i32>] != 0<32> @ 00403160 : bool)
+T_2239: (in (*((char *) &r12_218[0<i32>] + g_dw4031D4))[0<i32>] != 0<32> @ 00403160 : bool)
   Class: Eq_2239
   DataType: bool
   OrigDataType: bool
@@ -10096,7 +10096,7 @@ T_2257: (in 0<32> @ 0040318E : word32)
   Class: Eq_2256
   DataType: word32
   OrigDataType: word32
-T_2258: (in *r12_218[g_dw4031D8 / 4<i32>] != 0<32> @ 0040318E : bool)
+T_2258: (in (*((char *) &r12_218[0<i32>] + g_dw4031D8))[0<i32>] != 0<32> @ 0040318E : bool)
   Class: Eq_2258
   DataType: bool
   OrigDataType: bool
@@ -10176,7 +10176,7 @@ T_2277: (in 0<32> @ 0040319C : word32)
   Class: Eq_2196
   DataType: word32
   OrigDataType: word32
-T_2278: (in *r12_218[g_dw4031D4 / 4<i32>] != 0<32> @ 0040319C : bool)
+T_2278: (in (*((char *) &r12_218[0<i32>] + g_dw4031D4))[0<i32>] != 0<32> @ 0040319C : bool)
   Class: Eq_2278
   DataType: bool
   OrigDataType: bool
@@ -11028,7 +11028,7 @@ T_2490: (in 0<32> @ 004033F0 : word32)
   Class: Eq_2489
   DataType: word32
   OrigDataType: word32
-T_2491: (in *g_ptr403460[r12_100 / 4<i32>] == 0<32> @ 004033F0 : bool)
+T_2491: (in (*((char *) &g_ptr403460[0<i32>] + r12_100))[0<i32>] == 0<32> @ 004033F0 : bool)
   Class: Eq_2491
   DataType: bool
   OrigDataType: bool
@@ -11064,7 +11064,7 @@ T_2499: (in 0<32> @ 00403404 : word32)
   Class: Eq_2498
   DataType: word32
   OrigDataType: word32
-T_2500: (in *g_ptr403468[r12_100 / 4<i32>] == 0<32> @ 00403404 : bool)
+T_2500: (in (*((char *) &g_ptr403468[0<i32>] + r12_100))[0<i32>] == 0<32> @ 00403404 : bool)
   Class: Eq_2500
   DataType: bool
   OrigDataType: bool
@@ -11332,7 +11332,7 @@ T_2566: (in 0<32> @ 004034F8 : word32)
   Class: Eq_2565
   DataType: word32
   OrigDataType: word32
-T_2567: (in *g_ptr40358C[r12_14 / 4<i32>] == 0<32> @ 004034F8 : bool)
+T_2567: (in (*((char *) &g_ptr40358C[0<i32>] + r12_14))[0<i32>] == 0<32> @ 004034F8 : bool)
   Class: Eq_2567
   DataType: bool
   OrigDataType: bool
@@ -11368,7 +11368,7 @@ T_2575: (in 0<32> @ 004034EE : word32)
   Class: Eq_2574
   DataType: word32
   OrigDataType: word32
-T_2576: (in *g_ptr403588[r12_14 / 4<i32>] == 0<32> @ 004034EE : bool)
+T_2576: (in (*((char *) &g_ptr403588[0<i32>] + r12_14))[0<i32>] == 0<32> @ 004034EE : bool)
   Class: Eq_2576
   DataType: bool
   OrigDataType: bool
@@ -11416,7 +11416,7 @@ T_2587: (in 0<32> @ 00403544 : word32)
   Class: Eq_2586
   DataType: word32
   OrigDataType: word32
-T_2588: (in *g_ptr4035A8[r12_14 / 4<i32>] == 0<32> @ 00403544 : bool)
+T_2588: (in (*((char *) &g_ptr4035A8[0<i32>] + r12_14))[0<i32>] == 0<32> @ 00403544 : bool)
   Class: Eq_2588
   DataType: bool
   OrigDataType: bool
@@ -12704,7 +12704,7 @@ T_2909: (in 0<32> @ 00403808 : word32)
   Class: Eq_2908
   DataType: word32
   OrigDataType: word32
-T_2910: (in *g_ptr403924[r12_145 / 4<i32>] == 0<32> @ 00403808 : bool)
+T_2910: (in (*((char *) &g_ptr403924[0<i32>] + r12_145))[0<i32>] == 0<32> @ 00403808 : bool)
   Class: Eq_2910
   DataType: bool
   OrigDataType: bool
@@ -12768,7 +12768,7 @@ T_2925: (in 0<32> @ 0040385A : word32)
   Class: Eq_2924
   DataType: word32
   OrigDataType: word32
-T_2926: (in *g_ptr403944[r12_145 / 4<i32>] != 0<32> @ 0040385A : bool)
+T_2926: (in (*((char *) &g_ptr403944[0<i32>] + r12_145))[0<i32>] != 0<32> @ 0040385A : bool)
   Class: Eq_2926
   DataType: bool
   OrigDataType: bool
@@ -12804,7 +12804,7 @@ T_2934: (in 0<32> @ 00403814 : word32)
   Class: Eq_2933
   DataType: word32
   OrigDataType: word32
-T_2935: (in *g_ptr403928[r12_145 / 4<i32>] == 0<32> @ 00403814 : bool)
+T_2935: (in (*((char *) &g_ptr403928[0<i32>] + r12_145))[0<i32>] == 0<32> @ 00403814 : bool)
   Class: Eq_2935
   DataType: bool
   OrigDataType: bool
@@ -12852,7 +12852,7 @@ T_2946: (in 0<32> @ 004038B6 : word32)
   Class: Eq_2945
   DataType: word32
   OrigDataType: word32
-T_2947: (in *g_ptr403960[r12_145 / 4<i32>] == 0<32> @ 004038B6 : bool)
+T_2947: (in (*((char *) &g_ptr403960[0<i32>] + r12_145))[0<i32>] == 0<32> @ 004038B6 : bool)
   Class: Eq_2947
   DataType: bool
   OrigDataType: bool
@@ -13088,7 +13088,7 @@ T_3005: (in 0<32> @ 00403864 : word32)
   Class: Eq_3004
   DataType: word32
   OrigDataType: word32
-T_3006: (in *g_ptr403948[r12_145 / 4<i32>] == 0<32> @ 00403864 : bool)
+T_3006: (in (*((char *) &g_ptr403948[0<i32>] + r12_145))[0<i32>] == 0<32> @ 00403864 : bool)
   Class: Eq_3006
   DataType: bool
   OrigDataType: bool
@@ -13124,7 +13124,7 @@ T_3014: (in 0<32> @ 004038FA : word32)
   Class: Eq_3013
   DataType: word32
   OrigDataType: word32
-T_3015: (in *g_ptr403974[r12_145 / 4<i32>] == 0<32> @ 004038FA : bool)
+T_3015: (in (*((char *) &g_ptr403974[0<i32>] + r12_145))[0<i32>] == 0<32> @ 004038FA : bool)
   Class: Eq_3015
   DataType: bool
   OrigDataType: bool
@@ -13440,7 +13440,7 @@ T_3093: (in 0<32> @ 00403876 : word32)
   Class: Eq_3092
   DataType: word32
   OrigDataType: word32
-T_3094: (in *g_ptr403950[r12_245 / 4<i32>] != 0<32> @ 00403876 : bool)
+T_3094: (in (*((char *) &g_ptr403950[0<i32>] + r12_245))[0<i32>] != 0<32> @ 00403876 : bool)
   Class: Eq_3094
   DataType: bool
   OrigDataType: bool
@@ -13968,7 +13968,7 @@ T_3225: (in 0<32> @ 00403A5A : word32)
   Class: Eq_3224
   DataType: word32
   OrigDataType: word32
-T_3226: (in *g_ptr403AD0[r12_238 / 4<i32>] == 0<32> @ 00403A5A : bool)
+T_3226: (in (*((char *) &g_ptr403AD0[0<i32>] + r12_238))[0<i32>] == 0<32> @ 00403A5A : bool)
   Class: Eq_3226
   DataType: bool
   OrigDataType: bool
@@ -14188,7 +14188,7 @@ T_3280: (in 0<32> @ 00403A6C : word32)
   Class: Eq_3279
   DataType: word32
   OrigDataType: word32
-T_3281: (in *g_ptr403AD4[r12_238 / 4<i32>] != 0<32> @ 00403A6C : bool)
+T_3281: (in (*((char *) &g_ptr403AD4[0<i32>] + r12_238))[0<i32>] != 0<32> @ 00403A6C : bool)
   Class: Eq_3281
   DataType: bool
   OrigDataType: bool
@@ -14284,7 +14284,7 @@ T_3304: (in 0<32> @ 00403C0C : word32)
   Class: Eq_3303
   DataType: word32
   OrigDataType: word32
-T_3305: (in *g_ptr403D5C[r12_238 / 4<i32>] != 0<32> @ 00403C0C : bool)
+T_3305: (in (*((char *) &g_ptr403D5C[0<i32>] + r12_238))[0<i32>] != 0<32> @ 00403C0C : bool)
   Class: Eq_3305
   DataType: bool
   OrigDataType: bool
@@ -14668,7 +14668,7 @@ T_3400: (in 0<32> @ 00403C52 : word32)
   Class: Eq_3399
   DataType: word32
   OrigDataType: word32
-T_3401: (in *g_ptr403D74[r12_364 / 4<i32>] == 0<32> @ 00403C52 : bool)
+T_3401: (in (*((char *) &g_ptr403D74[0<i32>] + r12_364))[0<i32>] == 0<32> @ 00403C52 : bool)
   Class: Eq_3401
   DataType: bool
   OrigDataType: bool
@@ -14944,7 +14944,7 @@ T_3469: (in 0<32> @ 00403C90 : word32)
   Class: Eq_3303
   DataType: word32
   OrigDataType: word32
-T_3470: (in *g_ptr403D5C[r12_364 / 4<i32>] != 0<32> @ 00403C90 : bool)
+T_3470: (in (*((char *) &g_ptr403D5C[0<i32>] + r12_364))[0<i32>] != 0<32> @ 00403C90 : bool)
   Class: Eq_3470
   DataType: bool
   OrigDataType: bool
@@ -15152,7 +15152,7 @@ T_3521: (in 0<32> @ 00403CD2 : word32)
   Class: Eq_3520
   DataType: word32
   OrigDataType: word32
-T_3522: (in *g_ptr403D94[r12_588 / 4<i32>] == 0<32> @ 00403CD2 : bool)
+T_3522: (in (*((char *) &g_ptr403D94[0<i32>] + r12_588))[0<i32>] == 0<32> @ 00403CD2 : bool)
   Class: Eq_3522
   DataType: bool
   OrigDataType: bool
@@ -15244,7 +15244,7 @@ T_3544: (in 0<32> @ 00403BAA : word32)
   Class: Eq_3543
   DataType: word32
   OrigDataType: word32
-T_3545: (in *g_ptr403D34[r12_588 / 4<i32>] != 0<32> @ 00403BAA : bool)
+T_3545: (in (*((char *) &g_ptr403D34[0<i32>] + r12_588))[0<i32>] != 0<32> @ 00403BAA : bool)
   Class: Eq_3545
   DataType: bool
   OrigDataType: bool
@@ -15468,7 +15468,7 @@ T_3600: (in 0<32> @ 00403BC8 : word32)
   Class: Eq_3599
   DataType: word32
   OrigDataType: word32
-T_3601: (in *g_ptr403D40[r12_685 / 4<i32>] != 0<32> @ 00403BC8 : bool)
+T_3601: (in (*((char *) &g_ptr403D40[0<i32>] + r12_685))[0<i32>] != 0<32> @ 00403BC8 : bool)
   Class: Eq_3601
   DataType: bool
   OrigDataType: bool
@@ -15560,7 +15560,7 @@ T_3623: (in 0<32> @ 00403B94 : word32)
   Class: Eq_3622
   DataType: word32
   OrigDataType: word32
-T_3624: (in *g_ptr403D2C[r12_421 / 4<i32>] != 0<32> @ 00403B94 : bool)
+T_3624: (in (*((char *) &g_ptr403D2C[0<i32>] + r12_421))[0<i32>] != 0<32> @ 00403B94 : bool)
   Class: Eq_3624
   DataType: bool
   OrigDataType: bool
@@ -15672,7 +15672,7 @@ T_3651: (in 0<32> @ 00403DC2 : word32)
   Class: Eq_3650
   DataType: word32
   OrigDataType: word32
-T_3652: (in *r12_126[g_ptr403F2C / 4<i32>] == 0<32> @ 00403DC2 : bool)
+T_3652: (in (*((char *) &r12_126[0<i32>] + g_ptr403F2C))[0<i32>] == 0<32> @ 00403DC2 : bool)
   Class: Eq_3652
   DataType: bool
   OrigDataType: bool
@@ -16620,7 +16620,7 @@ T_3888: (in 0<32> @ 00403EDC : word32)
   Class: Eq_3690
   DataType: word32
   OrigDataType: word32
-T_3889: (in *g_ptr403F34[r12_282 / 4<i32>] == 0<32> @ 00403EDC : bool)
+T_3889: (in (*((char *) &g_ptr403F34[0<i32>] + r12_282))[0<i32>] == 0<32> @ 00403EDC : bool)
   Class: Eq_3889
   DataType: bool
   OrigDataType: bool
@@ -16968,7 +16968,7 @@ T_3975: (in 0<32> @ 00403FA4 : word32)
   Class: Eq_3974
   DataType: word32
   OrigDataType: word32
-T_3976: (in *g_ptr404088[r12_29 / 4<i32>] == 0<32> @ 00403FA4 : bool)
+T_3976: (in (*((char *) &g_ptr404088[0<i32>] + r12_29))[0<i32>] == 0<32> @ 00403FA4 : bool)
   Class: Eq_3976
   DataType: bool
   OrigDataType: bool
@@ -17056,7 +17056,7 @@ T_3997: (in 0<32> @ 00403FBE : word32)
   Class: Eq_3996
   DataType: word32
   OrigDataType: word32
-T_3998: (in *g_ptr404090[r12_29 / 4<i32>] != 0<32> @ 00403FBE : bool)
+T_3998: (in (*((char *) &g_ptr404090[0<i32>] + r12_29))[0<i32>] != 0<32> @ 00403FBE : bool)
   Class: Eq_3998
   DataType: bool
   OrigDataType: bool
@@ -17092,7 +17092,7 @@ T_4006: (in 0<32> @ 00403FAE : word32)
   Class: Eq_4005
   DataType: word32
   OrigDataType: word32
-T_4007: (in *g_ptr40408C[r12_29 / 4<i32>] == 0<32> @ 00403FAE : bool)
+T_4007: (in (*((char *) &g_ptr40408C[0<i32>] + r12_29))[0<i32>] == 0<32> @ 00403FAE : bool)
   Class: Eq_4007
   DataType: bool
   OrigDataType: bool
@@ -17164,7 +17164,7 @@ T_4024: (in 0<32> @ 00403FC8 : word32)
   Class: Eq_4023
   DataType: word32
   OrigDataType: word32
-T_4025: (in *g_ptr404094[r12_29 / 4<i32>] == 0<32> @ 00403FC8 : bool)
+T_4025: (in (*((char *) &g_ptr404094[0<i32>] + r12_29))[0<i32>] == 0<32> @ 00403FC8 : bool)
   Class: Eq_4025
   DataType: bool
   OrigDataType: bool
@@ -17744,7 +17744,7 @@ T_4169: (in 0<32> @ 004040E6 : word32)
   Class: Eq_4168
   DataType: word32
   OrigDataType: word32
-T_4170: (in *g_ptr40418C[r12_104 / 4<i32>] == 0<32> @ 004040E6 : bool)
+T_4170: (in (*((char *) &g_ptr40418C[0<i32>] + r12_104))[0<i32>] == 0<32> @ 004040E6 : bool)
   Class: Eq_4170
   DataType: bool
   OrigDataType: bool
@@ -17800,7 +17800,7 @@ T_4183: (in 0<32> @ 00404100 : word32)
   Class: Eq_4182
   DataType: word32
   OrigDataType: word32
-T_4184: (in *g_ptr404194[r12_104 / 4<i32>] == 0<32> @ 00404100 : bool)
+T_4184: (in (*((char *) &g_ptr404194[0<i32>] + r12_104))[0<i32>] == 0<32> @ 00404100 : bool)
   Class: Eq_4184
   DataType: bool
   OrigDataType: bool
@@ -17836,7 +17836,7 @@ T_4192: (in 0<32> @ 004040F0 : word32)
   Class: Eq_4191
   DataType: word32
   OrigDataType: word32
-T_4193: (in *g_ptr404190[r12_104 / 4<i32>] == 0<32> @ 004040F0 : bool)
+T_4193: (in (*((char *) &g_ptr404190[0<i32>] + r12_104))[0<i32>] == 0<32> @ 004040F0 : bool)
   Class: Eq_4193
   DataType: bool
   OrigDataType: bool

--- a/subjects/Elf/superH/netbsd-ls/ls.reko/ls_text.c
+++ b/subjects/Elf/superH/netbsd-ls/ls.reko/ls_text.c
@@ -8,7 +8,7 @@
 void _start(word32 r7, word32 r9)
 {
 	int32 r0_n = g_dw401D7C;
-	(&g_dw401D7C)[r0_n / 4]();
+	(*((char *) &g_dw401D7C + r0_n))();
 }
 
 int32 g_dw401D7C = 64; // 00401D7C
@@ -19,7 +19,7 @@ void ___start(word32 r4, struct Eq_n * r5, word32 r9, word32 r10, word32 r11, wo
 	word32 r9_n;
 	<anonymous> *** r9_n;
 	int32 r12_n;
-	Eq_n r12_n = &g_dw401E94 + g_dw401E94 / 4;
+	Eq_n r12_n = (char *) &g_dw401E94 + g_dw401E94;
 	if (r5 != null)
 	{
 		int32 r10_n = g_dw401EA8;
@@ -134,7 +134,7 @@ void modcmp(struct Eq_n * r4, struct Eq_n * r5, word32 pr)
 	struct Eq_n * r3_n = r4->ptr0050;
 	int32 r2_n = r7_n->dw0038;
 	int32 r1_n = r3_n->dw0038;
-	word32 r12_n = &g_dw4020A8 + g_dw4020A8 / 4;
+	word32 r12_n = (char *) &g_dw4020A8 + g_dw4020A8;
 	up32 r0_n = r7_n->dw0034;
 	if (r2_n > r1_n)
 		return;
@@ -172,7 +172,7 @@ void revmodcmp(struct Eq_n * r4, struct Eq_n * r5, word32 pr)
 	struct Eq_n * r3_n = r4->ptr0050;
 	int32 r2_n = r7_n->dw0038;
 	int32 r1_n = r3_n->dw0038;
-	word32 r12_n = &g_dw402114 + g_dw402114 / 4;
+	word32 r12_n = (char *) &g_dw402114 + g_dw402114;
 	up32 r0_n = r7_n->dw0034;
 	if (r2_n > r1_n)
 		return;
@@ -210,7 +210,7 @@ void acccmp(struct Eq_n * r4, struct Eq_n * r5, word32 pr)
 	struct Eq_n * r3_n = r4->ptr0050;
 	int32 r2_n = r7_n->dw002C;
 	int32 r1_n = r3_n->dw002C;
-	word32 r12_n = &g_dw402178 + g_dw402178 / 4;
+	word32 r12_n = (char *) &g_dw402178 + g_dw402178;
 	up32 r0_n = r7_n->dw0028;
 	if (r2_n > r1_n)
 		return;
@@ -248,7 +248,7 @@ void revacccmp(struct Eq_n * r4, struct Eq_n * r5, word32 pr)
 	struct Eq_n * r3_n = r4->ptr0050;
 	int32 r2_n = r7_n->dw002C;
 	int32 r1_n = r3_n->dw002C;
-	word32 r12_n = &g_dw4021E4 + g_dw4021E4 / 4;
+	word32 r12_n = (char *) &g_dw4021E4 + g_dw4021E4;
 	up32 r0_n = r7_n->dw0028;
 	if (r2_n > r1_n)
 		return;
@@ -286,7 +286,7 @@ void statcmp(struct Eq_n * r4, struct Eq_n * r5, word32 pr)
 	struct Eq_n * r1_n = r4->ptr0050;
 	int32 r7_n = r2_n->dw0044;
 	int32 r3_n = r1_n->dw0044;
-	word32 r12_n = &g_dw40224C + g_dw40224C / 4;
+	word32 r12_n = (char *) &g_dw40224C + g_dw40224C;
 	up32 r0_n = r2_n->dw0040;
 	if (r7_n > r3_n)
 		return;
@@ -324,7 +324,7 @@ void revstatcmp(struct Eq_n * r4, struct Eq_n * r5, word32 pr)
 	struct Eq_n * r1_n = r4->ptr0050;
 	int32 r7_n = r2_n->dw0044;
 	int32 r3_n = r1_n->dw0044;
-	word32 r12_n = &g_dw4022BC + g_dw4022BC / 4;
+	word32 r12_n = (char *) &g_dw4022BC + g_dw4022BC;
 	up32 r0_n = r2_n->dw0040;
 	if (r7_n > r3_n)
 		return;
@@ -362,7 +362,7 @@ void sizecmp(struct Eq_n * r4, struct Eq_n * r5, word32 pr)
 	struct Eq_n * r1_n = r4->ptr0050;
 	int32 r2_n = r1_n->dw005C;
 	int32 r1_n = r1_n->dw005C;
-	word32 r12_n = &g_dw402314 + g_dw402314 / 4;
+	word32 r12_n = (char *) &g_dw402314 + g_dw402314;
 	up32 r7_n = r1_n->dw0058;
 	up32 r3_n = r1_n->dw0058;
 	if (r2_n > r1_n)
@@ -395,7 +395,7 @@ void revsizecmp(struct Eq_n * r4, struct Eq_n * r5, word32 pr)
 	struct Eq_n * r1_n = r4->ptr0050;
 	int32 r2_n = r1_n->dw005C;
 	int32 r1_n = r1_n->dw005C;
-	word32 r12_n = &g_dw402374 + g_dw402374 / 4;
+	word32 r12_n = (char *) &g_dw402374 + g_dw402374;
 	up32 r6_n = r1_n->dw0058;
 	up32 r7_n = r1_n->dw0058;
 	if (r2_n > r1_n)
@@ -425,7 +425,7 @@ int32 g_dw402378 = -0x0B50; // 00402378
 void mastercmp(struct Eq_n ** r4, struct Eq_n ** r5, word32 pr)
 {
 	struct Eq_n * r4_n = (struct Eq_n *) *r4;
-	Eq_n r12_n = &g_dw402408 + g_dw402408 / 4;
+	Eq_n r12_n = (char *) &g_dw402408 + g_dw402408;
 	uint32 r7_n = (uint32) r4_n->w0048;
 	if (r7_n == 0x07)
 		return;
@@ -474,7 +474,7 @@ void display(struct Eq_n * r5, struct Eq_n * r9, word32 r11, word32 r13, word32 
 	int32 r12_n;
 	int32 r0_n;
 	ptr32 fp;
-	word32 ** r12_n = &g_dw402600 + g_dw402600 / 4;
+	word32 ** r12_n = (word32 **) ((char *) &g_dw402600 + g_dw402600);
 	struct Eq_n * r15_n = fp + ~0xF7;
 	if (r5 == null)
 		return;
@@ -662,14 +662,14 @@ l0040278A:
 						*r0_n = r0_n + 3;
 						(*((word32) 0x004028A4 + r1_n))();
 						int32 r3_n = g_dw4029A8;
-						word32 r4_n = r9_n + (r11_n + 0x0D) / 8;
+						word32 r4_n = (char *) r9_n + (r11_n + 0x0D);
 						r9_n->dw0004 = r4_n;
 						(*((word32) 4204722 + r3_n))();
 						word32 r2_n = **((char *) r12_n + g_dw4029AC);
 						if (r2_n != 0x00)
 						{
 							int32 r7_n = g_dw4029B0;
-							ui32 r4_n = r9 + (r15_n->dw005C + 0x0E) / 0x0068;
+							ui32 r4_n = (char *) r9 + (r15_n->dw005C + 0x0E);
 							r9->dw0008 = r4_n;
 							(*((word32) 4204748 + r7_n))();
 							int32 r0_n = g_dw4029B4;
@@ -711,7 +711,7 @@ l004025F6:
 	if (r2_n == 0x00)
 		return;
 	up32 r3_n = r15_n->dw004C;
-	struct Eq_n * r9_n = (struct Eq_n *) (r15_n + (int32) g_w4025FA / 100);
+	struct Eq_n * r9_n = (struct Eq_n *) ((char *) &r15_n->t0000.u0 + (int32) g_w4025FA);
 	int32 r1_n = r15_n->dw0028;
 	r9_n->ptr0000 = r14_n;
 	r9_n->dw0014 = r2_n;
@@ -737,7 +737,7 @@ l004025F6:
 			word32 * r15_n;
 			word32 r1_n;
 			*r15_n = r1_n;
-			word32 r10_n = r15_n + r10_n / 4;
+			word32 r10_n = (char *) r15_n + r10_n;
 			int32 r1_n = g_dw4029C0;
 			(*((word32) 0x00402910 + r1_n))();
 			int32 r2_n = g_dw4029C8;
@@ -759,12 +759,12 @@ l004025F6:
 			r9_n->dw001C = 0x04;
 		}
 		word32 r3_n = r15_n->dw0048;
-		struct Eq_n * r9_n = (struct Eq_n *) (r15_n + (int32) g_w4025FA / 100);
+		struct Eq_n * r9_n = (struct Eq_n *) ((char *) &r15_n->t0000.u0 + (int32) g_w4025FA);
 		r9_n->dw0020 = r15_n->dw0044;
 		Eq_n r2_n;
 		r2_n.u0 = r15_n->t0030.u0;
 		int32 r1_n = g_dw402618;
-		int32 r8_n = r15_n + (int32) g_w4025FC / 100;
+		int32 r8_n = (char *) &r15_n->t0000.u0 + (int32) g_w4025FC;
 		r9_n->dw0024 = r3_n;
 		word32 r6_n = g_dw40261C;
 		r15_n->t0000.u0 = (int32) r2_n;
@@ -850,7 +850,7 @@ l004025F6:
 	(*r1_n)();
 	int32 r12_n;
 	*((word32) g_ptr402648 + r12_n) = 0x01;
-	bool T_n = *g_ptr402608[r12_n / 4] == 0x00;
+	bool T_n = (*((char *) &g_ptr402608[0] + r12_n))[0] == 0x00;
 	while (!T_n)
 	{
 		int32 r7_n = g_dw40264C;
@@ -921,7 +921,7 @@ int32 g_dw4029D8 = -0x0C50; // 004029D8
 void traverse(word32 r5, word32 r6, word32 r8, word32 r9, word32 r11, word32 r13, word32 r14, word32 pr)
 {
 	Eq_n r12_n;
-	int32 r12_n = &g_dw402B7C + g_dw402B7C / 4;
+	int32 r12_n = (char *) &g_dw402B7C + g_dw402B7C;
 	word32 r6_n = 0x00;
 	if (**((word32) g_ptr402B80 + r12_n) == 0x00)
 		r6_n = g_dw402B84 + r12_n;
@@ -1061,7 +1061,7 @@ void ls_main(word32 r4, word32 r5, word32 r8, word32 r9, word32 r10, word32 r11,
 		if (r0_n <= 0x78)
 		{
 			int32 r1_n = (int32) g_a402D6C[r0_n + ~0x30];
-			g_a402D6C[r1_n / 2]();
+			(*((char *) g_a402D6C + r1_n))();
 			return;
 		}
 		int32 r1_n = g_dw403230;
@@ -1074,7 +1074,7 @@ void ls_main(word32 r4, word32 r5, word32 r8, word32 r9, word32 r10, word32 r11,
 		(*((word32) 0x00403068 + r7_n))();
 		goto l00403068;
 	}
-	word32 r10_n = *r12_n[g_ptr402E4C / 4];
+	word32 r10_n = (*((char *) &r12_n[0] + g_ptr402E4C))[0];
 	word32 r9_n;
 	word32 r9_n;
 	if (Mem201[Mem201[Mem201[0x00402E38<p32>:word32] + r12_n:word32] + 0x00:word32] == 0x00)
@@ -1087,8 +1087,8 @@ l00402CDE:
 			if (*r1_n == ~0x00)
 				*r1_n = 0x00;
 			int32 r14_n = g_dw402E6C;
-			ui32 r1_n = *r12_n[g_dw402E68 / 4];
-			ui32 r3_n = *r12_n[r14_n / 4];
+			ui32 r1_n = (*((char *) &r12_n[0] + g_dw402E68))[0];
+			ui32 r3_n = (*((char *) &r12_n[0] + r14_n))[0];
 			int32 r2_n = g_dw402E70;
 			if (r1_n == 0x00)
 			{
@@ -1096,14 +1096,14 @@ l00402CDE:
 				if (r3_n != 0x00)
 				{
 l0040306E:
-					if (*r12_n[g_dw40322C / 4] != 0x00)
+					if ((*((char *) &r12_n[0] + g_dw40322C))[0] != 0x00)
 						r8_n |= (int32) g_w4031B6;
 					word32 * (* r0_n)[];
 					bool T_n;
 					int32 r13_n;
 					if ((r1_n | r3_n) == 0x00)
 					{
-						if (*r12_n[g_dw403224 / 4] == 0x00)
+						if ((*((char *) &r12_n[0] + g_dw403224))[0] == 0x00)
 						{
 							r0_n = r12_n;
 							goto l004030BE;
@@ -1122,16 +1122,16 @@ l0040306E:
 						int32 * r15_n;
 						r2_n = *r15_n;
 					}
-					int32 * r7_n = r12_n[r13_n / 4];
+					int32 * r7_n = *((char *) &r12_n[0] + r13_n);
 					*r7_n = (0x00 - (word32) (r13_n == 0x00) & (int32) g_w4031B8) + *r7_n >> ~0x08;
 					r0_n = r12_n;
 l004030BE:
-					word32 r2_n = r0_n[r2_n / 4];
+					word32 r2_n = *((char *) &r0_n[0] + r2_n);
 					int32 r2_n;
 					int32 r1_n;
 					word32 r1_n;
 					word32 r1_n;
-					if (*r0_n[g_dw40321C / 4] == 0x00)
+					if ((*((char *) &r0_n[0] + g_dw40321C))[0] == 0x00)
 					{
 						if (r2_n != 0x01)
 						{
@@ -1139,41 +1139,41 @@ l004030BE:
 							{
 								r2_n = g_dw403270;
 								r1_n = g_dw403288;
-								if (*r12_n[g_dw4031D8 / 4] == 0x00)
+								if ((*((char *) &r12_n[0] + g_dw4031D8))[0] == 0x00)
 								{
 									r1_n = g_dw40328C;
-									if (*r12_n[g_dw4031D4 / 4] == 0x00)
+									if ((*((char *) &r12_n[0] + g_dw4031D4))[0] == 0x00)
 									{
-										r1_n = r12_n[g_dw403290 / 4];
+										r1_n = *((char *) &r12_n[0] + g_dw403290);
 l00403166:
-										r12_n[r2_n / 4] = r1_n;
+										*((char *) &r12_n[0] + r2_n) = r1_n;
 l004030DA:
 										int32 r2_n = g_dw40324C;
 										int32 r1_n = g_dw403250;
-										if (*r12_n[g_dw4031C4 / 4] == 0x00)
+										if ((*((char *) &r12_n[0] + g_dw4031C4))[0] == 0x00)
 										{
 											r1_n = g_dw403254;
-											if (*r12_n[g_dw4031CC / 4] == 0x00)
+											if ((*((char *) &r12_n[0] + g_dw4031CC))[0] == 0x00)
 											{
 												r1_n = g_dw403258;
-												if (*r12_n[r14_n / 4] == 0x00)
+												if ((*((char *) &r12_n[0] + r14_n))[0] == 0x00)
 												{
 													r1_n = g_dw40325C;
-													if (*r12_n[g_dw4031C0 / 4] == 0x00)
+													if ((*((char *) &r12_n[0] + g_dw4031C0))[0] == 0x00)
 														r1_n = g_dw403260;
 												}
 											}
 										}
-										word32 * r1_n = r12_n[r1_n / 4];
+										word32 * r1_n = *((char *) &r12_n[0] + r1_n);
 										if (r9_n != 0x00)
 										{
-											r12_n[r2_n / 4] = r1_n;
+											*((char *) &r12_n[0] + r2_n) = r1_n;
 											int32 r1_n = g_dw403264;
 											(*((word32) 0x00403124 + r1_n))();
 										}
 										else
 										{
-											r12_n[r2_n / 4] = r1_n;
+											*((char *) &r12_n[0] + r2_n) = r1_n;
 											int32 r7_n = g_dw403298;
 											(*((word32) 4207024 + r7_n))();
 										}
@@ -1185,12 +1185,12 @@ l004030DA:
 							int32 r0_n = g_dw403280;
 							if (r2_n != 0x00)
 								goto l004030DA;
-							r1_n = r12_n[r0_n / 4];
+							r1_n = *((char *) &r12_n[0] + r0_n);
 						}
 						else
-							r1_n = r12_n[g_dw403284 / 4];
+							r1_n = *((char *) &r12_n[0] + g_dw403284);
 l00403140:
-						r12_n[g_dw403270 / 4] = r1_n;
+						*((char *) &r12_n[0] + g_dw403270) = r1_n;
 						goto l004030DA;
 					}
 					else
@@ -1207,26 +1207,26 @@ l00403140:
 							if (r2_n != 0x00)
 								goto l004030DA;
 l0040313E:
-							r1_n = r12_n[r0_n / 4];
+							r1_n = *((char *) &r12_n[0] + r0_n);
 							goto l00403140;
 						}
 						r2_n = g_dw403270;
 						r1_n = g_dw403274;
-						if (*r12_n[g_dw4031D8 / 4] == 0x00)
+						if ((*((char *) &r12_n[0] + g_dw4031D8))[0] == 0x00)
 						{
 							r1_n = g_dw403278;
-							if (*r12_n[g_dw4031D4 / 4] == 0x00)
+							if ((*((char *) &r12_n[0] + g_dw4031D4))[0] == 0x00)
 								r1_n = g_dw40327C;
 						}
 l00403164:
-						r1_n = r12_n[r1_n / 4];
+						r1_n = *((char *) &r12_n[0] + r1_n);
 						goto l00403166;
 					}
 				}
-				if (*r12_n[g_dw402E74 / 4] == 0x00 && (*r12_n[g_dw402E78 / 4] == 0x00 && (*r12_n[g_dw402E7C / 4] == 0x00 && r12_n[r2_n / 4] == null)))
+				if ((*((char *) &r12_n[0] + g_dw402E74))[0] == 0x00 && ((*((char *) (&r12_n[0]) + g_dw402E78))[0] == 0x00 && ((*((char *) (&r12_n[0]) + g_dw402E7C))[0] == 0x00 && *((char *) (&r12_n[0]) + r2_n) == null)))
 					r8_n |= 0x08;
 l00402D32:
-				if (*r12_n[g_dw402E80 / 4] == 0x00 && *r12_n[g_dw402E78 / 4] == 0x00)
+				if ((*((char *) &r12_n[0] + g_dw402E80))[0] == 0x00 && (*((char *) (&r12_n[0]) + g_dw402E78))[0] == 0x00)
 					r8_n |= 0x01;
 				goto l00402D4A;
 			}
@@ -1247,7 +1247,7 @@ l00403068:
 		int32 r1_n = g_dw402E60;
 		(*((word32) 0x00402CD6 + r1_n))();
 		word32 * r0_n;
-		r12_n[g_dw402E30 / 4] = r0_n;
+		*((char *) &r12_n[0] + g_dw402E30) = r0_n;
 	}
 	goto l00402CDE;
 }
@@ -1319,7 +1319,7 @@ int32 g_dw403298 = -2004; // 00403298
 // 0040329C: void safe_printpath(Register word32 r4, Register word32 pr)
 void safe_printpath(word32 r4, word32 pr)
 {
-	int32 r12_n = &g_dw4032DC + g_dw4032DC / 4;
+	int32 r12_n = (char *) &g_dw4032DC + g_dw4032DC;
 	word32 r8_n = **((word32) g_ptr4032E0 + r12_n);
 	if (r8_n != 0x00)
 	{
@@ -1347,7 +1347,7 @@ int32 g_dw4032F0 = 3944; // 004032F0
 // 004032F4: void printescapedpath(Register word32 r4, Register word32 pr)
 void printescapedpath(word32 r4, word32 pr)
 {
-	int32 r12_n = &g_dw403334 + g_dw403334 / 4;
+	int32 r12_n = (char *) &g_dw403334 + g_dw403334;
 	word32 r8_n = **((word32) g_ptr403338 + r12_n);
 	if (r8_n != 0x00)
 	{
@@ -1377,7 +1377,7 @@ void printlink(struct Eq_n * r4, word32 r8, word32 pr)
 {
 	word32 r15_n;
 	ptr32 fp;
-	word32 r12_n = &g_dw403428 + g_dw403428 / 4;
+	word32 r12_n = (char *) &g_dw403428 + g_dw403428;
 	ptr32 * r15_n = fp - 16 - (int32) g_w40341E;
 	if (r4->dw0044 == 0x00)
 	{
@@ -1412,9 +1412,9 @@ void printlink(struct Eq_n * r4, word32 r8, word32 pr)
 		int32 r1_n = g_dw403454;
 		(*((word32) 0x004033DE + r1_n))();
 		int32 r12_n;
-		if (**((word32) g_ptr40345C + r12_n) == 0x00 && *g_ptr403460[r12_n / 4] == 0x00)
+		if (**((word32) g_ptr40345C + r12_n) == 0x00 && (*((char *) (&g_ptr403460[0]) + r12_n))[0] == 0x00)
 		{
-			if (*g_ptr403468[r12_n / 4] != 0x00)
+			if ((*((char *) &g_ptr403468[0] + r12_n))[0] != 0x00)
 			{
 				int32 r1_n = g_dw40346C;
 				(*((word32) 0x0040340C + r1_n))();
@@ -1453,7 +1453,7 @@ int32 g_dw403470 = -6834; // 00403470
 // 00403474: void printpath(Register word32 r4, Register word32 pr)
 void printpath(word32 r4, word32 pr)
 {
-	int32 r12_n = &g_dw4034AC + g_dw4034AC / 4;
+	int32 r12_n = (char *) &g_dw4034AC + g_dw4034AC;
 	if (**((word32) g_ptr4034B0 + r12_n) != 0x00)
 	{
 		int32 r1_n = g_dw4034B4;
@@ -1473,15 +1473,15 @@ int32 g_dw4034BC = -6974; // 004034BC
 // 004034C4: void printtotal(Register (ptr32 Eq_n) r4, Register word32 pr)
 void printtotal(struct Eq_n * r4, word32 pr)
 {
-	int32 r12_n = &g_dw403580 + g_dw403580 / 4;
-	if (r4->ptr0000->dw0044 == 0x00 || *(*((word32) g_ptr403584 + r12_n)) == 0x00 && *g_ptr403588[r12_n / 4] == 0x00)
+	int32 r12_n = (char *) &g_dw403580 + g_dw403580;
+	if (r4->ptr0000->dw0044 == 0x00 || *(*((word32) g_ptr403584 + r12_n)) == 0x00 && (*((char *) (&g_ptr403588[0]) + r12_n))[0] == 0x00)
 		return;
-	if (*g_ptr40358C[r12_n / 4] == 0x00)
+	if ((*((char *) &g_ptr40358C[0] + r12_n))[0] == 0x00)
 	{
 		word32 r8_n = g_dw4035AC;
-		if (*g_ptr4035A8[r12_n / 4] != 0x00)
+		if ((*((char *) &g_ptr4035A8[0] + r12_n))[0] != 0x00)
 			r8_n = g_dw4035B0;
-		int32 r3_n = *g_ptr4035B4[r12_n / 4];
+		int32 r3_n = (*((char *) &g_ptr4035B4[0] + r12_n))[0];
 		word32 r0_n = r4->dw0004;
 		word32 r1_n = 0x00 - (r3_n < 0x01);
 		int32 r2_n = g_dw4035B8;
@@ -1523,9 +1523,9 @@ int32 g_dw4035BC = -7188; // 004035BC
 // 004035C0: void __sputc.constprop.3(Register Eq_n r4, Register word32 pr)
 void __sputc.constprop.3(Eq_n r4, word32 pr)
 {
-	struct Eq_n * r12_n[] = &g_dw403610 + g_dw403610 / 4;
+	struct Eq_n * r12_n[] = (struct Eq_n * (*)[]) ((char *) &g_dw403610 + g_dw403610);
 	int32 r3_n = g_dw403614;
-	struct Eq_n * r2_n = (struct Eq_n *) r12_n[r3_n / 4];
+	struct Eq_n * r2_n = (struct Eq_n *) *((char *) &r12_n[0] + r3_n);
 	int32 r1_n = r2_n->dw0060;
 	if (r1_n < 0x01)
 	{
@@ -1539,7 +1539,7 @@ void __sputc.constprop.3(Eq_n r4, word32 pr)
 	}
 	else
 		r2_n->dw0060 = r1_n + ~0x00;
-	struct Eq_n * r1_n = r12_n[r3_n / 4];
+	struct Eq_n * r1_n = (struct Eq_n *) *((char *) &r12_n[0] + r3_n);
 	union Eq_n * r2_n = r1_n->ptr0058;
 	r1_n->ptr0058 = (union Eq_n *) ((char *) r2_n + 1);
 	r2_n->u0 = (byte) r4;
@@ -1651,7 +1651,7 @@ void printtype(ui32 r4, word32 pr)
 	Eq_n r2_n;
 	r2_n.u0 = g_t4037A4.u0;
 	Eq_n r1_n = g_dw4037A0 & r4;
-	word32 r12_n = &g_dw40379C + g_dw40379C / 4;
+	word32 r12_n = (char *) &g_dw40379C + g_dw40379C;
 	if (r1_n == r2_n)
 	{
 		int32 r1_n = g_dw4037C0;
@@ -1724,7 +1724,7 @@ int32 g_dw4037C4 = -468; // 004037C4
 void printaname(struct Eq_n * r4, word32 r6, word32 r9, word32 pr)
 {
 	ptr32 fp;
-	int32 r12_n = &g_dw403914 + g_dw403914 / 4;
+	int32 r12_n = (char *) &g_dw403914 + g_dw403914;
 	struct Eq_n * r15_n = fp - 0x30;
 	word32 r10_n = r4->dw0050;
 	struct Eq_n * r11_n = r4;
@@ -1740,9 +1740,9 @@ void printaname(struct Eq_n * r4, word32 r6, word32 r9, word32 pr)
 	{
 		word32 r13_n = r6;
 	}
-	if (*g_ptr403924[r12_n / 4] != 0x00)
+	if ((*((char *) &g_ptr403924[0] + r12_n))[0] != 0x00)
 	{
-		if (*g_ptr403928[r12_n / 4] != 0x00)
+		if ((*((char *) &g_ptr403928[0] + r12_n))[0] != 0x00)
 		{
 			r15_n->dw0008 = 0x07;
 			r15_n->dw0004 = 0x20;
@@ -1766,9 +1766,9 @@ void printaname(struct Eq_n * r4, word32 r6, word32 r9, word32 pr)
 		{
 			word32 r7_n = r10_n + 0x40;
 			word32 r9_n = g_dw40391C;
-			if (*g_ptr403960[r12_n / 4] != 0x00)
+			if ((*((char *) &g_ptr403960[0] + r12_n))[0] != 0x00)
 				r9_n = g_dw403964;
-			int32 r3_n = *g_ptr403968[r12_n / 4];
+			int32 r3_n = (*((char *) &g_ptr403968[0] + r12_n))[0];
 			word32 r1_n = 0x00 - (r3_n < 0x01);
 			int32 r2_n = g_dw40396C;
 			(*((word32) 4208866 + r2_n))();
@@ -1780,9 +1780,9 @@ void printaname(struct Eq_n * r4, word32 r6, word32 r9, word32 pr)
 		}
 	}
 	word32 r8_n;
-	if (*g_ptr403944[r12_n / 4] == 0x00 && *g_ptr403948[r12_n / 4] == 0x00)
+	if ((*((char *) &g_ptr403944[0] + r12_n))[0] == 0x00 && (*((char *) (&g_ptr403948[0]) + r12_n))[0] == 0x00)
 	{
-		if (*g_ptr403974[r12_n / 4] != 0x00)
+		if ((*((char *) &g_ptr403974[0] + r12_n))[0] != 0x00)
 		{
 			int32 r1_n = g_dw403978;
 			(*((word32) 0x00403904 + r1_n))();
@@ -1809,7 +1809,7 @@ void printaname(struct Eq_n * r4, word32 r6, word32 r9, word32 pr)
 	}
 	int32 r12_n;
 	struct Eq_n * r10_n;
-	if (*g_ptr403950[r12_n / 4] != 0x00 || *(*((word32) g_ptr403954 + r12_n)) != 0x00 && (r10_n->dw0008 & g_dw403958) == (int32) g_w403912)
+	if ((*((char *) &g_ptr403950[0] + r12_n))[0] != 0x00 || *(*((word32) g_ptr403954 + r12_n)) != 0x00 && (r10_n->dw0008 & g_dw403958) == (int32) g_w403912)
 	{
 		int32 r1_n = g_dw40395C;
 		(*((word32) 0x00403896 + r1_n))();
@@ -1845,7 +1845,7 @@ int32 g_dw40397C = -1178; // 0040397C
 // 00403980: void printscol(Register (ptr32 (ptr32 Eq_n)) r4, Register word32 pr)
 void printscol(struct Eq_n ** r4, word32 pr)
 {
-	word32 r12_n = &g_dw4039C0 + g_dw4039C0 / 4;
+	word32 r12_n = (char *) &g_dw4039C0 + g_dw4039C0;
 	struct Eq_n * r8_n;
 	for (r8_n = (struct Eq_n *) *r4; r8_n != null; r8_n = r8_n->ptr0008)
 	{
@@ -1902,17 +1902,17 @@ l00403A38:
 					int32 r1_n = g_dw403ACC;
 					(*((word32) 4209234 + r1_n))();
 				}
-				if (*g_ptr403AD0[r12_n / 4] != 0x00)
+				if ((*((char *) &g_ptr403AD0[0] + r12_n))[0] != 0x00)
 				{
 					word32 r1_n = r9_n->dw0060;
 					word32 r5_n = r9_n->dw0064;
-					if (*g_ptr403AD4[r12_n / 4] == 0x00)
+					if ((*((char *) &g_ptr403AD4[0] + r12_n))[0] == 0x00)
 					{
 						word32 r13_n = g_dw403D60;
-						if (*g_ptr403D5C[r12_n / 4] == 0x00)
+						if ((*((char *) &g_ptr403D5C[0] + r12_n))[0] == 0x00)
 							r13_n = g_dw403D64;
 						word32 * r0_n[] = g_ptr403D68;
-						word32 r3_n = *r0_n[r12_n / 4];
+						word32 r3_n = (*((char *) &r0_n[0] + r12_n))[0];
 						int32 r2_n = g_dw403D6C;
 						(*((word32) 0x00403C34 + r2_n))();
 						int32 r1_n = g_dw403D70;
@@ -1977,7 +1977,7 @@ l00403AF2:
 					int32 r1_n = g_dw403D28;
 					(*((word32) 0x00403B8C + r1_n))();
 				}
-				else if (*g_ptr403D74[r12_n / 4] != 0x00)
+				else if ((*((char *) &g_ptr403D74[0] + r12_n))[0] != 0x00)
 				{
 					r15_n->dw0008 = 0x07;
 					r15_n->dw0004 = 0x20;
@@ -1990,7 +1990,7 @@ l00403AF2:
 					{
 l00403AA4:
 						int32 r2_n = g_dw403AE4;
-						(&g_w403AAE)[r2_n / 2]();
+						(*((char *) &g_w403AAE + r2_n))();
 						Eq_n r0_n;
 						r0_n.u1->t0000.u0 = (byte) r0_n;
 						word32 * r7_n;
@@ -2004,7 +2004,7 @@ l00403AA4:
 				{
 					word32 r4_n = g_dw403D60;
 					word32 r4_n;
-					if (*g_ptr403D5C[r12_n / 4] == 0x00)
+					if ((*((char *) &g_ptr403D5C[0] + r12_n))[0] == 0x00)
 						r4_n = g_dw403D64 + r12_n;
 					else
 						r4_n = r4_n + r12_n;
@@ -2012,7 +2012,7 @@ l00403AA4:
 					(*((word32) 4209822 + r2_n))();
 				}
 				int32 r12_n;
-				if (*g_ptr403D2C[r12_n / 4] == 0x00)
+				if ((*((char *) &g_ptr403D2C[0] + r12_n))[0] == 0x00)
 				{
 					if (**((word32) g_ptr403D88 + r12_n) != 0x00)
 					{
@@ -2032,9 +2032,9 @@ l00403AA4:
 					(*((word32) 0x00403BA2 + r6_n))();
 				}
 				int32 r12_n;
-				if (*g_ptr403D34[r12_n / 4] == 0x00 && *(*((word32) g_ptr403D38 + r12_n)) == 0x00)
+				if ((*((char *) &g_ptr403D34[0] + r12_n))[0] == 0x00 && *(*((word32) g_ptr403D38 + r12_n)) == 0x00)
 				{
-					if (*g_ptr403D94[r12_n / 4] != 0x00)
+					if ((*((char *) &g_ptr403D94[0] + r12_n))[0] != 0x00)
 					{
 						int32 r1_n = g_dw403D98;
 						(*((word32) 4209882 + r1_n))();
@@ -2053,7 +2053,7 @@ l00403AA4:
 				int32 r12_n;
 				ui32 r4_n;
 				struct Eq_n * r9_n;
-				if (*g_ptr403D40[r12_n / 4] == 0x00)
+				if ((*((char *) &g_ptr403D40[0] + r12_n))[0] == 0x00)
 				{
 					r4_n = r9_n->dw0008;
 					if (**((word32) g_ptr403D44 + r12_n) == 0x00 || (g_dw403D48 & r4_n) != (int32) g_w403CEA)
@@ -2153,10 +2153,10 @@ void printcol(struct Eq_n * r4, word32 r8, word32 r9, word32 r14, word32 pr)
 	int32 r0_n;
 	int32 r12_n;
 	int32 r10_n;
-	word32 * r12_n[] = &g_dw403F28 + g_dw403F28 / 4;
+	word32 * r12_n[] = (word32 * (*)[]) ((char *) &g_dw403F28 + g_dw403F28);
 	struct Eq_n * r13_n = r4;
 	word32 r5_n;
-	if (*r12_n[g_ptr403F2C / 4] != 0x00)
+	if ((*((char *) &r12_n[0] + g_ptr403F2C))[0] != 0x00)
 	{
 		word32 r5_n = r4->dw0018;
 		r5_n = r5_n + r4->dw0028 + true;
@@ -2178,11 +2178,11 @@ void printcol(struct Eq_n * r4, word32 r8, word32 r9, word32 r14, word32 pr)
 	ui32 r10_n = r5_n + 0x01;
 	if (r10_n * 0x02 <= Mem28[Mem28[r12_n + r11_n:word32] + 0x00:word32])
 	{
-		int32 * r8_n = (int32 *) (r12_n + g_dw403F48 / 4);
+		int32 * r8_n = (int32 *) ((char *) r12_n + g_dw403F48);
 		int32 r5_n = r4->dw0014;
 		if (r5_n > *r8_n)
 		{
-			int32 r9_n = (int32) (r12_n + g_t403F4C.u0 / 4);
+			int32 r9_n = (char *) r12_n + g_t403F4C.u0;
 			int32 r3_n = g_dw403F50;
 			(*((word32) 0x00403E48 + r3_n))();
 			word32 r0_n;
@@ -2202,7 +2202,7 @@ void printcol(struct Eq_n * r4, word32 r8, word32 r9, word32 r14, word32 pr)
 		}
 		ui32 r9_n = 0x00;
 		struct Eq_n * r1_n;
-		struct Eq_n * r2_n[] = r12_n[g_t403F4C.u0 / 4];
+		struct Eq_n * r2_n[] = (struct Eq_n * (*)[]) *((char *) &r12_n[0] + g_t403F4C.u0);
 		for (r1_n = r13_n->ptr0000; r1_n != null; r1_n = r1_n->ptr0008)
 		{
 			if (r1_n->dw0010 == 0x00)
@@ -2221,7 +2221,7 @@ l00403EC0:
 		word32 * r1_n = Mem153[r12_n + r11_n:word32];
 		int32 r0_n = g_dw403F5C;
 		word32 r6_n = *r1_n;
-		<anonymous> ** r8_n = r12_n[r0_n / 4];
+		<anonymous> ** r8_n = (<anonymous> **) *((char *) &r12_n[0] + r0_n);
 		(*r8_n)();
 		<anonymous> ** r8_n;
 		(*r8_n)();
@@ -2253,7 +2253,7 @@ l00403EC0:
 			while (r2_n < r11_n)
 			{
 				word32 r4_n = *((word32) r15_n->t0008.u0 + *((word32) g_t403F4C.u0 + r12_n));
-				*g_ptr403F34[r12_n / 4] == 0x00;
+				(*((char *) &g_ptr403F34[0] + r12_n))[0] == 0x00;
 				int32 r1_n = g_dw403F64;
 				r15_n->dw0000 = r2_n;
 				(*((word32) 4210410 + r1_n))();
@@ -2312,7 +2312,7 @@ void printacol(struct Eq_n * r4, word32 r9, word32 r10, word32 r11, word32 r13, 
 {
 	int32 r0_n;
 	struct Eq_n ** r8_n;
-	int32 r12_n = &g_dw404080 + g_dw404080 / 4;
+	int32 r12_n = (char *) &g_dw404080 + g_dw404080;
 	word32 r5_n;
 	if (**((word32) g_ptr404084 + r12_n) != 0x00)
 	{
@@ -2321,22 +2321,22 @@ void printacol(struct Eq_n * r4, word32 r9, word32 r10, word32 r11, word32 r13, 
 	}
 	else
 		r5_n = r4->dw0018;
-	if (*g_ptr404088[r12_n / 4] != 0x00)
+	if ((*((char *) &g_ptr404088[0] + r12_n))[0] != 0x00)
 	{
 		word32 r1_n;
-		if (*g_ptr40408C[r12_n / 4] != 0x00)
+		if ((*((char *) &g_ptr40408C[0] + r12_n))[0] != 0x00)
 			r1_n = r4->dw0030;
 		else
 			r1_n = r4->dw001C;
 		r5_n = r5_n + r1_n + true;
 	}
-	if (*g_ptr404090[r12_n / 4] != 0x00 || *g_ptr404094[r12_n / 4] != 0x00)
+	if ((*((char *) &g_ptr404090[0] + r12_n))[0] != 0x00 || (*((char *) (&g_ptr404094[0]) + r12_n))[0] != 0x00)
 		++r5_n;
-	int32 r7_n = *g_ptr404098[r12_n / 4];
+	int32 r7_n = (*((char *) &g_ptr404098[0] + r12_n))[0];
 	if ((r5_n + 0x01) * 0x02 <= r7_n)
 	{
 		<anonymous> ****** r0_n[] = g_ptr4040A0;
-		<anonymous> ** r11_n = (<anonymous> **) r0_n[r12_n / 4];
+		<anonymous> ** r11_n = (<anonymous> **) *((char *) &r0_n[0] + r12_n);
 		(*r11_n)();
 		<anonymous> ** r11_n;
 		(*r11_n)();
@@ -2415,25 +2415,25 @@ int32 g_dw4040B4 = -0x0ABA; // 004040B4
 void printstream(struct Eq_n * r4, word32 pr)
 {
 	ptr32 fp;
-	int32 r12_n = &g_dw404184 + g_dw404184 / 4;
+	int32 r12_n = (char *) &g_dw404184 + g_dw404184;
 	ptr32 r15_n = fp - 32;
 	word32 r8_n = **((word32) g_ptr404188 + r12_n);
 	if (r8_n != 0x00)
 		r8_n = r4->dw0028 + 0x01;
 	struct Eq_n * r11_n = r4;
-	if (*g_ptr40418C[r12_n / 4] != 0x00)
+	if ((*((char *) &g_ptr40418C[0] + r12_n))[0] != 0x00)
 	{
 		word32 r1_n;
-		if (*g_ptr404190[r12_n / 4] != 0x00)
+		if ((*((char *) &g_ptr404190[0] + r12_n))[0] != 0x00)
 			r1_n = r4->dw0030;
 		else
 			r1_n = r4->dw001C;
 		r8_n = r8_n + r1_n + true;
 	}
-	if (*g_ptr404194[r12_n / 4] != 0x00)
+	if ((*((char *) &g_ptr404194[0] + r12_n))[0] != 0x00)
 		++r8_n;
 	int32 r10_n = 0x00;
-	word32 ** r13_n = (word32 **) (g_ptr404190 + r12_n / 4);
+	word32 ** r13_n = (word32 **) ((char *) g_ptr404190 + r12_n);
 	struct Eq_n * r9_n;
 	word32 r14_n = g_dw404198 + r12_n;
 	for (r9_n = r4->ptr0000; r9_n != null; r9_n = r9_n->ptr0008)
@@ -2526,7 +2526,7 @@ int32 g_dw404234 = -10556; // 00404234
 // 00404238: void safe_print(Register word32 r4, Register word32 r10, Register word32 pr)
 void safe_print(word32 r4, word32 r10, word32 pr)
 {
-	int32 r12_n = &g_dw4042C4 + g_dw4042C4 / 4;
+	int32 r12_n = (char *) &g_dw4042C4 + g_dw4042C4;
 	word32 r9_n;
 	if (**((word32) g_ptr4042C8 + r12_n) != 0x00)
 		r9_n = 0x1F;

--- a/subjects/Elf/x86-64/ls/ls.reko/ls.h
+++ b/subjects/Elf/x86-64/ls/ls.reko/ls.h
@@ -23207,7 +23207,7 @@ T_4017: (in rax_14 + rcx_34 @ 000000000040566A : word64)
   Class: Eq_4017
   DataType: ui64
   OrigDataType: ui64
-T_4018: (in (int64) ~(word32) rcx_34 & &(rax_14 + rcx_34 /64 8<i32>)->dw0000 @ 000000000040566A : word64)
+T_4018: (in (int64) ~(word32) rcx_34 & (char *) (&rax_14->dw0000) + rcx_34 @ 000000000040566A : word64)
   Class: Eq_3982
   DataType: (ptr64 (arr Eq_18004))
   OrigDataType: ui64
@@ -78313,7 +78313,7 @@ T_17751: (in &bLocB8 @ 0000000000411BDC : (ptr64 char))
   Class: Eq_17746
   DataType: (ptr64 char)
   OrigDataType: (ptr64 char)
-T_17752: (in strcpy(r13_350 + ((0xFFFFFFFFFFFFFFFE<64> - rdx_270) + r14_398) /64 2<i32>, &bLocB8) @ 0000000000411BDC : (ptr64 char))
+T_17752: (in strcpy(&r13_350->b0000 + ((0xFFFFFFFFFFFFFFFE<64> - rdx_270) + r14_398), &bLocB8) @ 0000000000411BDC : (ptr64 char))
   Class: Eq_17752
   DataType: (ptr64 char)
   OrigDataType: (ptr64 char)

--- a/subjects/Elf/x86-64/ls/ls.reko/ls_text.c
+++ b/subjects/Elf/x86-64/ls/ls.reko/ls_text.c
@@ -2160,7 +2160,7 @@ void fn0000000000405630(struct Eq_n * rsi, char * rdi)
 		rsi->b0050 |= 0x02;
 	int64 rcx_n = (int64) rsi->dw0030;
 	Eq_n (* rcx_n)[] = rsi->ptr0020;
-	Eq_n (* rdx_n)[] = (int64) ~(word32) rcx_n & &(rax_n + rcx_n /64 8)->dw0000;
+	Eq_n (* rdx_n)[] = (int64) ~(word32) rcx_n & (char *) (&rax_n->dw0000) + rcx_n;
 	int64 rax_n = rsi->qw0008;
 	rsi->ptr0018 = rdx_n;
 	if (rdx_n - rax_n > rcx_n - rax_n)
@@ -7605,7 +7605,7 @@ void fn000000000040E650(word32 edx, int32 esi, struct Eq_n * rdi)
 	struct Eq_n * rax_n = (struct Eq_n *) &g_qw61B320;
 	if (rdi != null)
 		rax_n = rdi;
-	struct Eq_n * rsi_n = (struct Eq_n *) (rax_n + ((uint64) (sil_n >> 0x05) * 0x04) /64 56);
+	struct Eq_n * rsi_n = (struct Eq_n *) (&rax_n->dw0000 + (uint64) (sil_n >> 0x05));
 	uint32 edi_n = rsi_n->dw0008;
 	byte cl_n = (byte) esi & 0x1F;
 	rsi_n->dw0008 = ((edx ^ edi_n >> cl_n) & 0x01) << cl_n ^ edi_n;
@@ -9324,7 +9324,7 @@ void fn0000000000410AC0(char * rcx, char * rdx, char * rsi, FILE * rdi, struct E
 			word64 * r10_n = r8->ptr0008;
 			r8->ptr0008 = r10_n + 1;
 			word64 rax_n = *r10_n;
-			(&tLoc58)[r9_n * 0x08 /64 72] = (struct Eq_n) rax_n;
+			tLoc58.a0000[r9_n] = rax_n;
 			if (rax_n == 0x00)
 				break;
 		}
@@ -9333,7 +9333,7 @@ void fn0000000000410AC0(char * rcx, char * rdx, char * rsi, FILE * rdi, struct E
 			word64 * r10_n = (uint64) eax_n + r8->qw0010;
 			r8->dw0000 = eax_n + 0x08;
 			word64 rax_n = *r10_n;
-			(&tLoc58)[r9_n * 0x08 /64 72] = (struct Eq_n) rax_n;
+			tLoc58.a0000[r9_n] = rax_n;
 			if (rax_n == 0x00)
 				break;
 		}
@@ -10361,7 +10361,7 @@ l0000000000411AC9:
 							fn0000000000411D30(rax_n);
 							if (qwLocD0_n == 0x00)
 								goto l0000000000411C28;
-							r14_n[qwLocD0_n /64 2] = (struct Eq_n) 0x00;
+							(&r14_n->b0000)[qwLocD0_n] = 0x00;
 							goto l0000000000411C2E;
 						}
 						ungetc(edi_n, rax_n);
@@ -10422,7 +10422,7 @@ l0000000000411AC9:
 							goto l0000000000411C2E;
 						}
 						int64 r14_n = qwLocD0_n - r10_n;
-						strcpy(r13_n + ((~0x01 - rdx_n) + r14_n) /64 2, &bLocB8);
+						strcpy(&r13_n->b0000 + ((~0x01 - rdx_n) + r14_n), &bLocB8);
 						strcpy(r13_n - 1 + r14_n, &bLoc78);
 						r14_n = r13_n;
 						rax_n = rax_n->ptr0008;

--- a/subjects/Elf/x86-64/simd_double/simd_double.reko/simd_double.h
+++ b/subjects/Elf/x86-64/simd_double/simd_double.reko/simd_double.h
@@ -1158,7 +1158,7 @@ T_254: (in rax_44[qwLoc28_232 * 8<64>] @ 0000000000000A23 : word64)
   Class: Eq_233
   DataType: real64
   OrigDataType: real64
-T_255: (in printf("%g\n", rax_44[qwLoc28_232 * 8<64> /64 32<i32>].u0) @ 0000000000000A23 : int32)
+T_255: (in printf("%g\n", (&rax_44[0<i32>].u0)[qwLoc28_232]) @ 0000000000000A23 : int32)
   Class: Eq_255
   DataType: int32
   OrigDataType: int32

--- a/subjects/Elf/x86-64/simd_double/simd_double.reko/simd_double_text.c
+++ b/subjects/Elf/x86-64/simd_double/simd_double.reko/simd_double_text.c
@@ -109,7 +109,7 @@ void main()
 	word128 xmm0;
 	while (qwLoc10_n < 0x0400)
 	{
-		real64 * rcx_n = &(rax_n + (qwLoc10_n * 0x08) /64 32)->u0;
+		real64 * rcx_n = (real64 *) (&rax_n->u0 + qwLoc10_n);
 		ui32 eax_n = (word32) qwLoc10_n;
 		if (qwLoc10_n >= 0x00)
 			xmm0 = SEQ(SLICE(xmm0, word64, 64), (real64) qwLoc10_n);
@@ -126,7 +126,7 @@ void main()
 	while (qwLoc18_n < 0x0400)
 	{
 		ui32 eax_n = (word32) qwLoc18_n + 0x01;
-		real64 * rcx_n = &(rax_n + (qwLoc18_n * 0x08) /64 32)->u0;
+		real64 * rcx_n = (real64 *) (&rax_n->u0 + qwLoc18_n);
 		if (qwLoc18_n >= ~0x00)
 			xmm0 = SEQ(SLICE(xmm0, word64, 64), (real64) ((word64) qwLoc18_n.u0 + 1));
 		else
@@ -139,11 +139,11 @@ void main()
 	}
 	uint64 qwLoc20_n;
 	for (qwLoc20_n = 0x00; qwLoc20_n < 0x0400; ++qwLoc20_n)
-		rax_n[qwLoc20_n * 0x08 /64 32].u0 = 0.0;
+		(&rax_n[0].u0)[qwLoc20_n] = 0.0;
 	vec_add(rax_n, rax_n, rax_n, 0x0400);
 	uint64 qwLoc28_n;
 	for (qwLoc28_n = 0x00; qwLoc28_n < 0x0400; ++qwLoc28_n)
-		printf("%g\n", rax_n[qwLoc28_n * 0x08 /64 32].u0);
+		printf("%g\n", (&rax_n[0].u0)[qwLoc28_n]);
 	_mm_free(rax_n);
 	_mm_free(rax_n);
 	_mm_free(rax_n);

--- a/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN.h
+++ b/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN.h
@@ -14074,7 +14074,7 @@ T_3018: (in SEQ(d0_71 % (uint16) d1_22, (word16) d2_75) - SEQ(SLICE(d2_75, word1
 T_3019: (in d0_108 @ 0000275A : Eq_609)
   Class: Eq_609
   DataType: Eq_609
-  OrigDataType: (ptr32 Eq_5737)
+  OrigDataType: (ptr32 char)
 T_3020: (in 0<32> @ 0000275C : word32)
   Class: Eq_609
   DataType: byte

--- a/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN_code.c
+++ b/subjects/Hunk-m68k/BENCHFN.reko/BENCHFN_code.c
@@ -1618,7 +1618,7 @@ Eq_n fn000026F2(Eq_n d0, Eq_n d1, Eq_n d2, ptr32 & d1Out)
 		if (d0_n < 0x00)
 		{
 			d3_n = SEQ(v52_n, v50_n - 0x01);
-			&d0_n.u2->ptr0000 = d0_n.u2 + d1_n / 4;
+			&d0_n.u2->ptr0000 = (char *) &d0_n.u2->ptr0000 + d1_n;
 			while (d0_n >= 0x00)
 				;
 		}

--- a/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG.h
+++ b/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG.h
@@ -5256,7 +5256,7 @@ T_812: (in SEQ(d0_71 % (uint16) d1_22, (word16) d2_75) - SEQ(SLICE(d2_75, word16
 T_813: (in d0_108 @ 00001586 : Eq_528)
   Class: Eq_528
   DataType: Eq_528
-  OrigDataType: (ptr32 Eq_5655)
+  OrigDataType: (ptr32 char)
 T_814: (in 0<32> @ 00001588 : word32)
   Class: Eq_528
   DataType: byte

--- a/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG_code.c
+++ b/subjects/Hunk-m68k/BENCHLNG.reko/BENCHLNG_code.c
@@ -480,7 +480,7 @@ Eq_n fn0000151E(Eq_n d0, Eq_n d1, Eq_n d2, ptr32 & d1Out)
 		if (d0_n < 0x00)
 		{
 			d3_n = SEQ(v52_n, v50_n - 0x01);
-			&d0_n.u2->ptr0000 = d0_n.u2 + d1_n / 4;
+			&d0_n.u2->ptr0000 = (char *) &d0_n.u2->ptr0000 + d1_n;
 			while (d0_n >= 0x00)
 				;
 		}

--- a/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL.h
+++ b/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL.h
@@ -16785,7 +16785,7 @@ T_3621: (in SEQ(d0_71 % (uint16) d1_22, (word16) d2_75) - SEQ(SLICE(d2_75, word1
 T_3622: (in d0_108 @ 000029E2 : Eq_548)
   Class: Eq_548
   DataType: Eq_548
-  OrigDataType: (ptr32 Eq_6340)
+  OrigDataType: (ptr32 char)
 T_3623: (in 0<32> @ 000029E4 : word32)
   Class: Eq_548
   DataType: byte

--- a/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL_code.c
+++ b/subjects/Hunk-m68k/BENCHMUL.reko/BENCHMUL_code.c
@@ -1655,7 +1655,7 @@ Eq_n fn0000297A(Eq_n d0, Eq_n d1, Eq_n d2, ptr32 & d1Out)
 		if (d0_n < 0x00)
 		{
 			d3_n = SEQ(v52_n, v50_n - 0x01);
-			&d0_n.u2->ptr0000 = d0_n.u2 + d1_n / 4;
+			&d0_n.u2->ptr0000 = (char *) &d0_n.u2->ptr0000 + d1_n;
 			while (d0_n >= 0x00)
 				;
 		}

--- a/subjects/Hunk-m68k/BYTEOPS.reko/BYTEOPS_code.c
+++ b/subjects/Hunk-m68k/BYTEOPS.reko/BYTEOPS_code.c
@@ -1724,7 +1724,7 @@ word32 * fn00002AFA(word32 * d0, word32 * d1, word32 * d2, ptr32 & d1Out)
 		if (d0_n < null)
 		{
 			d3_n = SEQ(v52_n, v50_n - 0x01);
-			d0_n += d1_n / 4;
+			d0_n = (word32 *) ((char *) d0_n + d1_n);
 			while (d0_n >= null)
 				;
 		}

--- a/subjects/Hunk-m68k/FIBO.reko/FIBO.h
+++ b/subjects/Hunk-m68k/FIBO.reko/FIBO.h
@@ -13988,7 +13988,7 @@ T_3005: (in SEQ(d0_71 % (uint16) d1_22, (word16) d2_75) - SEQ(SLICE(d2_75, word1
 T_3006: (in d0_108 @ 0000277E : Eq_572)
   Class: Eq_572
   DataType: Eq_572
-  OrigDataType: (ptr32 Eq_5723)
+  OrigDataType: (ptr32 char)
 T_3007: (in 0<32> @ 00002780 : word32)
   Class: Eq_572
   DataType: byte

--- a/subjects/Hunk-m68k/FIBO.reko/FIBO_code.c
+++ b/subjects/Hunk-m68k/FIBO.reko/FIBO_code.c
@@ -1601,7 +1601,7 @@ Eq_n fn00002716(Eq_n d0, Eq_n d1, Eq_n d2, ptr32 & d1Out)
 		if (d0_n < 0x00)
 		{
 			d3_n = SEQ(v52_n, v50_n - 0x01);
-			&d0_n.u2->ptr0000 = d0_n.u2 + d1_n / 4;
+			&d0_n.u2->ptr0000 = (char *) &d0_n.u2->ptr0000 + d1_n;
 			while (d0_n >= 0x00)
 				;
 		}

--- a/subjects/Hunk-m68k/MAX.reko/MAX.h
+++ b/subjects/Hunk-m68k/MAX.reko/MAX.h
@@ -13545,7 +13545,7 @@ T_2895: (in SEQ(d0_71 % (uint16) d1_22, (word16) d2_75) - SEQ(SLICE(d2_75, word1
 T_2896: (in d0_108 @ 000025E6 : Eq_528)
   Class: Eq_528
   DataType: Eq_528
-  OrigDataType: (ptr32 Eq_5589)
+  OrigDataType: (ptr32 char)
 T_2897: (in 0<32> @ 000025E8 : word32)
   Class: Eq_528
   DataType: byte

--- a/subjects/Hunk-m68k/MAX.reko/MAX_code.c
+++ b/subjects/Hunk-m68k/MAX.reko/MAX_code.c
@@ -1441,7 +1441,7 @@ Eq_n fn0000257E(Eq_n d0, Eq_n d1, Eq_n d2, ptr32 & d1Out)
 		if (d0_n < 0x00)
 		{
 			d3_n = SEQ(v52_n, v50_n - 0x01);
-			&d0_n.u2->ptr0000 = d0_n.u2 + d1_n / 4;
+			&d0_n.u2->ptr0000 = (char *) &d0_n.u2->ptr0000 + d1_n;
 			while (d0_n >= 0x00)
 				;
 		}

--- a/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG.h
+++ b/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG.h
@@ -13768,7 +13768,7 @@ T_2949: (in SEQ(d0_71 % (uint16) d1_22, (word16) d2_75) - SEQ(SLICE(d2_75, word1
 T_2950: (in d0_108 @ 000026E2 : Eq_528)
   Class: Eq_528
   DataType: Eq_528
-  OrigDataType: (ptr32 Eq_5581)
+  OrigDataType: (ptr32 char)
 T_2951: (in 0<32> @ 000026E4 : word32)
   Class: Eq_528
   DataType: byte

--- a/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG_code.c
+++ b/subjects/Hunk-m68k/TESTLONG.reko/TESTLONG_code.c
@@ -1589,7 +1589,7 @@ Eq_n fn0000267A(Eq_n d0, Eq_n d1, Eq_n d2, ptr32 & d1Out)
 		if (d0_n < 0x00)
 		{
 			d3_n = SEQ(v52_n, v50_n - 0x01);
-			&d0_n.u2->ptr0000 = d0_n.u2 + d1_n / 4;
+			&d0_n.u2->ptr0000 = (char *) &d0_n.u2->ptr0000 + d1_n;
 			while (d0_n >= 0x00)
 				;
 		}

--- a/subjects/MZ-x86/BENCHFN_0800.c
+++ b/subjects/MZ-x86/BENCHFN_0800.c
@@ -1562,7 +1562,7 @@ l0800_nF1:
 						(ss->*sp_n).wFFFFFFF6 = ax_n;
 						__REALCVT(ds);
 						(ss->*sp_n).tFFFFFFF4.u2 = (struct Eq_n *) ss;
-						struct Eq_n Eq_n::* wArg02_n = (struct Eq_n Eq_n::*) (wArg02_n + wLoc06_n /16 6);
+						struct Eq_n Eq_n::* wArg02_n = (struct Eq_n Eq_n::*) ((char *) &wArg02_n->t0000.u0 + wLoc06_n);
 						struct Eq_n Eq_n::* sp_n = sp_n - 0x0A;
 						ptr32 es_di_n = (ptr32) (fp - 0x89);
 l0800_n:

--- a/subjects/MachO/amd64/MachO-OSX-x64-ls.reko/MachO-OSX-x64-ls_TEXT_text.c
+++ b/subjects/MachO/amd64/MachO-OSX-x64-ls.reko/MachO-OSX-x64-ls_TEXT_text.c
@@ -416,7 +416,7 @@ void fn00000001000023B0(ui32 edx, int32 edi)
 					up32 eax_n = (word32) rax_n;
 					if (eax_n <= 0x06)
 					{
-						rax_n = (struct Eq_n *) (g_a2684 + (int64) g_a2684[rax_n] /64 4);
+						rax_n = (struct Eq_n *) ((char *) g_a2684 + (int64) g_a2684[rax_n]);
 						word32 rax_32_32_n = SLICE(rax_n, word32, 32);
 						word56 rax_56_8_n = SLICE(rax_n, word56, 8);
 						switch (eax_n)

--- a/subjects/OpenRISC/sunxi/blob.reko/blob.c
+++ b/subjects/OpenRISC/sunxi/blob.reko/blob.c
@@ -1591,7 +1591,7 @@ int32 fn00007338(uint32 r3, Eq_n r4)
 	int32 r11_n;
 	while (r5_n < r4)
 	{
-		union Eq_n * r7_n = (union Eq_n *) (r6_n + r3_n / 4);
+		union Eq_n * r7_n = (union Eq_n *) ((char *) r6_n + r3_n);
 		if (r7_n->u0 != (word32) r5_n.u0 - 19088744)
 		{
 			r11_n = -1;
@@ -2017,7 +2017,7 @@ l000079E0:
 		r8_n.u0 = 0;
 		struct Eq_n * r12_n = r15_n;
 		ui32 r4_n = 0x00;
-		int32 r14_n = r5_n + (-1 << r14_n) / 4;
+		int32 r14_n = (char *) &r5_n->dw0000 + (-1 << r14_n);
 		while (true)
 		{
 			struct Eq_n * r21_n;
@@ -2091,7 +2091,7 @@ l00007844:
 		Eq_n r12_n;
 		r12_n.u0 = 0;
 		struct Eq_n * r21_n = r15_n;
-		int32 r16_n = r5_n + r16_n / 4;
+		int32 r16_n = (char *) &r5_n->dw0000 + r16_n;
 		ui32 r8_n = 0x00;
 		while (true)
 		{
@@ -2152,7 +2152,7 @@ l0000799C:
 	{
 		r2_n->t0010.u0 = (int32) r8_n;
 		r19_n = (word32) r4_n.u0 + (((word32) r6_n.u0 + ((word32) r19_n.u0 - 2)) + (r4_n >> 0x1F));
-		r5_n += (-1 << (word32) r19_n - 1) / 4;
+		r5_n = (struct Eq_n *) ((char *) &r5_n->dw0000 + (-1 << (word32) r19_n - 1));
 		goto l000079E0;
 	}
 	r2_n->t0010.u0 = (int32) r8_n;
@@ -3466,7 +3466,7 @@ int32 fn00009C2C(Eq_n r3, Eq_n r4, Eq_n r15, uint32 VR, union Eq_n & r15Out, ptr
 		Eq_n r4_n;
 		&r4_n.u2->t0000.u0 = (word32) r4_n->w0008;
 		ui32 r11_n;
-		fn0000FEDC(r4.u1 + ((r4_n - 1) - r3_n) / 4, r4_n, r15, out r11_n, out r15);
+		fn0000FEDC((char *) r4.u1 + ((r4_n - 1) - r3_n), r4_n, r15, out r11_n, out r15);
 		r1_n = (struct Eq_n *) <invalid>;
 		r11_n = r11_n & 0x7F;
 	}
@@ -3479,7 +3479,7 @@ int32 fn00009C2C(Eq_n r3, Eq_n r4, Eq_n r15, uint32 VR, union Eq_n & r15Out, ptr
 		Eq_n r4_n;
 		&r4_n.u2->t0000.u0 = (word32) r4_n->w0010;
 		word32 r11_n;
-		fn0000FEDC(r4.u1 + ((r4_n - 1) - r3_n) / 4, r4_n, r15, out r11_n, out r15);
+		fn0000FEDC((char *) r4.u1 + ((r4_n - 1) - r3_n), r4_n, r15, out r11_n, out r15);
 		r1_n = (struct Eq_n *) <invalid>;
 		r11_n = r11_n + (word32) r4_n->bFFFFFFFB & 0x7F;
 	}
@@ -5968,7 +5968,7 @@ void fn0000DE28(struct Eq_n * r3, struct Eq_n * r4)
 	while (true)
 	{
 		int32 r6_n = (int32) r4[r5_n];
-		r3[r5_n / 2] = (struct Eq_n) (byte) r6_n;
+		r3->a0000[r5_n] = (byte) r6_n;
 		if (r6_n == 0x00)
 			break;
 		r5_n += -1;
@@ -6035,15 +6035,15 @@ word32 fn0000DF10(Eq_n r3[], struct Eq_n * r4, Eq_n r5)
 		bool F_n = r5 >> 0x02 != 0x00;
 		while (F_n)
 		{
-			word32 * r8_n = (word32 *) (r4 + r7_n / 20);
-			r3[r7_n / 4].u1 = *r8_n;
+			word32 * r8_n = (word32 *) ((char *) &r4->dw0000 + r7_n);
+			*((char *) &r3[0].u1 + r7_n) = *r8_n;
 			--r6_n;
 			r7_n += -4;
 			F_n = r6_n != 0x00;
 		}
 		ui32 r5_n;
-		ui32 r4_n = r4 + (r5 & ~0x03) / 20;
-		byte (* r7_n)[] = &(r3 + (r5 & ~0x03) / 4)->u0;
+		ui32 r4_n = (char *) &r4->dw0000 + (r5 & ~0x03);
+		byte (* r7_n)[] = (byte (*)[]) (&r3->u0 + (r5 & ~0x03));
 		for (r5_n = r5 & 0x03; r5_n != 0x00; --r5_n)
 		{
 			byte * r11_n = (word32) r6_n + r4_n;
@@ -6055,8 +6055,8 @@ word32 fn0000DF10(Eq_n r3[], struct Eq_n * r4, Eq_n r5)
 	{
 		for (; r5 != 0x00; --r5)
 		{
-			byte * r8_n = (byte *) (r4 + r6_n / 20);
-			r3[r6_n / 4].u0 = *r8_n;
+			byte * r8_n = (char *) &r4->dw0000 + r6_n;
+			(&r3[0].u0)[r6_n] = *r8_n;
 			r6_n += -1;
 		}
 	}
@@ -6631,7 +6631,7 @@ Eq_n fn0000EDF4(int32 r3, struct Eq_n * r4, Eq_n r15, uint32 VR)
 							struct Eq_n * r18_n = *r6_n;
 							fn0000DE28(r2_n, r18_n);
 							r6_n += -1;
-							r2_n += fn0000DE08(r18_n) / 2;
+							r2_n = (struct Eq_n *) (r2_n->a0000 + fn0000DE08(r18_n));
 						}
 						else
 						{
@@ -6658,7 +6658,7 @@ l0000F00C:
 				int32 r11_n = fn0000DE08(r1_n);
 				int32 r20_n = r11_n + fn0000ECF8(r1_n, r11_n, r18_n);
 				fn0000DE28(r2_n, r1_n);
-				r2_n += r20_n / 2;
+				r2_n = (struct Eq_n *) (r2_n->a0000 + r20_n);
 				r6_n = r24_n;
 			}
 			else
@@ -7571,7 +7571,7 @@ int32 fn00010570(union Eq_n * r3, Eq_n r9, Eq_n r15, uint32 VR)
 		r11_n = ~0x0B;
 		return r11_n;
 	}
-	struct Eq_n * r2_n = fn0000DF10(&g_dw134E4, dwLoc18 + (r4_n >> 0x01) / 20, -0x0224);
+	struct Eq_n * r2_n = fn0000DF10(&g_dw134E4, (char *) &dwLoc18->dw0000 + (r4_n >> 0x01), -0x0224);
 	struct Eq_n * r1_n = (struct Eq_n *) <invalid>;
 	r1_n[16] = (&r3->u0)[44];
 	fn0000AEDC(0xF3F31001);
@@ -8563,14 +8563,14 @@ void fn000187E8(Eq_n r3[], ui32 r4, uint32 r5)
 		while (F_n)
 		{
 			word32 * r8_n = r4 + r7_n;
-			r3[r7_n / 4].u1 = *r8_n;
+			*((char *) &r3[0].u1 + r7_n) = *r8_n;
 			--r6_n;
 			r7_n += -4;
 			F_n = r6_n != 0x00;
 		}
 		ui32 r5_n;
 		ui32 r4_n = r4 + (r5 & ~0x03);
-		byte (* r7_n)[] = &(r3 + (r5 & ~0x03) / 4)->u0;
+		byte (* r7_n)[] = (byte (*)[]) (&r3->u0 + (r5 & ~0x03));
 		for (r5_n = r5 & 0x03; r5_n != 0x00; --r5_n)
 		{
 			byte * r11_n = (word32) r6_n + r4_n;
@@ -8583,7 +8583,7 @@ void fn000187E8(Eq_n r3[], ui32 r4, uint32 r5)
 		for (; r5 != 0x00; --r5)
 		{
 			byte * r8_n = r4 + r6_n;
-			r3[r6_n / 4].u0 = *r8_n;
+			(&r3[0].u0)[r6_n] = *r8_n;
 			r6_n += -1;
 		}
 	}
@@ -8610,10 +8610,10 @@ void fn000188CC(struct Eq_n * r3, word32 r4, int32 r5, int32 r6)
 {
 	word32 (* r4_n)[] = r4 + (r6 << 0x02) *s (r5 - 1);
 	int32 r8_n = 0x00 - (r6 << 0x02);
-	word32 * r3_n = (word32 *) (r3 + ((r5 << 0x02) - 4) / 0x08E8);
+	word32 * r3_n = (word32 *) ((char *) r3 + ((r5 << 0x02) - 4));
 	for (; r5 != 0x00; --r5)
 	{
-		r4_n = (word32 (*)[]) (r4_n + r8_n / 4);
+		r4_n = (word32 (*)[]) ((char *) r4_n + r8_n);
 		*r3_n = r4_n[r6];
 		r3_n -= 4;
 	}
@@ -8628,11 +8628,11 @@ void fn000188CC(struct Eq_n * r3, word32 r4, int32 r5, int32 r6)
 void fn00018918(word32 r3, struct Eq_n * r4, int32 r5, int32 r6)
 {
 	int32 r8_n = 0x00 - (r6 << 0x02);
-	word32 * r4_n = (word32 *) (r4 + ((r5 << 0x02) - 4) / 0x08E8);
+	word32 * r4_n = (word32 *) ((char *) r4 + ((r5 << 0x02) - 4));
 	word32 (* r3_n)[] = r3 + (r6 << 0x02) *s (r5 - 1);
 	for (; r5 != 0x00; --r5)
 	{
-		r3_n = (word32 (*)[]) (r3_n + r8_n / 4);
+		r3_n = (word32 (*)[]) ((char *) r3_n + r8_n);
 		r3_n[r6] = *r4_n;
 		r4_n -= 4;
 	}
@@ -8676,7 +8676,7 @@ void fn00018AC4(Eq_n r3[], word32 r9)
 	fn00018F10(&g_tC768, -1, r9);
 	int32 r3_n;
 	for (r3_n = 0; r3_n <= 1; r3_n += -1)
-		*(r3 + r3_n)[0x0A] = *(r3 + r3_n)[0x0A] & (*((word96) (&(r3 + r3_n)[0x0A]) + 4) ^ 0xFFFF) | *((word96) (&(r3 + r3_n)[0x0A]) + 4) & *((word96) (&(r3 + ((r3_n + -1) * 0x02 + (r3_n + -1) << 0x02) / 0x0C)[9]) + 8);
+		*(r3 + r3_n)[0x0A] = *(r3 + r3_n)[0x0A] & (*((word96) (&(r3 + r3_n)[0x0A]) + 4) ^ 0xFFFF) | *((word96) (&(r3 + r3_n)[0x0A]) + 4) & ((char *) r3 + ((r3_n + -1) * 0x02 + (r3_n + -1) << 0x02))[116];
 }
 
 // 00018BDC: void fn00018BDC()

--- a/subjects/OpenRISC/sunxi/blob.reko/blob.h
+++ b/subjects/OpenRISC/sunxi/blob.reko/blob.h
@@ -5010,7 +5010,7 @@ Eq_8039: (struct "Eq_8039" (0 ui32 dw0000) (C ui32 dw000C) (10 ui32 dw0010))
 	T_13800 (in dwLoc18 @ 000105B0 : (ptr32 Eq_8039))
 	T_13802 (in fn0000DF10(fp - 72<i32>, dwLoc18, -32<i32>) @ 000105B0 : word32)
 	T_13815 (in (r4_44 >>u 1<32>) + dwLoc18 @ 000105DC : word32)
-	T_13817 (in fn0000DF10(&g_dw134E4, dwLoc18 + (r4_44 >> 1<32>) / 20<i32>, -548<i32>) @ 000105DC : word32)
+	T_13817 (in fn0000DF10(&g_dw134E4, (char *) &dwLoc18->dw0000 + (r4_44 >> 1<32>), -548<i32>) @ 000105DC : word32)
 	T_13818 (in r2_59 @ 000105DC : (ptr32 Eq_8039))
 Eq_8040: (union "Eq_8040" (int32 u0) (uint32 u1))
 	T_8040 (in r5 @ 0000A64C : Eq_8040)
@@ -36039,7 +36039,7 @@ T_7374: (in out r15 @ 00009CBC : word32)
   Class: Eq_6
   DataType: Eq_6
   OrigDataType: ptr32
-T_7375: (in fn0000FEDC(r4.u1 + ((r4_79 - 1<i32>) - r3_35) / 4<i32>, r4_79, r15, out r11_85, out r15) @ 00009CBC : word32)
+T_7375: (in fn0000FEDC((char *) r4.u1 + ((r4_79 - 1<i32>) - r3_35), r4_79, r15, out r11_85, out r15) @ 00009CBC : word32)
   Class: Eq_1065
   DataType: ptr32
   OrigDataType: word32
@@ -36263,7 +36263,7 @@ T_7430: (in out r15 @ 00009CF8 : word32)
   Class: Eq_6
   DataType: Eq_6
   OrigDataType: ptr32
-T_7431: (in fn0000FEDC(r4.u1 + ((r4_51 - 1<i32>) - r3_47) / 4<i32>, r4_51, r15, out r11_58, out r15) @ 00009CF8 : word32)
+T_7431: (in fn0000FEDC((char *) r4.u1 + ((r4_51 - 1<i32>) - r3_47), r4_51, r15, out r11_58, out r15) @ 00009CF8 : word32)
   Class: Eq_1065
   DataType: ptr32
   OrigDataType: word32
@@ -62057,7 +62057,7 @@ T_13816: (in -548<i32> @ 000105DC : int32)
   Class: Eq_8040
   DataType: int32
   OrigDataType: int32
-T_13817: (in fn0000DF10(&g_dw134E4, dwLoc18 + (r4_44 >> 1<32>) / 20<i32>, -548<i32>) @ 000105DC : word32)
+T_13817: (in fn0000DF10(&g_dw134E4, (char *) &dwLoc18->dw0000 + (r4_44 >> 1<32>), -548<i32>) @ 000105DC : word32)
   Class: Eq_8039
   DataType: (ptr32 Eq_8039)
   OrigDataType: word32
@@ -78030,11 +78030,11 @@ T_17626: (in Mem42[r3 + ((r3_38 + -1<i32>) * 2<32> + (r3_38 + -1<i32>) << 2<32>)
   Class: Eq_17626
   DataType: ui32
   OrigDataType: ui32
-T_17627: (in *((word96) &(r3 + r3_38)[10<i32>] + 4<i32>) & *((word96) (&(r3 + ((r3_38 + -1<i32>) * 2<32> + (r3_38 + -1<i32>) << 2<32>) / 12<i32>)[9<i32>]) + 8<i32>) @ 00018BAC : word32)
+T_17627: (in *((word96) &(r3 + r3_38)[10<i32>] + 4<i32>) & ((char *) r3 + ((r3_38 + -1<i32>) * 2<32> + (r3_38 + -1<i32>) << 2<32>))[116<i32>] @ 00018BAC : word32)
   Class: Eq_17627
   DataType: ui32
   OrigDataType: ui32
-T_17628: (in *(r3 + r3_38)[10<i32>] & (*((word96) (&(r3 + r3_38)[10<i32>]) + 4<i32>) ^ 0xFFFF<32>) | *((word96) (&(r3 + r3_38)[10<i32>]) + 4<i32>) & *((word96) (&(r3 + ((r3_38 + -1<i32>) * 2<32> + (r3_38 + -1<i32>) << 2<32>) / 12<i32>)[9<i32>]) + 8<i32>) @ 00018BAC : word32)
+T_17628: (in *(r3 + r3_38)[10<i32>] & (*((word96) (&(r3 + r3_38)[10<i32>]) + 4<i32>) ^ 0xFFFF<32>) | *((word96) (&(r3 + r3_38)[10<i32>]) + 4<i32>) & ((char *) r3 + ((r3_38 + -1<i32>) * 2<32> + (r3_38 + -1<i32>) << 2<32>))[116<i32>] @ 00018BAC : word32)
   Class: Eq_17599
   DataType: ui32
   OrigDataType: ui32

--- a/subjects/PDP-11/lunar.reko/lunar_image.c
+++ b/subjects/PDP-11/lunar.reko/lunar_image.c
@@ -858,7 +858,7 @@ l0D9C:
 			}
 			else
 			{
-				g_ptr0082 += (r4_n & 0x3F) /16 2;
+				g_ptr0082 = (word16 *) ((char *) g_ptr0082 + (r4_n & 0x3F));
 				r4_n = r4_n & 0x3F;
 			}
 			*r5 = r4_n | wLoc02_n;
@@ -1027,7 +1027,7 @@ void fn0F04(int16 r0)
 				g_w0F70 = 0x0ADF;
 			else if (g_w00AA <= ~0x02)
 				g_w0F70 = 0x0A9F;
-			word16 * r4_n = r4_n + g_w00AA /16 2 + r3_n /16 2;
+			word16 * r4_n = (word16 *) ((char *) r4_n + g_w00AA + r3_n);
 			sp_n->ptrFFFFFFFE = r4_n;
 			r5_n = fn0D78(r4_n, r5_n);
 			r4_n = sp_n->ptrFFFFFFFE;

--- a/subjects/PDP-11/space.h
+++ b/subjects/PDP-11/space.h
@@ -4564,7 +4564,7 @@ T_742: (in r5 + Mem0[r5 + 0<16>:word16] + Mem0[r5 + 0<16>:word16] + 2<16> @ 0820
   Class: Eq_731
   DataType: (ptr16 Eq_731)
   OrigDataType: word16
-T_743: (in fn11A6(r5 + *r5 /16 2<i32> + *r5 /16 2<i32> + 1<i32>, r5) @ 0820 : void)
+T_743: (in fn11A6((char *) r5 + *r5 + *r5 + 2<i32>, r5) @ 0820 : void)
   Class: Eq_743
   DataType: void
   OrigDataType: void
@@ -4624,7 +4624,7 @@ T_757: (in r5 + Mem0[r5 + 0<16>:word16] + Mem0[r5 + 0<16>:word16] + 2<16> @ 0A6C
   Class: Eq_731
   DataType: (ptr16 Eq_731)
   OrigDataType: word16
-T_758: (in fn11A6(r5 + *r5 /16 2<i32> + *r5 /16 2<i32> + 1<i32>, r5) @ 0A6C : void)
+T_758: (in fn11A6((char *) r5 + *r5 + *r5 + 2<i32>, r5) @ 0A6C : void)
   Class: Eq_743
   DataType: void
   OrigDataType: void

--- a/subjects/PDP-11/space_text.c
+++ b/subjects/PDP-11/space_text.c
@@ -619,7 +619,7 @@ void fn054C(ci16 r0, struct Eq_n * r3)
 {
 	r3->b00A0 = (byte) r0;
 	r3->b00A1 = r3->b00A2;
-	struct Eq_n * r0_n = (struct Eq_n *) (r3 + (r0 >> 3 & ~0x01) /16 0x00A3);
+	struct Eq_n * r0_n = (struct Eq_n *) ((char *) r3 + (r0 >> 3 & ~0x01));
 	ci16 r2_n = r0 & 0x0F;
 	struct Eq_n * wLoc02_n = null;
 	bool C_n = true;
@@ -987,7 +987,7 @@ struct Eq_n g_t07EC = // 07EC
 // 0818: void fn0818(Register (ptr16 word16) r5)
 void fn0818(word16 * r5)
 {
-	fn11A6(r5 + *r5 /16 2 + *r5 /16 2 + 1, r5);
+	fn11A6((char *) r5 + *r5 + *r5 + 2, r5);
 	g_ptr53F0();
 }
 
@@ -1053,7 +1053,7 @@ Eq_n g_t0A15 = // 0A15
 // 0A64: void fn0A64(Register (ptr16 word16) r5)
 void fn0A64(word16 * r5)
 {
-	fn11A6(r5 + *r5 /16 2 + *r5 /16 2 + 1, r5);
+	fn11A6((char *) r5 + *r5 + *r5 + 2, r5);
 	g_ptr5414();
 }
 
@@ -1234,7 +1234,7 @@ l0BC6:
 		struct Eq_n * r0_n;
 		sp_n->ptrFFFFFFFC = r0_n;
 		struct Eq_n * r3_n = g_ptr5424;
-		r3_n->ptr0044 += (int16) r3_n->b0053 /16 166;
+		r3_n->ptr0044 = (struct Eq_n *) ((char *) &r3_n->ptr0044->t0000 + (int16) r3_n->b0053);
 		struct Eq_n * v27_n = sp_n->ptrFFFFFFFC;
 		word16 v28_n = r3_n->w005A - 0x01;
 		r3_n->w005A = v28_n;

--- a/subjects/PDP-11/spcinv.reko/spcinv_text.c
+++ b/subjects/PDP-11/spcinv.reko/spcinv_text.c
@@ -409,7 +409,7 @@ bool fn05D4(Eq_n r0, Eq_n r3, byte * r4, union Eq_n & r0Out, union Eq_n & r3Out,
 		g_t0F0E.u0 = (int16) v28_n;
 		if (v28_n >= 0x00)
 			&r0_n.u1->t0000.u0 = (word32) r0_n + 200;
-		g_w0B58 = r0_n.u1 + g_w0B58 /16 2;
+		g_w0B58 = &r0_n.u1->t0000.u0 + g_w0B58;
 		Eq_n r0_n = fn0AB6(r0_n, r4_n, out r4_n, out r5_n);
 		bool Z_n = fn0AE8(r0_n, r4_n, &g_ptr0624, out r0_n, out r4_n, out r5_n);
 		r0Out = r0_n;

--- a/subjects/PE/PPC/hello_ppc.reko/hello_ppc.h
+++ b/subjects/PE/PPC/hello_ppc.reko/hello_ppc.h
@@ -1278,7 +1278,7 @@ Eq_1825: (struct "Eq_1825" 0010 (0 int32 dw0000))
 	T_2184 (in Mem16[r11_27 + 8<i32>:word32] @ 00401E00 : word32)
 	T_2185 (in r9_29 @ 00401E00 : (ptr32 Eq_1825))
 	T_2213 (in r28 @ 00401EA4 : (ptr32 Eq_1825))
-	T_2253 (in &(r9_29 + (r30_30 - r10_31) / 16<i32>)->dw0000 + 2<i32> & 0xFFFFFFF8<32> @ 00401E30 : word32)
+	T_2253 (in (char *) &r9_29->dw0000 + (r30_30 - r10_31) + 8<i32> & 0xFFFFFFF8<32> @ 00401E30 : word32)
 	T_2271 (in Mem55[r11_27 + 8<i32>:word32] @ 00401E78 : word32)
 	T_3740 (in Mem15[v6 + 8<i32>:word32] @ 00402CE8 : word32)
 Eq_1829: (union "Eq_1829" (int32 u0) (ptr32 u1))
@@ -11020,7 +11020,7 @@ T_2252: (in 0xFFFFFFF8<32> @ 00401E30 : word32)
   Class: Eq_2252
   DataType: ui32
   OrigDataType: ui32
-T_2253: (in &(r9_29 + (r30_30 - r10_31) / 16<i32>)->dw0000 + 2<i32> & 0xFFFFFFF8<32> @ 00401E30 : word32)
+T_2253: (in (char *) &r9_29->dw0000 + (r30_30 - r10_31) + 8<i32> & 0xFFFFFFF8<32> @ 00401E30 : word32)
   Class: Eq_1825
   DataType: (ptr32 Eq_1825)
   OrigDataType: ui32

--- a/subjects/PE/PPC/hello_ppc.reko/hello_ppc_text.c
+++ b/subjects/PE/PPC/hello_ppc.reko/hello_ppc_text.c
@@ -541,7 +541,7 @@ union Eq_n * fn0040115C(union Eq_n * r2, struct Eq_n * r3, struct Eq_n * r4, wor
 		r2 = fn004019CC(r2, out r3_n);
 		if (r3_n != null)
 		{
-			struct Eq_n * r29_n = (struct Eq_n *) (r4 + (r3->dw0004 & ~0x03) / 8);
+			struct Eq_n * r29_n = (struct Eq_n *) ((char *) &r4->ptr0000 + (r3->dw0004 & ~0x03));
 			r3_n->dw0004 = &r29_n->ptr0008;
 			r29_n->ptr0008 = r3_n;
 			r3_n->ptr0000 = (struct Eq_n *) r3->ptr0000;
@@ -1225,7 +1225,7 @@ union Eq_n * fn00401DD8(union Eq_n * r2, Eq_n r3, struct Eq_n * r4, struct Eq_n 
 	{
 		fn0040411C(r2);
 		Eq_n r10_n[] = (Eq_n (*)[]) **r29_n;
-		r28 = &(r9_n + (r30_n - r10_n) / 16)->dw0000 + 2 & ~0x07;
+		r28 = (char *) &r9_n->dw0000 + (r30_n - r10_n) + 8 & ~0x07;
 		union Eq_n * dwLoc3C;
 		r2 = dwLoc3C;
 		r11_n = (struct Eq_n *) &(r10_n + r3)->dw0000;
@@ -1379,11 +1379,11 @@ union Eq_n * fn004020BC(union Eq_n * r2, struct Eq_n * r3, ptr32 r29, ptr32 r30,
 				struct Eq_n * fp;
 				for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 				{
-					fp->aFFFFFFA0[r11_n / 4] = 0x00;
+					*((word32) &fp->aFFFFFFA0[0] + r11_n) = (word32[]) 0x00;
 					int32 r11_n = r11_n + 0x04;
-					fp->aFFFFFFA0[r11_n / 4] = 0x00;
-					fp->aFFFFFFA0[(r11_n + 0x04) / 4] = 0x00;
-					fp->aFFFFFFA0[(r11_n + 0x08) / 4] = 0x00;
+					*((word32) &fp->aFFFFFFA0[0] + r11_n) = (word32[]) 0x00;
+					*((word32) &fp->aFFFFFFA0[0] + (r11_n + 0x04)) = (word32[]) 0x00;
+					*((word32) &fp->aFFFFFFA0[0] + (r11_n + 0x08)) = (word32[]) 0x00;
 					r11_n = r11_n + 0x0C;
 				}
 				fn00404074(r2);
@@ -1394,11 +1394,11 @@ union Eq_n * fn004020BC(union Eq_n * r2, struct Eq_n * r3, ptr32 r29, ptr32 r30,
 					word32 ctr_n;
 					for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 					{
-						fp->aFFFFFFA0[r11_n / 4] = 0x00;
+						*((word32) &fp->aFFFFFFA0[0] + r11_n) = (word32[]) 0x00;
 						int32 r11_n = r11_n + 0x04;
-						fp->aFFFFFFA0[r11_n / 4] = 0x00;
-						fp->aFFFFFFA0[(r11_n + 0x04) / 4] = 0x00;
-						fp->aFFFFFFA0[(r11_n + 0x08) / 4] = 0x00;
+						*((word32) &fp->aFFFFFFA0[0] + r11_n) = (word32[]) 0x00;
+						*((word32) &fp->aFFFFFFA0[0] + (r11_n + 0x04)) = (word32[]) 0x00;
+						*((word32) &fp->aFFFFFFA0[0] + (r11_n + 0x08)) = (word32[]) 0x00;
 						r11_n = r11_n + 0x0C;
 					}
 					fn00403F3C(dwLoc84);
@@ -1674,11 +1674,11 @@ union Eq_n * fn004026B8(union Eq_n * r2, struct Eq_n * r3, word32 r5, ptr32 r26,
 					word32 ctr_n;
 					for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 					{
-						fp->aFFFFFF98[r11_n / 4] = 0x00;
+						*((word32) &fp->aFFFFFF98[0] + r11_n) = (word32[]) 0x00;
 						int32 r11_n = r11_n + 0x04;
-						fp->aFFFFFF98[r11_n / 4] = 0x00;
-						fp->aFFFFFF98[(r11_n + 0x04) / 4] = 0x00;
-						fp->aFFFFFF98[(r11_n + 0x08) / 4] = 0x00;
+						*((word32) &fp->aFFFFFF98[0] + r11_n) = (word32[]) 0x00;
+						*((word32) &fp->aFFFFFF98[0] + (r11_n + 0x04)) = (word32[]) 0x00;
+						*((word32) &fp->aFFFFFF98[0] + (r11_n + 0x08)) = (word32[]) 0x00;
 						r11_n = r11_n + 0x0C;
 					}
 					fn00403FFC(r2);
@@ -1691,11 +1691,11 @@ union Eq_n * fn004026B8(union Eq_n * r2, struct Eq_n * r3, word32 r5, ptr32 r26,
 					word32 ctr_n;
 					for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 					{
-						fp->aFFFFFF98[r11_n / 4] = 0x00;
+						*((word32) &fp->aFFFFFF98[0] + r11_n) = (word32[]) 0x00;
 						int32 r11_n = r11_n + 0x04;
-						fp->aFFFFFF98[r11_n / 4] = 0x00;
-						fp->aFFFFFF98[(r11_n + 0x04) / 4] = 0x00;
-						fp->aFFFFFF98[(r11_n + 0x08) / 4] = 0x00;
+						*((word32) &fp->aFFFFFF98[0] + r11_n) = (word32[]) 0x00;
+						*((word32) &fp->aFFFFFF98[0] + (r11_n + 0x04)) = (word32[]) 0x00;
+						*((word32) &fp->aFFFFFF98[0] + (r11_n + 0x08)) = (word32[]) 0x00;
 						r11_n = r11_n + 0x0C;
 					}
 					fn00403FE4(r2);
@@ -1711,11 +1711,11 @@ union Eq_n * fn004026B8(union Eq_n * r2, struct Eq_n * r3, word32 r5, ptr32 r26,
 				word32 ctr_n;
 				for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 				{
-					fp->aFFFFFF98[r11_n / 4] = 0x00;
+					*((word32) &fp->aFFFFFF98[0] + r11_n) = (word32[]) 0x00;
 					int32 r11_n = r11_n + 0x04;
-					fp->aFFFFFF98[r11_n / 4] = 0x00;
-					fp->aFFFFFF98[(r11_n + 0x04) / 4] = 0x00;
-					fp->aFFFFFF98[(r11_n + 0x08) / 4] = 0x00;
+					*((word32) &fp->aFFFFFF98[0] + r11_n) = (word32[]) 0x00;
+					*((word32) &fp->aFFFFFF98[0] + (r11_n + 0x04)) = (word32[]) 0x00;
+					*((word32) &fp->aFFFFFF98[0] + (r11_n + 0x08)) = (word32[]) 0x00;
 					r11_n = r11_n + 0x0C;
 				}
 				fn00404014(r2);
@@ -1727,11 +1727,11 @@ union Eq_n * fn004026B8(union Eq_n * r2, struct Eq_n * r3, word32 r5, ptr32 r26,
 					word32 ctr_n;
 					for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 					{
-						fp->aFFFFFF98[r11_n / 4] = 0x00;
+						*((word32) &fp->aFFFFFF98[0] + r11_n) = (word32[]) 0x00;
 						int32 r11_n = r11_n + 0x04;
-						fp->aFFFFFF98[r11_n / 4] = 0x00;
-						fp->aFFFFFF98[(r11_n + 0x04) / 4] = 0x00;
-						fp->aFFFFFF98[(r11_n + 0x08) / 4] = 0x00;
+						*((word32) &fp->aFFFFFF98[0] + r11_n) = (word32[]) 0x00;
+						*((word32) &fp->aFFFFFF98[0] + (r11_n + 0x04)) = (word32[]) 0x00;
+						*((word32) &fp->aFFFFFF98[0] + (r11_n + 0x08)) = (word32[]) 0x00;
 						r11_n = r11_n + 0x0C;
 					}
 					fn0040402C(dwLoc8C);
@@ -1743,11 +1743,11 @@ union Eq_n * fn004026B8(union Eq_n * r2, struct Eq_n * r3, word32 r5, ptr32 r26,
 						word32 ctr_n;
 						for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 						{
-							fp->aFFFFFF98[r11_n / 4] = 0x00;
+							*((word32) &fp->aFFFFFF98[0] + r11_n) = (word32[]) 0x00;
 							int32 r11_n = r11_n + 0x04;
-							fp->aFFFFFF98[r11_n / 4] = 0x00;
-							fp->aFFFFFF98[(r11_n + 0x04) / 4] = 0x00;
-							fp->aFFFFFF98[(r11_n + 0x08) / 4] = 0x00;
+							*((word32) &fp->aFFFFFF98[0] + r11_n) = (word32[]) 0x00;
+							*((word32) &fp->aFFFFFF98[0] + (r11_n + 0x04)) = (word32[]) 0x00;
+							*((word32) &fp->aFFFFFF98[0] + (r11_n + 0x08)) = (word32[]) 0x00;
 							r11_n = r11_n + 0x0C;
 						}
 						fn00404014(dwLoc8C);
@@ -1999,7 +1999,7 @@ union Eq_n * fn00402CE0(union Eq_n * r2, struct Eq_n * r3, int32 r4, struct Eq_n
 			{
 				fn00402DEC();
 				r31_n = (struct Eq_n *) (&r2_n->u0)[0x0068];
-				r31_n->dw0010 = r3 + r4 / 4;
+				r31_n->dw0010 = (char *) &r3->ptr0000 + r4;
 				fn00403070(r30_n, r4, &r31_n->dw0008 + 1, &tLoc28);
 				r31_n->ptr0004 = r30_n;
 				r31_n->ptr0000 = r30_n;
@@ -2534,11 +2534,11 @@ union Eq_n * fn00403744(union Eq_n * r2, Eq_n r3, struct Eq_n * r29, ptr32 r30, 
 			struct Eq_n * fp;
 			for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 			{
-				fp->aFFFFFFA0[r11_n / 4] = 0x00;
+				*((word32) &fp->aFFFFFFA0[0] + r11_n) = (word32[]) 0x00;
 				int32 r11_n = r11_n + 0x04;
-				fp->aFFFFFFA0[r11_n / 4] = 0x00;
-				fp->aFFFFFFA0[(r11_n + 0x04) / 4] = 0x00;
-				fp->aFFFFFFA0[(r11_n + 0x08) / 4] = 0x00;
+				*((word32) &fp->aFFFFFFA0[0] + r11_n) = (word32[]) 0x00;
+				*((word32) &fp->aFFFFFFA0[0] + (r11_n + 0x04)) = (word32[]) 0x00;
+				*((word32) &fp->aFFFFFFA0[0] + (r11_n + 0x08)) = (word32[]) 0x00;
 				r11_n = r11_n + 0x0C;
 			}
 			fn00403F54(r2);
@@ -2549,11 +2549,11 @@ union Eq_n * fn00403744(union Eq_n * r2, Eq_n r3, struct Eq_n * r29, ptr32 r30, 
 				word32 ctr_n;
 				for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 				{
-					fp->aFFFFFFA0[r11_n / 4] = 0x00;
+					*((word32) &fp->aFFFFFFA0[0] + r11_n) = (word32[]) 0x00;
 					int32 r11_n = r11_n + 0x04;
-					fp->aFFFFFFA0[r11_n / 4] = 0x00;
-					fp->aFFFFFFA0[(r11_n + 0x04) / 4] = 0x00;
-					fp->aFFFFFFA0[(r11_n + 0x08) / 4] = 0x00;
+					*((word32) &fp->aFFFFFFA0[0] + r11_n) = (word32[]) 0x00;
+					*((word32) &fp->aFFFFFFA0[0] + (r11_n + 0x04)) = (word32[]) 0x00;
+					*((word32) &fp->aFFFFFFA0[0] + (r11_n + 0x08)) = (word32[]) 0x00;
 					r11_n = r11_n + 0x0C;
 				}
 				fn00403F6C(dwLoc0184);
@@ -2631,11 +2631,11 @@ union Eq_n * fn00403898(union Eq_n * r2, struct Eq_n * r3, ptr32 r28, word32 r29
 					word32 ctr_n;
 					for (ctr_n = 0x05; ctr_n != 0x00; --ctr_n)
 					{
-						fp->aFFFFFFA0[r11_n / 4] = 0x00;
+						*((word32) &fp->aFFFFFFA0[0] + r11_n) = (word32[]) 0x00;
 						int32 r11_n = r11_n + 0x04;
-						fp->aFFFFFFA0[r11_n / 4] = 0x00;
-						fp->aFFFFFFA0[(r11_n + 0x04) / 4] = 0x00;
-						fp->aFFFFFFA0[(r11_n + 0x08) / 4] = 0x00;
+						*((word32) &fp->aFFFFFFA0[0] + r11_n) = (word32[]) 0x00;
+						*((word32) &fp->aFFFFFFA0[0] + (r11_n + 0x04)) = (word32[]) 0x00;
+						*((word32) &fp->aFFFFFFA0[0] + (r11_n + 0x08)) = (word32[]) 0x00;
 						r11_n = r11_n + 0x0C;
 					}
 					fn00403F3C(dwLoc84);

--- a/subjects/PE/m68k/hello_m68k.h
+++ b/subjects/PE/m68k/hello_m68k.h
@@ -11685,7 +11685,7 @@ T_2642: (in 0<32> @ 000028EE : word32)
   Class: Eq_2641
   DataType: word32
   OrigDataType: word32
-T_2643: (in a0.u1[d7_122 / 4<i32>] == 0<32> @ 000028EE : bool)
+T_2643: (in *((char *) &a0.u1->a0000[0<i32>].u1 + d7_122) == 0<32> @ 000028EE : bool)
   Class: Eq_2643
   DataType: bool
   OrigDataType: bool
@@ -11961,7 +11961,7 @@ T_2711: (in 0<32> @ 000028D4 : word32)
   Class: Eq_2641
   DataType: word32
   OrigDataType: word32
-T_2712: (in a5->tFFFFFADC.u1->a0000[0<i32>].u1[d7_122 / 4<i32>] == 0<32> @ 000028D4 : bool)
+T_2712: (in *((char *) &a5->tFFFFFADC.u1->a0000[0<i32>].u1->a0000[0<i32>].u1 + d7_122) == 0<32> @ 000028D4 : bool)
   Class: Eq_2712
   DataType: bool
   OrigDataType: bool

--- a/subjects/PE/m68k/hello_m68k_CRTHEAP.c
+++ b/subjects/PE/m68k/hello_m68k_CRTHEAP.c
@@ -123,7 +123,7 @@ struct Eq_n * fn000025B4(struct Eq_n * a5, struct Eq_n * dwArg04, Eq_n dwArg08)
 	if (d0_n == null)
 		return null;
 	uipr32 d0_n = dwArg04->dw0004;
-	struct Eq_n * d0_n = (struct Eq_n *) (dwArg08.u0 + SEQ(SLICE(d0_n, word16, 16), (word16) d0_n & ~0x03) / 4);
+	struct Eq_n * d0_n = (struct Eq_n *) ((char *) dwArg08.u0 + SEQ(SLICE(d0_n, word16, 16), (word16) d0_n & ~0x03));
 	d0_n->t0004.u2 = (struct Eq_n *) &d0_n->ptr0004;
 	d0_n->ptr0004 = d0_n;
 	d0_n->dw0000 = dwArg04->ptr0000;
@@ -335,7 +335,7 @@ int32 fn000028A0(Eq_n a0, struct Eq_n * a2, struct Eq_n * a5, Eq_n dwArg04, unio
 		int32 d7_n = d4_n << 0x04;
 		do
 		{
-			if (a5->tFFFFFADC.u1->a0000[0].u1[d7_n / 4] != 0x00)
+			if (*((char *) &a5->tFFFFFADC.u1->a0000[0].u1->a0000[0].u1 + d7_n) != 0x00)
 			{
 				struct Eq_n * a7_n = a7_n - 4;
 				a7_n->dw0000 = d3_n;
@@ -356,7 +356,7 @@ int32 fn000028A0(Eq_n a0, struct Eq_n * a2, struct Eq_n * a5, Eq_n dwArg04, unio
 				}
 			}
 			a0.u1->a0000 = a5->tFFFFFADC.u1->a0000[0].u1;
-			if (a0.u1[d7_n / 4] == 0x00)
+			if (*((char *) &a0.u1->a0000[0].u1 + d7_n) == 0x00)
 			{
 				d5_n = d4_n;
 				break;
@@ -632,7 +632,7 @@ int32 fn00002BB4(struct Eq_n * a5, Eq_n dwArg04, up32 dwArg08, struct Eq_n & a5O
 		if (d0_n <= 0x00)
 		{
 			word16 v25_n = g_a2C58[(int32) ((int16) d0_n + 3)];
-			g_a2C58[(int32) v25_n / 2]();
+			(*((char *) g_a2C58 + (int32) v25_n))();
 			struct Eq_n * a5_n;
 			a5Out = a5_n;
 			ptr32 a6_n;

--- a/subjects/PE/m68k/hello_m68k_CRTLOAD.c
+++ b/subjects/PE/m68k/hello_m68k_CRTLOAD.c
@@ -75,7 +75,7 @@ void fn000014E8(word32 a3, word32 a5, word16 wArg00, int32 dwArg02)
 			} while (d0_n != 0x00);
 		}
 		union Eq_n * a2_n = a2_n - a3_n->dw000C;
-		struct Eq_n * a3_n = (struct Eq_n *) (&a3_n->dw000C + 1 + a3_n->dw0004 / 16 + a3_n->dw000C / 16);
+		struct Eq_n * a3_n = (struct Eq_n *) ((char *) &(&a3_n->dw000C + 1)->dw0000 + a3_n->dw0004 + a3_n->dw000C);
 		__syscall<word16>(0xA02E);
 l00001556:
 		ci8 v18_n = a3_n->b0000;
@@ -94,7 +94,7 @@ l00001556:
 					a3_n += 4;
 					d0_n = SEQ(SLICE(SEQ(SLICE(v29_n, word16, 8), (word16) SEQ(v29_n, a3_n[2]) << 0x08), word24, 8), a3_n[3]) * 0x02;
 l00001578:
-					a2_n = &a2_n->u0 + d0_n / 4;
+					a2_n = (union Eq_n *) ((char *) &a2_n->u0 + d0_n);
 					if (dwArg02 != 0x00 && a2_n->u0 >= 0x00)
 						a2_n->u0 = (a2_n->u0 + dwArg02)->t0002.u0;
 					else

--- a/subjects/PE/m68k/hello_m68k_CRTSTDIO.c
+++ b/subjects/PE/m68k/hello_m68k_CRTSTDIO.c
@@ -97,7 +97,7 @@ void fn000016D0(word32 d6, struct Eq_n * a5, byte * dwArg08)
 			if (d0_n <= 7)
 			{
 				word16 v41_n = g_a1758[(int32) (int16) d0_n];
-				g_a1758[(int32) v41_n / 2]();
+				(*((char *) g_a1758 + (int32) v41_n))();
 				return;
 			}
 			byte v43_n = *dwArg08_n;

--- a/subjects/PE/x86-64/varargs_test/varargs_test.reko/varargs_test_text.c
+++ b/subjects/PE/x86-64/varargs_test/varargs_test.reko/varargs_test_text.c
@@ -375,14 +375,14 @@ word64 fn0000000140001718(<anonymous> ** rcx)
 	{
 		int64 rax_n = (int64) g_dw4000003C;
 		rax_56_8_n = SLICE(rax_n, word56, 8);
-		struct Eq_n * rcx_n = (struct Eq_n *) (&g_w40000000 + rax_n /64 2);
+		struct Eq_n * rcx_n = (struct Eq_n *) ((char *) &g_w40000000 + rax_n);
 		if (rcx_n->dw0000 == 0x4550)
 		{
 			rax_56_8_n = 0x02;
 			if (rcx_n->w0018 == 0x020B)
 			{
 				uint64 rax_n = (uint64) rcx_n->w0006;
-				struct Eq_n * rdx_n = (struct Eq_n *) (&rcx_n->w0018 + (uint64) rcx_n->w0014 /64 2);
+				struct Eq_n * rdx_n = (struct Eq_n *) ((char *) &rcx_n->w0018 + (uint64) rcx_n->w0014);
 				uint64 r8_n = rcx - &g_w40000000;
 				word56 rax_56_8_n = SLICE(rax_n, word56, 8);
 				struct Eq_n * r9_n = rdx_n + rax_n;
@@ -616,7 +616,7 @@ void fn0000000140001AC0()
 	Eq_n rax_n = GetModuleHandleW(null);
 	if (rax_n == null || rax_n->unused != 23117)
 		return;
-	struct Eq_n * rax_n = (struct Eq_n *) (rax_n + (int64) (&rax_n->unused)[0x0F] /64 4);
+	struct Eq_n * rax_n = (struct Eq_n *) ((char *) &rax_n->unused + (int64) (&rax_n->unused)[0x0F]);
 	if (rax_n->dw0000 != 0x4550 || (rax_n->w0018 != 0x020B || rax_n->dw0084 <= 0x0E))
 		;
 }

--- a/subjects/PE/x86/ExeDll/Executable.reko/Executable_text.c
+++ b/subjects/PE/x86/ExeDll/Executable.reko/Executable_text.c
@@ -174,8 +174,8 @@ void fn004012D8(struct _EXCEPTION_POINTERS * dwArg04)
 //      fn00401544
 struct Eq_n * fn004013FB(struct Eq_n * dwArg04, uint32 dwArg08, struct Eq_n & edxOut)
 {
-	struct Eq_n * ecx_n = (struct Eq_n *) (dwArg04 + dwArg04->dw003C / 64);
-	struct Eq_n * edx_n = (struct Eq_n *) (&ecx_n->w0014 + 2 + (word32) ecx_n->w0014 / 22);
+	struct Eq_n * ecx_n = (struct Eq_n *) ((char *) dwArg04 + dwArg04->dw003C);
+	struct Eq_n * edx_n = (struct Eq_n *) ((char *) (&ecx_n->w0014 + 2) + (word32) ecx_n->w0014);
 	struct Eq_n * esi_n = edx_n + (word32) ecx_n->w0006;
 	struct Eq_n * eax_n;
 	for (; edx_n != esi_n; ++edx_n)

--- a/subjects/PE/x86/import-ordinals/main_text.c
+++ b/subjects/PE/x86/import-ordinals/main_text.c
@@ -171,8 +171,8 @@ l004012C3:
 //      fn0040153F
 struct Eq_n * fn004013F6(struct Eq_n * dwArg04, uint32 dwArg08, struct Eq_n & edxOut)
 {
-	struct Eq_n * ecx_n = (struct Eq_n *) (dwArg04 + dwArg04->dw003C / 64);
-	struct Eq_n * edx_n = (struct Eq_n *) (&ecx_n->w0014 + 2 + (word32) ecx_n->w0014 / 22);
+	struct Eq_n * ecx_n = (struct Eq_n *) ((char *) dwArg04 + dwArg04->dw003C);
+	struct Eq_n * edx_n = (struct Eq_n *) ((char *) (&ecx_n->w0014 + 2) + (word32) ecx_n->w0014);
 	struct Eq_n * esi_n = edx_n + (word32) ecx_n->w0006;
 	struct Eq_n * eax_n;
 	for (; edx_n != esi_n; ++edx_n)

--- a/subjects/PE/x86/pySample/pySample_text.c
+++ b/subjects/PE/x86/pySample/pySample_text.c
@@ -273,7 +273,7 @@ uint32 fn100016D0(struct Eq_n * dwArg04)
 {
 	if (dwArg04->w0000 != 23117)
 		return 0x00;
-	struct Eq_n * eax_n = (struct Eq_n *) (dwArg04 + dwArg04->dw003C / 64);
+	struct Eq_n * eax_n = (struct Eq_n *) ((char *) &dwArg04->w0000 + dwArg04->dw003C);
 	if (eax_n->dw0000 != 0x4550)
 		return 0x00;
 	return (uint32) (eax_n->w0018 == 0x010B);
@@ -284,10 +284,10 @@ uint32 fn100016D0(struct Eq_n * dwArg04)
 //      fn10001742
 struct Eq_n * fn10001700(struct Eq_n * dwArg04, uint32 dwArg08)
 {
-	struct Eq_n * ecx_n = (struct Eq_n *) (dwArg04 + dwArg04->dw003C / 64);
+	struct Eq_n * ecx_n = (struct Eq_n *) ((char *) dwArg04 + dwArg04->dw003C);
 	up32 esi_n = (word32) ecx_n->w0006;
 	up32 edx_n = 0x00;
-	struct Eq_n * eax_n = (struct Eq_n *) (ecx_n + ((word32) ecx_n->w0014 + 24) / 22);
+	struct Eq_n * eax_n = (struct Eq_n *) ((char *) ecx_n + ((word32) ecx_n->w0014 + 24));
 	if (esi_n > 0x00)
 	{
 		do

--- a/subjects/PE/x86/pySample/shingledPySample.reko/pySample_text.c
+++ b/subjects/PE/x86/pySample/shingledPySample.reko/pySample_text.c
@@ -343,7 +343,7 @@ uint32 fn100016D0(struct Eq_n * dwArg04)
 {
 	if (dwArg04->w0000 != 23117)
 		return 0x00;
-	struct Eq_n * eax_n = (struct Eq_n *) (dwArg04 + dwArg04->dw003C / 64);
+	struct Eq_n * eax_n = (struct Eq_n *) ((char *) &dwArg04->w0000 + dwArg04->dw003C);
 	if (eax_n->dw0000 != 0x4550)
 		return 0x00;
 	return (uint32) (eax_n->w0018 == 0x010B);
@@ -354,10 +354,10 @@ uint32 fn100016D0(struct Eq_n * dwArg04)
 //      fn10001742
 struct Eq_n * fn10001700(struct Eq_n * dwArg04, uint32 dwArg08)
 {
-	struct Eq_n * ecx_n = (struct Eq_n *) (dwArg04 + dwArg04->dw003C / 64);
+	struct Eq_n * ecx_n = (struct Eq_n *) ((char *) dwArg04 + dwArg04->dw003C);
 	up32 esi_n = (word32) ecx_n->w0006;
 	up32 edx_n = 0x00;
-	struct Eq_n * eax_n = (struct Eq_n *) (ecx_n + ((word32) ecx_n->w0014 + 24) / 22);
+	struct Eq_n * eax_n = (struct Eq_n *) ((char *) ecx_n + ((word32) ecx_n->w0014 + 24));
 	if (esi_n > 0x00)
 	{
 		do

--- a/subjects/Raw/1750A/fft.reko/fft_normal.c
+++ b/subjects/Raw/1750A/fft.reko/fft_normal.c
@@ -327,7 +327,7 @@ word48 sin(int32 gp0_gp1, word16 gp2, union Eq_n & gp3Out, union Eq_n & gp4Out, 
 	}
 	ci16 gp1_n = (word16) gp0_gp1_n;
 	if (gp0_gp1 < 0x00)
-		gp1_n = *((char *) &g_dwFFFF805D + 2) + (word16) gp0_gp1_n /16 0x00008090;
+		gp1_n = (char *) &((*((char *) &g_dwFFFF805D + 2))->aFFFF8060 + 0x00002A8A)->r0000 + ((word16) gp0_gp1_n + 2);
 	word16 gp0_n = sincos(gp1_n, gp4_n, out gp1_n, out gp2_n, out gp3_n, out gp4_n, out gp14_n);
 	gp3Out = gp3_n;
 	gp4Out = gp4_n;

--- a/subjects/Raw/1750A/trigtst.reko/trigtst_seg000000.c
+++ b/subjects/Raw/1750A/trigtst.reko/trigtst_seg000000.c
@@ -201,7 +201,7 @@ int32 fn032A(int32 gp0_gp1, word16 gp2, ptr16 & gp2Out)
 	}
 	ci16 gp1_n = (word16) gp0_gp1_n;
 	if (gp0_gp1 < 0x00)
-		gp1_n = *((char *) &g_dwFFFF812B + 2) + (word16) gp0_gp1_n /16 33085;
+		gp1_n = (char *) &(*((char *) &g_dwFFFF812B + 2))->dwFFFF812B + ((word16) gp0_gp1_n + 0x00007ED5);
 	word16 gp0_n = fn02BF(gp1_n, gp4_n, out gp1_n, out gp2_n, out gp14_n);
 	gp2Out = gp2_n;
 	return SEQ(gp0_n, gp1_n);

--- a/subjects/Raw/CR16/CompactRISC.reko/CompactRISC.h
+++ b/subjects/Raw/CR16/CompactRISC.reko/CompactRISC.h
@@ -9645,7 +9645,7 @@ T_1376: (in r9_r8_1018 + 0<32> @ 00003340 : word32)
 T_1377: (in Mem207[r9_r8_1018 + 0<32>:word32] @ 00003340 : word32)
   Class: Eq_348
   DataType: Eq_348
-  OrigDataType: (ptr32 Eq_13524)
+  OrigDataType: (ptr32 char)
 T_1378: (in 8<32> @ 00003346 : word32)
   Class: Eq_1378
   DataType: word32
@@ -12402,7 +12402,7 @@ T_2060: (in r13_1071 + 0<32> @ 00003654 : word32)
 T_2061: (in Mem516[r13_1071 + 0<32>:word32] @ 00003654 : word32)
   Class: Eq_348
   DataType: Eq_348
-  OrigDataType: (ptr32 Eq_13524)
+  OrigDataType: (ptr32 char)
 T_2062: (in 8<32> @ 0000365A : word32)
   Class: Eq_2062
   DataType: word32
@@ -12922,7 +12922,7 @@ T_2188: (in r13_1071 + 0<32> @ 00003714 : word32)
 T_2189: (in Mem960[r13_1071 + 0<32>:word32] @ 00003714 : word32)
   Class: Eq_348
   DataType: Eq_348
-  OrigDataType: (ptr32 Eq_13524)
+  OrigDataType: (ptr32 char)
 T_2190: (in 8<32> @ 0000371A : word32)
   Class: Eq_2190
   DataType: word32
@@ -38915,7 +38915,7 @@ T_8597: (in Mem479[r3_r2_456 + r3_r2 + 0xFB2<32>:byte] @ 0000A884 : byte)
   Class: Eq_8592
   DataType: cu8
   OrigDataType: cu8
-T_8598: (in (&(r3_r2.u1 + r7_r6_480 / 9244<i32>)->w0FAE)[2<i32>] > (&(r3_r2.u1 + r3_r2_456 / 9244<i32>)->w0FAE)[2<i32>] @ 0000A884 : bool)
+T_8598: (in ((char *) &r3_r2.u1->a0000->u0 + r7_r6_480)[4018<i32>] > ((char *) (&((r3_r2.u1)->a0000)->u0) + r3_r2_456)[4018<i32>] @ 0000A884 : bool)
   Class: Eq_8598
   DataType: bool
   OrigDataType: bool
@@ -39031,7 +39031,7 @@ T_8626: (in Mem540[CONVERT(r8_455, word16, int32) + r3_r2 + 0xFB2<32>:byte] @ 00
   Class: Eq_8621
   DataType: cu8
   OrigDataType: cu8
-T_8627: (in r1_r0_428->b0FB2 > (&(r3_r2.u1 + (int32) r8_455 / 9244<i32>)->w0FAE)[2<i32>] @ 0000A900 : bool)
+T_8627: (in r1_r0_428->b0FB2 > ((char *) (&((r3_r2.u1)->a0000)->u0) + (int32) r8_455)[4018<i32>] @ 0000A900 : bool)
   Class: Eq_8627
   DataType: bool
   OrigDataType: bool
@@ -39527,7 +39527,7 @@ T_8750: (in Mem778[r3_r2_755 + r3_r2 + 0xFB2<32>:byte] @ 0000A89E : byte)
   Class: Eq_8745
   DataType: cu8
   OrigDataType: cu8
-T_8751: (in (&(r3_r2.u1 + r7_r6_779 / 9244<i32>)->w0FAE)[2<i32>] > (&(r3_r2.u1 + r3_r2_755 / 9244<i32>)->w0FAE)[2<i32>] @ 0000A89E : bool)
+T_8751: (in ((char *) &r3_r2.u1->a0000->u0 + r7_r6_779)[4018<i32>] > ((char *) (&((r3_r2.u1)->a0000)->u0) + r3_r2_755)[4018<i32>] @ 0000A89E : bool)
   Class: Eq_8751
   DataType: bool
   OrigDataType: bool
@@ -39667,7 +39667,7 @@ T_8785: (in CONVERT(Mem332[r3_r2_3334 + ra_45 + 2<32>:word16], word16, word32) @
   Class: Eq_8785
   DataType: word32
   OrigDataType: word32
-T_8786: (in r3_r2.u1->dw2400 - (word32) ((ra_45 + r3_r2_3334 / 4<i32>))[0<i32>].w0002 @ 0000A4F6 : word32)
+T_8786: (in r3_r2.u1->dw2400 - (word32) ((char *) ra_45 + r3_r2_3334)[2<i32>] @ 0000A4F6 : word32)
   Class: Eq_8780
   DataType: word32
   OrigDataType: word32
@@ -39747,7 +39747,7 @@ T_8805: (in Mem839[CONVERT(r8_754, word16, int32) + r3_r2 + 0xFB2<32>:byte] @ 00
   Class: Eq_8800
   DataType: cu8
   OrigDataType: cu8
-T_8806: (in r1_r0_724->b0FB2 > (&(r3_r2.u1 + (int32) r8_754 / 9244<i32>)->w0FAE)[2<i32>] @ 0000A8E8 : bool)
+T_8806: (in r1_r0_724->b0FB2 > ((char *) (&((r3_r2.u1)->a0000)->u0) + (int32) r8_754)[4018<i32>] @ 0000A8E8 : bool)
   Class: Eq_8806
   DataType: bool
   OrigDataType: bool
@@ -40495,7 +40495,7 @@ T_8992: (in Mem2034[r3_r2_2011 + r3_r2 + 0xFB2<32>:byte] @ 0000A8B8 : byte)
   Class: Eq_8987
   DataType: cu8
   OrigDataType: cu8
-T_8993: (in (&(r3_r2.u1 + r7_r6_2035 / 9244<i32>)->w0FAE)[2<i32>] > (&(r3_r2.u1 + r3_r2_2011 / 9244<i32>)->w0FAE)[2<i32>] @ 0000A8B8 : bool)
+T_8993: (in ((char *) &r3_r2.u1->a0000->u0 + r7_r6_2035)[4018<i32>] > ((char *) (&((r3_r2.u1)->a0000)->u0) + r3_r2_2011)[4018<i32>] @ 0000A8B8 : bool)
   Class: Eq_8993
   DataType: bool
   OrigDataType: bool
@@ -40867,7 +40867,7 @@ T_9085: (in Mem2095[CONVERT(r8_2010, word16, int32) + r3_r2 + 0xFB2<32>:byte] @ 
   Class: Eq_9080
   DataType: cu8
   OrigDataType: cu8
-T_9086: (in dwLoc1E_2389[4018<i32>] > (&(r3_r2.u1 + (int32) r8_2010 / 9244<i32>)->w0FAE)[2<i32>] @ 0000A8D2 : bool)
+T_9086: (in dwLoc1E_2389[4018<i32>] > ((char *) (&((r3_r2.u1)->a0000)->u0) + (int32) r8_2010)[4018<i32>] @ 0000A8D2 : bool)
   Class: Eq_9086
   DataType: bool
   OrigDataType: bool
@@ -50660,7 +50660,7 @@ T_11495: (in Mem1520[(CONVERT(Mem1520[r11_r10_2553 + 1<32>:byte], byte, int32) +
 T_11496: (in r5_1545 @ 0000B65A : Eq_1500)
   Class: Eq_1500
   DataType: Eq_1500
-  OrigDataType: cu16
+  OrigDataType: ci16
 T_11497: (in __a_shift<word16,word16> @ 0000B662 : ptr32)
   Class: Eq_6473
   DataType: (ptr32 Eq_6473)

--- a/subjects/Raw/CR16/CompactRISC.reko/CompactRISC_code.c
+++ b/subjects/Raw/CR16/CompactRISC.reko/CompactRISC_code.c
@@ -288,7 +288,7 @@ l00001F46:
 				}
 				r3_r2->t0078.u0 = (wchar_t) r11_n;
 				r3_r2->dw0070 = r3_r2_n;
-				&r1.u2->b0000 = r11_n.u2 + (r3_r2->t0008).u0 /16 16;
+				&r1.u2->b0000 = &r11_n.u2->b0000 + (r3_r2->t0008).u0;
 				r3_r2->t0008.u0 = (wchar_t) r1;
 				if (r0_n == 0x00 && fn00001BEC(SEQ(r1, r0_n), r3_r2, r13_n, ra, out r1) == ~0x00)
 				{
@@ -603,8 +603,8 @@ l0000313C:
 			word32 r11_r10_n;
 			r9_r8_n.u1->t0060.u0 = (int32) fn0000C0EE(r9_r8_n.u1->t0060.u0, r11_r10_n, r13_n, out r11_r10_n, out r13_n);
 		}
-		r9_r8_n->u1->a0000 = r9_r8_n->u1 + r12_n / 9244;
-		r9_r8_n.u1->t0008.u2 += r12_n / 16;
+		r9_r8_n->u1->a0000 = (char *) &r9_r8_n->u1->a0000->u0 + r12_n;
+		r9_r8_n.u1->t0008.u2 = &r9_r8_n.u1->t0008.u2->b0000 + r12_n;
 		r11_n.u0 = r13_n.u1->t00B4.u0;
 		r10_n = r7_n;
 l0000314C:
@@ -860,9 +860,9 @@ l00003664:
 			fn0000DB24();
 			r13_n = *r3_r2;
 			word32 r11_r10_n = (word32) r8_n;
-			r13_n.u1->t000C.u2 += r11_r10_n / 16;
+			r13_n.u1->t000C.u2 = &r13_n.u1->t000C.u2->b0000 + r11_r10_n;
 			r13_n.u1->t0010.u0 = (wchar_t) (r13_n.u1->t0010.u0 - r8_n);
-			r13_n.u1->t0014.u2 += r11_r10_n / 16;
+			r13_n.u1->t0014.u2 = &r13_n.u1->t0014.u2->b0000 + r11_r10_n;
 			r3_r2.u1->t0098.u0 = (int32) (r11_r10_n + ((r3_r2.u1)->t0098).u0);
 			r7_n -= r8_n;
 		}
@@ -898,16 +898,16 @@ l00003664:
 				r11_r10_n = r11_r10_n;
 				r13_n = r13_n;
 			}
-			r13_n->u1->a0000 = r13_n->u1 + r11_r10_n / 9244;
-			r13_n.u1->t0008.u2 += r11_r10_n / 16;
+			r13_n->u1->a0000 = (char *) &r13_n->u1->a0000->u0 + r11_r10_n;
+			r13_n.u1->t0008.u2 = &r13_n.u1->t0008.u2->b0000 + r11_r10_n;
 			r13_n = *r3_r2;
 			&r9_r8_n.u2->b0000 = r13_n.u1->t000C.u2;
 			r10_n.u1 = r13_n.u1->t0004.u1;
 l00003616:
 			word32 r1_r0_n = (word32) r7_n;
-			r13_n.u1->t000C.u2 = r9_r8_n.u2 + r1_r0_n / 16;
+			r13_n.u1->t000C.u2 = &r9_r8_n.u2->b0000 + r1_r0_n;
 			r13_n.u1->t0010.u0 = (wchar_t) (r13_n.u1->t0010.u0 - r7_n);
-			r13_n.u1->t0014.u2 += r1_r0_n / 16;
+			r13_n.u1->t0014.u2 = &r13_n.u1->t0014.u2->b0000 + r1_r0_n;
 		}
 	} while (wLoc26_n == 0x00);
 	r7_n = r7_n - r10_n;
@@ -1047,8 +1047,8 @@ l000036EA:
 				r13_n.u1->t0060.u0 = (int32) fn0000C0EE(r13_n.u1->t0060.u0, r9_r8_n, r13_n, out r11_r10_n, out r13_n);
 			}
 			word32 r3_r2_n = sp_n->dw0006;
-			r13_n->u1->a0000 = r13_n->u1 + r3_r2_n / 9244;
-			r13_n.u1->t0008.u2 += r3_r2_n / 16;
+			r13_n->u1->a0000 = (char *) &r13_n->u1->a0000->u0 + r3_r2_n;
+			r13_n.u1->t0008.u2 = &r13_n.u1->t0008.u2->b0000 + r3_r2_n;
 l0000371C:
 			r8_n = (word32) r7_n + ((r3_r2.u1)->t00AC).u0;
 			r3_r2.u1->t00AC.u0 = (cu16) r8_n;
@@ -1654,9 +1654,9 @@ l000059DC:
 													r13_n.u1->w23EC = r1_n + 0x01;
 													byte v91_n = (byte) r1_n;
 													Mem3741[r3_r2_n + r5_r4_n:byte] = v91_n + ~0x02;
-													struct Eq_n * r1_r0_n = (struct Eq_n *) (r13_n.u1 + ((word32) ((byte[]) 62254)[(int32) (v91_n + ~0x02)] << 0x02) / 9244);
+													struct Eq_n * r1_r0_n = (struct Eq_n *) &(r13_n.u1->a0000 + (word32) ((byte[]) 62254)[(int32) (v91_n + ~0x02)])->u0;
 													++r1_r0_n->w08DC;
-													struct Eq_n * r1_r0_n = (struct Eq_n *) (r13_n.u1 + ((word32) (*((byte *) 0xF42E)) << 0x02) / 9244);
+													struct Eq_n * r1_r0_n = (struct Eq_n *) &(r13_n.u1->a0000 + (word32) (*((byte *) 0xF42E)))->u0;
 													++r1_r0_n->w12BC;
 													Eq_n r0_n;
 													r0_n.u0 = r13_n.u1->t00A0.u0;
@@ -1677,7 +1677,7 @@ l000059F0:
 												byte (* r5_r4_n)[] = r13_n.u1->ptr23E0;
 												r13_n.u1->w23EC = r1_n + 0x01;
 												Mem3867[r3_r2_n + r5_r4_n:byte] = v73_n;
-												struct Eq_n * r1_r0_n = (struct Eq_n *) (r13_n.u1 + ((word32) v73_n << 0x02) / 9244);
+												struct Eq_n * r1_r0_n = (struct Eq_n *) &(r13_n.u1->a0000 + (word32) v73_n)->u0;
 												++r1_r0_n->w00D4;
 												Eq_n r11_n;
 												r11_n.u0 = r13_n.u1->t00B4.u0;
@@ -1718,9 +1718,9 @@ l000059F0:
 											{
 												fn0000DB24();
 												word32 r1_r0_n = (word32) r7_n;
-												r9_r8_n.u1->t000C.u2 += r1_r0_n / 16;
-												r11_r10_n.u1->t0010.u2 += r1_r0_n / 16;
-												r9_r8_n.u1->t0014.u2 += r1_r0_n / 16;
+												r9_r8_n.u1->t000C.u2 = &r9_r8_n.u1->t000C.u2->b0000 + r1_r0_n;
+												r11_r10_n.u1->t0010.u2 = &r11_r10_n.u1->t0010.u2->b0000 + r1_r0_n;
+												r9_r8_n.u1->t0014.u2 = &r9_r8_n.u1->t0014.u2->b0000 + r1_r0_n;
 												r9_r8_n.u1->t0010.u0 = (wchar_t) (r9_r8_n.u1->t0010.u0 - r7_n);
 												Eq_n r1_r0_n = r11_r10_n.u1->t0014.u2 - r1_r0_n;
 												r11_r10_n.u1->t0014.u2 = (struct Eq_n *) r1_r0_n;
@@ -1895,9 +1895,9 @@ l00004E2E:
 l000051C0:
 													fn0000DB24();
 													word32 r1_r0_n = (word32) r7_n;
-													r9_r8_n.u1->t000C.u2 += r1_r0_n / 16;
-													r11_r10_n.u1->t0010.u2 += r1_r0_n / 16;
-													r9_r8_n.u1->t0014.u2 += r1_r0_n / 16;
+													r9_r8_n.u1->t000C.u2 = &r9_r8_n.u1->t000C.u2->b0000 + r1_r0_n;
+													r11_r10_n.u1->t0010.u2 = &r11_r10_n.u1->t0010.u2->b0000 + r1_r0_n;
+													r9_r8_n.u1->t0014.u2 = &r9_r8_n.u1->t0014.u2->b0000 + r1_r0_n;
 													r9_r8_n.u1->t0010.u0 = (wchar_t) (r9_r8_n.u1->t0010.u0 - r7_n);
 													Eq_n r1_r0_n = r11_r10_n.u1->t0014.u2 - r1_r0_n;
 													r11_r10_n.u1->t0014.u2 = (struct Eq_n *) r1_r0_n;
@@ -2015,9 +2015,9 @@ l00004EBE:
 														{
 															fn0000DB24();
 															word32 r11_r10_n = (word32) r7_n;
-															r12_n.u1->t000C.u2 += r11_r10_n / 16;
-															r9_r8_n.u1->t0010.u2 += r11_r10_n / 16;
-															r12_n.u1->t0014.u2 += r11_r10_n / 16;
+															r12_n.u1->t000C.u2 = &r12_n.u1->t000C.u2->b0000 + r11_r10_n;
+															r9_r8_n.u1->t0010.u2 = &r9_r8_n.u1->t0010.u2->b0000 + r11_r10_n;
+															r12_n.u1->t0014.u2 = &r12_n.u1->t0014.u2->b0000 + r11_r10_n;
 															r12_n.u1->t0010.u0 = (wchar_t) (r12_n.u1->t0010.u0 - r7_n);
 															Eq_n r1_r0_n = r9_r8_n.u1->t0014.u2 - r11_r10_n;
 															r9_r8_n.u1->t0014.u2 = (struct Eq_n *) r1_r0_n;
@@ -2054,7 +2054,7 @@ l00004EBE:
 										byte r3_r2_n[] = r13_n.u1->ptr23E0;
 										r13_n.u1->w23EC = r1_n + 0x01;
 										r3_r2_n[r5_r4_n] = v77_n;
-										struct Eq_n * r1_r0_n = (struct Eq_n *) (r13_n.u1 + ((word32) v77_n << 0x02) / 9244);
+										struct Eq_n * r1_r0_n = (struct Eq_n *) &(r13_n.u1->a0000 + (word32) v77_n)->u0;
 										++r1_r0_n->w00D4;
 										r7_n.u0 = r13_n.u1->t00B4.u0;
 										cup16 r2_n = r13_n.u1->w23EC;
@@ -2097,9 +2097,9 @@ l00004EBE:
 											{
 												fn0000DB24();
 												word32 r3_r2_n = (word32) r7_n;
-												r9_r8_n.u1->t000C.u2 += r3_r2_n / 16;
-												r11_r10_n.u1->t0010.u2 += r3_r2_n / 16;
-												r9_r8_n.u1->t0014.u2 += r3_r2_n / 16;
+												r9_r8_n.u1->t000C.u2 = &r9_r8_n.u1->t000C.u2->b0000 + r3_r2_n;
+												r11_r10_n.u1->t0010.u2 = &r11_r10_n.u1->t0010.u2->b0000 + r3_r2_n;
+												r9_r8_n.u1->t0014.u2 = &r9_r8_n.u1->t0014.u2->b0000 + r3_r2_n;
 												r9_r8_n.u1->t0010.u0 = (wchar_t) (r9_r8_n.u1->t0010.u0 - r7_n);
 												Eq_n r1_r0_n = r11_r10_n.u1->t0014.u2 - r3_r2_n;
 												r11_r10_n.u1->t0014.u2 = (struct Eq_n *) r1_r0_n;
@@ -2558,7 +2558,7 @@ l00005506:
 														&r1_r0_n.u2->b0000 = r1_r0_n.u1->t0014.u2;
 														int32 r3_r2_n = r13_n.u1->dw0040;
 														r13_n.u1->dw0040 = r3_r2_n + 0x01;
-														byte v144_n = (byte) r1_r0_n.u2[r3_r2_n / 16];
+														byte v144_n = (&r1_r0_n.u2->b0000)[r3_r2_n];
 														Eq_n r1_r0_n;
 														&r1_r0_n.u2->b0000 = r13_n.u1->t0008.u2;
 														r13_n.u1->t0014.u2 = (struct Eq_n *) &r5_r4_n.u2->b0001;
@@ -2598,7 +2598,7 @@ l00005AC4:
 													r1_r0_n.u1->a0000 = r1_r0_n.u1->t0038.u1;
 													int32 r3_r2_n = r13_n.u1->dw0040;
 													r13_n.u1->dw0040 = r3_r2_n + 0x01;
-													byte v128_n = (byte) r1_r0_n.u1[r3_r2_n / 9244];
+													byte v128_n = (byte) *((char *) &r1_r0_n.u1->a0000[0] + r3_r2_n);
 													Eq_n r1_r0_n;
 													&r1_r0_n.u2->b0000 = r13_n.u1->t0008.u2;
 													r13_n.u1->t0014.u2 = (struct Eq_n *) &r5_r4_n.u2->b0001;
@@ -3253,7 +3253,7 @@ void fn00009C04(Eq_n r3_r2, Eq_n r5_r4, Eq_n r6)
 	if (r6 <= 0x00)
 	{
 		struct Eq_n * ra_n = (struct Eq_n *) &r5_r4.u1->w0006;
-		struct Eq_n * r9_r8_n = (struct Eq_n *) (r5_r4.u1 + (((int32) r6 << 0x02) + 0x0A) / 9244);
+		struct Eq_n * r9_r8_n = (struct Eq_n *) ((char *) &r5_r4.u1->a0000->u0 + (((int32) r6 << 0x02) + 0x0A));
 		ci16 r11_n = 0x00;
 		word16 r6_n = ~0x00;
 		word16 r10_n = v15_n;
@@ -3278,7 +3278,7 @@ void fn00009C04(Eq_n r3_r2, Eq_n r5_r4, Eq_n r6)
 			r3_n = r3_r2.u1->w2410;
 			if (r1_n >= r2_n)
 			{
-				struct Eq_n * r13_n = (struct Eq_n *) (r3_r2.u1 + ((int32) r10_n << 0x02) / 9244);
+				struct Eq_n * r13_n = (struct Eq_n *) &(r3_r2.u1->a0000 + (int32) r10_n)->u0;
 				ci16 r1_n = r13_n->w14A8;
 				Eq_n r4_n;
 				r4_n.u0 = r13_n->t14A4.u0;
@@ -3374,7 +3374,7 @@ l00009DA8:
 			{
 				if (r10_n != r6_n)
 				{
-					struct Eq_n * r1_r0_n = (struct Eq_n *) (r3_r2.u1 + ((int32) r10_n << 0x02) / 9244);
+					struct Eq_n * r1_r0_n = (struct Eq_n *) &(r3_r2.u1->a0000 + (int32) r10_n)->u0;
 					ci16 r4_n = r1_r0_n->w14A8;
 					Eq_n r5_n;
 					r5_n.u0 = r1_r0_n->t14A4.u0;
@@ -3667,7 +3667,7 @@ void fn0000A0E8(Eq_n r3_r2, Eq_n r5_r4, Eq_n r13)
 				word32 r10_r9_n = (word32) v20_n;
 				word32 r9_r8_n = (word32) ((byte[]) 62254)[(int32) (word16) r10_r9_n];
 				word16 r8_n = (word16) r9_r8_n;
-				struct Eq_n * r3_r2_n = (struct Eq_n *) (r5_r4.u1 + ((word32) (r8_n + 0x0101) << 0x02) / 9244);
+				struct Eq_n * r3_r2_n = (struct Eq_n *) &(r5_r4.u1->a0000 + (word32) (r8_n + 0x0101))->u0;
 				ci16 r0_n = r3_r2_n->w0002;
 				Eq_n r1_n;
 				r1_n.u0 = r3_r2_n->t0000.u0;
@@ -3744,7 +3744,7 @@ void fn0000A0E8(Eq_n r3_r2, Eq_n r5_r4, Eq_n r13)
 				else
 					ra_n = (word32) ((byte[]) 0x0000F42E)[(word32) ((v19_n + ~0x00 >> 0x07) + 0x0100)];
 				ui32 ra_n = (word32) (word16) ra_n;
-				struct Eq_n * r3_r2_n = (struct Eq_n *) (r13.u1 + (ra_n << 0x02) / 9244);
+				struct Eq_n * r3_r2_n = (struct Eq_n *) &(r13.u1->a0000 + ra_n)->u0;
 				ci16 r1_n = r3_r2_n->w0002;
 				Eq_n r8_n;
 				r8_n.u0 = r3_r2_n->t0000.u0;
@@ -3817,7 +3817,7 @@ l0000A182:
 					break;
 				continue;
 			}
-			struct Eq_n * r1_r0_n = (struct Eq_n *) (r5_r4.u1 + ((word32) v20_n << 0x02) / 9244);
+			struct Eq_n * r1_r0_n = (struct Eq_n *) &(r5_r4.u1->a0000 + (word32) v20_n)->u0;
 			r2_n = r1_r0_n->w0002;
 			Eq_n r3_n;
 			r3_n.u0 = r1_r0_n->t0000.u0;
@@ -3951,7 +3951,7 @@ l0000A49E:
 		if (ra_n != null)
 		{
 l0000A4A4:
-			struct Eq_n * r7_r6_n = (struct Eq_n *) (r3_r2.u1 + ((int32) (r11_n + 0x01) * 0x02) / 9244);
+			struct Eq_n * r7_r6_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) (r11_n + 0x01));
 			while (r11_n >= 0x01)
 			{
 				word16 r6_n = (word16) r7_r6_n;
@@ -3976,16 +3976,16 @@ l0000A4A4:
 				r3_r2.u1->w1F5C = r11_n;
 				r7_r6_n->w1668 = r0_n;
 				r5_r4_n->a0000[0].u2.w0000 = (ci16) 0x01;
-				(&(r3_r2.u1 + (int32) r0_n / 9244)->w0FAE)[2] = (word16) 0x00;
+				((char *) &r3_r2.u1->a0000->u0 + (int32) r0_n)[0x0FB2] = 0x00;
 				r3_r2.u1->dw23F8 += -1;
-				r3_r2.u1->dw2400 -= (word32) (ra_n + r3_r2_n / 4)[0].w0002;
+				r3_r2.u1->dw2400 -= (word32) ((char *) ra_n + r3_r2_n)[2];
 				r7_r6_n = SEQ(SLICE((char *) r7_r6_n + 2, word16, 16), r6_n + 0x02);
 			}
 			r7_n = wArg2A_n;
 			goto l0000A504;
 		}
 l0000ADDC:
-		struct Eq_n * r3_r2_n = (struct Eq_n *) (r3_r2.u1 + ((int32) (r11_n + 0x01) * 0x02) / 9244);
+		struct Eq_n * r3_r2_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) (r11_n + 0x01));
 		ci16 r5_n = wArg2A_n;
 		while (r11_n >= 0x01)
 		{
@@ -4007,7 +4007,7 @@ l0000ADDC:
 			r3_r2.u1->w1F5C = r11_n;
 			r3_r2_n->w1668 = r0_n;
 			r7_r6_n->a0000[0].u2.w0000 = 0x01;
-			(&(r3_r2.u1 + (int32) r0_n / 9244)->w0FAE)[2] = (word16) 0x00;
+			((char *) &r3_r2.u1->a0000->u0 + (int32) r0_n)[0x0FB2] = 0x00;
 			r3_r2.u1->dw23F8 += -1;
 			r3_r2_n = SEQ(SLICE((char *) r3_r2_n + 2, word16, 16), r2_n + 0x02);
 		}
@@ -4019,7 +4019,7 @@ l0000A504:
 		word16 wLoc02_n = wLoc02_n;
 		ci16 wLoc16_n = r2_n;
 		int16 wArg02_n = r10_n;
-		word16 * dwLoc0E_n = (word16 *) (&(r3_r2.u1 + ((int32) r10_n * 0x02) / 9244)->dw1628 + 16);
+		word16 * dwLoc0E_n = (word16 *) (&(&r3_r2.u1->a0000->u0 + (int32) r10_n)->dw1628 + 16);
 		int16 wLoc1E_n = r10_n * 0x02;
 		int16 wArg02_n;
 		do
@@ -4032,10 +4032,10 @@ l0000A504:
 				int32 r1_r0_n = (int32) r4_n;
 				cup16 v29_n = (cup16) r13_n[r1_r0_n];
 				r11_n = wArg02_n;
-				struct Eq_n * r1_r0_n = (struct Eq_n *) (r3_r2.u1 + r1_r0_n / 9244);
+				struct Eq_n * r1_r0_n = (struct Eq_n *) ((char *) &r3_r2.u1->a0000->u0 + r1_r0_n);
 				do
 				{
-					struct Eq_n * r5_r4_n = (struct Eq_n *) (r3_r2.u1 + ((int32) r10_n * 0x02) / 9244);
+					struct Eq_n * r5_r4_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) r10_n);
 					ci16 r8_n = r5_r4_n->w1668;
 					int32 r3_r2_n = (int32) r8_n;
 					cup16 r1_n = (cup16) r13_n[r3_r2_n];
@@ -4048,7 +4048,7 @@ l0000A504:
 						cup16 r4_n = (cup16) r13_n[r7_r6_n];
 						if (r4_n >= r1_n)
 						{
-							if (r4_n != r1_n || (&(r3_r2.u1 + r7_r6_n / 9244)->w0FAE)[2] > (&(r3_r2.u1 + r3_r2_n / 9244)->w0FAE)[2])
+							if (r4_n != r1_n || ((char *) (&((r3_r2.u1)->a0000)->u0) + r7_r6_n)[0x0FB2] > ((char *) (&((r3_r2.u1)->a0000)->u0) + r3_r2_n)[0x0FB2])
 								r0_n = r10_n;
 							else
 								r8_n = r7_n;
@@ -4059,7 +4059,7 @@ l0000A504:
 							r8_n = r7_n;
 						}
 					}
-					if (v29_n < r1_n || v29_n == r1_n && r1_r0_n->b0FB2 <= (&(r3_r2.u1 + (int32) r8_n / 9244)->w0FAE)[2])
+					if (v29_n < r1_n || v29_n == r1_n && r1_r0_n->b0FB2 <= ((char *) (&((r3_r2.u1)->a0000)->u0) + (int32) r8_n)[0x0FB2])
 						break;
 					((word32) r3_r2 + ((int32) r11_n + 1434) * 0x02)->u0 = r8_n;
 					r10_n = r0_n * 0x02;
@@ -4075,7 +4075,7 @@ l0000A504:
 			wArg02_n = wArg02_n;
 		} while (wArg02_n != 0x01);
 		ci16 r0_n = r3_r2.u1->w1F60;
-		struct Eq_n * r3_r2_n = (struct Eq_n *) (r3_r2.u1 + ((int32) r11_n * 0x02) / 9244);
+		struct Eq_n * r3_r2_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) r11_n);
 		ci16 r5_n = (ci16) r3_r2_n[2868];
 		ci16 wArg12_n = r3_r2.u1->w166C;
 		r3_r2.u1->w166C = r5_n;
@@ -4084,9 +4084,9 @@ l0000A504:
 		ci16 wArg06_n = r0_n;
 		struct Eq_n * dwArg0A_n = r3_r2_n;
 		struct Eq_n * dwLoc0E_n = (struct Eq_n *) (r13_n + r1_r0_n);
-		struct Eq_n * dwLoc1E_n = (struct Eq_n *) (r3_r2.u1 + r1_r0_n / 9244);
-		struct Eq_n * dwArg1A_n = (struct Eq_n *) (r3_r2.u1 + (r1_r0_n * 0x02) / 9244);
-		struct Eq_n * dwArg22_n = (struct Eq_n *) (r3_r2.u1 + (r1_r0_n * 0x02 + -2) / 9244);
+		struct Eq_n * dwLoc1E_n = (struct Eq_n *) ((char *) &r3_r2.u1->a0000->u0 + r1_r0_n);
+		struct Eq_n * dwArg1A_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + r1_r0_n);
+		struct Eq_n * dwArg22_n = (struct Eq_n *) ((char *) &r3_r2.u1->a0000->u0 + (r1_r0_n * 0x02 + -2));
 		int16 r9_n = r11_n + ~0x00;
 		ci16 wLoc26_n = r5_n;
 		ptr32 dwLoc04_n = r13;
@@ -4101,14 +4101,14 @@ l0000A85C:
 		}
 l0000A664:
 		int32 r1_r0_n = (int32) r5_n;
-		struct Eq_n * r1_r0_n = (struct Eq_n *) (r3_r2.u1 + r1_r0_n / 9244);
+		struct Eq_n * r1_r0_n = (struct Eq_n *) ((char *) &r3_r2.u1->a0000->u0 + r1_r0_n);
 		cup16 v43_n = (cup16) r13_n[r1_r0_n];
 		r11_n = 0x01;
 		int16 r10_n = 0x02;
 		word16 wLoc04_n = SLICE(&r1_r0_n->b0FB2, word16, 16);
 		do
 		{
-			struct Eq_n * r5_r4_n = (struct Eq_n *) (r3_r2.u1 + ((int32) r10_n * 0x02) / 9244);
+			struct Eq_n * r5_r4_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) r10_n);
 			ci16 r8_n = r5_r4_n->w1668;
 			int32 r3_r2_n = (int32) r8_n;
 			cup16 r1_n = (cup16) r13_n[r3_r2_n];
@@ -4121,7 +4121,7 @@ l0000A664:
 				cup16 r4_n = (cup16) r13_n[r7_r6_n];
 				if (r4_n >= r1_n)
 				{
-					if (r4_n != r1_n || (&(r3_r2.u1 + r7_r6_n / 9244)->w0FAE)[2] > (&(r3_r2.u1 + r3_r2_n / 9244)->w0FAE)[2])
+					if (r4_n != r1_n || ((char *) (&((r3_r2.u1)->a0000)->u0) + r7_r6_n)[0x0FB2] > ((char *) (&((r3_r2.u1)->a0000)->u0) + r3_r2_n)[0x0FB2])
 						r0_n = r10_n;
 					else
 						r8_n = r7_n;
@@ -4133,7 +4133,7 @@ l0000A664:
 				}
 			}
 			dwLoc04_n = SEQ(wLoc02_n, wLoc04_n);
-			if (v43_n < r1_n || v43_n == r1_n && r1_r0_n->b0FB2 <= (&(r3_r2.u1 + (int32) r8_n / 9244)->w0FAE)[2])
+			if (v43_n < r1_n || v43_n == r1_n && r1_r0_n->b0FB2 <= ((char *) (&((r3_r2.u1)->a0000)->u0) + (int32) r8_n)[0x0FB2])
 				break;
 			((word32) r3_r2 + ((int32) r11_n + 1434) * 0x02)->u0 = r8_n;
 			r10_n = r0_n * 0x02;
@@ -4154,8 +4154,8 @@ l0000A6E6:
 		wLoc02_n = SLICE(dwLoc04_n, word16, 16);
 		ci16 wLoc26_n = wArg06_n + ~0x01;
 		int32 ra_n = dwLoc0E_n - r13_n;
-		cu8 v53_n = (cu8) (&(r3_r2.u1 + r1_r0_n / 9244)->w0FAE)[2];
-		cu8 v54_n = (cu8) (&(r3_r2.u1 + r3_r2_n / 9244)->w0FAE)[2];
+		cu8 v53_n = ((char *) &r3_r2.u1->a0000->u0 + r1_r0_n)[0x0FB2];
+		cu8 v54_n = ((char *) &r3_r2.u1->a0000->u0 + r3_r2_n)[0x0FB2];
 		ci16 wLoc06_n;
 		if (v53_n >= v54_n)
 		{
@@ -4172,7 +4172,7 @@ l0000A77A:
 				int16 r10_n = 0x02;
 				do
 				{
-					struct Eq_n * r5_r4_n = (struct Eq_n *) (r3_r2.u1 + ((int32) r10_n * 0x02) / 9244);
+					struct Eq_n * r5_r4_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) r10_n);
 					ci16 r8_n = r5_r4_n->w1668;
 					int32 r3_r2_n = (int32) r8_n;
 					cup16 r1_n = (cup16) r13_n[r3_r2_n];
@@ -4185,7 +4185,7 @@ l0000A77A:
 						cup16 r4_n = (cup16) r13_n[r7_r6_n];
 						if (r4_n >= r1_n)
 						{
-							if (r4_n != r1_n || (&(r3_r2.u1 + r7_r6_n / 9244)->w0FAE)[2] > (&(r3_r2.u1 + r3_r2_n / 9244)->w0FAE)[2])
+							if (r4_n != r1_n || ((char *) (&((r3_r2.u1)->a0000)->u0) + r7_r6_n)[0x0FB2] > ((char *) (&((r3_r2.u1)->a0000)->u0) + r3_r2_n)[0x0FB2])
 								r0_n = r10_n;
 							else
 								r8_n = r6_n;
@@ -4196,7 +4196,7 @@ l0000A77A:
 							r8_n = r6_n;
 						}
 					}
-					if (v61_n < r1_n || v61_n == r1_n && dwLoc1E_n[0x0FB2] <= (&(r3_r2.u1 + (int32) r8_n / 9244)->w0FAE)[2])
+					if (v61_n < r1_n || v61_n == r1_n && dwLoc1E_n[0x0FB2] <= ((char *) (&((r3_r2.u1)->a0000)->u0) + (int32) r8_n)[0x0FB2])
 						break;
 					((word32) r3_r2 + ((int32) r11_n + 1434) * 0x02)->u0 = r8_n;
 					r10_n = r0_n * 0x02;
@@ -4248,7 +4248,7 @@ l0000A77A:
 		r3_r2.u1->dw0B28 = 0x00;
 		r3_r2.u1->dw0B2C = 0x00;
 		r3_r2.u1->dw0B4C = 0x00;
-		(r2_r1_n + ra_n / 4)->t0002.w0000 = 0x00;
+		((char *) r2_r1_n->a0000->u0 + ra_n)[2] = (char) 0x00;
 		word16 wLoc0E_n = (word16) r2_r1_n;
 		word16 wLoc0C_n = SLICE(r2_r1_n, word16, 16);
 		if (wArg06_n >= 0x023E)
@@ -4256,7 +4256,7 @@ l0000A77A:
 			int16 wLoc16_n;
 			if (r11_r10_n != null)
 			{
-				struct Eq_n * r11_r10_n = (struct Eq_n *) (r3_r2.u1 + ((int32) wLoc26_n * 0x02) / 9244);
+				struct Eq_n * r11_r10_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) wLoc26_n);
 				wLoc16_n = wArg02_n;
 				ci16 wLoc26_n;
 				do
@@ -4275,7 +4275,7 @@ l0000A77A:
 					r5_r4_n->w0002 = r2_n;
 					if (r3_n <= r0_n)
 					{
-						struct Eq_n * r7_r6_n = (struct Eq_n *) (r3_r2.u1 + ((int32) r2_n * 0x02) / 9244);
+						struct Eq_n * r7_r6_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) r2_n);
 						++r7_r6_n->w1628;
 						int16 r7_n = wArg02_n;
 						if (r11_n >= r0_n)
@@ -4296,7 +4296,7 @@ l0000A77A:
 			}
 			else
 			{
-				struct Eq_n * r9_r8_n = (struct Eq_n *) (r3_r2.u1 + ((int32) wLoc26_n * 0x02) / 9244);
+				struct Eq_n * r9_r8_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) wLoc26_n);
 				wLoc16_n = wArg02_n;
 				ci16 r7_n = wLoc26_n;
 				do
@@ -4314,7 +4314,7 @@ l0000A77A:
 					r1_r0_n->w0002 = r4_n;
 					if (r3_n <= r5_n)
 					{
-						struct Eq_n * r3_r2_n = (struct Eq_n *) (r3_r2.u1 + ((int32) r4_n * 0x02) / 9244);
+						struct Eq_n * r3_r2_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) r4_n);
 						++r3_r2_n->w1628;
 						if (r11_n >= r5_n)
 							r4_n += r11_r10_n[(int32) (r5_n - r11_n)];
@@ -4332,7 +4332,7 @@ l0000A77A:
 			{
 				int32 dwLoc16_n = (int32) r7_n;
 				int16 r3_n = wLoc16_n;
-				struct Eq_n * r5_r4_n = (struct Eq_n *) (r3_r2.u1 + (dwLoc16_n * 0x02) / 9244);
+				struct Eq_n * r5_r4_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + dwLoc16_n);
 				do
 				{
 					word16 r2_n = r5_r4_n->w1624;
@@ -4433,7 +4433,7 @@ l0000AE26:
 						r6_n = r7_n + ~0x00;
 l0000ABDE:
 					((word32) r3_r2 + ((int32) r0_n + 1418) * 0x02)->u0 = r2_n + ~0x00;
-					struct Eq_n * r1_r0_n = (struct Eq_n *) (r3_r2.u1 + ((int32) r6_n * 0x02) / 9244);
+					struct Eq_n * r1_r0_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) r6_n);
 					r1_r0_n->w1628 += 0x02;
 					r5_r4_n->w1628 += ~0x00;
 					r3_n += ~0x01;
@@ -4459,7 +4459,7 @@ l0000ACB8:
 				else
 				{
 					word16 r7_n = wLoc26_n + ~0x00;
-					struct Eq_n * r11_r10_n = (struct Eq_n *) (r3_r2.u1 + ((int32) (wLoc26_n + ~0x00) * 0x02) / 9244);
+					struct Eq_n * r11_r10_n = (struct Eq_n *) (&r3_r2.u1->a0000->u0 + (int32) (wLoc26_n + ~0x00));
 					while (true)
 					{
 						word16 r10_n = (word16) r11_r10_n;
@@ -4660,7 +4660,7 @@ l0000AFE2:
 	r3_r2.u1->t0014.u2 = (struct Eq_n *) &r3_r2_n.u2->b0001;
 	Mem236[r1_r0_n + r3_r2_n:byte] = SLICE(~r10_n >>u 0x08, byte, 0);
 	fn0000DB24();
-	r3_r2.u1->t0014.u2 += (fp - 8) / 16;
+	r3_r2.u1->t0014.u2 = &r3_r2.u1->t0014.u2->b0000 + (fp - 8);
 }
 
 // 0000B09C: Register word16 fn0000B09C(Sequence Eq_n r3_r2)
@@ -4899,7 +4899,7 @@ l0000B256:
 	ci16 r4_n = ~0x00;
 	if (r6_n <= 0x00)
 	{
-		ptr32 ra_n = &r9_r8_n.u1->w006A + ((r11_r10_n << 0x02) + 0x0A) / 2;
+		ptr32 ra_n = (char *) &r9_r8_n.u1->w006A + ((r11_r10_n << 0x02) + 0x0A);
 		ci16 r6_n = 0x00;
 		ci16 * r3_r2_n = SEQ(SLICE(&r9_r8_n.u1->ptr0070, word16, 16), r8_n + 0x70);
 		ci16 * r3_r2_n;
@@ -4914,7 +4914,7 @@ l0000B256:
 					goto l0000B2E8;
 				if (r6_n < r5_n)
 					goto l0000B722;
-				struct Eq_n * r5_r4_n = (struct Eq_n *) (r9_r8_n.u1 + ((int32) r0_n << 0x02) / 9244);
+				struct Eq_n * r5_r4_n = (struct Eq_n *) &(r9_r8_n.u1->a0000 + (int32) r0_n)->u0;
 				r5_r4_n->w14A4 = r6_n + r5_r4_n->w14A4;
 			}
 			else
@@ -4924,7 +4924,7 @@ l0000B722:
 				{
 					if (r4_n != r0_n)
 					{
-						struct Eq_n * r5_r4_n = (struct Eq_n *) (r9_r8_n.u1 + ((int32) r0_n << 0x02) / 9244);
+						struct Eq_n * r5_r4_n = (struct Eq_n *) &(r9_r8_n.u1->a0000 + (int32) r0_n)->u0;
 						++r5_r4_n->w14A4;
 					}
 					r9_r8_n.u1->t1524.u0 = (int16) (r9_r8_n.u1->t1524.u0 + 0x01);
@@ -4984,7 +4984,7 @@ l0000B2E8:
 	ci16 r4_n = ~0x00;
 	if (r6_n <= 0x00)
 	{
-		ptr32 ra_n = &r9_r8_n.u1->w095E + ((r11_r10_n << 0x02) + 0x0A) / 2;
+		ptr32 ra_n = (char *) &r9_r8_n.u1->w095E + ((r11_r10_n << 0x02) + 0x0A);
 		ci16 r6_n = 0x00;
 		ci16 * r3_r2_n = SEQ(SLICE((word32) r9_r8_n + 2404, word16, 16), r8_n + 2404);
 		ci16 * r3_r2_n;
@@ -4999,7 +4999,7 @@ l0000B2E8:
 					goto l0000B36E;
 				if (r5_n >= r6_n)
 					goto l0000B6FC;
-				struct Eq_n * r5_r4_n = (struct Eq_n *) (r9_r8_n.u1 + ((int32) r0_n << 0x02) / 9244);
+				struct Eq_n * r5_r4_n = (struct Eq_n *) &(r9_r8_n.u1->a0000 + (int32) r0_n)->u0;
 				r5_r4_n->w14A4 = r6_n + r5_r4_n->w14A4;
 			}
 			else
@@ -5009,7 +5009,7 @@ l0000B6FC:
 				{
 					if (r4_n != r0_n)
 					{
-						struct Eq_n * r5_r4_n = (struct Eq_n *) (r9_r8_n.u1 + ((int32) r0_n << 0x02) / 9244);
+						struct Eq_n * r5_r4_n = (struct Eq_n *) &(r9_r8_n.u1->a0000 + (int32) r0_n)->u0;
 						++r5_r4_n->w14A4;
 					}
 					r9_r8_n.u1->t1524.u0 = (int16) (r9_r8_n.u1->t1524.u0 + 0x01);
@@ -5370,8 +5370,7 @@ l0000B67A:
 						goto l0000B7C4;
 					}
 l0000B64A:
-					Eq_n r5_n;
-					r5_n.u1 = (r9_r8_n.u1 + ((int32) r11_r10_n->b0001 + 660 << 0x02) / 9244)->t0004.u1;
+					Eq_n r5_n = (&(r9_r8_n.u1->a0000 + ((int32) r11_r10_n->b0001 + 660))->u0)[2];
 					r0_n |= __a_shift<word16,word16>(r5_n, r4_n);
 					r9_r8_n.u1->w2410 = r0_n;
 					word16 r10_n = (word16) r11_r10_n;
@@ -5920,7 +5919,7 @@ word16 fn0000C224(Eq_n r3_r2, Eq_n r5_r4, Eq_n r13, union Eq_n & r1Out)
 		uint32 r1_r0_n = r1_r0_n;
 		if (r12_n > 0x1F)
 		{
-			&r11_r10_n.u2->b0000 = r11_r10_n.u2 + (((word32) r12_n + 0x0000FFE0 & ~0x1F) + 32) / 16;
+			&r11_r10_n.u2->b0000 += ((word32) r12_n + 0x0000FFE0 & ~0x1F) + 32;
 			r1_r0_n = r1_r0_n;
 			Eq_n r11_r10_n;
 			do
@@ -5974,7 +5973,7 @@ word16 fn0000C224(Eq_n r3_r2, Eq_n r5_r4, Eq_n r13, union Eq_n & r1Out)
 					}
 				}
 			}
-			&r11_r10_n.u2->b0000 = r11_r10_n.u2 + ((ra_n & ~0x03) + 4) / 16;
+			&r11_r10_n.u2->b0000 += (ra_n & ~0x03) + 4;
 			r12_n &= 0x03;
 			r1_r0_n = r1_r0_n;
 		}

--- a/subjects/Raw/MicroBlaze/MicroBlaze.reko/MicroBlaze.c
+++ b/subjects/Raw/MicroBlaze/MicroBlaze.reko/MicroBlaze.c
@@ -276,7 +276,7 @@ void fn00000378(Eq_n r0, Eq_n r5, Eq_n r26, word32 r27, word32 r28)
 				fn00018E58();
 				if (true)
 					goto l00000610;
-				struct Eq_n * r22_n = (struct Eq_n *) (&r1_n->ptrFFFFF7AC + r3_n / 4);
+				struct Eq_n * r22_n = (struct Eq_n *) ((char *) &r1_n->ptrFFFFF7AC + r3_n);
 				r22_n->b001C = 0x03;
 				r22_n = 0x01;
 			}
@@ -4799,7 +4799,7 @@ void fn0000AFBC(Eq_n r0, struct Eq_n * r5, Eq_n r6, int32 r7, Eq_n r26, word32 r
 	{
 		ui32 r4_n = r22_n * 0x02;
 		&r6_n.u2->t0000.u0 = r19_n.u2[0x0084];
-		if ((g_a19DBC[((byte) r22_n.u0 + r4_n) *32 0x04 / 0x0C] ^ g_a19DBC[r6_n]) == 0x00)
+		if (((&g_a19DBC->dw0000)[(byte) r22_n.u0 + r4_n] ^ g_a19DBC[r6_n]) == 0x00)
 		{
 			r3_n = r22_n ^ r6_n;
 			goto l0000B1A0;
@@ -6004,7 +6004,7 @@ l00011114:
 															}
 															else
 																r8_n = 0x01;
-															struct Eq_n * r3_n = (struct Eq_n *) (r29_n + ((r3_n - r8_n) * 0x04) / 8);
+															struct Eq_n * r3_n = (struct Eq_n *) &(r29_n->a0000 + (r3_n - r8_n))->u0;
 															ui32 r18_n = r24_n & 0x1F;
 															int32 r19_n;
 															if (r18_n != 0x00)
@@ -6029,7 +6029,7 @@ l00011114:
 																r5_n -= r8_n;
 																if (r5_n == 0x00)
 																	break;
-																r3_n += r19_n / 4;
+																r3_n = &r3_n->b0000 + r19_n;
 															}
 															int32 r5_n = r4_n + ~0x00;
 															ui32 r18_n = r5_n & 0x1F;
@@ -6058,7 +6058,7 @@ l00011114:
 															}
 															else
 																r7_n = r4_n * 0x02;
-															struct Eq_n * r7_n = (struct Eq_n *) (fp->aFFFFFF70 + r7_n / 2).w0000;
+															struct Eq_n * r7_n = (struct Eq_n *) ((word16) fp->aFFFFFF70.w0000 + r7_n);
 															ui32 r5_n = (word32) r7_n->w0020 + ~0x00 & 0xFFFF;
 															if (r5_n == 0x00)
 															{
@@ -6069,12 +6069,12 @@ l00011114:
 																	if (r3_n != 0x00)
 																	{
 																		ui32 r3_n = r3_n * 0x02;
-																		r29_n[r3_n * 0x02 / 8] = (struct Eq_n) 0x40;
-																		struct Eq_n * r5_n = (struct Eq_n *) (r29_n + (r3_n * 0x02) / 8);
+																		(&r29_n->a0000[0].u1.b0000)[r3_n * 0x02] = 0x40;
+																		struct Eq_n * r5_n = (struct Eq_n *) (&r29_n->a0000->u0 + r3_n);
 																		r5_n->b0001 = (byte) r20_n;
 																		r5_n->w0002 = (word16) r4_n;
 																	}
-																	*r8 = (struct Eq_n **) (r11_n + (r30_n * 0x04) / 8);
+																	*r8 = (struct Eq_n **) &(r11_n->a0000 + r30_n)->u0;
 																	*r9 = r27_n;
 																	return;
 																}
@@ -6115,7 +6115,7 @@ l000115D0:
 															else
 																r5_n = 0x04;
 															int32 r23_n = r4_n - r25_n;
-															r29_n += r5_n / 8;
+															r29_n = (struct Eq_n *) ((char *) &r29_n->a0000->u0 + r5_n);
 															ui32 r18_n = r23_n & 0x1F;
 															ui32 r5_n;
 															if ((r23_n & 0x1F) != 0x00)
@@ -6271,8 +6271,8 @@ l00011570:
 																															r24_n = r23_n;
 																															if (0x0354 - r30_n < 0x00 && dwLoc3C_n != 0x00 || 0x0250 - r30_n < 0x00 && dwLoc40_n != 0x00)
 																																return;
-																															r11_n[r7_n * 0x04 / 8] = (struct Eq_n) (byte) r23_n;
-																															struct Eq_n * r5_n = (struct Eq_n *) (r11_n + (r7_n * 0x04) / 8);
+																															r11_n->a0000[r7_n].u1.b0000 = (byte) r23_n;
+																															struct Eq_n * r5_n = (struct Eq_n *) &(r11_n->a0000 + r7_n)->u0;
 																															r5_n->b0001 = (byte) r27_n;
 																															r5_n->w0002 = (word16) (r29_n - r11_n >> 2);
 																															r21_n = r7_n;
@@ -6486,7 +6486,7 @@ void fn0001185C(Eq_n r5, struct Eq_n * r6, int32 r7)
 	int32 r3_n = 0x00;
 	struct Eq_n * r10_n = (struct Eq_n *) (&r6->w0002 + 2);
 	ui32 r29_n = ~0x00;
-	ptr32 r6_n = r6 + (r7 * 0x04 + 0x0A) / 4;
+	ptr32 r6_n = (char *) r6 + (r7 * 0x04 + 0x0A);
 l000118F0:
 	int32 r4_n = r3_n + 0x01;
 	ui32 r11_n;
@@ -7319,8 +7319,8 @@ l000124AC:
 		struct Eq_n * r19_n = CONVERT(Mem30[r8_n + r4_n:byte], byte, word32);
 		ui32 r23_n = (word32) r19_n->b1ABD8;
 		ui32 r8_n = (r23_n + 0x0101) * 0x02;
-		int32 r24_n = (word32) r6[r8_n * 0x02 / 0x0404];
-		int32 r22_n = (word32) (&(r6 + (r8_n * 0x02) / 0x0404)->a0000[0].u0)[1];
+		int32 r24_n = (word32) (&r6->a0000[0].u0)[r8_n];
+		int32 r22_n = (word32) (&(&r6->a0000->u0 + r8_n)->a0000[0].u0)[1];
 		ui32 r18_n = r9_n & 0x1F;
 		int32 r8_n;
 		if (r18_n != 0x00)
@@ -7603,8 +7603,8 @@ l000124AC:
 	else
 	{
 		ui32 r19_n = CONVERT(Mem30[r8_n + r4_n:byte], byte, word32);
-		int32 r21_n = (word32) r6[r19_n * 0x04 / 0x0404];
-		int32 r19_n = (word32) (&(r6 + (r19_n * 0x04) / 0x0404)->a0000[0].u0)[1];
+		int32 r21_n = (word32) r6->a0000[r19_n].u0.w0000;
+		int32 r19_n = (word32) (&(r6->a0000 + r19_n)->u0.w0000)[1];
 		ui32 r18_n = r9_n & 0x1F;
 		int32 r4_n;
 		if (r18_n != 0x00)
@@ -7803,7 +7803,7 @@ l00012AFC:
 							*r6_n = r5_n;
 							r8_n->a0000[0].u2.w0000 = 0x01;
 							Mem184[r5 + r5_n + 5208:byte] = SLICE(r0, byte, 0);
-							Eq_n r3_n = r5.u3->t16AC.u2 - (word32) ((r7_n + r3_n / 4))[0].w0002;
+							Eq_n r3_n = r5.u3->t16AC.u2 - (word32) ((char *) r7_n + r3_n)[2];
 							r5.u3->t16A8.u2 = (struct Eq_n *) &r5.u3->t16A8.u2->bFFFFFFFF;
 							r5.u3->t16AC.u2 = (struct Eq_n *) r3_n;
 							++r6_n;
@@ -8007,16 +8007,16 @@ l00012D9C:
 								r5.u2[(r3_n + 727) * 0x04] = (struct Eq_n) r22_n;
 								ui32 r3_n = r12_n * 0x02;
 								Eq_n (* r5_n)[] = (Eq_n (*)[]) r5.u3[0x00B6];
-								word32 r7_n = (word32) r21_n[r3_n * 0x02 / 4];
+								word32 r7_n = (word32) (&r21_n->a0000[0].u2.w0000)[r3_n];
 								word32 r8_n = (word32) r21_n[r5_n];
 								r28_n->dw0004 = r12_n;
 								int32 r23_n = r30_n + ~0x01;
 								r5.u3->dw1454 = r23_n;
 								r28_n->dw0000 = r5_n;
-								r21_n[r25_n / 4] = (struct Eq_n) (word16) (r7_n + r8_n);
+								*((char *) &r21_n->a0000[0].u2.w0000 + r25_n) = (struct Eq_n *) (word16) (r7_n + r8_n);
 								int32 r7_n = CONVERT(Mem540[r5 + r12_n + 5208:byte], byte, word32);
 								int32 r5_n = CONVERT(Mem540[r5 + r5_n + 5208:byte], byte, word32);
-								struct Eq_n * r3_n = (struct Eq_n *) (r21_n + (r3_n * 0x02) / 4);
+								struct Eq_n * r3_n = (struct Eq_n *) (r21_n->a0000->u0 + r3_n);
 								struct Eq_n * r6_n;
 								ui32 r5_n;
 								if (r7_n - r5_n >= 0x00)
@@ -8037,7 +8037,7 @@ l00012D9C:
 								if (r27_n != 0x00)
 								{
 									Eq_n (* r8_n)[] = (Eq_n (*)[]) ((char *) r24_n + 1);
-									int32 r9_n = (word32) r21_n[r25_n / 4];
+									int32 r9_n = (word32) *((char *) &r21_n->a0000[0].u2.w0000 + r25_n);
 									int32 r5_n = 0x01;
 									int32 r10_n = 0x02;
 									while (true)
@@ -8136,7 +8136,7 @@ l00012F18:
 								Eq_n r28_n;
 								r28_n.u0 = r8_n->t0010.u0;
 								fn00018C64();
-								struct Eq_n * r25_n = (struct Eq_n *) (r31_n + r25_n / 4);
+								struct Eq_n * r25_n = (struct Eq_n *) ((char *) r31_n->a0000->u0 + r25_n);
 								if (r23_n > 0x023C)
 								{
 									r25_n->w0002 = (word16) r27_n;
@@ -8219,7 +8219,7 @@ l00013348:
 										if (r22_n >= null)
 										{
 											struct Eq_n * r7_n = (struct Eq_n *) &r21_n->w0002;
-											ptr32 r21_n = r21_n + (r22_n * 0x04 + 0x06) / 4;
+											ptr32 r21_n = (char *) r21_n->a0000->u0 + (r22_n * 0x04 + 0x06);
 											do
 											{
 												ui32 r4_n = (word32) r7_n->w0000;
@@ -10633,7 +10633,7 @@ void fn000170A4(word32 r0, struct Eq_n * r5, word32 r6)
 	Eq_n r4_n;
 	r4_n.u0 = r5->t0004.u0;
 	Eq_n r6_n;
-	r6_n.u0 = &(r10_n.u0 + (r3_n - r6) / 4)->b0000;
+	r6_n.u0 = &r10_n.u0->b0000 + (r3_n - r6);
 	ui32 r18_n = r23_n & 0x1F;
 	ui32 r24_n;
 	if ((r23_n & 0x1F) != 0x00)
@@ -10678,7 +10678,7 @@ void fn000170A4(word32 r0, struct Eq_n * r5, word32 r6)
 	Eq_n r9_n[] = r20_n->ptr0050;
 	Eq_n r21_n[] = r20_n->ptr0054;
 	Eq_n r6_n;
-	r6_n.u0 = &(r27_n.u0 + (r22_n & ~0x03) / 4)->b0000;
+	r6_n.u0 = &r27_n.u0->b0000 + (r22_n & ~0x03);
 	Eq_n r30_n = r11_n + (r4_n + ~0x04);
 	Eq_n r31_n = r10_n + (r3_n + ~0x0100);
 	Eq_n r4_n = r22_n - (r22_n & ~0x03);
@@ -10779,7 +10779,7 @@ void fn000170A4(word32 r0, struct Eq_n * r5, word32 r6)
 						}
 						else
 							r3_n = ~0x00;
-						ui32 r3_n = &(r6_n.u0 + (~r3_n & r7_n) / 4)->b0000;
+						ui32 r3_n = &r6_n.u0->b0000 + (~r3_n & r7_n);
 						struct Eq_n * r6_n = (struct Eq_n *) &(r9_n + r3_n)->b0000;
 						Eq_n r19_n = (word32) r6_n->b0001;
 						r4_n = (word32) r9_n[r3_n].b0000;
@@ -10868,7 +10868,7 @@ l00017404:
 				}
 				else
 					r4_n = ~0x00;
-				r4_n.u0 = &(r6_n.u0 + (~r4_n & r7_n) / 4)->b0000;
+				r4_n.u0 = &r6_n.u0->b0000 + (~r4_n & r7_n);
 				ui32 r18_n = r3_n & 0x1F;
 				uint32 r6_n;
 				if (r18_n != 0x00)
@@ -10978,7 +10978,7 @@ l00017404:
 						}
 						else
 							r3_n = ~0x00;
-						ui32 r3_n = &(r19_n.u0 + (~r3_n & r7_n) / 4)->b0000;
+						ui32 r3_n = &r19_n.u0->b0000 + (~r3_n & r7_n);
 						struct Eq_n * r19_n = (struct Eq_n *) &(r21_n + r3_n)->b0000;
 						Eq_n r3_n = (word32) r19_n->b0001;
 						r6_n = (word32) r21_n[r3_n].b0000;
@@ -11119,7 +11119,7 @@ l00017574:
 				{
 					word32 r6_n = r29_n - r23_n;
 					Eq_n r6_n;
-					r6_n.u0 = &(r27_n.u0 + r6_n / 4)->b0000;
+					r6_n.u0 = &r27_n.u0->b0000 + r6_n;
 					if (r23_n - r4_n >= 0x00)
 					{
 						dwLoc40_n = r6_n;
@@ -11160,7 +11160,7 @@ l00017574:
 						if ((r23_n ^ r3_n * 0x04) != 0x00)
 						{
 							Eq_n r19_n = r23_n - r3_n * 0x04;
-							r10_n.u0[r3_n].b0000 = (byte) r6_n.u3[r3_n * 0x04 / 3];
+							r10_n.u0[r3_n].b0000 = r6_n.u0[r3_n].b0000;
 							if (r19_n != 0x01)
 							{
 								word32 r6_n = (word32) r6_n->b0001;
@@ -11178,7 +11178,7 @@ l00017574:
 					int32 r3_n = 0x00;
 					do
 					{
-						r10_n.u0[r3_n / 4].b0000 = (byte) r6_n.u3[r3_n / 3];
+						(&r10_n.u0[0].b0000)[r3_n] = (&r6_n.u0[0].b0000)[r3_n];
 						++r3_n;
 					} while ((r23_n ^ r3_n) != 0x00);
 					r10_n += r23_n;
@@ -11213,7 +11213,7 @@ l00017574:
 							int32 r19_n = 0x00;
 							while (true)
 							{
-								r10_n.u0[r19_n / 4].b0000 = (byte) *((word32) r19_n + r19_n);
+								(&r10_n.u0[0].b0000)[r19_n] = (byte) *((word32) r19_n + r19_n);
 								++r4_n;
 								if (r4_n - (r19_n >> 2) >= 0x00)
 									break;
@@ -11224,7 +11224,7 @@ l00017574:
 							Eq_n r6_n = r6_n + (r19_n & ~0x03);
 							if ((r19_n ^ r19_n & ~0x03) != 0x00)
 							{
-								r10_n.u0[(r19_n & ~0x03) / 4].b0000 = (byte) r6_n.u3[(r19_n & ~0x03) / 3];
+								(&r10_n.u0[0].b0000)[r19_n & ~0x03] = (&r6_n.u3->b0000)[r19_n & ~0x03];
 								if (r6_n != 0x01)
 								{
 									r6_n.u1->b0001 = r6_n.u1->b0001;
@@ -11238,7 +11238,7 @@ l00017574:
 							int32 r19_n = 0x00;
 							do
 							{
-								r10_n.u0[r19_n / 4].b0000 = (byte) r6_n.u3[r19_n / 3];
+								(&r10_n.u0[0].b0000)[r19_n] = (&r6_n.u3->b0000)[r19_n];
 								++r19_n;
 							} while ((r19_n ^ r19_n) != 0x00);
 						}
@@ -11282,7 +11282,7 @@ l00017574:
 								int32 r6_n = r3_n & 0x03;
 								while (true)
 								{
-									&((word32) r6_n + r3_n)->u0->b0000 = r27_n.u0[r3_n / 4].b0000;
+									&((word32) r6_n + r3_n)->u0->b0000 = (&r27_n.u0[0].b0000)[r3_n];
 									++r6_n;
 									if (r6_n - (r22_n >> 2) >= 0x00)
 										break;
@@ -11314,7 +11314,7 @@ l00017F00:
 						int32 r3_n = 0x00;
 						do
 						{
-							r6_n.u3[r3_n / 3] = (struct Eq_n) r27_n.u0[r3_n / 4].b0000;
+							(&r6_n.u3->b0000)[r3_n] = (&r27_n.u0[0].b0000)[r3_n];
 							++r3_n;
 						} while ((r22_n ^ r3_n) != 0x00);
 						r10_n += r23_n;
@@ -11352,7 +11352,7 @@ l00017F00:
 							Eq_n r3_n = (r23_n + ~0x03 >>u 2) + 0x01;
 							while (true)
 							{
-								r10_n.u0[r19_n / 4].b0000 = (byte) *((word32) r19_n + r19_n);
+								(&r10_n.u0[0].b0000)[r19_n] = (byte) *((word32) r19_n + r19_n);
 								r19_n += 0x04;
 								if (dwLoc88_n + 0x00 - r3_n >= 0x00)
 									break;
@@ -11363,7 +11363,7 @@ l00017F00:
 							if ((r23_n ^ r3_n * 0x04) != 0x00)
 							{
 								Eq_n r19_n = r10_n + r3_n * 0x04;
-								r10_n.u0[r3_n].b0000 = (byte) r6_n.u3[r3_n * 0x04 / 3];
+								r10_n.u0[r3_n].b0000 = (&r6_n.u3->b0000)[r3_n * 0x04];
 								if (r6_n != 0x01)
 								{
 									r19_n.u1->b0001 = r6_n.u1->b0001;
@@ -11379,7 +11379,7 @@ l00017B98:
 							int32 r3_n = 0x00;
 							do
 							{
-								r10_n.u0[r3_n / 4].b0000 = (byte) r6_n.u3[r3_n / 3];
+								(&r10_n.u0[0].b0000)[r3_n] = (&r6_n.u3->b0000)[r3_n];
 								++r3_n;
 							} while ((r23_n ^ r3_n) != 0x00);
 							r10_n += r23_n;
@@ -12054,7 +12054,7 @@ struct Eq_n * fn00019E48(struct Eq_n * r0, union Eq_n & r3Out, ptr32 & r19Out, p
 					else
 					{
 						word32 r19_n;
-						if (fn0001B134(r21_n[((word32) (r19_n * 0x02) + 4) / 2].ptr0000, &g_b16E54, &g_ptr0001, r22_n, r23_n, out r19_n, out r21_n, out r22_n, out r23_n, out r24_n, out r25_n) != 0x00)
+						if (fn0001B134(*((char *) &r21_n[0].ptr0000 + ((word32) (r19_n * 0x02) + 4)), &g_b16E54, &g_ptr0001, r22_n, r23_n, out r19_n, out r21_n, out r22_n, out r23_n, out r24_n, out r25_n) != 0x00)
 						{
 							g_t18E9C.u0 = 0x01;
 							&r30_n.u0->ptr0000 = (word32) r30_n + 1;
@@ -12062,7 +12062,7 @@ struct Eq_n * fn00019E48(struct Eq_n * r0, union Eq_n & r3Out, ptr32 & r19Out, p
 						else
 						{
 							word32 r19_n;
-							if (fn0001B134(r21_n[(r19_n * 0x02 + 0x04) / 2].ptr0000, &g_b16E60, &g_ptr0001, r22_n, r23_n, out r19_n, out r21_n, out r22_n, out r23_n, out r24_n, out r25_n) == 0x00)
+							if (fn0001B134(*((char *) &r21_n[0].ptr0000 + (r19_n * 0x02 + 0x04)), &g_b16E60, &g_ptr0001, r22_n, r23_n, out r19_n, out r21_n, out r22_n, out r23_n, out r24_n, out r25_n) == 0x00)
 								goto l0001A1B8;
 							g_t18E9C.u0 = 0x02;
 							&r30_n.u0->ptr0000 = (word32) r30_n + 1;
@@ -12107,7 +12107,7 @@ struct Eq_n * fn00019E48(struct Eq_n * r0, union Eq_n & r3Out, ptr32 & r19Out, p
 						goto l0001A064;
 					}
 					word32 r19_n;
-					if (fn0001B134(r21_n[r31_n / 2].ptr0000, &g_b16EF0, &g_ptr0001, r22_n, r23_n, out r19_n, out r21_n, out r22_n, out r23_n, out r24_n, out r25_n) == 0x00)
+					if (fn0001B134(*((char *) &r21_n[0].ptr0000 + r31_n), &g_b16EF0, &g_ptr0001, r22_n, r23_n, out r19_n, out r21_n, out r22_n, out r23_n, out r24_n, out r25_n) == 0x00)
 						goto l0001A1B8;
 					if ((g_ptr18E88 & ~0x02) != 0x00)
 						goto l0001A3C4;
@@ -12231,7 +12231,7 @@ struct Eq_n * fn00019E48(struct Eq_n * r0, union Eq_n & r3Out, ptr32 & r19Out, p
 					goto l0001A064;
 				}
 				word32 r19_n;
-				if (fn0001B134(r21_n[r31_n / 2].ptr0000, &g_b16F68, &g_t0003, r22_n, r23_n, out r19_n, out r21_n, out r22_n, out r23_n, out r24_n, out r25_n) != 0x00)
+				if (fn0001B134(*((char *) &r21_n[0].ptr0000 + r31_n), &g_b16F68, &g_t0003, r22_n, r23_n, out r19_n, out r21_n, out r22_n, out r23_n, out r24_n, out r25_n) != 0x00)
 				{
 					struct Eq_n * r3_n = g_ptr18E88;
 					if ((-r3_n | r3_n) < 0x00 && (-(r3_n ^ 0x06) | r3_n ^ 0x06) < 0x00)
@@ -12240,7 +12240,7 @@ struct Eq_n * fn00019E48(struct Eq_n * r0, union Eq_n & r3Out, ptr32 & r19Out, p
 					goto l0001A064;
 				}
 				word32 r19_n;
-				if (fn0001B134(r21_n[r31_n / 2].ptr0000, &g_b16F6C, &g_t0003, r22_n, r23_n, out r19_n, out r21_n, out r22_n, out r23_n, out r24_n, out r25_n) == 0x00)
+				if (fn0001B134(*((char *) &r21_n[0].ptr0000 + r31_n), &g_b16F6C, &g_t0003, r22_n, r23_n, out r19_n, out r21_n, out r22_n, out r23_n, out r24_n, out r25_n) == 0x00)
 					goto l0001A1B8;
 				struct Eq_n * r3_n = g_ptr18E88;
 				if ((-r3_n | r3_n) < 0x00 && (-(r3_n ^ 0x07) | r3_n ^ 0x07) < 0x00)
@@ -12947,7 +12947,7 @@ word32 * fn0001CE64(word32 * r3, struct Eq_n * r7, union Eq_n * r9, word32 r10, 
 										if (r31 >= r21_n)
 											break;
 										r29 += 0x04;
-										struct Eq_n * r23_n = (struct Eq_n *) (r30.u0 + dwLoc70->dw0040 / 36);
+										struct Eq_n * r23_n = (struct Eq_n *) ((char *) &r30.u0->ptr0000 + dwLoc70->dw0040);
 										Eq_n r3_n = fn0002E908(r23_n->t000C.u0, dwLoc6C, out r7_n);
 										if (r23_n->dw0020 != 0x00)
 										{
@@ -13339,7 +13339,7 @@ word32 fn0001E004(struct Eq_n * r5, int32 r6, int32 r7, Eq_n r8, ui32 r9, struct
 	{
 		if (0x03 - r6 >= 0x00)
 		{
-			struct Eq_n * r19_n = (struct Eq_n *) (r5 + (r6 * 0x04) / 272);
+			struct Eq_n * r19_n = (struct Eq_n *) ((char *) &r5->ptr0000 + r6 * 0x04);
 			struct Eq_n * r22_n = r19_n->ptr0044;
 			word32 r0;
 			if (r22_n == null)
@@ -13933,8 +13933,8 @@ l0001F0B4:
 						if (r3_n >= r28)
 						{
 							int32 r4_n = r1_n->dw0A54;
-							r29 = (word32 *) (r21.u1 + r4_n / 84);
-							&r21.u1->dw0000 = r21.u1 + r1_n->dw0A50 / 84;
+							r29 = (word32 *) ((char *) &r21.u1->dw0000 + r4_n);
+							&r21.u1->dw0000 = (char *) &r21.u1->dw0000 + r1_n->dw0A50;
 							do
 							{
 								int32 r4_n = *r29;
@@ -14185,8 +14185,8 @@ void fn0001F628(word32 r0, struct Eq_n * r5, word32 r19, word32 r21, word32 r22,
 				if (r3_n > 0x00)
 				{
 					word32 r6_n = r5->dw0144;
-					word32 * r3_n = (word32 *) (r5 + ((r6_n + 0x52) * 0x04) / 332);
-					ptr32 r4_n = r5 + (((word32) r3_n.u0 + (r6_n + 0x52)) * 0x04) / 332;
+					word32 * r3_n = (word32 *) ((char *) &r5->ptr0000 + (r6_n + 0x52) * 0x04);
+					ptr32 r4_n = (char *) &r5->ptr0000 + ((word32) r3_n.u0 + (r6_n + 0x52)) * 0x04;
 					do
 					{
 						*r3_n = r26_n;
@@ -14267,7 +14267,7 @@ void fn0001F8C4(word32 r0, struct Eq_n * r5)
 			r19_n->dw0128 = r3_n;
 			word32 r5_n = r19_n->dw0040;
 			word32 * r4_n = (word32 *) (&r19_n->dw0128 + 1);
-			ptr32 r3_n = r19_n + ((r3_n + 0x4B) * 0x04) / 388;
+			ptr32 r3_n = (char *) &r19_n->ptr0000 + (r3_n + 0x4B) * 0x04;
 			while (true)
 			{
 				*r4_n = r5_n;
@@ -14295,7 +14295,7 @@ void fn0001F8C4(word32 r0, struct Eq_n * r5)
 			word32 r10_n = r5->dw0040;
 			ui32 * r8_n = (ui32 *) ((char *) r9_n + 4);
 			struct Eq_n * r5_n = (struct Eq_n *) (&r5->dw0128 + 1);
-			ptr32 r7_n = r5 + ((r4_n + 0x4B) * 0x04) / 388;
+			ptr32 r7_n = (char *) &r5->ptr0000 + (r4_n + 0x4B) * 0x04;
 			while (true)
 			{
 				++r5_n;
@@ -14731,7 +14731,7 @@ l000203C4:
 	} while ((r19_n ^ r21_n) != 0x00);
 	if (r22_n > 0x00)
 	{
-		ptr32 r22_n = r24_n + ((r22_n + 0x11) * 0x02) / 552;
+		ptr32 r22_n = (char *) r24_n + (r22_n + 0x11) * 0x02;
 		do
 		{
 			r19_n = (union Eq_n *) ((char *) r19_n + 2);
@@ -14828,14 +14828,14 @@ void fn0002225C(struct Eq_n * r5, int32 r6, int32 r7, word32 (** r8)[], word32 r
 	word32 r23_n[];
 	if (r1_n->dw0560 != 0x00)
 	{
-		r22_n = (int32) r28_n[(r7 + 0x15) * 0x04 / 8];
+		r22_n = r28_n->a0000[r7 + 0x15];
 		if (r22_n != 0x00)
 			goto l000222EC;
 	}
 	else
 	{
 		int32 r3_n = r7 + 0x19;
-		r22_n = (int32) r28_n[r3_n * 0x04 / 8];
+		r22_n = r28_n->a0000[r3_n];
 		if (r22_n != 0x00)
 		{
 l000222EC:
@@ -15090,7 +15090,7 @@ l000228DC:
 		word32 r6_n = r26_n->dw0404;
 		int32 r5_n = fp->aFFFFF78C[r9_n].dw0000;
 		r7[r9_n * 0x02] += r7[r8_n * 0x02];
-		r7[r8_n * 0x02 / 4] = (struct Eq_n) (r3_n ^ 0x0101);
+		*((char *) &r7->a0000[0].u0 + r8_n * 0x02) = r3_n ^ 0x0101;
 		ui32 r3_n;
 		if (r5_n >= 0x00)
 		{
@@ -15215,7 +15215,7 @@ l000228DC:
 	}
 	else
 		r4_n = 0x20;
-	*((word32) (fp->aFFFFF78C + r4_n / 2).dw0000 + 0x0808) = (int32) ((word16) r3_n + ~0x00);
+	*((word32) ((word32) fp->aFFFFF78C.dw0000 + r4_n) + 0x0808) = (word32) ((word16) r3_n + ~0x00);
 	fn0002F60C();
 	word32 r6_n = 0x01;
 	word32 r7_n = 0x00;
@@ -15228,7 +15228,7 @@ l000228DC:
 			if ((*r5_n ^ r6_n) == 0x00)
 			{
 				++r5_n;
-				(r6 + ((r7_n + 0x10) * 0x02) / 552)->a0000[1] = (Eq_n) (word16) r4_n;
+				(r6->a0000 + (r7_n + 0x10))[1] = (Eq_n) (word16) r4_n;
 				++r7_n;
 			}
 			else
@@ -15415,14 +15415,14 @@ struct Eq_n * fn000233B0(struct Eq_n * r0, struct Eq_n * r5, word32 r22, word32 
 	if (r4_n != null)
 	{
 		word32 r3_n = r5->dw0034;
-		Eq_n r4_n[] = (Eq_n (*)[]) r5[(r3_n + 0x17) * 0x04 / 0x0044];
+		Eq_n r4_n[] = r5->a0000[r3_n + 0x17];
 		ui32 r19_n = r19_n * 0x02;
-		++r4_n[r19_n * 0x02 / 4].u0;
+		*((char *) &r4_n[0].u0 + r19_n * 0x02) = (Eq_n (*)[]) ((char *) *((char *) &r4_n[0].u0 + r19_n * 0x02) + 1);
 		goto l00023460;
 	}
 	word32 r3_n = r5->dw0034;
-	Eq_n r5_n[] = (Eq_n (*)[]) r5[(r3_n + 0x13) * 0x04 / 0x0044];
-	struct Eq_n * r19_n = (struct Eq_n *) &(r5_n + r19_n / 4)->u0;
+	Eq_n r5_n[] = r5->a0000[r3_n + 0x13];
+	struct Eq_n * r19_n = (struct Eq_n *) ((char *) &r5_n->u0 + r19_n);
 	ui32 r25_n = r5_n[r19_n].u0;
 	int32 r24_n = (int32) r19_n->b0400;
 	struct Eq_n * r22_n;
@@ -15441,7 +15441,7 @@ struct Eq_n * fn000233B0(struct Eq_n * r0, struct Eq_n * r5, word32 r22, word32 
 	else
 		r22_n = r5->ptr001C;
 	struct Eq_n * r5_n = r21_n->ptr0018;
-	struct Eq_n * r22_n = r22_n + r24_n / 0x0044;
+	struct Eq_n * r22_n = (struct Eq_n *) ((char *) r22_n->a0000 + r24_n);
 	ui32 r18_n = r24_n & 0x1F;
 	ui32 r3_n;
 	if (r18_n != 0x00)
@@ -15548,7 +15548,7 @@ l000237B8:
 	if (r4_n == null)
 	{
 		struct Eq_n * r3_n = r21_n->ptr0038;
-		struct Eq_n * r22_n = r22_n + r23_n / 0x0044;
+		struct Eq_n * r22_n = (struct Eq_n *) ((char *) r22_n->a0000 + r23_n);
 		ui32 r18_n = r23_n & 0x1F;
 		ui32 r5_n;
 		if (r18_n != 0x00)
@@ -15751,7 +15751,7 @@ l00023818:
 				if (r3_n <= 0x00)
 					return;
 				word32 * r3_n = (word32 *) ((char *) &r5->ptr0020 + 4);
-				ptr32 r21_n = r5 + ((r3_n + 0x09) * 0x04) / 0x0044;
+				ptr32 r21_n = (ptr32) (r5->a0000 + (r3_n + 0x09));
 				do
 				{
 					*r3_n = r0_n;
@@ -15989,7 +15989,7 @@ word32 fn00026018(word32 r0, struct Eq_n * r4, int32 r18, struct Eq_n * r19, str
 		r3_n = r4;
 	word32 r6_n = r21->dw0000;
 	r21->ptr0004 = r4 - r19;
-	r21->dw0000 = r19 + r6_n / 36;
+	r21->dw0000 = (char *) r19 + r6_n;
 	r3Out = r3_n;
 	r7Out = r7;
 	ptr32 dwArg1C;
@@ -16069,8 +16069,8 @@ void fn000261AC(word32 r0, struct Eq_n * r5, struct Eq_n * r21, int32 r22, word3
 				if (r3_n > 0x00)
 				{
 					word32 r6_n = r5->dw019C;
-					word32 * r3_n = (word32 *) (r5 + ((r6_n + 0x68) * 0x04) / 504);
-					ptr32 r4_n = r5 + (((word32) r3_n.u0 + (r6_n + 0x68)) * 0x04) / 504;
+					word32 * r3_n = &(r5->a0000 + (r6_n + 0x68))->u0;
+					ptr32 r4_n = &(r5->a0000 + ((word32) r3_n.u0 + (r6_n + 0x68)))->u0;
 					do
 					{
 						*r3_n = r26;
@@ -16146,7 +16146,7 @@ l0002642C:
 			word32 r19_n = r4_n + 0x29;
 			ui32 r3_n = (r4_n + 0x29) * 0x02;
 			int32 * r3_n;
-			if (r27 - r4_n >= 0x00 && r24_n[(r3_n * 0x02) / 504] != 0x00)
+			if (r27 - r4_n >= 0x00 && *((char *) (&((r24_n->a0000))[0].u0) + r3_n * 0x02) != 0x00)
 				r3_n = r24_n->ptr0004;
 			else
 			{
@@ -16995,7 +16995,7 @@ l000276EC:
 				int32 r6_n = r31 * 0x02;
 				struct Eq_n * r24_n = (struct Eq_n *) ((char *) r1_n + 28);
 				byte * r19_n = r3_n;
-				ptr32 r26_n = r24_n + r6_n / 2;
+				ptr32 r26_n = (char *) &r24_n->wFFFFFFFE + (r6_n + 2);
 				while (true)
 				{
 					if (r21_n == 0x00)
@@ -17025,13 +17025,13 @@ l000276EC:
 			if (r27 == 0x00)
 			{
 				r26_n = r4_n - r31;
-				r24 = (word32 *) (r23_n + ((r28 + 0x2D) * 0x04) / 272);
+				r24 = (word32 *) ((char *) &r23_n->ptr0000 + (r28 + 0x2D) * 0x04);
 			}
 			else
 			{
 				r26_n = r4_n - r31;
 				r28 += ~0x0F;
-				r24 = (word32 *) (r23_n + ((r28 + 0x31) * 0x04) / 272);
+				r24 = (word32 *) ((char *) &r23_n->ptr0000 + (r28 + 0x31) * 0x04);
 			}
 			if (0x03 - r28 < 0x00)
 			{
@@ -17194,7 +17194,7 @@ l000290A0:
 				}
 				r8_n = 0x0C;
 l00029138:
-				struct Eq_n * r6_n = (struct Eq_n *) (r9_n + (r6 * 0x04) / 100);
+				struct Eq_n * r6_n = (struct Eq_n *) ((char *) r9_n + r6 * 0x04);
 				r6_n->dwFFFFFCA0 = r7_n;
 				r6_n->dwFFFFFCE4 = r8_n;
 				return r6 + ~0xDF;
@@ -17243,14 +17243,14 @@ void fn000291C4(struct Eq_n * r5, int32 r6, int32 r7, struct Eq_n ** r8, word32 
 	struct Eq_n * r21_n;
 	if (r1_n->dw0564 != 0x00)
 	{
-		r23_n = (word16 (*)[]) r24_n[(r7 + 0x2D) * 0x04 / 8];
+		r23_n = (word16 (*)[]) r24_n->a0000[r7 + 0x2D];
 		if (r23_n != null)
 			goto l00029258;
 	}
 	else
 	{
 		int32 r3_n = r7 + 0x31;
-		r23_n = (word16 (*)[]) r24_n[r3_n * 0x04 / 8];
+		r23_n = (word16 (*)[]) r24_n->a0000[r3_n];
 		if (r23_n != null)
 		{
 l00029258:
@@ -17477,9 +17477,9 @@ l000293FC:
 						else
 							r4_n = r3_n;
 						r28_n = (int32) (int16) r28_n;
-						word32 * r3_n = (word32 *) (r21_n + ((r4_n + 0x24) * 0x04) / 144);
-						word16 * r4_n = (word16 *) (r21_n + ((r4_n + 0x0248) * 0x02) / 144);
-						r26_n = (word16 *) (r21_n + ((r10_n + r4_n) * 0x04) / 144);
+						word32 * r3_n = (word32 *) ((char *) r21_n + (r4_n + 0x24) * 0x04);
+						word16 * r4_n = (word16 *) ((char *) r21_n + (r4_n + 0x0248) * 0x02);
+						r26_n = (word16 *) ((char *) r21_n + (r10_n + r4_n) * 0x04);
 						while (true)
 						{
 							*r3_n = r5_n;
@@ -17496,7 +17496,7 @@ l000293FC:
 						++r7_n;
 					}
 					r7_n = r7_n + 1;
-					r9_n += r12_n / 2;
+					r9_n = (word16 *) ((char *) r9_n + r12_n);
 				}
 				++r5_n;
 			} while ((r5_n ^ 0x09) != 0x00);
@@ -17824,7 +17824,7 @@ void fn0002A2C0(int32 r0, struct Eq_n * r5, word32 r15, word32 r19, word32 r21)
 		if (r3_n > 0x00)
 		{
 			word32 * r3_n = (word32 *) (&r19_n->dw0014 + 1);
-			ptr32 r4_n = r19_n + ((r3_n + 0x06) * 0x04) / 44;
+			ptr32 r4_n = (char *) r19_n + (r3_n + 0x06) * 0x04;
 			do
 			{
 				*r3_n = r0_n;
@@ -18194,7 +18194,7 @@ struct Eq_n * fn0002D260(struct Eq_n * r0, struct Eq_n * r5, int32 r6, struct Eq
 		r3_n->dw0018 = r6;
 		(*((word32) 0x0002D304 + r4_n))();
 	}
-	struct Eq_n * r26_n = (struct Eq_n *) (r25_n + (r6 * 0x04) / 84);
+	struct Eq_n * r26_n = (struct Eq_n *) ((char *) r25_n + r6 * 0x04);
 	struct Eq_n * r21_n = r26_n->ptr0034;
 	int32 r4_n;
 	struct Eq_n * r3_n;
@@ -18244,7 +18244,7 @@ struct Eq_n * fn0002D260(struct Eq_n * r0, struct Eq_n * r5, int32 r6, struct Eq
 	int32 r24_n;
 	while (true)
 	{
-		r24_n = r19_n + r27_n / 0x0C;
+		r24_n = (char *) &r19_n->ptr0000 + r27_n;
 		fn0002E71C();
 		int32 r6_n = r24_n;
 		if (r3_n != null)
@@ -18255,7 +18255,7 @@ struct Eq_n * fn0002D260(struct Eq_n * r0, struct Eq_n * r5, int32 r6, struct Eq
 			r19_n >>= 1;
 			if (r28_n - r19_n < 0x00)
 				break;
-			int32 r24_n = r19_n + r27_n / 0x0C;
+			int32 r24_n = (char *) &r19_n->ptr0000 + r27_n;
 			struct Eq_n * r3_n = r23_n->ptr0000;
 			int32 r4_n = r3_n->dw0000;
 			r3_n->dw0014 = r30_n;
@@ -18345,7 +18345,7 @@ void fn0002D5F8(struct Eq_n * r0, struct Eq_n * r5, int32 r6, word32 r19, word32
 			r22_n->ptr0048 = r0;
 		}
 	}
-	struct Eq_n * r24_n = (struct Eq_n *) (r22_n + (r24_n * 0x04) / 80);
+	struct Eq_n * r24_n = (struct Eq_n *) ((char *) r22_n + r24_n * 0x04);
 	struct Eq_n * r19_n = r24_n->ptr003C;
 	if (r19_n != null)
 	{
@@ -18414,7 +18414,7 @@ word32 fn0002DA08(word32 r0, struct Eq_n * r5, int32 r6, Eq_n r7, ptr32 & r3Out)
 				r3_n = r1_n->ptr001C;
 			}
 			r22_n->dw004C = (word32) r21_n.u0 + (r22_n->dw004C + 0x0C);
-			struct Eq_n * r19_n = (struct Eq_n *) (r22_n + (r19_n * 0x04) / 84);
+			struct Eq_n * r19_n = (struct Eq_n *) ((char *) r22_n + r19_n * 0x04);
 			struct Eq_n * r4_n = r19_n->ptr003C;
 			r3_n->t0004.u0 = (int32) r21_n;
 			r3_n->dw0008 = r0;

--- a/subjects/Raw/Padauk/adctest_pfs173.reko/adctest_pfs173.h
+++ b/subjects/Raw/Padauk/adctest_pfs173.reko/adctest_pfs173.h
@@ -705,7 +705,7 @@ Eq_20: (union "Eq_20" (uint16 u0) ((ptr8 Eq_2516) u1))
 	T_1209 (in 0<8> @ 038E : byte)
 	T_1213 (in 0<8> @ 038E : byte)
 	T_1216 (in a_597 + CONVERT(v44_598 <u 0<8>, bool, byte) + CONVERT(v45_603 <u 0<8>, bool, byte) @ 038E : byte)
-	T_1217 (in fn05C0(a_597.u1 + (byte) (v44_598 < 0<8>) /8 2<i32> + (byte) (v45_603 < 0<8>) /8 2<i32>) @ 038E : byte)
+	T_1217 (in fn05C0((char *) &a_597.u1->t0000.u0 + (byte) (v44_598 < 0<8>) + (byte) (v45_603 < 0<8>)) @ 038E : byte)
 	T_1219 (in Mem614[0x005C<p16>:byte] @ 038E : byte)
 	T_1220 (in Mem614[null:byte] @ 0390 : byte)
 	T_1222 (in Mem616[0x005D<p16>:byte] @ 0390 : byte)
@@ -799,7 +799,7 @@ Eq_20: (union "Eq_20" (uint16 u0) ((ptr8 Eq_2516) u1))
 	T_1348 (in 0<8> @ 0406 : byte)
 	T_1352 (in 0<8> @ 0406 : byte)
 	T_1355 (in a_753 + CONVERT(v27_754 <u 0<8>, bool, byte) + CONVERT(v28_759 <u 0<8>, bool, byte) @ 0406 : byte)
-	T_1356 (in fn05C0(a_753.u1 + (byte) (v27_754 < 0<8>) /8 2<i32> + (byte) (v28_759 < 0<8>) /8 2<i32>) @ 0406 : byte)
+	T_1356 (in fn05C0((char *) &a_753.u1->t0000.u0 + (byte) (v27_754 < 0<8>) + (byte) (v28_759 < 0<8>)) @ 0406 : byte)
 	T_1358 (in Mem770[0x0070<p16>:byte] @ 0406 : byte)
 	T_1359 (in Mem770[null:byte] @ 0408 : byte)
 	T_1361 (in Mem772[0x0071<p16>:byte] @ 0408 : byte)
@@ -6564,7 +6564,7 @@ T_1216: (in a_597 + CONVERT(v44_598 <u 0<8>, bool, byte) + CONVERT(v45_603 <u 0<
   Class: Eq_20
   DataType: Eq_20
   OrigDataType: byte
-T_1217: (in fn05C0(a_597.u1 + (byte) (v44_598 < 0<8>) /8 2<i32> + (byte) (v45_603 < 0<8>) /8 2<i32>) @ 038E : byte)
+T_1217: (in fn05C0((char *) &a_597.u1->t0000.u0 + (byte) (v44_598 < 0<8>) + (byte) (v45_603 < 0<8>)) @ 038E : byte)
   Class: Eq_20
   DataType: Eq_20
   OrigDataType: byte
@@ -7120,7 +7120,7 @@ T_1355: (in a_753 + CONVERT(v27_754 <u 0<8>, bool, byte) + CONVERT(v28_759 <u 0<
   Class: Eq_20
   DataType: Eq_20
   OrigDataType: byte
-T_1356: (in fn05C0(a_753.u1 + (byte) (v27_754 < 0<8>) /8 2<i32> + (byte) (v28_759 < 0<8>) /8 2<i32>) @ 0406 : byte)
+T_1356: (in fn05C0((char *) &a_753.u1->t0000.u0 + (byte) (v27_754 < 0<8>) + (byte) (v28_759 < 0<8>)) @ 0406 : byte)
   Class: Eq_20
   DataType: Eq_20
   OrigDataType: byte
@@ -10603,7 +10603,7 @@ T_2225: (in fn056C() + Mem153[0x004E<p16>:byte] @ 023A : byte)
 T_2226: (in a_159 @ 023A : Eq_20)
   Class: Eq_20
   DataType: Eq_20
-  OrigDataType: (ptr8 Eq_2516)
+  OrigDataType: (ptr8 char)
 T_2227: (in 0<16> @ 023B : word16)
   Class: Eq_2227
   DataType: word16
@@ -10803,7 +10803,7 @@ T_2275: (in fn056C() + Mem114[0x004E<p16>:byte] @ 0222 : byte)
 T_2276: (in a_120 @ 0222 : Eq_20)
   Class: Eq_20
   DataType: Eq_20
-  OrigDataType: (ptr8 Eq_2516)
+  OrigDataType: (ptr8 char)
 T_2277: (in 0<16> @ 0223 : word16)
   Class: Eq_2277
   DataType: word16

--- a/subjects/Raw/Padauk/adctest_pfs173.reko/adctest_pfs173_CODE_02.c
+++ b/subjects/Raw/Padauk/adctest_pfs173.reko/adctest_pfs173_CODE_02.c
@@ -952,10 +952,10 @@ l01D1:
 						g_t00A9.u1 = g_t004A.u1;
 						g_t00AA.u1 = g_t004B.u1;
 						Eq_n a_n;
-						&a_n.u1->t0000.u0 = g_t004E.u1 + fn056C() /8 2;
+						&a_n.u1->t0000.u0 = (char *) &g_t004E.u1->t0000.u0 + fn056C();
 						sp_n->t0000.u1 = (struct Eq_n *) a_n;
 						sp_n->b0001 = f;
-						null = &null->u0 + (byte) (a_n < 0x00) /8 2;
+						null = (union Eq_n *) ((char *) &null->u0 + (byte) (a_n < 0x00));
 						Eq_n a_n;
 						&a_n.u1->t0000.u0 = sp_n->t0000.u1;
 						f = sp_n->b0001;
@@ -969,10 +969,10 @@ l01D1:
 						g_t00A9.u1 = g_t0048.u1;
 						g_t00AA.u1 = g_t0049.u1;
 						Eq_n a_n;
-						&a_n.u1->t0000.u0 = g_t004E.u1 + fn056C() /8 2;
+						&a_n.u1->t0000.u0 = (char *) &g_t004E.u1->t0000.u0 + fn056C();
 						sp_n->t0000.u1 = (struct Eq_n *) a_n;
 						sp_n->b0001 = f;
-						null = &null->u0 + (byte) (a_n < 0x00) /8 2;
+						null = (union Eq_n *) ((char *) &null->u0 + (byte) (a_n < 0x00));
 						Eq_n a_n;
 						&a_n.u1->t0000.u0 = sp_n->t0000.u1;
 						f = sp_n->b0001;
@@ -1288,7 +1288,7 @@ l0371:
 											Eq_n v28_n;
 											&v28_n.u1->t0000.u0 = (char *) null + 1;
 											null = (union Eq_n *) v28_n;
-											g_t0070.u1 = (struct Eq_n *) fn05C0(a_n.u1 + (byte) (v27_n < 0x00) /8 2 + (byte) (v28_n < 0x00) /8 2);
+											g_t0070.u1 = (struct Eq_n *) fn05C0((char *) &a_n.u1->t0000.u0 + (byte) (v27_n < 0x00) + (byte) (v28_n < 0x00));
 											g_t0071.u1 = (struct Eq_n *) null;
 											g_t0023.u1 = g_t006E.u1;
 											g_t0024.u1 = g_t006F.u1;
@@ -1567,7 +1567,7 @@ l0371:
 								Eq_n v45_n;
 								&v45_n.u1->t0000.u0 = (char *) null + 1;
 								null = (union Eq_n *) v45_n;
-								g_t005C.u1 = (struct Eq_n *) fn05C0(a_n.u1 + (byte) (v44_n < 0x00) /8 2 + (byte) (v45_n < 0x00) /8 2);
+								g_t005C.u1 = (struct Eq_n *) fn05C0((char *) &a_n.u1->t0000.u0 + (byte) (v44_n < 0x00) + (byte) (v45_n < 0x00));
 								g_t005D.u1 = (struct Eq_n *) null;
 								g_t0023.u1 = g_t005A.u1;
 								g_t0024.u1 = g_t005B.u1;

--- a/subjects/Raw/TriCore/bootloader.reko/bootloader_code.c
+++ b/subjects/Raw/TriCore/bootloader.reko/bootloader_code.c
@@ -294,7 +294,7 @@ void fn000005CE(ui32 d4, ui16 * a4)
 			int32 d4_n = d15_n + 0x01;
 			if ((d15_n & 0xFF) >= d2_n)
 				break;
-			(a4 + d15_n / 2)[6] = (ui16) ((char *) a15_n - 0x10000000 + d15_n)[16];
+			((char *) a4 + d15_n)[0x0C] = ((char *) a15_n - 0x10000000 + d15_n)[16];
 			d15_n = d4_n;
 		}
 		Eq_n d15_n;
@@ -372,7 +372,7 @@ void fn00000690(ui32 d4, struct Eq_n * a4)
 				++d4_n;
 				if (d4_n >= (int32) SLICE((int32) a4->w0000, word4, 4))
 					break;
-				(&a15_n->dwF0000000 + d4_n / 4)[4] = (&(a4 + d4_n / 22)->dw0008)[1];
+				((char *) &a15_n->dwF0000000 + d4_n)[16] = ((char *) &a4->w0000 + d4_n)[0x0C];
 			}
 			d15_n = 0x06280000;
 		}
@@ -493,7 +493,7 @@ void fn000008BE(struct Eq_n * d4, ui16 * a4)
 						int32 d4_n = d15_n + 0x01;
 						if ((d15_n & 0xFF) >= d2_n)
 							break;
-						(a4 + d15_n / 2)[6] = (ui16) ((char *) a15_n - 0x10000000 + d15_n)[16];
+						((char *) a4 + d15_n)[0x0C] = ((char *) a15_n - 0x10000000 + d15_n)[16];
 						d15_n = d4_n;
 					}
 					Eq_n d15_n;

--- a/subjects/VMS-vax/unzip.h
+++ b/subjects/VMS-vax/unzip.h
@@ -18940,7 +18940,7 @@ T_3397: (in 3<8> @ 0000A963 : byte)
   Class: Eq_3397
   DataType: byte
   OrigDataType: byte
-T_3398: (in r10_129[(int32) (fp->bFFFFFFF2 & 0x7F<8>) / 4<i32>].u1 & 3<8> @ 0000A963 : byte)
+T_3398: (in (&r10_129[0<i32>].u1)[(int32) (fp->bFFFFFFF2 & 0x7F<8>)] & 3<8> @ 0000A963 : byte)
   Class: Eq_3398
   DataType: byte
   OrigDataType: byte
@@ -18948,7 +18948,7 @@ T_3399: (in 0<8> @ 0000A963 : byte)
   Class: Eq_3398
   DataType: byte
   OrigDataType: byte
-T_3400: (in (r10_129[(int32) (fp->bFFFFFFF2 & 0x7F<8>) / 4<i32>].u1 & 3<8>) != 0<8> @ 0000A963 : bool)
+T_3400: (in ((&r10_129[0<i32>].u1)[(int32) (fp->bFFFFFFF2 & 0x7F<8>)] & 3<8>) != 0<8> @ 0000A963 : bool)
   Class: Eq_3400
   DataType: bool
   OrigDataType: bool
@@ -28429,7 +28429,7 @@ T_5762: (in 0xFF<32> @ 0000CC4E : word32)
   Class: Eq_5761
   DataType: up32
   OrigDataType: up32
-T_5763: (in r2_602 + r0_591 / 1357414402<i32> <= 0xFF<32> @ 0000CC4E : bool)
+T_5763: (in &r2_602->b0000 + r0_591 <= 0xFF<32> @ 0000CC4E : bool)
   Class: Eq_5763
   DataType: bool
   OrigDataType: bool
@@ -54375,7 +54375,7 @@ T_12212: (in 0xA<8> @ 000126EA : byte)
   Class: Eq_12211
   DataType: byte
   OrigDataType: byte
-T_12213: (in sp_108->ptr0000[(r2_324 - 1<32>) / 4<i32>].u0 != 0xA<8> @ 000126EA : bool)
+T_12213: (in (&sp_108->ptr0000[0<i32>].u0)[r2_324 - 1<32>] != 0xA<8> @ 000126EA : bool)
   Class: Eq_12213
   DataType: bool
   OrigDataType: bool

--- a/subjects/VMS-vax/unzip_code_0000.c
+++ b/subjects/VMS-vax/unzip_code_0000.c
@@ -1155,7 +1155,7 @@ void fn0000A8D6(word32 r0, word32 r6, word32 r7, struct Eq_n * r9, struct Eq_n *
 			word32 fp_n;
 			sp_n->dwFFFFFFF4 = fp_n + -0x0E;
 			(*((word32) g_ptr19290 + 2))();
-			if (r0 != 0x00 || ((r10_n)[(int32) (fp->bFFFFFFF2 & 0x7F) / 4].u1 & 0x03) != 0x00)
+			if (r0 != 0x00 || ((&(r10_n)[0].u1)[(int32) (fp->bFFFFFFF2 & 0x7F)] & 0x03) != 0x00)
 				break;
 			sp_n->dwFFFFFFFC = (int32) fp->bFFFFFFF2;
 			ptr32 r3_n;
@@ -1932,7 +1932,7 @@ void fn0000C1FE(struct Eq_n * r2, struct Eq_n * r3, ptr32 * pc)
 		struct Eq_n * r11_n;
 		ui32 r6_n;
 		struct Eq_n * r2_n;
-		r11_n->aFFFFF08F[r6_n * 2 / 4].u0 = atomic_fetch_add<word32>(r11_n->aFFFFF08F[0].u0, r2_n->t50E97FFE.u0);
+		*((char *) &r11_n->aFFFFF08F[0].u0 + r6_n * 2) = atomic_fetch_add<word32>(r11_n->aFFFFF08F[0].u0, r2_n->t50E97FFE.u0);
 	}
 	else
 	{
@@ -2166,7 +2166,7 @@ struct Eq_n * fn0000C6FA(struct Eq_n * r6, struct Eq_n * r7, struct Eq_n * r8, s
 			(*((word32) g_ptr192C4 + 2))();
 			struct Eq_n * r2_n = r6_n->dw10CDC - ((char *) r6_n + 68284);
 			up32 r0_n;
-			if (r2_n + r0_n / 0x50E88002 <= 0xFF)
+			if (&r2_n->b0000 + r0_n <= 0xFF)
 			{
 				struct Eq_n * sp_n;
 				struct Eq_n * ap_n;
@@ -2934,7 +2934,7 @@ struct Eq_n * fn0000D5BE(struct Eq_n * r0, struct Eq_n * r4, struct Eq_n * ap, u
 		sp_n->dwFFFFFFFC = r4->dwC5F7;
 		sp_n->ptrFFFFFFF8 = ap->ptr0004;
 		(*((word32) g_ptr1929C + 2))();
-		ap->ptr0004 += r3 / 4;
+		ap->ptr0004 = (word32 *) ((char *) ap->ptr0004 + r3);
 		r4->dwC5F7 += r3;
 		r4->ptrC5FB -= r3;
 		word32 r2_n;
@@ -3014,7 +3014,7 @@ Eq_n fn0000D69A(struct Eq_n * r4, union Eq_n * fp, ptr32 * pc, struct Eq_n & r2O
 				{
 					if (r4->dw0084 < 0x00)
 						r4->dw0084 = 0x00;
-					r4->dwC84D = r4->ptrC5F7 + r4->dw0084 / 0x0000C5FF;
+					r4->dwC84D = &r4->ptrC5F7->b0000 + r4->dw0084;
 					r4->dwC849 = r4->dwC5FB - r4->dw0084;
 					r4->dwC5FB = r4->dw0084;
 				}
@@ -4225,7 +4225,7 @@ void fn000100C2(struct Eq_n * r2, ptr32 r7, ptr32 r11, struct Eq_n * ap)
 			}
 			word32 r1_n = (word32) r8_n.u0 + 4;
 			*r9_n -= r1_n;
-			ap->ptr0004 = (Eq_n (*)[]) &(ap->ptr0004 + r1_n / 6)->b0000;
+			ap->ptr0004 = &ap->ptr0004->b0000 + r1_n;
 		} while (*r9_n >= 0x04);
 	}
 	if (r2->dw0040 == 0x00)
@@ -4278,7 +4278,7 @@ struct Eq_n * fn000105F2(ptr32 r7, struct Eq_n * ap, union Eq_n * fp, struct Eq_
 				struct Eq_n * sp_n;
 				struct Eq_n * ap_n;
 				sp_n->dwFFFFFFFC = ap_n->dw0008 - ap_n->dw000C;
-				sp_n->dwFFFFFFF8 = ap_n->ptr0004 + (ap_n->dw000C + 0x04) / 2;
+				sp_n->dwFFFFFFF8 = &ap_n->ptr0004->b0000 + (ap_n->dw000C + 0x04);
 				real32 ** r4_n;
 				sp_n->ptrFFFFFFF4 = r4_n;
 				sp_n->dwFFFFFFF0 = r0_n;

--- a/subjects/VMS-vax/unzip_code_0001.c
+++ b/subjects/VMS-vax/unzip_code_0001.c
@@ -535,9 +535,9 @@ void fn00012616(word32 r8)
 		ptr32 r11_n;
 		(*((word32) r11_n + 2))();
 		r9_n = r8_n + 0x0F;
-	} while (sp_n->ptr0000[(r2_n - 0x01) / 4].u0 != 0x0A);
+	} while ((&sp_n->ptr0000[0].u0)[r2_n - 0x01] != 0x0A);
 	Eq_n r3_n[] = ap_n->ptr0008;
-	r3_n[(r2_n - 0x01) / 4].u1 = (word32) 0<32>;
+	*((char *) &r3_n[0].u1 + (r2_n - 0x01)) = (Eq_n (*)[]) 0<32>;
 	word32 r6_n;
 	sp_n->dwFFFFFFFC = r6_n;
 	(*((word32) g_ptr19250 + 2))();
@@ -2279,17 +2279,17 @@ l00014154:
 												Eq_n r3_n;
 												if (r3_n >= (word32) r4_n.u1 + 0x0D)
 												{
-													uint32 r0_n = (uint32) r7_n[((word32) r4_n.u1 + 5) / 5];
+													uint32 r0_n = (uint32) *((char *) r7_n + ((word32) r4_n.u1 + 5));
 													fp_n->tFFFFFF65.u0 = (int8) r0_n;
-													r7_n[((word32) r4_n.u1 + 5) / 5] = (struct Eq_n) 0<32>;
+													*((char *) r7_n + ((word32) r4_n.u1 + 5)) = (struct Eq_n *) 0<32>;
 													sp_n->ptrFFFFFFFC = 0x00;
-													sp_n->ptrFFFFFFF8 = (uint32) r7_n[((word32) r4_n.u1 + 0x0C) / 5];
-													sp_n->ptrFFFFFFF4 = (uint32) r7_n[((word32) r4_n.u1 + 11) / 5];
-													sp_n->tFFFFFFF0.u0 = (uint32) r7_n[((word32) r4_n.u1 + 0x0A) / 5];
-													sp_n->dwFFFFFFEC = (uint32) r7_n[((word32) r4_n.u1 + 9) / 5];
-													sp_n->dwFFFFFFE8 = (uint32) r7_n[((word32) r4_n.u1 + 8) / 5];
-													sp_n->tFFFFFFE4.u0 = (uint32) r7_n[((word32) r4_n.u1 + 7) / 5];
-													sp_n->dwFFFFFFE0 = (uint32) r7_n[((word32) r4_n.u1 + 6) / 5];
+													sp_n->ptrFFFFFFF8 = (uint32) *((char *) r7_n + ((word32) r4_n.u1 + 0x0C));
+													sp_n->ptrFFFFFFF4 = (uint32) *((char *) r7_n + ((word32) r4_n.u1 + 11));
+													sp_n->tFFFFFFF0.u0 = (uint32) *((char *) r7_n + ((word32) r4_n.u1 + 0x0A));
+													sp_n->dwFFFFFFEC = (uint32) *((char *) r7_n + ((word32) r4_n.u1 + 9));
+													sp_n->dwFFFFFFE8 = (uint32) *((char *) r7_n + ((word32) r4_n.u1 + 8));
+													sp_n->tFFFFFFE4.u0 = (uint32) *((char *) r7_n + ((word32) r4_n.u1 + 7));
+													sp_n->dwFFFFFFE0 = (uint32) *((char *) r7_n + ((word32) r4_n.u1 + 6));
 													sp_n->dwFFFFFFDC = (int32) fp_n->tFFFFFF65.u0;
 													sp_n->ptrFFFFFFD8 = &r7_n->b0004 + 1;
 													sp_n->dwFFFFFFD4 = &r6_n->b0004 + 4405;
@@ -2352,7 +2352,7 @@ l00014154:
 										do
 										{
 											struct Eq_n * sp_n = sp_n - 0x04;
-											sp_n->dw0000 = (uint32) r7_n[(0x0F - r2_n) / 5];
+											sp_n->dw0000 = (uint32) (&r7_n->b0000)[0x0F - r2_n];
 											sp_n->dwFFFFFFFC = r8_n + 0x00D9;
 											ui32 r0_n = r2_n << 1;
 											sp_n->ptrFFFFFFF8 = (char *) fp_n - 188 + r0_n * 4;

--- a/subjects/regressions/reko-90/PP.reko/PP_0800.c
+++ b/subjects/regressions/reko-90/PP.reko/PP_0800.c
@@ -3112,7 +3112,7 @@ void fn0800-2201(Eq_n ds, Eq_n ptrArg02)
 	Eq_n es_bx_n = Mem12[ds:11857:segptr32];
 	uint16 dx_n = Mem31[ds:11857:word16] + ((CONVERT(Mem31[ptrArg02 + 0x00:byte], byte, int16) << 8) + CONVERT(Mem31[ptrArg02 + 1:byte], byte, uint16)) - wArg02_n;
 	uint16 ax_n = ((uint16) es_bx_n.u6->b0004 << 0x08) + (uint16) (*((word32) es_bx_n + 5));
-	word16 ax_n = (word16) (wArg02_n.u1 + dx_n /16 2);
+	word16 ax_n = (word16) (&wArg02_n.u1->b0000 + dx_n);
 	fn0800_B0F3(ptrArg02, SEQ(wArg04_n, ax_n), Mem26[ds:11857:word16] + ax_n - ax_n);
 	Eq_n es_bx_n = Mem72[ds:11857:segptr32];
 	es_bx_n.u6->b0004 = (byte) (ax_n - dx_n >> 0x08);

--- a/subjects/regressions/reko-90/PP.reko/PP_1483.c
+++ b/subjects/regressions/reko-90/PP.reko/PP_1483.c
@@ -151,13 +151,13 @@ word16 fn1483-0CA0(byte * es_di, struct Eq_n * ss_bp, Eq_n si, struct Eq_n * ds,
 	byte bl_n = bl_n & ds->*bx_n;
 	*es_di = (byte) ax_n - 0xAC;
 	word16 Eq_n::* bx_n = SEQ(bh_n, bl_n);
-	ds->*bx_n = bx_n + ds->*bx_n /16 2;
+	ds->*bx_n = (char *) bx_n + ds->*bx_n;
 	ds->*((word16) di + 21) = ax_n - ~0x4234;
 	fn1483-4FE0();
 	word16 dx_n;
 	ds->wF7E3 -= dx_n;
 	word16 Eq_n::* bx_n;
-	bx_n[((word16) di + 1) /16 2] += bp - 0x01;
+	ds->*((char *) bx_n + ((word16) di + 1)) = (word16 Eq_n::*) ((char *) (ds->*((char *) bx_n + ((word16) di + 1))) + (bp - 0x01));
 	word16 ax_n = __in<word16>(0x8B);
 	diOut = (word16) di + 1;
 	return ax_n;
@@ -220,8 +220,8 @@ Eq_n fn1483-0CFC(struct Eq_n * ds_di, struct Eq_n * ss_bp, byte al, byte ah, Eq_
 	struct Eq_n * ds = SLICE(ds_di, selector, 16);
 	Eq_n di = (word16) ds_di;
 	word16 bx_n = SEQ(bh, bl ^ al);
-	cu8 al_n = (cu8) ds_di[(uipr32) bx_n / 46];
-	ss_bp[(uipr32) si / 0x007D] = (struct Eq_n) ~0x2E00;
+	cu8 al_n = (&ds_di->b0000)[(uipr32) bx_n];
+	*((char *) ss_bp + (uipr32) si) = (struct Eq_n *) ~0x2E00;
 	if (cx == 0x00)
 	{
 		Eq_n di_n;
@@ -403,7 +403,7 @@ Eq_n fn1483-0D3F(struct Eq_n * ds_di, struct Eq_n * ss_bp, Eq_n ax, Eq_n cx, ui1
 							byte ch_n;
 							do
 							{
-								di_n += (uint16) (bx_n->*si_n) /16 2;
+								di_n = (word16 Eq_n::*) ((char *) di_n + (uint16) (bx_n->*si_n));
 								psegArg01A4->*di_n = (word16) dx_n.u0 + psegArg01A4->*di_n;
 								--cx_n;
 								++si_n;

--- a/subjects/wasm/hello.reko/hello_text_0000.c
+++ b/subjects/wasm/hello.reko/hello_text_0000.c
@@ -455,13 +455,13 @@ l000D0750:
 	Eq_n v164_n;
 	&v164_n.u5->t0000.u0 = arg0.u5->t0000.u5;
 	int32 v164_n = (int32) *((char *) v164_n.u5 - 0x0C);
-	struct Eq_n * v164_n = (struct Eq_n *) (arg0.u5 + v164_n / 8);
+	struct Eq_n * v164_n = (struct Eq_n *) (&arg0.u5->t0000.u0 + v164_n);
 	word32 v164_n = v164_n->dw0018;
 	&((char *) &v164_n.u5->t0000 + 4)->u5->t0000.u0 = v164_n;
 	Eq_n v164_n;
 	&v164_n.u5->t0000.u0 = arg0.u5->t0000.u5;
 	int32 v164_n = (int32) *((char *) v164_n.u5 - 0x0C);
-	struct Eq_n * v164_n = (struct Eq_n *) (arg0.u5 + v164_n / 8);
+	struct Eq_n * v164_n = (struct Eq_n *) (&arg0.u5->t0000.u0 + v164_n);
 	ui32 v164_n = v164_n->dw0004;
 	bool v166_n = (v164_n & 0xB0) == 0x20;
 	Eq_n v164_n = arg1 + arg2;
@@ -476,11 +476,11 @@ l000D0750:
 	Eq_n v164_n;
 	&v164_n.u5->t0000.u0 = arg0.u5->t0000.u5;
 	int32 v164_n = (int32) *((char *) v164_n.u5 - 0x0C);
-	ptr32 v164_n = arg0.u5 + v164_n / 8;
+	ptr32 v164_n = &arg0.u5->t0000.u0 + v164_n;
 	Eq_n v164_n;
 	&v164_n.u5->t0000.u0 = arg0.u5->t0000.u5;
 	int32 v164_n = (int32) *((char *) v164_n.u5 - 0x0C);
-	struct Eq_n * v164_n = (struct Eq_n *) (arg0.u5 + v164_n / 8);
+	struct Eq_n * v164_n = (struct Eq_n *) (&arg0.u5->t0000.u0 + v164_n);
 	Eq_n v164_n = fn000D0EAE();
 	Eq_n v164_n;
 	&v164_n.u5->t0000.u0 = v164_n->t004C.u5;
@@ -566,7 +566,7 @@ l000D05FB:
 							Eq_n v164_n;
 							&v164_n.u5->t0000.u0 = arg0.u5->t0000.u5;
 							int32 v164_n = (int32) *((char *) v164_n.u5 - 0x0C);
-							struct Eq_n * v164_n = (struct Eq_n *) (arg0.u5 + v164_n / 8);
+							struct Eq_n * v164_n = (struct Eq_n *) (&arg0.u5->t0000.u0 + v164_n);
 							ui32 v164_n = v164_n->dw0010;
 							g_t140048.u5 = (struct Eq_n *) 0x00;
 							invoke_vii(0x0169, v164_n, v164_n | 0x05);
@@ -628,7 +628,7 @@ l000D0783:
 						Eq_n v164_n;
 						&v164_n.u5->t0000.u0 = arg0.u5->t0000.u5;
 						int32 v164_n = (int32) *((char *) v164_n.u5 - 0x0C);
-						ptr32 v164_n = arg0.u5 + v164_n / 8;
+						ptr32 v164_n = &arg0.u5->t0000.u0 + v164_n;
 						g_t140048.u5 = (struct Eq_n *) 0x00;
 						invoke_vi(363, v164_n);
 						Eq_n v164_n;

--- a/subjects/wasm/hello.reko/hello_text_0001.c
+++ b/subjects/wasm/hello.reko/hello_text_0001.c
@@ -5797,7 +5797,7 @@ void fn000E59BE(Eq_n arg0, word32 arg1, word64 arg2, word32 arg3, word32 arg4)
 	v6.u5->t0000.u3 = (uint64) v7;
 	v6 = arg0;
 	int32 v8 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v8 / 8;
+	&v6.u5->t0000.u0 += v8;
 	Eq_n loc5 = v6;
 	v6 = loc5;
 	v7.u0 = ~0x00;
@@ -5816,7 +5816,7 @@ void fn000E59DC(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3)
 	v6.u5->t0000.u3 = (uint64) v7;
 	v6 = arg0;
 	int32 v8 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v8 / 8;
+	&v6.u5->t0000.u0 += v8;
 	Eq_n loc4 = v6;
 	v6 = loc4;
 	v7.u0 = ~0x00;
@@ -6118,7 +6118,7 @@ void fn000E5CE1(Eq_n arg0, word32 arg1, word64 arg2, word32 arg3, word32 arg4)
 	v6.u5->t0000.u3 = (uint64) v7;
 	v6 = arg0;
 	int32 v8 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v8 / 8;
+	&v6.u5->t0000.u0 += v8;
 	Eq_n loc5 = v6;
 	v6 = loc5;
 	v7.u0 = ~0x00;
@@ -6137,7 +6137,7 @@ void fn000E5CFF(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3)
 	v6.u5->t0000.u3 = (uint64) v7;
 	v6 = arg0;
 	int32 v8 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v8 / 8;
+	&v6.u5->t0000.u0 += v8;
 	Eq_n loc4 = v6;
 	v6 = loc4;
 	v7.u0 = ~0x00;
@@ -6466,7 +6466,7 @@ void fn000E5FBC(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn000E5823(v6);
@@ -6482,7 +6482,7 @@ void fn000E5FD1(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn000E5823(v6);
@@ -6552,7 +6552,7 @@ void fn000E6046(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn000E5823(v6);
@@ -6568,7 +6568,7 @@ void fn000E605B(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn000E5823(v6);
@@ -6638,7 +6638,7 @@ void fn000E60D0(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x04;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn000E5823(v6);
@@ -6654,7 +6654,7 @@ void fn000E60E5(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x04;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn000E5823(v6);
@@ -6724,7 +6724,7 @@ void fn000E615A(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x04;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn000E5823(v6);
@@ -6740,7 +6740,7 @@ void fn000E616F(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x04;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn000E5823(v6);

--- a/subjects/wasm/hello.reko/hello_text_0002.c
+++ b/subjects/wasm/hello.reko/hello_text_0002.c
@@ -20955,7 +20955,7 @@ Eq_n fn000FA7EA(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4)
 		int32 v42 = 0x01FF;
 		v41 &= v42;
 		v42 = 0x2520;
-		&v41.u5->t0000.u0 = v41.u5 + v42 / 8;
+		&v41.u5->t0000.u0 += v42;
 	}
 	else
 	{
@@ -21965,7 +21965,7 @@ void fn000FAEBB(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4, Eq_n arg5
 	int32 v216 = 0x01FF;
 	v215 &= v216;
 	v216 = 0x0700;
-	&v215.u5->t0000.u0 = v215.u5 + v216 / 8;
+	&v215.u5->t0000.u0 += v216;
 }
 
 // 000FB8CE: void fn000FB8CE(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3)
@@ -22251,7 +22251,7 @@ void fn000FBA39(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4, Eq_n arg5
 	int32 v151 = 0x01FF;
 	v150 &= v151;
 	v151 = 0x0700;
-	&v150.u5->t0000.u0 = v150.u5 + v151 / 8;
+	&v150.u5->t0000.u0 += v151;
 }
 
 // 000FC0C8: void fn000FC0C8(Stack Eq_n arg0)
@@ -24586,7 +24586,7 @@ Eq_n fn000FD2EB(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4)
 		int32 v42 = 0x01FF;
 		v41 &= v42;
 		v42 = 0x2520;
-		&v41.u5->t0000.u0 = v41.u5 + v42 / 8;
+		&v41.u5->t0000.u0 += v42;
 	}
 	else
 	{
@@ -24758,7 +24758,7 @@ void fn000FD67D(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4, Eq_n arg5
 	int32 v216 = 0x01FF;
 	v215 &= v216;
 	v216 = 0x0700;
-	&v215.u5->t0000.u0 = v215.u5 + v216 / 8;
+	&v215.u5->t0000.u0 += v216;
 }
 
 // 000FE09E: void fn000FE09E(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3, Stack Eq_n arg4, Stack Eq_n arg5, Stack Eq_n arg6)
@@ -24806,7 +24806,7 @@ void fn000FE09E(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4, Eq_n arg5
 	int32 v148 = 0x01FF;
 	v147 &= v148;
 	v148 = 0x0700;
-	&v147.u5->t0000.u0 = v147.u5 + v148 / 8;
+	&v147.u5->t0000.u0 += v148;
 }
 
 // 000FE711: void fn000FE711(Stack Eq_n arg0)

--- a/subjects/wasm/hello.reko/hello_text_0003.c
+++ b/subjects/wasm/hello.reko/hello_text_0003.c
@@ -5492,7 +5492,7 @@ void fn00106657(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn00106868(v6);
@@ -5506,7 +5506,7 @@ void fn0010666C(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn00106868(v6);
@@ -5815,7 +5815,7 @@ void fn001068DE(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn00106868(v6);
@@ -5829,7 +5829,7 @@ void fn001068F3(Eq_n arg0)
 	Eq_n loc3 = v6;
 	v6 = arg0;
 	word32 v7 = 0x08;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 	Eq_n loc1 = v6;
 	v6 = loc1;
 	fn00106868(v6);
@@ -15438,7 +15438,7 @@ void fn0010B494(Eq_n arg0, Eq_n arg1, Eq_n arg2, word32 arg3, word32 arg4, word3
 	int32 v182 = 0x01FF;
 	v181 &= v182;
 	v182 = 0x0700;
-	&v181.u5->t0000.u0 = v181.u5 + v182 / 8;
+	&v181.u5->t0000.u0 += v182;
 }
 
 // 0010BEC2: void fn0010BEC2(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2)

--- a/subjects/wasm/hello.reko/hello_text_0004.c
+++ b/subjects/wasm/hello.reko/hello_text_0004.c
@@ -329,7 +329,7 @@ void fn00110427(Eq_n arg0, Eq_n arg1, Eq_n arg2, word32 arg3, word32 arg4, word3
 	int32 v188 = 0x01FF;
 	v187 &= v188;
 	v188 = 0x0700;
-	&v187.u5->t0000.u0 = v187.u5 + v188 / 8;
+	&v187.u5->t0000.u0 += v188;
 }
 
 // 00110E8A: void fn00110E8A(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2)
@@ -2636,7 +2636,7 @@ void fn00111F27(Eq_n arg0, Eq_n arg1, Eq_n arg2, word32 arg3, word32 arg4, word3
 	int32 v194 = 0x01FF;
 	v193 &= v194;
 	v194 = 0x0700;
-	&v193.u5->t0000.u0 = v193.u5 + v194 / 8;
+	&v193.u5->t0000.u0 += v194;
 }
 
 // 00112A04: void fn00112A04(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3, Stack Eq_n arg4, Stack word32 arg5, Stack Eq_n arg6, Stack word32 arg7, Stack Eq_n arg8, Stack word32 arg9, Stack word32 arg10, Stack Eq_n arg11, Stack Eq_n arg12, Stack Eq_n arg13, Stack Eq_n arg14)
@@ -4915,7 +4915,7 @@ void fn00114190(Eq_n arg0, Eq_n arg1, Eq_n arg2, word32 arg3, word32 arg4, word3
 	int32 v198 = 0x01FF;
 	v197 &= v198;
 	v198 = 0x0700;
-	&v197.u5->t0000.u0 = v197.u5 + v198 / 8;
+	&v197.u5->t0000.u0 += v198;
 }
 
 // 00114C7D: void fn00114C7D(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3, Stack Eq_n arg4, Stack word32 arg5, Stack Eq_n arg6, Stack word32 arg7, Stack Eq_n arg8, Stack word32 arg9, Stack word32 arg10, Stack Eq_n arg11, Stack Eq_n arg12, Stack Eq_n arg13, Stack Eq_n arg14)
@@ -22585,7 +22585,7 @@ Eq_n fn0011D084(Eq_n arg0, Eq_n arg1, Eq_n arg2)
 	int32 v23 = 0x01FF;
 	v22 &= v23;
 	v23 = 0x2820;
-	&v22.u5->t0000.u0 = v22.u5 + v23 / 8;
+	&v22.u5->t0000.u0 += v23;
 }
 
 // 0011D119: Stack Eq_n fn0011D119(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2)
@@ -26300,7 +26300,7 @@ Eq_n ___cxa_can_catch(Eq_n arg0, Eq_n arg1, Eq_n arg2)
 	int32 v18 = 0x01FF;
 	v17 &= v18;
 	v18 = 0x0F20;
-	&v17.u5->t0000.u0 = v17.u5 + v18 / 8;
+	&v17.u5->t0000.u0 += v18;
 }
 
 // 0011EF3E: Stack Eq_n ___cxa_is_pointer_type(Stack Eq_n arg0)
@@ -26792,7 +26792,7 @@ Eq_n dynCall_iiiiiiii(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4, Eq_
 	ui32 v11 = 0x01FF;
 	v10 &= v11;
 	v11 = 0x00;
-	&v10.u5->t0000.u0 = v10.u5 + v11 / 8;
+	&v10.u5->t0000.u0 += v11;
 }
 
 // 0011F215: void dynCall_viiiii(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3, Stack Eq_n arg4, Stack Eq_n arg5)
@@ -26807,7 +26807,7 @@ void dynCall_viiiii(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4, Eq_n 
 	ui32 v9 = 0x01FF;
 	v8 &= v9;
 	v9 = 0x0200;
-	&v8.u5->t0000.u0 = v8.u5 + v9 / 8;
+	&v8.u5->t0000.u0 += v9;
 }
 
 // 0011F22D: Stack word32 dynCall_iiiiiid(Stack ui32 arg0, Stack word32 arg1, Stack word32 arg2, Stack word32 arg3, Stack word32 arg4, Stack word32 arg5, Stack real64 arg6)
@@ -26834,7 +26834,7 @@ void dynCall_vi(Eq_n arg0, Eq_n arg1)
 	ui32 v5 = 0x01FF;
 	v4 &= v5;
 	v5 = 0x0500;
-	&v4.u5->t0000.u0 = v4.u5 + v5 / 8;
+	&v4.u5->t0000.u0 += v5;
 }
 
 // 0011F258: void dynCall_vii(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2)
@@ -26846,7 +26846,7 @@ void dynCall_vii(Eq_n arg0, Eq_n arg1, Eq_n arg2)
 	ui32 v6 = 0x01FF;
 	v5 &= v6;
 	v6 = 0x0700;
-	&v5.u5->t0000.u0 = v5.u5 + v6 / 8;
+	&v5.u5->t0000.u0 += v6;
 }
 
 // 0011F26A: Stack Eq_n dynCall_iiiiiii(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3, Stack Eq_n arg4, Stack Eq_n arg5, Stack Eq_n arg6)
@@ -26862,7 +26862,7 @@ Eq_n dynCall_iiiiiii(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4, Eq_n
 	ui32 v10 = 0x01FF;
 	v9 &= v10;
 	v10 = 0x0900;
-	&v9.u5->t0000.u0 = v9.u5 + v10 / 8;
+	&v9.u5->t0000.u0 += v10;
 }
 
 // 0011F285: Stack Eq_n dynCall_ii(Stack Eq_n arg0, Stack Eq_n arg1)
@@ -26873,7 +26873,7 @@ Eq_n dynCall_ii(Eq_n arg0, Eq_n arg1)
 	ui32 v5 = 0x01FF;
 	v4 &= v5;
 	v5 = 0x0B00;
-	&v4.u5->t0000.u0 = v4.u5 + v5 / 8;
+	&v4.u5->t0000.u0 += v5;
 }
 
 // 0011F296: void fn0011F296(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack ui64 arg3, Stack Eq_n arg4, Stack Eq_n arg5)
@@ -26890,7 +26890,7 @@ void fn0011F296(Eq_n arg0, Eq_n arg1, Eq_n arg2, ui64 arg3, Eq_n arg4, Eq_n arg5
 	ui32 v9 = 0x1F;
 	v8 &= v9;
 	v9 = 0x0D00;
-	&v8.u5->t0000.u0 = v8.u5 + v9 / 8;
+	&v8.u5->t0000.u0 += v9;
 }
 
 // 0011F2AD: Stack Eq_n dynCall_iiiiiiiiiiii(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3, Stack Eq_n arg4, Stack Eq_n arg5, Stack Eq_n arg6, Stack Eq_n arg7, Stack Eq_n arg8, Stack Eq_n arg9, Stack Eq_n arg10, Stack Eq_n arg11)
@@ -26911,7 +26911,7 @@ Eq_n dynCall_iiiiiiiiiiii(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4,
 	ui32 v15 = 0x01FF;
 	v14 &= v15;
 	v15 = 0x0D20;
-	&v14.u5->t0000.u0 = v14.u5 + v15 / 8;
+	&v14.u5->t0000.u0 += v15;
 }
 
 // 0011F2D2: Stack Eq_n dynCall_iiii(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3)
@@ -26924,7 +26924,7 @@ Eq_n dynCall_iiii(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3)
 	ui32 v7 = 0x01FF;
 	v6 &= v7;
 	v7 = 0x0F20;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 }
 
 // 0011F2E7: void dynCall_viiiiiiiiiiiiiii(Stack ui32 arg0, Stack word32 arg1, Stack word32 arg2, Stack word32 arg3, Stack word32 arg4, Stack word32 arg5, Stack word32 arg6, Stack word32 arg7, Stack word32 arg8, Stack word32 arg9, Stack word32 arg10, Stack word32 arg11, Stack word32 arg12, Stack word32 arg13, Stack word32 arg14, Stack word32 arg15)
@@ -26965,7 +26965,7 @@ void dynCall_viiiiii(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4, Eq_n
 	ui32 v10 = 0x01FF;
 	v9 &= v10;
 	v10 = 0x1320;
-	&v9.u5->t0000.u0 = v9.u5 + v10 / 8;
+	&v9.u5->t0000.u0 += v10;
 }
 
 // 0011F32D: Stack real32 dynCall_fiii(Stack ui32 arg0, Stack word32 arg1, Stack word32 arg2, Stack word32 arg3)
@@ -26995,7 +26995,7 @@ void dynCall_viiiiiii(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4, Eq_
 	ui32 v11 = 0x01FF;
 	v10 &= v11;
 	v11 = 0x1720;
-	&v10.u5->t0000.u0 = v10.u5 + v11 / 8;
+	&v10.u5->t0000.u0 += v11;
 }
 
 // 0011F35E: void dynCall_viiiiiiiiii(Stack ui32 arg0, Stack word32 arg1, Stack word32 arg2, Stack word32 arg3, Stack word32 arg4, Stack word32 arg5, Stack word32 arg6, Stack word32 arg7, Stack word32 arg8, Stack word32 arg9, Stack word32 arg10)
@@ -27043,7 +27043,7 @@ Eq_n dynCall_iiiiii(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4, Eq_n 
 	ui32 v9 = 0x01FF;
 	v8 &= v9;
 	v9 = 0x1D20;
-	&v8.u5->t0000.u0 = v8.u5 + v9 / 8;
+	&v8.u5->t0000.u0 += v9;
 }
 
 // 0011F3AC: Stack real64 dynCall_diii(Stack ui32 arg0, Stack word32 arg1, Stack word32 arg2, Stack word32 arg3)
@@ -27083,7 +27083,7 @@ ui64 fn0011F3D1(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4)
 	ui32 v8 = 0x01FF;
 	v7 &= v8;
 	v8 = 0x2320;
-	&v7.u5->t0000.u0 = v7.u5 + v8 / 8;
+	&v7.u5->t0000.u0 += v8;
 }
 
 // 0011F3E9: Stack Eq_n dynCall_iiiii(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3, Stack Eq_n arg4)
@@ -27097,7 +27097,7 @@ Eq_n dynCall_iiiii(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4)
 	ui32 v8 = 0x01FF;
 	v7 &= v8;
 	v8 = 0x2520;
-	&v7.u5->t0000.u0 = v7.u5 + v8 / 8;
+	&v7.u5->t0000.u0 += v8;
 }
 
 // 0011F401: Stack word32 fn0011F401(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3, Stack Eq_n arg4, Stack ui64 arg5)
@@ -27114,7 +27114,7 @@ word32 fn0011F401(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4, ui64 ar
 	ui32 v9 = 0xFF;
 	v8 &= v9;
 	v9 = 0x2720;
-	&v8.u5->t0000.u0 = v8.u5 + v9 / 8;
+	&v8.u5->t0000.u0 += v9;
 }
 
 // 0011F41B: void dynCall_viii(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3)
@@ -27127,7 +27127,7 @@ void dynCall_viii(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3)
 	ui32 v7 = 0x01FF;
 	v6 &= v7;
 	v7 = 0x2820;
-	&v6.u5->t0000.u0 = v6.u5 + v7 / 8;
+	&v6.u5->t0000.u0 += v7;
 }
 
 // 0011F430: void dynCall_v(Stack Eq_n arg0)
@@ -27137,7 +27137,7 @@ void dynCall_v(Eq_n arg0)
 	ui32 v4 = 0x01FF;
 	v3 &= v4;
 	v4 = 0x2A20;
-	&v3.u5->t0000.u0 = v3.u5 + v4 / 8;
+	&v3.u5->t0000.u0 += v4;
 }
 
 // 0011F43F: Stack word32 dynCall_iiiiiiiii(Stack ui32 arg0, Stack word32 arg1, Stack word32 arg2, Stack word32 arg3, Stack word32 arg4, Stack word32 arg5, Stack word32 arg6, Stack word32 arg7, Stack word32 arg8)
@@ -27184,7 +27184,7 @@ void dynCall_viiii(Eq_n arg0, Eq_n arg1, Eq_n arg2, Eq_n arg3, Eq_n arg4)
 	ui32 v8 = 0x01FF;
 	v7 &= v8;
 	v8 = 0x2F20;
-	&v7.u5->t0000.u0 = v7.u5 + v8 / 8;
+	&v7.u5->t0000.u0 += v8;
 }
 
 // 0011F490: Stack Eq_n fn0011F490(Stack Eq_n arg0, Stack Eq_n arg1, Stack Eq_n arg2, Stack Eq_n arg3, Stack Eq_n arg4, Stack Eq_n arg5, Stack Eq_n arg6)

--- a/subjects/wasm/nbody.reko/nbody.h
+++ b/subjects/wasm/nbody.reko/nbody.h
@@ -275,7 +275,7 @@ T_18: (in arg1[v19_12 * 0x38<32>] @ 000E0090 : real64)
   Class: Eq_15
   DataType: real64
   OrigDataType: real64
-T_19: (in arg1[loc3_19 * 0x38<32> / 280<i32>] - arg1[(v19_12 * 0x38<32>) / 280<i32>] @ 000E0090 : real64)
+T_19: (in arg1->a0000[loc3_19].r0000 - ((arg1->a0000))[v19_12].r0000 @ 000E0090 : real64)
   Class: Eq_19
   DataType: real64
   OrigDataType: real64
@@ -331,7 +331,7 @@ T_32: (in Mem24[arg1 + v19_12 * 0x38<32> + 8<u32>:real64] @ 000E00A3 : real64)
   Class: Eq_26
   DataType: real64
   OrigDataType: real64
-T_33: (in (arg1 + (loc3_19 * 0x38<32>) / 280<i32>)->a0000[0<i32>].r0008 - (((arg1 + (v19_12 * 0x38<32>) / 280<i32>)->a0000))[0<i32>].r0008 @ 000E00A3 : real64)
+T_33: (in (&(arg1->a0000 + loc3_19)->r0000)[1<i32>] - (&(arg1->a0000 + v19_12)->r0000)[1<i32>] @ 000E00A3 : real64)
   Class: Eq_33
   DataType: real64
   OrigDataType: real64
@@ -387,7 +387,7 @@ T_46: (in Mem24[arg1 + v19_12 * 0x38<32> + 0x10<u32>:real64] @ 000E00B7 : real64
   Class: Eq_40
   DataType: real64
   OrigDataType: real64
-T_47: (in (arg1 + (loc3_19 * 0x38<32>) / 280<i32>)->a0000[0<i32>].r0010 - (((arg1 + (v19_12 * 0x38<32>) / 280<i32>)->a0000))[0<i32>].r0010 @ 000E00B7 : real64)
+T_47: (in (&(arg1->a0000 + loc3_19)->r0000)[2<i32>] - (&(arg1->a0000 + v19_12)->r0000)[2<i32>] @ 000E00B7 : real64)
   Class: Eq_47
   DataType: real64
   OrigDataType: real64
@@ -879,11 +879,11 @@ T_169: (in Mem234[arg1 + loc4_224 * 0x38<32> + 0x18<u32>:real64] @ 000E01B0 : re
   Class: Eq_169
   DataType: real64
   OrigDataType: real64
-T_170: (in (arg1 + (loc4_224 * 0x38<32>) / 280<i32>)->r0018 * arg2 @ 000E01B0 : real64)
+T_170: (in (&(arg1->a0000 + loc4_224)->r0000)[3<i32>] * arg2 @ 000E01B0 : real64)
   Class: Eq_170
   DataType: real64
   OrigDataType: real64
-T_171: (in *v19_231 + (arg1 + (loc4_224 * 0x38<32>) / 280<i32>)->r0018 * arg2 @ 000E01B0 : real64)
+T_171: (in *v19_231 + (&(arg1->a0000 + loc4_224)->r0000)[3<i32>] * arg2 @ 000E01B0 : real64)
   Class: Eq_163
   DataType: real64
   OrigDataType: real64
@@ -951,11 +951,11 @@ T_187: (in Mem246[arg1 + loc4_224 * 0x38<32> + 0x20<u32>:real64] @ 000E01D4 : re
   Class: Eq_187
   DataType: real64
   OrigDataType: real64
-T_188: (in (arg1 + (loc4_224 * 0x38<32>) / 280<i32>)->r0020 * arg2 @ 000E01D4 : real64)
+T_188: (in (&(arg1->a0000 + loc4_224)->r0000)[4<i32>] * arg2 @ 000E01D4 : real64)
   Class: Eq_188
   DataType: real64
   OrigDataType: real64
-T_189: (in v19_251->r0008 + (arg1 + (loc4_224 * 0x38<32>) / 280<i32>)->r0020 * arg2 @ 000E01D4 : real64)
+T_189: (in v19_251->r0008 + (&(arg1->a0000 + loc4_224)->r0000)[4<i32>] * arg2 @ 000E01D4 : real64)
   Class: Eq_181
   DataType: real64
   OrigDataType: real64
@@ -1019,11 +1019,11 @@ T_204: (in Mem266[arg1 + loc4_224 * 0x38<32> + 0x28<u32>:real64] @ 000E01F8 : re
   Class: Eq_204
   DataType: real64
   OrigDataType: real64
-T_205: (in (arg1 + (loc4_224 * 0x38<32>) / 280<i32>)->r0028 * arg2 @ 000E01F8 : real64)
+T_205: (in (&(arg1->a0000 + loc4_224)->r0000)[5<i32>] * arg2 @ 000E01F8 : real64)
   Class: Eq_205
   DataType: real64
   OrigDataType: real64
-T_206: (in v19_271->r0010 + (arg1 + (loc4_224 * 0x38<32>) / 280<i32>)->r0028 * arg2 @ 000E01F8 : real64)
+T_206: (in v19_271->r0010 + (&(arg1->a0000 + loc4_224)->r0000)[5<i32>] * arg2 @ 000E01F8 : real64)
   Class: Eq_198
   DataType: real64
   OrigDataType: real64

--- a/subjects/wasm/nbody.reko/nbody_text.c
+++ b/subjects/wasm/nbody.reko/nbody_text.c
@@ -19,24 +19,24 @@ void _advance(int32 arg0, struct Eq_n * arg1, real64 arg2)
 		{
 			do
 			{
-				real64 v24_n = arg1[loc3_n * 0x38 / 0x0118] - arg1[(v19_n * 0x38) / 0x0118];
-				real64 v27_n = (arg1 + (loc3_n * 0x38) / 0x0118)->a0000[0].r0008 - (((arg1 + (v19_n * 0x38) / 0x0118)->a0000))[0].r0008;
-				real64 v27_n = (arg1 + (loc3_n * 0x38) / 0x0118)->a0000[0].r0010 - (((arg1 + (v19_n * 0x38) / 0x0118)->a0000))[0].r0010;
-				real64 v23_n = (arg1 + (loc3_n * 0x38) / 0x0118)->r0030;
+				real64 v24_n = arg1->a0000[loc3_n].r0000 - ((arg1->a0000))[v19_n].r0000;
+				real64 v27_n = (&(arg1->a0000 + loc3_n)->r0000)[1] - (&(arg1->a0000 + v19_n)->r0000)[1];
+				real64 v27_n = (&(arg1->a0000 + loc3_n)->r0000)[2] - (&(arg1->a0000 + v19_n)->r0000)[2];
+				real64 v23_n = (&(arg1->a0000 + loc3_n)->r0000)[6];
 				real64 v24_n = sqrt(v24_n * v24_n + v27_n * v27_n + v27_n * v27_n);
-				struct Eq_n * v19_n = (struct Eq_n *) (arg1 + (loc3_n * 0x38) / 0x0118);
-				real64 v29_n = (arg1 + (v19_n * 0x38) / 0x0118)->r0030;
+				struct Eq_n * v19_n = (struct Eq_n *) &(arg1->a0000 + loc3_n)->r0000;
+				real64 v29_n = (&(arg1->a0000 + v19_n)->r0000)[6];
 				real64 v23_n = arg2 / (v24_n * (v24_n * v24_n));
 				v19_n->r0018 -= v24_n * v29_n * v23_n;
-				struct Eq_n * v19_n = (struct Eq_n *) (arg1 + (loc3_n * 0x38) / 0x0118);
+				struct Eq_n * v19_n = (struct Eq_n *) &(arg1->a0000 + loc3_n)->r0000;
 				v19_n->r0020 -= v23_n * (v27_n * v29_n);
-				struct Eq_n * v19_n = (struct Eq_n *) (arg1 + (loc3_n * 0x38) / 0x0118);
+				struct Eq_n * v19_n = (struct Eq_n *) &(arg1->a0000 + loc3_n)->r0000;
 				v19_n->r0028 -= v23_n * (v27_n * v29_n);
-				struct Eq_n * v19_n = (struct Eq_n *) (arg1 + (v19_n * 0x38) / 0x0118);
+				struct Eq_n * v19_n = (struct Eq_n *) &(arg1->a0000 + v19_n)->r0000;
 				v19_n->r0018 += v23_n * (v24_n * v23_n);
-				struct Eq_n * v19_n = (struct Eq_n *) (arg1 + (v19_n * 0x38) / 0x0118);
+				struct Eq_n * v19_n = (struct Eq_n *) &(arg1->a0000 + v19_n)->r0000;
 				v19_n->r0020 += v23_n * (v27_n * v23_n);
-				struct Eq_n * v19_n = (struct Eq_n *) (arg1 + (v19_n * 0x38) / 0x0118);
+				struct Eq_n * v19_n = (struct Eq_n *) &(arg1->a0000 + v19_n)->r0000;
 				v19_n->r0028 += v23_n * (v27_n * v23_n);
 				loc3_n = v19_n + 0x01;
 			} while (v19_n + 0x01 != arg0);
@@ -51,12 +51,12 @@ void _advance(int32 arg0, struct Eq_n * arg1, real64 arg2)
 	int32 v19_n;
 	do
 	{
-		real64 * v19_n = (real64 *) (arg1 + (loc4_n * 0x38) / 0x0118);
-		*v19_n += (arg1 + (loc4_n * 0x38) / 0x0118)->r0018 * arg2;
-		struct Eq_n * v19_n = (struct Eq_n *) (arg1 + (loc4_n * 0x38) / 0x0118);
-		v19_n->r0008 += (arg1 + (loc4_n * 0x38) / 0x0118)->r0020 * arg2;
-		struct Eq_n * v19_n = (struct Eq_n *) (arg1 + (loc4_n * 0x38) / 0x0118);
-		v19_n->r0010 += (arg1 + (loc4_n * 0x38) / 0x0118)->r0028 * arg2;
+		real64 * v19_n = &(arg1->a0000 + loc4_n)->r0000;
+		*v19_n += (&(arg1->a0000 + loc4_n)->r0000)[3] * arg2;
+		struct Eq_n * v19_n = (struct Eq_n *) &(arg1->a0000 + loc4_n)->r0000;
+		v19_n->r0008 += (&(arg1->a0000 + loc4_n)->r0000)[4] * arg2;
+		struct Eq_n * v19_n = (struct Eq_n *) &(arg1->a0000 + loc4_n)->r0000;
+		v19_n->r0010 += (&(arg1->a0000 + loc4_n)->r0000)[5] * arg2;
 		v19_n = loc4_n + 0x01;
 		loc4_n = v19_n;
 	} while (v19_n != arg0);


### PR DESCRIPTION
- Create CEB test: pointer to struct with array field
Expected: `id->a0000[index]`
But was:  `id[index * 0x00000008<p32> / 32<i32>]`
- Do not scale array index down if it can't be divided by element size
Avoid expressions like `a[index / 9244]`.