### PR TITLE
Fix MN103 decoding of (d32,SP) operands and CALLS with 32-bit displacement

### DIFF
--- a/src/Arch/MN103/MN103Disassembler.cs
+++ b/src/Arch/MN103/MN103Disassembler.cs
@@ -243,7 +243,7 @@ namespace Reko.Arch.MN103
                 return true;
             };
         }
-        private static readonly Mutator<MN103Disassembler> d32_sp = reg_relative_u16(Registers.sp);
+        private static readonly Mutator<MN103Disassembler> d32_sp = reg_relative_u32(Registers.sp);
 
 
         private static bool d8_pc(uint uInstr, MN103Disassembler dasm)
@@ -905,7 +905,7 @@ namespace Reko.Arch.MN103
                     invalid,
                     invalid,
                     Instr(Mnemonic.add, imm32, sp),
-                    Instr(Mnemonic.calls, d32_sp)));
+                    Instr(Mnemonic.calls, d32_pc)));
             var fddecoders = Mask(2, 6, "  FD",
                 Instr(Mnemonic.udf00, imm32, dn),
                 Instr(Mnemonic.udfu00, imm32, dn),

--- a/src/UnitTests/Arch/MN103/MN103DisassemblerTests.cs
+++ b/src/UnitTests/Arch/MN103/MN103DisassemblerTests.cs
@@ -47,6 +47,52 @@ namespace Reko.UnitTests.Arch.MN103
 
         public override Address LoadAddress => addr;
 
+        private void AssertCode(string sExpected, string hexBytes)
+        {
+            var instr = DisassembleHexBytes(hexBytes);
+            Assert.AreEqual(sExpected, instr.ToString());
+        }
+
+        [Test]
+        public void MN103Dis_calls_d32()
+        {
+            // FC FF: calls (d32,PC); the target is relative to the address
+            // of the calls instruction itself.
+            AssertCode("calls\t00101234", "FCFF34120000");
+        }
+
+        [Test]
+        public void MN103Dis_calls_d32_negative_displacement()
+        {
+            AssertCode("calls\t000FFF00", "FCFF00FFFFFF");
+        }
+
+        [Test]
+        public void MN103Dis_mov_d32_sp_load()
+        {
+            // FC Bx: (d32,SP) accesses are 6-byte instructions carrying
+            // a full 32-bit displacement.
+            AssertCode("mov\t(12345678,sp),d1", "FCB578563412");
+        }
+
+        [Test]
+        public void MN103Dis_mov_d32_sp_store()
+        {
+            AssertCode("mov\td1,(12345678,sp)", "FC9578563412");
+        }
+
+        [Test]
+        public void MN103Dis_movbu_d32_sp_store()
+        {
+            AssertCode("movbu\td1,(12345678,sp)", "FC9678563412");
+        }
+
+        [Test]
+        public void MN103Dis_movhu_d32_sp_load()
+        {
+            AssertCode("movhu\t(12345678,sp),d1", "FCBD78563412");
+        }
+
         [Test]
         public void MN103Dis_Generate()
         {

--- a/src/UnitTests/Arch/MN103/MN103RewriterTests.cs
+++ b/src/UnitTests/Arch/MN103/MN103RewriterTests.cs
@@ -197,6 +197,16 @@ namespace Reko.UnitTests.Arch.MN103
         }
 
         [Test]
+        public void Mn103Rw_calls_d32()
+        {
+            Given_HexString("FCFF34120000");
+            AssertCode(     // calls	00101234
+                "0|L--|00100000(6): 2 instructions",
+                "1|L--|mdr = 00100006",
+                "2|T--|call 00101234 (4)");
+        }
+
+        [Test]
         public void Mn103Rw_clr_d0()
         {
             Given_HexString("00");
@@ -331,6 +341,15 @@ namespace Reko.UnitTests.Arch.MN103
             AssertCode(     // mov	(F7,sp),a1
                 "0|L--|00100000(2): 1 instructions",
                 "1|L--|a1 = Mem0[sp + 247<i32>:word32]");
+        }
+
+        [Test]
+        public void Mn103Rw_mov_d32_sp()
+        {
+            Given_HexString("FCB578563412");
+            AssertCode(     // mov	(12345678,sp),d1
+                "0|L--|00100000(6): 1 instructions",
+                "1|L--|d1 = Mem0[sp + 305419896<i32>:word32]");
         }
 
         [Test]


### PR DESCRIPTION
While disassembling MN103 camera firmware with Reko I ran into two decoding
bugs in the FC-prefix (6-byte instruction) page of the MN103 disassembler:

**1. `d32_sp` reads only 16 of its 32 displacement bits.**

```csharp
private static readonly Mutator<MN103Disassembler> d32_sp = reg_relative_u16(Registers.sp);
```

Every `(d32,SP)` memory operand (the `MOV`/`MOVBU`/`MOVHU` forms at
`FC 8x/9x/Bx`) decoded with a truncated displacement and a length of 4 bytes
instead of 6, desynchronizing the instruction stream from that point on. For
example, `FC B4 78 56 34 12` (`mov (0x12345678,sp),d0`) decoded as
`mov (5678,sp),d0` with length 4, and the remaining displacement bytes were
then decoded as the start of the next instruction.

**2. `CALLS` with a 32-bit displacement (`FC FF`) decoded as `calls (d32,sp)`.**

This form is PC-relative — the target is the address of the `CALLS`
instruction plus the displacement — analogous to the 16-bit form (`FA FF`),
which already decodes with `d16_pc`. With the fix the operand is the resolved
call target address, so far calls no longer appear as SP-relative memory
accesses.

References:

- Panasonic MN1030/MN103S Series Instruction Manual (13250-040E): the CALLS
  specification (p. 88) gives `PC+6 → mem32(SP), PC+6 → MDR, PC+d32 → PC`,
  size 6, for the 32-bit form (this also answers the `//$REVIEW` question in
  `d32_pc`: the displacement is anchored at the start of the instruction);
  the FC-prefix instruction map (p. 189) lists `CALLS (d32,PC)` at `FC FF`
  and full 32-bit displacements for the `(d32,SP)` moves.
- GNU binutils `opcodes/m10300-opc.c` agrees:
  `"calls" 0xfcff0000 … {IMM32_PCREL}`, and the `(d32,SP)` moves are `FMT_D4`
  (6 bytes) with `IMM32`.

Added six disassembler tests covering the affected forms and two rewriter
tests (`calls (d32,PC)`, `mov (d32,SP),Dn`). All eight fail without the fix;
the whole MN103 suite passes with it.

One observation left out of scope: `calls` decoder entries carry no
`InstrClass.Transfer | InstrClass.Call`, so `calls` instructions report
`InstrClass.Linear` (visible in the existing `Mn103Rw_calls` test's `L--`
cluster class). Happy to address that in a follow-up if there's interest.
