### PR TITLE
Implement missing logic in WildPatternMatcher + re-enable unit tests

### DIFF
--- a/src/Core/Lib/WildPatternMatcher.cs
+++ b/src/Core/Lib/WildPatternMatcher.cs
@@ -59,7 +59,7 @@ namespace Reko.Core.Lib
                 foreach (var pos in occ_Pi)
                 {
                     int adjustedPos = pos - Val[i];
-                    if (!isValidPos(adjustedPos,Val[i], nextPatternWildcards, textLength))
+                    if (!IsValidPos(adjustedPos,Val[i], nextPatternWildcards, textLength))
                         continue;
                     ++permitted[adjustedPos];
                     if (permitted[adjustedPos] == patternLength)
@@ -71,7 +71,7 @@ namespace Reko.Core.Lib
             return occ_P;
         }
 
-        private bool isValidPos(int pos,int len,int nextPatternWildcards,int textLength)
+        private bool IsValidPos(int pos,int len,int nextPatternWildcards,int textLength)
         {
             // checks that match at the position is within the text
             return pos >= 0 && pos + len + nextPatternWildcards < textLength;
@@ -96,7 +96,7 @@ namespace Reko.Core.Lib
                 foreach (var pos in occ_Pi)
                 {
                     int adjustedPos = pos - Val[i];
-                    if (!isValidPos(adjustedPos,Val[i], nextPatternWildcards, textLength))
+                    if (!IsValidPos(adjustedPos,Val[i], nextPatternWildcards, textLength))
                         continue;
                     if (permitted.TryGetValue(adjustedPos, out int c))
                     {

--- a/src/Core/Lib/WildPatternMatcher.cs
+++ b/src/Core/Lib/WildPatternMatcher.cs
@@ -70,10 +70,12 @@ namespace Reko.Core.Lib
             }
             return occ_P;
         }
-
+        /// <summary>
+        /// Checks that a match at the position <paramref name="pos" /> and
+        /// length <paramref name="len" /> fits in the text
+        /// </summary>
         private bool IsValidPos(int pos,int len,int nextPatternWildcards,int textLength)
         {
-            // checks that match at the position is within the text
             return pos >= 0 && pos + len + nextPatternWildcards < textLength;
         }
 

--- a/src/Core/Lib/WildPatternMatcher.cs
+++ b/src/Core/Lib/WildPatternMatcher.cs
@@ -45,64 +45,81 @@ namespace Reko.Core.Lib
         public IEnumerable<int> FindDcp(string T, string P)
         {
             var sa = new SuffixArray<char>(T.ToCharArray());
+            int textLength = T.Length;
             int[] permitted = new int[T.Length];
-            (string[], int[]) pat = SplitPattern(P);
-            var l = pat.Item1.Length;
-            var Val = new int[l];
-            Val[0] = 0;
-            for (int i = 1; i < l; ++i)
-            {
-                Val[i] = Val[i - 1] + pat.Item1[i - 1].Length + pat.Item2[i - 1];
-            }
+            (string[] patternParts, int[] dontCares) = SplitPattern(P);
+            var patternLength = patternParts.Length;
+            var Val = CalculateOffsets(patternParts, dontCares);
             var occ_P = new SortedSet<int>();
-            for (int i = 0; i < l; ++i)
+            for (int i = 0; i < patternLength; ++i)
             {
-                var Pi = pat.Item1[i];
+                var Pi = patternParts[i];
+                var nextPatternWildcards = i<dontCares.Length ? dontCares[i] : 0;
                 var occ_Pi = new SortedSet<int>(sa.FindOccurences(Pi.ToCharArray()));
-                foreach (var r in occ_Pi)
+                foreach (var pos in occ_Pi)
                 {
-                    ++permitted[r - Val[i]];
-                    if (permitted[r - Val[i]] == l)
+                    int adjustedPos = pos - Val[i];
+                    if (!isValidPos(adjustedPos,Val[i], nextPatternWildcards, textLength))
+                        continue;
+                    ++permitted[adjustedPos];
+                    if (permitted[adjustedPos] == patternLength)
                     {
-                        occ_P.Add(r - Val[i]);
+                        occ_P.Add(adjustedPos);
                     }
                 }
             }
             return occ_P;
         }
 
+        private bool isValidPos(int pos,int len,int nextPatternWildcards,int textLength)
+        {
+            // checks that match at the position is within the text
+            return pos >= 0 && pos + len + nextPatternWildcards < textLength;
+        }
+
         public IEnumerable<int> FindIdcp(string T, string P)
         {
             var sa = new SuffixArray<char>(T.ToCharArray());
-            (string[], int[]) pat = SplitPattern(P);
-            var l = pat.Item1.Length;
-            var Val = new int[l];
-            Val[0] = 0;
-            for (int i = 1; i < l; ++i)
-            {
-                Val[i] = Val[i - 1] + pat.Item1[i - 1].Length + pat.Item2[i - 1];
-            }
+            int textLength = T.Length;
+            (string[] patternParts, int[] dontCares) = SplitPattern(P);
+            var patternLength = patternParts.Length;
+            var Val = CalculateOffsets(patternParts, dontCares);
             var occ_P = new SortedSet<int>();
-            var P_1 = pat.Item1[0];
+            var P_1 = patternParts[0];
             var occ_P1 = sa.FindOccurences(P_1.ToCharArray());
             var permitted = occ_P1.ToDictionary(i => i, v => 1);
-            for (int i =0; i < l; ++i)
+            for (int i =0; i < patternLength; ++i)
             {
-                var Pi = pat.Item1[i];
+                var Pi = patternParts[i];
+                var nextPatternWildcards = i<dontCares.Length ? dontCares[i] : 0;
                 var occ_Pi = sa.FindOccurences(Pi.ToCharArray());
-                foreach (var r in occ_Pi)
+                foreach (var pos in occ_Pi)
                 {
-                    int r_val = r - Val[i];
-                    if (permitted.TryGetValue(r_val, out int c))
+                    int adjustedPos = pos - Val[i];
+                    if (!isValidPos(adjustedPos,Val[i], nextPatternWildcards, textLength))
+                        continue;
+                    if (permitted.TryGetValue(adjustedPos, out int c))
                     {
                         ++c;
-                        permitted[r_val] = c;
-                        if (c == l)
-                            occ_P.Add(r_val);
+                        permitted[adjustedPos] = c;
+                        if (c == patternLength)
+                            occ_P.Add(adjustedPos);
                     }
                 }
             }
             return occ_P;
+        }
+
+        private int[] CalculateOffsets(string[] patternParts, int[] wildcards)
+        {
+            int length = patternParts.Length;
+            var offsets = new int[length];      
+            offsets[0] = 0;
+            for (int i = 1; i < length; ++i)
+            {
+                offsets[i] = offsets[i - 1] + patternParts[i - 1].Length + wildcards[i - 1];
+            }
+            return offsets;
         }
 
         private (string[], int[]) SplitPattern(string P)
@@ -124,6 +141,7 @@ namespace Reko.Core.Lib
                         Ps.Add(Pi.ToString());
                         Pi = new StringBuilder();
                         Ks.Add(1);
+                        inWildcards = true;
                     }
                 }
                 else
@@ -135,7 +153,10 @@ namespace Reko.Core.Lib
                     Pi.Append(ch);
                 }
             }
-            Ps.Add(Pi.ToString());
+            if (Pi.Length > 0) // pattern can be followed by a wildcard, and the Pi will be empty then
+            {
+                Ps.Add(Pi.ToString());
+            }
             return (Ps.ToArray(), Ks.ToArray());
         }
     }

--- a/src/UnitTests/Core/Lib/WildPatternMatcher.Tests.cs
+++ b/src/UnitTests/Core/Lib/WildPatternMatcher.Tests.cs
@@ -40,12 +40,16 @@ namespace Reko.UnitTests.Core.Lib
         }
 
         [Test]
-        [Ignore("Get this working soon")]
         public void Wpm_Wildcard()
         {
             var dcp = new WildPatternMatcher();
             var x = dcp.FindDcp("abracadabraaska", "a**a");
-            Assert.AreEqual(new[] { 0, 3 }, x.ToArray());
+            Assert.AreEqual(new[] { 0, 7,11 }, x.ToArray());
+            
+            // test with a pattern that has a wildcard at the end
+            x = dcp.FindDcp("abracadabraaska", "a**a*");
+            // the 'aska' at the end of the string should not be matched - it is not followed by any character.
+            Assert.AreEqual(new[] { 0, 7 }, x.ToArray());
         }
     }
 }

--- a/src/UnitTests/Core/Lib/WildPatternMatcher.Tests.cs
+++ b/src/UnitTests/Core/Lib/WildPatternMatcher.Tests.cs
@@ -40,14 +40,19 @@ namespace Reko.UnitTests.Core.Lib
         }
 
         [Test]
-        public void Wpm_Wildcard()
+        public void Wpm_PatternWithWildcardInTheMiddle()
         {
             var dcp = new WildPatternMatcher();
             var x = dcp.FindDcp("abracadabraaska", "a**a");
-            Assert.AreEqual(new[] { 0, 7,11 }, x.ToArray());
-            
+            Assert.AreEqual(new[] { 0, 7,11 }, x.ToArray());            
+        }
+
+        [Test]
+        public void Wpm_PatternWithWildcardAtEnd()
+        {
+            var dcp = new WildPatternMatcher();
             // test with a pattern that has a wildcard at the end
-            x = dcp.FindDcp("abracadabraaska", "a**a*");
+            var x = dcp.FindDcp("abracadabraaska", "a**a*");
             // the 'aska' at the end of the string should not be matched - it is not followed by any character.
             Assert.AreEqual(new[] { 0, 7 }, x.ToArray());
         }


### PR DESCRIPTION
The unit test was also extended to check additional case for patterns ending with wildcard