### PR TITLE
AEON: Add bt.lwst instruction

### DIFF
--- a/src/Arch/OpenRISC/Aeon/AeonDisassembler.cs
+++ b/src/Arch/OpenRISC/Aeon/AeonDisassembler.cs
@@ -504,9 +504,13 @@ namespace Reko.Arch.OpenRISC.Aeon
                 Instr(Mnemonic.bt_trap, uimm1_4),                   // source
                 Instr(Mnemonic.bt_nop, uimm1_4));                   // source
 
+            var decoder100000_stack = Mask(0, 1, "  opc=100000",
+                Instr(Mnemonic.bt_swst____, MuStack(1, 4, 2, PrimitiveType.Word32), R5),
+                Instr(Mnemonic.bt_lwst____, Ru5, MuStack(1, 4, 2, PrimitiveType.Word32)));
+
             var decoder100000 = Select((5, 5), u => u == 0,
                 decoder100000_special,
-                Instr(Mnemonic.bt_swst____, MuStack(0, 5, 1, PrimitiveType.Word32), R5));    // guess
+                decoder100000_stack);
 
             var decoder100001_sub0 = Select((5, 5), u => u == 0,
                 Instr(Mnemonic.bt_rfe, InstrClass.Transfer | InstrClass.Return), // source

--- a/src/Arch/OpenRISC/Aeon/AeonRewriter.cs
+++ b/src/Arch/OpenRISC/Aeon/AeonRewriter.cs
@@ -143,6 +143,7 @@ namespace Reko.Arch.OpenRISC.Aeon
                 case Mnemonic.bg_lhs__: RewriteLoadExt(PrimitiveType.Int16); break;
                 case Mnemonic.bn_lhz:
                 case Mnemonic.bg_lhz__: RewriteLoadExt(PrimitiveType.UInt16); break;
+                case Mnemonic.bt_lwst____:
                 case Mnemonic.bn_lwz:
                 case Mnemonic.bg_lwz: RewriteLoadExt(PrimitiveType.Word32); break;
                 case Mnemonic.bg_mfspr1__: RewriteMfspr(true); break;

--- a/src/Arch/OpenRISC/Aeon/Mnemonic.cs
+++ b/src/Arch/OpenRISC/Aeon/Mnemonic.cs
@@ -94,6 +94,7 @@ namespace Reko.Arch.OpenRISC.Aeon
         bg_lhs__,
         bn_lhz,
         bg_lhz__,
+        bt_lwst____,
         bn_lwz,
         bg_lwz,
         bg_mfspr,

--- a/src/UnitTests/Arch/OpenRISC/AeonDisassemblerTests.cs
+++ b/src/UnitTests/Arch/OpenRISC/AeonDisassemblerTests.cs
@@ -461,6 +461,12 @@ namespace Reko.UnitTests.Arch.OpenRISC
         }
 
         [Test]
+        public void AeonDis_bt_lwst____()
+        {
+            AssertCode("bt.lwst??\tr4,0x14(r1)", "80 8B");
+        }
+
+        [Test]
         public void AeonDis_bn_lwz()
         {
             // confirmed with source

--- a/src/UnitTests/Arch/OpenRISC/AeonRewriterTests.cs
+++ b/src/UnitTests/Arch/OpenRISC/AeonRewriterTests.cs
@@ -624,6 +624,15 @@ namespace Reko.UnitTests.Arch.OpenRISC
         }
 
         [Test]
+        public void AeonRw_bt_lwst____()
+        {
+            Given_HexString("815D");
+            AssertCode(     // bt.lwst??	r10,0x38(r1)
+                "0|L--|00100000(2): 1 instructions",
+                "1|L--|r10 = Mem0[r1 + 56<i32>:word32]");
+        }
+
+        [Test]
         public void AeonRw_bn_lwz()
         {
             Given_HexString("0CE302");


### PR DESCRIPTION
The encoding for `bt.lwst` is almost the same as that of `bt.swst` except that it has the LSB set. This means the value for the immediate starts at bit 1, is 4 bits long, and is shifted left by 2 bits to calculate the offset. These instructions seem to be intended to provide more efficient stack access, using only 16 bits rather than the 24 bits of `bn.sw`/`bn.lwz`.

The `bt.lwst` and `bt.swst` mnemonics are both entirely made up. I would love to know what the official mnemonics are or if these are actually just special cases of other load/store word instructions.