### PR TITLE
Output external demangled procedures in the header file

### DIFF
--- a/src/Core/DynamicLinker.cs
+++ b/src/Core/DynamicLinker.cs
@@ -99,7 +99,7 @@ namespace Reko.Core
                         ep = epNew;
                     }
                 }
-                else if (moduleName is not null && sProc.Signature is not null)
+                else if (sProc.Signature is not null)
                 {
                     program.EnsureExternalProcedure(
                         moduleName, importName, sProc.Signature.Convention,

--- a/src/Core/DynamicLinker.cs
+++ b/src/Core/DynamicLinker.cs
@@ -99,6 +99,12 @@ namespace Reko.Core
                         ep = epNew;
                     }
                 }
+                else if (moduleName is not null && sProc.Signature is not null)
+                {
+                    program.EnsureExternalProcedure(
+                        moduleName, importName, sProc.Signature.Convention,
+                        ep);
+                }
                 return ep;
             }
             return null;

--- a/src/Core/Procedure.cs
+++ b/src/Core/Procedure.cs
@@ -181,19 +181,6 @@ namespace Reko.Core
         }
 
         /// <summary>
-        /// If the procedure is a member of a class, write the class name first.
-        /// </summary>
-        /// <returns></returns>
-        public string QualifiedName()
-        {
-            if (EnclosingType == null)
-                return Name;
-            if (EnclosingType is StructType_v1 str)
-                return string.Format("{0}::{1}", str.Name, Name);
-            return Name;
-        }
-
-        /// <summary>
         /// Writes the blocks sorted by address ascending.
         /// </summary>
         /// <param name="emitFrame"></param>

--- a/src/Core/ProcedureBase.cs
+++ b/src/Core/ProcedureBase.cs
@@ -212,6 +212,19 @@ namespace Reko.Core
             return false;
         }
 
+        /// <summary>
+        /// If the procedure is a member of a class, write the class name first.
+        /// </summary>
+        /// <returns></returns>
+        public string QualifiedName()
+        {
+            if (EnclosingType == null)
+                return Name;
+            if (EnclosingType is StructType_v1 str)
+                return string.Format("{0}::{1}", str.Name, Name);
+            return Name;
+        }
+
         public override string ToString()
         {
             var sw = new StringWriter();

--- a/src/Core/Program.cs
+++ b/src/Core/Program.cs
@@ -381,7 +381,7 @@ namespace Reko.Core
         /// indexed by mangled import name. External declarations from system
         /// or user-defined metafiles aren't here to avoid dublication.
         /// </summary>
-        public Dictionary<string, (string, string?, ExternalProcedure)> ExternalProcedures { get; private set; }
+        public Dictionary<string, (string?, string?, ExternalProcedure)> ExternalProcedures { get; private set; }
 
         /// <summary>
         /// List of resources stored in the binary. Some executable file formats support the
@@ -832,8 +832,24 @@ namespace Reko.Core
             fields.Add(offset, dt, name);
         }
 
+        /// <summary>
+        /// Add new imported external procedure if there is not one with same
+        /// import name.
+        /// </summary>
+        /// <param name="moduleName">
+        /// Name of module of external procedure.
+        /// </param>
+        /// <param name="importName">
+        /// Mangled import name of external procedure.
+        /// </param>
+        /// <param name="callingConvention">
+        /// Calling convention of external procedure.
+        /// </param>
+        /// <param name="ep">
+        /// <see cref="ExternalProcedure" /> object
+        /// </param>
         public void EnsureExternalProcedure(
-            string moduleName, string importName, string? callingConvention,
+            string? moduleName, string importName, string? callingConvention,
             ExternalProcedure ep)
         {
             if (ExternalProcedures.ContainsKey(importName))

--- a/src/Core/Program.cs
+++ b/src/Core/Program.cs
@@ -73,6 +73,7 @@ namespace Reko.Core
             this.InterceptedCalls = new Dictionary<Address, ExternalProcedure>(new Address.Comparer());
             this.Intrinsics = new Dictionary<string, Dictionary<FunctionType, IntrinsicProcedure>>();
             this.InductionVariables = new Dictionary<Identifier, LinearInductionVariable>();
+            this.ExternalProcedures = new();
             this.TypeFactory = new TypeFactory();
             this.TypeStore = new TypeStore();
             this.Resources = new List<ProgramResource>();
@@ -373,6 +374,8 @@ namespace Reko.Core
         /// The program's intrinsic procedures, indexed by name and by signature.
         /// </summary>
         public Dictionary<string, Dictionary<FunctionType, IntrinsicProcedure>> Intrinsics { get; private set; }
+
+        public Dictionary<string, (string, string?, ExternalProcedure)> ExternalProcedures { get; private set; }
 
         /// <summary>
         /// List of resources stored in the binary. Some executable file formats support the
@@ -821,6 +824,16 @@ namespace Reko.Core
                 fields.Remove(globalField);
             }
             fields.Add(offset, dt, name);
+        }
+
+        public void EnsureExternalProcedure(
+            string moduleName, string importName, string? callingConvention,
+            ExternalProcedure ep)
+        {
+            if (ExternalProcedures.ContainsKey(importName))
+                return;
+            ExternalProcedures.Add(
+                importName, (moduleName, callingConvention, ep));
         }
     }
 }

--- a/src/Core/Program.cs
+++ b/src/Core/Program.cs
@@ -375,6 +375,12 @@ namespace Reko.Core
         /// </summary>
         public Dictionary<string, Dictionary<FunctionType, IntrinsicProcedure>> Intrinsics { get; private set; }
 
+        /// <summary>
+        /// The program's imported external demangled procedures. Contains
+        /// tuple of dll name, calling convention and ExtrernalProcedure,
+        /// indexed by mangled import name. External declarations from system
+        /// or user-defined metafiles aren't here to avoid dublication.
+        /// </summary>
         public Dictionary<string, (string, string?, ExternalProcedure)> ExternalProcedures { get; private set; }
 
         /// <summary>

--- a/src/Decompiler/Decompiler.cs
+++ b/src/Decompiler/Decompiler.cs
@@ -430,10 +430,8 @@ namespace Reko
                 return;
             w.WriteLine("// Declarations for external procedures");
             w.WriteLine();
-            foreach (var epKv in externalProcedures)
+            foreach (var (importName, (dllName, convention, ep)) in externalProcedures)
             {
-                var importName = epKv.Key;
-                var (dllName, convention, ep) = epKv.Value;
                 var qualifiedName = ep.QualifiedName();
                 if (!string.IsNullOrEmpty(convention))
                 {

--- a/src/Decompiler/Decompiler.cs
+++ b/src/Decompiler/Decompiler.cs
@@ -309,7 +309,7 @@ namespace Reko
                 }
                 finally
                 {
-                    host.WriteDecls(program, analyzer.WriteTypes);
+                    host.WriteDeclarations(program, analyzer.WriteTypes);
                 }
             }
         }
@@ -394,7 +394,7 @@ namespace Reko
             w.WriteLine();
         }
     
-        public void WriteDecompiledDecls(Program program, string headerFilename, TextWriter w)
+        public void WriteDecompiledDeclarations(Program program, string headerFilename, TextWriter w)
         {
             WriteHeaderComment(headerFilename, program, w);
             w.WriteLine("/*"); program.TypeStore.Write(true, w); w.WriteLine("*/");
@@ -601,7 +601,7 @@ namespace Reko
                 return;
             foreach (var program in Project.Programs)
             {
-                host.WriteDecls(program, (n, w) => WriteDecompiledDecls(program, n, w));
+                host.WriteDeclarations(program, (n, w) => WriteDecompiledDeclarations(program, n, w));
                 host.WriteDecompiledCode(program, (n, p, w) => WriteDecompiledObjects(program, n, p, w));
             }
 		}

--- a/src/Decompiler/Decompiler.cs
+++ b/src/Decompiler/Decompiler.cs
@@ -441,7 +441,16 @@ namespace Reko
                     qualifiedName,
                     FunctionType.EmitFlags.None,
                     w);
-                w.WriteLine($"; // {dllName}!{importName}");
+                string comment;
+                if (!string.IsNullOrEmpty(dllName))
+                {
+                    comment = $"{dllName}!{importName}";
+                }
+                else
+                {
+                    comment = importName;
+                }
+                w.WriteLine($"; // {comment}");
             }
         }
 

--- a/src/Decompiler/Decompiler.cs
+++ b/src/Decompiler/Decompiler.cs
@@ -309,7 +309,7 @@ namespace Reko
                 }
                 finally
                 {
-                    host.WriteTypes(program, analyzer.WriteTypes);
+                    host.WriteDecls(program, analyzer.WriteTypes);
                 }
             }
         }
@@ -394,7 +394,7 @@ namespace Reko
             w.WriteLine();
         }
     
-        public void WriteDecompiledTypes(Program program, string headerFilename, TextWriter w)
+        public void WriteDecompiledDecls(Program program, string headerFilename, TextWriter w)
         {
             WriteHeaderComment(headerFilename, program, w);
             w.WriteLine("/*"); program.TypeStore.Write(true, w); w.WriteLine("*/");
@@ -413,6 +413,37 @@ namespace Reko
                     w.WriteLine(";");
                     w.WriteLine();
                 }
+            }
+            WriteExternalProcedures(program, w);
+        }
+
+        public static void WriteExternalProcedures(
+            Program program, TextWriter w)
+        {
+            var externalProcedures = program.ExternalProcedures.OrderBy(
+                p => (
+                    p.Value.Item1,
+                    p.Value.Item3.EnclosingType?.ToString(),
+                    p.Value.Item3.Name)
+            ).ToList();
+            if (externalProcedures.Count == 0)
+                return;
+            w.WriteLine("// Declarations for external procedures");
+            w.WriteLine();
+            foreach (var epKv in externalProcedures)
+            {
+                var importName = epKv.Key;
+                var (dllName, convention, ep) = epKv.Value;
+                var qualifiedName = ep.QualifiedName();
+                if (!string.IsNullOrEmpty(convention))
+                {
+                    qualifiedName = $"{convention} {qualifiedName}";
+                }
+                ep.Signature.Emit(
+                    qualifiedName,
+                    FunctionType.EmitFlags.None,
+                    w);
+                w.WriteLine($"; // {dllName}!{importName}");
             }
         }
 
@@ -572,7 +603,7 @@ namespace Reko
                 return;
             foreach (var program in Project.Programs)
             {
-                host.WriteTypes(program, (n, w) => WriteDecompiledTypes(program, n, w));
+                host.WriteDecls(program, (n, w) => WriteDecompiledDecls(program, n, w));
                 host.WriteDecompiledCode(program, (n, p, w) => WriteDecompiledObjects(program, n, p, w));
             }
 		}

--- a/src/Decompiler/Services/IDecompiledFileService.cs
+++ b/src/Decompiler/Services/IDecompiledFileService.cs
@@ -49,7 +49,7 @@ namespace Reko.Services
         TextWriter CreateTextWriter(string filename);
         void WriteDisassembly(Program program, Action<string, Dictionary<ImageSegment, List<ImageMapItem>>, Formatter> writer);
         void WriteIntermediateCode(Program program, Action<string, IEnumerable<IAddressable>, TextWriter> writer);
-        void WriteDecls(Program program, Action<string, TextWriter> writer);
+        void WriteDeclarations(Program program, Action<string, TextWriter> writer);
         void WriteDecompiledCode(Program program, Action<string, IEnumerable<IAddressable>, TextWriter> writer);
         void WriteGlobals(Program program, Action<string, TextWriter> writer);
     }
@@ -82,7 +82,7 @@ namespace Reko.Services
             writer("", program.Procedures.Values, TextWriter.Null);
         }
 
-        public void WriteDecls(Program program, Action<string,TextWriter> writer)
+        public void WriteDeclarations(Program program, Action<string,TextWriter> writer)
         {
             writer("", TextWriter.Null);
         }
@@ -153,7 +153,7 @@ namespace Reko.Services
             }
         }
 
-        public void WriteDecls(Program program, Action<string, TextWriter> writer)
+        public void WriteDeclarations(Program program, Action<string, TextWriter> writer)
         {
             var incFilename = GenerateDerivedFilename(program, ".h");
             var incPath = Path.Combine(program.IncludeDirectory, incFilename);

--- a/src/Decompiler/Services/IDecompiledFileService.cs
+++ b/src/Decompiler/Services/IDecompiledFileService.cs
@@ -49,7 +49,7 @@ namespace Reko.Services
         TextWriter CreateTextWriter(string filename);
         void WriteDisassembly(Program program, Action<string, Dictionary<ImageSegment, List<ImageMapItem>>, Formatter> writer);
         void WriteIntermediateCode(Program program, Action<string, IEnumerable<IAddressable>, TextWriter> writer);
-        void WriteTypes(Program program, Action<string, TextWriter> writer);
+        void WriteDecls(Program program, Action<string, TextWriter> writer);
         void WriteDecompiledCode(Program program, Action<string, IEnumerable<IAddressable>, TextWriter> writer);
         void WriteGlobals(Program program, Action<string, TextWriter> writer);
     }
@@ -82,7 +82,7 @@ namespace Reko.Services
             writer("", program.Procedures.Values, TextWriter.Null);
         }
 
-        public void WriteTypes(Program program, Action<string,TextWriter> writer)
+        public void WriteDecls(Program program, Action<string,TextWriter> writer)
         {
             writer("", TextWriter.Null);
         }
@@ -153,7 +153,7 @@ namespace Reko.Services
             }
         }
 
-        public void WriteTypes(Program program, Action<string, TextWriter> writer)
+        public void WriteDecls(Program program, Action<string, TextWriter> writer)
         {
             var incFilename = GenerateDerivedFilename(program, ".h");
             var incPath = Path.Combine(program.IncludeDirectory, incFilename);

--- a/src/UnitTests/Mocks/FakeDecompilerHost.cs
+++ b/src/UnitTests/Mocks/FakeDecompilerHost.cs
@@ -64,7 +64,7 @@ namespace Reko.UnitTests.Mocks
             writer("test.dis", Array.Empty<Procedure>(), intermediate);
         }
 
-        public void WriteDecls(Program program, Action<string, TextWriter> writer)
+        public void WriteDeclarations(Program program, Action<string, TextWriter> writer)
         {
             writer("test.h", typesWriter);
         }

--- a/src/UnitTests/Mocks/FakeDecompilerHost.cs
+++ b/src/UnitTests/Mocks/FakeDecompilerHost.cs
@@ -64,7 +64,7 @@ namespace Reko.UnitTests.Mocks
             writer("test.dis", Array.Empty<Procedure>(), intermediate);
         }
 
-        public void WriteTypes(Program program, Action<string, TextWriter> writer)
+        public void WriteDecls(Program program, Action<string, TextWriter> writer)
         {
             writer("test.h", typesWriter);
         }

--- a/subjects/PE/x86/ExeDll/Executable.reko/Executable.h
+++ b/subjects/PE/x86/ExeDll/Executable.reko/Executable.h
@@ -6123,3 +6123,6 @@ typedef struct Eq_1232 {
 	Eq_73 t0000;	// 0
 } Eq_1232;
 
+// Declarations for external procedures
+
+int32 __cdecl slow_and_safe_increment(int32 dwArg04); // DynamicLibrary.dll!?slow_and_safe_increment@@YAHH@Z

--- a/subjects/PE/x86/RussianText/RussianText.reko/RussianText.h
+++ b/subjects/PE/x86/RussianText/RussianText.reko/RussianText.h
@@ -706,3 +706,6 @@ typedef struct Eq_73 {	// size: 8 8
 	void * ptr0004;	// 4
 } Eq_73;
 
+// Declarations for external procedures
+
+void _InitTermAndUnexPtrs(); // CC3260.DLL!@_InitTermAndUnexPtrs$qv

--- a/subjects/PE/x86/UserDefinedSignatures/UserDefinedSignatures.reko/UserDefinedSignatures.h
+++ b/subjects/PE/x86/UserDefinedSignatures/UserDefinedSignatures.reko/UserDefinedSignatures.h
@@ -1342,3 +1342,6 @@ typedef real64 (Eq_181)(char *);
 
 typedef void (Eq_193)(Eq_5 *, int32, word32 *);
 
+// Declarations for external procedures
+
+void * __cdecl operator new(uint32 dwArg04); // MSVCR80.dll!??2@YAPAXI@Z


### PR DESCRIPTION
They are sorted by (DLL name; class name; function name). External declarations from system or user-defined metafiles aren't here to avoid dublication.