### PR TITLE
Update action versions in workflows

### DIFF
--- a/.github/workflows/reko.yml
+++ b/.github/workflows/reko.yml
@@ -24,9 +24,9 @@ jobs:
           - os: windows-latest
             build_config: Release
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
     - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
         BUILD_CONFIG: ${{ matrix.build_config }}
       run: dotnet msbuild -p:Platform=x64 -p:Configuration=Release -t:create_release -m ./src/BuildTargets/BuildTargets.csproj
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: reko-${{ matrix.os }}
         if-no-files-found: warn


### PR DESCRIPTION
The existing actions were using Node.js v12—or at least trying to. They were actually [forced](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/) to run on Node.js v16, but that's also EOL.

Updating to the latest versions of `actions/checkout`, `actions/setup-dotnet`, and `actions/upload-artifact` (`v4` for all three) eliminates the warnings about outdated Node.js. The workflow still runs fine.