### PR TITLE
Fix `indenpendent` -> `independent` typo in glossary

### DIFF
--- a/doc/guide/glossary.md
+++ b/doc/guide/glossary.md
@@ -22,7 +22,7 @@ program_start:      push            ebp
   discover.
 
 ### Intermediate representation
-  Intermediate representation (IR) is a machine-indenpendent representation of executable code.
+  Intermediate representation (IR) is a machine-independent representation of executable code.
   Reko converts machine code from different architectures into this representation so that it can
   use common algorithms during the decompilation process.
 


### PR DESCRIPTION
Line 25 of `doc/guide/glossary.md` has `indenpendent` (extra n) in the IR definition.