### PR TITLE
CParser: Define __REKO_DECOMPILER__ macro

### DIFF
--- a/src/Core/Hll/C/CDirectiveLexer.cs
+++ b/src/Core/Hll/C/CDirectiveLexer.cs
@@ -61,7 +61,10 @@ namespace Reko.Core.Hll.C
         {
             this.parserState = state;
             this.lexer = lexer;
-            this.macros = new();
+            this.macros = new()
+            {
+                { "__REKO_DECOMPILER__", new () { new CToken(CTokenType.NumericLiteral, 1) } }
+            };
             this.state = State.StartLine;
             this.ifdefs = new Stack<(bool, bool)>();
             this.expandedTokens = new();

--- a/src/UnitTests/Core/Hll/C/CDirectiveLexerTests.cs
+++ b/src/UnitTests/Core/Hll/C/CDirectiveLexerTests.cs
@@ -416,5 +416,25 @@ B");
             Assert.AreEqual(CTokenType.RParen, lexer.Read().Type);
             Assert.AreEqual(CTokenType.EOF, lexer.Read().Type);
         }
+
+        [Test]
+        public void CDirectiveLexer_reko_macro()
+        {
+            Lex(
+                "#ifdef __REKO_DECOMPILER__\r\n" +
+                "# define result1 good1\r\n" +
+                "#else\r\n" +
+                "# define result1 bad1\r\n" +
+                "#endif\r\n" +
+                "#ifndef __REKO_DECOMPILER__\r\n" +
+                "# define result2 bad2\r\n" +
+                "#else\r\n" +
+                "# define result2 good2\r\n" +
+                "#endif\r\n" +
+                "result1 result2");
+            Assert.AreEqual("good1", lexer.Read().Value);
+            Assert.AreEqual("good2", lexer.Read().Value);
+            Assert.AreEqual(CTokenType.EOF, lexer.Read().Type);
+        }
     }
 }


### PR DESCRIPTION
This is useful for keeping headers compatible with IDA, Ghidra, etc.

CParser doesn't have `#if` support yet, so there's no point in doing anything fancy; the value of `__REKO_DECOMPILER__` is 1.

Added a unit test.